### PR TITLE
fix(#2614): CLI output writers — PascalCase filenames + mkdir-before-validate (Cat D, 3 tests)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/batch_processor.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/batch_processor.py
@@ -128,6 +128,12 @@ class BatchProcessor:
             else:
                 raise ValueError(f"Unknown source type: {config.source_type}")
 
+            # Ensure output directory exists for validation + export.
+            # Without this, validate_results() can fail with FileNotFoundError
+            # writing the validation JSON before the exporter has a chance to
+            # mkdir, leaving the per-vessel output directory absent.
+            config.output_dir.mkdir(parents=True, exist_ok=True)
+
             # Validate if requested
             if config.validate:
                 print(f"  Validating results...")

--- a/src/digitalmodel/hydrodynamics/diffraction/orcaflex_exporter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcaflex_exporter.py
@@ -85,11 +85,11 @@ class OrcaFlexExporter:
                 'CreatedDate': self.results.created_date,
 
                 # RAO data references
-                'RAODataFile': f"{self.vessel_name}_raos.csv",
+                'RAODataFile': f"{self.vessel_name}_RAOs.csv",
 
                 # Added mass and damping data
-                'AddedMassDataFile': f"{self.vessel_name}_added_mass.csv",
-                'DampingDataFile': f"{self.vessel_name}_damping.csv",
+                'AddedMassDataFile': f"{self.vessel_name}_AddedMass.csv",
+                'DampingDataFile': f"{self.vessel_name}_Damping.csv",
 
                 # Metadata
                 'Notes': self.results.notes or f"Generated from {self.results.analysis_tool} analysis"
@@ -113,7 +113,7 @@ class OrcaFlexExporter:
         Returns:
             Path to created CSV file
         """
-        output_file = self.output_dir / f"{self.vessel_name}_raos.csv"
+        output_file = self.output_dir / f"{self.vessel_name}_RAOs.csv"
 
         raos = self.results.raos
         freqs = raos.surge.frequencies.values
@@ -170,7 +170,7 @@ class OrcaFlexExporter:
         Returns:
             Path to created CSV file
         """
-        output_file = self.output_dir / f"{self.vessel_name}_added_mass.csv"
+        output_file = self.output_dir / f"{self.vessel_name}_AddedMass.csv"
 
         am_set = self.results.added_mass
 
@@ -205,7 +205,7 @@ class OrcaFlexExporter:
         Returns:
             Path to created CSV file
         """
-        output_file = self.output_dir / f"{self.vessel_name}_damping.csv"
+        output_file = self.output_dir / f"{self.vessel_name}_Damping.csv"
 
         damp_set = self.results.damping
 
@@ -247,7 +247,7 @@ class OrcaFlexExporter:
         Returns:
             Path to created Excel file
         """
-        output_file = self.output_dir / f"{self.vessel_name}_hydrodynamics.xlsx"
+        output_file = self.output_dir / f"{self.vessel_name}_Results.xlsx"
 
         with pd.ExcelWriter(output_file, engine='openpyxl') as writer:
             # Summary sheet
@@ -267,6 +267,10 @@ class OrcaFlexExporter:
 
         print(f"Excel workbook exported: {output_file}")
         return output_file
+
+    def export_summary(self) -> Path:
+        """Alias for export_summary_report kept for CLI/batch compatibility."""
+        return self.export_summary_report()
 
     def export_summary_report(self) -> Path:
         """
@@ -306,10 +310,10 @@ class OrcaFlexExporter:
         # Output files
         lines.append("Generated Files:")
         lines.append(f"  - {self.vessel_name}_vessel_type.yml")
-        lines.append(f"  - {self.vessel_name}_raos.csv")
-        lines.append(f"  - {self.vessel_name}_added_mass.csv")
-        lines.append(f"  - {self.vessel_name}_damping.csv")
-        lines.append(f"  - {self.vessel_name}_hydrodynamics.xlsx")
+        lines.append(f"  - {self.vessel_name}_RAOs.csv")
+        lines.append(f"  - {self.vessel_name}_AddedMass.csv")
+        lines.append(f"  - {self.vessel_name}_Damping.csv")
+        lines.append(f"  - {self.vessel_name}_Results.xlsx")
         lines.append("")
 
         lines.append("=" * 80)


### PR DESCRIPTION
## Category D — CLI \`convert-aqwa\` / \`batch\` output regression

**Tracker:** workspace-hub [#2614](https://github.com/vamseeachanta/workspace-hub/issues/2614) (4 of 4 categories — final)

### Mixed scenario: A (filename drift) + B (silent swallow)

**Defect 1 (filename drift, Scenario A)**: \`OrcaFlexExporter\` wrote \`*_raos.csv\`, \`*_added_mass.csv\`, \`*_damping.csv\`, \`*_hydrodynamics.xlsx\` while the test contract requires PascalCase \`*_RAOs.csv\`, \`*_AddedMass.csv\`, \`*_Damping.csv\`, \`*_Results.xlsx\`. CLI ran, writers executed, files landed — under the wrong names.

**Defect 2 (silent swallow, Scenario B)**: \`BatchProcessor.process_configuration()\` called \`validate_results()\` (which writes JSON to \`config.output_dir\`) BEFORE the \`OrcaFlexExporter\` constructor (which historically did the \`mkdir\`). On a fresh \`tmp_path\`, validation raised \`FileNotFoundError\`, was logged via \`traceback.print_exc()\`, but the per-vessel \`output_dir\` was never created. Batch CLI returned 0 even though zero output files landed.

### Fix

- \`src/digitalmodel/hydrodynamics/diffraction/orcaflex_exporter.py\`: PascalCase output filenames + add \`export_summary\` alias method (called by \`cli.py:136/246\` and \`batch_processor.py:159\` — alias makes \`-f summary\` actually work for users)
- \`src/digitalmodel/hydrodynamics/diffraction/batch_processor.py\`: \`mkdir(parents=True, exist_ok=True)\` on \`config.output_dir\` immediately after conversion, before validation

### Validation
- **Cat D 3 tests: 3/3 PASS** (was 0/3)
- **Full \`test_cli_integration.py\`: 12/12 PASS** in 46.65s
- Regression sweep across \`test_orcaflex_exporter.py\` + \`test_batch_processor.py\` + \`test_polars_exporter_additional.py\`: **67 passed, 0 failed**
- Team A's 9 \"environmental\" CLI tests confirmed as dep-wall (not regressions): when run with \`--with-editable .\` so the \`diffraction\` console script resolves, **all 9 pass**

### Triage-doc inversion noted

Triage hypothesized OrcFxAPI/Cat-A coupling could be a contributing cause for Cat D. **Confirmed NOT**. \`OrcaFlexExporter\` and \`BatchProcessor\` import only from \`output_schemas\`, \`aqwa_converter\`, \`output_validator\` — none touch \`solver/\`. Cat A's lazy-import boundary changed nothing for Cat D. Pure Cat D = filename drift + missing mkdir, fully independent of OrcFxAPI.

### Latent issue surfaced (filed-as-note, not in this PR)

\`process_batch_from_config_file\` reads \`export_formats\` config key, but the test JSON config uses \`formats\` — selective formats are silently ignored and \`'all'\` is used. Test still passes (\`'all'\` produces a superset). Worth a future cleanup; contract mismatch between CLI users and config loader.

### Note for [#2129](https://github.com/vamseeachanta/workspace-hub/issues/2129) drift audit

The 9 environmental CLI failures should be picked up by quality-gate scripts as an entry-point requirement: tests use \`subprocess.run([\"diffraction\", ...])\` so the CLI must be installed in the venv that runs them. Worth adding to the QG validator's pre-flight checks.

Refs workspace-hub #2614 part 4 of 4 (Cat D — final)