### PR TITLE
fix(naval-arch): re-export rudder_stock_torque public API (workspace-hub#2603)

### DIFF
--- a/src/digitalmodel/naval_architecture/__init__.py
+++ b/src/digitalmodel/naval_architecture/__init__.py
@@ -48,6 +48,10 @@ from digitalmodel.naval_architecture.b1528_sirocco_time_trace import (
     simulate_b1528_time_trace,
     write_b1528_time_trace_report,
 )
+from digitalmodel.naval_architecture.rudder_stock_torque import (
+    load_packaged_rudder_stock_torque_yaml,
+    run_rudder_stock_torque_sweep,
+)
 from digitalmodel.naval_architecture.yaw_moment import (
     load_packaged_typical_ship_yaml,
     load_yaw_moment_input,
@@ -72,6 +76,7 @@ __all__ = [
     "load_dimension_template",
     "load_packaged_b1528_time_trace_config",
     "load_packaged_b1528_yaw_config",
+    "load_packaged_rudder_stock_torque_yaml",
     "load_packaged_typical_ship_yaml",
     "load_yaw_moment_input",
     "merge_template_into_registry",
@@ -85,6 +90,7 @@ __all__ = [
     "rudder_yaw_moment",
     "run_b1528_static_yaw_report",
     "run_b1528_time_trace_report",
+    "run_rudder_stock_torque_sweep",
     "run_yaw_moment_sweep",
     "simulate_b1528_time_trace",
     "stability_curve_estimate",


### PR DESCRIPTION
## Summary

Adds `load_packaged_rudder_stock_torque_yaml` and `run_rudder_stock_torque_sweep` to `digitalmodel.naval_architecture.__init__.py` (both block import + `__all__`), so consumers can do `from digitalmodel.naval_architecture import ...` without pytest's `sys.path` injection.

## Why

`tests/naval_architecture/test_rudder_stock_torque_sweep.py::test_public_import_surface_outside_pytest_path_injection` was failing with `ImportError: cannot import name 'load_packaged_rudder_stock_torque_yaml' from 'digitalmodel.naval_architecture'`. The loader (and the runner the test also imports) existed in `rudder_stock_torque.py` but were not re-exported.

## Scope (strict YAGNI)

ONLY the two test-required names are exported. `write_rudder_stock_torque_results` exists in the module but has no test demand — file separately as "rudder writer parity" if external consumers need it.

## Verification

| Gate | Result |
|------|--------|
| Target test | ✅ PASSED in 13.39s |
| Full `test_rudder_stock_torque_sweep.py` | ✅ 19/19 PASS in 109s (was 18/19 pre-fix) |
| Regression `test_yaw_moment_sweep.py` | ✅ 21/21 PASS in 71s (no regression) |

## Plan + adversarial review

- Plan: [`workspace-hub` `plan/2603-...` branch](https://github.com/vamseeachanta/workspace-hub/tree/plan/2603-rudder-loader-public-export) (commit [`014734e30`](https://github.com/vamseeachanta/workspace-hub/commit/014734e30))
- r1 verdict: MINOR (0 P1, 2 P2 fixed, 2 P3 fixed)
- Approval: workspace-hub `status:plan-approved` applied

## Test plan

- [x] Target test passes locally
- [x] Full file passes (no regression)
- [x] Sibling yaw test file passes (no regression)
- [ ] CI passes

Closes vamseeachanta/workspace-hub#2603