### PR TITLE
fix(#2621): extend _HAS_WED_DCF skipif to 4 sibling test classes (Cluster B, 14 failures)

### DIFF
--- a/tests/field_development/test_economics.py
+++ b/tests/field_development/test_economics.py
@@ -574,6 +574,15 @@ class TestBuildEconomicsSchedule:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HAS_WED_DCF,
+    reason=(
+        "Cross-repo dep: worldenergydata.economics.dcf not importable. "
+        "digitalmodel CI installs the package standalone (no sibling repo "
+        "checkout) so this class is gated on CI but runs locally under "
+        "workspace-hub."
+    ),
+)
 class TestCarbonSensitivity:
     """Test the carbon sensitivity pass-through."""
 
@@ -826,6 +835,15 @@ class TestProductionFactors:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HAS_WED_DCF,
+    reason=(
+        "Cross-repo dep: worldenergydata.economics.dcf not importable. "
+        "digitalmodel CI installs the package standalone (no sibling repo "
+        "checkout) so this class is gated on CI but runs locally under "
+        "workspace-hub."
+    ),
+)
 class TestDeclineBackwardCompatibility:
     """Verify that adding decline fields does not break existing behaviour."""
 
@@ -857,6 +875,15 @@ class TestDeclineBackwardCompatibility:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HAS_WED_DCF,
+    reason=(
+        "Cross-repo dep: worldenergydata.economics.dcf not importable. "
+        "digitalmodel CI installs the package standalone (no sibling repo "
+        "checkout) so this class is gated on CI but runs locally under "
+        "workspace-hub."
+    ),
+)
 class TestScheduleDeclineIntegration:
     """Verify build_economics_schedule uses decline params, not hardcoded linear."""
 
@@ -1003,6 +1030,15 @@ class TestEURDeclineParameterization:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HAS_WED_DCF,
+    reason=(
+        "Cross-repo dep: worldenergydata.economics.dcf not importable. "
+        "digitalmodel CI installs the package standalone (no sibling repo "
+        "checkout) so this class is gated on CI but runs locally under "
+        "workspace-hub."
+    ),
+)
 class TestFiscalRegimeTaxAdjustment:
     """Test fiscal regime tax adjustment applied to economics cashflows."""
 


### PR DESCRIPTION
## Cluster B — \`tests/field_development/test_economics.py\` skipif extension

**Tracker:** workspace-hub [#2621](https://github.com/vamseeachanta/workspace-hub/issues/2621), part of [#2616](https://github.com/vamseeachanta/workspace-hub/issues/2616) sweep

### Root cause

PR [#543](https://github.com/vamseeachanta/digitalmodel/pull/543)'s \`_HAS_WED_DCF\` probe + \`@pytest.mark.skipif\` was applied only to \`TestBuildEconomicsSchedule\` (line 486). Four sibling classes share the same \`worldenergydata.economics.*\` import paths but were never decorated:

| Class | Line | Import path |
|---|---|---|
| \`TestCarbonSensitivity\` | 577 | \`worldenergydata.economics.carbon\` |
| \`TestDeclineBackwardCompatibility\` | 829 | \`worldenergydata.economics.dcf.CashFlowSchedule\` |
| \`TestScheduleDeclineIntegration\` | 860 | same |
| \`TestFiscalRegimeTaxAdjustment\` | 1006 | \`worldenergydata.{eia_us,ukcs,brazil_anp,west_africa,sodir}\` |

### Strategy: per-class skipif (matches PR #543 precedent)

Same decorator text verbatim from line 486; same paragraph about CI vs. workspace-hub.

### Files changed (1)
- \`tests/field_development/test_economics.py\` (+36/-0)

### Validation
\`pytest tests/field_development/test_economics.py -p no:randomly\`:
- **Before fix**: 14 failures (\`ModuleNotFoundError: worldenergydata\`)
- **After fix**: \`58 passed, 28 skipped, 0 failed, 0 errors in 1.83s\`
- Cluster B cleared

### Skip count breakdown (when \`worldenergydata\` is absent)
- \`TestBuildEconomicsSchedule\` (7, pre-existing from PR #543)
- \`TestCarbonSensitivity\` (5)
- \`TestDeclineBackwardCompatibility\` (3)
- \`TestScheduleDeclineIntegration\` (2)
- \`TestFiscalRegimeTaxAdjustment\` (11)
- = 28 newly + 7 pre-existing = 28 total newly-skipped

### Strategy nuance acknowledged

Of the 28 methods now skipped via per-class decorators, ~3 currently pass without exercising the import path (early returns / mocked passthrough / structural checks). They are over-skipped under per-class strategy but will pass when \`worldenergydata\` is installed. This matches the precedent's granularity; per-method skipif was rejected as inconsistent with PR #543's approach.

Refs workspace-hub #2621 (Cluster B), part of #2616 sweep