### PR TITLE
docs(orcawave): diffraction domain architecture + issue completeness scorecard

### DIFF
--- a/docs/domains/orcawave/2026-05-27-issue-completeness-scorecard.html
+++ b/docs/domains/orcawave/2026-05-27-issue-completeness-scorecard.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OrcaWave Issue Completeness Scorecard — 2026-05-27</title>
+<style>
+  :root{
+    --bg:#0f1419; --panel:#1a2129; --ink:#e6edf3; --muted:#9aa7b4;
+    --line:#2a3540; --accent:#4f9cf9; --good:#3fb950; --warn:#d29922; --bad:#f85149;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:1120px;margin:0 auto;padding:32px 24px 80px}
+  h1{font-size:26px;margin:0 0 4px}
+  h2{font-size:19px;margin:38px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  h3{font-size:15px;margin:24px 0 6px;color:var(--accent)}
+  .sub{color:var(--muted);margin:0 0 4px}
+  code{background:#0b0f14;border:1px solid var(--line);border-radius:4px;padding:1px 5px;font-size:12.5px;color:#cdd9e5}
+  a{color:var(--accent);text-decoration:none}
+  a:hover{text-decoration:underline}
+  table{width:100%;border-collapse:collapse;margin:10px 0 6px;font-size:13.5px}
+  th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--muted);font-weight:600;background:var(--panel)}
+  tr:hover td{background:#161d25}
+  .score{font-weight:700;white-space:nowrap;text-align:center}
+  .bar{position:relative;height:8px;border-radius:5px;background:#0b0f14;overflow:hidden;min-width:90px}
+  .bar > i{position:absolute;left:0;top:0;bottom:0;border-radius:5px;display:block}
+  .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11.5px;font-weight:600}
+  .done{color:var(--good)} .part{color:var(--warn)} .miss{color:var(--bad)}
+  .b-done{background:var(--good)} .b-part{background:var(--warn)} .b-bad{background:var(--bad)} .b-mid{background:var(--accent)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:14px 18px;margin:14px 0}
+  .meta{display:flex;flex-wrap:wrap;gap:18px;color:var(--muted);font-size:13px;margin:10px 0 22px}
+  .note{background:#1d1607;border:1px solid #6b5114;border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13.5px}
+  .legend{font-size:12.5px;color:var(--muted);margin:6px 0 0}
+  ul.gap{margin:6px 0 0;padding-left:18px}
+  ul.gap li{margin:3px 0;font-size:13.5px}
+  .tag{font-size:11px;color:var(--muted);border:1px solid var(--line);border-radius:4px;padding:1px 6px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>OrcaWave Issue Completeness Scorecard</h1>
+<p class="sub">Repository <code>vamseeachanta/digitalmodel</code> · branch <code>main</code> @ <code>998abd24</code></p>
+<div class="meta">
+  <span><strong>Generated:</strong> 2026-05-27</span>
+  <span><strong>Scope:</strong> 17 open + 5 closed OrcaWave issues</span>
+  <span><strong>Method:</strong> adversarial, per-acceptance-criterion audit with <code>file:line</code> evidence</span>
+</div>
+
+<div class="card">
+  <strong>How to read this.</strong> Each score is the share of an issue's acceptance criteria <em>already implemented</em>
+  in the codebase — not a quality grade. Criteria were marked
+  <span class="done">DONE</span> / <span class="part">PARTIAL</span> / <span class="miss">MISSING</span>
+  against actual source, with no credit for stubs, aspirational docs, or self-reported checkboxes. Audits ran adversarially
+  (defect-hunting, not charitable reading).
+</div>
+
+<!-- ============ CORE CLUSTER ============ -->
+<h2>Tier 1 — Core spec→run pipeline (open epic #605–#614, +#500/#501)</h2>
+<p class="sub">Filed 2026-05-15 (#605–#614) and 2026-04-10 (#500/#501). Coherent, well-specified roadmap — largely unbuilt. Cluster average ≈ 19%.</p>
+
+<table>
+  <thead><tr><th>Issue</th><th>Title</th><th style="width:110px">Score</th><th style="width:140px"></th><th>Biggest remaining gap</th></tr></thead>
+  <tbody>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/500">#500</a></td>
+      <td>mesh pre-flight validation + auto-copy</td>
+      <td class="score">55%</td><td><div class="bar"><i class="b-mid" style="width:55%"></i></div></td>
+      <td>Runner auto-copy is done &amp; tested; the headline <code>SpecConverter</code> existence-validation is absent — missing meshes only <em>warn</em>.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/609">#609</a></td>
+      <td>normalize auxiliary mesh handling</td>
+      <td class="score">30%</td><td><div class="bar"><i class="b-part" style="width:30%"></i></div></td>
+      <td><code>BodySpec.control_surface</code> silently ignored by backend + runner (only vessel-level read); aux paths untested.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/610">#610</a></td>
+      <td>licensed E2E acceptance test (arbitrary mesh)</td>
+      <td class="score">25%</td><td><div class="bar"><i class="b-part" style="width:25%"></i></div></td>
+      <td>Only the #468 known-<code>.yml</code> path exists; no arbitrary mesh→generated-inputs test; pytest wrappers lack Linux <code>skipif</code>.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/605">#605</a></td>
+      <td>self-contained solver packages</td>
+      <td class="score">20%</td><td><div class="bar"><i class="b-part" style="width:20%"></i></div></td>
+      <td><code>convert-spec</code> emits YAML with dangling basenames; copies nothing, no pre-write existence gate.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/608">#608</a></td>
+      <td>mesh quality gates before solve</td>
+      <td class="score">20%</td><td><div class="bar"><i class="b-part" style="width:20%"></i></div></td>
+      <td><code>GeometryQualityChecker</code> exists &amp; unit-tested but wired into no validate/preflight/solve gate.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/611">#611</a></td>
+      <td>result export / postprocess contract</td>
+      <td class="score">20%</td><td><div class="bar"><i class="b-part" style="width:20%"></i></div></td>
+      <td><code>RunResult</code> has no <code>owr_path</code>/<code>xlsx_path</code>; <code>.owr</code> still smuggled through <code>log_file</code>; data-file path discarded.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/613">#613</a></td>
+      <td>environment / license doctor</td>
+      <td class="score">15%</td><td><div class="bar"><i class="b-bad" style="width:15%"></i></div></td>
+      <td>Detection primitives exist in runner (~80% of logic) but no <code>orcawave-doctor</code> command, no PASS/WARN/FAIL, no tests.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/612">#612</a></td>
+      <td>batch mesh convergence / grid sensitivity</td>
+      <td class="score">15%</td><td><div class="bar"><i class="b-bad" style="width:15%"></i></div></td>
+      <td>Generic batch + solver-vs-solver benchmark exist; no YAML convergence study, no mesh-refinement/grid-sensitivity metrics.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/606">#606</a></td>
+      <td>integrate MeshPipeline into convert/run</td>
+      <td class="score">10%</td><td><div class="bar"><i class="b-bad" style="width:10%"></i></div></td>
+      <td>Zero call sites of <code>MeshPipeline.prepare_for_solver</code> in convert/run/cli paths.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/607">#607</a></td>
+      <td>given-mesh CLI workflow</td>
+      <td class="score">10%</td><td><div class="bar"><i class="b-bad" style="width:10%"></i></div></td>
+      <td><code>mesh-to-spec</code> builder module + CLI command do not exist at all.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/501">#501</a></td>
+      <td>QTF config + field points + irreg-freq method</td>
+      <td class="score">5%</td><td><div class="bar"><i class="b-bad" style="width:5%"></i></div></td>
+      <td>None of <code>QTFOptions</code>/<code>FieldPointSpec</code>/<code>IrregularFrequencyMethod</code> exist; crossing angles hardcoded 0–180.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/614">#614</a></td>
+      <td>docs for canonical spec-to-run workflow</td>
+      <td class="score">5%</td><td><div class="bar"><i class="b-bad" style="width:5%"></i></div></td>
+      <td>README documents a <code>modules/</code> tree + orchestrator commands that no longer exist; broken QUICK_START link; zero real CLI names.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ TIER 2 OLDER ============ -->
+<h2>Tier 2 — Broader OrcaWave-adjacent issues (open)</h2>
+
+<table>
+  <thead><tr><th>Issue</th><th>Title</th><th style="width:110px">Score</th><th style="width:140px"></th><th>Key adversarial finding</th></tr></thead>
+  <tbody>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/282">#282</a></td>
+      <td>WRK-130 standardized reporting</td>
+      <td class="score">80%</td><td><div class="bar"><i class="b-done" style="width:80%"></i></div></td>
+      <td>Full report framework real &amp; tested; missing the <code>hull_id</code>-keyed API signature + hull-catalog auto-integration.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/136">#136</a></td>
+      <td>WRK-043 parametric hull RAO</td>
+      <td class="score">75%</td><td><div class="bar"><i class="b-done" style="width:75%"></i></div></td>
+      <td>Every <code>[x]</code> claim backed by real tested code; batch diffraction + RAO extraction <strong>honestly DEFERRED</strong> on solver runtime.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/62">#62</a></td>
+      <td>engg debt | OrcaWave (umbrella)</td>
+      <td class="score">~70%</td><td><div class="bar"><i class="b-done" style="width:70%"></i></div></td>
+      <td>Ecosystem/basic/postprocess/AQWA done; analytical-ship-RAO + WLNG FST diffraction are the soft spots.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/141">#141</a></td>
+      <td>WRK-099 3-way Unit Box benchmark</td>
+      <td class="score">50%</td><td><div class="bar"><i class="b-part" style="width:50%"></i></div></td>
+      <td><strong>⚠ Synthetic.</strong> Artifacts + pipeline real, but the three "solver" datasets are seed/bias stand-ins — not a real AQWA/OrcaWave/BEMRosetta run. "All <code>[x]</code>" is honest only under its own "(synthetic)" caveat.</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/503">#503</a></td>
+      <td>Ingest Orcina help → LLM format</td>
+      <td class="score">45%</td><td><div class="bar"><i class="b-part" style="width:45%"></i></div></td>
+      <td>Real ingestion script + in-repo reference markdown, but ace-drive storage location, llm-wiki retrieval skill, and agent-skill wiring all absent.</td></tr>
+  </tbody>
+</table>
+
+<div class="note">
+  <strong>Cross-cutting blocker.</strong> #141 and #136 share one real constraint: no AQWA/OrcaWave/BEMRosetta executables in this
+  environment. Their "RAO database" and "3-way benchmark" therefore validate <em>plumbing</em>, not physics. #141's green
+  checkboxes are circular — "FULL consensus" among three near-identical <em>fabricated</em> datasets proves nothing about solver
+  agreement. #136 is more honest, explicitly deferring the runtime-dependent items.
+</div>
+
+<!-- ============ CLOSED VERIFICATION ============ -->
+<h2>Closed-issue reopen check</h2>
+<p class="sub">The semantic-equivalence + smoke-test cluster that the open epic leans on as "completed" foundations. <strong>Verdict: no reopen warranted.</strong></p>
+
+<table>
+  <thead><tr><th>Issue</th><th>Title</th><th>Verdict</th><th>Evidence</th></tr></thead>
+  <tbody>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/468">#468</a></td><td>smoke L01 <code>.yml</code>→<code>.owr</code>→<code>.xlsx</code></td>
+      <td class="done">CONFIRMED-COMPLETE</td><td><code>tests/solver/smoke_test.py</code> L01 + <code>run_orcawave_api.py</code> chain</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/516">#516</a></td><td>semantic-equivalence gaps (parent)</td>
+      <td class="done">CONFIRMED-COMPLETE</td><td>Deliverables landed via children #521/#524/#525</td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/521">#521</a></td><td>taxonomy + regression tests</td>
+      <td class="done">CONFIRMED-COMPLETE</td><td>7-category <code>SEMANTIC_TAXONOMY</code> in <code>benchmark_input_comparison.py:19</code></td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/524">#524</a></td><td>value-level roundtrip tests</td>
+      <td class="done">CONFIRMED-COMPLETE</td><td>16 passing tests in <code>test_orcawave_semantic_roundtrip.py</code></td></tr>
+    <tr><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/525">#525</a></td><td>remove silent parser defaults</td>
+      <td class="done">CONFIRMED-COMPLETE</td><td>All 3 defaults now <code>raise</code> (<code>reverse_parsers.py:456,500,541</code>)</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ EVIDENCE APPENDIX ============ -->
+<h2>Evidence appendix — recurring structural findings</h2>
+
+<h3>Capable libraries exist but are unwired</h3>
+<table>
+  <thead><tr><th>Component</th><th>State</th><th>Consumed by convert/validate/run?</th></tr></thead>
+  <tbody>
+    <tr><td><code>MeshPipeline.prepare_for_solver</code> (<code>mesh_pipeline.py:190</code>)</td><td>Implemented + unit-tested</td><td class="miss">No — zero call sites (#606)</td></tr>
+    <tr><td><code>GeometryQualityChecker</code> (<code>geometry_quality.py</code>)</td><td>PASS/WARN/FAIL engine + JSON export</td><td class="miss">No — re-exported only, never invoked (#608)</td></tr>
+    <tr><td>OrcFxAPI / <code>ORCAWAVE_PATH</code> detection (<code>orcawave_runner.py:349,411</code>)</td><td>Working dry-run fallback + exe detection</td><td class="part">Internal only — not surfaced as a doctor command (#613)</td></tr>
+  </tbody>
+</table>
+
+<h3>Schema / contract defects</h3>
+<ul class="gap">
+  <li><strong>#609:</strong> backend <code>orcawave_backend.py:261</code> and runner <code>orcawave_runner.py:503</code> read only <code>vessel.control_surface</code>; <code>BodySpec.control_surface</code> (<code>input_schemas.py:644</code>) is silently dropped for multi-body specs.</li>
+  <li><strong>#611:</strong> <code>RunResult</code> (<code>orcawave_runner.py:148</code>) overloads <code>log_file = results_file</code> for the <code>.owr</code> (<code>:397</code>); the written <code>_data.dat</code> path is computed then discarded.</li>
+  <li><strong>#501:</strong> <code>_build_headings_section</code> hardcodes <code>QTFMinCrossingAngle=0</code>/<code>QTFMaxCrossingAngle=180</code> (<code>orcawave_backend.py:515-516</code>).</li>
+  <li><strong>#614:</strong> <code>docs/domains/orcawave/README.md</code> references a non-existent <code>src/digitalmodel/modules/</code> tree and a broken <code>QUICK_START.md</code> link.</li>
+</ul>
+
+<p class="legend">
+  Bars: <span class="pill b-done">&ge;70%</span> <span class="pill b-mid">~55%</span>
+  <span class="pill b-part">20–50%</span> <span class="pill b-bad">&lt;20%</span>.
+  Scores reflect implementation coverage of acceptance criteria as of the commit above; re-audit after any landing PR.
+</p>
+
+</div>
+</body>
+</html>

--- a/docs/domains/orcawave/DIFFRACTION_DOMAIN_ARCHITECTURE.html
+++ b/docs/domains/orcawave/DIFFRACTION_DOMAIN_ARCHITECTURE.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Diffraction Domain Architecture — Output-Driven Analysis Contract</title>
+<style>
+  :root{--bg:#0f1419;--panel:#1a2129;--ink:#e6edf3;--muted:#9aa7b4;--line:#2a3540;
+    --accent:#4f9cf9;--good:#3fb950;--warn:#d29922;--bad:#f85149;--violet:#a371f7;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:1140px;margin:0 auto;padding:34px 24px 90px}
+  h1{font-size:27px;margin:0 0 4px}
+  h2{font-size:20px;margin:42px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  h3{font-size:16px;margin:26px 0 6px;color:var(--accent)}
+  .sub{color:var(--muted);margin:0 0 4px}
+  code{background:#0b0f14;border:1px solid var(--line);border-radius:4px;padding:1px 5px;font-size:12.5px;color:#cdd9e5}
+  a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
+  table{width:100%;border-collapse:collapse;margin:10px 0 6px;font-size:13.5px}
+  th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--muted);font-weight:600;background:var(--panel)}
+  tr:hover td{background:#161d25}
+  .meta{display:flex;flex-wrap:wrap;gap:18px;color:var(--muted);font-size:13px;margin:10px 0 22px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:14px 18px;margin:14px 0}
+  .key{background:#0d1f17;border:1px solid #1c5b3a;border-left:4px solid var(--good);border-radius:6px;padding:12px 16px;margin:14px 0}
+  .note{background:#1d1607;border:1px solid #6b5114;border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13.5px}
+  .done{color:var(--good)} .part{color:var(--warn)} .miss{color:var(--bad)}
+  pre.diag{background:#0b0f14;border:1px solid var(--line);border-radius:8px;padding:16px;overflow:auto;
+    font:12.5px/1.5 "SFMono-Regular",Consolas,monospace;color:#cdd9e5}
+  .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11.5px;font-weight:600;border:1px solid var(--line)}
+  .pa{color:var(--violet);border-color:#3d2a63} .pb{color:var(--accent);border-color:#1c3a5b} .pc{color:var(--good);border-color:#1c5b3a}
+  ul{margin:6px 0;padding-left:20px} li{margin:3px 0}
+  .legend{font-size:12.5px;color:var(--muted);margin-top:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Diffraction Domain Architecture</h1>
+<p class="sub">Output-driven analysis contract · OrcaWave (pilot) + AQWA · <code>digitalmodel</code></p>
+<div class="meta">
+  <span><strong>Date:</strong> 2026-05-27</span>
+  <span><strong>Status:</strong> design / proposal</span>
+  <span><strong>Scope:</strong> <code>src/digitalmodel/hydrodynamics/diffraction/</code></span>
+  <span><strong>Companion:</strong> output-driven reframe of <code>DIFFRACTION_CAPABILITIES_EXPANSION_PLAN.md</code></span>
+</div>
+
+<div class="card">
+  <strong>Domain objective (all analysis domains, all analysis repos).</strong>
+  Given <strong>(1)</strong> a <em>defined output/outcome</em> and <strong>(2)</strong> raw data — which may be
+  <em>barebones or fully detailed</em> — the domain module shall:
+  <ul>
+    <li><span class="pill pa">a</span> <strong>Q&amp;A + assume missing data</strong> — detect what the requested outcome needs, ask the user, and where unanswered supply suitable assumed values drawn from maintained reference data.</li>
+    <li><span class="pill pb">b</span> <strong>prepare input data</strong> — assemble the solver-ready input package from the now-complete dataset.</li>
+    <li><span class="pill pc">c</span> <strong>provide output with sanity checks</strong> — run, then return results gated by physical / range / coverage validation.</li>
+  </ul>
+  This is an <strong>output-driven (inverse)</strong> contract — outcome defined first, inputs inferred — not the usual
+  input-driven <code>spec&nbsp;→&nbsp;run&nbsp;→&nbsp;results</code> flow.
+</div>
+
+<div class="key">
+  <strong>★ The load-bearing requirement.</strong> The module must work whether the user supplies almost nothing or a
+  complete dataset. The non-negotiable is that <strong>every value the module assumed (rather than received) is highlighted
+  in the output report and brought to the user's attention</strong>, with its source and engineering basis. The report is
+  the place where assumptions become visible and reviewable — silent assumptions are forbidden.
+</div>
+
+<!-- ============ DATA SPECTRUM ============ -->
+<h2>1 · The data spectrum</h2>
+<p class="sub">The same entry point accepts any point on this spectrum; the assumption engine fills the delta.</p>
+<table>
+  <thead><tr><th style="width:22%">Input richness</th><th>What the user provides</th><th>What the module fills (→ flagged in report)</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Barebones</strong></td><td>Outcome (e.g. "ship RAOs"), a mesh or principal dimensions, water depth</td><td>Mass, CoG, radii of gyration, frequency grid, heading grid, QTF/irregular-freq settings, damping — all assumed</td></tr>
+    <tr><td><strong>Partial</strong></td><td>Above + mass &amp; CoG</td><td>Radii of gyration, grids, solver options — assumed</td></tr>
+    <tr><td><strong>Detailed</strong></td><td>A complete <code>DiffractionSpec</code></td><td>Nothing assumed; module validates &amp; runs (report shows an empty assumption ledger)</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ ARCHITECTURE ============ -->
+<h2>2 · Architecture — the canonical spec as solver-agnostic hub</h2>
+<p class="sub">Confirmed: <code>SpecConverter.backends = {"aqwa": AQWABackend, "orcawave": OrcaWaveBackend}</code>
+  (<code>spec_converter.py:46</code>). The intelligence layers attach to <code>DiffractionSpec</code>, so they serve
+  <strong>both diffraction solvers at once</strong> — this is why OrcaWave-first / AQWA-next is nearly free.</p>
+
+<pre class="diag">
+  outcome + raw data (barebones … detailed)
+            │
+            ▼
+  ┌───────────────────────────────────────────────┐
+  │  (a) RESOLVER  — Q&A + assumption engine        │  ← maintained reference DBs
+  │      detect-missing → ask → assume → LEDGER     │     (hull catalog, RAO db,
+  └───────────────────────────────────────────────┘      examples L00–L06, WAMIT ref)
+            │  complete DiffractionSpec + AssumptionLedger
+            ▼
+  ┌───────────────────────────────────────────────┐
+  │            DiffractionSpec  (canonical hub)     │   ← solver-agnostic
+  └───────────────────────────────────────────────┘
+            │
+   ┌────────┴────────┐
+   ▼                 ▼
+ (b) OrcaWaveBackend   (b) AQWABackend        ← + MeshPipeline, GeometryQualityChecker
+   │  + Runner            │  + Runner
+   ▼                 ▼
+  ┌───────────────────────────────────────────────┐
+  │  (c) OutputValidator → sanity-checked results   │
+  │      physical / range / coverage / symmetry     │
+  └───────────────────────────────────────────────┘
+            │
+            ▼
+   OUTPUT REPORT  =  results  +  ASSUMPTION LEDGER  +  sanity verdict
+</pre>
+
+<!-- ============ PILLARS ============ -->
+<h2>3 · The three pillars — component inventory</h2>
+<p class="sub">Most capability already exists as code; the gap is integration into one output-driven orchestrator. Status as of <code>main@998abd24</code>.</p>
+
+<h3><span class="pill pa">a</span> Q&amp;A + assume missing data</h3>
+<table>
+  <thead><tr><th>Component (exists)</th><th>Role</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td><code>parametric_spec_generator.estimate_mass / estimate_cog / estimate_radii_of_gyration</code></td><td>Engineering estimators with <code>X_override or estimate_X(...)</code> pattern</td><td class="part">Exists, but tied to <code>HullProfile</code>; silent; no ledger</td></tr>
+    <tr><td><code>hull_library</code> (catalog, profile_schema), <code>rao_database.py</code></td><td>Maintained reference data to look up assumptions</td><td class="part">Exist; not consulted by a resolver</td></tr>
+    <tr><td>Interactive Q&amp;A / detect-missing layer</td><td>Ask user for outcome-critical gaps before assuming</td><td class="miss">Missing</td></tr>
+    <tr><td><strong>AssumptionLedger</strong></td><td>Record value + source + basis per field; surface in report</td><td class="miss">Missing — the key new component</td></tr>
+  </tbody>
+</table>
+
+<h3><span class="pill pb">b</span> Prepare input data</h3>
+<table>
+  <thead><tr><th>Component (exists)</th><th>Role</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td><code>SpecConverter</code> + <code>OrcaWaveBackend</code> / <code>AQWABackend</code></td><td>Spec → solver input files</td><td class="part">Works; not self-contained packaging (#605)</td></tr>
+    <tr><td><code>OrcaWaveRunner._copy_mesh_files</code></td><td>Co-locate mesh + aux files</td><td class="done">Done (#500 runner half)</td></tr>
+    <tr><td><code>MeshPipeline.prepare_for_solver</code></td><td>Convert/normalize arbitrary mesh → solver-ready</td><td class="miss">Unwired — 0 call sites (#606)</td></tr>
+    <tr><td><code>GeometryQualityChecker</code></td><td>Pre-solve mesh QA gate</td><td class="miss">Unwired (#608)</td></tr>
+  </tbody>
+</table>
+
+<h3><span class="pill pc">c</span> Output with sanity checks</h3>
+<table>
+  <thead><tr><th>Component (exists)</th><th>Role</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td><code>output_validator.py</code> (<code>OutputValidator</code>)</td><td>Physical validity, ranges, freq/heading coverage, symmetry, resonance → PASS/WARN</td><td class="part">Real &amp; complete; <strong>not auto-invoked</strong> after a run</td></tr>
+    <tr><td><code>report_generator.py</code> + <code>report_builders_*</code></td><td>Standardized HTML report (per-DOF, hydrostatics, roll damping)</td><td class="done">Strong (#282 ≈80%)</td></tr>
+    <tr><td><code>RunResult</code> structured result paths</td><td>Expose <code>.owr</code>/<code>.xlsx</code>/report paths</td><td class="miss"><code>.owr</code> overloaded into <code>log_file</code> (#611)</td></tr>
+    <tr><td><code>orcawave_batch_runner</code> / convergence study</td><td>Cross-variant sanity (mesh / grid convergence)</td><td class="miss">No convergence schema (#612)</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ ASSUMPTION LEDGER ============ -->
+<h2>4 · Assumption ledger — the heart of pillar (a)</h2>
+<p class="sub">Every resolved field carries provenance. This is what makes assumptions visible in the report.</p>
+<pre class="diag">
+AssumptionRecord:
+  field:        "bodies[0].inertia.radii_of_gyration"
+  value:        [12.4, 31.8, 33.1]   # m
+  source:       user_supplied | assumed_default | estimated_from_data | database_lookup
+  basis:        "estimate_radii_of_gyration(profile) — empirical k=0.34·B, 0.30·L"
+  reference:    "hull_catalog: barge-class / parametric_spec_generator.py:173"
+  confidence:   high | medium | low
+</pre>
+<div class="note">
+  <strong>Reconciliation with #525.</strong> Issue #525 removed <em>silent</em> defaults from the OrcaWave parser (it now
+  raises on missing data). That is fully compatible with this contract: assumed values are permitted <strong>only when
+  recorded in the ledger and surfaced</strong>. "No silent defaults" and "fill missing data" are the same rule viewed from
+  two sides — the ledger is the bridge.
+</div>
+<p>The output report gains a mandatory <strong>Assumptions</strong> section listing every record where
+  <code>source ≠ user_supplied</code>, sorted by impact/confidence, so the engineer reviews exactly what the module decided
+  on their behalf before trusting the results.</p>
+
+<!-- ============ DATABASES ============ -->
+<h2>5 · Maintained reference data feeds pillar (a)</h2>
+<p class="sub">Per direction: assumption quality improves over time as example/analysis databases are maintained and grow.</p>
+<ul>
+  <li><strong>Hull library</strong> (<code>hydrodynamics/hull_library/</code>) — catalog + parametric profiles → mass/CoG/gyradii lookups.</li>
+  <li><strong>RAO database</strong> (<code>rao_database.py</code>) — prior-analysis RAOs indexed by hull parameters → first-guess responses &amp; cross-checks.</li>
+  <li><strong>Example sets</strong> (<code>docs/domains/orcawave/L00–L06</code>, AQWA benchmark) — canonical worked cases → templates for grids &amp; solver options.</li>
+  <li><strong>WAMIT / analytical reference</strong> (<code>wamit_reference_loader.py</code>, <code>L00_validation_wamit</code>) → validation baselines for pillar (c).</li>
+</ul>
+<p>The resolver consults these in priority order (exact match → parametric estimate → conservative default), tagging each
+  result's <code>source</code>/<code>confidence</code> accordingly.</p>
+
+<!-- ============ GAPS ============ -->
+<h2>6 · The three integration gaps (tracked in epic <a href="https://github.com/vamseeachanta/digitalmodel/issues/622">#622</a>)</h2>
+<table>
+  <thead><tr><th style="width:30%">Missing piece</th><th>Why it's the high-leverage gap</th></tr></thead>
+  <tbody>
+    <tr><td><span class="pill pa">a</span> <strong>Inverse entry point + resolver</strong> · <a href="https://github.com/vamseeachanta/digitalmodel/issues/623">#623</a></td><td>No "define outcome + barebones data → resolve" front door. #607 (given-mesh) is mesh-driven, not outcome-driven; estimators are siloed in the hull library.</td></tr>
+    <tr><td><span class="pill pa">a</span> <strong>AssumptionLedger</strong> · <a href="https://github.com/vamseeachanta/digitalmodel/issues/624">#624</a></td><td>The component that records &amp; surfaces every assumed value. Without it the contract's core promise (highlight assumptions) cannot be met.</td></tr>
+    <tr><td><span class="pill pc">c</span> <strong>Auto-wire <code>OutputValidator</code></strong> · <a href="https://github.com/vamseeachanta/digitalmodel/issues/625">#625</a></td><td>Sanity checks exist but are opt-in; the contract requires every run to return a validation verdict automatically.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ ROLLOUT ============ -->
+<h2>7 · Rollout sequence</h2>
+<table>
+  <thead><tr><th>Phase</th><th>Solver</th><th>Cost</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td>1 — pilot</td><td><strong>OrcaWave</strong></td><td>full build</td><td>Resolver + ledger + auto-validation prove out on the OrcaWave backend.</td></tr>
+    <tr><td>2 — near-free</td><td><strong>AQWA</strong></td><td>low</td><td>Same diffraction domain; resolver/ledger/validator attach to the shared <code>DiffractionSpec</code> hub — only AQWA-specific input prep differs.</td></tr>
+    <tr><td>3 — adapt</td><td>OrcaFlex &amp; others</td><td>medium</td><td>Different paradigm (time-domain). The a/b/c contract carries over; the spec/assumption/validation layers are re-implemented per domain.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ ISSUE MAP ============ -->
+<h2>8 · Existing issue map</h2>
+<table>
+  <thead><tr><th>Pillar</th><th>Issues already open</th></tr></thead>
+  <tbody>
+    <tr><td><span class="pill pa">a</span></td><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/607">#607</a> (front-door, mesh-driven), <a href="https://github.com/vamseeachanta/digitalmodel/issues/501">#501</a> (options/defaults) — <em>+ 2 new pieces needed</em></td></tr>
+    <tr><td><span class="pill pb">b</span></td><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/500">#500</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/605">#605</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/606">#606</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/608">#608</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/609">#609</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/614">#614</a></td></tr>
+    <tr><td><span class="pill pc">c</span></td><td><a href="https://github.com/vamseeachanta/digitalmodel/issues/611">#611</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/610">#610</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/612">#612</a> <a href="https://github.com/vamseeachanta/digitalmodel/issues/282">#282</a> <em>+ auto-wire OutputValidator</em></td></tr>
+  </tbody>
+</table>
+
+<p class="legend">
+  <span class="pill pa">a</span> resolve / assume &nbsp; <span class="pill pb">b</span> prepare input &nbsp; <span class="pill pc">c</span> validated output.
+  Status badges reflect implementation coverage at <code>main@998abd24</code>; re-audit after any landing PR.
+</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Docs: output-driven diffraction domain architecture + OrcaWave completeness scorecard

Docs-only. Two artifacts:

1. **`docs/domains/orcawave/DIFFRACTION_DOMAIN_ARCHITECTURE.html`** — the output-driven domain-objective contract for the diffraction module: given a defined outcome + raw data (barebones → detailed), the module (a) Q&As + assumes missing data with a recorded assumption ledger, (b) prepares solver input, (c) returns sanity-checked output. Anchored on the confirmed solver-agnostic `DiffractionSpec` hub (`SpecConverter.backends`), so the layer serves OrcaWave (pilot) and AQWA (next) alike. Tracks the three missing integration pieces.

2. **`docs/domains/orcawave/2026-05-27-issue-completeness-scorecard.html`** — adversarial, per-acceptance-criterion completeness scores (with `file:line` evidence) for 17 open + 5 closed OrcaWave issues.

Epic: #622 · sub-issues: #623 (resolver), #624 (AssumptionLedger), #625 (auto-wire OutputValidator).

Refs #622, #623, #624, #625
