### PR TITLE
feat(canonical-spec): promote multibody OrcaWave benchmark (#2458)

### DIFF
--- a/docs/domains/orcawave/README.md
+++ b/docs/domains/orcawave/README.md
@@ -97,6 +97,12 @@ Practical interpretation:
 
 This means the repo is strong for engineering round-trip fidelity, but it does not claim universal identity across every strict OrcaWave YAML key or solver-internal default.
 
+## Named multi-body benchmark (#2458)
+
+`multibody_fpso_turret_v1` promotes the FPSO hull plus turret fixture as a named OrcaWave benchmark under `tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/`. The benchmark manifest records the claim boundary as near-equivalent for key engineering inputs and tested round-trip pathways, not strict identity across every native OrcaWave YAML field.
+
+The benchmark is a bridge candidate for future OrcaWave -> OrcaFlex handoff validation. It extends the delivered foundations from #1605, #1592, and #1768 with a stable multi-body case that preserves body count, body identity, fixed DOFs, connection parent, body position, attitude, mass, COG, and radii-of-gyration-derived inertia through the OrcaWave forward and reverse path.
+
 ---
 
 ## Workflow Phases

--- a/src/digitalmodel/benchmarks/inventory.py
+++ b/src/digitalmodel/benchmarks/inventory.py
@@ -186,6 +186,26 @@ def build_model_inventory() -> List[ModelInventoryEntry]:
                 "Cached hydrodynamic coefficient loading and RAO queries"),
             tags=["hydrodynamics", "rao", "frequency_domain", "cache"],
         ),
+        ModelInventoryEntry(
+            name="multibody_fpso_turret_v1",
+            category=ModelCategory.FREQUENCY_DOMAIN,
+            path=Path(
+                "tests/hydrodynamics/diffraction/fixtures/benchmarks/"
+                "multibody_fpso_turret_v1/spec.yml"
+            ),
+            description=(
+                "Multi-body OrcaWave benchmark - FPSO hull + turret with "
+                "fixed DOFs and parent connection"
+            ),
+            tags=[
+                "orcawave",
+                "multibody",
+                "fpso",
+                "turret",
+                "benchmark",
+                "roundtrip",
+            ],
+        ),
         # ----------------------------------------------------------------
         # Fatigue — time domain and frequency domain
         # ----------------------------------------------------------------

--- a/tests/hydrodynamics/diffraction/benchmarks/__init__.py
+++ b/tests/hydrodynamics/diffraction/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark regression tests for diffraction fixtures."""

--- a/tests/hydrodynamics/diffraction/benchmarks/test_multibody_fpso_turret_benchmark.py
+++ b/tests/hydrodynamics/diffraction/benchmarks/test_multibody_fpso_turret_benchmark.py
@@ -1,0 +1,179 @@
+"""Named multi-body OrcaWave benchmark regression tests (#2458)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.benchmarks.inventory import ModelCategory, build_model_inventory
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
+from digitalmodel.hydrodynamics.diffraction.reverse_parsers import OrcaWaveInputParser
+
+BENCHMARK_ID = "multibody_fpso_turret_v1"
+DIFFRACTION_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BENCHMARK_DIR = DIFFRACTION_DIR / "fixtures" / "benchmarks" / BENCHMARK_ID
+SPEC_PATH = BENCHMARK_DIR / "spec.yml"
+MANIFEST_PATH = BENCHMARK_DIR / "manifest.yaml"
+
+
+def _load_spec() -> DiffractionSpec:
+    return DiffractionSpec.from_yaml(SPEC_PATH)
+
+
+def _load_manifest() -> dict:
+    return yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _generate_orcawave_yml(spec: DiffractionSpec, tmp_path: Path) -> Path:
+    return OrcaWaveBackend().generate_single(spec, tmp_path)
+
+
+def _roundtrip(tmp_path: Path) -> tuple[DiffractionSpec, DiffractionSpec]:
+    original = _load_spec()
+    yml_path = _generate_orcawave_yml(original, tmp_path)
+    parsed = OrcaWaveInputParser().parse(yml_path)
+    assert parsed.bodies is not None
+    return original, parsed
+
+
+def _body_map(spec: DiffractionSpec):
+    assert spec.bodies is not None
+    return {body.vessel.name: body for body in spec.bodies}
+
+
+def _expected_inertia_from_radii(body) -> dict[str, float]:
+    inertia = body.vessel.inertia
+    assert inertia.radii_of_gyration is not None
+    return {
+        "Ixx": inertia.mass * inertia.radii_of_gyration[0] ** 2,
+        "Iyy": inertia.mass * inertia.radii_of_gyration[1] ** 2,
+        "Izz": inertia.mass * inertia.radii_of_gyration[2] ** 2,
+    }
+
+
+class TestMultibodyFpsoTurretBenchmark:
+    def test_benchmark_manifest_exists(self) -> None:
+        assert MANIFEST_PATH.is_file()
+        assert _load_manifest()
+
+    def test_benchmark_id_in_manifest_matches_folder(self) -> None:
+        assert _load_manifest()["benchmark_id"] == BENCHMARK_ID
+        assert BENCHMARK_DIR.name == BENCHMARK_ID
+
+    def test_benchmark_spec_loads_as_diffraction_spec(self) -> None:
+        assert isinstance(_load_spec(), DiffractionSpec)
+
+    def test_benchmark_has_two_bodies_with_expected_names(self) -> None:
+        spec = _load_spec()
+        assert spec.bodies is not None
+        assert [body.vessel.name for body in spec.bodies] == ["FPSO_Hull", "Turret"]
+
+    def test_mesh_files_referenced_by_spec_exist_on_disk(self) -> None:
+        spec = _load_spec()
+        for body in spec.get_bodies():
+            mesh_path = (SPEC_PATH.parent / body.vessel.geometry.mesh_file).resolve()
+            assert mesh_path.is_file(), mesh_path
+
+    def test_forward_generation_does_not_raise(self, tmp_path: Path) -> None:
+        yml_path = _generate_orcawave_yml(_load_spec(), tmp_path)
+        assert yml_path.is_file()
+
+    def test_roundtrip_preserves_body_count(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        assert parsed.bodies is not None
+        assert original.bodies is not None
+        assert len(parsed.bodies) == len(original.bodies)
+
+    def test_roundtrip_preserves_body_names(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        assert [body.vessel.name for body in parsed.bodies] == [
+            body.vessel.name for body in original.bodies
+        ]
+
+    def test_roundtrip_preserves_fixed_dofs_on_turret(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        original_turret = _body_map(original)["Turret"]
+        parsed_turret = _body_map(parsed)["Turret"]
+        assert sorted(parsed_turret.vessel.fixed_dofs or []) == sorted(
+            original_turret.vessel.fixed_dofs or []
+        )
+
+    def test_roundtrip_preserves_connection_parent(self, tmp_path: Path) -> None:
+        _, parsed = _roundtrip(tmp_path)
+        assert _body_map(parsed)["Turret"].connection_parent == "FPSO_Hull"
+
+    def test_roundtrip_preserves_body_position(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        parsed_bodies = _body_map(parsed)
+        for name, original_body in _body_map(original).items():
+            assert parsed_bodies[name].position == pytest.approx(
+                original_body.position, abs=1e-6
+            )
+
+    def test_roundtrip_preserves_body_attitude(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        parsed_bodies = _body_map(parsed)
+        for name, original_body in _body_map(original).items():
+            assert parsed_bodies[name].attitude == pytest.approx(
+                original_body.attitude, abs=1e-6
+            )
+
+    def test_roundtrip_preserves_body_mass(self, tmp_path: Path) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        parsed_bodies = _body_map(parsed)
+        for name, original_body in _body_map(original).items():
+            assert parsed_bodies[name].vessel.inertia.mass == pytest.approx(
+                original_body.vessel.inertia.mass, rel=1e-6
+            )
+
+    def test_roundtrip_preserves_centre_of_gravity_per_body(
+        self, tmp_path: Path
+    ) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        parsed_bodies = _body_map(parsed)
+        for name, original_body in _body_map(original).items():
+            assert (
+                parsed_bodies[name].vessel.inertia.centre_of_gravity
+                == pytest.approx(
+                    original_body.vessel.inertia.centre_of_gravity,
+                    rel=1e-6,
+                )
+            )
+
+    def test_roundtrip_preserves_radii_of_gyration_derived_inertia(
+        self, tmp_path: Path
+    ) -> None:
+        original, parsed = _roundtrip(tmp_path)
+        parsed_bodies = _body_map(parsed)
+        for name, original_body in _body_map(original).items():
+            expected = _expected_inertia_from_radii(original_body)
+            parsed_tensor = parsed_bodies[name].vessel.inertia.inertia_tensor
+            assert parsed_tensor is not None
+            for key, expected_value in expected.items():
+                assert parsed_tensor[key] == pytest.approx(expected_value, rel=1e-4)
+
+    def test_benchmark_declares_handoff_bridge_candidate_in_manifest(self) -> None:
+        bridge_text = " ".join(_load_manifest().get("bridge_candidates", []))
+        assert "future OrcaWave -> OrcaFlex handoff validation" in bridge_text
+
+    def test_benchmark_registered_in_model_inventory(self) -> None:
+        entries = {entry.name: entry for entry in build_model_inventory()}
+        entry = entries[BENCHMARK_ID]
+        assert entry.category is ModelCategory.FREQUENCY_DOMAIN
+        assert entry.path == Path(
+            "tests/hydrodynamics/diffraction/fixtures/benchmarks/"
+            "multibody_fpso_turret_v1/spec.yml"
+        )
+        assert set(entry.tags) >= {
+            "orcawave",
+            "multibody",
+            "fpso",
+            "turret",
+            "benchmark",
+            "roundtrip",
+        }
+        assert (REPO_ROOT / entry.path).is_file()

--- a/tests/hydrodynamics/diffraction/fixtures/benchmarks/__init__.py
+++ b/tests/hydrodynamics/diffraction/fixtures/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Named benchmark fixtures for diffraction tests."""

--- a/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/__init__.py
+++ b/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/__init__.py
@@ -1,0 +1,1 @@
+"""FPSO hull plus turret multi-body OrcaWave benchmark fixture."""

--- a/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/manifest.yaml
+++ b/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/manifest.yaml
@@ -1,0 +1,31 @@
+benchmark_id: multibody_fpso_turret_v1
+title: "Multi-body OrcaWave benchmark - FPSO hull + turret"
+category: frequency_domain
+solvers_proven:
+  - solver: orcawave
+    direction: forward
+    path: "spec.yml -> native OrcaWave YAML"
+  - solver: orcawave
+    direction: reverse
+    path: "native OrcaWave YAML -> DiffractionSpec"
+body_count: 2
+bodies:
+  - name: FPSO_Hull
+    free_body: true
+  - name: Turret
+    fixed_dofs: [surge, sway, yaw]
+    connection_parent: FPSO_Hull
+claim_boundary: "near-equivalent for key engineering inputs and tested round-trip pathways; not strict identity across every native OrcaWave YAML field"
+bridge_candidates:
+  - "future OrcaWave -> OrcaFlex handoff validation"
+source_history:
+  - "promoted from tests/hydrodynamics/diffraction/fixtures/spec_fpso_turret.yml under #2458"
+meshes_referenced:
+  - "tests/hydrodynamics/bemrosetta/fixtures/sample_box.gdf"
+  - "tests/hydrodynamics/bemrosetta/fixtures/sample_box.dat"
+related_issues:
+  promotion: 2458
+  delivered_foundations: [1605, 1592, 1768, 1638]
+  parent_roadmap: 1572
+  sibling_single_body: 2457
+version: 1

--- a/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/spec.yml
+++ b/tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/spec.yml
@@ -1,0 +1,71 @@
+version: "1.0"
+analysis_type: diffraction
+
+bodies:
+  - vessel:
+      name: "FPSO_Hull"
+      type: "FPSO"
+      geometry:
+        mesh_file: "../../../../bemrosetta/fixtures/sample_box.gdf"
+        mesh_format: gdf
+        symmetry: xz
+        reference_point: [0.0, 0.0, 0.0]
+        waterline_z: 0.0
+        length_units: m
+      inertia:
+        mass: 250000000.0
+        centre_of_gravity: [0.0, 0.0, -5.0]
+        radii_of_gyration: [20.0, 80.0, 80.0]
+    position: [0.0, 0.0, 0.0]
+    attitude: [0.0, 0.0, 0.0]
+
+  - vessel:
+      name: "Turret"
+      type: "turret"
+      geometry:
+        mesh_file: "../../../../bemrosetta/fixtures/sample_box.dat"
+        mesh_format: dat
+        symmetry: none
+        reference_point: [100.0, 0.0, 0.0]
+        waterline_z: 0.0
+        length_units: m
+      inertia:
+        mass: 5000000.0
+        centre_of_gravity: [100.0, 0.0, -3.0]
+        radii_of_gyration: [5.0, 5.0, 5.0]
+      fixed_dofs: [surge, sway, yaw]
+    position: [100.0, 0.0, 0.0]
+    attitude: [0.0, 0.0, 0.0]
+    connection_parent: "FPSO_Hull"
+
+environment:
+  water_depth: infinite
+  water_density: 1025.0
+  gravity: 9.80665
+
+frequencies:
+  input_type: frequency
+  range:
+    start: 0.1
+    end: 2.0
+    count: 30
+    distribution: logarithmic
+
+wave_headings:
+  values: [0.0, 30.0, 60.0, 90.0, 120.0, 150.0, 180.0]
+  symmetry: false
+
+solver_options:
+  remove_irregular_frequencies: true
+  qtf_calculation: false
+  load_rao_method: haskind
+  precision: double
+
+outputs:
+  formats: [csv, orcaflex_yml]
+  components: [raos, added_mass, damping, excitation]
+
+metadata:
+  project: "test_fpso_turret"
+  description: "Multi-body FPSO with turret analysis for testing"
+  tags: [test, fpso, turret, multibody]


### PR DESCRIPTION
## Summary

Promotes the FPSO hull + turret fixture as a named OrcaWave benchmark `multibody_fpso_turret_v1`. Registers it in the model inventory, documents the claim boundary in the OrcaWave domain README, and adds a benchmark test that exercises forward + reverse roundtrip through the spec converter.

Closes vamseeachanta/workspace-hub#2458 (`status:plan-approved`).

Plan reference: `docs/plans/2026-04-22-issue-2458-orcawave-multibody-benchmark-fixture.md` (already on main).

## What's added

- `tests/hydrodynamics/diffraction/fixtures/benchmarks/multibody_fpso_turret_v1/`
  - `spec.yml` — multi-body OrcaWave spec (FPSO hull + turret, fixed DOFs, parent connection)
  - `manifest.yaml` — claim boundary: near-equivalent for engineering inputs + tested round-trip pathways, not strict identity across every native OrcaWave YAML field
  - `__init__.py` — package markers
- `tests/hydrodynamics/diffraction/benchmarks/test_multibody_fpso_turret_benchmark.py` — benchmark roundtrip test (179 lines)
- `src/digitalmodel/benchmarks/inventory.py` — register `multibody_fpso_turret_v1` ModelInventoryEntry under FREQUENCY_DOMAIN
- `docs/domains/orcawave/README.md` — Named multi-body benchmark section documenting the boundary

## Validation

- Benchmark test passes: 17 passed
- Existing multi-body semantic roundtrip passes: 3 passed
- OrcaWave backend / spec-converter / runner sanity: 93 passed
- Full diffraction sweep stopped on an unrelated AQWA modular concatenation mismatch in `test_aqwa_backend.py` — out of scope for this PR

## Provenance

This PR replaces the original `codex/burn-20260427-issue-2458` scratch branch with a clean cherry-pick onto current main. The original branch had only this one commit and is being deleted post-merge.

## Test plan

- [ ] Reviewer runs `pytest tests/hydrodynamics/diffraction/benchmarks/test_multibody_fpso_turret_benchmark.py -v` — expect 17 passed
- [ ] Reviewer confirms `multibody_fpso_turret_v1` appears in `digitalmodel.benchmarks.inventory.build_model_inventory()` output