### PR TITLE
fix: 5-issue followup batch — #2604/#2605/#2606/#2607/#2617

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ A Python package of engineering calculations where every function traces to an i
 
 ## Installation
 
+### System prerequisites
+
+A few transitive dependencies (notably `lxml`) need native compilation when a pre-built wheel is not available for your platform/Python combination. On Ubuntu/Debian, install the build toolchain and XML headers before `pip install`:
+
+```bash
+sudo apt-get install build-essential python3-dev libxml2-dev libxslt1-dev
+```
+
+Other Linux distros / macOS / Windows: install equivalents of those packages or use a pre-built `lxml` wheel. A follow-up issue tracks bumping `lxml` to a version with broader wheel coverage so this step is no longer required for most users.
+
 ```bash
 pip install digitalmodel
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,7 +343,7 @@ print_blob = false
 python = "3.11"
 system = false
 seed = true
-compile = true
+compile = false
 
 [tool.uv.pip]
 index-url = "https://pypi.org/simple"

--- a/tests/naval_architecture/test_b1528_sirocco_yaw_moment.py
+++ b/tests/naval_architecture/test_b1528_sirocco_yaw_moment.py
@@ -3,6 +3,7 @@
 
 import json
 import math
+import tomllib
 from importlib import resources
 from pathlib import Path
 
@@ -107,5 +108,26 @@ def test_interactive_report_outputs_and_no_compliance_overclaim(tmp_path):
 
 
 def test_packaged_b1528_yaml_declared_as_package_data():
-    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
-    assert 'digitalmodel = ["naval_architecture/data/*.yml"]' in pyproject
+    # Pin path to the digitalmodel repo root so this test is robust to pytest's
+    # invocation cwd. Mirrors the sibling pattern in
+    # ``test_packaged_yaml_in_built_distribution_preserves_existing_package_data``.
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    pyproject_text = pyproject_path.read_text(encoding="utf-8")
+    toml = tomllib.loads(pyproject_text)
+
+    try:
+        package_data = toml["tool"]["setuptools"]["package-data"]["digitalmodel"]
+    except KeyError as exc:  # pragma: no cover - diagnostic path
+        # Surface a readable assertion instead of a bare ``KeyError`` so the
+        # diagnostic clearly identifies which key in the pyproject.toml chain
+        # is missing.
+        raise AssertionError(
+            "pyproject.toml is missing [tool.setuptools.package-data].digitalmodel "
+            f"(missing key: {exc!r}); cannot verify b1528 yaml is shipped as package data"
+        ) from exc
+
+    assert "naval_architecture/data/*.yml" in package_data, (
+        "Expected 'naval_architecture/data/*.yml' to be declared in "
+        "[tool.setuptools.package-data].digitalmodel so the packaged b1528 "
+        f"YAML ships with the wheel; got: {package_data!r}"
+    )

--- a/tests/naval_architecture/test_rudder_stock_torque_sweep.py
+++ b/tests/naval_architecture/test_rudder_stock_torque_sweep.py
@@ -14,6 +14,14 @@ import yaml
 
 from digitalmodel.naval_architecture.maneuverability import rudder_normal_force
 
+# Serialize wheel-build tests across this module under pytest-xdist:
+# default `--dist loadscope` keeps a module on one worker, but adding
+# `xdist_group` is defense-in-depth in case dispatch policy changes.
+# The load-bearing fix is removing `--no-isolation` below — isolated
+# builds prevent shared-state races on `build/` and `digitalmodel.egg-info/`
+# (issue #2617).
+pytestmark = pytest.mark.xdist_group(name="wheel_build")
+
 BASE_RUDDER_KWARGS = {
     "velocity_m_s": 5.0,
     "rho_kg_m3": 1025.0,
@@ -194,7 +202,6 @@ def test_packaged_yaml_in_built_distribution_preserves_existing_package_data(tmp
             "-m",
             "build",
             "--wheel",
-            "--no-isolation",
             "--outdir",
             str(tmp_path),
         ],

--- a/tests/naval_architecture/test_vessel_fleet_adapter.py
+++ b/tests/naval_architecture/test_vessel_fleet_adapter.py
@@ -205,6 +205,20 @@ class TestRegisterFleetVessels:
         assert added == 1
         assert skipped == 0
 
+        # Verify the registry was actually mutated by the overwrite — not just
+        # that counters changed.  The overwritten entry must be retrievable and
+        # carry THIALF_RECORD's converted dimensions and displacement.
+        # Note: merge_template_into_registry strips hull_id and stores it as
+        # hull_number on the registry entry.
+        result = get_ship("THIALF")
+        assert result is not None
+        assert result["hull_number"] == "THIALF"
+        assert result["loa_ft"] == pytest.approx(201.0 * _M_TO_FT, rel=1e-3)
+        assert result["beam_ft"] == pytest.approx(88.4 * _M_TO_FT, rel=1e-3)
+        assert result["displacement_lt"] == pytest.approx(
+            71368.0 * _TONNES_TO_LT, rel=1e-3
+        )
+
 
 class TestStabilityIntegration:
     """Integration: fleet vessel dimensions feed into hydrostatics calculations."""

--- a/tests/naval_architecture/test_yaw_moment_sweep.py
+++ b/tests/naval_architecture/test_yaw_moment_sweep.py
@@ -15,6 +15,15 @@ import yaml
 from digitalmodel.naval_architecture.maneuverability import rudder_normal_force
 
 
+# Serialize wheel-build tests across this module under pytest-xdist:
+# default `--dist loadscope` keeps a module on one worker, but adding
+# `xdist_group` is defense-in-depth in case dispatch policy changes.
+# The load-bearing fix is removing `--no-isolation` below — isolated
+# builds prevent shared-state races on `build/` and `digitalmodel.egg-info/`
+# (issue #2617).
+pytestmark = pytest.mark.xdist_group(name="wheel_build")
+
+
 BASE_RUDDER_KWARGS = {
     "velocity_m_s": 5.0,
     "rho_kg_m3": 1025.0,
@@ -149,7 +158,6 @@ def test_packaged_yaml_in_built_distribution(tmp_path):
             "-m",
             "build",
             "--wheel",
-            "--no-isolation",
             "--outdir",
             str(tmp_path),
         ],

--- a/uv.toml
+++ b/uv.toml
@@ -12,7 +12,7 @@ index-url = "https://pypi.org/simple"
 index-strategy = "first-index"
 
 # Build settings
-compile-bytecode = true
+compile-bytecode = false
 
 # Cache settings
 no-cache = false


### PR DESCRIPTION
## Summary

5 atomic commits, one per workspace-hub follow-up issue. Each commit includes `Closes vamseeachanta/workspace-hub#NNNN` for cross-repo auto-close.

| SHA | Issue | Type | Files |
|-----|-------|------|-------|
| `87b7bcac` | [#2604](https://github.com/vamseeachanta/workspace-hub/issues/2604) | Test fix | `test_b1528_sirocco_yaw_moment.py` (TOML-parse + path pin) |
| `91569a6d` | [#2605](https://github.com/vamseeachanta/workspace-hub/issues/2605) | Test improvement | `test_vessel_fleet_adapter.py` (add missing assertion) |
| `5916e574` | [#2606](https://github.com/vamseeachanta/workspace-hub/issues/2606) | Build config | `uv.toml` + `pyproject.toml` (compile-bytecode → false) |
| `30bb55fd` | [#2607](https://github.com/vamseeachanta/workspace-hub/issues/2607) | Docs | `README.md` (system prereqs section) |
| `14a35f0c` | [#2617](https://github.com/vamseeachanta/workspace-hub/issues/2617) | Test isolation | `test_yaw_moment_sweep.py` + `test_rudder_stock_torque_sweep.py` (drop --no-isolation + xdist_group) |

## Sanity verified locally on ace-linux-1

- ✅ `test_packaged_b1528_yaml_declared_as_package_data` (#2604): 1 passed in 2.03s
- ✅ `test_overwrite_when_requested` (#2605): 1 passed in 1.55s
- (#2606 / #2607 / #2617 verified statically; user verifies #2606 via `uv sync` post-merge)

## Scope notes

- **#2617:** the issue body's "3 files" includes `test_turning_circle_estimator.py` which is currently **untracked on origin/main** (left over from #2568 planning). The flake fix is preserved in working-tree state; should be applied when that file officially lands via its own PR.
- **#2606:** primary suspect (`compile-bytecode = true`) flipped. If `uv sync` still hangs after this lands, the secondary hypothesis (assetutilities editable build hook) needs separate investigation.
- **#2604:** the test had a hidden cwd-drift bug — `Path("pyproject.toml")` could match workspace-hub's pyproject if pytest is invoked from the wrong directory. Now pinned via `Path(__file__).resolve().parents[2]`.
- **#2605:** issue title said "13 F401" but live ruff scan shows 1 in this file + 12 spread across 8 sibling files. Plan kept narrow (1 file) and proposed turning the abandoned import into a real assertion (better than ruff --fix removal).

## Test plan

- [x] Targeted regression tests pass (#2604, #2605)
- [ ] CI passes
- [ ] User verifies `uv sync` exits cleanly (#2606)

## Closes (cross-repo)

- vamseeachanta/workspace-hub#2604
- vamseeachanta/workspace-hub#2605
- vamseeachanta/workspace-hub#2606
- vamseeachanta/workspace-hub#2607
- vamseeachanta/workspace-hub#2617