### PR TITLE
chore(gitignore): exclude .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ coverage.wrk*.xml
 *.wrk*.xml
 outputs/
 specs/
+
+# Agent worktrees (local-only, must not be tracked as gitlinks)
+.claude/worktrees/


### PR DESCRIPTION
Prevents Claude-agent worktrees from being tracked as submodule gitlinks.

Ref: vamseeachanta/workspace-hub#2326