### PR TITLE
test(canonical-spec): add OrcaWave and OrcaFlex semantic proofs

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
@@ -364,6 +364,20 @@ def _build_body_dict(
     return body
 
 
+def _effective_solve_type(spec: DiffractionSpec) -> str:
+    """Resolve OrcaWave solve type from explicit solver options + analysis type.
+
+    Older canonical specs may set ``analysis_type: full_qtf`` while relying on
+    default ``solver_options.solve_type``.  Treat that top-level analysis intent
+    as authoritative unless the solver option is explicitly a non-default mode.
+    """
+    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    analysis_type = getattr(getattr(spec, "analysis_type", None), "value", None)
+    if analysis_type == "full_qtf" and solve_type == "potential_and_source":
+        return "full_qtf"
+    return solve_type
+
+
 # ---------------------------------------------------------------------------
 # Section builders
 # ---------------------------------------------------------------------------
@@ -383,7 +397,7 @@ def _build_general_section(spec: DiffractionSpec) -> dict[str, Any]:
     }
 
     section: dict[str, Any] = {}
-    solve_type_key = getattr(solver, "solve_type", "potential_and_source")
+    solve_type_key = _effective_solve_type(spec)
     section["SolveType"] = _SOLVE_TYPE_MAP.get(
         solve_type_key, "Potential and source formulations"
     )
@@ -495,13 +509,23 @@ def _build_headings_section(spec: DiffractionSpec) -> dict[str, Any]:
     section: dict[str, Any] = {
         "WaveHeading": _headings_from_spec(spec),
     }
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     is_qtf = solve_type in ("diagonal_qtf", "full_qtf")
     if spec.solver_options.qtf_calculation or is_qtf:
         section["QTFMinCrossingAngle"] = 0
         section["QTFMaxCrossingAngle"] = 180
-        section["QTFMinPeriodOrFrequency"] = 0
-        section["QTFMaxPeriodOrFrequency"] = "Infinity"
+        qtf_max_period = "Infinity"
+        qtf_min_period: float | int = 0
+        if spec.solver_options.qtf_max_frequency is not None:
+            qtf_min_period = round(
+                rad_per_s_to_period_s(spec.solver_options.qtf_max_frequency), 6
+            )
+        if spec.solver_options.qtf_min_frequency is not None:
+            qtf_max_period = round(
+                rad_per_s_to_period_s(spec.solver_options.qtf_min_frequency), 6
+            )
+        section["QTFMinPeriodOrFrequency"] = qtf_min_period
+        section["QTFMaxPeriodOrFrequency"] = qtf_max_period
         if solve_type == "full_qtf":
             section["QTFFrequencyTypes"] = "Sum frequencies"
             section["IncludeMeanDriftFullQTFs"] = "No"
@@ -519,7 +543,7 @@ def _build_solver_section(spec: DiffractionSpec) -> dict[str, Any]:
 
 def _build_outputs_section(spec: DiffractionSpec) -> dict[str, Any]:
     """Build the outputs section."""
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     has_source = solve_type != "potential_only"
 
     section: dict[str, Any] = {}
@@ -547,7 +571,7 @@ def _build_damping_lid_section(spec: DiffractionSpec) -> dict[str, Any]:
 
 def _build_qtf_section(spec: DiffractionSpec) -> dict[str, Any]:
     """Build QTF-specific properties for Full QTF / diagonal QTF solve types."""
-    solve_type = getattr(spec.solver_options, "solve_type", "potential_and_source")
+    solve_type = _effective_solve_type(spec)
     if solve_type not in ("diagonal_qtf", "full_qtf"):
         return {}
 

--- a/tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py
@@ -1,10 +1,11 @@
-"""Semantic roundtrip regression tests for OrcaWave strict YAML (#521)."""
+"""Semantic roundtrip regression tests for OrcaWave strict YAML (#521, #2457)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
+import yaml
 
 from digitalmodel.hydrodynamics.diffraction.benchmark_input_comparison import (
     build_semantic_equivalence_html,
@@ -14,6 +15,14 @@ from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBack
 from digitalmodel.hydrodynamics.diffraction.reverse_parsers import OrcaWaveInputParser
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+L03_SPEC_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "domains"
+    / "orcawave"
+    / "L03_ship_benchmark"
+    / "spec.yml"
+)
 
 
 def _load_ship_spec() -> DiffractionSpec:
@@ -26,6 +35,10 @@ def _load_multibody_spec() -> DiffractionSpec:
 
 def _load_semisub_spec() -> DiffractionSpec:
     return DiffractionSpec.from_yaml(FIXTURES_DIR / "spec_semisub.yml")
+
+
+def _load_l03_ship_benchmark_spec() -> DiffractionSpec:
+    return DiffractionSpec.from_yaml(L03_SPEC_PATH)
 
 
 def _generate_orcawave_yml(spec: DiffractionSpec, tmp_path: Path) -> Path:
@@ -121,6 +134,76 @@ class TestOrcaWaveSemanticRoundTripMultiBody:
         assert parsed.bodies is not None
         turret = next(body for body in parsed.bodies if body.vessel.name == "Turret")
         assert turret.connection_parent == "FPSO_Hull"
+
+
+class TestOrcaWaveL03ShipBenchmarkRoundTrip:
+    """Flagship L03 ship benchmark proof for #2457.
+
+    The L03 fixture is the richest single-body OrcaWave benchmark in the
+    repository: ship mesh, finite water depth, explicit inertia tensor, roll
+    damping, dense heading/period grid, and QTF-enabled solve intent.  These
+    tests lock the engineering-significant canonical-spec contract without
+    claiming byte-for-byte OrcaWave YAML identity.
+    """
+
+    def test_l03_spec_file_exists_and_is_ship_benchmark(self) -> None:
+        original = _load_l03_ship_benchmark_spec()
+
+        assert L03_SPEC_PATH.exists()
+        assert original.vessel.name == "Body1"
+        assert original.vessel.type == "ship"
+        assert "L03" in original.metadata.tags
+        assert original.environment.water_depth == pytest.approx(500.0)
+
+    def test_l03_roundtrip_preserves_frequency_and_heading_grid(self, tmp_path: Path) -> None:
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert parsed.frequencies.to_periods_s() == pytest.approx(
+            original.frequencies.to_periods_s(), rel=1e-6
+        )
+        assert parsed.wave_headings.to_heading_list() == pytest.approx(
+            original.wave_headings.to_heading_list(), abs=1e-9
+        )
+
+    def test_l03_roundtrip_preserves_inertia_cog_and_roll_damping(self, tmp_path: Path) -> None:
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert parsed.vessel is not None
+        assert parsed.vessel.inertia.centre_of_gravity == pytest.approx(
+            original.vessel.inertia.centre_of_gravity, rel=1e-9
+        )
+        for key, expected in original.vessel.inertia.inertia_tensor.items():
+            assert parsed.vessel.inertia.inertia_tensor[key] == pytest.approx(
+                expected, rel=1e-9
+            )
+        assert parsed.vessel.external_damping[3][3] == pytest.approx(36010.0)
+
+    def test_l03_generated_native_yaml_preserves_qtf_solve_intent(self, tmp_path: Path) -> None:
+        """QTF min/max are native backend settings, not currently reverse-parsed.
+
+        The forward native YAML must still carry the analysis-significant QTF
+        solve controls from the canonical L03 spec.  This keeps the #2457 claim
+        boundary explicit: native forward fidelity for QTF intent, roundtrip for
+        the core engineering grid/inertia/damping fields.
+        """
+        original = _load_l03_ship_benchmark_spec()
+        yml_path = _generate_orcawave_yml(original, tmp_path)
+        native = yaml.safe_load(yml_path.read_text(encoding="utf-8"))
+        parsed = OrcaWaveInputParser().parse(yml_path)
+
+        assert original.solver_options.qtf_calculation is True
+        assert native["SolveType"] == "Full QTF calculation"
+        assert native["QuadraticLoadPressureIntegration"] is True
+        assert native["QuadraticLoadControlSurface"] is False
+        assert native["QTFFrequencyTypes"] == "Sum frequencies"
+        assert native["QTFMinPeriodOrFrequency"] == pytest.approx(2.0, rel=1e-6)
+        assert native["QTFMaxPeriodOrFrequency"] == pytest.approx(10.0, rel=1e-6)
+        assert parsed.solver_options.qtf_calculation is True
+        assert parsed.solver_options.remove_irregular_frequencies is True
 
 
 class TestOrcaWaveReverseParserHardening:

--- a/tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py
+++ b/tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py
@@ -1,0 +1,301 @@
+"""Semantic proof: PLET-to-PLEM rigid jumper spec.yml -> native OrcaFlex YAML (#2455).
+
+Locks in the forward-path contract for the rigid-jumper family:
+
+    canonical spec.yml
+        --> ProjectInputSpec (pydantic validation)
+        --> ModularModelGenerator.from_spec(spec).generate(tmpdir)
+        --> includes/*.yml
+
+Assertions inspect the generated include tree to prove that
+analysis-significant jumper properties survive generation:
+
+* Three jumper line-type variants (bare coated / with buoyancy / with strakes)
+* OCS 200-V collet connector line type mass-per-length
+* CoatingThickness/CoatingMaterialDensity on the coated variant
+* JumperLine instance with all three variants referenced cross-section
+* Every LineType reference in Lines resolves to a LineType definition by name
+* PLET/PLEM-side CraneBoomBase constraint with ConstraintType preserved
+* Water depth / density carried through to the Environment include
+* Multi-stage simulation durations carried through to parameters.yml
+
+Runs deterministic YAML generation only; does not require OrcFxAPI.
+
+See also: ``test_semantic_roundtrip.py`` which covers the reverse
+(``extract -> spec -> generate``) roundtrip for the generic family.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+
+SPEC_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "docs"
+    / "domains"
+    / "orcaflex"
+    / "jumper"
+    / "plet_to_plem"
+    / "spec.yml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped generate() cache — loading + generating from a 68k-line spec
+# is expensive; every assertion reads from the same generated tree.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def generated_includes(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    """Load the canonical PLET-to-PLEM spec and generate the modular model once.
+
+    Returns a dict mapping include filename -> loaded YAML body, plus
+    ``_parameters`` and ``_master_text`` entries for parameters.yml / master.yml.
+    """
+    if not SPEC_PATH.exists():
+        pytest.skip(f"Canonical jumper spec not present: {SPEC_PATH}")
+
+    with open(SPEC_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    spec = ProjectInputSpec(**data)
+    assert spec.is_generic(), "plet_to_plem spec should be a generic-track model"
+
+    out_dir = tmp_path_factory.mktemp("jumper_plet_to_plem_proof")
+    ModularModelGenerator.from_spec(spec).generate(out_dir)
+
+    includes_dir = out_dir / "includes"
+    loaded: dict[str, dict] = {}
+    for yml in sorted(includes_dir.glob("*.yml")):
+        with open(yml, encoding="utf-8") as f:
+            loaded[yml.name] = yaml.safe_load(f) or {}
+
+    params_path = out_dir / "inputs" / "parameters.yml"
+    if params_path.exists():
+        with open(params_path, encoding="utf-8") as f:
+            loaded["_parameters"] = yaml.safe_load(f) or {}
+
+    master_path = out_dir / "master.yml"
+    if master_path.exists():
+        loaded["_master_text"] = master_path.read_text(encoding="utf-8")
+
+    return loaded
+
+
+def _generic_section(generated_includes: dict[str, dict], key: str):
+    """Pull a section out of ``20_generic_objects.yml``."""
+    generic = generated_includes.get("20_generic_objects.yml", {})
+    assert generic, "20_generic_objects.yml missing — generic builder did not run"
+    return generic.get(key)
+
+
+# ---------------------------------------------------------------------------
+# LineTypes — jumper coating/buoyancy/strake variants
+# ---------------------------------------------------------------------------
+
+
+class TestJumperLineTypes:
+    """Three jumper LineType variants plus the OCS 200-V connector must survive."""
+
+    def test_three_jumper_variants_emitted(self, generated_includes):
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        names = {lt.get("Name") for lt in line_types}
+        expected = {
+            '10.75"Jumper_wCoat',
+            '10.75"Jumper_wCoat_wBuoy',
+            '10.75"Jumper_wCoat_wStrake',
+        }
+        missing = expected - names
+        assert not missing, (
+            f"Missing jumper LineType variants in generated output: {missing}. "
+            f"Present: {sorted(names)[:20]}"
+        )
+
+    def test_wcoat_coating_properties_preserved(self, generated_includes):
+        """CoatingThickness/CoatingMaterialDensity on the bare-coated variant
+        must appear with their exact spec values — they drive heat-transfer
+        and wet-weight calculations and cannot silently default."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        coated = next(
+            (lt for lt in line_types if lt.get("Name") == '10.75"Jumper_wCoat'),
+            None,
+        )
+        assert coated is not None, '10.75"Jumper_wCoat LineType not emitted'
+        assert coated.get("CoatingThickness") == 0.0762, (
+            f"CoatingThickness drift: expected 0.0762, got {coated.get('CoatingThickness')!r}"
+        )
+        assert coated.get("CoatingMaterialDensity") == 0.97873, (
+            f"CoatingMaterialDensity drift: expected 0.97873, "
+            f"got {coated.get('CoatingMaterialDensity')!r}"
+        )
+
+    def test_wbuoy_and_wstrake_reference_named_variable_data(self, generated_includes):
+        """The buoyancy and strake layers are expressed via a VariableData
+        reference on CoatingThickness (Insulation+Buoyancy / Insulation+Strakes),
+        not a float — that name-ref must not be downgraded to a numeric default."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        by_name = {lt.get("Name"): lt for lt in line_types}
+        wbuoy = by_name.get('10.75"Jumper_wCoat_wBuoy')
+        wstrake = by_name.get('10.75"Jumper_wCoat_wStrake')
+        assert wbuoy is not None and wstrake is not None
+        assert wbuoy.get("CoatingThickness") == "Insulation+Buoyancy", (
+            f"wBuoy CoatingThickness ref lost: {wbuoy.get('CoatingThickness')!r}"
+        )
+        assert wstrake.get("CoatingThickness") == "Insulation+Strakes", (
+            f"wStrake CoatingThickness ref lost: {wstrake.get('CoatingThickness')!r}"
+        )
+
+    def test_ocs_200v_connector_mass_per_length(self, generated_includes):
+        """OCS 200-V collet connector mass-per-length carries the weight of
+        the in-water connector assembly; rounding loses the field's engineering intent."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        connector = next(
+            (lt for lt in line_types if lt.get("Name") == "OCS 200-V"), None
+        )
+        assert connector is not None, "OCS 200-V connector LineType not emitted"
+        assert connector.get("MassPerUnitLength") == pytest.approx(2.514045409), (
+            f"OCS 200-V MassPerUnitLength drift: "
+            f"got {connector.get('MassPerUnitLength')!r}"
+        )
+        assert connector.get("Category") == "General"
+
+
+# ---------------------------------------------------------------------------
+# Lines — JumperLine references jumper line-types by name
+# ---------------------------------------------------------------------------
+
+
+class TestJumperLineReferences:
+    """JumperLine must reference the three variants by name and every
+    reference must resolve to a defined LineType."""
+
+    def test_jumper_line_present(self, generated_includes):
+        lines = _generic_section(generated_includes, "Lines") or []
+        names = {ln.get("Name") for ln in lines}
+        assert "JumperLine" in names, (
+            f"JumperLine missing from generated Lines. Present: {sorted(names)}"
+        )
+
+    def test_jumper_line_uses_all_three_variants(self, generated_includes):
+        lines = _generic_section(generated_includes, "Lines") or []
+        jumper = next((ln for ln in lines if ln.get("Name") == "JumperLine"), None)
+        assert jumper is not None
+        # OrcaFlex compact-key format: the sections array is keyed by a
+        # comma-joined string starting with "LineType, Length, ...".
+        sections_key = next(
+            (k for k in jumper if isinstance(k, str) and k.startswith("LineType,")),
+            None,
+        )
+        assert sections_key is not None, (
+            f"JumperLine has no LineType sections array. Keys: {list(jumper)[:10]}"
+        )
+        referenced = {row[0] for row in jumper[sections_key] if row}
+        expected = {
+            '10.75"Jumper_wCoat',
+            '10.75"Jumper_wCoat_wBuoy',
+            '10.75"Jumper_wCoat_wStrake',
+        }
+        missing = expected - referenced
+        assert not missing, (
+            f"JumperLine does not reference all three jumper variants: missing {missing}"
+        )
+
+    def test_every_line_linetype_reference_resolves(self, generated_includes):
+        """Cross-reference closure: every LineType token in every Line
+        section must name a LineType defined in the LineTypes section."""
+        line_types = _generic_section(generated_includes, "LineTypes") or []
+        lines = _generic_section(generated_includes, "Lines") or []
+        defined = {lt.get("Name") for lt in line_types if lt.get("Name")}
+        assert defined, "LineTypes section emitted but empty"
+
+        unresolved: list[tuple[str, str]] = []
+        for line in lines:
+            line_name = line.get("Name", "<unnamed>")
+            for key, val in line.items():
+                if not (isinstance(key, str) and key.startswith("LineType,")):
+                    continue
+                for row in val or []:
+                    if not row:
+                        continue
+                    ref = row[0]
+                    if ref not in defined:
+                        unresolved.append((line_name, ref))
+        assert not unresolved, (
+            f"Unresolved LineType references: {unresolved[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constraints — CraneBoomBase anchors the installation kinematics
+# ---------------------------------------------------------------------------
+
+
+class TestCraneConstraint:
+    def test_crane_boom_base_constraint_emitted(self, generated_includes):
+        constraints = _generic_section(generated_includes, "Constraints") or []
+        crane = next(
+            (c for c in constraints if c.get("Name") == "CraneBoomBase"), None
+        )
+        assert crane is not None, (
+            "CraneBoomBase constraint missing from generated Constraints"
+        )
+        assert crane.get("ConstraintType") == "Calculated DOFs", (
+            f"CraneBoomBase ConstraintType drift: got {crane.get('ConstraintType')!r}"
+        )
+        assert crane.get("InFrameConnection") == "Main Crane Pedestal", (
+            f"CraneBoomBase InFrameConnection drift: "
+            f"got {crane.get('InFrameConnection')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Environment & Simulation — deep-water parameters must not be defaulted
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentAndSimulation:
+    def test_water_depth_and_density_carried_through(self, generated_includes):
+        env_yml = generated_includes.get("03_environment.yml", {})
+        env = env_yml.get("Environment") if isinstance(env_yml, dict) else None
+        assert env, "Environment section missing from 03_environment.yml"
+        # The spec records water depth 1996 m and density 1.025 te/m3.
+        assert env.get("WaterDepth") == 1996 or env.get("SeabedOriginDepth") == 1996, (
+            f"WaterDepth drift: depth fields {{"
+            f"WaterDepth: {env.get('WaterDepth')!r}, "
+            f"SeabedOriginDepth: {env.get('SeabedOriginDepth')!r}}}"
+        )
+        assert env.get("Density") == 1.025, (
+            f"Water density drift: got {env.get('Density')!r}"
+        )
+
+    def test_stage_durations_preserved_in_parameters(self, generated_includes):
+        params = generated_includes.get("_parameters", {})
+        assert params, "parameters.yml missing from generated output"
+        stages = params.get("stage_durations")
+        assert stages == [10, 10, 1], (
+            f"simulation.stages drift: expected [10, 10, 1], got {stages!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Master file — proves the includes are actually wired into the model
+# ---------------------------------------------------------------------------
+
+
+class TestMasterIncludesWired:
+    def test_master_includes_generic_objects_and_environment(self, generated_includes):
+        master = generated_includes.get("_master_text", "")
+        assert "includes/20_generic_objects.yml" in master, (
+            "master.yml does not include 20_generic_objects.yml"
+        )
+        assert "includes/03_environment.yml" in master, (
+            "master.yml does not include 03_environment.yml"
+        )

--- a/tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py
+++ b/tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py
@@ -1,0 +1,152 @@
+"""Semantic proof: non-catenary riser spec.yml -> native OrcaFlex YAML (#2456).
+
+Locks in forward-path evidence for lazy-wave and steep-wave riser variants:
+
+    canonical spec.yml
+        --> ProjectInputSpec validation
+        --> ModularModelGenerator.from_spec(spec).generate(tmpdir)
+        --> includes/*.yml
+
+The assertions are deterministic YAML inspections and do not require OrcFxAPI.
+They focus on analysis-significant fields that distinguish these variants from a
+simple catenary baseline: buoyancy/floats line types, multiple line sections,
+BSR/steel-root support line types for the steep-wave family, environment/current
+coupling, and cross-reference closure from Lines to LineTypes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+DOMAIN_ROOT = Path(__file__).resolve().parents[4] / "docs" / "domains" / "orcaflex"
+LAZY_SPEC = DOMAIN_ROOT / "library" / "model_library" / "a01_lazy_wave_riser" / "spec.yml"
+STEEP_SPEC = DOMAIN_ROOT / "library" / "model_library" / "a01_steep_wave_riser" / "spec.yml"
+
+
+def _generate_case(spec_path: Path, tmp_path: Path) -> dict[str, dict]:
+    """Generate a modular OrcaFlex model and return loaded YAML includes."""
+    with spec_path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    spec = ProjectInputSpec(**data)
+    assert spec.is_generic(), f"{spec_path} should remain on the generic pass-through track"
+
+    out_dir = tmp_path / spec_path.parent.name
+    ModularModelGenerator.from_spec(spec).generate(out_dir)
+
+    result: dict[str, dict] = {}
+    for yml in sorted((out_dir / "includes").glob("*.yml")):
+        with yml.open(encoding="utf-8") as f:
+            result[yml.name] = yaml.safe_load(f) or {}
+    with (out_dir / "inputs" / "parameters.yml").open(encoding="utf-8") as f:
+        result["_parameters"] = yaml.safe_load(f) or {}
+    result["_master"] = {"text": (out_dir / "master.yml").read_text(encoding="utf-8")}
+    return result
+
+
+@pytest.fixture(scope="module")
+def lazy_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    return _generate_case(LAZY_SPEC, tmp_path_factory.mktemp("lazy_wave_proof"))
+
+
+@pytest.fixture(scope="module")
+def steep_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict]:
+    return _generate_case(STEEP_SPEC, tmp_path_factory.mktemp("steep_wave_proof"))
+
+
+def _generic(generated: dict[str, dict], key: str):
+    generic = generated.get("20_generic_objects.yml", {})
+    assert generic, "20_generic_objects.yml missing — generic builder did not run"
+    return generic.get(key) or []
+
+
+def _environment(generated: dict[str, dict]) -> dict:
+    env = generated.get("03_environment.yml", {}).get("Environment")
+    assert env, "03_environment.yml missing Environment section"
+    return env
+
+
+def _assert_line_type_references_resolve(generated: dict[str, dict]) -> None:
+    line_type_names = {lt.get("Name") for lt in _generic(generated, "LineTypes") if lt.get("Name")}
+    assert line_type_names, "No generated LineTypes found"
+
+    unresolved: list[tuple[str, str]] = []
+    for line in _generic(generated, "Lines"):
+        line_name = line.get("Name", "<unnamed>")
+        for key, rows in line.items():
+            if not (isinstance(key, str) and key.startswith("LineType,")):
+                continue
+            for row in rows or []:
+                if row and row[0] not in line_type_names:
+                    unresolved.append((line_name, row[0]))
+    assert not unresolved, f"Unresolved LineType references: {unresolved[:10]}"
+
+
+class TestLazyWaveRiserSemanticProof:
+    def test_lazy_wave_preserves_float_line_type_properties(self, lazy_case: dict[str, dict]) -> None:
+        by_name = {lt.get("Name"): lt for lt in _generic(lazy_case, "LineTypes")}
+        assert {"10\" flexible", "10\"+Floats"}.issubset(by_name)
+
+        floats = by_name["10\"+Floats"]
+        assert floats["OD"] == pytest.approx(0.8073851720213842)
+        assert floats["MassPerUnitLength"] == pytest.approx(0.3592915903022746)
+        assert floats["OuterContactDiameter"] == pytest.approx(1.2)
+        assert floats["Cd"][0] == '10"+Floats drag'
+
+    def test_lazy_wave_preserves_two_riser_line_variants(self, lazy_case: dict[str, dict]) -> None:
+        line_names = {line.get("Name") for line in _generic(lazy_case, "Lines")}
+        assert {"10\" Lazy Wave Distributed", "10\" Lazy Wave Discrete"}.issubset(line_names)
+        _assert_line_type_references_resolve(lazy_case)
+
+    def test_lazy_wave_environment_and_current_profile_survive(self, lazy_case: dict[str, dict]) -> None:
+        env = _environment(lazy_case)
+        assert env["SeabedOriginDepth"] == pytest.approx(100.0)
+        assert env["WaveTrains"][0]["WaveType"] == "Dean stream"
+        assert env["WaveTrains"][0]["WaveHeight"] == pytest.approx(6.0)
+        assert env["WaveTrains"][0]["WaveDirection"] == pytest.approx(90.0)
+        assert env["CurrentDepth, CurrentFactor, CurrentRotation"] == [
+            [0.0, 1.0, 0],
+            [70.0, 0.9, 0],
+            [100.0, 0.3, 0],
+        ]
+
+
+class TestSteepWaveRiserSemanticProof:
+    def test_steep_wave_preserves_bsr_and_steel_root_line_types(self, steep_case: dict[str, dict]) -> None:
+        by_name = {lt.get("Name"): lt for lt in _generic(steep_case, "LineTypes")}
+        expected = {
+            "10\" flexible",
+            "10\"+Floats",
+            "BSR Cone",
+            "Steel Root",
+            "Topside BSR Properties",
+            "Seabed BSR Properties",
+        }
+        assert expected.issubset(by_name)
+        assert by_name["Steel Root"]["OD"] == pytest.approx(0.5)
+        assert by_name["Steel Root"]["MassPerUnitLength"] == pytest.approx(0.60359026954339)
+        assert by_name["BSR Cone"]["Category"] == "Homogeneous pipe"
+
+    def test_steep_wave_preserves_line_family_and_contact_data(self, steep_case: dict[str, dict]) -> None:
+        line_names = {line.get("Name") for line in _generic(steep_case, "Lines")}
+        assert {"10\" Steep Wave1", "TopEnd BSR", "Seabed End BSR", "10\" Steep Wave"}.issubset(
+            line_names
+        )
+        assert _generic(steep_case, "LineContactData"), "Steep-wave contact data not emitted"
+        _assert_line_type_references_resolve(steep_case)
+
+    def test_steep_wave_environment_and_simulation_survive(self, steep_case: dict[str, dict]) -> None:
+        env = _environment(steep_case)
+        params = steep_case["_parameters"]
+        assert env["SeabedOriginDepth"] == pytest.approx(100.0)
+        assert env["WaveTrains"][0]["WaveHeight"] == pytest.approx(3.5)
+        assert env["WaveTrains"][0]["WavePeriod"] == pytest.approx(17.0)
+        assert env["RefCurrentSpeed"] == pytest.approx(0.5)
+        assert env["RefCurrentDirection"] == pytest.approx(75.0)
+        assert params["stage_durations"] == [17, 85]
+        assert params["time_step"] == pytest.approx(0.1)


### PR DESCRIPTION
Implements workspace-hub issues vamseeachanta/workspace-hub#2455, vamseeachanta/workspace-hub#2456, and vamseeachanta/workspace-hub#2457.\n\nClean branch note: this replaces closed PR #527, which accidentally included an unrelated prior commit. This PR contains only the semantic-proof commit f956f512.\n\nSummary:\n- Adds L03 OrcaWave ship benchmark roundtrip proof and fixes backend full-QTF solve intent/QTF period bounds from canonical analysis_type.\n- Adds deterministic PLET-to-PLEM rigid jumper spec.yml -> native OrcaFlex YAML semantic proof.\n- Adds deterministic lazy/steep-wave riser spec.yml -> native OrcaFlex YAML semantic proof.\n\nValidation:\n- PYTHONPATH=src ./.venv/bin/python -m pytest tests/hydrodynamics/diffraction/test_orcawave_semantic_roundtrip.py tests/hydrodynamics/diffraction/test_validate_owd_vs_spec_semantics.py tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py tests/solvers/orcaflex/modular_generator/test_riser_variant_semantic_proof.py -q\n- Result on clean branch: 35 passed in 20.46s\n\nAdversarial review:\n- Initial review: MAJOR. It caught QTF solve-intent degradation and reporting-fixture overclaim.\n- Fixes applied: backend QTF/full-QTF behavior corrected; over-scoped reporting fixtures removed from this wave.\n- Re-review: PASS; same targeted suite passed.\n\nNo OrcFxAPI/license required; tests use deterministic YAML generation/inspection.