### PR TITLE
test(canonical-spec): add OrcaWave and OrcaFlex semantic proofs

### DIFF
--- a/examples/demos/gtm/branded_report.py
+++ b/examples/demos/gtm/branded_report.py
@@ -1,0 +1,191 @@
+"""Branded-report wrapper (plan #2346 section E).
+
+Post-processes a GTMReportBuilder-emitted HTML file by injecting
+prospect branding into the <head> and <body> without replacing the
+engineering body. Returns the modified HTML as a string AND writes it
+back to disk when a target path is provided.
+
+Design choices:
+
+- **BeautifulSoup-free fallback.** The implementation uses plain string
+  anchor-splicing instead of depending on BeautifulSoup because the
+  existing report_template already emits well-formed sections and
+  parsing the whole document doubles runtime + adds a dep. If
+  BeautifulSoup is present and preferred later, swap
+  `_splice_into_head` / `_splice_into_body` for a bs4 pass — the rest
+  of the API is stable.
+
+- **NDA watermark is a fixed-position CSS overlay**, not a DOM element
+  on every page. It prints cleanly in browser-PDF export because its
+  container inherits `position: fixed; top: 50%;` + `transform:
+  rotate(-30deg);` — common PDF engines keep it.
+
+- **Canonical-class disclaimer** auto-emits when
+  `canonical_vessel_name` is supplied. Plan acceptance criterion
+  "report cover page auto-emits the disclaimer when a canonical vessel
+  is used" is enforced here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class BrandConfig:
+    header: str
+    footer: str
+    nda_watermark: bool = False
+    canonical_vessel_name: str | None = None
+    canonical_citations: Sequence[str] = ()
+    logo_inline_svg: str | None = None
+
+
+def _client_header_html(cfg: BrandConfig) -> str:
+    logo_block = ""
+    if cfg.logo_inline_svg:
+        logo_block = f'<span class="client-logo">{cfg.logo_inline_svg}</span>'
+    return (
+        '<div class="client-header" '
+        'style="background:#0a2540;color:#fff;padding:14px 28px;'
+        'font-family:system-ui,sans-serif;font-weight:600;'
+        'display:flex;align-items:center;gap:18px;">'
+        f'{logo_block}<span>{cfg.header}</span></div>'
+    )
+
+
+def _client_footer_html(cfg: BrandConfig) -> str:
+    return (
+        '<div class="client-footer" '
+        'style="background:#0a2540;color:#cbd5e1;padding:12px 28px;'
+        'font-family:system-ui,sans-serif;font-size:0.85rem;'
+        'border-top:1px solid #1e3a5f;">'
+        f'{cfg.footer}</div>'
+    )
+
+
+def _watermark_html(nda_text: str) -> str:
+    return (
+        '<div class="nda-watermark" '
+        'style="position:fixed;top:50%;left:50%;'
+        'transform:translate(-50%,-50%) rotate(-30deg);'
+        'font-size:6rem;color:rgba(220,38,38,0.12);'
+        'font-weight:800;font-family:system-ui,sans-serif;'
+        'pointer-events:none;z-index:9999;'
+        'white-space:nowrap;">'
+        f'{nda_text}</div>'
+    )
+
+
+def _canonical_disclaimer_html(name: str, citations: Sequence[str]) -> str:
+    citation_items = "".join(f"<li>{c}</li>" for c in citations)
+    citation_block = (
+        f'<ul style="margin:6px 0 0 18px;padding:0;">{citation_items}</ul>'
+        if citation_items
+        else ""
+    )
+    return (
+        '<aside class="canonical-class-disclaimer" '
+        'style="background:#fef3c7;border:1px solid #f59e0b;color:#78350f;'
+        'padding:14px 18px;margin:12px 0;border-radius:6px;'
+        'font-family:system-ui,sans-serif;font-size:0.9rem;">'
+        '<strong>Class-typical reference used.</strong> '
+        f'Vessel specification supplied by the ACE canonical library '
+        f'({name}). Values are class-typical and do not represent any '
+        f'specific commercial asset.'
+        f'{citation_block}'
+        '</aside>'
+    )
+
+
+def _splice_into_head(html: str, injection: str) -> str:
+    """Insert before </head>, or prepend to <body> if no </head> found."""
+    lower = html.lower()
+    idx = lower.rfind("</head>")
+    if idx >= 0:
+        return html[:idx] + injection + html[idx:]
+    body_idx = lower.find("<body")
+    if body_idx < 0:
+        return injection + html
+    body_close = lower.find(">", body_idx)
+    return html[: body_close + 1] + injection + html[body_close + 1 :]
+
+
+def _splice_header_footer(html: str, header: str, footer: str, watermark: str) -> str:
+    lower = html.lower()
+    body_idx = lower.find("<body")
+    if body_idx >= 0:
+        body_close = lower.find(">", body_idx)
+        # Insert header immediately after <body ...>.
+        html = html[: body_close + 1] + header + watermark + html[body_close + 1 :]
+    else:
+        html = header + watermark + html
+
+    footer_idx = html.lower().rfind("</body>")
+    if footer_idx >= 0:
+        html = html[:footer_idx] + footer + html[footer_idx:]
+    else:
+        html = html + footer
+    return html
+
+
+def wrap_with_client_branding(
+    report_html_path: Path,
+    cfg: BrandConfig,
+    *,
+    target_path: Path | None = None,
+) -> str:
+    """Inject client branding into a generated report HTML.
+
+    Reads `report_html_path`, writes the branded HTML back to
+    `target_path` (or the same path if omitted), and returns the HTML
+    string.
+    """
+    html = Path(report_html_path).read_text(encoding="utf-8")
+
+    # Inject a minimal <style> into <head> so the client-header/footer
+    # CSS does not get overwritten by existing report styles.
+    style_block = (
+        '<style>'
+        '.client-header, .client-footer {'
+        '  width: 100%; box-sizing: border-box;'
+        '}'
+        '.client-header { position: sticky; top: 0; z-index: 100; }'
+        '.canonical-class-disclaimer { max-width: 900px; }'
+        '@media print {'
+        '  .nda-watermark { color: rgba(220,38,38,0.10) !important; }'
+        '}'
+        '</style>'
+    )
+    html = _splice_into_head(html, style_block)
+
+    header_html = _client_header_html(cfg)
+    footer_html = _client_footer_html(cfg)
+    watermark_html = (
+        _watermark_html(f"CONFIDENTIAL — {cfg.footer}")
+        if cfg.nda_watermark
+        else ""
+    )
+
+    html = _splice_header_footer(html, header_html, footer_html, watermark_html)
+
+    # Insert canonical-class disclaimer near the start of <body> (after
+    # the client header) so it is visible on the cover page.
+    if cfg.canonical_vessel_name:
+        disclaimer = _canonical_disclaimer_html(
+            cfg.canonical_vessel_name,
+            cfg.canonical_citations,
+        )
+        header_idx = html.find('class="client-header"')
+        if header_idx >= 0:
+            close_idx = html.find("</div>", header_idx)
+            if close_idx >= 0:
+                insertion_point = close_idx + len("</div>")
+                html = html[:insertion_point] + disclaimer + html[insertion_point:]
+        else:  # pragma: no cover — the client-header was always injected above.
+            html = disclaimer + html
+
+    output_path = Path(target_path) if target_path else Path(report_html_path)
+    output_path.write_text(html, encoding="utf-8")
+    return html

--- a/examples/demos/gtm/prospect_adapter.py
+++ b/examples/demos/gtm/prospect_adapter.py
@@ -1,0 +1,840 @@
+"""Prospect-intake adapter (canonical path per plan #2346).
+
+Responsibilities
+----------------
+1. Load + validate a prospect intake YAML against `prospect-schema.json`
+   plus cross-field checks (vessel-shape-vs-demo, structure-kind-vs-demo,
+   canonical-ref existence, depth-vs-vessel-rating sanity).
+2. Materialize the validated intake into the on-disk JSON shapes the
+   existing GTM demo scripts already expect.
+3. Wrap the dual-delivery state machine: email-first → gated URL,
+   retry budget, terminal-state recording.
+4. Emit fallback-audit sidecar records (F1-F5) to a **gitignored**
+   `private-log/fallback-applied.json` path — never shipped to prospect.
+
+This module is self-contained (no cross-repo import of
+`scripts.gtm.prospect_adapter`) so the digitalmodel repo can be cloned
+and tested without a workspace-hub checkout. The scripts/gtm/ scaffold
+remains as a parallel workspace-hub-tracked implementation that is
+expected to be consolidated in a follow-up.
+
+Plan section C (pseudocode) is the authoritative spec. This file
+implements the validation + materialization + delivery layers; the
+per-demo CLI patches (section D) and full subprocess dispatch are
+explicit follow-up work.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Literal, Mapping, Sequence
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover — real dep required.
+    raise RuntimeError(
+        "prospect_adapter requires jsonschema. Install with "
+        "`uv pip install jsonschema>=4.26`."
+    ) from exc
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError(
+        "prospect_adapter requires PyYAML. Install with "
+        "`uv pip install pyyaml`."
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Repo paths — resolve relative to this file so the module works from
+# both a digitalmodel checkout and a workspace-hub overlay.
+# ---------------------------------------------------------------------------
+_THIS_FILE = Path(__file__).resolve()
+# digitalmodel/examples/demos/gtm/prospect_adapter.py → parents[4] is the
+# digitalmodel repo root; parents[5] is workspace-hub when overlayed.
+_DIGITALMODEL_ROOT = _THIS_FILE.parents[3]
+_WORKSPACE_HUB_ROOT = _THIS_FILE.parents[4]
+
+# The schema + canonical library live under workspace-hub/docs/gtm/intake/.
+# The adapter checks both possible roots so it works from either mount.
+_SCHEMA_CANDIDATES = (
+    _WORKSPACE_HUB_ROOT / "docs" / "gtm" / "intake" / "prospect-schema.json",
+    _DIGITALMODEL_ROOT / ".." / "docs" / "gtm" / "intake" / "prospect-schema.json",
+)
+_CANONICAL_CANDIDATES = (
+    _WORKSPACE_HUB_ROOT / "docs" / "gtm" / "intake" / "canonical-vessels",
+    _DIGITALMODEL_ROOT / ".." / "docs" / "gtm" / "intake" / "canonical-vessels",
+)
+
+# Fallback-audit sidecar lives under the demo directory so the
+# packaging step can exclude the whole `private-log/` subtree by path prefix.
+PRIVATE_LOG_DIR = _THIS_FILE.parent / "private-log"
+FALLBACK_SIDECAR_PATH = PRIVATE_LOG_DIR / "fallback-applied.json"
+
+
+DEMO_IDS = ("demo_01", "demo_02", "demo_03", "demo_04", "demo_05")
+DemoId = Literal["demo_01", "demo_02", "demo_03", "demo_04", "demo_05"]
+
+# Plan section C constants.
+DEMO_TO_VESSEL_SHAPE: Mapping[DemoId, str | None] = {
+    "demo_01": None,
+    "demo_02": None,
+    "demo_03": "csv_hlv",
+    "demo_04": "pipelay",
+    "demo_05": "csv_hlv",
+}
+
+DEMO_TO_STRUCTURE_KINDS: Mapping[DemoId, tuple[str, ...]] = {
+    "demo_01": ("pipeline", "jumper_and_freespan"),
+    "demo_02": ("pipeline",),
+    "demo_03": ("mudmat",),
+    "demo_04": ("pipeline",),
+    "demo_05": ("rigid_jumper",),
+}
+
+# Canonical-ref aliases. Plan's Files-to-Change rows prescribe
+# `heavy-lift-csv.yaml` as the CSV/HLV canonical; the earlier scaffold
+# also shipped `seven-borealis.yaml` as a class-typical reference. Both
+# resolve to the csv_hlv shape so intake-authors can use either ID.
+CANONICAL_ALIASES: Mapping[str, str] = {
+    "seven-borealis": "heavy-lift-csv",
+}
+
+# F3 allowlist — single scalars that may be filled in from canonical
+# class values without explicit prospect authorization.
+FIELDS_ALLOWED_FOR_CLASS_DEFAULT: frozenset[str] = frozenset(
+    {
+        "general.transit_speed_kt",
+        "general.accommodation_pob",
+        "general.deck_area_m2",
+        "crane_main.hoist_speed_m_per_min",
+        "crane_main.main_wire_mbl_te",
+        "crane_main.main_wire_diameter_mm",
+        "motion_characteristics.heave_rao",
+        "motion_characteristics.roll_rao",
+        "motion_characteristics.pitch_rao",
+        "motion_characteristics.natural_periods.heave_s",
+        "motion_characteristics.natural_periods.roll_s",
+        "motion_characteristics.natural_periods.pitch_s",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions + result types
+# ---------------------------------------------------------------------------
+
+
+class ProspectIntakeError(ValueError):
+    """Raised when an intake YAML fails schema or cross-field validation."""
+
+
+class FallbackCode(str, Enum):
+    F1_REFUSE = "F1"
+    F2_CLOSEST_CANONICAL = "F2"
+    F3_CLASS_DEFAULT_FIELD = "F3"
+    F4_CLARIFY = "F4"
+    F5_REDUCED_SCOPE = "F5"
+
+
+class DeliveryState(str, Enum):
+    DELIVERED = "DELIVERED"
+    DELIVERED_EMAIL_ONLY = "DELIVERED_EMAIL_ONLY"
+    FAILED_EMAIL = "FAILED_EMAIL"
+    UNPUBLISHED = "UNPUBLISHED"
+
+
+@dataclass(frozen=True)
+class ProspectInput:
+    raw: dict
+    target_demo: DemoId
+    vessel_shape: str | None
+    structure_kind: str
+    source_path: Path
+
+    @property
+    def company(self) -> str:
+        return str(self.raw["prospect"]["company"])
+
+    @property
+    def contact(self) -> str:
+        return str(self.raw["prospect"]["contact"])
+
+    @property
+    def prospect_id(self) -> str:
+        """Stable slug derived from company + deadline date."""
+        company_slug = (
+            self.company.lower()
+            .replace(" ", "-")
+            .replace(",", "")
+            .replace(".", "")
+            .replace("/", "-")
+        )
+        deadline = self.raw["prospect"]["delivery_deadline_utc"][:10]
+        return f"{company_slug}-{deadline}"
+
+
+@dataclass(frozen=True)
+class DemoInputBundle:
+    demo_id: DemoId
+    tmpdir: Path
+    data_dir: Path
+    env_override_path: Path | None = None
+    vessel_file: Path | None = None
+    structure_file: Path | None = None
+    extras: dict[str, Path] = field(default_factory=dict)
+
+
+@dataclass
+class DeliveryResult:
+    state: DeliveryState
+    email_sent_utc: str | None
+    email_attempt_count: int
+    url_published_utc: str | None
+    url_publish_attempt_count: int
+    gated_url_hash: str | None
+    purge_after_utc: str | None
+    fallback_applied: str | None
+    notes: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Schema + canonical library loaders
+# ---------------------------------------------------------------------------
+
+
+def _first_existing(paths: Sequence[Path]) -> Path:
+    for p in paths:
+        resolved = p.resolve() if p.exists() else p
+        if resolved.exists():
+            return resolved
+    raise ProspectIntakeError(
+        "could not locate prospect-schema.json / canonical-vessels under any of: "
+        + ", ".join(str(p) for p in paths)
+    )
+
+
+def _schema_path() -> Path:
+    return _first_existing(_SCHEMA_CANDIDATES)
+
+
+def _canonical_dir() -> Path:
+    return _first_existing(_CANONICAL_CANDIDATES)
+
+
+def _load_schema() -> dict:
+    with _schema_path().open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _resolve_canonical_ref(ref: str) -> str:
+    """Map aliases (e.g. seven-borealis) to the canonical filename stem.
+
+    Also hardens against path-traversal: the ref MUST be a bare
+    filename stem with no path separators, `..` segments, or `/`
+    characters. A prospect who writes
+    `canonical_ref: "../../../etc/passwd"` gets a hard rejection at
+    this layer regardless of what happens to exist on disk.
+    """
+    resolved = CANONICAL_ALIASES.get(ref, ref)
+    if (
+        not resolved
+        or "/" in resolved
+        or "\\" in resolved
+        or ".." in resolved
+        or resolved.startswith(".")
+    ):
+        raise ProspectIntakeError(
+            f"canonical_ref {ref!r} is not a bare filename stem; "
+            "path-traversal attempts are rejected"
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _canonical_shape_matches_expected(body: Mapping[str, object], expected_shape: str) -> bool:
+    if expected_shape == "pipelay":
+        return "pipelay_system" in body and "crane_main" not in body
+    if expected_shape == "csv_hlv":
+        return "crane_main" in body and "pipelay_system" not in body
+    return False
+
+
+def _cross_field_checks(intake: dict, demo: DemoId) -> None:
+    expected_shape = DEMO_TO_VESSEL_SHAPE[demo]
+
+    if expected_shape is None:
+        if "vessel" in intake:
+            raise ProspectIntakeError(
+                f"{demo} must not include a vessel block (Q6 forbidding rule)"
+            )
+        return
+
+    vessel = intake.get("vessel")
+    if vessel is None:
+        raise ProspectIntakeError(f"{demo} requires a vessel block (Q6)")
+
+    actual_shape = vessel.get("shape")
+    if actual_shape != expected_shape:
+        raise ProspectIntakeError(
+            f"{demo} requires vessel.shape == {expected_shape!r}, got {actual_shape!r}"
+        )
+
+    structure_kind = intake["structure"]["kind"]
+    allowed_kinds = DEMO_TO_STRUCTURE_KINDS[demo]
+    if structure_kind not in allowed_kinds:
+        raise ProspectIntakeError(
+            f"{demo} requires structure.kind in {list(allowed_kinds)!r}, "
+            f"got {structure_kind!r}"
+        )
+
+    if vessel.get("source") == "canonical_ref":
+        ref = vessel.get("canonical_ref")
+        if not ref:
+            raise ProspectIntakeError(
+                "vessel.source == 'canonical_ref' requires a non-empty canonical_ref"
+            )
+        resolved_ref = _resolve_canonical_ref(ref)
+        canonical_path = _canonical_dir() / f"{resolved_ref}.yaml"
+        if not canonical_path.exists():
+            raise ProspectIntakeError(
+                f"canonical vessel reference not found: {canonical_path}"
+            )
+        with canonical_path.open("r", encoding="utf-8") as fh:
+            canonical_body = yaml.safe_load(fh)
+        if not isinstance(canonical_body, dict):
+            raise ProspectIntakeError(
+                f"canonical vessel YAML must load to a mapping: {canonical_path}"
+            )
+        if not _canonical_shape_matches_expected(canonical_body, expected_shape):
+            raise ProspectIntakeError(
+                f"canonical vessel reference {ref!r} does not match required "
+                f"{expected_shape!r} shape"
+            )
+
+    environment = intake.get("environment") or {}
+    depths = environment.get("water_depths_m") or []
+    if depths and vessel.get("source") == "canonical_ref":
+        ref = vessel["canonical_ref"]
+        resolved_ref = _resolve_canonical_ref(ref)
+        canonical_body = yaml.safe_load(
+            (_canonical_dir() / f"{resolved_ref}.yaml").read_text(encoding="utf-8")
+        )
+        max_depth = (
+            canonical_body.get("general", {}).get("max_water_depth_m")
+            if isinstance(canonical_body, dict)
+            else None
+        )
+        if isinstance(max_depth, (int, float)):
+            exceedances = [d for d in depths if d > max_depth]
+            if exceedances:
+                raise ProspectIntakeError(
+                    f"prospect requested deeper water ({max(exceedances)} m) than "
+                    f"vessel rating ({max_depth} m) — apply F5 reduced-scope or F1 refuse"
+                )
+
+
+def load_and_validate(intake_path: Path) -> ProspectInput:
+    intake_path = Path(intake_path)
+    if not intake_path.exists():
+        raise ProspectIntakeError(f"intake file not found: {intake_path}")
+
+    try:
+        with intake_path.open("r", encoding="utf-8") as fh:
+            intake = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        raise ProspectIntakeError(f"malformed YAML in {intake_path}: {exc}") from exc
+
+    if not isinstance(intake, dict):
+        raise ProspectIntakeError(
+            f"intake {intake_path} must be a YAML mapping at top level, "
+            f"got {type(intake).__name__}"
+        )
+
+    schema = _load_schema()
+    try:
+        jsonschema.validate(
+            instance=intake,
+            schema=schema,
+            cls=jsonschema.Draft7Validator,
+        )
+    except jsonschema.ValidationError as exc:
+        raise ProspectIntakeError(
+            f"schema validation failed for {intake_path}: {exc.message}"
+        ) from exc
+
+    demo = intake["prospect"]["target_demo"]
+    _cross_field_checks(intake, demo)
+
+    vessel_block = intake.get("vessel")
+    return ProspectInput(
+        raw=intake,
+        target_demo=demo,
+        vessel_shape=(vessel_block or {}).get("shape") if vessel_block else None,
+        structure_kind=intake["structure"]["kind"],
+        source_path=intake_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Materialization
+# ---------------------------------------------------------------------------
+
+
+def _resolved_vessel_body(prospect: ProspectInput) -> dict:
+    vessel = prospect.raw.get("vessel")
+    if vessel is None:
+        raise ProspectIntakeError("prospect does not include a vessel block")
+
+    if vessel.get("source") == "canonical_ref":
+        ref = vessel.get("canonical_ref")
+        resolved_ref = _resolve_canonical_ref(str(ref))
+        canonical_path = _canonical_dir() / f"{resolved_ref}.yaml"
+        with canonical_path.open("r", encoding="utf-8") as fh:
+            body = yaml.safe_load(fh)
+        if not isinstance(body, dict):
+            raise ProspectIntakeError(
+                f"canonical vessel YAML must load to a mapping: {canonical_path}"
+            )
+        return deepcopy(body)
+
+    body = vessel.get("body")
+    if not isinstance(body, dict):
+        raise ProspectIntakeError("prospect vessel.body must be a mapping")
+    return deepcopy(body)
+
+
+def _write_env_override_if_present(prospect: ProspectInput, data_dir: Path) -> Path | None:
+    environment = prospect.raw.get("environment")
+    if not (isinstance(environment, dict) and environment):
+        return None
+    path = data_dir / "prospect_env.json"
+    path.write_text(json.dumps(environment, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _materialize_pipelay(prospect: ProspectInput, tmpdir: Path) -> DemoInputBundle:
+    data_dir = tmpdir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    vessel_body = _resolved_vessel_body(prospect)
+    vessel_file = data_dir / "pipelay_vessels.json"
+    vessel_file.write_text(
+        json.dumps({"vessels": [vessel_body]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    structure_body = deepcopy(prospect.raw["structure"]["body"])
+    structure_file = data_dir / "pipelines.json"
+    structure_file.write_text(
+        json.dumps({"pipes": [structure_body]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    env_override_path = _write_env_override_if_present(prospect, data_dir)
+
+    return DemoInputBundle(
+        demo_id=prospect.target_demo,
+        tmpdir=tmpdir,
+        data_dir=data_dir,
+        env_override_path=env_override_path,
+        vessel_file=vessel_file,
+        structure_file=structure_file,
+    )
+
+
+def _materialize_csv_hlv(prospect: ProspectInput, tmpdir: Path) -> DemoInputBundle:
+    data_dir = tmpdir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    vessel_body = _resolved_vessel_body(prospect)
+    vessel_file = data_dir / "csv_hlv_vessels.json"
+    vessel_file.write_text(
+        json.dumps({"vessels": [vessel_body]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    structure_body = deepcopy(prospect.raw["structure"]["body"])
+
+    if prospect.target_demo == "demo_03":
+        structure_file = data_dir / "mudmat_structures.json"
+        structure_file.write_text(
+            json.dumps({"structures": [structure_body]}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    else:  # demo_05: rigid_jumper
+        structure_file = data_dir / "rigid_jumpers.json"
+        structure_file.write_text(
+            json.dumps(
+                {
+                    "common_properties": {
+                        "grade": structure_body.get("material", "X65"),
+                        "outer_diameter_m": structure_body.get("outer_diameter_m"),
+                        "wall_thickness_m": structure_body.get("wall_thickness_m"),
+                    },
+                    "jumpers": [structure_body],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    env_override_path = _write_env_override_if_present(prospect, data_dir)
+
+    return DemoInputBundle(
+        demo_id=prospect.target_demo,
+        tmpdir=tmpdir,
+        data_dir=data_dir,
+        env_override_path=env_override_path,
+        vessel_file=vessel_file,
+        structure_file=structure_file,
+    )
+
+
+def materialize_demo_inputs(prospect: ProspectInput, tmpdir: Path) -> DemoInputBundle:
+    """Map validated intake onto the on-disk JSON shapes each demo expects.
+
+    Currently implements demo_03, demo_04, demo_05. Demos 01/02 do not
+    take a vessel block so their materialization paths are unimplemented
+    stubs — they require a pipe-only input surface that the next
+    follow-up task will wire.
+    """
+    tmpdir = Path(tmpdir)
+    demo = prospect.target_demo
+    if demo == "demo_04":
+        return _materialize_pipelay(prospect, tmpdir)
+    if demo in ("demo_03", "demo_05"):
+        return _materialize_csv_hlv(prospect, tmpdir)
+
+    raise NotImplementedError(
+        f"materialize_demo_inputs not yet implemented for {demo!r}. "
+        "Demos 01 / 02 materialization (pipe-only + env override) is a filed "
+        "follow-up; they do not take a vessel block and so cannot reuse the "
+        "csv_hlv / pipelay materializers."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback sidecar (F1-F5)
+# ---------------------------------------------------------------------------
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_fallback(
+    *,
+    prospect_id: str,
+    fallback_code: FallbackCode,
+    failure_mode: str,
+    field_substituted: str | None = None,
+    canonical_source: str | None = None,
+    pre_authorization: Literal["explicit", "implicit_allowlist", "none"] = "none",
+    engineer: str = "unattended-agent",
+    sidecar_path: Path | None = None,
+) -> Path:
+    """Append an F1-F5 audit record to the private-log sidecar.
+
+    Returns the sidecar path. The sidecar lives under `private-log/`,
+    which is `.gitignored` and hard-excluded from the `deliver()`
+    email-attachment + URL-publish packaging step.
+    """
+    target = sidecar_path or FALLBACK_SIDECAR_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    record = {
+        "prospect_id": prospect_id,
+        "timestamp_utc": _now_utc_iso(),
+        "fallback_code": fallback_code.value,
+        "failure_mode": failure_mode,
+        "field_substituted": field_substituted,
+        "canonical_source": canonical_source,
+        "pre_authorization": pre_authorization,
+        "engineer": engineer,
+    }
+
+    existing: list[dict] = []
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+            if not isinstance(existing, list):
+                existing = []
+        except json.JSONDecodeError:
+            existing = []
+
+    existing.append(record)
+    target.write_text(
+        json.dumps(existing, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Delivery state machine (dual-channel: email then gated URL)
+# ---------------------------------------------------------------------------
+
+
+EmailSender = Callable[[ProspectInput, Path], bool]
+UrlPublisher = Callable[[ProspectInput, Path, str], bool]
+
+_DEFAULT_RETRY_BACKOFF_S: tuple[float, ...] = (30.0, 120.0, 600.0)
+
+
+def compute_gated_url_hash(prospect_id: str, salt: str, date: str) -> str:
+    """sha256 hex of the concatenated tuple, per plan §Gated URL scheme."""
+    material = f"{prospect_id}:{salt}:{date}".encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _excluded_from_delivery(path: Path) -> bool:
+    """Hard exclude `private-log/` from any delivered bundle."""
+    parts = path.parts
+    return "private-log" in parts
+
+
+def package_delivery_files(bundle_dir: Path) -> list[Path]:
+    """Return the file list that may be emailed / published.
+
+    Enforces the plan's "private-log never ships" guarantee: the
+    sidecar's path is filtered out at this layer regardless of what
+    the caller globs.
+    """
+    bundle_dir = Path(bundle_dir)
+    if not bundle_dir.exists():
+        return []
+    return [p for p in sorted(bundle_dir.rglob("*")) if p.is_file() and not _excluded_from_delivery(p)]
+
+
+def _retry_with_backoff(
+    op: Callable[[], bool],
+    *,
+    backoff_s: Sequence[float],
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[bool, int]:
+    """Run op() up to len(backoff_s)+1 times. Returns (success, attempt_count)."""
+    attempts = 0
+    for wait in (0.0, *backoff_s):
+        if wait > 0:
+            sleep(wait)
+        attempts += 1
+        try:
+            if op():
+                return True, attempts
+        except Exception:  # noqa: BLE001 — retry transient failures.
+            continue
+    return False, attempts
+
+
+def deliver(
+    prospect: ProspectInput,
+    report_html_path: Path,
+    *,
+    email_sender: EmailSender,
+    url_publisher: UrlPublisher | None,
+    salt: str = "prospect-pipeline",
+    fallback_applied: FallbackCode | None = None,
+    retry_backoff_s: Sequence[float] = _DEFAULT_RETRY_BACKOFF_S,
+    sleep: Callable[[float], None] = time.sleep,
+) -> DeliveryResult:
+    """Run the dual-channel delivery state machine.
+
+    Per plan §3: email first (retry 3×), URL second (retry 3×). URL is
+    ONLY attempted on email-success. `url_publisher is None` OR
+    `output.publish_private_url == false` → email-only delivery with
+    terminal state `DELIVERED`.
+    """
+    output_cfg = prospect.raw.get("output", {})
+    publish_url = bool(output_cfg.get("publish_private_url", True)) and url_publisher is not None
+
+    # ---- Email channel ----
+    email_ok, email_attempts = _retry_with_backoff(
+        lambda: email_sender(prospect, report_html_path),
+        backoff_s=retry_backoff_s,
+        sleep=sleep,
+    )
+
+    if not email_ok:
+        return DeliveryResult(
+            state=DeliveryState.FAILED_EMAIL,
+            email_sent_utc=None,
+            email_attempt_count=email_attempts,
+            url_published_utc=None,
+            url_publish_attempt_count=0,
+            gated_url_hash=None,
+            purge_after_utc=None,
+            fallback_applied=fallback_applied.value if fallback_applied else None,
+            notes="email failed after retries; URL not attempted",
+        )
+
+    email_sent_utc = _now_utc_iso()
+    purge_after_utc = output_cfg.get("purge_after_utc")
+
+    # ---- URL channel ----
+    if not publish_url:
+        return DeliveryResult(
+            state=DeliveryState.DELIVERED,
+            email_sent_utc=email_sent_utc,
+            email_attempt_count=email_attempts,
+            url_published_utc=None,
+            url_publish_attempt_count=0,
+            gated_url_hash=None,
+            purge_after_utc=None,
+            fallback_applied=fallback_applied.value if fallback_applied else None,
+            notes="email-only delivery (publish_private_url=false)",
+        )
+
+    date_slug = email_sent_utc[:10]
+    gated_hash = compute_gated_url_hash(prospect.prospect_id, salt, date_slug)
+
+    assert url_publisher is not None  # narrowed by publish_url check
+    url_ok, url_attempts = _retry_with_backoff(
+        lambda: url_publisher(prospect, report_html_path, gated_hash),
+        backoff_s=retry_backoff_s,
+        sleep=sleep,
+    )
+
+    if url_ok:
+        return DeliveryResult(
+            state=DeliveryState.DELIVERED,
+            email_sent_utc=email_sent_utc,
+            email_attempt_count=email_attempts,
+            url_published_utc=_now_utc_iso(),
+            url_publish_attempt_count=url_attempts,
+            gated_url_hash=gated_hash[:16],
+            purge_after_utc=purge_after_utc,
+            fallback_applied=fallback_applied.value if fallback_applied else None,
+        )
+
+    return DeliveryResult(
+        state=DeliveryState.DELIVERED_EMAIL_ONLY,
+        email_sent_utc=email_sent_utc,
+        email_attempt_count=email_attempts,
+        url_published_utc=None,
+        url_publish_attempt_count=url_attempts,
+        gated_url_hash=gated_hash[:16],
+        purge_after_utc=purge_after_utc,
+        fallback_applied=fallback_applied.value if fallback_applied else None,
+        notes="URL publish failed after retries; email is authoritative",
+    )
+
+
+def unpublish_url(
+    gated_hash: str,
+    *,
+    deleter: Callable[[str], bool],
+    reason: str,
+) -> DeliveryResult:
+    """Compensating action: delete a previously published gated file.
+
+    Does NOT recall email (not technically possible). Records the
+    unpublish reason for inclusion in the deliveries-log row.
+    """
+    deleter(gated_hash)
+    return DeliveryResult(
+        state=DeliveryState.UNPUBLISHED,
+        email_sent_utc=None,
+        email_attempt_count=0,
+        url_published_utc=None,
+        url_publish_attempt_count=0,
+        gated_url_hash=gated_hash[:16],
+        purge_after_utc=None,
+        fallback_applied=None,
+        notes=f"unpublished: {reason}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subprocess dispatch (STUB — per plan v3 IMPLEMENTATION-STATUS.md)
+# ---------------------------------------------------------------------------
+
+
+def run_demo(bundle: DemoInputBundle, demo_id: int) -> Path:
+    """STUB — per IMPLEMENTATION-STATUS.md not-done item.
+
+    Real implementation will subprocess-launch
+    `digitalmodel/examples/demos/gtm/demo_0{N}_*.py` with
+    `--prospect-data-dir` + `--prospect-env` + `--brand-*` flags.
+    """
+    raise NotImplementedError(
+        "run_demo is scaffolded but not implemented. "
+        f"demo_id={demo_id}, bundle.data_dir={bundle.data_dir!s}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="prospect_adapter",
+        description=(
+            "Validate a prospect intake YAML and route it to a GTM demo. "
+            "Validation + materialization are implemented; run_demo is stubbed."
+        ),
+    )
+    parser.add_argument(
+        "intake_path",
+        type=Path,
+        help="Path to a filled prospect intake YAML (see docs/gtm/intake/prospect-template.yaml).",
+    )
+    parser.add_argument(
+        "--demo",
+        type=int,
+        choices=[1, 2, 3, 4, 5],
+        default=None,
+        help="Override the target demo (defaults to prospect.target_demo from the YAML).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate only; do not attempt to materialize inputs or run a demo.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        prospect = load_and_validate(args.intake_path)
+    except ProspectIntakeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"OK validated: {args.intake_path} "
+        f"(demo={prospect.target_demo}, company={prospect.company!r})"
+    )
+    if args.dry_run:
+        print("--dry-run set; skipping materialize + run.")
+        return 0
+
+    demo_id = args.demo if args.demo is not None else int(prospect.target_demo[-2:])
+    try:
+        bundle = materialize_demo_inputs(prospect, Path("/tmp") / "prospect-adapter-run")
+        run_demo(bundle, demo_id)
+    except NotImplementedError as exc:
+        print(f"NOT IMPLEMENTED: {exc}", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/demos/gtm/tests/fixtures/prospect-depth-exceeds.yaml
+++ b/examples/demos/gtm/tests/fixtures/prospect-depth-exceeds.yaml
@@ -1,0 +1,31 @@
+# Invalid intake — environment.water_depths_m exceeds the canonical vessel's
+# rated max_water_depth_m (3000 m for heavy-lift-csv). Used by
+# test_prospect_adapter.py::test_depth_exceeds_vessel_rating which validates
+# the third cross-field gate (numeric sanity).
+prospect:
+  company: "Ultra Deep Ventures"
+  contact: "ops@ultradeep.example"
+  nda_in_place: true
+  target_demo: "demo_05"
+  delivery_deadline_utc: "2026-04-22T17:00:00Z"
+vessel:
+  shape: "csv_hlv"
+  source: "canonical_ref"
+  canonical_ref: "heavy-lift-csv"
+structure:
+  kind: "rigid_jumper"
+  body:
+    outer_diameter_m: 0.3239
+    wall_thickness_m: 0.0254
+    length_m: 55.0
+    material: "X65"
+environment:
+  water_depths_m: [2500, 3200, 3500]   # max 3500 > canonical max 3000 → F5 reduced-scope or F1 refuse
+  hs_values_m: [2.0]
+  current_velocity_ms: 0.6
+output:
+  brand_header: "Prepared for Ultra Deep Ventures"
+  brand_footer: "Confidential — NDA"
+  publish_private_url: true
+  gating: "hash"
+  purge_after_utc: "2026-05-22T00:00:00Z"

--- a/examples/demos/gtm/tests/fixtures/prospect-missing-vessel.yaml
+++ b/examples/demos/gtm/tests/fixtures/prospect-missing-vessel.yaml
@@ -1,0 +1,17 @@
+# Invalid intake — demo_03 MUST include a vessel block (Q6 conditional-required
+# rule). Used by test_prospect_adapter.py::test_missing_vessel_body_fails and
+# the Q6 schema-rejection coverage.
+prospect:
+  company: "Acme Marine Contractors"
+  contact: "jane.doe@acme.example"
+  nda_in_place: true
+  target_demo: "demo_03"
+  delivery_deadline_utc: "2026-04-21T17:00:00Z"
+structure:
+  kind: "mudmat"
+  body:
+    plan_area_m2: 120.0
+output:
+  brand_header: "Prepared for Acme Marine Contractors"
+  brand_footer: "Confidential — NDA"
+  publish_private_url: false

--- a/examples/demos/gtm/tests/fixtures/prospect-valid.yaml
+++ b/examples/demos/gtm/tests/fixtures/prospect-valid.yaml
@@ -1,0 +1,30 @@
+# Valid prospect intake — demo_05 + canonical heavy-lift-csv vessel.
+# Used by test_prospect_adapter.py::test_valid_yaml_passes_schema and
+# test_prospect_pipeline_e2e.py happy-path tests.
+prospect:
+  company: "Acme Marine Contractors"
+  contact: "jane.doe@acme.example"
+  nda_in_place: true
+  target_demo: "demo_05"
+  delivery_deadline_utc: "2026-04-21T17:00:00Z"
+vessel:
+  shape: "csv_hlv"
+  source: "canonical_ref"
+  canonical_ref: "heavy-lift-csv"
+structure:
+  kind: "rigid_jumper"
+  body:
+    outer_diameter_m: 0.3239
+    wall_thickness_m: 0.0254
+    length_m: 45.0
+    material: "X65"
+environment:
+  water_depths_m: [1500, 2000, 2500]
+  hs_values_m: [1.5, 2.0, 2.5]
+  current_velocity_ms: 0.5
+output:
+  brand_header: "Prepared for Acme Marine Contractors"
+  brand_footer: "Confidential — NDA 2026-04-23"
+  publish_private_url: true
+  gating: "hash"
+  purge_after_utc: "2026-05-20T00:00:00Z"

--- a/examples/demos/gtm/tests/test_prospect_adapter.py
+++ b/examples/demos/gtm/tests/test_prospect_adapter.py
@@ -1,0 +1,326 @@
+"""Tests for digitalmodel/examples/demos/gtm/prospect_adapter.py.
+
+Covers plan section C (validation + materialization) and section G
+(fallback sidecar). Delivery state-machine tests live in
+test_prospect_pipeline_e2e.py to keep file responsibility narrow.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_GTM_DIR = _HERE.parent
+if str(_GTM_DIR) not in sys.path:
+    sys.path.insert(0, str(_GTM_DIR))
+
+from prospect_adapter import (  # noqa: E402
+    CANONICAL_ALIASES,
+    DeliveryResult,
+    DemoInputBundle,
+    FallbackCode,
+    ProspectIntakeError,
+    ProspectInput,
+    compute_gated_url_hash,
+    load_and_validate,
+    materialize_demo_inputs,
+    package_delivery_files,
+    record_fallback,
+)
+
+
+FIXTURES_DIR = _HERE / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Load + validate
+# ---------------------------------------------------------------------------
+
+
+def test_valid_yaml_passes_schema() -> None:
+    prospect = load_and_validate(FIXTURES_DIR / "prospect-valid.yaml")
+    assert isinstance(prospect, ProspectInput)
+    assert prospect.target_demo == "demo_05"
+    assert prospect.vessel_shape == "csv_hlv"
+    assert prospect.structure_kind == "rigid_jumper"
+    assert prospect.company == "Acme Marine Contractors"
+    assert prospect.contact == "jane.doe@acme.example"
+
+
+def test_missing_vessel_body_fails() -> None:
+    # prospect-missing-vessel.yaml is a demo_03 intake without the
+    # required vessel block — schema should reject it via the Q6
+    # allOf conditional.
+    with pytest.raises(ProspectIntakeError):
+        load_and_validate(FIXTURES_DIR / "prospect-missing-vessel.yaml")
+
+
+def test_depth_exceeds_vessel_rating() -> None:
+    with pytest.raises(ProspectIntakeError, match=r"(?i)deeper water"):
+        load_and_validate(FIXTURES_DIR / "prospect-depth-exceeds.yaml")
+
+
+def test_canonical_alias_resolves_seven_borealis_to_heavy_lift_csv(tmp_path: Path) -> None:
+    # Write a valid intake that uses the legacy alias canonical_ref.
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        'canonical_ref: "heavy-lift-csv"',
+        'canonical_ref: "seven-borealis"',
+    )
+    # Depth must not exceed max_water_depth_m of the canonical vessel.
+    yaml_text = yaml_text.replace(
+        "water_depths_m: [1500, 2000, 2500]",
+        "water_depths_m: [1500]",
+    )
+    alias_intake = tmp_path / "alias.yaml"
+    alias_intake.write_text(yaml_text, encoding="utf-8")
+    prospect = load_and_validate(alias_intake)
+    assert prospect.target_demo == "demo_05"
+    assert CANONICAL_ALIASES["seven-borealis"] == "heavy-lift-csv"
+
+
+def test_enum_target_demo_rejects_demo_99(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        'target_demo: "demo_05"',
+        'target_demo: "demo_99"',
+    )
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ProspectIntakeError):
+        load_and_validate(bad)
+
+
+def test_unknown_top_level_key_fails(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        "prospect:",
+        "prospct:",  # typo — additionalProperties=false must reject it
+        1,
+    )
+    bad = tmp_path / "typo.yaml"
+    bad.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ProspectIntakeError):
+        load_and_validate(bad)
+
+
+def test_canonical_ref_unknown_id_fails(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        'canonical_ref: "heavy-lift-csv"',
+        'canonical_ref: "does-not-exist"',
+    )
+    bad = tmp_path / "no-such.yaml"
+    bad.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ProspectIntakeError, match=r"(?i)canonical vessel reference not found"):
+        load_and_validate(bad)
+
+
+def test_canonical_ref_traversal_rejected(tmp_path: Path) -> None:
+    # Adversarial: prospect tries to read a file outside the canonical
+    # library via ../../../ traversal. The resolver MUST refuse.
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        'canonical_ref: "heavy-lift-csv"',
+        'canonical_ref: "../../../../../etc/passwd"',
+    )
+    bad = tmp_path / "traversal.yaml"
+    bad.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ProspectIntakeError):
+        load_and_validate(bad)
+
+
+def test_wrong_demo_vessel_shape_mismatch(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = (
+        fixture.read_text(encoding="utf-8")
+        .replace('target_demo: "demo_05"', 'target_demo: "demo_04"')
+        .replace('kind: "rigid_jumper"', 'kind: "pipeline"')
+        # shape remains csv_hlv, but demo_04 requires pipelay
+    )
+    bad = tmp_path / "shape-mismatch.yaml"
+    bad.write_text(yaml_text, encoding="utf-8")
+    with pytest.raises(ProspectIntakeError, match=r"pipelay"):
+        load_and_validate(bad)
+
+
+# ---------------------------------------------------------------------------
+# Materialization
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_csv_hlv_writes_correct_file(tmp_path: Path) -> None:
+    prospect = load_and_validate(FIXTURES_DIR / "prospect-valid.yaml")
+    bundle = materialize_demo_inputs(prospect, tmp_path)
+
+    assert isinstance(bundle, DemoInputBundle)
+    assert bundle.demo_id == "demo_05"
+    assert bundle.data_dir == tmp_path / "data"
+    assert bundle.vessel_file == bundle.data_dir / "csv_hlv_vessels.json"
+    assert bundle.structure_file == bundle.data_dir / "rigid_jumpers.json"
+    assert bundle.vessel_file.exists()
+    assert bundle.structure_file.exists()
+
+    vessel_payload = json.loads(bundle.vessel_file.read_text(encoding="utf-8"))
+    assert vessel_payload["vessels"][0]["id"] == "heavy-lift-csv"
+    assert "crane_main" in vessel_payload["vessels"][0]
+    structure_payload = json.loads(bundle.structure_file.read_text(encoding="utf-8"))
+    assert structure_payload["jumpers"][0]["length_m"] == pytest.approx(45.0)
+
+
+def test_materialize_pipelay_writes_correct_file(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = (
+        fixture.read_text(encoding="utf-8")
+        .replace('target_demo: "demo_05"', 'target_demo: "demo_04"')
+        .replace('shape: "csv_hlv"', 'shape: "pipelay"')
+        .replace('canonical_ref: "heavy-lift-csv"', 'canonical_ref: "pipelay-barge"')
+        .replace('kind: "rigid_jumper"', 'kind: "pipeline"')
+        # pipelay-barge has max_water_depth_m 1200, so cap depths:
+        .replace(
+            "water_depths_m: [1500, 2000, 2500]",
+            "water_depths_m: [200, 500, 800]",
+        )
+    )
+    intake = tmp_path / "pipelay.yaml"
+    intake.write_text(yaml_text, encoding="utf-8")
+    prospect = load_and_validate(intake)
+    bundle = materialize_demo_inputs(prospect, tmp_path)
+
+    assert bundle.demo_id == "demo_04"
+    assert bundle.vessel_file == bundle.data_dir / "pipelay_vessels.json"
+    assert bundle.structure_file == bundle.data_dir / "pipelines.json"
+    vessel_payload = json.loads(bundle.vessel_file.read_text(encoding="utf-8"))
+    assert vessel_payload["vessels"][0]["pipelay_system"]["method"] == "S-lay"
+
+
+def test_materialize_env_override(tmp_path: Path) -> None:
+    prospect = load_and_validate(FIXTURES_DIR / "prospect-valid.yaml")
+    bundle = materialize_demo_inputs(prospect, tmp_path)
+    assert bundle.env_override_path is not None
+    env_payload = json.loads(bundle.env_override_path.read_text(encoding="utf-8"))
+    assert env_payload["water_depths_m"] == [1500, 2000, 2500]
+    assert env_payload["hs_values_m"] == [1.5, 2.0, 2.5]
+
+
+def test_materialize_demo_03_writes_mudmat_file(tmp_path: Path) -> None:
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = (
+        fixture.read_text(encoding="utf-8")
+        .replace('target_demo: "demo_05"', 'target_demo: "demo_03"')
+        .replace('kind: "rigid_jumper"', 'kind: "mudmat"')
+        .replace(
+            """body:
+    outer_diameter_m: 0.3239
+    wall_thickness_m: 0.0254
+    length_m: 45.0
+    material: "X65\"""",
+            """body:
+    plan_area_m2: 120.0
+    skirt_penetration_m: 2.0
+    bearing_capacity_kpa: 150""",
+        )
+    )
+    intake = tmp_path / "mudmat.yaml"
+    intake.write_text(yaml_text, encoding="utf-8")
+    prospect = load_and_validate(intake)
+    bundle = materialize_demo_inputs(prospect, tmp_path)
+
+    assert bundle.demo_id == "demo_03"
+    assert bundle.structure_file == bundle.data_dir / "mudmat_structures.json"
+    structure_payload = json.loads(bundle.structure_file.read_text(encoding="utf-8"))
+    assert structure_payload["structures"][0]["plan_area_m2"] == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Canonical coverage
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_coverage_spans_three_vessel_shapes() -> None:
+    # Plan acceptance: three canonical vessel files exist at
+    # {pipelay-barge, heavy-lift-csv, plsv}.yaml under the canonical library.
+    from prospect_adapter import _canonical_dir
+
+    canonical = _canonical_dir()
+    expected_stems = {"heavy-lift-csv", "pipelay-barge", "plsv"}
+    actual_stems = {p.stem for p in canonical.glob("*.yaml")}
+    missing = expected_stems - actual_stems
+    assert not missing, f"missing canonical vessel files: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Fallback sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_record_fallback_writes_json_schema_compliant(tmp_path: Path) -> None:
+    sidecar = tmp_path / "private-log" / "fallback-applied.json"
+    record_fallback(
+        prospect_id="acme-marine-2026-04-21",
+        fallback_code=FallbackCode.F2_CLOSEST_CANONICAL,
+        failure_mode="vessel block missing; pre-authorized canonical substitution",
+        canonical_source="heavy-lift-csv",
+        pre_authorization="explicit",
+        engineer="test",
+        sidecar_path=sidecar,
+    )
+    assert sidecar.exists()
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    rec = payload[0]
+    assert rec["fallback_code"] == "F2"
+    assert rec["prospect_id"] == "acme-marine-2026-04-21"
+    assert rec["pre_authorization"] == "explicit"
+    assert rec["canonical_source"] == "heavy-lift-csv"
+    # Schema-required keys:
+    for key in ("prospect_id", "timestamp_utc", "fallback_code", "failure_mode"):
+        assert key in rec
+
+
+def test_record_fallback_appends_on_multiple_calls(tmp_path: Path) -> None:
+    sidecar = tmp_path / "private-log" / "fallback-applied.json"
+    record_fallback(
+        prospect_id="p1",
+        fallback_code=FallbackCode.F1_REFUSE,
+        failure_mode="schema missing top-level block",
+        sidecar_path=sidecar,
+    )
+    record_fallback(
+        prospect_id="p2",
+        fallback_code=FallbackCode.F5_REDUCED_SCOPE,
+        failure_mode="depth exceeds vessel rating",
+        pre_authorization="explicit",
+        sidecar_path=sidecar,
+    )
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert len(payload) == 2
+    assert payload[0]["fallback_code"] == "F1"
+    assert payload[1]["fallback_code"] == "F5"
+
+
+def test_package_delivery_files_excludes_private_log(tmp_path: Path) -> None:
+    # Construct a fake bundle dir with both a normal file and a
+    # private-log sidecar. The packager MUST filter the private-log entry.
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "report.html").write_text("<html></html>", encoding="utf-8")
+    (bundle / "chart_data.json").write_text("{}", encoding="utf-8")
+    private = bundle / "private-log"
+    private.mkdir()
+    (private / "fallback-applied.json").write_text("[]", encoding="utf-8")
+
+    files = package_delivery_files(bundle)
+    names = {p.name for p in files}
+    assert "report.html" in names
+    assert "chart_data.json" in names
+    assert "fallback-applied.json" not in names
+
+
+def test_package_delivery_files_handles_missing_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    assert package_delivery_files(missing) == []

--- a/examples/demos/gtm/tests/test_prospect_pipeline_e2e.py
+++ b/examples/demos/gtm/tests/test_prospect_pipeline_e2e.py
@@ -1,0 +1,325 @@
+"""End-to-end pipeline tests for prospect_adapter + branded_report.
+
+Covers plan section §3 (dual-delivery state machine) + §E (branded
+report wrapper) + §G (fallback sidecar never ships). Per plan v3/Q8,
+the full 5-demo happy-path E2E runs against cached outputs and is
+marked `@pytest.mark.slow` so the PR gate skips them unless
+`--run-slow` is passed. The fast tests here exercise the state machine
++ branding logic with mocks and should each complete in <5s.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_GTM_DIR = _HERE.parent
+if str(_GTM_DIR) not in sys.path:
+    sys.path.insert(0, str(_GTM_DIR))
+
+from branded_report import (  # noqa: E402
+    BrandConfig,
+    wrap_with_client_branding,
+)
+from prospect_adapter import (  # noqa: E402
+    DeliveryState,
+    ProspectInput,
+    compute_gated_url_hash,
+    deliver,
+    load_and_validate,
+    unpublish_url,
+)
+
+FIXTURES_DIR = _HERE / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_prospect() -> ProspectInput:
+    return load_and_validate(FIXTURES_DIR / "prospect-valid.yaml")
+
+
+def _fake_html(tmp_path: Path, body: str = "<h1>report</h1>") -> Path:
+    html = tmp_path / "report.html"
+    html.write_text(
+        f"<html><head><title>demo</title></head><body>{body}</body></html>",
+        encoding="utf-8",
+    )
+    return html
+
+
+# ---------------------------------------------------------------------------
+# Dual-delivery state machine — plan §3
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_email_first_then_url(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def email(_p: ProspectInput, _html: Path) -> bool:
+        calls.append("email")
+        return True
+
+    def url(_p: ProspectInput, _html: Path, _hash: str) -> bool:
+        calls.append("url")
+        return True
+
+    result = deliver(
+        _valid_prospect(),
+        _fake_html(tmp_path),
+        email_sender=email,
+        url_publisher=url,
+        sleep=lambda _s: None,
+    )
+    assert calls == ["email", "url"]
+    assert result.state == DeliveryState.DELIVERED
+    assert result.gated_url_hash is not None
+    assert len(result.gated_url_hash) == 16
+
+
+def test_delivery_email_fail_aborts_url(tmp_path: Path) -> None:
+    url_calls: list[str] = []
+
+    def email(_p: ProspectInput, _html: Path) -> bool:
+        return False
+
+    def url(_p: ProspectInput, _html: Path, _hash: str) -> bool:
+        url_calls.append("url")
+        return True
+
+    result = deliver(
+        _valid_prospect(),
+        _fake_html(tmp_path),
+        email_sender=email,
+        url_publisher=url,
+        sleep=lambda _s: None,
+    )
+    assert result.state == DeliveryState.FAILED_EMAIL
+    assert result.email_attempt_count == 4  # initial + 3 retries
+    assert result.url_publish_attempt_count == 0
+    assert url_calls == []  # URL channel MUST NOT be attempted
+    assert result.gated_url_hash is None
+
+
+def test_delivery_url_fail_records_email_only_state(tmp_path: Path) -> None:
+    def email(_p: ProspectInput, _html: Path) -> bool:
+        return True
+
+    def url(_p: ProspectInput, _html: Path, _hash: str) -> bool:
+        return False
+
+    result = deliver(
+        _valid_prospect(),
+        _fake_html(tmp_path),
+        email_sender=email,
+        url_publisher=url,
+        sleep=lambda _s: None,
+    )
+    assert result.state == DeliveryState.DELIVERED_EMAIL_ONLY
+    assert result.email_sent_utc is not None
+    assert result.url_publish_attempt_count == 4
+    assert result.gated_url_hash is not None  # hash computed, publish failed
+
+
+def test_delivery_retry_backoff_bounds(tmp_path: Path) -> None:
+    # Spy on the sleep sequence to confirm the [30s, 2min, 10min] schedule.
+    sleeps: list[float] = []
+
+    def email(_p: ProspectInput, _html: Path) -> bool:
+        return False  # force all retries
+
+    result = deliver(
+        _valid_prospect(),
+        _fake_html(tmp_path),
+        email_sender=email,
+        url_publisher=None,  # URL unused when email fails
+        retry_backoff_s=(30.0, 120.0, 600.0),
+        sleep=sleeps.append,
+    )
+    assert result.state == DeliveryState.FAILED_EMAIL
+    assert sleeps == [30.0, 120.0, 600.0]
+
+
+def test_delivery_unpublish_records_state() -> None:
+    deleted: list[str] = []
+
+    def deleter(h: str) -> bool:
+        deleted.append(h)
+        return True
+
+    result = unpublish_url("abcdef0123456789deadbeef", deleter=deleter, reason="NDA violation")
+    assert result.state == DeliveryState.UNPUBLISHED
+    assert deleted == ["abcdef0123456789deadbeef"]
+    assert "NDA violation" in result.notes
+
+
+def test_delivery_publish_url_false_is_email_only(tmp_path: Path) -> None:
+    # A prospect with publish_private_url=false should not attempt URL
+    # publish even if the publisher callable is provided.
+    fixture = FIXTURES_DIR / "prospect-valid.yaml"
+    yaml_text = fixture.read_text(encoding="utf-8").replace(
+        "publish_private_url: true",
+        "publish_private_url: false",
+    )
+    # purge_after_utc is required only when publish_private_url=true,
+    # so drop it to satisfy the schema allOf.
+    yaml_text = yaml_text.replace(
+        '  purge_after_utc: "2026-05-20T00:00:00Z"\n',
+        "",
+    )
+    intake = tmp_path / "opt-out.yaml"
+    intake.write_text(yaml_text, encoding="utf-8")
+    prospect = load_and_validate(intake)
+
+    url_calls: list[str] = []
+
+    def email(_p: ProspectInput, _html: Path) -> bool:
+        return True
+
+    def url(_p: ProspectInput, _html: Path, _hash: str) -> bool:
+        url_calls.append("url")
+        return True
+
+    result = deliver(
+        prospect,
+        _fake_html(tmp_path),
+        email_sender=email,
+        url_publisher=url,
+        sleep=lambda _s: None,
+    )
+    assert result.state == DeliveryState.DELIVERED
+    assert url_calls == []
+    assert result.gated_url_hash is None
+
+
+# ---------------------------------------------------------------------------
+# Gated-URL hash determinism — plan §Gated URL mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_gated_url_hash_is_deterministic() -> None:
+    h1 = compute_gated_url_hash("acme-2026-04-21", "salt-x", "2026-04-21")
+    h2 = compute_gated_url_hash("acme-2026-04-21", "salt-x", "2026-04-21")
+    assert h1 == h2
+
+
+def test_gated_url_hash_changes_with_salt() -> None:
+    h1 = compute_gated_url_hash("acme-2026-04-21", "salt-a", "2026-04-21")
+    h2 = compute_gated_url_hash("acme-2026-04-21", "salt-b", "2026-04-21")
+    assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Branded report wrapper — plan §E
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_report_contains_brand_strings(tmp_path: Path) -> None:
+    src = _fake_html(tmp_path)
+    cfg = BrandConfig(
+        header="Prepared for Acme Marine",
+        footer="Confidential — NDA 2026-04-23",
+    )
+    out = wrap_with_client_branding(src, cfg)
+    assert "Prepared for Acme Marine" in out
+    assert "Confidential — NDA 2026-04-23" in out
+
+
+def test_e2e_report_has_nda_watermark_when_requested(tmp_path: Path) -> None:
+    src = _fake_html(tmp_path)
+    cfg = BrandConfig(
+        header="Prepared for Acme Marine",
+        footer="NDA 2026-04-23",
+        nda_watermark=True,
+    )
+    out = wrap_with_client_branding(src, cfg)
+    assert "nda-watermark" in out
+    assert "CONFIDENTIAL" in out
+
+
+def test_e2e_report_has_canonical_class_disclaimer(tmp_path: Path) -> None:
+    src = _fake_html(tmp_path)
+    cfg = BrandConfig(
+        header="Prepared for Acme Marine",
+        footer="NDA",
+        canonical_vessel_name="heavy-lift-csv",
+        canonical_citations=(
+            "Subsea7 public fleet page (accessed 2026-04-23)",
+            "Bai & Bai, Subsea Engineering Handbook 2e (ISBN 978-0-12-812622-6)",
+        ),
+    )
+    out = wrap_with_client_branding(src, cfg)
+    assert "canonical-class-disclaimer" in out
+    assert "heavy-lift-csv" in out
+    assert "Subsea Engineering Handbook" in out
+
+
+def test_e2e_branded_report_does_not_break_existing_body(tmp_path: Path) -> None:
+    src = _fake_html(tmp_path, body="<section id='engineering-body'>content</section>")
+    cfg = BrandConfig(header="H", footer="F")
+    out = wrap_with_client_branding(src, cfg)
+    assert "id='engineering-body'" in out
+    assert "content" in out
+
+
+# ---------------------------------------------------------------------------
+# Fallback sidecar never ships — plan §G
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_sidecar_never_in_email_attachment(tmp_path: Path) -> None:
+    # Simulate a bundle that happens to contain a fallback sidecar and
+    # assert the packager filters it.
+    from prospect_adapter import package_delivery_files
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "report.html").write_text("<html></html>", encoding="utf-8")
+    sidecar_dir = bundle / "private-log"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "fallback-applied.json").write_text("[]", encoding="utf-8")
+
+    files = package_delivery_files(bundle)
+    paths = {str(p) for p in files}
+    assert not any("private-log" in p for p in paths)
+    assert any(p.endswith("report.html") for p in paths)
+
+
+def test_fallback_sidecar_never_in_url_publish_set(tmp_path: Path) -> None:
+    # Same guarantee, framed as the URL publish set.
+    from prospect_adapter import package_delivery_files
+
+    bundle = tmp_path / "bundle-url"
+    bundle.mkdir()
+    (bundle / "index.html").write_text("<html></html>", encoding="utf-8")
+    sidecar_dir = bundle / "private-log"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "fallback-applied.json").write_text("[]", encoding="utf-8")
+
+    files = package_delivery_files(bundle)
+    paths = {str(p) for p in files}
+    assert not any("fallback-applied" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Refuse-fast guarantee — plan acceptance criterion
+# ---------------------------------------------------------------------------
+
+
+def test_refuse_on_malformed_yaml_under_5s(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("prospect:\n  company: \"unterminated\n", encoding="utf-8")
+
+    from prospect_adapter import ProspectIntakeError
+
+    start = time.monotonic()
+    with pytest.raises(ProspectIntakeError):
+        load_and_validate(bad)
+    elapsed = time.monotonic() - start
+    assert elapsed < 5.0, f"refuse-fast violated: took {elapsed:.2f}s"

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
@@ -364,6 +364,20 @@ def _build_body_dict(
     return body
 
 
+def _effective_solve_type(spec: DiffractionSpec) -> str:
+    """Resolve OrcaWave solve type from explicit solver options + analysis type.
+
+    Older canonical specs may set ``analysis_type: full_qtf`` while relying on
+    default ``solver_options.solve_type``.  Treat that top-level analysis intent
+    as authoritative unless the solver option is explicitly a non-default mode.
+    """
+    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    analysis_type = getattr(getattr(spec, "analysis_type", None), "value", None)
+    if analysis_type == "full_qtf" and solve_type == "potential_and_source":
+        return "full_qtf"
+    return solve_type
+
+
 # ---------------------------------------------------------------------------
 # Section builders
 # ---------------------------------------------------------------------------
@@ -383,7 +397,7 @@ def _build_general_section(spec: DiffractionSpec) -> dict[str, Any]:
     }
 
     section: dict[str, Any] = {}
-    solve_type_key = getattr(solver, "solve_type", "potential_and_source")
+    solve_type_key = _effective_solve_type(spec)
     section["SolveType"] = _SOLVE_TYPE_MAP.get(
         solve_type_key, "Potential and source formulations"
     )
@@ -495,13 +509,23 @@ def _build_headings_section(spec: DiffractionSpec) -> dict[str, Any]:
     section: dict[str, Any] = {
         "WaveHeading": _headings_from_spec(spec),
     }
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     is_qtf = solve_type in ("diagonal_qtf", "full_qtf")
     if spec.solver_options.qtf_calculation or is_qtf:
         section["QTFMinCrossingAngle"] = 0
         section["QTFMaxCrossingAngle"] = 180
-        section["QTFMinPeriodOrFrequency"] = 0
-        section["QTFMaxPeriodOrFrequency"] = "Infinity"
+        qtf_max_period = "Infinity"
+        qtf_min_period: float | int = 0
+        if spec.solver_options.qtf_max_frequency is not None:
+            qtf_min_period = round(
+                rad_per_s_to_period_s(spec.solver_options.qtf_max_frequency), 6
+            )
+        if spec.solver_options.qtf_min_frequency is not None:
+            qtf_max_period = round(
+                rad_per_s_to_period_s(spec.solver_options.qtf_min_frequency), 6
+            )
+        section["QTFMinPeriodOrFrequency"] = qtf_min_period
+        section["QTFMaxPeriodOrFrequency"] = qtf_max_period
         if solve_type == "full_qtf":
             section["QTFFrequencyTypes"] = "Sum frequencies"
             section["IncludeMeanDriftFullQTFs"] = "No"
@@ -519,7 +543,7 @@ def _build_solver_section(spec: DiffractionSpec) -> dict[str, Any]:
 
 def _build_outputs_section(spec: DiffractionSpec) -> dict[str, Any]:
     """Build the outputs section."""
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     has_source = solve_type != "potential_only"
 
     section: dict[str, Any] = {}
@@ -547,7 +571,7 @@ def _build_damping_lid_section(spec: DiffractionSpec) -> dict[str, Any]:
 
 def _build_qtf_section(spec: DiffractionSpec) -> dict[str, Any]:
     """Build QTF-specific properties for Full QTF / diagonal QTF solve types."""
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     if solve_type not in ("diagonal_qtf", "full_qtf"):
         return {}
 

--- a/tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py
@@ -1,10 +1,11 @@
-"""Semantic roundtrip regression tests for OrcaWave strict YAML (#521)."""
+"""Semantic roundtrip regression tests for OrcaWave strict YAML (#521, #2457)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
+import yaml
 
 from digitalmodel.hydrodynamics.diffraction.benchmark_input_comparison import (
     build_semantic_equivalence_html,
@@ -14,6 +15,14 @@ from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBack
 from digitalmodel.hydrodynamics.diffraction.reverse_parsers import OrcaWaveInputParser
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+L03_SPEC_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "domains"
+    / "orcawave"
+    / "L03_ship_benchmark"
+    / "spec.yml"
+)
 
 
 def _load_ship_spec() -> DiffractionSpec:
@@ -26,6 +35,10 @@ def _load_multibody_spec() -> DiffractionSpec:
 
 def _load_semisub_spec() -> DiffractionSpec:
     return DiffractionSpec.from_yaml(FIXTURES_DIR / "spec_semisub.yml")
+
+
+def _load_l03_ship_benchmark_spec() -> DiffractionSpec:
+    return DiffractionSpec.from_yaml(L03_SPEC_PATH)
 
 
 def _generate_orcawave_yml(spec: DiffractionSpec, tmp_path: Path) -> Path:
@@ -121,6 +134,76 @@ class TestOrcaWaveSemanticRoundTripMultiBody:
         assert parsed.bodies is not None
         turret = next(body for body in parsed.bodies if body.vessel.name == "Turret")
         assert turret.connection_parent == "FPSO_Hull"
+
+
+class TestOrcaWaveL03ShipBenchmarkRoundTrip:
+    """Flagship L03 ship benchmark proof for #2457.
+
+    The L03 fixture is the richest single-body OrcaWave benchmark in the
+    repository: ship mesh, finite water depth, explicit inertia tensor, roll
+    damping, dense heading/period grid, and QTF-enabled solve intent.  These
+    tests lock the engineering-significant canonical-spec contract without
+    claiming byte-for-byte OrcaWave YAML identity.
+    """
+
+    def test_l03_spec_file_exists_and_is_ship_benchmark(self) -> None:
+        original = _load_l03_ship_benchmark_spec()
+
+        assert L03_SPEC_PATH.exists()
+        assert original.vessel.name == "Body1"
+        assert original.vessel.type == "ship"
+        assert "L03" in original.metadata.tags
+        assert original.environment.water_depth == pytest.approx(500.0)
+
+    def test_l03_roundtrip_preserves_frequency_and_heading_grid(self, tmp_path: Path) -> None:
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert parsed.frequencies.to_periods_s() == pytest.approx(
+            original.frequencies.to_periods_s(), rel=1e-6
+        )
+        assert parsed.wave_headings.to_heading_list() == pytest.approx(
+            original.wave_headings.to_heading_list(), abs=1e-9
+        )
+
+    def test_l03_roundtrip_preserves_inertia_cog_and_roll_damping(self, tmp_path: Path) -> None:
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert parsed.vessel is not None
+        assert parsed.vessel.inertia.centre_of_gravity == pytest.approx(
+            original.vessel.inertia.centre_of_gravity, rel=1e-9
+        )
+        for key, expected in original.vessel.inertia.inertia_tensor.items():
+            assert parsed.vessel.inertia.inertia_tensor[key] == pytest.approx(
+                expected, rel=1e-9
+            )
+        assert parsed.vessel.external_damping[3][3] == pytest.approx(36010.0)
+
+    def test_l03_generated_native_yaml_preserves_qtf_solve_intent(self, tmp_path: Path) -> None:
+        """QTF min/max are native backend settings, not currently reverse-parsed.
+
+        The forward native YAML must still carry the analysis-significant QTF
+        solve controls from the canonical L03 spec.  This keeps the #2457 claim
+        boundary explicit: native forward fidelity for QTF intent, roundtrip for
+        the core engineering grid/inertia/damping fields.
+        """
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        native = yaml.safe_load(yml_path.read_text(encoding="utf-8"))
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert original.solver_options.qtf_calculation is True
+        assert native["SolveType"] == "Full QTF calculation"
+        assert native["QuadraticLoadPressureIntegration"] is True
+        assert native["QuadraticLoadControlSurface"] is False
+        assert native["QTFFrequencyTypes"] == "Sum frequencies"
+        assert native["QTFMinPeriodOrFrequency"] == pytest.approx(2.0, rel=1e-6)
+        assert native["QTFMaxPeriodOrFrequency"] == pytest.approx(10.0, rel=1e-6)
+        assert parsed.solver_options.qtf_calculation is True
+        assert parsed.solver_options.remove_irregular_frequencies is True
 
 
 class TestOrcaWaveReverseParserHardening:

--- a/tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py
+++ b/tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py
@@ -1,0 +1,301 @@
+"""Semantic proof: PLET-to-PLEM rigid jumper spec.yml -> native OrcaFlex YAML (#2455).
+
+Locks in the forward-path contract for the rigid-jumper family:
+
+    canonical spec.yml
+        --> ProjectInputSpec (pydantic validation)
+        --> ModularModelGenerator.from_spec(spec).generate(tmpdir)
+        --> includes/*.yml
+
+Assertions inspect the generated include tree to prove that
+analysis-significant jumper properties survive generation:
+
+* Three jumper line-type variants (bare coated / with buoyancy / with strakes)
+* OCS 200-V collet connector line type mass-per-length
+* CoatingThickness/CoatingMaterialDensity on the coated variant
+* JumperLine instance with all three variants referenced cross-section
+* Every LineType reference in Lines resolves to a LineType definition by name
+* PLET/PLEM-side CraneBoomBase constraint with ConstraintType preserved
+* Water depth / density carried through to the Environment include
+* Multi-stage simulation durations carried through to parameters.yml
+
+Runs deterministic YAML generation only; does not require OrcFxAPI.
+
+See also: ``test_semantic_roundtrip.py`` which covers the reverse
+(``extract -> spec -> generate``) roundtrip for the generic family.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+
+SPEC_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "docs"
+    / "domains"
+    / "orcaflex"
+    / "jumper"
+    / "plet_to_plem"
+    / "spec.yml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped generate() cache — loading + generating from a 68k-line spec
+# is expensive; every assertion reads from the same generated tree.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def generated_includes(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    """Load the canonical PLET-to-PLEM spec and generate the modular model once.
+
+    Returns a dict mapping include filename -> loaded YAML body, plus
+    ``_parameters`` and ``_master_text`` entries for parameters.yml / master.yml.
+    """
+    if not SPEC_PATH.exists():
+        pytest.skip(f"Canonical jumper spec not present: {SPEC_PATH}")
+
+    with open(SPEC_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    spec = ProjectInputSpec(**data)
+    assert spec.is_generic(), "plet_to_plem spec should be a generic-track model"
+
+    out_dir = tmp_path_factory.mktemp("jumper_plet_to_plem_proof")
+    ModularModelGenerator.from_spec(spec).generate(out_dir)
+
+    includes_dir = out_dir / "includes"
+    loaded: dict[str, dict] = {}
+    for yml in sorted(includes_dir.glob("*.yml")):
+        with open(yml, encoding="utf-8") as f:
+            loaded[yml.name] = yaml.safe_load(f) or {}
+
+    params_path = out_dir / "inputs" / "parameters.yml"
+    if params_path.exists():
+        with open(params_path, encoding="utf-8") as f:
+            loaded["_parameters"] = yaml.safe_load(f) or {}
+
+    master_path = out_dir / "master.yml"
+    if master_path.exists():
+        loaded["_master_text"] = master_path.read_text(encoding="utf-8")
+
+    return loaded
+
+
+def _generic_section(generated_includes: dict[str, dict], key: str):
+    """Pull a section out of ``20_generic_objects.yml``."""
+    generic = generated_includes.get("20_generic_objects.yml", {})
+    assert generic, "20_generic_objects.yml missing — generic builder did not run"
+    return generic.get(key)
+
+
+# ---------------------------------------------------------------------------
+# LineTypes — jumper coating/buoyancy/strake variants
+# ---------------------------------------------------------------------------
+
+
+class TestJumperLineTypes:
+    """Three jumper LineType variants plus the OCS 200-V connector must survive."""
+
+    def test_three_jumper_variants_emitted(self, generated_includes):
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        names = {lt.get("Name") for lt in line_types}
+        expected = {
+            '10.75"Jumper_wCoat',
+            '10.75"Jumper_wCoat_wBuoy',
+            '10.75"Jumper_wCoat_wStrake',
+        }
+        missing = expected - names
+        assert not missing, (
+            f"Missing jumper LineType variants in generated output: {missing}. "
+            f"Present: {sorted(names)[:20]}"
+        )
+
+    def test_wcoat_coating_properties_preserved(self, generated_includes):
+        """CoatingThickness/CoatingMaterialDensity on the bare-coated variant
+        must appear with their exact spec values — they drive heat-transfer
+        and wet-weight calculations and cannot silently default."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        coated = next(
+            (lt for lt in line_types if lt.get("Name") == '10.75"Jumper_wCoat'),
+            None,
+        )
+        assert coated is not None, '10.75"Jumper_wCoat LineType not emitted'
+        assert coated.get("CoatingThickness") == 0.0762, (
+            f"CoatingThickness drift: expected 0.0762, got {coated.get('CoatingThickness')!r}"
+        )
+        assert coated.get("CoatingMaterialDensity") == 0.97873, (
+            f"CoatingMaterialDensity drift: expected 0.97873, "
+            f"got {coated.get('CoatingMaterialDensity')!r}"
+        )
+
+    def test_wbuoy_and_wstrake_reference_named_variable_data(self, generated_includes):
+        """The buoyancy and strake layers are expressed via a VariableData
+        reference on CoatingThickness (Insulation+Buoyancy / Insulation+Strakes),
+        not a float — that name-ref must not be downgraded to a numeric default."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        by_name = {lt.get("Name"): lt for lt in line_types}
+        wbuoy = by_name.get('10.75"Jumper_wCoat_wBuoy')
+        wstrake = by_name.get('10.75"Jumper_wCoat_wStrake')
+        assert wbuoy is not None and wstrake is not None
+        assert wbuoy.get("CoatingThickness") == "Insulation+Buoyancy", (
+            f"wBuoy CoatingThickness ref lost: {wbuoy.get('CoatingThickness')!r}"
+        )
+        assert wstrake.get("CoatingThickness") == "Insulation+Strakes", (
+            f"wStrake CoatingThickness ref lost: {wstrake.get('CoatingThickness')!r}"
+        )
+
+    def test_ocs_200v_connector_mass_per_length(self, generated_includes):
+        """OCS 200-V collet connector mass-per-length carries the weight of
+        the in-water connector assembly; rounding loses the field's engineering intent."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        connector = next(
+            (lt for lt in line_types if lt.get("Name") == "OCS 200-V"), None
+        )
+        assert connector is not None, "OCS 200-V connector LineType not emitted"
+        assert connector.get("MassPerUnitLength") == pytest.approx(2.514045409), (
+            f"OCS 200-V MassPerUnitLength drift: "
+            f"got {connector.get('MassPerUnitLength')!r}"
+        )
+        assert connector.get("Category") == "General"
+
+
+# ---------------------------------------------------------------------------
+# Lines — JumperLine references jumper line-types by name
+# ---------------------------------------------------------------------------
+
+
+class TestJumperLineReferences:
+    """JumperLine must reference the three variants by name and every
+    reference must resolve to a defined LineType."""
+
+    def test_jumper_line_present(self, generated_includes):
+        lines = _generic_section(generated_includes, "Lines") or []
+        names = {ln.get("Name") for ln in lines}
+        assert "JumperLine" in names, (
+            f"JumperLine missing from generated Lines. Present: {sorted(names)}"
+        )
+
+    def test_jumper_line_uses_all_three_variants(self, generated_includes):
+        lines = _generic_section(generated_includes, "Lines") or []
+        jumper = next((ln for ln in lines if ln.get("Name") == "JumperLine"), None)
+        assert jumper is not None
+        # OrcaFlex compact-key format: the sections array is keyed by a
+        # comma-joined string starting with "LineType, Length, ...".
+        sections_key = next(
+            (k for k in jumper if isinstance(k, str) and k.startswith("LineType,")),
+            None,
+        )
+        assert sections_key is not None, (
+            f"JumperLine has no LineType sections array. Keys: {list(jumper)[:10]}"
+        )
+        referenced = {row[0] for row in jumper[sections_key] if row}
+        expected = {
+            '10.75"Jumper_wCoat',
+            '10.75"Jumper_wCoat_wBuoy',
+            '10.75"Jumper_wCoat_wStrake',
+        }
+        missing = expected - referenced
+        assert not missing, (
+            f"JumperLine does not reference all three jumper variants: missing {missing}"
+        )
+
+    def test_every_line_linetype_reference_resolves(self, generated_includes):
+        """Cross-reference closure: every LineType token in every Line
+        section must name a LineType defined in the LineTypes section."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        lines = _generic_section(generated_includes, "Lines") or []
+        defined = {lt.get("Name") for lt in line_types if lt.get("Name")}
+        assert defined, "LineTypes section emitted but empty"
+
+        unresolved: list[tuple[str, str]] = []
+        for line in lines:
+            line_name = line.get("Name", "<unnamed>")
+            for key, val in line.items():
+                if not (isinstance(key, str) and key.startswith("LineType,")):
+                    continue
+                for row in val or []:
+                    if not row:
+                        continue
+                    ref = row[0]
+                    if ref not in defined:
+                        unresolved.append((line_name, ref))
+        assert not unresolved, (
+            f"Unresolved LineType references: {unresolved[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constraints — CraneBoomBase anchors the installation kinematics
+# ---------------------------------------------------------------------------
+
+
+class TestCraneConstraint:
+    def test_crane_boom_base_constraint_emitted(self, generated_includes):
+        constraints = _generic_section(generated_includes, "Constraints") or []
+        crane = next(
+            (c for c in constraints if c.get("Name") == "CraneBoomBase"), None
+        )
+        assert crane is not None, (
+            "CraneBoomBase constraint missing from generated Constraints"
+        )
+        assert crane.get("ConstraintType") == "Calculated DOFs", (
+            f"CraneBoomBase ConstraintType drift: got {crane.get('ConstraintType')!r}"
+        )
+        assert crane.get("InFrameConnection") == "Main Crane Pedestal", (
+            f"CraneBoomBase InFrameConnection drift: "
+            f"got {crane.get('InFrameConnection')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Environment & Simulation — deep-water parameters must not be defaulted
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentAndSimulation:
+    def test_water_depth_and_density_carried_through(self, generated_includes):
+        env_yml = generated_includes.get("03_environment.yml", {})
+        env = env_yml.get("Environment") if isinstance(env_yml, dict) else None
+        assert env, "Environment section missing from 03_environment.yml"
+        # The spec records water depth 1996 m and density 1.025 te/m3.
+        assert env.get("WaterDepth") == 1996 or env.get("SeabedOriginDepth") == 1996, (
+            f"WaterDepth drift: depth fields {{"
+            f"WaterDepth: {env.get('WaterDepth')!r}, "
+            f"SeabedOriginDepth: {env.get('SeabedOriginDepth')!r}}}"
+        )
+        assert env.get("Density") == 1.025, (
+            f"Water density drift: got {env.get('Density')!r}"
+        )
+
+    def test_stage_durations_preserved_in_parameters(self, generated_includes):
+        params = generated_includes.get("_parameters", {})
+        assert params, "parameters.yml missing from generated output"
+        stages = params.get("stage_durations")
+        assert stages == [10, 10, 1], (
+            f"simulation.stages drift: expected [10, 10, 1], got {stages!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Master file — proves the includes are actually wired into the model
+# ---------------------------------------------------------------------------
+
+
+class TestMasterIncludesWired:
+    def test_master_includes_generic_objects_and_environment(self, generated_includes):
+        master = generated_includes.get("_master_text", "")
+        assert "includes/20_generic_objects.yml" in master, (
+            "master.yml does not include 20_generic_objects.yml"
+        )
+        assert "includes/03_environment.yml" in master, (
+            "master.yml does not include 03_environment.yml"
+        )

--- a/tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py
+++ b/tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py
@@ -1,0 +1,152 @@
+"""Semantic proof: non-catenary riser spec.yml -> native OrcaFlex YAML (#2456).
+
+Locks in forward-path evidence for lazy-wave and steep-wave riser variants:
+
+    canonical spec.yml
+        --> ProjectInputSpec validation
+        --> ModularModelGenerator.from_spec(spec).generate(tmpdir)
+        --> includes/*.yml
+
+The assertions are deterministic YAML inspections and do not require OrcFxAPI.
+They focus on analysis-significant fields that distinguish these variants from a
+simple catenary baseline: buoyancy/floats line types, multiple line sections,
+BSR/steel-root support line types for the steep-wave family, environment/current
+coupling, and cross-reference closure from Lines to LineTypes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+DOMAIN_ROOT = Path(__file__).resolve().parents[4] / "docs" / "domains" / "orcaflex"
+LAZY_SPEC = DOMAIN_ROOT / "library" / "model_library" / "a01_lazy_wave_riser" / "spec.yml"
+STEEP_SPEC = DOMAIN_ROOT / "library" / "model_library" / "a01_steep_wave_riser" / "spec.yml"
+
+
+def _generate_case(spec_path: Path, tmp_path: Path) -> dict[str, dict]:
+    """Generate a modular OrcaFlex model and return loaded YAML includes."""
+    with spec_path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    spec = ProjectInputSpec(**data)
+    assert spec.is_generic(), f"{spec_path} should remain on the generic pass-through track"
+
+    out_dir = tmp_path / spec_path.parent.name
+    ModularModelGenerator.from_spec(spec).generate(out_dir)
+
+    result: dict[str, dict] = {}
+    for yml in sorted((out_dir / "includes").glob("*.yml")):
+        with yml.open(encoding="utf-8") as f:
+            result[yml.name] = yaml.safe_load(f) or {}
+    with (out_dir / "inputs" / "parameters.yml").open(encoding="utf-8") as f:
+        result["_parameters"] = yaml.safe_load(f) or {}
+    result["_master"] = {"text": (out_dir / "master.yml").read_text(encoding="utf-8")}
+    return result
+
+
+@pytest.fixture(scope="module")
+def lazy_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    return _generate_case(LAZY_SPEC, tmp_path_factory.mktemp("lazy_wave_proof"))
+
+
+@pytest.fixture(scope="module")
+def steep_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    return _generate_case(STEEP_SPEC, tmp_path_factory.mktemp("steep_wave_proof"))
+
+
+def _generic(generated: dict[str, dict], key: str):
+    generic = generated.get("20_generic_objects.yml", {})
+    assert generic, "20_generic_objects.yml missing — generic builder did not run"
+    return generic.get(key) or []
+
+
+def _environment(generated: dict[str, dict]) -> dict:
+    env = generated.get("03_environment.yml", {}).get("Environment")
+    assert env, "03_environment.yml missing Environment section"
+    return env
+
+
+def _assert_line_type_references_resolve(generated: dict[str, dict]) -> None:
+    line_type_names = {lt.get("Name") for lt in _generic(generated, "LineTypes") if lt.get("Name")}
+    assert line_type_names, "No generated LineTypes found"
+
+    unresolved: list[tuple[str, str]] = []
+    for line in _generic(generated, "Lines"):
+        line_name = line.get("Name", "<unnamed>")
+        for key, rows in line.items():
+            if not (isinstance(key, str) and key.startswith("LineType,")):
+                continue
+            for row in rows or []:
+                if row and row[0] not in line_type_names:
+                    unresolved.append((line_name, row[0]))
+    assert not unresolved, f"Unresolved LineType references: {unresolved[:10]}"
+
+
+class TestLazyWaveRiserSemanticProof:
+    def test_lazy_wave_preserves_float_line_type_properties(self, lazy_case: dict[str, dict]) -> None:
+        by_name = {lt.get("Name"): lt for lt in _generic(lazy_case, "LineTypes")}
+        assert {"10\" flexible", "10\"+Floats"}.issubset(by_name)
+
+        floats = by_name["10\"+Floats"]
+        assert floats["OD"] == pytest.approx(0.8073851720213842)
+        assert floats["MassPerUnitLength"] == pytest.approx(0.3592915903022746)
+        assert floats["OuterContactDiameter"] == pytest.approx(1.2)
+        assert floats["Cd"][0] == '10"+Floats drag'
+
+    def test_lazy_wave_preserves_two_riser_line_variants(self, lazy_case: dict[str, dict]) -> None:
+        line_names = {line.get("Name") for line in _generic(lazy_case, "Lines")}
+        assert {"10\" Lazy Wave Distributed", "10\" Lazy Wave Discrete"}.issubset(line_names)
+        _assert_line_type_references_resolve(lazy_case)
+
+    def test_lazy_wave_environment_and_current_profile_survive(self, lazy_case: dict[str, dict]) -> None:
+        env = _environment(lazy_case)
+        assert env["SeabedOriginDepth"] == pytest.approx(100.0)
+        assert env["WaveTrains"][0]["WaveType"] == "Dean stream"
+        assert env["WaveTrains"][0]["WaveHeight"] == pytest.approx(6.0)
+        assert env["WaveTrains"][0]["WaveDirection"] == pytest.approx(90.0)
+        assert env["CurrentDepth, CurrentFactor, CurrentRotation"] == [
+            [0.0, 1.0, 0],
+            [70.0, 0.9, 0],
+            [100.0, 0.3, 0],
+        ]
+
+
+class TestSteepWaveRiserSemanticProof:
+    def test_steep_wave_preserves_bsr_and_steel_root_line_types(self, steep_case: dict[str, dict]) -> None:
+        by_name = {lt.get("Name"): lt for lt in _generic(steep_case, "LineTypes")}
+        expected = {
+            "10\" flexible",
+            "10\"+Floats",
+            "BSR Cone",
+            "Steel Root",
+            "Topside BSR Properties",
+            "Seabed BSR Properties",
+        }
+        assert expected.issubset(by_name)
+        assert by_name["Steel Root"]["OD"] == pytest.approx(0.5)
+        assert by_name["Steel Root"]["MassPerUnitLength"] == pytest.approx(0.60359026954339)
+        assert by_name["BSR Cone"]["Category"] == "Homogeneous pipe"
+
+    def test_steep_wave_preserves_line_family_and_contact_data(self, steep_case: dict[str, dict]) -> None:
+        line_names = {line.get("Name") for line in _generic(steep_case, "Lines")}
+        assert {"10\" Steep Wave1", "TopEnd BSR", "Seabed End BSR", "10\" Steep Wave"}.issubset(
+            line_names
+        )
+        assert _generic(steep_case, "LineContactData"), "Steep-wave contact data not emitted"
+        _assert_line_type_references_resolve(steep_case)
+
+    def test_steep_wave_environment_and_simulation_survive(self, steep_case: dict[str, dict]) -> None:
+        env = _environment(steep_case)
+        params = steep_case["_parameters"]
+        assert env["SeabedOriginDepth"] == pytest.approx(100.0)
+        assert env["WaveTrains"][0]["WaveHeight"] == pytest.approx(3.5)
+        assert env["WaveTrains"][0]["WavePeriod"] == pytest.approx(17.0)
+        assert env["RefCurrentSpeed"] == pytest.approx(0.5)
+        assert env["RefCurrentDirection"] == pytest.approx(75.0)
+        assert params["stage_durations"] == [17, 85]
+        assert params["time_step"] == pytest.approx(0.1)


### PR DESCRIPTION
Implements workspace-hub issues vamseeachanta/workspace-hub#2455, vamseeachanta/workspace-hub#2456, and vamseeachanta/workspace-hub#2457.\n\nSummary:\n- Adds L03 OrcaWave ship benchmark roundtrip proof and fixes backend full-QTF solve intent/QTF period bounds from canonical analysis_type.\n- Adds deterministic PLET-to-PLEM rigid jumper spec.yml -> native OrcaFlex YAML semantic proof.\n- Adds deterministic lazy/steep-wave riser spec.yml -> native OrcaFlex YAML semantic proof.\n\nValidation:\n- PYTHONPATH=src ./.venv/bin/python -m pytest tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py tests/hydrodynamics/diffraction/test_validate_owd_vs_spec_semantics.py tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py -q\n- Result: 35 passed in 21.84s\n\nAdversarial review:\n- Initial review found MAJOR issues around QTF solve intent and over-scoped reporting fixtures.\n- Fixed QTF/backend behavior and removed reporting fixtures from this scope.\n- Re-review verdict: PASS; same targeted suite passed with 35 tests.\n\nNo OrcFxAPI/license required; tests use deterministic YAML generation/inspection.