### PR TITLE
docs(naval): point B1528 SIROCCO outputs to acma-projects

### DIFF
--- a/docs/domains/marine-engineering/b1528-sirocco-time-trace-report.md
+++ b/docs/domains/marine-engineering/b1528-sirocco-time-trace-report.md
@@ -40,7 +40,7 @@ The Nomoto coefficients are marked as assumptions for source-gap sensitivity rep
 
 ## Generated outputs
 
-Default output directory: `outputs/b1528_sirocco/time_trace/`
+Default output directory: `../acma-projects/B1528/yaw-and-time-trace/time_trace/` (project-specific outputs are owned by `acma-projects`, not `digitalmodel`).
 
 - `b1528_sirocco_time_trace_results.csv`
 - `b1528_sirocco_time_trace_results.json`

--- a/docs/domains/marine-engineering/b1528-sirocco-yaw-moment-report.md
+++ b/docs/domains/marine-engineering/b1528-sirocco-yaw-moment-report.md
@@ -3,10 +3,12 @@
 This document records the durable report contract for issue #2570. The generated interactive report is produced by:
 
 ```bash
+# Project-specific outputs land in acma-projects/B1528/yaw-and-time-trace/.
+# Adjust the path to your local acma-projects checkout.
 UV_NO_SYNC=1 PYTHONPATH=src uv run --with pyyaml --with plotly python - <<'PY'
 from digitalmodel.naval_architecture.b1528_sirocco_yaw_report import load_packaged_b1528_yaw_config, run_b1528_static_yaw_report, write_b1528_static_yaw_report
 result = run_b1528_static_yaw_report(load_packaged_b1528_yaw_config())
-print(write_b1528_static_yaw_report(result, 'outputs/b1528_sirocco'))
+print(write_b1528_static_yaw_report(result, '../acma-projects/B1528/yaw-and-time-trace'))
 PY
 ```
 

--- a/src/digitalmodel/naval_architecture/data/b1528_sirocco_time_trace.yml
+++ b/src/digitalmodel/naval_architecture/data/b1528_sirocco_time_trace.yml
@@ -34,7 +34,8 @@ benchmark:
   comparison_mode: source_gap_panel
   notes: VDR/Rosepoint points have heading/SOG narrative anchors but no x/y coordinates and include tug/current/anchor effects.
 outputs:
-  directory: outputs/b1528_sirocco/time_trace
+  directory: ../acma-projects/B1528/yaw-and-time-trace/time_trace
+  directory_note: project-specific outputs live in acma-projects; caller passes output_dir explicitly
 limitations:
   - source-gap sensitivity mode; Nomoto K/T are assumptions, not B1528 calibration evidence
   - preliminary first-order Nomoto time trace only

--- a/src/digitalmodel/naval_architecture/data/b1528_sirocco_yaw_moment.yml
+++ b/src/digitalmodel/naval_architecture/data/b1528_sirocco_yaw_moment.yml
@@ -36,10 +36,12 @@ sweep:
 environment:
   rho_kg_m3: 1025.0
 outputs:
-  directory: outputs/b1528_sirocco
+  directory: ../acma-projects/B1528/yaw-and-time-trace
+  directory_note: project-specific outputs live in acma-projects; caller passes output_dir explicitly
   report_basename: b1528_sirocco_yaw_moment_report
 limitations:
   - preliminary static rudder-induced yaw moment only
   - not a full MMG simulation
+  - not an incident reconstruction
   - not an IMO compliance assessment
   - no class compliance conclusion


### PR DESCRIPTION
## Summary

- Project-specific outputs for B1528 SIROCCO (workspace-hub #2569 / #2570 / #2571) are owned by `acma-projects`, not `digitalmodel`. The reusable engine (`src/`, `tests/`, packaged YAML, domain doc) stays here; the published CSV/JSON/HTML/MD deliverables now live at `acma-projects/B1528/yaw-and-time-trace/` (committed as `vamseeachanta/acma-projects@30d0860b`).
- Packaged YAML defaults retarget to `../acma-projects/B1528/yaw-and-time-trace/` (informational; the writer functions take `output_dir` as a parameter, so callers can override).
- Domain docs (`b1528-sirocco-{yaw-moment,time-trace}-report.md`) update smoke-generation invocation paths to land outputs in the project repo.
- `b1528_sirocco_yaw_moment.yml` limitations gain `not an incident reconstruction` for caveat consistency with the markdown report and provenance JSON.

No source-code changes. Anchor values `+112.158527` and `-98.467815 kN-m` remain pytest-locked in `tests/naval_architecture/`.

## Test plan

- [ ] `pytest tests/naval_architecture/test_b1528_sirocco_yaw_moment.py tests/naval_architecture/test_b1528_sirocco_time_trace.py` passes (no behavioral changes; YAML/doc only)
- [ ] Smoke regen against the new acma-projects path produces identical CSVs to `vamseeachanta/acma-projects@30d0860b:B1528/yaw-and-time-trace/`
- [ ] Companion PR or follow-up issue tracks `tactical_diameter_m` -> `tactical_diameter_proxy_m` rename in `b1528_sirocco_time_trace.py:285` (Codex MINOR, deferred)