### PR TITLE
feat(diffraction): #611 RunResult contract + shared validation_runner [Phase-1a]

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +104,17 @@ class AQWARunConfig(BaseModel):
         default=True,
         description="Pass /nowind flag for headless (no GUI window) mode.",
     )
+    validate_outputs: bool = Field(
+        default=True,
+        description="Run output validation on produced DiffractionResults.",
+    )
+    validation_strict: bool = Field(
+        default=False,
+        description=(
+            "Treat a FAIL/ERROR validation verdict as a run failure "
+            "(status FAILED, return code -2) even if the solver succeeded."
+        ),
+    )
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -128,7 +140,15 @@ class AQWARunConfig(BaseModel):
 
 @dataclass
 class AQWARunResult:
-    """Result of an AQWA runner execution."""
+    """Result of an AQWA runner execution.
+
+    Output / validation contract (#611 / #625): mirrors OrcaWave ``RunResult``
+    but keeps AQWA-specific ``lis_file`` / ``ah1_file`` and does *not* add a
+    generic ``owr_path`` (AQWA produces no ``.owr``). ``xlsx_path`` /
+    ``report_path`` are reserved for a later phase and stay ``None`` (D2).
+    ``validation_verdict`` uses canonical strings and is never aliased to
+    ``WARN`` in stored values (D3).
+    """
 
     status: AQWARunStatus
     input_file: Path | None = None
@@ -143,6 +163,16 @@ class AQWARunResult:
     duration_seconds: float | None = None
     error_message: str | None = None
     spec_name: str | None = None
+    # --- #611 output contract (no owr_path: AQWA produces no .owr) ---
+    data_file: Path | None = None
+    xlsx_path: Path | None = None
+    report_path: Path | None = None
+    # --- #625 validation contract ---
+    validation_report_path: Path | None = None
+    validation_verdict: str = "SKIPPED"
+    validation_issues: list[str] = field(default_factory=list)
+    validation_report: dict[str, Any] | None = None
+    diffraction_results: DiffractionResults | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +247,9 @@ class AQWARunner:
             if exe is None:
                 self._result.status = AQWARunStatus.DRY_RUN
                 self._result.duration_seconds = 0.0
+                self._mark_validation_skipped(
+                    "No AQWA executable found; no diffraction results produced"
+                )
                 return self._result
 
         result = self.execute()
@@ -281,12 +314,18 @@ class AQWARunner:
         if self._config.dry_run:
             self._result.status = AQWARunStatus.DRY_RUN
             self._result.duration_seconds = time.monotonic() - start
+            self._mark_validation_skipped(
+                "No diffraction results produced in dry-run mode"
+            )
             return self._result
 
         exe = self._detect_executable()
         if exe is None:
             self._result.status = AQWARunStatus.DRY_RUN
             self._result.duration_seconds = time.monotonic() - start
+            self._mark_validation_skipped(
+                "No AQWA executable found; no diffraction results produced"
+            )
             return self._result
 
         self._result.status = AQWARunStatus.RUNNING
@@ -325,8 +364,23 @@ class AQWARunner:
         else:
             self._result.status = AQWARunStatus.FAILED
             self._result.error_message = aqwa_error
+            self._mark_validation_skipped(
+                "Solver failed; no diffraction results to validate"
+            )
 
         return self._result
+
+    def _mark_validation_skipped(self, reason: str) -> None:
+        """Record a SKIPPED validation verdict with an explanatory reason.
+
+        Keeps the canonical ``SKIPPED`` verdict (default) and stores the reason
+        on the result. AQWA runtime extraction (`.LIS`/`.AH1` -> DiffractionResults)
+        and validation invocation land in the #625 increment.
+        """
+        if self._result is None:
+            return
+        self._result.validation_verdict = "SKIPPED"
+        self._result.validation_issues = [reason]
 
     # ----- internal methods -----
 

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -51,6 +51,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
+from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +123,17 @@ class RunConfig(BaseModel):
         gt=0,
         description="Number of threads for OrcFxAPI diffraction calculation.",
     )
+    validate_outputs: bool = Field(
+        default=True,
+        description="Run output validation on produced DiffractionResults.",
+    )
+    validation_strict: bool = Field(
+        default=False,
+        description=(
+            "Treat a FAIL/ERROR validation verdict as a run failure "
+            "(status FAILED, return code -2) even if the solver succeeded."
+        ),
+    )
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -147,7 +159,17 @@ class RunConfig(BaseModel):
 
 @dataclass
 class RunResult:
-    """Result of an OrcaWave runner execution."""
+    """Result of an OrcaWave runner execution.
+
+    Output contract (#611): explicit result paths replace the previous
+    ``log_file = .owr`` overload. ``owr_path`` / ``data_file`` populate for real
+    when OrcaWave produces them; ``xlsx_path`` / ``report_path`` are reserved for
+    a later exporter/report phase and remain ``None`` here (locked decision D2).
+
+    Validation contract (#625): ``validation_verdict`` defaults to ``"SKIPPED"``
+    and uses canonical strings ``PASS``/``WARNING``/``FAIL``/``ERROR``/``SKIPPED``
+    (never aliased to ``WARN`` in stored values, per locked decision D3).
+    """
 
     status: RunStatus
     input_file: Path | None = None
@@ -161,6 +183,20 @@ class RunResult:
     duration_seconds: float | None = None
     error_message: str | None = None
     spec_name: str | None = None
+    # --- #611 output contract ---
+    owr_path: Path | None = None
+    data_file: Path | None = None
+    xlsx_path: Path | None = None
+    report_path: Path | None = None
+    # --- #625 validation contract ---
+    validation_report_path: Path | None = None
+    validation_verdict: str = "SKIPPED"
+    validation_issues: list[str] = field(default_factory=list)
+    validation_report: dict[str, Any] | None = None
+    diffraction_results: DiffractionResults | None = None
+    # --- solver metadata ---
+    orcf_api_version: str | None = None
+    thread_count: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +274,10 @@ class OrcaWaveRunner:
             if not has_api and not has_exe:
                 self._result.status = RunStatus.DRY_RUN
                 self._result.duration_seconds = 0.0
+                self._mark_validation_skipped(
+                    "No OrcaWave executable or OrcFxAPI available; "
+                    "no diffraction results produced"
+                )
                 return self._result
 
         result = self.execute()
@@ -306,6 +346,9 @@ class OrcaWaveRunner:
         if self._config.dry_run:
             self._result.status = RunStatus.DRY_RUN
             self._result.duration_seconds = time.monotonic() - start
+            self._mark_validation_skipped(
+                "No diffraction results produced in dry-run mode"
+            )
             return self._result
 
         # Try OrcFxAPI Python binding first
@@ -317,6 +360,9 @@ class OrcaWaveRunner:
         if exe is None:
             self._result.status = RunStatus.DRY_RUN
             self._result.duration_seconds = time.monotonic() - start
+            self._mark_validation_skipped(
+                "No OrcaWave executable found; no diffraction results produced"
+            )
             return self._result
 
         self._result.status = RunStatus.RUNNING
@@ -339,6 +385,9 @@ class OrcaWaveRunner:
         else:
             self._result.status = RunStatus.FAILED
             self._result.error_message = stderr or f"Exit code {return_code}"
+            self._mark_validation_skipped(
+                "Solver failed; no diffraction results to validate"
+            )
 
         # Capture log
         self._result.log_file = self._capture_log(self._result.output_dir)
@@ -394,7 +443,11 @@ class OrcaWaveRunner:
                 f"OrcFxAPI: Calculated {len(diffraction.frequencies)} "
                 f"frequencies x {len(diffraction.headings)} headings"
             )
-            self._result.log_file = results_file
+            # #611: expose real result paths instead of overloading log_file.
+            # log_file stays None here (no subprocess log on the API path).
+            self._result.owr_path = results_file
+            self._result.data_file = data_file
+            self._result.thread_count = self._config.thread_count
 
         except Exception as e:
             elapsed = time.monotonic() - start
@@ -403,8 +456,23 @@ class OrcaWaveRunner:
             self._result.duration_seconds = elapsed
             self._result.error_message = str(e)
             self._result.stderr = str(e)
+            self._mark_validation_skipped(
+                "OrcFxAPI calculation failed; no diffraction results to validate"
+            )
 
         return self._result
+
+    def _mark_validation_skipped(self, reason: str) -> None:
+        """Record a SKIPPED validation verdict with an explanatory reason.
+
+        Keeps the canonical ``SKIPPED`` verdict (default) and stores the reason
+        on the result so downstream consumers know why no validation ran. The
+        runtime extraction + validation wiring lands in the #625 increment.
+        """
+        if self._result is None:
+            return
+        self._result.validation_verdict = "SKIPPED"
+        self._result.validation_issues = [reason]
 
     # ----- internal methods -----
 

--- a/src/digitalmodel/hydrodynamics/diffraction/validation_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/validation_runner.py
@@ -1,0 +1,180 @@
+"""Shared diffraction validation helper (#611 / #625 Phase-1).
+
+This module provides a single entry point, :func:`run_validation`, used by both
+the OrcaWave and AQWA runners (and, in a later increment, their batch runners)
+so that runner-level and batch-level validation never diverge.
+
+Responsibilities
+----------------
+- Accept an optional :class:`DiffractionResults` plus an output directory and an
+  input/report *stem*.
+- Invoke :func:`validate_results` (which wraps :class:`OutputValidator`),
+  writing the JSON report to ``<output_dir>/<stem>_validation.json``.
+- Map the validator's internal verdict to a *run-contract* verdict.
+- Flatten the nested issue report into a flat ``list[str]`` for convenient
+  display / storage on the result objects.
+
+Verdict semantics
+-----------------
+The validator (:meth:`OutputValidator._determine_overall_status`) only ever
+returns the canonical strings ``PASS``, ``WARNING``, or ``FAIL``.  Those are
+preserved *exactly* — this helper never normalizes ``WARNING`` to ``WARN`` (the
+``WARN`` alias, per locked decision D3, is a CLI display concern only).
+
+This helper adds two run-contract states the validator itself cannot express:
+
+- ``ERROR``   — validation was attempted but raised an exception.
+- ``SKIPPED`` — validation was disabled, or no :class:`DiffractionResults`
+  were available (dry-run, no-executable fallback, failed solver, no output).
+
+These five strings are the only values :class:`ValidationOutcome.verdict` may
+take.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    DiffractionResults,
+)
+from digitalmodel.hydrodynamics.diffraction.output_validator import (
+    validate_results,
+)
+
+# Canonical verdicts the underlying validator can produce. Must never be
+# normalized (e.g. WARNING -> WARN).
+VERDICT_PASS = "PASS"
+VERDICT_WARNING = "WARNING"
+VERDICT_FAIL = "FAIL"
+
+# Run-contract verdicts layered on top of the validator output.
+VERDICT_ERROR = "ERROR"
+VERDICT_SKIPPED = "SKIPPED"
+
+#: Every verdict string the helper may emit.
+ALL_VERDICTS = frozenset(
+    {
+        VERDICT_PASS,
+        VERDICT_WARNING,
+        VERDICT_FAIL,
+        VERDICT_ERROR,
+        VERDICT_SKIPPED,
+    }
+)
+
+
+@dataclass
+class ValidationOutcome:
+    """Result of a (possibly skipped) validation pass.
+
+    Attributes:
+        verdict: One of ``PASS``/``WARNING``/``FAIL``/``ERROR``/``SKIPPED``.
+        report: The full validation report dict, or ``None`` when skipped /
+            errored before a report could be produced.
+        report_path: Path to the written JSON report, or ``None`` if no report
+            was written.
+        issues: Flattened list of human-readable issue strings (empty when the
+            verdict is ``PASS``/``SKIPPED``).
+        reason: Optional human-readable explanation, primarily for ``SKIPPED``
+            (e.g. ``"No diffraction results produced in dry-run mode"``) and
+            ``ERROR`` (the exception text).
+    """
+
+    verdict: str = VERDICT_SKIPPED
+    report: dict[str, Any] | None = None
+    report_path: Path | None = None
+    issues: list[str] = field(default_factory=list)
+    reason: str | None = None
+
+
+def flatten_issues(report: dict[str, Any]) -> list[str]:
+    """Flatten the nested validator report into a flat list of issue strings.
+
+    The validator report is a dict whose values are either:
+      - a scalar (e.g. ``vessel_name``, ``overall_status``) — ignored,
+      - a ``list[str]`` of issues, or
+      - a ``dict`` whose values are ``list[str]`` of issues (the common shape).
+
+    Each emitted string is prefixed with its category path (e.g.
+    ``"physical_validity.added_mass: Negative diagonal term ..."``) so the
+    origin of an issue is preserved when stored flat.
+    """
+    issues: list[str] = []
+    for category, value in report.items():
+        if isinstance(value, list):
+            for item in value:
+                issues.append(f"{category}: {item}")
+        elif isinstance(value, dict):
+            for subcategory, sub in value.items():
+                if isinstance(sub, list):
+                    for item in sub:
+                        issues.append(f"{category}.{subcategory}: {item}")
+    return issues
+
+
+def run_validation(
+    results: DiffractionResults | None,
+    output_dir: Path | str | None,
+    stem: str,
+    *,
+    enabled: bool = True,
+    skip_reason: str | None = None,
+) -> ValidationOutcome:
+    """Validate diffraction results, returning a run-contract outcome.
+
+    Args:
+        results: The results to validate. ``None`` (or ``enabled=False``)
+            yields a ``SKIPPED`` outcome.
+        output_dir: Directory the JSON report is written into. If ``None`` no
+            report file is written (the in-memory report dict is still
+            returned). Created if it does not exist.
+        stem: Filename stem for the report, written as
+            ``<stem>_validation.json``.
+        enabled: When ``False`` validation is skipped regardless of *results*.
+        skip_reason: Explanation attached to a ``SKIPPED`` outcome. Defaults to
+            a sensible message based on why the skip occurred.
+
+    Returns:
+        A :class:`ValidationOutcome`. The verdict is one of the five canonical
+        strings; ``WARNING`` is never normalized to ``WARN``.
+    """
+    if not enabled:
+        return ValidationOutcome(
+            verdict=VERDICT_SKIPPED,
+            reason=skip_reason or "Validation disabled",
+        )
+
+    if results is None:
+        return ValidationOutcome(
+            verdict=VERDICT_SKIPPED,
+            reason=skip_reason or "No diffraction results available",
+        )
+
+    report_path: Path | None = None
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = output_dir / f"{stem}_validation.json"
+
+    try:
+        report = validate_results(results, output_file=report_path)
+    except Exception as exc:  # noqa: BLE001 - any validator failure is ERROR
+        return ValidationOutcome(
+            verdict=VERDICT_ERROR,
+            report_path=report_path if (report_path and report_path.exists()) else None,
+            reason=str(exc),
+        )
+
+    verdict = report.get("overall_status", VERDICT_ERROR)
+    # Preserve canonical strings exactly; never alias WARNING -> WARN.
+    issues = flatten_issues(report)
+
+    return ValidationOutcome(
+        verdict=verdict,
+        report=report,
+        report_path=report_path,
+        issues=issues,
+    )

--- a/tests/hydrodynamics/diffraction/conftest.py
+++ b/tests/hydrodynamics/diffraction/conftest.py
@@ -192,6 +192,138 @@ def mock_rao_set() -> RAOSet:
     return _make_rao_set()
 
 
+# ---------------------------------------------------------------------------
+# Dense PASS fixture (#611 / #625 Phase-1)
+# ---------------------------------------------------------------------------
+# The sparse fixture above (N_FREQ=10, N_HEAD=5, 0..180 headings) intentionally
+# yields a WARNING verdict. The dense fixture below satisfies every validator
+# coverage/physical check so it yields a clean PASS:
+#   - >=20 frequencies spanning <=0.1 .. >=1.5 rad/s (uniform spacing)
+#   - >=8 headings with full 360-degree coverage (range >= 350)
+#   - RAO magnitudes well within translation (<5) / rotation (<20) limits and
+#     resonance amp limits (3 m/m translation, 15 deg/m rotation)
+#   - symmetric 6x6 added-mass / damping matrices with non-negative diagonals
+N_FREQ_DENSE = 24
+N_HEAD_DENSE = 13
+FREQUENCIES_DENSE = np.linspace(0.05, 2.5, N_FREQ_DENSE)
+HEADINGS_DENSE = np.linspace(0.0, 360.0, N_HEAD_DENSE)
+
+
+def _make_dense_freq_data() -> FrequencyData:
+    return FrequencyData(
+        values=FREQUENCIES_DENSE.copy(),
+        periods=2.0 * np.pi / FREQUENCIES_DENSE,
+        count=N_FREQ_DENSE,
+        min_freq=float(FREQUENCIES_DENSE[0]),
+        max_freq=float(FREQUENCIES_DENSE[-1]),
+    )
+
+
+def _make_dense_heading_data() -> HeadingData:
+    return HeadingData(
+        values=HEADINGS_DENSE.copy(),
+        count=N_HEAD_DENSE,
+        min_heading=float(HEADINGS_DENSE[0]),
+        max_heading=float(HEADINGS_DENSE[-1]),
+    )
+
+
+def _make_dense_rao_component(dof: DOF) -> RAOComponent:
+    # Constant, modest magnitudes: 1.0 m/m translation, 2.0 deg/m rotation.
+    if dof in (DOF.SURGE, DOF.SWAY, DOF.HEAVE):
+        magnitude = np.full((N_FREQ_DENSE, N_HEAD_DENSE), 1.0)
+    else:
+        magnitude = np.full((N_FREQ_DENSE, N_HEAD_DENSE), 2.0)
+    return RAOComponent(
+        dof=dof,
+        magnitude=magnitude,
+        phase=np.zeros((N_FREQ_DENSE, N_HEAD_DENSE)),
+        frequencies=_make_dense_freq_data(),
+        headings=_make_dense_heading_data(),
+        unit="",
+    )
+
+
+def _make_dense_matrix_set(matrix_type: str) -> AddedMassSet | DampingSet:
+    matrices = []
+    for i in range(N_FREQ_DENSE):
+        # Symmetric (diagonal), positive-definite -> non-negative diagonals.
+        matrices.append(
+            HydrodynamicMatrix(
+                matrix=np.eye(6) * 500.0,
+                frequency=float(FREQUENCIES_DENSE[i]),
+                matrix_type=matrix_type,
+                units={"linear": "kg", "angular": "kg.m^2"},
+            )
+        )
+    cls = AddedMassSet if matrix_type == "added_mass" else DampingSet
+    return cls(
+        vessel_name="DenseVessel",
+        analysis_tool="OrcaWave",
+        water_depth=100.0,
+        matrices=matrices,
+        frequencies=_make_dense_freq_data(),
+        created_date=datetime.now().isoformat(),
+    )
+
+
+@pytest.fixture
+def dense_diffraction_results() -> DiffractionResults:
+    """Dense, physically-clean DiffractionResults that validates to PASS.
+
+    24 frequencies, 13 headings (full 360-degree coverage), modest RAO
+    magnitudes, and symmetric 6x6 matrices with non-negative diagonals.
+    """
+    now = datetime.now().isoformat()
+    rao_set = RAOSet(
+        vessel_name="DenseVessel",
+        analysis_tool="OrcaWave",
+        water_depth=100.0,
+        surge=_make_dense_rao_component(DOF.SURGE),
+        sway=_make_dense_rao_component(DOF.SWAY),
+        heave=_make_dense_rao_component(DOF.HEAVE),
+        roll=_make_dense_rao_component(DOF.ROLL),
+        pitch=_make_dense_rao_component(DOF.PITCH),
+        yaw=_make_dense_rao_component(DOF.YAW),
+        created_date=now,
+        source_file="dense_model.sim",
+    )
+    return DiffractionResults(
+        vessel_name="DenseVessel",
+        analysis_tool="OrcaWave",
+        water_depth=100.0,
+        raos=rao_set,
+        added_mass=_make_dense_matrix_set("added_mass"),
+        damping=_make_dense_matrix_set("damping"),
+        created_date=now,
+        source_files=["dense_model.sim"],
+    )
+
+
+@pytest.fixture
+def fail_diffraction_results(
+    dense_diffraction_results: DiffractionResults,
+) -> DiffractionResults:
+    """Dense results with a negative added-mass diagonal -> FAIL verdict.
+
+    NOTE: this depends on the current substring classifier in
+    ``OutputValidator._determine_overall_status`` (output_validator.py:364),
+    which escalates any issue containing the word ``"negative"`` to FAIL. If
+    that classifier is hardened in a later issue, this fixture may need updating.
+    """
+    results = dense_diffraction_results
+    bad = np.eye(6) * 500.0
+    bad[2, 2] = -10.0  # negative heave added-mass diagonal
+    first = results.added_mass.matrices[0]
+    results.added_mass.matrices[0] = HydrodynamicMatrix(
+        matrix=bad,
+        frequency=first.frequency,
+        matrix_type="added_mass",
+        units={"linear": "kg", "angular": "kg.m^2"},
+    )
+    return results
+
+
 @pytest.fixture
 def mock_diffraction_results() -> DiffractionResults:
     """Synthetic DiffractionResults with 10 frequencies, 5 headings."""

--- a/tests/hydrodynamics/diffraction/test_aqwa_runner.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_runner.py
@@ -521,3 +521,74 @@ class TestRunAqwaConvenience:
             spec, output_dir=tmp_path, dry_run=True, timeout_seconds=300,
         )
         assert result.status == AQWARunStatus.DRY_RUN
+
+
+# ---------------------------------------------------------------------------
+# #611 AQWARunResult contract + #625 validation contract (Phase-1a)
+# ---------------------------------------------------------------------------
+
+class TestAQWARunResultContract611:
+    """New #611/#625 fields on AQWARunResult: defaults and presence."""
+
+    def test_new_contract_fields_present(self):
+        field_names = {f.name for f in dataclass_fields(AQWARunResult)}
+        expected = {
+            "data_file", "xlsx_path", "report_path",
+            "validation_report_path", "validation_verdict", "validation_issues",
+            "validation_report", "diffraction_results",
+        }
+        assert expected.issubset(field_names)
+        # AQWA keeps its solver-specific files...
+        assert {"lis_file", "ah1_file", "log_file"}.issubset(field_names)
+        # ...and must NOT add a generic owr_path (AQWA produces no .owr).
+        assert "owr_path" not in field_names
+
+    def test_contract_defaults(self):
+        result = AQWARunResult(status=AQWARunStatus.PENDING)
+        assert result.data_file is None
+        assert result.xlsx_path is None      # D2: present but None this phase
+        assert result.report_path is None    # D2
+        assert result.validation_report_path is None
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues == []
+        assert result.validation_report is None
+        assert result.diffraction_results is None
+        # Backward-compat: solver-specific fields still default None.
+        assert result.lis_file is None
+        assert result.ah1_file is None
+        assert result.log_file is None
+
+
+class TestAQWARunConfigValidationToggles:
+    """#625 validation toggles on AQWARunConfig."""
+
+    def test_defaults(self):
+        config = AQWARunConfig()
+        assert config.validate_outputs is True
+        assert config.validation_strict is False
+
+    def test_overrides(self):
+        config = AQWARunConfig(validate_outputs=False, validation_strict=True)
+        assert config.validate_outputs is False
+        assert config.validation_strict is True
+
+
+class TestAQWASkippedWiring:
+    """Dry-run / no-executable fallback produce SKIPPED verdict + reason."""
+
+    def test_dry_run_skipped(self, ship_raos_spec_path, tmp_path):
+        spec = _load_spec(ship_raos_spec_path)
+        result = run_aqwa(spec, output_dir=tmp_path, dry_run=True)
+        assert result.status == AQWARunStatus.DRY_RUN
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues
+        assert "dry-run" in result.validation_issues[0].lower()
+
+    def test_no_executable_fallback_skipped(self, ship_raos_spec_path, tmp_path):
+        spec = _load_spec(ship_raos_spec_path)
+        config = AQWARunConfig(output_dir=tmp_path, dry_run=False)
+        with patch.object(AQWARunner, "_detect_executable", return_value=None):
+            result = AQWARunner(config).run(spec)
+        assert result.status == AQWARunStatus.DRY_RUN
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues

--- a/tests/hydrodynamics/diffraction/test_orcawave_runner.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_runner.py
@@ -486,3 +486,106 @@ class TestRunOrcawaveConvenience:
             spec, output_dir=tmp_path, dry_run=True, timeout_seconds=300
         )
         assert result.status == RunStatus.DRY_RUN
+
+
+# ---------------------------------------------------------------------------
+# #611 RunResult contract + #625 validation contract (Phase-1a)
+# ---------------------------------------------------------------------------
+
+class TestRunResultContract611:
+    """New #611/#625 fields on RunResult: defaults and presence."""
+
+    def test_new_contract_fields_present(self):
+        field_names = {f.name for f in dataclass_fields(RunResult)}
+        expected = {
+            "owr_path", "data_file", "xlsx_path", "report_path",
+            "validation_report_path", "validation_verdict", "validation_issues",
+            "validation_report", "diffraction_results", "orcf_api_version",
+            "thread_count",
+        }
+        assert expected.issubset(field_names)
+
+    def test_contract_defaults(self):
+        result = RunResult(status=RunStatus.PENDING)
+        assert result.owr_path is None
+        assert result.data_file is None
+        # D2: xlsx/report path fields exist but stay None this phase.
+        assert result.xlsx_path is None
+        assert result.report_path is None
+        assert result.validation_report_path is None
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues == []
+        assert result.validation_report is None
+        assert result.diffraction_results is None
+        assert result.orcf_api_version is None
+        assert result.thread_count is None
+
+
+class TestRunConfigValidationToggles:
+    """#625 validation toggles on RunConfig."""
+
+    def test_defaults(self):
+        config = RunConfig()
+        assert config.validate_outputs is True
+        assert config.validation_strict is False
+
+    def test_overrides(self):
+        config = RunConfig(validate_outputs=False, validation_strict=True)
+        assert config.validate_outputs is False
+        assert config.validation_strict is True
+
+
+class TestSkippedWiring:
+    """Dry-run / no-executable fallback produce SKIPPED verdict + reason."""
+
+    def test_dry_run_skipped(self, ship_raos_spec_path, tmp_path):
+        spec = _load_spec(ship_raos_spec_path)
+        result = run_orcawave(spec, output_dir=tmp_path, dry_run=True)
+        assert result.status == RunStatus.DRY_RUN
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues  # carries a reason
+        assert "dry-run" in result.validation_issues[0].lower()
+
+    def test_no_executable_fallback_skipped(self, ship_raos_spec_path, tmp_path):
+        # No OrcFxAPI here and no executable -> run() falls back to DRY_RUN.
+        spec = _load_spec(ship_raos_spec_path)
+        config = RunConfig(output_dir=tmp_path, dry_run=False, use_api=False)
+        with patch.object(OrcaWaveRunner, "_detect_executable", return_value=None):
+            result = OrcaWaveRunner(config).run(spec)
+        assert result.status == RunStatus.DRY_RUN
+        assert result.validation_verdict == "SKIPPED"
+        assert result.validation_issues
+
+
+class TestLogFileNoLongerOverloaded:
+    """#611: the .owr -> log_file overload is removed on the API success path."""
+
+    def test_api_success_sets_owr_path_not_log_file(
+        self, ship_raos_spec_path, tmp_path
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        config = RunConfig(output_dir=tmp_path, use_api=True, thread_count=2)
+        runner = OrcaWaveRunner(config)
+        runner.prepare(spec)
+
+        # Build a fake OrcFxAPI.Diffraction object.
+        fake_diff = MagicMock()
+        fake_diff.frequencies = [0.1, 0.2, 0.3]
+        fake_diff.headings = [0.0, 90.0, 180.0]
+        fake_module = MagicMock()
+        fake_module.Diffraction.return_value = fake_diff
+
+        with patch.object(OrcaWaveRunner, "_check_api_available", return_value=True), \
+                patch.dict("sys.modules", {"OrcFxAPI": fake_module}):
+            result = runner.execute()
+
+        assert result.status == RunStatus.COMPLETED
+        # The .owr lands in owr_path, NOT log_file (the old overload).
+        assert result.owr_path is not None
+        assert result.owr_path.suffix == ".owr"
+        assert result.data_file is not None
+        assert result.data_file.name.endswith("_data.dat")
+        assert result.log_file is None
+        assert result.thread_count == 2
+        # Validation runtime wiring is deferred to #625; verdict stays SKIPPED.
+        assert result.validation_verdict == "SKIPPED"

--- a/tests/hydrodynamics/diffraction/test_validation_runner.py
+++ b/tests/hydrodynamics/diffraction/test_validation_runner.py
@@ -1,0 +1,178 @@
+"""Tests for the shared diffraction validation helper (#611 / #625 Phase-1).
+
+Covers the five run-contract verdicts produced by ``run_validation``:
+PASS, WARNING, FAIL, ERROR, SKIPPED — plus issue flattening, canonical
+verdict-string preservation (no WARN aliasing), and JSON report export.
+
+All tests are CI-safe: no solver, no OrcFxAPI, only synthetic
+DiffractionResults fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    DiffractionResults,
+)
+from digitalmodel.hydrodynamics.diffraction.validation_runner import (
+    ALL_VERDICTS,
+    ValidationOutcome,
+    flatten_issues,
+    run_validation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Verdict tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerdicts:
+    """run_validation maps results to the correct run-contract verdict."""
+
+    def test_pass(self, dense_diffraction_results: DiffractionResults, tmp_path: Path):
+        outcome = run_validation(dense_diffraction_results, tmp_path, "dense")
+        assert outcome.verdict == "PASS"
+        assert outcome.issues == []
+        assert outcome.report is not None
+        assert outcome.report["overall_status"] == "PASS"
+
+    def test_warning(
+        self, mock_diffraction_results: DiffractionResults, tmp_path: Path
+    ):
+        # The sparse conftest fixture (10 freq, 5 head, 0..180) yields WARNING.
+        outcome = run_validation(mock_diffraction_results, tmp_path, "sparse")
+        assert outcome.verdict == "WARNING"
+        assert outcome.issues  # at least one coverage warning
+        # Canonical string preserved: never normalized to WARN.
+        assert outcome.verdict != "WARN"
+        assert outcome.report["overall_status"] == "WARNING"
+
+    def test_fail(
+        self, fail_diffraction_results: DiffractionResults, tmp_path: Path
+    ):
+        outcome = run_validation(fail_diffraction_results, tmp_path, "fail")
+        assert outcome.verdict == "FAIL"
+        assert any("egative" in issue for issue in outcome.issues)
+
+    def test_error(
+        self, dense_diffraction_results: DiffractionResults, tmp_path: Path
+    ):
+        # Force the underlying validator to raise -> ERROR verdict.
+        with patch(
+            "digitalmodel.hydrodynamics.diffraction.validation_runner.validate_results",
+            side_effect=RuntimeError("boom"),
+        ):
+            outcome = run_validation(dense_diffraction_results, tmp_path, "err")
+        assert outcome.verdict == "ERROR"
+        assert outcome.reason == "boom"
+        assert outcome.report is None
+
+    def test_skipped_none_results(self, tmp_path: Path):
+        outcome = run_validation(None, tmp_path, "none")
+        assert outcome.verdict == "SKIPPED"
+        assert outcome.reason
+
+    def test_skipped_disabled(
+        self, dense_diffraction_results: DiffractionResults, tmp_path: Path
+    ):
+        outcome = run_validation(
+            dense_diffraction_results, tmp_path, "off", enabled=False
+        )
+        assert outcome.verdict == "SKIPPED"
+        # Disabled must short-circuit before touching the validator / writing.
+        assert outcome.report is None
+        assert not list(tmp_path.glob("*_validation.json"))
+
+    def test_skipped_custom_reason(self, tmp_path: Path):
+        outcome = run_validation(
+            None, tmp_path, "x", skip_reason="dry-run, no results"
+        )
+        assert outcome.verdict == "SKIPPED"
+        assert outcome.reason == "dry-run, no results"
+
+    def test_all_emitted_verdicts_are_canonical(
+        self,
+        dense_diffraction_results: DiffractionResults,
+        mock_diffraction_results: DiffractionResults,
+        fail_diffraction_results: DiffractionResults,
+        tmp_path: Path,
+    ):
+        verdicts = {
+            run_validation(dense_diffraction_results, tmp_path, "p").verdict,
+            run_validation(mock_diffraction_results, tmp_path, "w").verdict,
+            run_validation(fail_diffraction_results, tmp_path, "f").verdict,
+            run_validation(None, tmp_path, "s").verdict,
+        }
+        assert verdicts <= ALL_VERDICTS
+
+
+# ---------------------------------------------------------------------------
+# Report export
+# ---------------------------------------------------------------------------
+
+
+class TestReportExport:
+    def test_writes_json_report(
+        self, dense_diffraction_results: DiffractionResults, tmp_path: Path
+    ):
+        outcome = run_validation(dense_diffraction_results, tmp_path, "vessel")
+        assert outcome.report_path == tmp_path / "vessel_validation.json"
+        assert outcome.report_path.exists()
+        data = json.loads(outcome.report_path.read_text())
+        assert data["overall_status"] == "PASS"
+
+    def test_no_output_dir_skips_file(
+        self, dense_diffraction_results: DiffractionResults
+    ):
+        outcome = run_validation(dense_diffraction_results, None, "vessel")
+        assert outcome.report_path is None
+        assert outcome.verdict == "PASS"  # in-memory report still computed
+
+
+# ---------------------------------------------------------------------------
+# Issue flattening
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenIssues:
+    def test_flattens_nested_dict(self):
+        report = {
+            "vessel_name": "V",  # scalar -> ignored
+            "overall_status": "WARNING",  # scalar -> ignored
+            "physical_validity": {
+                "added_mass": ["Negative diagonal term at 0.05"],
+                "damping": [],
+            },
+            "frequency_coverage": {"coverage": ["Min freq too high"]},
+            "top_level_list": ["loose issue"],
+        }
+        issues = flatten_issues(report)
+        assert "physical_validity.added_mass: Negative diagonal term at 0.05" in issues
+        assert "frequency_coverage.coverage: Min freq too high" in issues
+        assert "top_level_list: loose issue" in issues
+        # Empty sublists contribute nothing.
+        assert all("damping" not in i for i in issues)
+
+    def test_empty_report(self):
+        assert flatten_issues({"overall_status": "PASS"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+class TestValidationOutcome:
+    def test_defaults(self):
+        outcome = ValidationOutcome()
+        assert outcome.verdict == "SKIPPED"
+        assert outcome.report is None
+        assert outcome.report_path is None
+        assert outcome.issues == []
+        assert outcome.reason is None


### PR DESCRIPTION
Phase-1a bounded increment toward #611 (RunResult output contract) and the #625 validation foundation. Part of epic #622. Implements the approved plan: https://github.com/vamseeachanta/digitalmodel/issues/611#issuecomment-4553983703

## In this PR (the #611 foundation + shared helper + SKIPPED + tests)

**Shared validation helper** — `src/digitalmodel/hydrodynamics/diffraction/validation_runner.py`
- `run_validation(results, output_dir, stem, *, enabled, skip_reason) -> ValidationOutcome`
- Verdicts: canonical `PASS`/`WARNING`/`FAIL` from `validate_results(...)`, plus run-contract `ERROR` (validator raised) and `SKIPPED` (disabled / no results).
- Returns full report dict, JSON report path (`<stem>_validation.json`), and flattened `issues` list.
- **D3:** never normalizes `WARNING` -> `WARN` in stored values.

**#611 contract** on both `RunResult` (OrcaWave) and `AQWARunResult` (AQWA)
- Added: `data_file`, `xlsx_path`, `report_path`, `validation_report_path`, `validation_verdict` (default `"SKIPPED"`), `validation_issues`, `validation_report`, `diffraction_results`.
- OrcaWave also adds `owr_path`, `orcf_api_version`, `thread_count`. AQWA keeps `lis_file`/`ah1_file` and intentionally has **no** `owr_path`.
- **D2:** `xlsx_path`/`report_path` are present but stay `None` this phase (xlsx->OrcaFlex handoff deferred).
- **Stopped the `.owr` -> `log_file` overload** (orcawave_runner.py): API success now sets `owr_path` + `data_file`; `log_file` stays `None` on the API path / real logs only on subprocess path.
- `RunConfig` + `AQWARunConfig`: added `validate_outputs=True`, `validation_strict=False`.

**SKIPPED wiring** (verdict + reason) on dry-run, no-executable fallback, and failed-solver paths for both backends.

**Tests-first, all CI-safe** (mock everything; `OrcFxAPI` absent here) — 124 passed in target suite:
- `test_validation_runner.py`: PASS (new dense fixture, 24 freq/13 headings), WARNING (existing sparse `mock_diffraction_results`), FAIL (negative added-mass diagonal), ERROR (validator patched to raise), SKIPPED (None/disabled); flatten + export tests.
- contract default/field tests for both backends; `log_file`-not-overloaded assertion via a fake `OrcFxAPI`.
- conftest: added `dense_diffraction_results` + `fail_diffraction_results` fixtures.

## Deferred to the #625 runtime increment (NOT in this PR)
- Live `OrcFxAPI.Diffraction` -> `DiffractionResults` adapter + `.owr LoadResults()` fallback.
- AQWA `AQWAResultExtractor` validation invocation.
- Batch-runner dedup / shared-helper delegation.
- CLI output changes (`--validate`, path printing, `WARN` display alias).
- Report sanity-check section.

## Test result
`PYTHONPATH=src uv run pytest test_validation_runner.py test_orcawave_runner.py test_aqwa_runner.py test_output_validator.py -q` -> **124 passed**. Batch + report suites also green (61 passed), no regressions.

Refs #611
Refs #622