### PR TITLE
fix(#2614): align _FakeDiffraction mock with smoke_test API (Cat B, 4 tests)

### DIFF
--- a/tests/hydrodynamics/diffraction/test_solver_smoke_unit.py
+++ b/tests/hydrodynamics/diffraction/test_solver_smoke_unit.py
@@ -19,7 +19,9 @@ class _FakeDiffraction:
     def __init__(self, source_path: str, export_raises: bool = False) -> None:
         self.source_path = source_path
         self.state = "loaded"
-        self.frequencyCount = 3
+        # OrcFxAPI v11+ exposes plural sequence attributes; mock matches that surface.
+        self.frequencies = [0.1, 0.2, 0.3]
+        self.headings = [0.0, 90.0, 180.0]
         self._export_raises = export_raises
 
     def Calculate(self) -> None:
@@ -28,13 +30,13 @@ class _FakeDiffraction:
     def SaveData(self, target: str) -> None:
         Path(target).write_text(f"saved from {self.source_path}\n", encoding="utf-8")
 
-    def ExportResults(self, target: str) -> None:
+    def SaveResults(self, target: str) -> None:
+        Path(target).write_text(f"results from {self.source_path}\n", encoding="utf-8")
+
+    def SaveResultsSpreadsheet(self, target: str) -> None:
         if self._export_raises:
             raise RuntimeError("native export unavailable")
         Path(target).write_text("native export\n", encoding="utf-8")
-
-    def frequency(self, index: int) -> float:
-        return [0.1, 0.2, 0.3][index]
 
 
 def _install_fake_orcfxapi(monkeypatch, export_raises: bool = False) -> None:


### PR DESCRIPTION
## Category B — Mock-vs-source attribute drift

**Tracker:** workspace-hub [#2614](https://github.com/vamseeachanta/workspace-hub/issues/2614) (2 of 4 categories)

### Root cause
`_FakeDiffraction` in `test_solver_smoke_unit.py` declared `frequencyCount = 3` and `frequency(index)` (sequence-style, OrcFxAPI v10) but `tests/solver/smoke_test.py` iterates `diff.frequencies` (plural attribute, OrcFxAPI v11+ API). All 4 tests in `test_solver_smoke_unit.py` fail with `AttributeError`.

### Fix
Single-file mock alignment in `tests/hydrodynamics/diffraction/test_solver_smoke_unit.py`:
- Added `frequencies = [0.1, 0.2, 0.3]` (matching the existing `frequency(0..2)` semantics)
- Removed dead `frequencyCount` and `frequency(i)` (no remaining consumers in `tests/solver/smoke_test.py`)
- **Bonus drift fixes discovered while in there** (same root-cause class, no scope expansion):
  - Renamed `ExportResults(target)` → `SaveResultsSpreadsheet(target)`; added `SaveResults(target)` — `smoke_test.py` calls both, never `ExportResults`
  - Added `headings = [0.0, 90.0, 180.0]` — `run_orcawave_from_yml` (reached by `run_l01_smoke_test`) accesses `diff.headings`

### Files changed (1)
- `tests/hydrodynamics/diffraction/test_solver_smoke_unit.py`

### Validation
- **Cat B: 4/4 PASS** (was 0/4). Plus the 5th in-file test (`test_promote_committed_artifacts_copies_available_files`) still passes
- Adjacent regression sweep: 1342 passed, 21 failed (8 Cat A + 1 Cat C + 3 Cat D + 9 environmental — all expected)
- Zero collateral damage

Refs workspace-hub #2614, part 2 of 4 (Cat B)