### PR TITLE
refactor: flatten tests/, examples/, and cleanup repo structure (Phases 7-11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,3 +306,4 @@ benchmarks/reports/
 benchmarks/results/
 # OrcaFlex simulation files (large binary)
 docs/modules/orcaflex/pipeline/installation/floating/24in_pipeline/monolithic/runs/*.sim
+.benchmarks/


### PR DESCRIPTION
## Summary

Completes the repo-wide restructuring that began in PR #129 (src/ flattening, Phases 0-6). This PR addresses all remaining structural debt:

- **Phase 7A+7B**: Flatten `tests/modules/` → `tests/` (48 directories, 663 files moved)
- **Phase 7C**: Organize 44 loose root test files into appropriate subdirectories
- **Phase 8**: Update 160 files with legacy `digitalmodel.modules.*` references (67 Python imports + 453 markdown + 115 JSON refs)
- **Phase 9**: Flatten `examples/modules/` → `examples/` (23 directories)
- **Phase 10**: Remove stale empty directories (`results/`, `htmlcov/`, `.benchmarks/`, `coordination/`), update `.gitignore`
- **Phase 11**: Verification — all 9 structural checks pass, 30/30 backward compat tests pass

### What changed
- 962 files changed, net +1 line (overwhelmingly renames)
- Zero functional code changes — only file moves and import path updates
- Backward compat shim (`MetaPathFinder`) preserved and verified working

### What's preserved (by design)
- `src/digitalmodel/modules/__init__.py` — MetaPathFinder compat shim
- `src/digitalmodel/_compat.py` — moved modules registry  
- `tests/compat/test_restructure_compat.py` — 30 compat tests (all pass)
- `scripts/build_import_map.py` — import scanner tool

## Test plan
- [x] All 30 backward-compat tests pass (`tests/compat/test_restructure_compat.py`)
- [x] `tests/modules/` directory no longer exists
- [x] `examples/modules/` directory no longer exists
- [x] `grep -r "digitalmodel.modules."` returns only compat layer files
- [x] All 18 CLI entry points reference flattened paths
- [x] `pyproject.toml` testpaths unchanged (`["tests"]`)
- [ ] Full CI test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)