### PR TITLE
fix(tests/orcaflex): repair 4 test files after rename + path-drift (#510)

### DIFF
--- a/tests/solvers/orcaflex/modular_generator/test_generic_builder.py
+++ b/tests/solvers/orcaflex/modular_generator/test_generic_builder.py
@@ -205,8 +205,8 @@ class TestBuildListSections:
 # ---------------------------------------------------------------------------
 
 
-class TestBuildVariableDataSources:
-    """Tests for building VariableDataSources section."""
+class TestBuildVariableData:
+    """Tests for building VariableData section."""
 
     def test_build_variable_data_sources(self):
         model = GenericModel(
@@ -222,10 +222,10 @@ class TestBuildVariableDataSources:
         builder, _ = _make_builder(model)
         result = builder.build()
 
-        assert "VariableDataSources" in result
-        vds = result["VariableDataSources"][0]
+        assert "VariableData" in result
+        assert "Dragcoefficient" in result["VariableData"]
+        vds = result["VariableData"]["Dragcoefficient"][0]
         assert vds["Name"] == "GenericDrag"
-        assert vds["DataType"] == "Dragcoefficient"
         assert vds["Interpolation"] == "Linear"
 
 
@@ -246,8 +246,8 @@ class TestBuildSingletonSections:
         builder, _ = _make_builder(model)
         result = builder.build()
 
-        assert "SolidFrictionCoefficients" in result
-        assert result["SolidFrictionCoefficients"]["StaticFriction"] == 0.3
+        assert "FrictionCoefficients" in result
+        assert result["FrictionCoefficients"]["StaticFriction"] == 0.3
 
     def test_build_line_contact_data(self):
         model = GenericModel(
@@ -266,7 +266,7 @@ class TestBuildSingletonSections:
         builder, _ = _make_builder(model)
         result = builder.build()
 
-        assert "SolidFrictionCoefficients" not in result
+        assert "FrictionCoefficients" not in result
         assert "LineContactData" not in result
 
     def test_empty_singleton_data_is_skipped(self):
@@ -276,7 +276,7 @@ class TestBuildSingletonSections:
         builder, _ = _make_builder(model)
         result = builder.build()
 
-        assert "SolidFrictionCoefficients" not in result
+        assert "FrictionCoefficients" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/solvers/orcaflex/modular_generator/test_generic_schema.py
+++ b/tests/solvers/orcaflex/modular_generator/test_generic_schema.py
@@ -353,7 +353,7 @@ class TestFieldToSection:
         assert FIELD_TO_SECTION["buoys_6d"] == "6DBuoys"
 
     def test_contains_variable_data_sources(self):
-        assert FIELD_TO_SECTION["variable_data_sources"] == "VariableDataSources"
+        assert FIELD_TO_SECTION["variable_data_sources"] == "VariableData"
 
     def test_contains_links(self):
         assert FIELD_TO_SECTION["links"] == "Links"
@@ -411,7 +411,7 @@ class TestSectionRegistry:
 
 class TestSingletonSections:
     def test_solid_friction_coefficients(self):
-        assert SINGLETON_SECTIONS["SolidFrictionCoefficients"] == "friction_coefficients"
+        assert SINGLETON_SECTIONS["FrictionCoefficients"] == "friction_coefficients"
 
     def test_line_contact_data(self):
         assert SINGLETON_SECTIONS["LineContactData"] == "line_contact_data"

--- a/tests/solvers/orcaflex/modular_generator/test_modular_vs_monolithic.py
+++ b/tests/solvers/orcaflex/modular_generator/test_modular_vs_monolithic.py
@@ -48,7 +48,7 @@ _DOCS_ROOT = Path(__file__).parent.parent.parent.parent.parent / "docs"
 
 PIPELINE_24IN = (
     _DOCS_ROOT
-    / "modules/orcaflex/pipeline/installation/floating/24in_pipeline"
+    / "domains/orcaflex/pipeline/installation/floating/24in_pipeline"
 )
 SPEC_24IN = PIPELINE_24IN / "spec.yml"
 MONOLITHIC_24IN_YML = (
@@ -61,7 +61,7 @@ MONOLITHIC_24IN_SIM = PIPELINE_24IN / "monolithic/basefile/statics.sim"
 
 PIPELINE_30IN = (
     _DOCS_ROOT
-    / "modules/orcaflex/pipeline/installation/floating/30in_pipeline"
+    / "domains/orcaflex/pipeline/installation/floating/30in_pipeline"
 )
 MONOLITHIC_30IN_SIM = PIPELINE_30IN / "monolithic.sim"
 MODULAR_30IN_SIM = PIPELINE_30IN / "modular/master.sim"
@@ -74,18 +74,18 @@ SPEC_24IN_QA = PIPELINE_24IN / "spec_qa.yml"
 
 # A01 Catenary Riser - simple model for instant validation (<10s statics)
 A01_RISER = (
-    _DOCS_ROOT / "modules/orcaflex/examples/raw/A01/A01 Catenary riser.dat"
+    _DOCS_ROOT / "domains/orcaflex/examples/raw/A01/A01 Catenary riser.dat"
 )
 
 # Additional Tier 2 fast models for library validation
 A01_LAZY_WAVE = (
-    _DOCS_ROOT / "modules/orcaflex/examples/raw/A01/A01 Lazy wave riser.yml"
+    _DOCS_ROOT / "domains/orcaflex/examples/raw/A01/A01 Lazy wave riser.yml"
 )
 C09_FENDERS = (
-    _DOCS_ROOT / "modules/orcaflex/examples/raw/C09/C09 Fenders.yml"
+    _DOCS_ROOT / "domains/orcaflex/examples/raw/C09/C09 Fenders.yml"
 )
 D02_PULL_IN = (
-    _DOCS_ROOT / "modules/orcaflex/examples/raw/D02/D02 Pull in analysis.yml"
+    _DOCS_ROOT / "domains/orcaflex/examples/raw/D02/D02 Pull in analysis.yml"
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/solvers/orcaflex/test_orcaflex_converter_enhanced.py
+++ b/tests/solvers/orcaflex/test_orcaflex_converter_enhanced.py
@@ -25,8 +25,8 @@ import shutil
 from digitalmodel.solvers.orcaflex.orcaflex_converter_enhanced import OrcaFlexConverterEnhanced
 
 
-# Test data paths
-TEST_EXAMPLES_DIR = Path("docs/domains/orcaflex/examples/raw")
+# Test data paths — anchored to repo root so tests pass regardless of pytest's cwd
+TEST_EXAMPLES_DIR = Path(__file__).resolve().parents[3] / "docs/domains/orcaflex/examples/raw"
 
 
 class TestOrcaFlexConverterEnhanced:


### PR DESCRIPTION
## Summary

Test-side repairs for 4 OrcaFlex test files after schema renames and path drift. **Zero `src/` edits** — plan-approved scope was test-side only.

Branch: `issue-510-fix-test-drift @ 190555410`

## Baseline delta (full `tests/solvers/orcaflex/` suite)

| | Failed | Errors | Passed | Skipped |
|---|---|---|---|---|
| Before | 20 | 5 | ? | ? |
| After  | 10 | 3 | 966 | 154 |

Remaining failures/errors are tracked in follow-up issues (see below) — all were pre-existing and out of plan scope.

## Changes

- `VariableDataSources` → `VariableData` rename tracked (schema/generic.py:339-367)
- `SolidFrictionCoefficients` → `FrictionCoefficients` rename tracked (schema/generic.py:328-337)
- Path drift: `docs/modules/orcaflex/` → `docs/domains/orcaflex/` in test_modular_vs_monolithic.py
- `TEST_EXAMPLES_DIR` now anchored to `Path(__file__).resolve().parents[3]` (cwd-independent)
- Extractor alias-input coverage preserved — `test_extractor.py:329` intentionally retains the legacy YAML fixture to exercise `_SECTION_ALIASES`
- `VariableData` structural note: builder emits nested-by-sub-category dict (not flat list); test assertions updated accordingly

## Plan + review artifacts

- Plan: [`workspace-hub/docs/plans/2026-04-24-issue-510-fix-20-test-failures.md`](https://github.com/vamseeachanta/workspace-hub/blob/main/docs/plans/2026-04-24-issue-510-fix-20-test-failures.md)
- Adversarial review: `workspace-hub/scripts/review/results/2026-04-24-plan-510-*` (5 files)

## Follow-ups (out of plan scope)

- #529 — convert_batch() parallel path doesn't aggregate success counts into self.stats
- #530 — hoist class-scoped fixtures in test_orcaflex_converter_enhanced.py to module level
- #531 — umbrella: 9 pre-existing test failures across 5 files not covered by #510 plan scope

Closes #510.

## Test plan

- [x] Full `tests/solvers/orcaflex/` suite run — 10 failed, 966 passed, 154 skipped, 3 errors (all pre-existing, out of scope)
- [x] No new regressions introduced by #510 test-side edits
- [x] Extractor alias-input coverage intentionally preserved and verified