### PR TITLE
docs(citations): add FIXTURE_PROVENANCE.md for vendored DNV-OS-E301 (#2580 followup)

### DIFF
--- a/tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/FIXTURE_PROVENANCE.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/FIXTURE_PROVENANCE.md
@@ -1,0 +1,53 @@
+# Fixture Provenance — `dnv-os-e301.md`
+
+This directory contains a vendored copy of a wiki page from the workspace-hub
+knowledge base. The vendored copy lets digitalmodel's citation tests
+(`tests/citations/test_registry.py`, `tests/citations/test_schema.py`) pass on
+a standalone digitalmodel CI checkout without requiring `knowledge/wikis/`
+from workspace-hub. See workspace-hub issue
+[#2580](https://github.com/vamseeachanta/workspace-hub/issues/2580) Defect 1
+and the merged implementation in digitalmodel
+[PR #542](https://github.com/vamseeachanta/digitalmodel/pull/542).
+
+## Canonical source
+
+- **Repo:** `vamseeachanta/workspace-hub`
+- **Path:** `knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md`
+- **Canonical SHA at vendoring time:** `bd11f33bfb358aec233ebaaf7da1c11479117575`
+  (last commit touching the canonical file in workspace-hub as of vendoring)
+
+## Vendored copy
+
+- **Path in this repo:** `tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md`
+- **Vendored on:** 2026-05-02 (digitalmodel commit `b1346acb`, PR #542 merge)
+- **Provenance pinned by:** workspace-hub commit landing this file.
+
+## Freshness contract
+
+Per the workspace-hub plan
+`docs/plans/2026-05-02-issue-2580-digitalmodel-collect-ignore-test-fixes.md`
+(r2 "Fixture Freshness — Mechanism A"):
+
+1. **Cadence:** review monthly. Next review: **2026-06-02**.
+2. **Procedure:** compare the vendored copy against the canonical workspace-hub
+   path:
+   ```bash
+   diff -u \
+     <workspace-hub>/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md \
+     tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md
+   ```
+3. **If diverged:** re-vendor by copying the canonical file over the vendored
+   copy, then update the *Canonical SHA at vendoring time* and *Vendored on*
+   fields above. Re-run
+   `PYTHONPATH=src uv run pytest tests/citations/ -v` to confirm the citation
+   tests still match the new frontmatter (revision, publisher, etc.) before
+   committing.
+4. **If frontmatter changes:** the citation tests assert specific values
+   (e.g. `revision == "2021-07"`). Update both the test expectations and this
+   provenance record in the same commit; do NOT silently re-vendor.
+
+## Mechanism B (CI staleness check) — follow-up
+
+A CI hook that compares the two files when workspace-hub is checked out
+alongside digitalmodel was deferred to a follow-up issue. See plan r2
+"Fixture Freshness — Mechanism B" for the rationale.


### PR DESCRIPTION
## Context

The originally-requested scope of [workspace-hub#2580](https://github.com/vamseeachanta/workspace-hub/issues/2580) Defect 1 (vendor wiki fixture, refactor `_repo_root()`, drop citation entries from `tests/conftest.py:collect_ignore`) was **already merged** as [PR #542](https://github.com/vamseeachanta/digitalmodel/pull/542) (`b1346acb`). Verified on `origin/main` (`60d59565`):

- `tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/dnv-os-e301.md` is present
- `tests/citations/test_registry.py` and `tests/citations/test_schema.py` use `Path(__file__).resolve().parent / "fixtures"` as `_repo_root()`
- `tests/conftest.py:collect_ignore` carries no `tests/citations/` entries

The 4 representative citation tests pass against the vendored fixture (manually exercised in this branch using the workspace-hub digitalmodel `.venv`):
- `test_intact_quasi_static_factor_emits_cited_value`
- `test_damaged_quasi_static_factor_emits_cited_value`
- `test_resolution_passes_for_real_page`
- `test_resolution_fails_on_missing_page`

## Summary

Plan r2 (`docs/plans/2026-05-02-issue-2580-digitalmodel-collect-ignore-test-fixes.md` in workspace-hub) calls out one ship-along that PR #542 did **not** include: a `FIXTURE_PROVENANCE.md` next to the vendored wiki page recording the canonical SHA and review cadence (Fixture Freshness — Mechanism A). This PR lands only that file.

- Add `tests/citations/fixtures/knowledge/wikis/engineering/wiki/standards/FIXTURE_PROVENANCE.md`
- Pins canonical workspace-hub SHA `bd11f33b` for `dnv-os-e301.md`
- Records vendoring date 2026-05-02 (PR #542 merge) and monthly review cadence

## Out of scope

- Defect 2 of [workspace-hub#2580](https://github.com/vamseeachanta/workspace-hub/issues/2580) (yml-utilities capsys -> caplog conversion) — handled in a parallel lane per plan r2.
- Mechanism B (CI staleness check) — deferred to a follow-up issue per plan r2.

## Test plan

- [x] Manually exercised the 4 representative citation tests against the vendored fixture: all 4 PASS (no source/test changes; documentation-only PR cannot regress them).
- [ ] CI Quality Gates green (no source/test changes expected to break)

Refs vamseeachanta/workspace-hub#2580