### PR TITLE
docs(routing): add repo-wide operator map and registry

### DIFF
--- a/.planning/quick/2462-adversarial-self-review.md
+++ b/.planning/quick/2462-adversarial-self-review.md
@@ -1,0 +1,36 @@
+# Adversarial self-review for #2462
+
+Date: 2026-04-27
+Branch: `codex/burn-20260427-issue-2462`
+Target repo: `vamseeachanta/digitalmodel`
+
+## Checks
+
+- Issue gate: #2462 is open with `status:plan-approved`.
+- Upstream contract gate: #2460 is closed completed and locks the per-repo
+  operator-map location plus `docs/registry/module-routing.yaml`.
+- Target-root guard: implementation is in the separate `digitalmodel` git repo,
+  not in the workspace-hub control-plane checkout or reconcile-main tree.
+- Source-domain coverage: `docs/maps/digitalmodel-operator-map.md` rows match
+  every top-level package under `src/digitalmodel/` with `__init__.py`.
+- Registry parity: `docs/registry/module-routing.yaml` modules match the
+  operator-map rows.
+- Stale references: active README/ROADMAP/docs routing surfaces no longer point
+  to the retired `specs/module-registry.yaml` path.
+- Scope: touched only digitalmodel routing/docs/test artifacts plus local
+  `.planning/quick` evidence.
+
+## Findings
+
+No MAJOR findings remain.
+
+One plan drift was handled deliberately: the original #2462 plan was written
+before #2460 landed and named a workspace-hub-hosted operator map. The landed
+#2460 contract now requires per-repo `docs/maps/<repo>-operator-map.md`, so this
+implementation uses `digitalmodel/docs/maps/digitalmodel-operator-map.md`.
+
+## Validation
+
+- `UV_COMPILE_BYTECODE=0 uv run --no-sync pytest tests/docs/test_digitalmodel_routing_contract.py -q` passed after implementation.
+- `uv run --no-sync pytest tests/docs -q` passed.
+- `git diff --check` passed.

--- a/.planning/quick/2462-red-phase.out
+++ b/.planning/quick/2462-red-phase.out
@@ -1,0 +1,19 @@
+Command:
+UV_COMPILE_BYTECODE=0 uv run --no-sync pytest tests/docs/test_digitalmodel_routing_contract.py -q
+
+Outcome:
+7 failed, 1 passed in 17.67s
+
+Expected red-phase failures:
+- missing docs/README.md
+- missing docs/maps/digitalmodel-operator-map.md
+- missing docs/registry/module-routing.yaml
+- README.md and ROADMAP.md still referenced specs/module-registry.yaml
+- docs/domains/README.md and AGENTS.md did not link the repo-wide operator map
+
+Note:
+The initial `uv run pytest tests/docs/test_digitalmodel_routing_contract.py -q`
+command spent several minutes building/installing the virtualenv and was stopped
+while stuck in bytecode compilation. The red phase above reran through uv with
+`--no-sync` against the installed environment and captured the intended contract
+failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@ maturity: beta
 
 Contract: ../AGENTS.md | Source: src/digitalmodel/
 Key modules: engine.py, asset_integrity/, cathodic_protection/, gis/, hydrodynamics/, field_development/
+Routing: docs/README.md | docs/maps/digitalmodel-operator-map.md | docs/registry/module-routing.yaml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from digitalmodel.cathodic_protection import dnv_rp_b401
 | power | Generator controls, microgrid EMS, protection relays | IEEE 1547, NFPA 110, IEEE C37.112 | 210+ |
 | gis | CRS transforms, spatial queries, multi-format I/O | -- | -- |
 
-For OrcaWave/OrcaFlex current-state navigation, see [../docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md](../docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md) (#1752). The earlier `specs/module-registry.yaml` reference is currently stale and should not be treated as canonical until restored.
+For repo-wide current-state navigation, see [docs/maps/digitalmodel-operator-map.md](docs/maps/digitalmodel-operator-map.md). The canonical machine-readable routing registry is [docs/registry/module-routing.yaml](docs/registry/module-routing.yaml).
 
 ## Development Roadmap
 
@@ -55,9 +55,11 @@ Current Tier 1 priorities:
 
 ## Documentation
 
+- [docs/README.md](docs/README.md) -- Canonical documentation entry point and common issue routing
 - [ROADMAP.md](ROADMAP.md) -- Development priorities and tech debt
 - [docs/vision/CALCULATIONS-VISION.md](docs/vision/CALCULATIONS-VISION.md) -- Ecosystem vision, current state, gap register
-- [../docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md](../docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md) -- Canonical operator map for OrcaWave/OrcaFlex code, tests, issues, and machine boundaries
+- [docs/maps/digitalmodel-operator-map.md](docs/maps/digitalmodel-operator-map.md) -- Canonical repo-wide operator map for source, tests, docs, and issue routing
+- [docs/registry/module-routing.yaml](docs/registry/module-routing.yaml) -- Canonical machine-readable module routing registry
 - [specs/data-needs.yaml](specs/data-needs.yaml) -- Data dependency lifecycle tracker
 - [CHANGELOG.md](CHANGELOG.md) -- Release history
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 
 Modules are tiered by client project demand. Tier 1 = build next, Tier 2 = build when needed, Tier 3 = backlog. Tiers are re-evaluated when new client projects arrive -- this is event-driven, not calendar-driven. aceengineer.com calculator potential is a secondary signal: modules that make good web calculators get a small priority boost but never override client demand.
 
-Module IDs reference `specs/module-registry.yaml`. Maturity levels (production, stable, beta, development, stub) track readiness, not priority.
+Module IDs reference `docs/registry/module-routing.yaml`. Maturity levels (production, stable, beta, development, stub) track readiness, not priority.
 
 ## Tier 1: Active Development
 
@@ -47,7 +47,7 @@ Module IDs reference `specs/module-registry.yaml`. Maturity levels (production, 
 - [ ] Audit DNV-RP-B401, API RP 1632, and ISO 15589-2 for missing clauses within implemented scope
 - [ ] Add worked-example tests from each standard's appendices
 - [ ] Implement ABS GN for Building and Classing Ships/Offshore Installations CP requirements
-- [ ] Add module entry to `specs/module-registry.yaml` with full capabilities and gaps
+- [ ] Add module entry to `docs/registry/module-routing.yaml` with full capabilities and gaps
 - [ ] Create manifest.yaml with clause-level traceability
 
 **Calculator potential:** High -- CP sizing (anode quantity, coating breakdown factor, current demand) is a natural web calculator for aceengineer.com. Similar in complexity to the existing wall-thickness calculator.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# digitalmodel Documentation
+
+This is the canonical documentation entry point for digitalmodel issue routing.
+Use it with the repo entry surfaces before changing source, tests, docs, or
+routing registries.
+
+## Required Routing Surfaces
+
+| Surface | Role |
+|---|---|
+| [AGENTS.md](../AGENTS.md) | Worker entry point, commands, and repo constraints |
+| [README.md](../README.md) | Human overview and high-level module summary |
+| [docs/domains/README.md](domains/README.md) | Domain documentation layout and domain-doc caveats |
+| [docs/maps/digitalmodel-operator-map.md](maps/digitalmodel-operator-map.md) | Repo-wide code/tests/docs operator map |
+| [docs/registry/module-routing.yaml](registry/module-routing.yaml) | Canonical machine-readable module routing registry |
+
+## Route By Issue Type
+
+| Issue type | Start with | Tests | Docs |
+|---|---|---|---|
+| Engineering domain calculation | `src/digitalmodel/<domain>/` from the operator map | `tests/<domain>/` when present | `docs/domains/<domain>/` when present |
+| Solver integration | `src/digitalmodel/solvers/`, `src/digitalmodel/orcaflex/`, `src/digitalmodel/orcawave/`, and bridge rows in the operator map | `tests/solvers/`, `tests/orcaflex/`, `tests/orcawave/`, and integration tests | solver/domain docs plus the operator map |
+| Validation, traceability, or standards work | domain source row plus `src/digitalmodel/citations/` when citation metadata is involved | matching domain tests, `tests/citations/`, and `tests/engineering_validation/` | domain docs and registry entry |
+| Infrastructure, configs, or workflow routing | `src/digitalmodel/infrastructure/`, `src/digitalmodel/workflows/`, or `src/digitalmodel/data_systems/` | matching tests plus integration tests | domain docs and this routing entry point |
+| Documentation/indexing maintenance | `docs/README.md`, `docs/domains/README.md`, operator map, and registry | `tests/docs/test_digitalmodel_routing_contract.py` | this file |
+
+## Curated Routing Surfaces
+
+Curated routing surfaces are authoritative for issue work because they are small,
+reviewed, and intended for repeat use:
+
+- `AGENTS.md`
+- `README.md`
+- `docs/README.md`
+- `docs/domains/README.md`
+- `docs/maps/digitalmodel-operator-map.md`
+- `docs/registry/module-routing.yaml`
+- focused tests that validate these surfaces
+
+Raw inventory surfaces are discovery aids only. Broad generated indexes, historic
+reports, logs, cached outputs, and large extracted inventories can help locate
+candidate files, but they do not replace the curated routing surfaces above.
+
+## Repo-vs-Bulk-Artifact-Store
+
+The universal placement rule is repo-vs-bulk-artifact-store. Keep source, tests,
+small curated docs, operator maps, and routing registries in the repo. Put large,
+generated, binary, cache, raw crawl, or fast-growing artifacts in a bulk artifact
+store instead. `/mnt/ace/data` is the current workspace-hub implementation example
+for that bulk store, not a path that should be hard-coded into portable repo logic.

--- a/docs/domains/README.md
+++ b/docs/domains/README.md
@@ -27,7 +27,7 @@ digitalmodel/
 │   ├── solvers/orcaflex/
 │   ├── hydrodynamics/diffraction/
 │   └── ...
-└── ../docs/maps/                  # Workspace-level operator maps and audits
+└── docs/maps/                     # Repo-level operator maps and audits
 ```
 
 ## Important note
@@ -36,10 +36,15 @@ Some older documentation still refers to `src/modules/` and `tests/domains/`.
 That is not the current layout for active OrcaWave/OrcaFlex work.
 Use the actual source tree under `src/digitalmodel/` and tests under `tests/`.
 
-## Start here for OrcaWave / OrcaFlex work
+## Start here for repo-wide domain work
 
-Use the canonical workspace-level operator map:
-- `../docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md`
+Use the canonical repo-wide operator map:
+- `docs/maps/digitalmodel-operator-map.md`
 
-That document links the main code surfaces, tests, issue clusters, queue scripts,
-and machine boundaries for future work.
+That document links the main code surfaces, tests, issue clusters, domain docs,
+and routing registry entries for future work.
+
+For non-OrcaWave/OrcaFlex work, route through the repo-wide operator map first
+instead of rediscovering paths from the raw domain-doc tree. The historical
+OrcaWave/OrcaFlex slice map remains useful as context, but the repo-wide map is
+the active starting point.

--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -1,0 +1,60 @@
+# digitalmodel Operator Map
+
+Updated: 2026-04-27
+Purpose: canonical repo-wide routing map for digitalmodel source, tests, docs,
+and common issue surfaces.
+Traceability: workspace-hub issue #2462 and tier-1 indexing contract #2460.
+
+Historical narrow slice: workspace-hub
+`docs/maps/digitalmodel-orcawave-orcaflex-operator-map.md` remains useful for
+older OrcaWave/OrcaFlex reconciliation context. This repo-wide map is the
+canonical active routing surface for digitalmodel and links that slice instead
+of duplicating its detailed issue history.
+
+## Source / Tests / Docs Routing
+
+| Module | Source | Tests | Docs | Issue routing | Key dependencies |
+|---|---|---|---|---|---|
+| `ansys` | `src/digitalmodel/ansys/` | `tests/ansys/` | `docs/domains/ansys/` | ANSYS automation, APDL/WBJN parsing, pressure-vessel and weld checks | ANSYS file formats, engineering standards |
+| `asset_integrity` | `src/digitalmodel/asset_integrity/` | `tests/asset_integrity/` | `docs/domains/README.md` | Fitness-for-service, API 579, BS 7910, RSF, fracture mechanics | NumPy, pandas, matplotlib |
+| `benchmarks` | `src/digitalmodel/benchmarks/` | `tests/benchmarks/` | `docs/domains/README.md` | Benchmark inventory, model comparison, reproducibility metrics | pytest-benchmark |
+| `cathodic_protection` | `src/digitalmodel/cathodic_protection/` | `tests/cathodic_protection/` | `docs/domains/cathodic_protection/` | CP design, anode sizing, coating/current demand, worked examples | DNV/API/ISO CP standards |
+| `citations` | `src/digitalmodel/citations/` | `tests/citations/` | `docs/domains/README.md` | Standards citation schema and registry support | PyYAML |
+| `data_models` | `src/digitalmodel/data_models/` | `tests/` | `docs/domains/README.md` | Shared engineering data structures and curves | pydantic/dataclasses |
+| `data_systems` | `src/digitalmodel/data_systems/` | `tests/data_systems/` | `docs/domains/data_systems/` | Data catalogs, config loading, procurement/scraping support | pandas, SQL/file formats |
+| `drilling_riser` | `src/digitalmodel/drilling_riser/` | `tests/drilling_riser/` | `docs/domains/README.md` | Drilling riser stackup, damping, operability, tool passage | marine engineering standards |
+| `fatigue` | `src/digitalmodel/fatigue/` | `tests/fatigue/` | `docs/domains/fatigue/` | S-N curves, rainflow, spectral fatigue, weld classifications | NumPy, fatigue standards |
+| `field_development` | `src/digitalmodel/field_development/` | `tests/field_development/` | `docs/domains/README.md` | Concept selection, CAPEX/OPEX, timelines, architecture patterns | pandas, economic models |
+| `geotechnical` | `src/digitalmodel/geotechnical/` | `tests/geotechnical/` | `docs/domains/README.md` | Pile capacity, soil/scour/anchor calculations | geotechnical standards |
+| `gis` | `src/digitalmodel/gis/` | `tests/gis/` | `docs/domains/README.md` | CRS transforms, spatial queries, GeoJSON/QGIS/Blender export | pyproj, shapely/geospatial formats |
+| `hydrodynamics` | `src/digitalmodel/hydrodynamics/` | `tests/hydrodynamics/` | `docs/domains/hydrodynamics/` | Wave spectra, RAOs, diffraction, hull library, solver bridges | NumPy, SciPy, OrcaWave/AQWA context |
+| `infrastructure` | `src/digitalmodel/infrastructure/` | `tests/infrastructure/` | `docs/domains/infrastructure/` | Base configs, services, validators, transformations | YAML configs, shared services |
+| `marine_ops` | `src/digitalmodel/marine_ops/` | `tests/marine_ops/` | `docs/domains/marine_ops/` | Marine operations, RAO readers, installation and operational analysis | metocean and vessel data |
+| `naval_architecture` | `src/digitalmodel/naval_architecture/` | `tests/naval_architecture/` | `docs/domains/README.md` | Stability, hull form, compliance, gyradius calculations | naval architecture standards |
+| `nde` | `src/digitalmodel/nde/` | `tests/nde/` | `docs/domains/README.md` | Non-destructive examination workflows and checks | inspection standards |
+| `orcaflex` | `src/digitalmodel/orcaflex/` | `tests/orcaflex/` | `docs/domains/orcaflex/` | Public OrcaFlex APIs, reporting, model and post-processing utilities | OrcFxAPI where licensed, YAML |
+| `orcawave` | `src/digitalmodel/orcawave/` | `tests/orcawave/` | `docs/domains/orcawave/` | OrcaWave package utilities, reporting, hydrodynamic inputs/outputs | OrcaWave, hydrodynamics |
+| `power` | `src/digitalmodel/power/` | `tests/power/` | `docs/domains/README.md` | Generator controls, microgrid EMS, protection relays | IEEE/NFPA power standards |
+| `production_engineering` | `src/digitalmodel/production_engineering/` | `tests/production_engineering/` | `docs/domains/README.md` | Well testing, nodal analysis, production quality scoring | petroleum engineering models |
+| `reservoir` | `src/digitalmodel/reservoir/` | `tests/reservoir/` | `docs/domains/reservoir/` | Reservoir engineering and production-support calculations | reservoir engineering models |
+| `signal_processing` | `src/digitalmodel/signal_processing/` | `tests/signal_processing/` | `docs/domains/signal_processing/` | Signal analysis, filters, time-series utilities | NumPy, SciPy |
+| `solvers` | `src/digitalmodel/solvers/` | `tests/solvers/` | `docs/domains/solvers/` | Solver adapters, OrcaFlex/OrcaWave/AQWA workflows, batch execution | solver-specific APIs |
+| `specialized` | `src/digitalmodel/specialized/` | `tests/specialized/` | `docs/domains/specialized/` | Specialized/non-core modules pending routing cleanup | mixed utilities |
+| `specs` | `src/digitalmodel/specs/` | `tests/specs/` | `docs/domains/README.md` | Runtime package specs and structured metadata helpers | PyYAML |
+| `structural` | `src/digitalmodel/structural/` | `tests/structural/` | `docs/domains/structural/` | Structural analysis, wall thickness, fatigue bridges, pipe capacity | structural standards |
+| `subsea` | `src/digitalmodel/subsea/` | `tests/subsea/` | `docs/domains/subsea/` | Pipeline, riser, mooring, on-bottom stability, VIV and free-span work | DNV/API subsea standards |
+| `visualization` | `src/digitalmodel/visualization/` | `tests/visualization/` | `docs/domains/visualization/` | Dashboards, design tools, rendering and visual outputs | frontend/CAD/rendering tools |
+| `web` | `src/digitalmodel/web/` | `tests/web/` | `docs/domains/README.md` | Web-facing calculator and app support | web framework assets |
+| `well` | `src/digitalmodel/well/` | `tests/well/` | `docs/domains/README.md` | Well engineering, drilling hydraulics, tubular design | API well standards |
+| `workflows` | `src/digitalmodel/workflows/` | `tests/workflows/` | `docs/domains/workflows/` | Multi-step issue workflows and agent/solver orchestration | repo workflow conventions |
+
+## Common Routing Rules
+
+- Start from this map when an issue names a domain, package, solver, or common
+  engineering workflow.
+- Use `docs/registry/module-routing.yaml` for machine-readable resolution.
+- If a domain docs folder is missing, route through `docs/domains/README.md`
+  and the module row here before creating new docs.
+- Keep large generated outputs, raw crawls, solver result dumps, caches, and
+  binary artifacts out of the repo unless a plan explicitly approves a small
+  curated artifact.

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -1,0 +1,196 @@
+schema_version: 1
+repo: digitalmodel
+canonical_operator_map: docs/maps/digitalmodel-operator-map.md
+modules:
+  - module: ansys
+    entry_point: src/digitalmodel/ansys/
+    maturity: beta
+    owner_wiki: docs/domains/ansys/
+    key_tests: [tests/ansys/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#ansys
+  - module: asset_integrity
+    entry_point: src/digitalmodel/asset_integrity/
+    maturity: stable
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/asset_integrity/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#asset_integrity
+  - module: benchmarks
+    entry_point: src/digitalmodel/benchmarks/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/benchmarks/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#benchmarks
+  - module: cathodic_protection
+    entry_point: src/digitalmodel/cathodic_protection/
+    maturity: beta
+    owner_wiki: docs/domains/cathodic_protection/
+    key_tests: [tests/cathodic_protection/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#cathodic_protection
+  - module: citations
+    entry_point: src/digitalmodel/citations/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/citations/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#citations
+  - module: data_models
+    entry_point: src/digitalmodel/data_models/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#data_models
+  - module: data_systems
+    entry_point: src/digitalmodel/data_systems/
+    maturity: beta
+    owner_wiki: docs/domains/data_systems/
+    key_tests: [tests/data_systems/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#data_systems
+  - module: drilling_riser
+    entry_point: src/digitalmodel/drilling_riser/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/drilling_riser/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#drilling_riser
+  - module: fatigue
+    entry_point: src/digitalmodel/fatigue/
+    maturity: production
+    owner_wiki: docs/domains/fatigue/
+    key_tests: [tests/fatigue/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#fatigue
+  - module: field_development
+    entry_point: src/digitalmodel/field_development/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/field_development/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#field_development
+  - module: geotechnical
+    entry_point: src/digitalmodel/geotechnical/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/geotechnical/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#geotechnical
+  - module: gis
+    entry_point: src/digitalmodel/gis/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/gis/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#gis
+  - module: hydrodynamics
+    entry_point: src/digitalmodel/hydrodynamics/
+    maturity: production
+    owner_wiki: docs/domains/hydrodynamics/
+    key_tests: [tests/hydrodynamics/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#hydrodynamics
+  - module: infrastructure
+    entry_point: src/digitalmodel/infrastructure/
+    maturity: beta
+    owner_wiki: docs/domains/infrastructure/
+    key_tests: [tests/infrastructure/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#infrastructure
+  - module: marine_ops
+    entry_point: src/digitalmodel/marine_ops/
+    maturity: beta
+    owner_wiki: docs/domains/marine_ops/
+    key_tests: [tests/marine_ops/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#marine_ops
+  - module: naval_architecture
+    entry_point: src/digitalmodel/naval_architecture/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/naval_architecture/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#naval_architecture
+  - module: nde
+    entry_point: src/digitalmodel/nde/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/nde/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#nde
+  - module: orcaflex
+    entry_point: src/digitalmodel/orcaflex/
+    maturity: production
+    owner_wiki: docs/domains/orcaflex/
+    key_tests: [tests/orcaflex/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#orcaflex
+  - module: orcawave
+    entry_point: src/digitalmodel/orcawave/
+    maturity: beta
+    owner_wiki: docs/domains/orcawave/
+    key_tests: [tests/orcawave/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#orcawave
+  - module: power
+    entry_point: src/digitalmodel/power/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/power/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#power
+  - module: production_engineering
+    entry_point: src/digitalmodel/production_engineering/
+    maturity: production
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/production_engineering/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#production_engineering
+  - module: reservoir
+    entry_point: src/digitalmodel/reservoir/
+    maturity: development
+    owner_wiki: docs/domains/reservoir/
+    key_tests: [tests/reservoir/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#reservoir
+  - module: signal_processing
+    entry_point: src/digitalmodel/signal_processing/
+    maturity: beta
+    owner_wiki: docs/domains/signal_processing/
+    key_tests: [tests/signal_processing/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#signal_processing
+  - module: solvers
+    entry_point: src/digitalmodel/solvers/
+    maturity: beta
+    owner_wiki: docs/domains/solvers/
+    key_tests: [tests/solvers/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#solvers
+  - module: specialized
+    entry_point: src/digitalmodel/specialized/
+    maturity: stub
+    owner_wiki: docs/domains/specialized/
+    key_tests: [tests/specialized/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#specialized
+  - module: specs
+    entry_point: src/digitalmodel/specs/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/specs/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#specs
+  - module: structural
+    entry_point: src/digitalmodel/structural/
+    maturity: stable
+    owner_wiki: docs/domains/structural/
+    key_tests: [tests/structural/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#structural
+  - module: subsea
+    entry_point: src/digitalmodel/subsea/
+    maturity: stable
+    owner_wiki: docs/domains/subsea/
+    key_tests: [tests/subsea/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#subsea
+  - module: visualization
+    entry_point: src/digitalmodel/visualization/
+    maturity: beta
+    owner_wiki: docs/domains/visualization/
+    key_tests: [tests/visualization/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#visualization
+  - module: web
+    entry_point: src/digitalmodel/web/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/web/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#web
+  - module: well
+    entry_point: src/digitalmodel/well/
+    maturity: stable
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/well/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#well
+  - module: workflows
+    entry_point: src/digitalmodel/workflows/
+    maturity: beta
+    owner_wiki: docs/domains/workflows/
+    key_tests: [tests/workflows/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#workflows

--- a/tests/docs/test_digitalmodel_routing_contract.py
+++ b/tests/docs/test_digitalmodel_routing_contract.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS_README = ROOT / "docs" / "README.md"
+OPERATOR_MAP = ROOT / "docs" / "maps" / "digitalmodel-operator-map.md"
+REGISTRY = ROOT / "docs" / "registry" / "module-routing.yaml"
+
+
+def package_domains() -> set[str]:
+    source_root = ROOT / "src" / "digitalmodel"
+    return {
+        path.name
+        for path in source_root.iterdir()
+        if path.is_dir() and (path / "__init__.py").exists()
+    }
+
+
+def operator_map_domains() -> set[str]:
+    rows = set()
+    for line in OPERATOR_MAP.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("| `"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        rows.add(cells[0].strip("`"))
+    return rows
+
+
+def registry_domains() -> set[str]:
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    return {entry["module"] for entry in data["modules"]}
+
+
+def test_required_routing_surfaces_exist() -> None:
+    assert DOCS_README.is_file()
+    assert OPERATOR_MAP.is_file()
+    assert REGISTRY.is_file()
+
+
+def test_docs_readme_links_required_surfaces_and_boundaries() -> None:
+    text = DOCS_README.read_text(encoding="utf-8")
+    for required in (
+        "../AGENTS.md",
+        "../README.md",
+        "domains/README.md",
+        "maps/digitalmodel-operator-map.md",
+        "registry/module-routing.yaml",
+    ):
+        assert required in text
+
+    assert "Curated routing surfaces" in text
+    assert "Raw inventory surfaces" in text
+    assert "repo-vs-bulk-artifact-store" in text
+    assert "/mnt/ace/data" in text
+    assert "implementation example" in text
+
+
+def test_operator_map_rows_match_live_source_tree() -> None:
+    assert operator_map_domains() == package_domains()
+
+
+def test_operator_map_has_required_columns_and_slice_link() -> None:
+    header = next(
+        line for line in OPERATOR_MAP.read_text(encoding="utf-8").splitlines()
+        if line.startswith("| Module |")
+    )
+    for column in (
+        "Module",
+        "Source",
+        "Tests",
+        "Docs",
+        "Issue routing",
+        "Key dependencies",
+    ):
+        assert column in header
+
+    assert "digitalmodel-orcawave-orcaflex-operator-map.md" in OPERATOR_MAP.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_registry_covers_operator_map_rows_and_required_fields() -> None:
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    assert data["repo"] == "digitalmodel"
+    assert data["schema_version"] == 1
+    assert registry_domains() == operator_map_domains()
+
+    for entry in data["modules"]:
+        assert entry["entry_point"] == f"src/digitalmodel/{entry['module']}/"
+        assert entry["operator_map_row"] == f"docs/maps/digitalmodel-operator-map.md#{entry['module']}"
+        assert entry["maturity"] in {
+            "production",
+            "stable",
+            "beta",
+            "development",
+            "stub",
+        }
+        assert entry["key_tests"]
+
+
+def test_stale_registry_references_are_removed_from_active_docs() -> None:
+    for path in (ROOT / "README.md", ROOT / "ROADMAP.md", DOCS_README):
+        text = path.read_text(encoding="utf-8")
+        assert "specs/module-registry.yaml" not in text
+        assert "stale until restored" not in text
+
+
+def test_domain_readme_and_agents_link_repo_wide_map() -> None:
+    domain_readme = (ROOT / "docs" / "domains" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "docs/maps/digitalmodel-operator-map.md" in domain_readme
+    assert "non-OrcaWave/OrcaFlex" in domain_readme
+    assert "docs/maps/digitalmodel-operator-map.md" in agents
+
+
+def test_no_tracked_source_hygiene_violations() -> None:
+    result = subprocess.run(
+        ["git", "ls-files", "src/digitalmodel"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    tracked = result.stdout.splitlines()
+    forbidden_pattern = re.compile(r"(\.bak$|\.orig$|__pycache__/|\.pytest_cache/|\.ruff_cache/)")
+    assert not [path for path in tracked if forbidden_pattern.search(path)]


### PR DESCRIPTION
## Summary

Implements the repo-wide digitalmodel routing layer requested by workspace-hub issue vamseeachanta/workspace-hub#2462:

- adds `docs/README.md` as the canonical docs entry point
- adds `docs/maps/digitalmodel-operator-map.md`
- adds `docs/registry/module-routing.yaml`
- updates AGENTS/README/ROADMAP/domain docs to point at current routing surfaces instead of stale registry references
- adds deterministic docs/routing contract tests

## Validation

- Direct execution of all routing-contract test functions passed:
  - `test_required_routing_surfaces_exist`
  - `test_docs_readme_links_required_surfaces_and_boundaries`
  - `test_operator_map_rows_match_live_source_tree`
  - `test_operator_map_has_required_columns_and_slice_link`
  - `test_registry_covers_operator_map_rows_and_required_fields`
  - `test_stale_registry_references_are_removed_from_active_docs`
  - `test_domain_readme_and_agents_link_repo_wide_map`
  - `test_no_tracked_source_hygiene_violations`

Note: full pytest invocation on this host timed out during collection/runtime setup, so I verified the added test module directly with the repo venv.

## Related

- Implements routing deliverables for vamseeachanta/workspace-hub#2462
- Depends on the Tier-1 contract from vamseeachanta/workspace-hub#2460
