### PR TITLE
fix(#2580): vendor citations wiki fixtures to decouple from workspace-hub root

### DIFF
--- a/tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md
@@ -1,0 +1,38 @@
+---
+title: "DNV-OS-E301 — Position Mooring"
+code_id: DNV-OS-E301
+publisher: DNV
+revision: 2021-07
+tags: [standard, dnv, mooring, position-mooring, infragravity, nearshore, fsru]
+sources:
+  - mooring-failures-seed
+  - skills-metadata
+added: 2026-04-09
+last_updated: 2026-04-24
+---
+
+# DNV-OS-E301 — Position Mooring
+
+DNV-OS-E301 (Edition July 2021) covers position mooring systems for all floating offshore units. Defines wave frequency motion (first-order wave loads) and low-frequency motion (horizontal resonant oscillatory motion induced by oscillatory wind and second-order wave loads).
+
+## Key Content
+
+- **Infragravity waves**: Explicitly recognizes periods of 20s to several minutes on low-sloping seabeds as relevant to mooring design
+- **Low-frequency motion**: Second-order wave loads drive resonant horizontal oscillation
+- **Fatigue assessment**: Section 7 covers mooring line fatigue using T-N curves and design fatigue factors (DFF)
+- **Dynamic amplification**: Mooring line damping from drag can dominate total system damping for catenary systems
+
+## OTG-18: Nearshore Gap
+
+DNV acknowledged existing rules did not fully address nearshore mooring. This led to DNV Offshore Technical Guidance OTG-18 for long-term nearshore positional mooring, specifically addressing FSRUs, FLNGs, and floating storage units in shallow water at jetties/quayside.
+
+## API RP 2SK 4th Edition (2024) Alignment
+
+API RP 2SK critical finding: mean wave drift forces and low-frequency vessel motions increase with decreasing wave period — the N-year return period wave condition may **not** yield the most onerous mooring response.
+
+## Cross-References
+
+- **Related concept**: [Mooring Line Failure Physics](../concepts/mooring-line-failure-physics.md)
+- **Related entity**: [Mooring Analysis System](../entities/mooring-analysis-system.md)
+- **Related standard**: [OCIMF MEG4](../standards/ocimf-meg4.md)
+- **Related standard**: [DNV-RP-C205](../standards/dnv-rp-c205.md)

--- a/tests/citations/test_registry.py
+++ b/tests/citations/test_registry.py
@@ -16,11 +16,11 @@ from digitalmodel.citations.registry import (
 
 
 def _repo_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "knowledge" / "wikis").is_dir():
-            return parent
-    raise RuntimeError("could not locate workspace-hub root above test file")
+    # Option B (workspace-hub #2580): vendor wiki fixtures into the test tree so
+    # the citation resolver works regardless of how digitalmodel is checked out
+    # (workspace-hub overlay vs. standalone CI clone). The fixture tree mirrors
+    # the resolver's expected `knowledge/wikis/...` subpath bit-for-bit.
+    return Path(__file__).resolve().parent / "fixtures"
 
 
 def test_intact_quasi_static_factor_emits_cited_value():

--- a/tests/citations/test_schema.py
+++ b/tests/citations/test_schema.py
@@ -22,11 +22,11 @@ REAL_DNV_PAGE = "knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md"
 
 
 def _repo_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "knowledge" / "wikis").is_dir():
-            return parent
-    raise RuntimeError("could not locate workspace-hub root above test file")
+    # Option B (workspace-hub #2580): vendor wiki fixtures into the test tree so
+    # the citation resolver works regardless of how digitalmodel is checked out
+    # (workspace-hub overlay vs. standalone CI clone). The fixture tree mirrors
+    # the resolver's expected `knowledge/wikis/...` subpath bit-for-bit.
+    return Path(__file__).resolve().parent / "fixtures"
 
 
 def _valid_kwargs(**overrides):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,10 +40,6 @@ collect_ignore = [
     # CP tests fail intermittently with random ordering (shared state issue)
     str(_tests_dir / "specialized/cathodic_protection/test_abs_ship_variants_wrk271.py"),
     str(_tests_dir / "specialized/cathodic_protection/test_cathodic_protection_b401.py"),
-    # Citations tests assume workspace-hub root above digitalmodel (knowledge/wikis/);
-    # CI checks out digitalmodel standalone. Tracked for proper fix in workspace-hub #2580.
-    str(_tests_dir / "citations/test_registry.py"),
-    str(_tests_dir / "citations/test_schema.py"),
     # yml_utilities_additional uses capsys fixture which is unavailable under
     # pytest-xdist worker mode (worker_id fixture loaded but capsys/capfd are not).
     # Tracked for proper fix in workspace-hub #2580.


### PR DESCRIPTION
## Summary
- Vendor `knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md` into `tests/citations/fixtures/` so the citation resolver works regardless of how digitalmodel is checked out (workspace-hub overlay vs. standalone CI clone).
- Update `_repo_root()` in `tests/citations/test_registry.py` and `tests/citations/test_schema.py` to point at the fixtures dir (no parent-walk).
- Remove the citations entries from `tests/conftest.py:collect_ignore` so the suite runs.

Implements **Option B** from workspace-hub#2580. yml_utilities_additional capsys/xdist (Option A) is intentionally left as a separate follow-up — it requires a source-code refactor.

## Why Option B
- **concrete** — tests own their fixture, no external state
- **bit-exact** — the vendored copy pins the exact frontmatter the tests assert on (`code_id=DNV-OS-E301`, `publisher=DNV`, `revision=2021-07`)
- **decoupled** — works under workspace-hub overlay, standalone clone, and CI

The fixture tree mirrors the resolver's expected `knowledge/wikis/...` subpath bit-for-bit, so `src/digitalmodel/citations/schema.py:validate_citation()` needs **no** source changes — it still does `repo_root / wiki_path`.

## Test plan
- [x] `UV_NO_SYNC=1 uv run --with seaborn python -m pytest -x -q tests/citations/` -> **14 passed in 1.25s**
- [ ] CI Quality Gates (running)
- [ ] Confirm `tests/citations/test_registry.py` and `tests/citations/test_schema.py` are no longer skipped on CI
- [ ] Spot-check `test_resolution_fails_on_missing_page` (uses `does-not-exist.md`) and `test_registry_with_broken_repo_root_fails_closed` (uses `tmp_path`) — both unaffected by fixture tree

## Out of scope
- yml_utilities_additional capsys/xdist — separate follow-up issue/PR
- Migration to MCP `wiki_search` resolver — tracked by workspace-hub#2400; schema is forward-compatible

Refs: workspace-hub#2580, workspace-hub#2481 (citation contract)