### PR TITLE
feat(#511): OrcaFlex campaign spec generation — parametric sweep from spec.yml

### DIFF
--- a/src/digitalmodel/citations/__init__.py
+++ b/src/digitalmodel/citations/__init__.py
@@ -1,0 +1,20 @@
+"""Citation schema and registry for standards-derived calc constants.
+
+Contract: docs/standards/calc-output-citation.md (workspace-hub)
+Governing issue: #2481
+"""
+from __future__ import annotations
+
+from digitalmodel.citations.schema import (
+    Citation,
+    CitedValue,
+    CitationResolutionError,
+    validate_citation,
+)
+
+__all__ = [
+    "Citation",
+    "CitedValue",
+    "CitationResolutionError",
+    "validate_citation",
+]

--- a/src/digitalmodel/citations/registry.py
+++ b/src/digitalmodel/citations/registry.py
@@ -1,0 +1,58 @@
+"""Registry of citation-emitting getters for standards-derived constants.
+
+Pilot scope (#2481 D1): mooring design factors from DNV-OS-E301 and OCIMF-MEG4.
+
+Each getter returns a CitedValue whose citation is validated before return
+(fail-closed per #2481 D2).
+"""
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Final
+
+from digitalmodel.citations.schema import (
+    Citation,
+    CitedValue,
+    validate_citation,
+)
+
+
+class MooringCondition(str, Enum):
+    INTACT_QUASI_STATIC = "intact-quasi-static"
+    DAMAGED_QUASI_STATIC = "damaged-quasi-static"
+
+
+_DNV_OS_E301_CITATION_TEMPLATE: Final = {
+    "code_id": "DNV-OS-E301",
+    "publisher": "DNV",
+    "revision": "2021-07",
+    "wiki_path": "knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md",
+}
+
+# DNV-OS-E301 Section 2.2 design load factors for mooring systems.
+# Values are industry-standard and also appear in API RP 2SK Table C-1.
+_MOORING_SAFETY_FACTORS: Final[dict[MooringCondition, tuple[float, str]]] = {
+    MooringCondition.INTACT_QUASI_STATIC: (1.67, "Section 2.2.3 (intact, quasi-static)"),
+    MooringCondition.DAMAGED_QUASI_STATIC: (1.25, "Section 2.2.3 (damaged, quasi-static)"),
+}
+
+
+def get_mooring_safety_factor(
+    condition: MooringCondition, *, repo_root: Path
+) -> CitedValue:
+    """Return the DNV-OS-E301 mooring safety factor for the given condition.
+
+    Fail-closed: raises CitationResolutionError if the cited wiki page is missing
+    or its frontmatter no longer matches the citation.
+    """
+    if condition not in _MOORING_SAFETY_FACTORS:
+        raise ValueError(f"Unknown mooring condition: {condition!r}")
+    value, section = _MOORING_SAFETY_FACTORS[condition]
+    citation = Citation(
+        section=section,
+        note=f"Design factor for {condition.value} condition",
+        **_DNV_OS_E301_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="dimensionless")

--- a/src/digitalmodel/citations/schema.py
+++ b/src/digitalmodel/citations/schema.py
@@ -1,0 +1,132 @@
+"""Citation schema + fail-closed validator.
+
+Per #2481 decisions:
+- D2: fail-closed at calc time; CitationResolutionError carries code_id
+- D3: direct file read for v1; migrate to MCP #2400 later without schema change
+
+Contract: docs/standards/calc-output-citation.md (workspace-hub).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+_WIKI_PATH_PREFIX = "knowledge/wikis/"
+_FORBIDDEN_SEGMENTS = ("..", "")
+
+
+class CitationResolutionError(RuntimeError):
+    """Raised when a citation cannot be resolved against the live wiki.
+
+    Message always carries code_id so operators can retarget a cited constant
+    rather than disabling the citation when a wiki page is moved or archived.
+    """
+
+    def __init__(self, *, code_id: str, wiki_path: str, reason: str) -> None:
+        self.code_id = code_id
+        self.wiki_path = wiki_path
+        self.reason = reason
+        super().__init__(
+            f"CitationResolutionError: code_id={code_id!r} wiki_path={wiki_path!r} reason={reason}"
+        )
+
+
+class CitationValidationError(ValueError):
+    """Raised at schema-construction time for structurally invalid citations."""
+
+
+@dataclass(frozen=True)
+class Citation:
+    code_id: str
+    publisher: str
+    revision: str
+    section: str
+    wiki_path: str
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        for f in ("code_id", "publisher", "revision", "section", "wiki_path"):
+            v = getattr(self, f)
+            if not isinstance(v, str) or not v.strip():
+                raise CitationValidationError(f"Citation.{f} must be a non-empty string")
+        _validate_wiki_path(self.wiki_path)
+
+
+@dataclass(frozen=True)
+class CitedValue:
+    value: float
+    citation: Citation
+    units: str = ""
+
+
+def _validate_wiki_path(wiki_path: str) -> None:
+    if not wiki_path.startswith(_WIKI_PATH_PREFIX):
+        raise CitationValidationError(
+            f"wiki_path must be under {_WIKI_PATH_PREFIX!r}: got {wiki_path!r}"
+        )
+    if any(seg in _FORBIDDEN_SEGMENTS for seg in wiki_path.split("/")):
+        raise CitationValidationError(
+            f"wiki_path may not contain empty or '..' segments: got {wiki_path!r}"
+        )
+    if "\\" in wiki_path:
+        raise CitationValidationError(
+            f"wiki_path must use forward slashes: got {wiki_path!r}"
+        )
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def _read_frontmatter(path: Path) -> Mapping[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    # Minimal YAML-frontmatter parser covering the fields this validator needs.
+    # Avoids adding a yaml dependency for the pilot; the three fields are flat scalars.
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" not in line or line.lstrip().startswith("#"):
+            continue
+        key, _, rest = line.partition(":")
+        key = key.strip()
+        value = rest.strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        fm[key] = value
+    return fm
+
+
+def validate_citation(citation: Citation, *, repo_root: Path) -> None:
+    """Fail-closed resolution check.
+
+    Raises CitationResolutionError if:
+    - the cited wiki page does not exist
+    - the page frontmatter lacks code_id / publisher / revision
+    - any of the three fields disagree with the citation
+
+    Does NOT validate the `section` locator — that's a human-readable field.
+    """
+    path = repo_root / citation.wiki_path
+    if not path.is_file():
+        raise CitationResolutionError(
+            code_id=citation.code_id, wiki_path=citation.wiki_path, reason="page_missing"
+        )
+    fm = _read_frontmatter(path)
+    for field_name in ("code_id", "publisher", "revision"):
+        expected = getattr(citation, field_name)
+        actual = fm.get(field_name)
+        if actual is None:
+            raise CitationResolutionError(
+                code_id=citation.code_id,
+                wiki_path=citation.wiki_path,
+                reason=f"frontmatter_missing:{field_name}",
+            )
+        if actual != expected:
+            raise CitationResolutionError(
+                code_id=citation.code_id,
+                wiki_path=citation.wiki_path,
+                reason=f"frontmatter_mismatch:{field_name}:{actual!r}!={expected!r}",
+            )

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/cli.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/cli.py
@@ -318,7 +318,9 @@ def cmd_campaign(args: argparse.Namespace) -> int:
         combos = gen.preview()
         print(f"Campaign: {gen.spec.base.metadata.name}")
         matrix = gen.spec.campaign
-        parts = [f"{len(matrix.water_depths)} depths"]
+        parts: list[str] = []
+        if matrix.water_depths:
+            parts.append(f"{len(matrix.water_depths)} depths")
         if matrix.route_lengths:
             parts.append(f"{len(matrix.route_lengths)} lengths")
         if matrix.tensions:
@@ -327,6 +329,8 @@ def cmd_campaign(args: argparse.Namespace) -> int:
             parts.append(f"{len(matrix.environments)} environments")
         if matrix.soils:
             parts.append(f"{len(matrix.soils)} soils")
+        if matrix.sweeps:
+            parts.append(f"{len(matrix.sweeps)} sweep(s)")
         print(f"Matrix: {' x '.join(parts)} = {len(combos)} runs")
         print()
 
@@ -355,6 +359,7 @@ def cmd_campaign(args: argparse.Namespace) -> int:
         output_dir=output_dir,
         force=getattr(args, "force", False),
         resume=getattr(args, "resume", False),
+        spec_only=getattr(args, "spec_only", False),
     )
 
     print("Campaign generation complete:")
@@ -461,7 +466,12 @@ For more information, see the documentation at:
     campaign_parser.add_argument(
         "--resume",
         action="store_true",
-        help="Skip runs with existing master.yml",
+        help="Skip runs with existing master.yml (or spec.yml in --spec-only mode)",
+    )
+    campaign_parser.add_argument(
+        "--spec-only",
+        action="store_true",
+        help="Emit per-run spec.yml only (no master.yml/includes), plus top-level manifest.yml",
     )
     campaign_parser.add_argument(
         "--verbose",

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/_overrides.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/_overrides.py
@@ -31,7 +31,7 @@ def _set_nested_safe(d: dict, path: str, value: Any) -> None:
             else:
                 cursor = cursor[idx]
         elif isinstance(cursor, dict):
-            if not is_terminal and k not in cursor:
+            if k not in cursor:
                 raise KeyError(
                     f"path segment {k!r} not found in dotted path {path!r}"
                 )

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/_overrides.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/_overrides.py
@@ -1,0 +1,53 @@
+"""Dotted-path override helper for ProjectInputSpec with Pydantic re-validation.
+
+Dotted paths target the canonical ``model_dump()`` shape; use integer segments
+to index into list-valued fields (e.g. ``pipeline.segments.0.length``).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .root import ProjectInputSpec
+
+
+def _set_nested_safe(d: dict, path: str, value: Any) -> None:
+    keys = path.split(".")
+    cursor: Any = d
+    for i, k in enumerate(keys):
+        is_terminal = i == len(keys) - 1
+        if isinstance(cursor, list):
+            try:
+                idx = int(k)
+            except ValueError:
+                raise KeyError(
+                    f"non-integer segment {k!r} for list at dotted path {path!r}"
+                )
+            if not 0 <= idx < len(cursor):
+                raise IndexError(
+                    f"list index {idx} out of range at dotted path {path!r}"
+                )
+            if is_terminal:
+                cursor[idx] = value
+            else:
+                cursor = cursor[idx]
+        elif isinstance(cursor, dict):
+            if not is_terminal and k not in cursor:
+                raise KeyError(
+                    f"path segment {k!r} not found in dotted path {path!r}"
+                )
+            if is_terminal:
+                cursor[k] = value
+            else:
+                cursor = cursor[k]
+        else:
+            raise TypeError(
+                f"cannot traverse non-container at segment {k!r} in dotted path {path!r}"
+            )
+
+
+def apply_dotted_override(
+    spec: ProjectInputSpec, dotted: str, value: Any
+) -> ProjectInputSpec:
+    d = spec.model_dump()
+    _set_nested_safe(d, dotted, value)
+    return ProjectInputSpec.model_validate(d)

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -71,12 +71,16 @@ class ParameterSweep(BaseModel):
     parameter: str = Field(
         ...,
         min_length=1,
-        description="Dotted path into ProjectInputSpec (e.g., 'environment.waves.height')",
+        description="Dotted path into ProjectInputSpec (e.g., 'environment.waves.trains.0.height')",
     )
     values: list[Any] = Field(
         ...,
         min_length=1,
         description="Discrete values; cross-multiplied with other axes at combination time",
+    )
+    alias: str | None = Field(
+        default=None,
+        description="Short name for output_naming template; full-path slug is used when absent.",
     )
 
     @field_validator("parameter")
@@ -85,6 +89,26 @@ class ParameterSweep(BaseModel):
         if v.endswith("."):
             raise ValueError("parameter must not end with '.'")
         return v
+
+
+def _slug(parameter: str) -> str:
+    """Convert dotted path to slug for output_naming template (e.g., a.b.0.c → a-b-0-c)."""
+    return parameter.replace(".", "-")
+
+
+def _resolve_combo_for_naming(
+    combo: dict[str, Any], sweeps: list[ParameterSweep]
+) -> dict[str, Any]:
+    """Rename sweep dotted-path keys in combo to alias-or-slug for str.format compatibility."""
+    sweep_by_param = {s.parameter: s for s in sweeps}
+    resolved: dict[str, Any] = {}
+    for k, v in combo.items():
+        sweep = sweep_by_param.get(k)
+        if sweep is None:
+            resolved[k] = v
+        else:
+            resolved[sweep.alias if sweep.alias else _slug(k)] = v
+    return resolved
 
 
 class CampaignMatrix(BaseModel):
@@ -319,11 +343,18 @@ class CampaignSpec(BaseModel):
                     f"output_naming template: '{self.output_naming}'"
                 )
         for sweep in self.campaign.sweeps:
-            logger.warning(
-                f"Sweep parameter '{sweep.parameter}' varies in campaign but has "
-                f"no alias; it will not appear by name in output_naming template "
-                f"'{self.output_naming}'."
-            )
+            if sweep.alias:
+                if f"{{{sweep.alias}}}" not in self.output_naming:
+                    raise ValueError(
+                        f"Sweep alias '{sweep.alias}' (parameter '{sweep.parameter}') "
+                        f"is missing from output_naming template '{self.output_naming}'"
+                    )
+            else:
+                logger.warning(
+                    f"Sweep parameter '{sweep.parameter}' has no alias; "
+                    f"slug '{_slug(sweep.parameter)}' must appear in template "
+                    f"'{self.output_naming}' to be referenced by name."
+                )
         return self
 
     def generate_run_specs(self) -> Iterator[tuple[str, ProjectInputSpec]]:
@@ -339,8 +370,9 @@ class CampaignSpec(BaseModel):
                 break
             spec = self.base.model_copy(deep=True)
             spec = _apply_overrides(spec, combo, self.campaign)
+            naming_combo = _resolve_combo_for_naming(combo, self.campaign.sweeps)
             name = self.output_naming.format(
-                base_name=spec.metadata.name, **combo
+                base_name=spec.metadata.name, **naming_combo
             )
             yield (name, spec)
 

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -89,7 +89,10 @@ class ParameterSweep(BaseModel):
 class CampaignMatrix(BaseModel):
     """Defines the parametric variation space for batch generation."""
 
-    water_depths: list[float] = Field(..., min_length=1, description="Water depths (m)")
+    water_depths: list[float] | None = Field(
+        default=None,
+        description="Water depths (m). Optional when sweeps populate the axis space.",
+    )
     route_lengths: list[float] | None = Field(
         default=None,
         description="Route lengths (m). Adjusts last pipeline segment only.",
@@ -100,27 +103,43 @@ class CampaignMatrix(BaseModel):
     )
     environments: list[EnvironmentVariation] | None = None
     soils: list[SoilVariation] | None = None
+    sweeps: list[ParameterSweep] = Field(
+        default_factory=list,
+        description="Dotted-path parameter sweep axes.",
+    )
 
     @field_validator("water_depths")
     @classmethod
-    def validate_water_depths(cls, v: list[float]) -> list[float]:
+    def validate_water_depths(cls, v: list[float] | None) -> list[float] | None:
+        if v is None:
+            return v
         for depth in v:
             if depth <= 0:
                 raise ValueError(f"Water depth must be positive, got {depth}")
         return v
 
-    def combinations(self) -> list[dict[str, float | str]]:
-        """Generate cartesian product of all non-None parameters.
+    @model_validator(mode="after")
+    def _validate_axes(self):
+        if not any([
+            self.water_depths, self.route_lengths, self.tensions,
+            self.environments, self.soils, self.sweeps,
+        ]):
+            raise ValueError("CampaignMatrix requires at least one populated axis")
+        typed_axis_keys = {"water_depth", "route_length", "tension", "environment", "soil"}
+        for sweep in self.sweeps:
+            if sweep.parameter in typed_axis_keys:
+                raise ValueError(
+                    f"sweep parameter {sweep.parameter!r} shadows typed axis combo key; "
+                    "use the corresponding typed field instead"
+                )
+        return self
 
-        Returns list of dicts with keys:
-          - "water_depth": float (always present)
-          - "route_length": float (if route_lengths specified)
-          - "tension": float (if tensions specified)
-          - "environment": str (name, if environments specified)
-          - "soil": str (name, if soils specified)
-        """
-        axes: list[tuple[str, list]] = [("water_depth", self.water_depths)]
+    def combinations(self) -> list[dict[str, Any]]:
+        """Generate cartesian product of all non-None parameters and sweeps."""
+        axes: list[tuple[str, list]] = []
 
+        if self.water_depths:
+            axes.append(("water_depth", self.water_depths))
         if self.route_lengths:
             axes.append(("route_length", self.route_lengths))
         if self.tensions:
@@ -129,6 +148,8 @@ class CampaignMatrix(BaseModel):
             axes.append(("environment", [e.name for e in self.environments]))
         if self.soils:
             axes.append(("soil", [s.name for s in self.soils]))
+        for sweep in self.sweeps:
+            axes.append((sweep.parameter, sweep.values))
 
         keys = [k for k, _ in axes]
         value_lists = [v for _, v in axes]

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -10,6 +10,7 @@ from typing import Any, Iterator
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from ._overrides import apply_dotted_override
 from .environment import Current, SeabedStiffness, Waves, Wind
 from .root import ProjectInputSpec
 
@@ -317,6 +318,12 @@ class CampaignSpec(BaseModel):
                     f"Parameter '{param}' varies in campaign but is missing from "
                     f"output_naming template: '{self.output_naming}'"
                 )
+        for sweep in self.campaign.sweeps:
+            logger.warning(
+                f"Sweep parameter '{sweep.parameter}' varies in campaign but has "
+                f"no alias; it will not appear by name in output_naming template "
+                f"'{self.output_naming}'."
+            )
         return self
 
     def generate_run_specs(self) -> Iterator[tuple[str, ProjectInputSpec]]:
@@ -331,7 +338,7 @@ class CampaignSpec(BaseModel):
             if i >= limit:
                 break
             spec = self.base.model_copy(deep=True)
-            _apply_overrides(spec, combo, self.campaign)
+            spec = _apply_overrides(spec, combo, self.campaign)
             name = self.output_naming.format(
                 base_name=spec.metadata.name, **combo
             )
@@ -340,10 +347,15 @@ class CampaignSpec(BaseModel):
 
 def _apply_overrides(
     spec: ProjectInputSpec,
-    combo: dict[str, float | str],
+    combo: dict[str, Any],
     matrix: CampaignMatrix,
-) -> None:
-    """Apply parameter overrides to a deep-copied spec."""
+) -> ProjectInputSpec:
+    """Apply parameter overrides to a deep-copied spec.
+
+    Typed-axis overrides mutate spec in-place; sweeps rebind spec through
+    apply_dotted_override (Pydantic re-validation). Sweeps apply last so
+    their values win if a dotted path overlaps a typed axis's target.
+    """
     if "water_depth" in combo:
         old_depth = spec.environment.water.depth
         new_depth = combo["water_depth"]
@@ -389,6 +401,12 @@ def _apply_overrides(
         spec.environment.seabed.friction_coefficient = soil_var.friction_coefficient
         if soil_var.slope is not None:
             spec.environment.seabed.slope = soil_var.slope
+
+    for sweep in matrix.sweeps:
+        if sweep.parameter in combo:
+            spec = apply_dotted_override(spec, sweep.parameter, combo[sweep.parameter])
+
+    return spec
 
 
 @dataclass

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -157,6 +157,11 @@ class CampaignMatrix(BaseModel):
                     f"sweep parameter {sweep.parameter!r} shadows typed axis combo key; "
                     "use the corresponding typed field instead"
                 )
+            if sweep.alias and sweep.alias in typed_axis_keys:
+                raise ValueError(
+                    f"sweep alias {sweep.alias!r} shadows typed axis combo key; "
+                    "choose a different alias"
+                )
         return self
 
     def combinations(self) -> list[dict[str, Any]]:
@@ -477,8 +482,9 @@ class CampaignGenerator:
         # Check for duplicate run names after template formatting
         names: set[str] = set()
         for combo in combos:
+            naming_combo = _resolve_combo_for_naming(combo, self.spec.campaign.sweeps)
             name = self.spec.output_naming.format(
-                base_name=self.spec.base.metadata.name, **combo
+                base_name=self.spec.base.metadata.name, **naming_combo
             )
             if name in names:
                 warnings.append(f"Duplicate run name: '{name}'")

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -450,6 +450,7 @@ class CampaignResult:
     run_dirs: list[Path]
     errors: list[str]
     matrix_summary: dict[str, list]
+    manifest_path: Path | None = None
 
 
 class CampaignGenerator:
@@ -502,31 +503,59 @@ class CampaignGenerator:
         output_dir: Path,
         force: bool = False,
         resume: bool = False,
+        spec_only: bool = False,
     ) -> CampaignResult:
         """Generate all campaign runs.
-
-        Streams through the matrix one run at a time.
 
         Args:
             output_dir: Root directory for all generated run directories.
             force: If True, overwrite existing run directories.
-            resume: If True, skip runs where master.yml already exists.
+            resume: If True, skip runs where the sentinel file already exists.
+            spec_only: If True, emit per-run spec.yml only (no master.yml /
+                includes/), plus a top-level manifest.yml mapping run name to
+                combo parameters.
 
         Returns:
-            CampaignResult with aggregated statistics.
+            CampaignResult with aggregated statistics. manifest_path is set
+            only in spec_only mode.
         """
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
+        combos = self.spec.campaign.combinations()
+        n_combos = len(combos)
+        limit = self.spec.max_runs if self.spec.max_runs else n_combos
+
+        if self.spec.max_runs and n_combos > self.spec.max_runs:
+            logger.warning(
+                "Campaign produces %d combinations but max_runs=%d; only first %d will be generated.",
+                n_combos, self.spec.max_runs, self.spec.max_runs,
+            )
+        elif self.spec.max_runs is None and n_combos > 100:
+            logger.warning(
+                "Campaign produces %d combinations (>100); consider setting max_runs to limit batch size.",
+                n_combos,
+            )
+
         run_dirs: list[Path] = []
         errors: list[str] = []
         skipped = 0
+        manifest_runs: list[dict] = []
+        sentinel = "spec.yml" if spec_only else "master.yml"
 
-        for name, spec in self.spec.generate_run_specs():
+        for i, combo in enumerate(combos):
+            if i >= limit:
+                break
+            spec = self.spec.base.model_copy(deep=True)
+            spec = _apply_overrides(spec, combo, self.spec.campaign)
+            naming_combo = _resolve_combo_for_naming(combo, self.spec.campaign.sweeps)
+            name = self.spec.output_naming.format(
+                base_name=spec.metadata.name, **naming_combo
+            )
             run_dir = output_dir / name
 
             if run_dir.exists():
-                if resume and (run_dir / "master.yml").exists():
+                if resume and (run_dir / sentinel).exists():
                     logger.info("Skipping (resume): %s", name)
                     skipped += 1
                     continue
@@ -536,34 +565,43 @@ class CampaignGenerator:
                     continue
 
             try:
-                # Import here to avoid circular imports
-                from digitalmodel.solvers.orcaflex.modular_generator import (
-                    ModularModelGenerator,
-                )
-
-                gen = ModularModelGenerator.from_spec(spec)
-
-                # Use generate_with_overrides if campaign has sections
-                if self.spec.sections:
-                    gen.generate_with_overrides(
-                        output_dir=run_dir,
-                        sections=self.spec.sections,
-                        variables={"water_depth": spec.environment.water.depth},
-                        template_base_dir=self.campaign_file.parent,
+                if spec_only:
+                    run_dir.mkdir(parents=True, exist_ok=True)
+                    (run_dir / "spec.yml").write_text(
+                        yaml.dump(spec.model_dump(), default_flow_style=False)
                     )
+                    manifest_runs.append({"name": name, "combo": combo})
+                    logger.info("Generated spec: %s", name)
                 else:
-                    gen.generate(run_dir)
-
+                    from digitalmodel.solvers.orcaflex.modular_generator import (
+                        ModularModelGenerator,
+                    )
+                    gen_obj = ModularModelGenerator.from_spec(spec)
+                    if self.spec.sections:
+                        gen_obj.generate_with_overrides(
+                            output_dir=run_dir,
+                            sections=self.spec.sections,
+                            variables={"water_depth": spec.environment.water.depth},
+                            template_base_dir=self.campaign_file.parent,
+                        )
+                    else:
+                        gen_obj.generate(run_dir)
+                    logger.info("Generated: %s", name)
                 run_dirs.append(run_dir)
-                logger.info("Generated: %s", name)
-
             except Exception as exc:
                 msg = f"Failed to generate run '{name}': {exc}"
                 logger.error(msg)
                 errors.append(msg)
 
-        # Build matrix summary
-        combos = self.preview()
+        manifest_path: Path | None = None
+        if spec_only and manifest_runs:
+            manifest_path = output_dir / "manifest.yml"
+            manifest_path.write_text(yaml.dump({
+                "campaign": self.spec.base.metadata.name,
+                "total_runs": len(manifest_runs),
+                "runs": manifest_runs,
+            }, default_flow_style=False))
+
         matrix_summary: dict[str, list] = {}
         if combos:
             for key in combos[0]:
@@ -577,4 +615,5 @@ class CampaignGenerator:
             run_dirs=run_dirs,
             errors=errors,
             matrix_summary=matrix_summary,
+            manifest_path=manifest_path,
         )

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/schema/campaign.py
@@ -64,6 +64,28 @@ class InstallationSection(BaseModel):
     enabled: bool = Field(default=True)
 
 
+class ParameterSweep(BaseModel):
+    """Dotted-path parameter sweep axis for campaign matrix."""
+
+    parameter: str = Field(
+        ...,
+        min_length=1,
+        description="Dotted path into ProjectInputSpec (e.g., 'environment.waves.height')",
+    )
+    values: list[Any] = Field(
+        ...,
+        min_length=1,
+        description="Discrete values; cross-multiplied with other axes at combination time",
+    )
+
+    @field_validator("parameter")
+    @classmethod
+    def _no_trailing_dot(cls, v: str) -> str:
+        if v.endswith("."):
+            raise ValueError("parameter must not end with '.'")
+        return v
+
+
 class CampaignMatrix(BaseModel):
     """Defines the parametric variation space for batch generation."""
 

--- a/tests/citations/test_registry.py
+++ b/tests/citations/test_registry.py
@@ -1,0 +1,54 @@
+"""Registry integration tests — pilot: mooring safety factors from DNV-OS-E301.
+
+Per #2481 D1: mooring load-factor is the pilot calc target.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.registry import (
+    MooringCondition,
+    get_mooring_safety_factor,
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "knowledge" / "wikis").is_dir():
+            return parent
+    raise RuntimeError("could not locate workspace-hub root above test file")
+
+
+def test_intact_quasi_static_factor_emits_cited_value():
+    cv = get_mooring_safety_factor(MooringCondition.INTACT_QUASI_STATIC, repo_root=_repo_root())
+    assert cv.value == 1.67
+    assert cv.citation.code_id == "DNV-OS-E301"
+    assert cv.citation.publisher == "DNV"
+    assert cv.citation.revision == "2021-07"
+    assert "Section 2.2.3" in cv.citation.section
+    assert cv.citation.wiki_path.endswith("dnv-os-e301.md")
+    assert cv.units == "dimensionless"
+
+
+def test_damaged_quasi_static_factor_emits_cited_value():
+    cv = get_mooring_safety_factor(MooringCondition.DAMAGED_QUASI_STATIC, repo_root=_repo_root())
+    assert cv.value == 1.25
+    assert cv.citation.code_id == "DNV-OS-E301"
+
+
+def test_registry_unknown_condition_raises():
+    with pytest.raises(ValueError):
+        get_mooring_safety_factor("nonexistent-condition", repo_root=_repo_root())  # type: ignore[arg-type]
+
+
+def test_registry_with_broken_repo_root_fails_closed(tmp_path):
+    # If the "repo root" does not actually contain the cited wiki page,
+    # the registry must raise CitationResolutionError rather than returning a value.
+    with pytest.raises(CitationResolutionError) as exc:
+        get_mooring_safety_factor(MooringCondition.INTACT_QUASI_STATIC, repo_root=tmp_path)
+    assert exc.value.code_id == "DNV-OS-E301"
+    assert exc.value.reason == "page_missing"

--- a/tests/citations/test_schema.py
+++ b/tests/citations/test_schema.py
@@ -1,0 +1,101 @@
+"""Schema + resolution tests for digitalmodel.citations.
+
+Covers #2481 TDD list items: schema validation, wiki-path security,
+fail-closed resolution with code_id in the error message.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import (
+    Citation,
+    CitedValue,
+    CitationResolutionError,
+    validate_citation,
+)
+from digitalmodel.citations.schema import CitationValidationError
+
+
+REAL_DNV_PAGE = "knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md"
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "knowledge" / "wikis").is_dir():
+            return parent
+    raise RuntimeError("could not locate workspace-hub root above test file")
+
+
+def _valid_kwargs(**overrides):
+    base = dict(
+        code_id="DNV-OS-E301",
+        publisher="DNV",
+        revision="2021-07",
+        section="Section 2.2.3",
+        wiki_path=REAL_DNV_PAGE,
+        note="",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_schema_accepts_well_formed_citation():
+    c = Citation(**_valid_kwargs())
+    assert c.code_id == "DNV-OS-E301"
+
+
+def test_schema_rejects_missing_code_id():
+    with pytest.raises(CitationValidationError):
+        Citation(**_valid_kwargs(code_id=""))
+
+
+def test_schema_rejects_missing_publisher():
+    with pytest.raises(CitationValidationError):
+        Citation(**_valid_kwargs(publisher=""))
+
+
+def test_schema_rejects_wiki_path_outside_wiki_tree():
+    with pytest.raises(CitationValidationError):
+        Citation(**_valid_kwargs(wiki_path="../../etc/passwd"))
+
+
+def test_schema_rejects_wiki_path_absolute():
+    with pytest.raises(CitationValidationError):
+        Citation(**_valid_kwargs(wiki_path="/etc/passwd"))
+
+
+def test_schema_rejects_wiki_path_with_backslash():
+    with pytest.raises(CitationValidationError):
+        Citation(**_valid_kwargs(wiki_path="knowledge\\wikis\\engineering.md"))
+
+
+def test_resolution_passes_for_real_page():
+    c = Citation(**_valid_kwargs())
+    validate_citation(c, repo_root=_repo_root())
+
+
+def test_resolution_fails_on_missing_page():
+    c = Citation(**_valid_kwargs(wiki_path="knowledge/wikis/engineering/wiki/standards/does-not-exist.md"))
+    with pytest.raises(CitationResolutionError) as exc:
+        validate_citation(c, repo_root=_repo_root())
+    assert "DNV-OS-E301" in str(exc.value)
+    assert exc.value.code_id == "DNV-OS-E301"
+    assert exc.value.reason == "page_missing"
+
+
+def test_resolution_fails_on_frontmatter_mismatch_revision():
+    c = Citation(**_valid_kwargs(revision="2099-99"))
+    with pytest.raises(CitationResolutionError) as exc:
+        validate_citation(c, repo_root=_repo_root())
+    assert "DNV-OS-E301" in str(exc.value)
+    assert "frontmatter_mismatch:revision" in exc.value.reason
+
+
+def test_cited_value_preserves_numeric_interface():
+    c = Citation(**_valid_kwargs())
+    v = CitedValue(value=1.67, citation=c, units="dimensionless")
+    assert v.value == 1.67
+    assert v.units == "dimensionless"

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -114,6 +114,32 @@ class TestSoilVariation:
         assert sv.slope is None
 
 
+class TestParameterSweep:
+    def test_parameter_sweep_valid(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import ParameterSweep
+        ps = ParameterSweep(
+            parameter="environment.waves.height",
+            values=[1.0, 2.0, 3.0],
+        )
+        assert ps.parameter == "environment.waves.height"
+        assert ps.values == [1.0, 2.0, 3.0]
+
+    def test_parameter_sweep_empty_values_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import ParameterSweep
+        with pytest.raises(ValidationError):
+            ParameterSweep(parameter="environment.waves.height", values=[])
+
+    def test_parameter_sweep_empty_parameter_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import ParameterSweep
+        with pytest.raises(ValidationError):
+            ParameterSweep(parameter="", values=[1.0, 2.0])
+
+    def test_parameter_sweep_dot_terminal_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import ParameterSweep
+        with pytest.raises(ValidationError):
+            ParameterSweep(parameter="environment.waves.", values=[1.0, 2.0])
+
+
 class TestCampaignMatrixCombinations:
     def test_depths_only(self):
         from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import CampaignMatrix

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -237,6 +237,63 @@ class TestCampaignMatrixCombinations:
         with pytest.raises(ValidationError):
             CampaignMatrix(water_depths=[-5, 10])
 
+    def test_campaign_matrix_single_sweep_only(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignMatrix, ParameterSweep,
+        )
+        m = CampaignMatrix(
+            sweeps=[ParameterSweep(parameter="environment.waves.trains.0.height", values=[1.0, 2.0, 3.0])]
+        )
+        combos = m.combinations()
+        assert len(combos) == 3
+        assert [c["environment.waves.trains.0.height"] for c in combos] == [1.0, 2.0, 3.0]
+
+    def test_campaign_matrix_sweeps_crossed_with_typed_axis(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignMatrix, ParameterSweep,
+        )
+        m = CampaignMatrix(
+            water_depths=[10, 20],
+            sweeps=[ParameterSweep(parameter="environment.waves.trains.0.height", values=[1.0, 2.0])],
+        )
+        combos = m.combinations()
+        assert len(combos) == 4  # 2 x 2
+
+    def test_campaign_matrix_two_sweeps_crossed(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignMatrix, ParameterSweep,
+        )
+        m = CampaignMatrix(
+            sweeps=[
+                ParameterSweep(parameter="environment.waves.trains.0.height", values=[1.0, 2.0]),
+                ParameterSweep(parameter="environment.waves.trains.0.period", values=[6, 8, 10]),
+            ]
+        )
+        combos = m.combinations()
+        assert len(combos) == 6  # 2 x 3
+
+    def test_campaign_matrix_no_axes_and_no_sweeps_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import CampaignMatrix
+        with pytest.raises(ValidationError):
+            CampaignMatrix()
+
+    def test_sweep_parameter_shadowing_typed_axis_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignMatrix, ParameterSweep,
+        )
+        with pytest.raises(ValidationError):
+            CampaignMatrix(
+                water_depths=[10, 20],
+                sweeps=[ParameterSweep(parameter="water_depth", values=[30, 40])],
+            )
+
+    def test_backward_compat_no_sweeps_field(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import CampaignMatrix
+        m = CampaignMatrix(water_depths=[10, 20])
+        combos = m.combinations()
+        assert len(combos) == 2
+        assert all(set(c.keys()) == {"water_depth"} for c in combos)
+
 
 class TestCampaignSpecValidators:
     def test_tensions_without_slay_raises(self):

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -140,6 +140,42 @@ class TestParameterSweep:
             ParameterSweep(parameter="environment.waves.", values=[1.0, 2.0])
 
 
+class TestApplyDottedOverride:
+    def test_apply_dotted_override_leaf_value_set(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        assert spec.environment.waves.height == 1.0
+        result = apply_dotted_override(spec, "environment.waves.trains.0.height", 5.0)
+        assert result.environment.waves.height == 5.0
+        assert spec.environment.waves.height == 1.0
+
+    def test_apply_dotted_override_pydantic_validates_type_error(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        with pytest.raises(ValidationError):
+            apply_dotted_override(spec, "environment.waves.trains.0.height", "not-a-float")
+
+    def test_apply_dotted_override_unresolvable_path_raises(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        with pytest.raises(KeyError):
+            apply_dotted_override(spec, "environment.nonexistent.foo", 1.0)
+
+    def test_apply_dotted_override_list_index_sets_value(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        assert spec.pipeline.segments[0].length == 2000
+        result = apply_dotted_override(spec, "pipeline.segments.0.length", 999.0)
+        assert result.pipeline.segments[0].length == 999
+        assert spec.pipeline.segments[0].length == 2000
+
+    def test_apply_dotted_override_list_index_out_of_bounds_raises(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        with pytest.raises(IndexError):
+            apply_dotted_override(spec, "pipeline.segments.99.length", 1.0)
+
+
 class TestCampaignMatrixCombinations:
     def test_depths_only(self):
         from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import CampaignMatrix

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -339,6 +339,76 @@ class TestApplyOverridesWithSweeps:
         assert any("environment.waves.trains.0.height" in r.message for r in caplog.records)
 
 
+class TestSweepNaming:
+    def test_parameter_sweep_alias_accepted(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import ParameterSweep
+        ps = ParameterSweep(
+            parameter="environment.waves.trains.0.height",
+            values=[1.0, 2.0],
+            alias="wave_h",
+        )
+        assert ps.alias == "wave_h"
+
+    def test_sweep_naming_with_alias(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignSpec, CampaignMatrix, ParameterSweep,
+        )
+        base = _make_base_spec()
+        spec = CampaignSpec(
+            base=base,
+            campaign=CampaignMatrix(
+                water_depths=[10],
+                sweeps=[ParameterSweep(
+                    parameter="environment.waves.trains.0.height",
+                    values=[1.5, 2.5],
+                    alias="wave_h",
+                )]
+            ),
+            output_naming="{base_name}_wd{water_depth}m_h{wave_h}",
+        )
+        names = [name for name, _ in spec.generate_run_specs()]
+        assert len(names) == 2
+        assert "h1.5" in names[0] and "h2.5" in names[1]
+
+    def test_sweep_naming_slug_fallback(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignSpec, CampaignMatrix, ParameterSweep,
+        )
+        base = _make_base_spec()
+        spec = CampaignSpec(
+            base=base,
+            campaign=CampaignMatrix(
+                water_depths=[10],
+                sweeps=[ParameterSweep(
+                    parameter="environment.waves.trains.0.height",
+                    values=[1.5],
+                )]
+            ),
+            output_naming="{base_name}_wd{water_depth}m_h{environment-waves-trains-0-height}",
+        )
+        names = [name for name, _ in spec.generate_run_specs()]
+        assert "h1.5" in names[0]
+
+    def test_validate_output_naming_raises_on_aliased_sweep_missing_from_template(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignSpec, CampaignMatrix, ParameterSweep,
+        )
+        base = _make_base_spec()
+        with pytest.raises(ValidationError, match="alias"):
+            CampaignSpec(
+                base=base,
+                campaign=CampaignMatrix(
+                    water_depths=[10],
+                    sweeps=[ParameterSweep(
+                        parameter="environment.waves.trains.0.height",
+                        values=[1.0],
+                        alias="wave_h",
+                    )]
+                ),
+                output_naming="{base_name}_wd{water_depth}m",
+            )
+
+
 class TestCampaignSpecValidators:
     def test_tensions_without_slay_raises(self):
         from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -175,6 +175,12 @@ class TestApplyDottedOverride:
         with pytest.raises(IndexError):
             apply_dotted_override(spec, "pipeline.segments.99.length", 1.0)
 
+    def test_apply_dotted_override_terminal_typo_raises(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema._overrides import apply_dotted_override
+        spec = _make_base_spec()
+        with pytest.raises(KeyError, match="heigh"):
+            apply_dotted_override(spec, "environment.waves.trains.0.heigh", 5.0)
+
 
 class TestCampaignMatrixCombinations:
     def test_depths_only(self):
@@ -285,6 +291,20 @@ class TestCampaignMatrixCombinations:
             CampaignMatrix(
                 water_depths=[10, 20],
                 sweeps=[ParameterSweep(parameter="water_depth", values=[30, 40])],
+            )
+
+    def test_sweep_alias_shadowing_typed_axis_rejected(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignMatrix, ParameterSweep,
+        )
+        with pytest.raises(ValidationError):
+            CampaignMatrix(
+                water_depths=[10, 20],
+                sweeps=[ParameterSweep(
+                    parameter="environment.waves.trains.0.height",
+                    values=[1.0, 2.0],
+                    alias="water_depth",
+                )],
             )
 
     def test_backward_compat_no_sweeps_field(self):

--- a/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
+++ b/tests/solvers/orcaflex/modular_generator/schema/test_campaign.py
@@ -295,6 +295,50 @@ class TestCampaignMatrixCombinations:
         assert all(set(c.keys()) == {"water_depth"} for c in combos)
 
 
+class TestApplyOverridesWithSweeps:
+    def test_apply_overrides_with_sweep_modifies_spec(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            _apply_overrides, CampaignMatrix, ParameterSweep,
+        )
+        spec = _make_base_spec()
+        matrix = CampaignMatrix(
+            sweeps=[ParameterSweep(parameter="environment.waves.trains.0.height", values=[5.0])]
+        )
+        combo = {"environment.waves.trains.0.height": 5.0}
+        result = _apply_overrides(spec, combo, matrix)
+        assert result.environment.waves.height == 5.0
+
+    def test_apply_overrides_sweep_applies_after_typed_axis(self):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            _apply_overrides, CampaignMatrix, ParameterSweep,
+        )
+        spec = _make_base_spec()
+        matrix = CampaignMatrix(
+            water_depths=[50],
+            sweeps=[ParameterSweep(parameter="environment.water.depth", values=[200])],
+        )
+        combo = {"water_depth": 50, "environment.water.depth": 200}
+        result = _apply_overrides(spec, combo, matrix)
+        assert result.environment.water.depth == 200
+
+    def test_validate_output_naming_warns_on_sweep_axis_without_alias(self, caplog):
+        import logging
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignSpec, CampaignMatrix, ParameterSweep,
+        )
+        base = _make_base_spec()
+        caplog.set_level(logging.WARNING)
+        CampaignSpec(
+            base=base,
+            campaign=CampaignMatrix(
+                water_depths=[10],
+                sweeps=[ParameterSweep(parameter="environment.waves.trains.0.height", values=[1.0, 2.0])]
+            ),
+            output_naming="{base_name}_wd{water_depth}m",
+        )
+        assert any("environment.waves.trains.0.height" in r.message for r in caplog.records)
+
+
 class TestCampaignSpecValidators:
     def test_tensions_without_slay_raises(self):
         from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (

--- a/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
+++ b/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
@@ -410,3 +410,49 @@ class TestCLICampaignGenerate:
         exit_code = cmd_campaign(args)
 
         assert exit_code == 1
+
+
+class TestCLICampaignSpecOnly:
+    def test_cli_campaign_spec_only_flag(self, tmp_path, capsys):
+        from digitalmodel.solvers.orcaflex.modular_generator.cli import (
+            cmd_campaign,
+            create_parser,
+        )
+        cf = _write_campaign_yaml(tmp_path)
+        out = tmp_path / "cli_spec_only_out"
+        parser = create_parser()
+        args = parser.parse_args([
+            "campaign", str(cf), "--output", str(out), "--spec-only",
+        ])
+        exit_code = cmd_campaign(args)
+        assert exit_code == 0
+        spec_files = list(out.glob("*/spec.yml"))
+        assert len(spec_files) == 4
+        assert (out / "manifest.yml").exists()
+        assert list(out.glob("*/master.yml")) == []
+
+    def test_cli_preview_shows_sweep_counts(self, tmp_path, capsys):
+        from digitalmodel.solvers.orcaflex.modular_generator.cli import (
+            cmd_campaign,
+            create_parser,
+        )
+        data = _make_campaign_data()
+        data["campaign"]["sweeps"] = [
+            {
+                "parameter": "environment.waves.trains.0.height",
+                "values": [1.0, 2.0, 3.0],
+                "alias": "wave_h",
+            }
+        ]
+        data["output_naming"] = "{base_name}_wd{water_depth}m_{environment}_h{wave_h}"
+        cf = tmp_path / "campaign_sweep.yml"
+        cf.write_text(yaml.dump(data, default_flow_style=False))
+
+        parser = create_parser()
+        args = parser.parse_args(["campaign", str(cf), "--preview"])
+        exit_code = cmd_campaign(args)
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "sweep" in captured.out.lower()
+        assert "12 runs" in captured.out  # 2 depths × 2 envs × 3 sweep values

--- a/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
+++ b/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
@@ -456,3 +456,75 @@ class TestCLICampaignSpecOnly:
         assert exit_code == 0
         assert "sweep" in captured.out.lower()
         assert "12 runs" in captured.out  # 2 depths × 2 envs × 3 sweep values
+
+
+class TestCampaignE2E:
+    def test_e2e_two_dotted_sweeps_produce_n_spec_ymls(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        data = _make_campaign_data()
+        data["campaign"] = {
+            "water_depths": [10],
+            "sweeps": [
+                {
+                    "parameter": "environment.waves.trains.0.height",
+                    "values": [1.0, 2.0],
+                    "alias": "wave_h",
+                },
+                {
+                    "parameter": "environment.waves.trains.0.period",
+                    "values": [6, 8, 10],
+                    "alias": "wave_p",
+                },
+            ],
+        }
+        data["output_naming"] = "{base_name}_wd{water_depth}m_h{wave_h}_p{wave_p}"
+        cf = tmp_path / "campaign_two_sweeps.yml"
+        cf.write_text(yaml.dump(data, default_flow_style=False))
+
+        gen = CampaignGenerator(cf)
+        out = tmp_path / "out"
+        result = gen.generate(out, spec_only=True)
+
+        assert result.run_count == 6  # 1 × 2 × 3
+        spec_files = list(out.glob("*/spec.yml"))
+        assert len(spec_files) == 6
+
+    def test_e2e_each_spec_yml_validates_as_project_input_spec(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        data = _make_campaign_data()
+        data["campaign"]["sweeps"] = [
+            {
+                "parameter": "environment.waves.trains.0.height",
+                "values": [1.0, 2.0],
+                "alias": "wave_h",
+            }
+        ]
+        data["output_naming"] = "{base_name}_wd{water_depth}m_{environment}_h{wave_h}"
+        cf = tmp_path / "campaign_validates.yml"
+        cf.write_text(yaml.dump(data, default_flow_style=False))
+
+        gen = CampaignGenerator(cf)
+        out = tmp_path / "out"
+        gen.generate(out, spec_only=True)
+
+        spec_files = list(out.glob("*/spec.yml"))
+        assert len(spec_files) > 0
+        for spec_file in spec_files:
+            loaded = yaml.safe_load(spec_file.read_text())
+            ProjectInputSpec.model_validate(loaded)
+
+    def test_campaign_loader_handles_bom_encoded_yaml(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        cf = tmp_path / "campaign_bom.yml"
+        yaml_text = yaml.dump(_make_campaign_data(), default_flow_style=False)
+        cf.write_bytes(b"\xef\xbb\xbf" + yaml_text.encode("utf-8"))
+
+        gen = CampaignGenerator(cf)
+        assert gen.spec.base.metadata.name == "test_pipe"

--- a/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
+++ b/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
@@ -528,3 +528,23 @@ class TestCampaignE2E:
 
         gen = CampaignGenerator(cf)
         assert gen.spec.base.metadata.name == "test_pipe"
+
+    def test_validate_with_sweeps_does_not_crash(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        data = _make_campaign_data()
+        data["campaign"]["sweeps"] = [
+            {
+                "parameter": "environment.waves.trains.0.height",
+                "values": [1.0, 2.0],
+                "alias": "wave_h",
+            }
+        ]
+        data["output_naming"] = "{base_name}_wd{water_depth}m_{environment}_h{wave_h}"
+        cf = tmp_path / "campaign_validate_sweep.yml"
+        cf.write_text(yaml.dump(data, default_flow_style=False))
+
+        gen = CampaignGenerator(cf)
+        warnings = gen.validate()
+        assert isinstance(warnings, list)

--- a/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
+++ b/tests/solvers/orcaflex/modular_generator/test_campaign_generator.py
@@ -247,6 +247,70 @@ class TestCampaignGeneratorGenerate:
         assert sorted(result.matrix_summary["environment"]) == ["calm", "storm"]
 
 
+class TestCampaignGeneratorSpecOnly:
+    def test_campaign_generator_spec_only_writes_spec_yml_per_combo(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        cf = _write_campaign_yaml(tmp_path)
+        gen = CampaignGenerator(cf)
+        out = tmp_path / "out"
+        result = gen.generate(out, spec_only=True)
+        # 2 water_depths × 2 environments = 4 runs
+        assert result.run_count == 4
+        spec_files = sorted(out.glob("*/spec.yml"))
+        assert len(spec_files) == 4
+
+    def test_campaign_generator_spec_only_skips_master_and_includes(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        cf = _write_campaign_yaml(tmp_path)
+        gen = CampaignGenerator(cf)
+        out = tmp_path / "out"
+        gen.generate(out, spec_only=True)
+        master_files = list(out.glob("*/master.yml"))
+        includes_dirs = list(out.glob("*/includes"))
+        assert master_files == []
+        assert includes_dirs == []
+
+    def test_spec_only_writes_top_level_manifest_with_combo_index(self, tmp_path):
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        cf = _write_campaign_yaml(tmp_path)
+        gen = CampaignGenerator(cf)
+        out = tmp_path / "out"
+        result = gen.generate(out, spec_only=True)
+
+        manifest = out / "manifest.yml"
+        assert manifest.exists()
+        assert result.manifest_path == manifest
+
+        data = yaml.safe_load(manifest.read_text())
+        assert data["total_runs"] == 4
+        assert len(data["runs"]) == 4
+
+    def test_preflight_warning_above_max_runs_threshold(self, tmp_path, caplog):
+        import logging
+        from digitalmodel.solvers.orcaflex.modular_generator.schema.campaign import (
+            CampaignGenerator,
+        )
+        data = _make_campaign_data()
+        data["campaign"]["water_depths"] = [10, 20, 30, 40, 50]  # 5 × 2 envs = 10 combos
+        data["max_runs"] = 3
+        cf = tmp_path / "campaign_overload.yml"
+        cf.write_text(yaml.dump(data, default_flow_style=False))
+
+        gen = CampaignGenerator(cf)
+        caplog.set_level(logging.WARNING)
+        gen.generate(tmp_path / "out", spec_only=True)
+        assert any(
+            "max_runs" in r.message and "10" in r.message
+            for r in caplog.records
+        )
+
+
 class TestCampaignGeneratorMaxRuns:
     """Test 8: max_runs limits generation count."""
 


### PR DESCRIPTION
## Summary

Implements #511 — parametric sweep mechanism for OrcaFlex `CampaignMatrix`/`CampaignGenerator` plus `spec_only` emission mode. 8 atomic TDD slices + 1 review-fix commit. Closes #511.

## What's new

### Schema (`schema/campaign.py` + new `schema/_overrides.py`)

- **`ParameterSweep`** Pydantic model: `parameter` (dotted path), `values` (list[Any]), optional `alias` (short template name)
- **`apply_dotted_override(spec, dotted, value)`**: Pydantic-aware override via `model_dump → mutate → model_validate` round-trip. Bounds-checked list-index support (`pipeline.segments.0.length`), strict missing-key detection.
- **`CampaignMatrix.sweeps`** field — cross-multiplies into `combinations()` cartesian product
- **`water_depths` is now optional** (was `Field(..., min_length=1)`); model validator enforces "at least one axis populated"
- **Sweep + alias shadowing guard**: rejects sweeps whose `parameter` or `alias` shadows typed-axis combo keys
- **Output-naming alias/slug resolution**: aliases promoted to typed-axis-equivalent strictness; alias-less sweeps get auto-slug fallback (`environment.waves.trains.0.height` → `environment-waves-trains-0-height`)

### Generator (`schema/campaign.py` `CampaignGenerator.generate`)

- **`spec_only: bool = False`** — emits per-run `spec.yml` only (no `master.yml`/`includes/`); resume sentinel switches accordingly
- **`manifest.yml`** at output_dir top level mapping run name → combo parameters
- **Preflight warning** when combo count exceeds `max_runs` or 100 (no `max_runs`)
- **`CampaignResult.manifest_path`** field populated in spec_only mode

### CLI (`cli.py` `cmd_campaign`)

- `--spec-only` flag plumbs through to generator
- Preview block shows sweep axis count alongside typed axes; `water_depths` part is now conditional

## Decision rationale (user-locked)

- **A1 (LHS scope):** `Literal["full_factorial"]` only. No LHS/OAAT in v1 — defer to follow-up if a real use case emerges. OrcaWave sibling `parametric_spec_generator.py` has no sampler; no examples request LHS.
- **B1 (`water_depths` optionality):** required → optional, with `_validate_axes` enforcing the at-least-one-axis invariant. Enables sweep-only campaigns as a first-class v1 feature.
- **C1 (`manifest.yml` scope):** in scope. Downstream post-processing benefits from a stable `run_NNN → combo` index without re-parsing per-run spec.yml files.

## Path 1 design deviation (TDD-surfaced, user-approved)

Slice 2's first GREEN attempt revealed: `Waves` model uses a `@model_validator` + `@property` compatibility shim. Input shape `{height: 1.0}` is auto-wrapped into `{trains: [{height: 1.0}]}` during validation; `model_dump()` produces only the canonical shape. Setting `environment.waves.height` on the dumped dict silently no-ops (Pydantic v2 default `extra="ignore"` discards the unknown top-level key).

**Resolution:** users write **canonical dumped-shape paths** like `environment.waves.trains.0.height`. `_set_nested_safe` gained bounds-checked integer-segment support (`trains.0` → `list[0]`). Full path slug is the auto-fallback when no alias.

This generalizes to any model with a Pydantic compat shim — not a one-off `Waves` workaround. See Slice 2 commit body for full discussion.

## Test deltas

| Layer | Before | After | Delta |
|---|---|---|---|
| `tests/solvers/orcaflex/modular_generator/schema/` | 57 | 79 | **+22** |
| `tests/solvers/orcaflex/modular_generator/` (incl. above) | 91 | 122 | **+31** |
| Full `tests/solvers/orcaflex/` (vs #510 baseline) | 966 P / 10 F / 154 S / 3 E | 997 P / 10 F / 154 S / 3 E | **+31 P, 0 new F** |

All 10 pre-existing failures + 3 errors are unchanged (documented in #510 PR #532 commit body). Zero regressions introduced by #511.

## Code review

Independent review (`pr-review-toolkit:code-reviewer`) found 1 MAJOR + 2 verified MINOR before merge — all fixed in commit `1d96aa63`:
- **M2 silent typo absorption** in `_set_nested_safe` — terminal-key existence check added
- **m1 alias shadowing** typed-axis combo key — guard extended to cover `sweep.alias`
- **m4 `validate()` crash** on dotted combo keys — `_resolve_combo_for_naming` applied symmetrically with `generate()`

4 lower-priority MINOR findings deferred to follow-up issues if desired (perf, error-chaining, `next()` defensive guard, manifest-empty-run docstring nit).

## Test plan

- [x] Slice-by-slice TDD with RED→GREEN verification per atomic commit
- [x] Schema suite: 79 passed (was 57 baseline)
- [x] modular_generator suite: 615+ passed (3 pre-existing failures unchanged)
- [x] Full `tests/solvers/orcaflex/` regression: 997/10/154/3 — zero new failures vs #510 baseline
- [x] Independent code review applied; 3 verified findings fixed
- [x] Backward compat verified: pre-#511 campaign YAML loads + generates unchanged
- [x] R2 hazard fixed: `str.format(**combo)` no longer crashes on dotted combo keys
- [x] R8 hazard verified non-issue: stdlib `yaml.safe_load` tolerates UTF-8 BOM as leading whitespace; no encoding fallback needed

## Artifacts (workspace-hub)

- Plan: [`docs/plans/2026-04-24-issue-511-orcaflex-campaign-spec-generation.md`](https://github.com/vamseeachanta/workspace-hub/blob/main/docs/plans/2026-04-24-issue-511-orcaflex-campaign-spec-generation.md)
- Phase 2 architecture blueprint: [`docs/plans/2026-04-24-issue-511-blueprint-phase2.md`](https://github.com/vamseeachanta/workspace-hub/blob/main/docs/plans/2026-04-24-issue-511-blueprint-phase2.md)
- Adversarial review (R3): [`scripts/review/results/2026-04-24-plan-511-adversarial.md`](https://github.com/vamseeachanta/workspace-hub/blob/main/scripts/review/results/2026-04-24-plan-511-adversarial.md)
- Execution handoff: [`docs/handoffs/2026-04-24-orcaflex-wave-a-issue-511-handoff.md`](https://github.com/vamseeachanta/workspace-hub/blob/main/docs/handoffs/2026-04-24-orcaflex-wave-a-issue-511-handoff.md)

Closes #511.