### PR TITLE
fix(marine_ops): expand chain database diameter slice to include 76mm

### DIFF
--- a/tests/marine_ops/marine_engineering/legacy/test_component_database.py
+++ b/tests/marine_ops/marine_engineering/legacy/test_component_database.py
@@ -221,7 +221,7 @@ class ComponentDatabase:
         print(f"Loaded {len(self.line_db)} synthetic line components")
 
     def _generate_chain_database(self) -> pd.DataFrame:
-        """Generate chain database (60 components)."""
+        """Generate chain database (72 components)."""
         data = []
 
         # Standard diameters (16mm to 162mm)
@@ -233,7 +233,7 @@ class ComponentDatabase:
         grades = [ChainGrade.R3, ChainGrade.R4, ChainGrade.R5]
         link_types = [LinkType.STUD_LINK]
 
-        for diameter in diameters[:20]:  # Generate 60 components
+        for diameter in diameters[:24]:  # Generate 72 components (24 diameters × 3 grades, includes 76mm)
             for grade in grades:
                 chain = ChainProperties.from_excel_formula(diameter, grade, link_types[0])
                 data.append({
@@ -562,10 +562,10 @@ class TestComponentDatabase:
         return ComponentDatabase()
 
     def test_database_loading(self, database):
-        """Validate all 336 components load correctly."""
-        # Chain: 60 components (20 diameters × 3 grades)
-        assert len(database.chain_db) == 60, (
-            f"Expected 60 chain components, got {len(database.chain_db)}"
+        """Validate all 348 components load correctly."""
+        # Chain: 72 components (24 diameters × 3 grades)
+        assert len(database.chain_db) == 72, (
+            f"Expected 72 chain components, got {len(database.chain_db)}"
         )
 
         # Wire: 24 components (8 diameters × 3 constructions)
@@ -578,10 +578,10 @@ class TestComponentDatabase:
             f"Expected 252 synthetic components, got {len(database.line_db)}"
         )
 
-        # Total: 336 components
+        # Total: 348 components
         total = len(database.chain_db) + len(database.wire_db) + len(database.line_db)
-        assert total == 336, (
-            f"Expected 336 total components, got {total}"
+        assert total == 348, (
+            f"Expected 348 total components, got {total}"
         )
 
     def test_get_chain_by_specification(self, database):

--- a/tests/marine_ops/marine_engineering/test_component_database.py
+++ b/tests/marine_ops/marine_engineering/test_component_database.py
@@ -221,7 +221,7 @@ class ComponentDatabase:
         print(f"Loaded {len(self.line_db)} synthetic line components")
 
     def _generate_chain_database(self) -> pd.DataFrame:
-        """Generate chain database (60 components)."""
+        """Generate chain database (72 components)."""
         data = []
 
         # Standard diameters (16mm to 162mm)
@@ -233,7 +233,7 @@ class ComponentDatabase:
         grades = [ChainGrade.R3, ChainGrade.R4, ChainGrade.R5]
         link_types = [LinkType.STUD_LINK]
 
-        for diameter in diameters[:20]:  # Generate 60 components
+        for diameter in diameters[:24]:  # Generate 72 components (24 diameters × 3 grades, includes 76mm)
             for grade in grades:
                 chain = ChainProperties.from_excel_formula(diameter, grade, link_types[0])
                 data.append({
@@ -562,10 +562,10 @@ class TestComponentDatabase:
         return ComponentDatabase()
 
     def test_database_loading(self, database):
-        """Validate all 336 components load correctly."""
-        # Chain: 60 components (20 diameters × 3 grades)
-        assert len(database.chain_db) == 60, (
-            f"Expected 60 chain components, got {len(database.chain_db)}"
+        """Validate all 348 components load correctly."""
+        # Chain: 72 components (24 diameters × 3 grades)
+        assert len(database.chain_db) == 72, (
+            f"Expected 72 chain components, got {len(database.chain_db)}"
         )
 
         # Wire: 24 components (8 diameters × 3 constructions)
@@ -578,10 +578,10 @@ class TestComponentDatabase:
             f"Expected 252 synthetic components, got {len(database.line_db)}"
         )
 
-        # Total: 336 components
+        # Total: 348 components
         total = len(database.chain_db) + len(database.wire_db) + len(database.line_db)
-        assert total == 336, (
-            f"Expected 336 total components, got {total}"
+        assert total == 348, (
+            f"Expected 348 total components, got {total}"
         )
 
     def test_get_chain_by_specification(self, database):


### PR DESCRIPTION
Closes #555.

## Summary
Off-by-one slice fix mirrored across two test files. The `_generate_chain_database` helper used `for diameter in diameters[:20]` which truncates the diameter list at 64mm; 76mm sits at index 23, so any test querying `76mm R4 Stud Link` failed with `ValueError: Chain not found`.

## Change
- Expanded slice from `[:20]` to `[:24]` (option (b) from the plan) — includes 70mm, 76mm.
- Updated count assertions in `test_database_loading`: chain components 60 → 72, total 336 → 348.
- Mirrored across both `tests/marine_ops/marine_engineering/test_component_database.py` and `tests/marine_ops/marine_engineering/legacy/test_component_database.py`.

## Test plan
- [x] `test_get_chain_by_specification` passes (was failing) — directly verifies 76mm R4 lookup.
- [x] `test_database_loading` passes against new 72/348 counts.
- [ ] `test_find_chain_with_safety_factor` still fails — exposed pre-existing bug: requires MBL ≥ 150 kN R4, needs diameter ≥ 78mm; outside `[:24]` scope. Out of scope for #555.
- [ ] `test_weight_scales_with_diameter_squared` still fails — queries `20mm` which is absent from the diameters array entirely (array starts 16, 19, 22). Out of scope for #555.
- [ ] `test_database_performance` flaky — perf threshold 1ms vs ~1-2ms observed. Environment-dependent, not slice-related.

## References
- Plan: `docs/plans/2026-05-05-issue-555-chain-database-diameters-slice.md`