### PR TITLE
feat(gis): imagery-timelapse pipeline (gis.imagery) for workspace-hub #2538

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pandas>=2.0.0,<3.0.0",
     "passlib[bcrypt]==1.7.4",
     "pillow==10.1.0", # Image processing
+    "imageio>=2.25.0,<3.0.0", # GIF/MP4 frame writing for imagery timelapses
     "pint>=0.25.3,<1.0.0",
     "plotly==5.17.0",
     "poetry",
@@ -143,6 +144,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gis-imagery = [
+    # Optional Earth Engine support for the gis.imagery timelapse pipeline.
+    # Not required: the pipeline falls back to public Planetary Computer STAC.
+    "earthengine-api>=0.1.370,<1.0.0",
+    "planetary-computer>=0.5.0,<2.0.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio==0.21.1",
@@ -210,6 +217,7 @@ gmsh-meshing = "digitalmodel.solvers.gmsh_meshing.cli:main"
 workflow-automation = "digitalmodel.workflows.workflow_automation.cli:main"
 bemrosetta = "digitalmodel.hydrodynamics.bemrosetta.cli:main"
 dynacard = "digitalmodel.marine_ops.artificial_lift.dynacard.cli:main"
+imagery-timelapse = "digitalmodel.gis.imagery.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/digitalmodel/gis/__init__.py
+++ b/src/digitalmodel/gis/__init__.py
@@ -8,6 +8,7 @@ from .layers.well_layer import WellLayer
 from . import io
 from . import integrations
 from . import layers
+from . import imagery
 
 __all__ = [
     "CoordinatePoint",
@@ -27,4 +28,5 @@ __all__ = [
     "io",
     "integrations",
     "layers",
+    "imagery",
 ]

--- a/src/digitalmodel/gis/imagery/__init__.py
+++ b/src/digitalmodel/gis/imagery/__init__.py
@@ -1,0 +1,42 @@
+"""Historical-imagery timelapse pipeline for the digitalmodel GIS package.
+
+Generates property- and neighborhood-scale historical-imagery timelapse
+artifacts (GIF/MP4/contact-sheet) for a manifest of geocoded addresses, using
+public NAIP/Landsat/Sentinel-2 imagery via the Microsoft Planetary Computer
+STAC API (with optional Earth Engine support).
+
+Pipeline stages:
+    1. :func:`~digitalmodel.gis.imagery.aoi.prepare_all` -- build AOI buffers.
+    2. :func:`~digitalmodel.gis.imagery.stac_client.probe_imagery_access` -- probe source coverage.
+    3. :func:`~digitalmodel.gis.imagery.renderer.render_all` -- render artifacts.
+
+See ``ace-examples/gis-timelapse-2538`` for a worked example (workspace-hub #2538).
+"""
+
+from __future__ import annotations
+
+from digitalmodel.gis.imagery.aoi import build_aoi, prepare_all
+from digitalmodel.gis.imagery.manifest import (
+    AddressRecord,
+    ImageryManifest,
+    ManifestDefaults,
+)
+from digitalmodel.gis.imagery.renderer import render_address, render_all
+from digitalmodel.gis.imagery.stac_client import (
+    probe_from_metadata,
+    probe_imagery_access,
+    stac_search,
+)
+
+__all__ = [
+    "AddressRecord",
+    "ImageryManifest",
+    "ManifestDefaults",
+    "build_aoi",
+    "prepare_all",
+    "probe_from_metadata",
+    "probe_imagery_access",
+    "stac_search",
+    "render_address",
+    "render_all",
+]

--- a/src/digitalmodel/gis/imagery/aoi.py
+++ b/src/digitalmodel/gis/imagery/aoi.py
@@ -1,0 +1,183 @@
+"""Area-of-interest (AOI) buffer generation for imagery timelapses.
+
+Builds point, property-scale and neighborhood-scale AOI buffers around a
+geocoded address and writes them as WGS84 GeoJSON plus a metadata manifest.
+Buffers are computed in a local UTM projection so the radius is honoured in
+metres, then reprojected back to WGS84.
+
+Ported from the workspace-hub issue #2538 ``prepare_aoi.py`` script, with the
+hard-coded working directory replaced by an :class:`ImageryManifest`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+import geopandas as gpd
+from shapely.geometry import Point, mapping
+
+from digitalmodel.gis.imagery.manifest import AddressRecord, ImageryManifest
+
+logger = logging.getLogger(__name__)
+
+MILES_TO_METERS = 1609.344
+
+
+def local_utm_epsg(lat: float, lon: float) -> int:
+    """Return the EPSG code of the UTM zone containing ``(lat, lon)``."""
+    zone = int(math.floor((lon + 180.0) / 6.0) + 1)
+    return (32600 if lat >= 0 else 32700) + zone
+
+
+def feature_collection(geometry, properties: dict) -> dict:
+    """Wrap a single geometry + properties as a GeoJSON FeatureCollection."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": mapping(geometry),
+                "properties": properties,
+            }
+        ],
+    }
+
+
+def build_aoi(manifest: ImageryManifest, address: AddressRecord) -> dict:
+    """Generate point + property/neighborhood AOI GeoJSON for one address.
+
+    Returns the metadata dict (also written to ``manifests/<slug>-aoi-metadata.json``)
+    describing the generated files and buffer bounds.
+    """
+    output_root = manifest.output_root
+    cache_root = manifest.cache_root
+    log_root = manifest.log_root
+    now = datetime.now(timezone.utc).isoformat()
+
+    slug = address.slug
+    lat = float(address.latitude)
+    lon = float(address.longitude)
+    utm = f"EPSG:{local_utm_epsg(lat, lon)}"
+
+    out_dir = output_root / slug
+    aoi_dir = out_dir / "aoi"
+    manifest_dir = out_dir / "manifests"
+    report_dir = out_dir / "reports"
+    frame_dirs = [out_dir / "frames" / "property", out_dir / "frames" / "neighborhood"]
+    media_dir = out_dir / "media"
+    cache_dir = cache_root / slug
+    for d in [aoi_dir, manifest_dir, report_dir, media_dir, cache_dir, log_root, *frame_dirs]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    gdf = gpd.GeoDataFrame(
+        [{"slug": slug, "label": address.label, "address": address.address}],
+        geometry=[Point(lon, lat)],
+        crs="EPSG:4326",
+    )
+    metric = gdf.to_crs(utm)
+    outputs: dict[str, dict] = {}
+    radii = {
+        "property": manifest.property_radius(address),
+        "neighborhood": manifest.neighborhood_radius(address),
+    }
+    for scale, radius_miles in radii.items():
+        buffer_metric = metric.geometry.iloc[0].buffer(radius_miles * MILES_TO_METERS)
+        buffer_wgs84 = gpd.GeoSeries([buffer_metric], crs=utm).to_crs("EPSG:4326").iloc[0]
+        props = {
+            "slug": slug,
+            "label": address.label,
+            "address": address.address,
+            "scale": scale,
+            "radius_miles": radius_miles,
+            "radius_meters": radius_miles * MILES_TO_METERS,
+            "center_latitude": lat,
+            "center_longitude": lon,
+            "source_crs": "EPSG:4326",
+            "buffer_crs": utm,
+            "generated_at": now,
+        }
+        geojson_path = aoi_dir / f"{slug}-{scale}-aoi.geojson"
+        geojson_path.write_text(json.dumps(feature_collection(buffer_wgs84, props), indent=2))
+        outputs[scale] = {
+            "geojson": str(geojson_path),
+            "radius_miles": radius_miles,
+            "radius_meters": radius_miles * MILES_TO_METERS,
+            "bounds_wgs84": list(buffer_wgs84.bounds),
+            "buffer_crs": utm,
+        }
+
+    point_path = aoi_dir / f"{slug}-point.geojson"
+    point_path.write_text(
+        json.dumps(
+            feature_collection(
+                Point(lon, lat),
+                {
+                    "slug": slug,
+                    "label": address.label,
+                    "address": address.address,
+                    "latitude": lat,
+                    "longitude": lon,
+                    "geocode_source": address.geocode_source,
+                    "generated_at": now,
+                },
+            ),
+            indent=2,
+        )
+    )
+
+    metadata = {
+        "slug": slug,
+        "label": address.label,
+        "address": address.address,
+        "latitude": lat,
+        "longitude": lon,
+        "geocode_source": address.geocode_source,
+        "generated_at": now,
+        "point_geojson": str(point_path),
+        "aoi": outputs,
+        "output_dirs": {
+            "aoi": str(aoi_dir),
+            "frames_property": str(frame_dirs[0]),
+            "frames_neighborhood": str(frame_dirs[1]),
+            "media": str(media_dir),
+            "reports": str(report_dir),
+            "manifests": str(manifest_dir),
+            "cache": str(cache_dir),
+        },
+    }
+    metadata_path = manifest_dir / f"{slug}-aoi-metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2))
+    logger.info("Prepared AOI for %s -> %s", slug, metadata_path)
+    return metadata
+
+
+def prepare_all(manifest: ImageryManifest) -> dict:
+    """Build AOIs for every address in the manifest; write ``batch-status.json``."""
+    now = datetime.now(timezone.utc).isoformat()
+    statuses = []
+    for address in manifest.addresses:
+        metadata = build_aoi(manifest, address)
+        statuses.append(
+            {
+                "slug": address.slug,
+                "stage": "aoi_prepared",
+                "status": "complete",
+                "metadata": str(manifest.output_root / address.slug / "manifests" / f"{address.slug}-aoi-metadata.json"),
+            }
+        )
+        _ = metadata
+    batch_status = {
+        "issue": manifest.created_for_issue,
+        "generated_at": now,
+        "stage": "aoi_preparation",
+        "addresses_total": len(manifest.addresses),
+        "addresses": statuses,
+    }
+    status_path = manifest.output_root / "batch-status.json"
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    status_path.write_text(json.dumps(batch_status, indent=2))
+    return batch_status

--- a/src/digitalmodel/gis/imagery/cli.py
+++ b/src/digitalmodel/gis/imagery/cli.py
@@ -1,0 +1,86 @@
+"""Command-line interface for the GIS imagery-timelapse pipeline.
+
+Exposes the pipeline stages (``prepare-aoi``, ``probe``, ``render``) and an
+end-to-end ``run`` command, all driven by an imagery manifest file.  Registered
+as the ``imagery-timelapse`` console script.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import click
+
+from digitalmodel.gis.imagery.aoi import prepare_all
+from digitalmodel.gis.imagery.manifest import ImageryManifest
+from digitalmodel.gis.imagery.renderer import render_all
+from digitalmodel.gis.imagery.stac_client import probe_from_metadata
+
+_MANIFEST_OPTION = click.option(
+    "--manifest",
+    "manifest_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the imagery manifest (.yaml/.yml/.json).",
+)
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Enable info-level logging.")
+def cli(verbose: bool) -> None:
+    """Generate historical-imagery timelapse artifacts from an address manifest."""
+    logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
+
+
+@cli.command("prepare-aoi")
+@_MANIFEST_OPTION
+def prepare_aoi_cmd(manifest_path: str) -> None:
+    """Build point/property/neighborhood AOI GeoJSON for every address."""
+    manifest = ImageryManifest.from_file(manifest_path)
+    click.echo(json.dumps(prepare_all(manifest), indent=2))
+
+
+@cli.command("probe")
+@_MANIFEST_OPTION
+def probe_cmd(manifest_path: str) -> None:
+    """Probe Earth Engine + Planetary Computer STAC coverage per address."""
+    manifest = ImageryManifest.from_file(manifest_path)
+    results = []
+    for address in manifest.addresses:
+        meta_path = manifest.output_root / address.slug / "manifests" / f"{address.slug}-aoi-metadata.json"
+        results.append(probe_from_metadata(meta_path))
+    click.echo(json.dumps(results, indent=2))
+
+
+@cli.command("render")
+@_MANIFEST_OPTION
+@click.option("--max-years", default=8, show_default=True, help="Maximum number of yearly frames.")
+def render_cmd(manifest_path: str, max_years: int) -> None:
+    """Render GIF/MP4/contact-sheet preview artifacts for every address."""
+    manifest = ImageryManifest.from_file(manifest_path)
+    click.echo(json.dumps(render_all(manifest, max_years=max_years), indent=2))
+
+
+@cli.command("run")
+@_MANIFEST_OPTION
+@click.option("--max-years", default=8, show_default=True, help="Maximum number of yearly frames.")
+@click.option("--probe/--no-probe", default=True, show_default=True, help="Run the imagery-access probe stage.")
+def run_cmd(manifest_path: str, max_years: int, probe: bool) -> None:
+    """Run the full pipeline: prepare AOIs, (optionally) probe, then render."""
+    manifest = ImageryManifest.from_file(manifest_path)
+    prepare_all(manifest)
+    if probe:
+        for address in manifest.addresses:
+            meta_path = manifest.output_root / address.slug / "manifests" / f"{address.slug}-aoi-metadata.json"
+            probe_from_metadata(meta_path)
+    click.echo(json.dumps(render_all(manifest, max_years=max_years), indent=2))
+
+
+def main() -> None:
+    """Console-script entry point."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/gis/imagery/manifest.py
+++ b/src/digitalmodel/gis/imagery/manifest.py
@@ -1,0 +1,93 @@
+"""Manifest models for the GIS imagery-timelapse pipeline.
+
+Provides :class:`ImageryManifest`, a manifest describing one or more addresses
+for which historical-imagery timelapse artifacts should be generated.  The
+manifest decouples the pipeline from any hard-coded working directory: output,
+cache and log roots are read from the manifest (and may be resolved relative to
+the manifest file), so the same code runs for any address set in any workspace.
+
+The schema mirrors the original ``addresses.yaml``/``addresses.json`` files
+developed for workspace-hub issue #2538 (see
+``ace-examples/gis-timelapse-2538`` for a worked example).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+DEFAULT_PROPERTY_RADIUS_MILES = 0.20
+DEFAULT_NEIGHBORHOOD_RADIUS_MILES = 1.50
+
+
+class ManifestDefaults(BaseModel):
+    """Pipeline defaults applied to addresses that do not override them."""
+
+    property_radius_miles: float = DEFAULT_PROPERTY_RADIUS_MILES
+    neighborhood_radius_miles: float = DEFAULT_NEIGHBORHOOD_RADIUS_MILES
+    requested_outputs: list[str] = Field(default_factory=list)
+    sources_to_evaluate: list[str] = Field(default_factory=list)
+
+
+class AddressRecord(BaseModel):
+    """A single address to render, with optional per-address overrides."""
+
+    label: str
+    slug: str
+    address: str
+    latitude: float
+    longitude: float
+    geocode_source: str = "unknown"
+    property_radius_miles: float | None = None
+    neighborhood_radius_miles: float | None = None
+    requested_outputs: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class ImageryManifest(BaseModel):
+    """Top-level manifest binding addresses to output/cache/log roots."""
+
+    version: int = 1
+    created_for_issue: int | None = None
+    coordinate_crs: str = "EPSG:4326"
+    output_root: Path
+    cache_root: Path
+    log_root: Path
+    defaults: ManifestDefaults = Field(default_factory=ManifestDefaults)
+    addresses: list[AddressRecord] = Field(default_factory=list)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "ImageryManifest":
+        """Load a manifest from a ``.yaml``/``.yml`` or ``.json`` file.
+
+        Relative ``output_root``/``cache_root``/``log_root`` values are resolved
+        relative to the manifest's parent directory so a manifest is portable.
+        """
+        path = Path(path)
+        raw = path.read_text()
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            data: dict[str, Any] = yaml.safe_load(raw)
+        else:
+            data = json.loads(raw)
+        base_dir = path.parent
+        for key in ("output_root", "cache_root", "log_root"):
+            value = data.get(key)
+            if value is not None and not Path(value).is_absolute():
+                data[key] = str((base_dir / value).resolve())
+        return cls.model_validate(data)
+
+    def property_radius(self, address: AddressRecord) -> float:
+        """Effective property-scale radius for ``address`` (miles)."""
+        if address.property_radius_miles is not None:
+            return address.property_radius_miles
+        return self.defaults.property_radius_miles
+
+    def neighborhood_radius(self, address: AddressRecord) -> float:
+        """Effective neighborhood-scale radius for ``address`` (miles)."""
+        if address.neighborhood_radius_miles is not None:
+            return address.neighborhood_radius_miles
+        return self.defaults.neighborhood_radius_miles

--- a/src/digitalmodel/gis/imagery/renderer.py
+++ b/src/digitalmodel/gis/imagery/renderer.py
@@ -1,0 +1,250 @@
+"""NAIP preview-frame renderer for the imagery timelapse pipeline.
+
+A fallback renderer that uses Microsoft Planetary Computer NAIP STAC
+preview/thumbnail assets to produce a labelled GIF, MP4 and contact sheet per
+address.  It proves the multi-address artifact loop without requiring Earth
+Engine authentication; the generated report documents this limitation and the
+recommended production upgrade (NAIP COG/tile crop/mosaic).
+
+Ported from the workspace-hub issue #2538
+``render_naip_preview_artifacts.py`` script.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import subprocess
+from collections import OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import imageio.v2 as imageio
+import requests
+from PIL import Image, ImageDraw, ImageFont
+
+from digitalmodel.gis.imagery.manifest import AddressRecord, ImageryManifest
+
+logger = logging.getLogger(__name__)
+
+STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1/search"
+_FONT_PATHS = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+]
+
+
+def load_font(size: int = 24):
+    """Return a TrueType font if one is installed, else PIL's default."""
+    for p in _FONT_PATHS:
+        if Path(p).exists():
+            return ImageFont.truetype(p, size)
+    return ImageFont.load_default()
+
+
+def label_image(img: Image.Image, lines: list[str]) -> Image.Image:
+    """Resize ``img`` to 960x720 and overlay a translucent caption block."""
+    img = img.convert("RGB").resize((960, 720))
+    draw = ImageDraw.Draw(img, "RGBA")
+    font = load_font(24)
+    small = load_font(18)
+    pad = 14
+    box_h = 34 + 28 * len(lines)
+    draw.rectangle([0, 0, img.width, box_h], fill=(0, 0, 0, 170))
+    y = pad
+    for i, line in enumerate(lines):
+        draw.text((pad, y), line, fill=(255, 255, 255, 255), font=font if i == 0 else small)
+        y += 30 if i == 0 else 26
+    return img
+
+
+def stac_naip_items(bbox: list[float]) -> list[dict]:
+    """Return all NAIP STAC items intersecting ``bbox`` (2003-present)."""
+    payload = {"collections": ["naip"], "bbox": bbox, "datetime": "2003-01-01/2026-12-31", "limit": 100}
+    r = requests.post(STAC_URL, json=payload, timeout=60)
+    r.raise_for_status()
+    return r.json().get("features", [])
+
+
+def choose_representative_by_year(items: list[dict], max_years: int = 8) -> list[dict]:
+    """Pick one item per year, evenly spread to at most ``max_years`` frames."""
+    by_year: "OrderedDict[str, dict]" = OrderedDict()
+    for item in sorted(items, key=lambda f: f.get("properties", {}).get("datetime", "")):
+        dt = item.get("properties", {}).get("datetime", "")
+        year = dt[:4]
+        if year and year not in by_year:
+            by_year[year] = item
+    selected = list(by_year.values())
+    if len(selected) > max_years:
+        idxs = sorted(set(round(i * (len(selected) - 1) / (max_years - 1)) for i in range(max_years)))
+        selected = [selected[i] for i in idxs]
+    return selected
+
+
+def download_preview(item: dict) -> Image.Image:
+    """Download a STAC item's rendered_preview (or thumbnail) asset as an image."""
+    assets = item.get("assets", {})
+    href = assets.get("rendered_preview", {}).get("href") or assets.get("thumbnail", {}).get("href")
+    if not href:
+        raise RuntimeError(f"No preview/thumbnail asset for {item.get('id')}")
+    r = requests.get(href, timeout=90)
+    r.raise_for_status()
+    return Image.open(io.BytesIO(r.content))
+
+
+def render_address(manifest: ImageryManifest, address: AddressRecord, max_years: int = 8) -> dict:
+    """Render GIF/MP4/contact-sheet preview artifacts for one address.
+
+    Requires that :func:`digitalmodel.gis.imagery.aoi.build_aoi` has already run
+    for this address (reads its ``<slug>-aoi-metadata.json``).  Returns a status
+    dict describing the generated artifacts.
+    """
+    output_root = manifest.output_root
+    slug = address.slug
+    meta_path = output_root / slug / "manifests" / f"{slug}-aoi-metadata.json"
+    meta = json.loads(meta_path.read_text())
+    bbox = meta["aoi"]["neighborhood"]["bounds_wgs84"]
+    radius_miles = meta["aoi"]["neighborhood"]["radius_miles"]
+    out_dir = output_root / slug
+    frame_dir = out_dir / "frames" / "neighborhood"
+    media_dir = out_dir / "media"
+    report_dir = out_dir / "reports"
+    manifest_dir = out_dir / "manifests"
+    for d in [frame_dir, media_dir, report_dir, manifest_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    items = stac_naip_items(bbox)
+    selected = choose_representative_by_year(items, max_years=max_years)
+    frame_records = []
+    frames: list[Image.Image] = []
+    for n, item in enumerate(selected, 1):
+        dt = item.get("properties", {}).get("datetime", "")
+        year = dt[:4] or "unknown"
+        item_id = item.get("id", "unknown")
+        img = download_preview(item)
+        labeled = label_image(
+            img,
+            [
+                f"{address.label} — NAIP preview {year}",
+                f"Scale: neighborhood fallback preview | radius: {radius_miles} mi",
+                f"Source item: {item_id}",
+                "Limitation: STAC preview/thumbnail proves pipeline; final frame should crop COG/tiles consistently.",
+            ],
+        )
+        frame_path = frame_dir / f"{slug}-naip-{year}-{n:02d}.png"
+        labeled.save(frame_path)
+        frames.append(labeled)
+        frame_records.append(
+            {
+                "frame": str(frame_path),
+                "source": "NAIP via Microsoft Planetary Computer STAC rendered_preview/thumbnail",
+                "item_id": item_id,
+                "datetime": dt,
+                "year": year,
+                "scale": "neighborhood",
+                "radius_miles": radius_miles,
+                "asset_used": "rendered_preview" if item.get("assets", {}).get("rendered_preview") else "thumbnail",
+            }
+        )
+
+    if not frames:
+        raise RuntimeError("No NAIP frames selected")
+
+    gif_path = media_dir / f"{slug}-naip-neighborhood-preview.gif"
+    mp4_path = media_dir / f"{slug}-naip-neighborhood-preview.mp4"
+    contact_path = report_dir / f"{slug}-naip-contact-sheet.png"
+    imageio.mimsave(gif_path, [f.copy() for f in frames], duration=1.25)
+    ffmpeg_list = media_dir / f"{slug}-ffmpeg-frames.txt"
+    ffmpeg_list.write_text(
+        "".join(f"file '{Path(r['frame']).resolve()}'\nduration 1.25\n" for r in frame_records)
+        + f"file '{Path(frame_records[-1]['frame']).resolve()}'\n"
+    )
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "concat", "-safe", "0", "-i", str(ffmpeg_list),
+            "-vf", "fps=1,format=yuv420p", str(mp4_path),
+        ],
+        check=True,
+    )
+
+    cols = min(3, len(frames))
+    rows = (len(frames) + cols - 1) // cols
+    thumb_w, thumb_h = 480, 360
+    contact = Image.new("RGB", (cols * thumb_w, rows * thumb_h), "white")
+    for i, f in enumerate(frames):
+        contact.paste(f.resize((thumb_w, thumb_h)), ((i % cols) * thumb_w, (i // cols) * thumb_h))
+    contact.save(contact_path)
+
+    frame_manifest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "slug": slug,
+        "address": address.address,
+        "scale": "neighborhood",
+        "bbox_wgs84": bbox,
+        "renderer": "naip_stac_preview_fallback_v1",
+        "limitations": [
+            "Earth Engine is not authenticated on this machine, so this renderer uses public STAC previews/thumbnails.",
+            "Preview frames are review artifacts, not final measurement-grade orthomosaic crops.",
+            "Final production rendering should use NAIP COG/tile crop/mosaic with consistent AOI extent.",
+        ],
+        "frames": frame_records,
+        "artifacts": {"gif": str(gif_path), "mp4": str(mp4_path), "contact_sheet": str(contact_path)},
+    }
+    frame_manifest_path = manifest_dir / f"{slug}-frame-manifest.json"
+    frame_manifest_path.write_text(json.dumps(frame_manifest, indent=2))
+
+    report_path = report_dir / f"{slug}-review-report.md"
+    report_path.write_text(
+        f"# {address.label} historical imagery review artifact\n\n"
+        f"Address: `{address.address}`\n\n"
+        f"Generated: `{frame_manifest['generated_at']}`\n\n"
+        f"## Artifacts\n\n"
+        f"- GIF: `{gif_path}`\n"
+        f"- MP4: `{mp4_path}`\n"
+        f"- Contact sheet: `{contact_path}`\n"
+        f"- Frame manifest: `{frame_manifest_path}`\n\n"
+        f"## Source and date coverage\n\n"
+        + "".join(f"- {r['year']}: {r['item_id']} ({r['datetime']})\n" for r in frame_records)
+        + "\n## Limitations and next step\n\n"
+        + "These are NAIP public STAC preview frames used to validate the multi-address "
+        "pipeline. Next step is to switch the renderer from preview assets to NAIP COG/tile "
+        "crop/mosaic for a consistent AOI extent at parcel/neighborhood scale.\n"
+    )
+
+    logger.info("Rendered %d frames for %s", len(frame_records), slug)
+    return {
+        "slug": slug,
+        "status": "complete",
+        "frames": len(frame_records),
+        "years": [r["year"] for r in frame_records],
+        "artifacts": frame_manifest["artifacts"],
+        "frame_manifest": str(frame_manifest_path),
+        "report": str(report_path),
+    }
+
+
+def render_all(manifest: ImageryManifest, max_years: int = 8) -> dict:
+    """Render preview artifacts for every address; write ``batch-render-status.json``."""
+    status: dict = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "stage": "render_preview_artifacts",
+        "addresses": [],
+    }
+    for address in manifest.addresses:
+        try:
+            status["addresses"].append(render_address(manifest, address, max_years=max_years))
+        except Exception as e:  # noqa: BLE001 - isolate per-address failure, continue batch
+            status["addresses"].append(
+                {
+                    "slug": address.slug,
+                    "status": "failed",
+                    "error_type": type(e).__name__,
+                    "error": str(e)[:1000],
+                }
+            )
+    status_path = manifest.output_root / "batch-render-status.json"
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    status_path.write_text(json.dumps(status, indent=2))
+    return status

--- a/src/digitalmodel/gis/imagery/stac_client.py
+++ b/src/digitalmodel/gis/imagery/stac_client.py
@@ -1,0 +1,147 @@
+"""Imagery-source access probing for the timelapse pipeline.
+
+Probes the Microsoft Planetary Computer STAC API for NAIP/Landsat/Sentinel-2
+coverage of an AOI, and (optionally) checks whether Earth Engine is importable
+and authenticated.  No credentials are required for the STAC probe; Earth Engine
+is treated as an optional enhancement that degrades gracefully when unavailable.
+
+Ported from the workspace-hub issue #2538 ``probe_imagery_access.py`` script.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1/search"
+COLLECTIONS = {
+    "naip": {"datetime": "2003-01-01/2026-12-31"},
+    "landsat-c2-l2": {"datetime": "1984-01-01/2026-12-31"},
+    "sentinel-2-l2a": {"datetime": "2015-01-01/2026-12-31"},
+}
+
+
+def stac_search(collection: str, bbox: list[float], dt: str, limit: int = 10) -> dict:
+    """Search one STAC collection over ``bbox``/``dt`` and summarise the result."""
+    payload = {
+        "collections": [collection],
+        "bbox": bbox,
+        "datetime": dt,
+        "limit": limit,
+    }
+    r = requests.post(STAC_URL, json=payload, timeout=45)
+    info: dict = {
+        "http_status": r.status_code,
+        "ok": r.ok,
+        "url": STAC_URL,
+        "collection": collection,
+    }
+    if not r.ok:
+        info["error"] = r.text[:1000]
+        return info
+    data = r.json()
+    features = data.get("features", [])
+    years = sorted(
+        {
+            (f.get("properties", {}).get("datetime") or "")[:4]
+            for f in features
+            if f.get("properties", {}).get("datetime")
+        }
+    )
+    sample = []
+    for f in features[:3]:
+        props = f.get("properties", {})
+        assets = f.get("assets", {})
+        sample.append(
+            {
+                "id": f.get("id"),
+                "datetime": props.get("datetime"),
+                "eo_cloud_cover": props.get("eo:cloud_cover"),
+                "asset_keys": sorted(list(assets.keys()))[:12],
+            }
+        )
+    info.update(
+        {
+            "matched_returned": len(features),
+            "sample_years_returned": years,
+            "sample_items": sample,
+        }
+    )
+    return info
+
+
+def probe_earth_engine() -> dict:
+    """Report whether the Earth Engine SDK is importable and initialises."""
+    try:
+        import ee
+    except Exception as e:  # noqa: BLE001 - report any import failure verbatim
+        return {"import": "error", "error_type": type(e).__name__, "error": str(e)[:1000]}
+    try:
+        ee.Initialize()
+        return {"initialize": "ok", "probe": ee.Number(1).getInfo()}
+    except Exception as e:  # noqa: BLE001 - auth/init failures are expected & non-fatal
+        return {"initialize": "error", "error_type": type(e).__name__, "error": str(e)[:1000]}
+
+
+def probe_imagery_access(bbox: list[float], *, address: str | None = None, slug: str | None = None) -> dict:
+    """Probe Earth Engine + Planetary Computer STAC coverage for ``bbox``."""
+    result: dict = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "address_slug": slug,
+        "address": address,
+        "bbox_used": bbox,
+        "earth_engine": probe_earth_engine(),
+        "planetary_computer_stac": {},
+        "interpretation": [],
+    }
+    for collection, cfg in COLLECTIONS.items():
+        try:
+            result["planetary_computer_stac"][collection] = stac_search(collection, bbox, cfg["datetime"])
+        except Exception as e:  # noqa: BLE001 - record per-collection failures, keep going
+            result["planetary_computer_stac"][collection] = {
+                "ok": False,
+                "error_type": type(e).__name__,
+                "error": str(e)[:1000],
+            }
+
+    if result["earth_engine"].get("initialize") == "error":
+        result["interpretation"].append(
+            "Earth Engine Python libraries are installed, but account authentication is "
+            "missing; run earthengine authenticate or use public STAC fallback."
+        )
+    for collection, probe in result["planetary_computer_stac"].items():
+        if probe.get("ok") and probe.get("matched_returned", 0) > 0:
+            result["interpretation"].append(
+                f"{collection}: public STAC returned sample items; viable for automated "
+                "discovery/rendering with follow-up asset signing/download."
+            )
+        else:
+            result["interpretation"].append(
+                f"{collection}: no sample items returned or probe failed; document as "
+                "blocker/fallback candidate."
+            )
+    return result
+
+
+def probe_from_metadata(metadata_path: str | Path) -> dict:
+    """Probe imagery access using the neighborhood bbox from an AOI metadata file.
+
+    Writes the probe report next to the address's ``reports/`` directory and
+    returns the result dict.
+    """
+    metadata_path = Path(metadata_path)
+    meta = json.loads(metadata_path.read_text())
+    bbox = meta["aoi"]["neighborhood"]["bounds_wgs84"]
+    result = probe_imagery_access(bbox, address=meta.get("address"), slug=meta.get("slug"))
+    report_dir = Path(meta["output_dirs"]["reports"])
+    report_dir.mkdir(parents=True, exist_ok=True)
+    out = report_dir / "imagery-access-probe.json"
+    out.write_text(json.dumps(result, indent=2))
+    logger.info("Wrote imagery access probe -> %s", out)
+    return result

--- a/tests/gis/test_imagery_aoi.py
+++ b/tests/gis/test_imagery_aoi.py
@@ -1,0 +1,88 @@
+"""Offline tests for the gis.imagery AOI + manifest stages (no network)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from digitalmodel.gis.imagery import ImageryManifest
+from digitalmodel.gis.imagery.aoi import build_aoi, local_utm_epsg, prepare_all
+
+PIPING_ROCK = {
+    "version": 1,
+    "created_for_issue": 2538,
+    "coordinate_crs": "EPSG:4326",
+    "output_root": "outputs",
+    "cache_root": "cache",
+    "log_root": "logs",
+    "defaults": {"property_radius_miles": 0.20, "neighborhood_radius_miles": 1.50},
+    "addresses": [
+        {
+            "label": "11511 Piping Rock Dr",
+            "slug": "11511-piping-rock",
+            "address": "11511 Piping Rock Dr., Houston, TX 77077",
+            "latitude": 29.7397219,
+            "longitude": -95.5971637,
+            "geocode_source": "issue_body_nominatim",
+        }
+    ],
+}
+
+
+def test_local_utm_epsg_houston_is_zone_15n():
+    # Houston (~-95.6 lon, +29.7 lat) falls in UTM zone 15 North -> EPSG:32615.
+    assert local_utm_epsg(29.7397219, -95.5971637) == 32615
+
+
+def test_local_utm_epsg_southern_hemisphere():
+    # Southern-hemisphere points use the 327xx band.
+    assert local_utm_epsg(-33.86, 151.20) == 32756
+
+
+def _write_manifest(tmp_path):
+    manifest_path = tmp_path / "addresses.json"
+    manifest_path.write_text(json.dumps(PIPING_ROCK))
+    return manifest_path
+
+
+def test_manifest_roots_resolved_relative_to_file(tmp_path):
+    manifest = ImageryManifest.from_file(_write_manifest(tmp_path))
+    # Relative roots in the manifest are resolved against the manifest's dir.
+    assert manifest.output_root == (tmp_path / "outputs").resolve()
+    assert manifest.created_for_issue == 2538
+
+
+def test_manifest_radius_falls_back_to_defaults(tmp_path):
+    manifest = ImageryManifest.from_file(_write_manifest(tmp_path))
+    addr = manifest.addresses[0]
+    assert manifest.property_radius(addr) == pytest.approx(0.20)
+    assert manifest.neighborhood_radius(addr) == pytest.approx(1.50)
+
+
+def test_build_aoi_writes_expected_geojson(tmp_path):
+    manifest = ImageryManifest.from_file(_write_manifest(tmp_path))
+    addr = manifest.addresses[0]
+    meta = build_aoi(manifest, addr)
+
+    slug = "11511-piping-rock"
+    aoi_dir = manifest.output_root / slug / "aoi"
+    for name in (f"{slug}-point.geojson", f"{slug}-property-aoi.geojson", f"{slug}-neighborhood-aoi.geojson"):
+        assert (aoi_dir / name).exists(), name
+
+    # Neighborhood bbox must be wider than the property bbox (1.5 mi vs 0.2 mi).
+    prop = meta["aoi"]["property"]["bounds_wgs84"]
+    nbhd = meta["aoi"]["neighborhood"]["bounds_wgs84"]
+    prop_width = prop[2] - prop[0]
+    nbhd_width = nbhd[2] - nbhd[0]
+    assert nbhd_width > prop_width
+    assert meta["aoi"]["neighborhood"]["buffer_crs"] == "EPSG:32615"
+
+
+def test_prepare_all_writes_batch_status(tmp_path):
+    manifest = ImageryManifest.from_file(_write_manifest(tmp_path))
+    batch = prepare_all(manifest)
+    assert batch["issue"] == 2538
+    assert batch["addresses_total"] == 1
+    assert batch["addresses"][0]["status"] == "complete"
+    assert (manifest.output_root / "batch-status.json").exists()


### PR DESCRIPTION
## Summary

Generalizes the workspace-hub #2538 historical-imagery timelapse scripts (previously loose, un-versioned scripts under `/mnt/local-analysis/ace2-gis-timelapse`) into a reusable, manifest-driven subpackage `digitalmodel.gis.imagery`, so the capability is importable across the repo ecosystem rather than living as one-off scripts.

## What's included

- **`gis.imagery.manifest`** — Pydantic `ImageryManifest`/`AddressRecord` models. Output/cache/log roots come from the manifest (relative roots resolve against the manifest file), replacing the original hard-coded working directory.
- **`gis.imagery.aoi`** — point/property/neighborhood AOI buffer generation (UTM-metric buffering → WGS84 GeoJSON).
- **`gis.imagery.stac_client`** — Planetary Computer STAC coverage probe + optional Earth Engine check (graceful fallback).
- **`gis.imagery.renderer`** — NAIP STAC preview GIF/MP4/contact-sheet fallback renderer.
- **`gis.imagery.cli`** — `imagery-timelapse` console script (`prepare-aoi` / `probe` / `render` / `run`).
- **pyproject** — adds `imageio`; new `gis-imagery` extra (`earthengine-api`, `planetary-computer`); registers the CLI entry point.
- **tests/gis/test_imagery_aoi.py** — offline AOI/manifest tests (6 passing, no network).

## Fidelity

The ported AOI math reproduces the original #2538 run's buffer bounds **exactly** (0.0° max difference for both property and neighborhood scales).

## Traceability

The full as-run evidence (manifest, ~17 MB media, reports, GitHub comment draft, original scripts) is preserved as a worked example at `ace-examples/gis-timelapse-2538/` with a README mapping each original script to its new module.

## Notes for review

- Per `CLAUDE.md`, this should map to a `WRK-*` work-queue entry — flagging for the cross-review gate.
- The #2538 GitHub comment draft has **not** been posted (issue guardrail: GitHub mutations from ace-linux-1 control plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)