### PR TITLE
fix(#2614): reconcile AQWABackend.generate_modular with generate_single (Cat C, 1 test)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
@@ -207,10 +207,15 @@ class AQWABackend:
         self._mesh_cache.clear()
 
         deck_builders = self._ordered_deck_builders(spec)
+        header = self._workbench_header()
         for idx, (deck_num, cards) in enumerate(deck_builders):
             file_name = f"deck_{idx:02d}_{deck_num:02d}.dat"
             file_path = output_dir / file_name
-            file_path.write_text("\n".join(cards) + "\n")
+            # Prepend the Workbench-compatible file header to the first
+            # deck file so concatenating modular outputs reproduces the
+            # single-file output byte-for-byte (after whitespace strip).
+            file_cards = header + cards if idx == 0 else cards
+            file_path.write_text("\n".join(file_cards) + "\n")
 
         return output_dir
 


### PR DESCRIPTION
## Category C — AQWA modular vs single output divergence

**Tracker:** workspace-hub [#2614](https://github.com/vamseeachanta/workspace-hub/issues/2614) (3 of 4 categories)

### Root cause
`AQWABackend.generate_modular()` writes each deck-builder tuple directly to disk WITHOUT the 5-line Workbench-compatible file header that `_workbench_header()` prepends in `_assemble_all_decks` for `generate_single()`. So concatenated modular output diverges from the single output by exactly the missing preamble.

### Strategy: Y — `generate_single` is canonical; modular needed the missing header

Confirmed by reading both paths: `generate_single` calls `_assemble_all_decks` which prepends `_workbench_header()`; `generate_modular` calls deck builders directly without that step.

Fix: prepend `_workbench_header()` to the first emitted deck file (`deck_00_00.dat`) in the modular path so concatenation matches.

### Triage doc inversion noted
The original triage stated the digit ruler was extra in modular and modular added 5 extra `NONE` cards. Actual pytest output showed the opposite: single had 5 extra prefix lines (the workbench header) that modular was missing. The "Left contains 5 more items" message was a count-asymmetry artifact, not 5 extra `NONE` cards. Both outputs already had identical 12 `NONE` deck cards (decks 9–20). Worth filing as a triage-doc lesson.

### Latent CRLF/LF inconsistency surfaced (not fixed in this PR)
- `generate_single` writes CRLF via `newline=''`
- `generate_modular` uses `write_text(...)` which normalizes to LF
- Test strips empty lines and compares stripped text, so this difference doesn't break the assertion as written
- Worth a separate followup if any future byte-equality test is added

### Files changed (+6/-1)
- `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py`

### Validation
- **Cat C: 1/1 PASS** (was 0/1). Full `test_aqwa_backend.py` 35/35 pass (was 34/35)
- Zero regressions

Refs workspace-hub #2614, part 3 of 4 (Cat C)