### PR TITLE
fix(ci): upload full pytest log as quality-gate-results artifact (#546)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -55,6 +55,7 @@ jobs:
           path: |
             reports/quality_gates_results.json
             reports/bandit_report.json
+            reports/quality-gates-pytest-full.log
             coverage.json
           retention-days: 30
 

--- a/src/digitalmodel/workflows/automation/quality_gates.py
+++ b/src/digitalmodel/workflows/automation/quality_gates.py
@@ -227,6 +227,16 @@ class QualityGateValidator:
             # (exit code may be wrong due to capture plugin bug)
             import re
             combined = (result.stdout or "") + "\n" + (result.stderr or "")
+
+            # Write full pytest output to a sibling log file for CI artifact upload (#546).
+            # The existing output_tail JSON field is preserved for backward compatibility.
+            full_log_path = self.reports_dir / "quality-gates-pytest-full.log"
+            try:
+                full_log_path.write_text(combined, encoding="utf-8", errors="replace")
+                logger.info(f"Pytest full log written to {full_log_path} ({len(combined)} bytes)")
+            except OSError as e:
+                logger.warning(f"Could not write pytest full log: {e}")
+
             summary_match = re.search(
                 r"(\d+) passed", combined
             )
@@ -267,7 +277,19 @@ class QualityGateValidator:
                     },
                     errors=[result.stderr] if result.stderr else [],
                 )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
+            # Capture whatever pytest emitted before SIGKILL so triagers still
+            # get partial output in the CI artifact (#546).
+            partial = e.stdout
+            if isinstance(partial, bytes):
+                partial = partial.decode("utf-8", errors="replace")
+            partial = partial or ""
+            full_log_path = self.reports_dir / "quality-gates-pytest-full.log"
+            try:
+                full_log_path.write_text(partial, encoding="utf-8", errors="replace")
+                logger.info(f"Pytest full log written to {full_log_path} ({len(partial)} bytes, timeout)")
+            except OSError as write_err:
+                logger.warning(f"Could not write pytest full log on timeout: {write_err}")
             return GateResult(
                 gate_name="tests",
                 status=GateStatus.ERROR,

--- a/tests/workflows/automation/test_quality_gates.py
+++ b/tests/workflows/automation/test_quality_gates.py
@@ -179,6 +179,53 @@ class TestQualityGateValidator:
         assert result.status == GateStatus.FAILURE
         assert result.metrics["exit_code"] == 1
 
+    @patch("subprocess.run")
+    def test_execute_tests_gate_writes_full_log(self, mock_run, validator, tmp_path):
+        """Tests gate must write reports/quality-gates-pytest-full.log on every run (#546)."""
+        fake_output = ("FAILED tests/x.py::test_a - AssertionError\n" * 1200)  # ~50 KB
+        mock_run.return_value = MagicMock(returncode=1, stdout=fake_output, stderr="")
+        validator.reports_dir = tmp_path  # redirect writes
+
+        result = validator._execute_tests_gate({"command": "pytest --maxfail=20"})
+
+        log_path = tmp_path / "quality-gates-pytest-full.log"
+        assert log_path.exists(), "full pytest log must be written"
+        contents = log_path.read_text(encoding="utf-8")
+        assert "FAILED tests/x.py::test_a" in contents
+        assert len(contents) >= 50_000, "full log must contain entire pytest output, not truncated tail"
+        # Existing JSON metric stays intact
+        assert "output_tail" in result.metrics
+
+    def test_execute_tests_gate_writes_full_log_live(self, validator, tmp_path):
+        """Live (un-mocked) subprocess invocation: tiny shell command stands in for pytest (#546).
+
+        Note: _execute_tests_gate uses command.split() (whitespace tokenization),
+        so we use a command whose arguments contain no spaces.
+        """
+        validator.reports_dir = tmp_path
+        # 'yes' would be unbounded; use 'seq 1 100' which prints 1\n2\n...\n100\n (100 newlines).
+        cmd = "seq 1 100"
+
+        validator._execute_tests_gate({"command": cmd})
+
+        log_path = tmp_path / "quality-gates-pytest-full.log"
+        assert log_path.exists()
+        assert log_path.read_text().count("\n") >= 100
+
+    @patch("subprocess.run")
+    def test_execute_tests_gate_writes_full_log_on_timeout(self, mock_run, validator, tmp_path):
+        """Even on TimeoutExpired, partial pytest stdout must be written to the full log (#546)."""
+        from subprocess import TimeoutExpired
+        mock_run.side_effect = TimeoutExpired(cmd="pytest", timeout=600, output="partial output before kill\n")
+        validator.reports_dir = tmp_path
+
+        result = validator._execute_tests_gate({"command": "pytest --maxfail=20"})
+
+        log_path = tmp_path / "quality-gates-pytest-full.log"
+        assert log_path.exists()
+        assert "partial output before kill" in log_path.read_text()
+        assert result.status == GateStatus.ERROR
+
     def test_execute_coverage_gate_pass(self, validator, tmp_path):
         """Test coverage gate execution - passing coverage."""
         coverage_data = {


### PR DESCRIPTION
## Summary
- `_execute_tests_gate` writes `reports/quality-gates-pytest-full.log` on every branch (PASS / FAILURE / TimeoutExpired)
- `actions/upload-artifact@v4` `path:` list extended by one filename — same artifact name (`quality-gate-results`), no new step
- Existing `output_tail` JSON field preserved unchanged — PR-comment script unaffected
- Three new tests cover mocked / live / timeout paths

## Test plan
- [x] `uv run pytest tests/workflows/automation/test_quality_gates.py -k full_log -v` — 3 new tests pass
- [x] `uv run pytest tests/workflows/automation/test_quality_gates.py -v` — no existing-test regression (23/23 passing, was 20/20)
- [x] Local CLI run: both `quality-gates-pytest-full.log` (166 KB) AND `quality_gates_results.json` (15 KB) produced
- [ ] CI Quality Gates run on this branch uploads both files in `quality-gate-results` artifact

Closes [#546](https://github.com/vamseeachanta/digitalmodel/issues/546)