### PR TITLE
fix(#2622): drop -p no:capture from QG command so capsys is available (Cluster C, ~13 errors)

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -7,7 +7,7 @@ gates:
     enabled: true
     order: 1
     description: "All tests must pass"
-    command: "python -m pytest --maxfail=20 -rfE -p no:asyncio -p no:randomly -p no:sugar -p no:capture --no-header -q --tb=line --cov=src --cov-report=json"
+    command: "python -m pytest --maxfail=20 -rfE -p no:asyncio -p no:randomly -p no:sugar --no-header -q --tb=line --cov=src --cov-report=json"
     failure_action: "block"
     warning_action: "report"
 


### PR DESCRIPTION
## Cluster C — \`-p no:capture\` strips capsys/capfd from QG

**Tracker:** workspace-hub [#2622](https://github.com/vamseeachanta/workspace-hub/issues/2622), part of [#2616](https://github.com/vamseeachanta/workspace-hub/issues/2616) sweep

### Root cause

The QG command in \`.claude/quality-gates.yaml:10\` disabled the pytest capture plugin via \`-p no:capture\`, which removes the \`capsys\`/\`capfd\` fixtures. Tests that declare \`capsys\` parameter then fail collection with \`fixture 'capsys' not found\`. \`caplog\` is unaffected (different plugin).

### Probe of git history

\`-p no:capture\` was carried in unchanged from the file's introducing commit \`2c185d2d\` (\"chore: fresh repo after slimming\"). Three later edits (maxfail bump, \`--tb=line\`, \`--cov=src\`) left it untouched. **No commit message in the file's history mentions performance, coverage, or any documented rationale for disabling capture.** No \`capsys\`/\`capfd\`/\`capture\` references elsewhere in \`.claude/quality-gates.yaml\`, \`pytest.ini\`, or \`pyproject.toml\`. Safe to drop.

### Files changed (1)
- \`.claude/quality-gates.yaml\`: line 10 — removed \` -p no:capture\` token

### Validation

Targeted suite (\`tests/hydrodynamics/passing_ship/test_passing_ship_cli.py tests/solvers/orcaflex/test_template_generator.py tests/solvers/orcaflex/modular_generator/test_campaign_generator.py\`):

| Run | passed | skipped | errors |
|---|---|---|---|
| Before fix (with \`-p no:capture\`) | 40 | 5 | **13** (2+5+6, all \"fixture 'capsys' not found\") |
| After fix | **52** | 6 | **0** |

Sanity check: \`tests/asset_integrity/test_yml_utilities_additional.py\` (#2580 Cat B \`caplog\` work) — **23/23 passed** in 1.65s. No regression.

### Why option (a) over (b)

Recommended (a) drop \`-p no:capture\` was sufficient: cleared all 13 errors with zero side effects, no test refactor needed. Option (b) refactor capsys → monkeypatch would have been needless churn.

Refs workspace-hub #2622 (Cluster C), part of #2616 sweep