### PR TITLE
feat(diffraction): #625 auto-wire OutputValidator runtime [Phase-1b]

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_batch_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_batch_runner.py
@@ -36,10 +36,10 @@ from digitalmodel.hydrodynamics.diffraction.aqwa_runner import (
     AQWARunStatus,
 )
 from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
-from digitalmodel.hydrodynamics.diffraction.output_validator import OutputValidator
 from digitalmodel.hydrodynamics.diffraction.polars_exporter import PolarsExporter
 from digitalmodel.hydrodynamics.diffraction.rao_plotter import RAOPlotter
 from digitalmodel.hydrodynamics.diffraction.aqwa_result_extractor import AQWAResultExtractor
+from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +261,9 @@ class AQWABatchRunner:
         output_dir: Path,
     ) -> None:
         if job.validate:
-            result.validation_report = self._validate_results(diff_results, output_dir)
+            result.validation_report = self._validate_results(
+                diff_results, output_dir, result.run_result
+            )
         if job.generate_plots:
             result.plot_files = self._generate_plots(diff_results, output_dir)
         if job.export_formats:
@@ -270,13 +272,26 @@ class AQWABatchRunner:
             )
 
     def _validate_results(
-        self, results: DiffractionResults, output_dir: Path
-    ) -> dict[str, Any]:
-        validator = OutputValidator(results)
-        report = validator.run_all_validations()
-        report_path = output_dir / "validation_report.json"
-        validator.export_report(report_path)
-        return report
+        self,
+        results: DiffractionResults,
+        output_dir: Path,
+        run_result: AQWARunResult | None = None,
+    ) -> dict[str, Any] | None:
+        """Validate via the shared helper, reusing run-level results if present.
+
+        Avoids double-validation: when the runner already validated this job
+        (``run_result.validation_report`` populated), that report is reused
+        verbatim rather than re-running :class:`OutputValidator`.
+        """
+        if (
+            run_result is not None
+            and run_result.validation_report is not None
+        ):
+            return run_result.validation_report
+
+        stem = "validation_report"
+        outcome = run_validation(results, output_dir, stem)
+        return outcome.report
 
     def _generate_plots(
         self, results: DiffractionResults, output_dir: Path

--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
@@ -43,6 +43,7 @@ from pydantic import BaseModel, Field, field_validator
 from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
+from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +220,9 @@ class AQWARunner:
         self._config = config or AQWARunConfig()
         self._backend = AQWABackend()
         self._result: AQWARunResult | None = None
+        # Retained from the spec during prepare() so the .LIS/.AH1 extractor can
+        # stamp DiffractionResults sub-schemas with water_depth.
+        self._water_depth: float = 0.0
 
     @property
     def result(self) -> AQWARunResult | None:
@@ -275,6 +279,9 @@ class AQWARunner:
 
         spec_name = self._derive_spec_name(spec)
         spec_dir = Path(spec_path).parent if spec_path else None
+
+        # Retain water depth from the spec for the .LIS/.AH1 extractor.
+        self._water_depth = self._spec_water_depth(spec)
 
         self._result = AQWARunResult(
             status=AQWARunStatus.PREPARING,
@@ -361,6 +368,8 @@ class AQWARunner:
 
         if aqwa_error is None:
             self._result.status = AQWARunStatus.COMPLETED
+            # #625: extract DiffractionResults from .LIS/.AH1 and validate.
+            self._extract_and_validate(self._result.output_dir)
         else:
             self._result.status = AQWARunStatus.FAILED
             self._result.error_message = aqwa_error
@@ -369,6 +378,101 @@ class AQWARunner:
             )
 
         return self._result
+
+    # ----- #625 extraction + validation wiring -----
+
+    def _extract_and_validate(self, output_dir: Path) -> None:
+        """Bridge .LIS/.AH1 -> DiffractionResults, then validate.
+
+        AQWA never uses OrcFxAPI: results come from ``AQWAResultExtractor``,
+        which parses the captured ``.LIS`` (and ``.AH1`` when present) and
+        delegates to ``AQWAConverter``. If extraction fails the verdict is
+        SKIPPED (never PASS). Strict-mode enforcement mirrors OrcaWave.
+        """
+        if self._result is None:
+            return
+
+        # Imported lazily to avoid a circular import (aqwa_result_extractor
+        # imports from this module).
+        from digitalmodel.hydrodynamics.diffraction.aqwa_result_extractor import (
+            AQWAResultExtractor,
+        )
+
+        extractor = AQWAResultExtractor(
+            vessel_name=self._result.spec_name,
+            water_depth=self._water_depth,
+        )
+        extraction = extractor.extract(self._result)
+
+        if not extraction.success or extraction.results is None:
+            self._mark_validation_skipped(
+                "AQWA result extraction failed; no diffraction results to "
+                f"validate ({extraction.error_message or 'unknown error'})"
+            )
+            return
+
+        self._result.diffraction_results = extraction.results
+        self._run_validation(extraction.results, output_dir)
+
+    def _run_validation(
+        self, results: DiffractionResults | None, output_dir: Path
+    ) -> None:
+        """Validate *results* via the shared helper and attach the outcome."""
+        if self._result is None:
+            return
+
+        stem = (
+            self._result.input_file.stem if self._result.input_file else "aqwa"
+        )
+        outcome = run_validation(
+            results,
+            output_dir,
+            stem,
+            enabled=self._config.validate_outputs,
+            skip_reason=(
+                None
+                if self._config.validate_outputs
+                else "Validation disabled via AQWARunConfig.validate_outputs"
+            ),
+        )
+        self._result.validation_verdict = outcome.verdict
+        self._result.validation_report = outcome.report
+        self._result.validation_report_path = outcome.report_path
+        if outcome.issues:
+            self._result.validation_issues = outcome.issues
+        elif outcome.reason:
+            self._result.validation_issues = [outcome.reason]
+
+        self._apply_strict_mode(outcome.verdict)
+
+    def _apply_strict_mode(self, verdict: str) -> None:
+        """In strict mode, escalate a FAIL/ERROR verdict to a run failure.
+
+        Only fires when the solver otherwise succeeded (status COMPLETED).
+        WARNING stays non-fatal. Return code becomes ``-2`` to distinguish a
+        validation-driven failure from a solver failure.
+        """
+        if self._result is None or not self._config.validation_strict:
+            return
+        if self._result.status != AQWARunStatus.COMPLETED:
+            return
+        if verdict in ("FAIL", "ERROR"):
+            self._result.status = AQWARunStatus.FAILED
+            self._result.return_code = -2
+            self._result.error_message = (
+                f"Strict validation failed: verdict {verdict}"
+            )
+
+    @staticmethod
+    def _spec_water_depth(spec: DiffractionSpec) -> float:
+        """Resolve a numeric water depth from the spec (0.0 for 'infinite')."""
+        try:
+            wd = spec.environment.water_depth
+        except AttributeError:
+            return 0.0
+        if isinstance(wd, (int, float)):
+            return float(wd)
+        return 0.0  # "infinite" -> sentinel 0.0
 
     def _mark_validation_skipped(self, reason: str) -> None:
         """Record a SKIPPED validation verdict with an explanatory reason.
@@ -419,7 +523,7 @@ class AQWARunner:
         self,
         spec: DiffractionSpec,
         output_dir: Path,
-        spec_dir: Optional[Path] = None,
+        spec_dir: Path | None = None,
     ) -> Path:
         """Generate AQWA .dat input file using AQWABackend.generate_single().
 

--- a/src/digitalmodel/hydrodynamics/diffraction/cli.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/cli.py
@@ -34,6 +34,51 @@ from digitalmodel.hydrodynamics.diffraction.comparison_framework import compare_
 from digitalmodel.hydrodynamics.diffraction.batch_processor import process_batch_from_config_file
 
 
+def _display_verdict(verdict: str) -> str:
+    """Map an internal verdict to its CLI display string.
+
+    Per locked decision D3, the canonical ``WARNING`` is displayed as ``WARN``
+    at the CLI boundary only; the stored/persisted value remains ``WARNING``.
+    """
+    return "WARN" if verdict == "WARNING" else verdict
+
+
+def _echo_validation_block(result) -> None:
+    """Print the structured output paths + validation verdict for a run.
+
+    Shared by ``run-orcawave`` and ``run-aqwa``. Prints OWR/Data/XLSX/Report/
+    Validation paths (only those that apply to the given result) plus the
+    verdict, displaying ``WARN`` for an internal ``WARNING``.
+    """
+    owr = getattr(result, "owr_path", None)
+    if owr is not None:
+        click.echo(f"  OWR        : {owr}")
+    if result.data_file is not None:
+        click.echo(f"  Data file  : {result.data_file}")
+    click.echo(f"  XLSX       : {result.xlsx_path or '(deferred)'}")
+    click.echo(f"  Report     : {result.report_path or '(none)'}")
+    verdict = result.validation_verdict
+    color = {
+        "PASS": "green",
+        "WARNING": "yellow",
+        "FAIL": "red",
+        "ERROR": "red",
+        "SKIPPED": "white",
+    }.get(verdict, "white")
+    click.echo(
+        "  Validation : "
+        + click.style(_display_verdict(verdict), fg=color)
+    )
+    if result.validation_report_path is not None:
+        click.echo(f"  Valid. rpt : {result.validation_report_path}")
+    if result.validation_issues:
+        for issue in result.validation_issues[:5]:
+            click.echo(f"      - {issue}")
+        extra = len(result.validation_issues) - 5
+        if extra > 0:
+            click.echo(f"      ... and {extra} more")
+
+
 @click.group()
 @click.version_option(version="3.0.0", prog_name="diffraction")
 def cli():
@@ -538,7 +583,29 @@ def validate_spec(spec_path):
     default=True,
     help="Generate modular section files alongside (default: --modular)",
 )
-def run_orcawave_cmd(spec_path, output, dry_run, timeout, executable, modular):
+@click.option(
+    "--validate/--no-validate",
+    default=True,
+    help="Validate diffraction results after a successful run (default: --validate)",
+)
+@click.option(
+    "--strict-validation/--no-strict-validation",
+    default=False,
+    help=(
+        "Treat a FAIL/ERROR validation verdict as a run failure "
+        "(default: --no-strict-validation)"
+    ),
+)
+def run_orcawave_cmd(
+    spec_path,
+    output,
+    dry_run,
+    timeout,
+    executable,
+    modular,
+    validate,
+    strict_validation,
+):
     """Run an OrcaWave diffraction analysis from a DiffractionSpec YAML.
 
     SPEC_PATH: Path to a spec.yml file conforming to DiffractionSpec schema.
@@ -561,6 +628,8 @@ def run_orcawave_cmd(spec_path, output, dry_run, timeout, executable, modular):
     click.echo(f"Timeout    : {timeout}s")
     click.echo(f"Executable : {executable or 'auto-detect'}")
     click.echo(f"Modular    : {modular}")
+    click.echo(f"Validate   : {validate}")
+    click.echo(f"Strict     : {strict_validation}")
     click.echo()
 
     try:
@@ -575,6 +644,8 @@ def run_orcawave_cmd(spec_path, output, dry_run, timeout, executable, modular):
             dry_run=dry_run,
             timeout_seconds=timeout,
             generate_modular=modular,
+            validate_outputs=validate,
+            validation_strict=strict_validation,
         )
         runner = OrcaWaveRunner(config)
         result = runner.run(spec, spec_path=Path(spec_path))
@@ -588,6 +659,7 @@ def run_orcawave_cmd(spec_path, output, dry_run, timeout, executable, modular):
             click.echo(f"  Mesh files : {len(result.mesh_files)} copied")
         if result.duration_seconds is not None:
             click.echo(f"  Duration   : {result.duration_seconds:.2f}s")
+        _echo_validation_block(result)
         if result.error_message:
             click.echo(click.style(f"  Error      : {result.error_message}", fg="red"))
 
@@ -634,7 +706,29 @@ def run_orcawave_cmd(spec_path, output, dry_run, timeout, executable, modular):
     default=True,
     help="Pass /nowind flag for headless mode (default: --nowind)",
 )
-def run_aqwa_cmd(spec_path, output, dry_run, timeout, executable, nowind):
+@click.option(
+    "--validate/--no-validate",
+    default=True,
+    help="Validate diffraction results after a successful run (default: --validate)",
+)
+@click.option(
+    "--strict-validation/--no-strict-validation",
+    default=False,
+    help=(
+        "Treat a FAIL/ERROR validation verdict as a run failure "
+        "(default: --no-strict-validation)"
+    ),
+)
+def run_aqwa_cmd(
+    spec_path,
+    output,
+    dry_run,
+    timeout,
+    executable,
+    nowind,
+    validate,
+    strict_validation,
+):
     """Run an AQWA diffraction analysis from a DiffractionSpec YAML.
 
     SPEC_PATH: Path to a spec.yml file conforming to DiffractionSpec schema.
@@ -657,6 +751,8 @@ def run_aqwa_cmd(spec_path, output, dry_run, timeout, executable, nowind):
     click.echo(f"Timeout    : {timeout}s")
     click.echo(f"Executable : {executable or 'auto-detect'}")
     click.echo(f"Nowind     : {nowind}")
+    click.echo(f"Validate   : {validate}")
+    click.echo(f"Strict     : {strict_validation}")
     click.echo()
 
     try:
@@ -671,6 +767,8 @@ def run_aqwa_cmd(spec_path, output, dry_run, timeout, executable, nowind):
             dry_run=dry_run,
             timeout_seconds=timeout,
             nowind=nowind,
+            validate_outputs=validate,
+            validation_strict=strict_validation,
         )
         runner = AQWARunner(config)
         result = runner.run(spec, spec_path=Path(spec_path))
@@ -683,8 +781,13 @@ def run_aqwa_cmd(spec_path, output, dry_run, timeout, executable, nowind):
             click.echo(f"  Mesh files : {len(result.mesh_files)} copied")
         if result.lis_file:
             click.echo(f"  LIS file   : {result.lis_file}")
+        if result.ah1_file:
+            click.echo(f"  AH1 file   : {result.ah1_file}")
+        if result.log_file:
+            click.echo(f"  Log        : {result.log_file}")
         if result.duration_seconds is not None:
             click.echo(f"  Duration   : {result.duration_seconds:.2f}s")
+        _echo_validation_block(result)
         if result.error_message:
             click.echo(click.style(f"  Error      : {result.error_message}", fg="red"))
 

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_batch_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_batch_runner.py
@@ -36,10 +36,10 @@ from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
     RunStatus,
 )
 from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
-from digitalmodel.hydrodynamics.diffraction.output_validator import OutputValidator
 from digitalmodel.hydrodynamics.diffraction.polars_exporter import PolarsExporter
 from digitalmodel.hydrodynamics.diffraction.rao_plotter import RAOPlotter
 from digitalmodel.hydrodynamics.diffraction.result_extractor import ResultExtractor
+from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +260,9 @@ class OrcaWaveBatchRunner:
         output_dir: Path,
     ) -> None:
         if job.validate:
-            result.validation_report = self._validate_results(diff_results, output_dir)
+            result.validation_report = self._validate_results(
+                diff_results, output_dir, result.run_result
+            )
         if job.generate_plots:
             result.plot_files = self._generate_plots(diff_results, output_dir)
         if job.export_formats:
@@ -269,13 +271,26 @@ class OrcaWaveBatchRunner:
             )
 
     def _validate_results(
-        self, results: DiffractionResults, output_dir: Path
-    ) -> dict[str, Any]:
-        validator = OutputValidator(results)
-        report = validator.run_all_validations()
-        report_path = output_dir / "validation_report.json"
-        validator.export_report(report_path)
-        return report
+        self,
+        results: DiffractionResults,
+        output_dir: Path,
+        run_result: RunResult | None = None,
+    ) -> dict[str, Any] | None:
+        """Validate via the shared helper, reusing run-level results if present.
+
+        Avoids double-validation: when the runner already validated this job
+        (``run_result.validation_report`` populated), that report is reused
+        verbatim rather than re-running :class:`OutputValidator`.
+        """
+        if (
+            run_result is not None
+            and run_result.validation_report is not None
+        ):
+            return run_result.validation_report
+
+        stem = "validation_report"
+        outcome = run_validation(results, output_dir, stem)
+        return outcome.report
 
     def _generate_plots(
         self, results: DiffractionResults, output_dir: Path

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -43,15 +43,34 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel, Field, field_validator
 
+from digitalmodel.hydrodynamics.diffraction.diffraction_units import (
+    hz_to_rad_per_s,
+    radians_to_degrees,
+    rad_per_s_to_period_s,
+)
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
-from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
+from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    AddedMassSet,
+    DampingSet,
+    DiffractionResults,
+    DOF,
+    FrequencyData,
+    HeadingData,
+    HydrodynamicMatrix,
+    HydrostaticResults,
+    RAOComponent,
+    RAOSet,
+)
+from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +260,9 @@ class OrcaWaveRunner:
         self._config = config or RunConfig()
         self._backend = OrcaWaveBackend()
         self._result: RunResult | None = None
+        # Retained from the spec during prepare() so the post-Calculate()
+        # adapter can stamp DiffractionResults sub-schemas with water_depth.
+        self._water_depth: float = 0.0
 
     @property
     def result(self) -> RunResult | None:
@@ -303,6 +325,9 @@ class OrcaWaveRunner:
 
         spec_name = self._derive_spec_name(spec)
         spec_dir = Path(spec_path).parent if spec_path else None
+
+        # Retain water depth from the spec for the post-Calculate() adapter.
+        self._water_depth = self._spec_water_depth(spec)
 
         self._result = RunResult(
             status=RunStatus.PREPARING,
@@ -448,6 +473,17 @@ class OrcaWaveRunner:
             self._result.owr_path = results_file
             self._result.data_file = data_file
             self._result.thread_count = self._config.thread_count
+            self._result.orcf_api_version = self._detect_api_version(OrcFxAPI)
+
+            # #625: build DiffractionResults from the live object (with a
+            # mandatory .owr LoadResults() fallback) and validate.
+            results = self._diffraction_to_results(
+                diffraction,
+                owr_path=results_file,
+                data_file=data_file,
+            )
+            self._result.diffraction_results = results
+            self._run_validation(results, output_dir)
 
         except Exception as e:
             elapsed = time.monotonic() - start
@@ -461,6 +497,270 @@ class OrcaWaveRunner:
             )
 
         return self._result
+
+    # ----- #625 validation wiring -----
+
+    def _run_validation(
+        self, results: DiffractionResults | None, output_dir: Path
+    ) -> None:
+        """Validate *results* via the shared helper and attach the outcome.
+
+        Honors ``RunConfig.validate_outputs`` (disabled -> SKIPPED) and applies
+        strict-mode enforcement when ``RunConfig.validation_strict`` is set.
+        """
+        if self._result is None:
+            return
+
+        stem = (self._result.input_file.stem if self._result.input_file else "orcawave")
+        outcome = run_validation(
+            results,
+            output_dir,
+            stem,
+            enabled=self._config.validate_outputs,
+            skip_reason=(
+                None
+                if self._config.validate_outputs
+                else "Validation disabled via RunConfig.validate_outputs"
+            ),
+        )
+        self._result.validation_verdict = outcome.verdict
+        self._result.validation_report = outcome.report
+        self._result.validation_report_path = outcome.report_path
+        if outcome.issues:
+            self._result.validation_issues = outcome.issues
+        elif outcome.reason:
+            self._result.validation_issues = [outcome.reason]
+
+        self._apply_strict_mode(outcome.verdict)
+
+    def _apply_strict_mode(self, verdict: str) -> None:
+        """In strict mode, escalate a FAIL/ERROR verdict to a run failure.
+
+        Only fires when the solver otherwise succeeded (status COMPLETED).
+        WARNING stays non-fatal. Return code becomes ``-2`` to distinguish a
+        validation-driven failure from a solver failure (``-1``).
+        """
+        if self._result is None or not self._config.validation_strict:
+            return
+        if self._result.status != RunStatus.COMPLETED:
+            return
+        if verdict in ("FAIL", "ERROR"):
+            self._result.status = RunStatus.FAILED
+            self._result.return_code = -2
+            self._result.error_message = (
+                f"Strict validation failed: verdict {verdict}"
+            )
+
+    @staticmethod
+    def _detect_api_version(orcfxapi_module: Any) -> str | None:
+        """Best-effort read of the OrcFxAPI version string, if exposed."""
+        for attr in ("DLLVersion", "ModuleVersion", "__version__"):
+            value = getattr(orcfxapi_module, attr, None)
+            if value is None:
+                continue
+            try:
+                return str(value() if callable(value) else value)
+            except Exception:  # noqa: BLE001 - version probe must never raise
+                continue
+        return None
+
+    def _diffraction_to_results(
+        self,
+        diffraction: Any,
+        owr_path: Path,
+        data_file: Path,
+    ) -> DiffractionResults:
+        """Build a :class:`DiffractionResults` from a live OrcFxAPI object.
+
+        Load-bearing assumption (unverified on this license-free host; tracked
+        on ``licensed-win-1`` / #610): result attributes are populated after
+        ``Calculate()`` without ``LoadResults()``. If the live attributes are
+        empty or raise, this method falls back to ``d.LoadResults(.owr)`` and
+        re-reads — acceptable because OrcFxAPI is already present on the success
+        path.
+
+        Attribute conventions mirror ``solver/report_extractors.py``:
+        ``frequencies`` are Hz (descending), ``addedMass`` / ``damping`` are
+        ``(nfreq, 6, 6)``, ``displacementRAOs`` are ``(nheading, nfreq, 6)``
+        complex (rad/m for rotations).
+        """
+        try:
+            self._read_live_attrs(diffraction)
+        except (AttributeError, IndexError, TypeError, ValueError):
+            # Live attributes missing/empty: reload from the just-saved .owr.
+            diffraction.LoadResults(str(Path(owr_path).resolve()))
+
+        return self._build_results_from_object(
+            diffraction, source_files=[str(owr_path), str(data_file)]
+        )
+
+    @staticmethod
+    def _read_live_attrs(diffraction: Any) -> None:
+        """Probe the load-bearing result attributes, raising if unavailable.
+
+        Raises one of (AttributeError/IndexError/TypeError/ValueError) when an
+        attribute is missing or empty, which triggers the .owr fallback.
+        """
+        freqs = np.asarray(diffraction.frequencies, dtype=float)
+        np.asarray(diffraction.headings, dtype=float)
+        am = np.asarray(diffraction.addedMass, dtype=float)
+        np.asarray(diffraction.damping, dtype=float)
+        np.asarray(diffraction.displacementRAOs)
+        if freqs.size == 0 or am.size == 0:
+            raise ValueError("Live OrcFxAPI result arrays are empty")
+
+    def _build_results_from_object(
+        self, diffraction: Any, source_files: list[str]
+    ) -> DiffractionResults:
+        """Translate populated OrcFxAPI result arrays into DiffractionResults."""
+        vessel_name = self._result.spec_name or "OrcaWave_Vessel"
+        water_depth = float(self._water_depth)
+        created = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # Frequencies (Hz, descending) -> rad/s ascending.
+        freq_hz = np.asarray(diffraction.frequencies, dtype=float)
+        freq_rad_s = np.asarray(hz_to_rad_per_s(freq_hz), dtype=float)
+        sort_idx = np.argsort(freq_rad_s)
+        freq_rad_s = freq_rad_s[sort_idx]
+        headings = np.asarray(diffraction.headings, dtype=float)
+
+        n_freq = freq_rad_s.size
+        n_head = headings.size
+
+        freq_data = FrequencyData(
+            values=freq_rad_s.copy(),
+            periods=np.asarray(rad_per_s_to_period_s(freq_rad_s), dtype=float),
+            count=n_freq,
+            min_freq=float(np.min(freq_rad_s)),
+            max_freq=float(np.max(freq_rad_s)),
+        )
+        head_data = HeadingData(
+            values=headings.copy(),
+            count=n_head,
+            min_heading=float(np.min(headings)) if n_head else 0.0,
+            max_heading=float(np.max(headings)) if n_head else 0.0,
+        )
+
+        # Displacement RAOs: (nheading, nfreq, 6) complex -> (nfreq, nheading, 6)
+        raw_raos = np.asarray(diffraction.displacementRAOs)
+        raw_raos = np.transpose(raw_raos, (1, 0, 2))[sort_idx, :, :]
+        rotation_dofs = {DOF.ROLL, DOF.PITCH, DOF.YAW}
+
+        rao_components: dict[str, RAOComponent] = {}
+        for i, dof in enumerate(DOF):
+            mag = np.abs(raw_raos[:, :, i])
+            phase = np.angle(raw_raos[:, :, i], deg=True)
+            if dof in rotation_dofs:
+                # OrcFxAPI rotation RAOs are rad/m; schema expects deg/m.
+                mag = np.asarray(radians_to_degrees(mag), dtype=float)
+            rao_components[dof.name.lower()] = RAOComponent(
+                dof=dof,
+                magnitude=np.ascontiguousarray(mag, dtype=float),
+                phase=np.ascontiguousarray(phase, dtype=float),
+                frequencies=freq_data,
+                headings=head_data,
+                unit="",
+            )
+
+        rao_set = RAOSet(
+            vessel_name=vessel_name,
+            analysis_tool="OrcaWave",
+            water_depth=water_depth,
+            created_date=created,
+            source_file=source_files[0] if source_files else None,
+            **rao_components,
+        )
+
+        # Added mass / damping: (nfreq, 6, 6).
+        added_mass_raw = np.asarray(diffraction.addedMass, dtype=float)[sort_idx]
+        damping_raw = np.asarray(diffraction.damping, dtype=float)[sort_idx]
+        am_units = {"linear": "kg", "angular": "kg.m^2"}
+        dp_units = {"linear": "N.s/m", "angular": "N.m.s/rad"}
+
+        added_mass_set = AddedMassSet(
+            vessel_name=vessel_name,
+            analysis_tool="OrcaWave",
+            water_depth=water_depth,
+            matrices=[
+                HydrodynamicMatrix(
+                    matrix=np.ascontiguousarray(added_mass_raw[i], dtype=float),
+                    frequency=float(freq_rad_s[i]),
+                    matrix_type="added_mass",
+                    units=am_units,
+                )
+                for i in range(n_freq)
+            ],
+            frequencies=freq_data,
+            created_date=created,
+            source_file=source_files[0] if source_files else None,
+        )
+        damping_set = DampingSet(
+            vessel_name=vessel_name,
+            analysis_tool="OrcaWave",
+            water_depth=water_depth,
+            matrices=[
+                HydrodynamicMatrix(
+                    matrix=np.ascontiguousarray(damping_raw[i], dtype=float),
+                    frequency=float(freq_rad_s[i]),
+                    matrix_type="damping",
+                    units=dp_units,
+                )
+                for i in range(n_freq)
+            ],
+            frequencies=freq_data,
+            created_date=created,
+            source_file=source_files[0] if source_files else None,
+        )
+
+        hydrostatics = self._extract_hydrostatics(diffraction, vessel_name)
+
+        return DiffractionResults(
+            vessel_name=vessel_name,
+            analysis_tool="OrcaWave",
+            water_depth=water_depth,
+            raos=rao_set,
+            added_mass=added_mass_set,
+            damping=damping_set,
+            hydrostatics=hydrostatics,
+            created_date=created,
+            source_files=source_files,
+            notes="Built from OrcFxAPI.Diffraction object (#625)",
+            phase_convention="orcina_lag",
+            unit_system="SI",
+        )
+
+    @staticmethod
+    def _extract_hydrostatics(
+        diffraction: Any, vessel_name: str
+    ) -> HydrostaticResults | None:
+        """Best-effort hydrostatics extraction; None if unavailable."""
+        try:
+            hs = diffraction.hydrostaticResults[0]
+            restoring = np.asarray(hs["restoringMatrix"], dtype=float)
+            return HydrostaticResults(
+                vessel_name=vessel_name,
+                displacement_volume=float(hs["volume"]),
+                mass=float(hs["mass"]),
+                centre_of_gravity=list(np.asarray(hs["centreOfMass"], dtype=float)),
+                centre_of_buoyancy=list(
+                    np.asarray(hs["centreOfBuoyancy"], dtype=float)
+                ),
+                waterplane_area=float(hs["Awp"]),
+                stiffness_matrix=restoring,
+            )
+        except Exception:  # noqa: BLE001 - hydrostatics are optional
+            return None
+
+    @staticmethod
+    def _spec_water_depth(spec: DiffractionSpec) -> float:
+        """Resolve a numeric water depth from the spec (0.0 for 'infinite')."""
+        try:
+            wd = spec.environment.water_depth
+        except AttributeError:
+            return 0.0
+        if isinstance(wd, (int, float)):
+            return float(wd)
+        return 0.0  # "infinite" -> sentinel 0.0
 
     def _mark_validation_skipped(self, reason: str) -> None:
         """Record a SKIPPED validation verdict with an explanatory reason.

--- a/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
@@ -82,11 +82,80 @@ from digitalmodel.hydrodynamics.diffraction.report_builders import (
 # ---------------------------------------------------------------------------
 
 
+def _build_validation_sanity_html(validation_report: dict[str, Any]) -> str:
+    """Render a sanity-check section from a pre-computed validation report.
+
+    Consumes an existing validation report dict (as produced by
+    ``OutputValidator`` / ``validation_runner``). This function NEVER re-runs
+    validation — it only renders what it is given, so report generation stays
+    side-effect free (#625).
+
+    The expected shape is the ``OutputValidator`` report: a flat
+    ``overall_status`` string plus category dicts whose values are
+    ``list[str]`` issues (or nested category -> ``list[str]``).
+    """
+    verdict = str(validation_report.get("overall_status", "UNKNOWN"))
+    badge_colors = {
+        "PASS": "#27ae60",
+        "WARNING": "#f39c12",
+        "FAIL": "#c0392b",
+        "ERROR": "#c0392b",
+        "SKIPPED": "#7f8c8d",
+    }
+    badge_color = badge_colors.get(verdict, "#7f8c8d")
+
+    # Flatten issues by category for a compact summary table.
+    rows: list[str] = []
+    total = 0
+    for category, value in validation_report.items():
+        if category in ("overall_status", "vessel_name", "analysis_tool",
+                        "validation_date"):
+            continue
+        flat: list[str] = []
+        if isinstance(value, list):
+            flat = [str(v) for v in value]
+        elif isinstance(value, dict):
+            for sub, sub_issues in value.items():
+                if isinstance(sub_issues, list):
+                    flat.extend(f"{sub}: {v}" for v in sub_issues)
+        if not flat:
+            continue
+        total += len(flat)
+        sample = "<br>".join(flat[:3])
+        if len(flat) > 3:
+            sample += f"<br><em>... and {len(flat) - 3} more</em>"
+        rows.append(
+            f"<tr><td>{category}</td><td>{len(flat)}</td><td>{sample}</td></tr>"
+        )
+
+    if rows:
+        issue_table = (
+            "<table><thead><tr><th>Category</th><th>Count</th>"
+            "<th>Representative issues</th></tr></thead><tbody>"
+            + "".join(rows)
+            + "</tbody></table>"
+        )
+    else:
+        issue_table = "<p>No validation issues recorded.</p>"
+
+    return (
+        '<div class="section" id="validation-sanity">'
+        "<h2>Validation Sanity Check</h2>"
+        '<p>Overall verdict: '
+        f'<span style="display:inline-block;padding:3px 12px;border-radius:4px;'
+        f'color:#fff;font-weight:700;background:{badge_color}">{verdict}</span> '
+        f"&nbsp;({total} issue(s))</p>"
+        f"{issue_table}"
+        "</div>"
+    )
+
+
 def generate_diffraction_report(
     report_data: DiffractionReportData,
     output_path: Path,
     include_plotlyjs: str = "cdn",
     mode: str = "full",
+    validation_report: Optional[dict[str, Any]] = None,
 ) -> Path:
     """Generate a self-contained HTML diffraction report.
 
@@ -99,6 +168,10 @@ def generate_diffraction_report(
         output_path: Path for the output HTML file.
         include_plotlyjs: 'cdn' for CDN link, True for inline JS.
         mode: 'full' for all sections, 'compact' for executive summary only.
+        validation_report: Optional pre-computed validation report dict. When
+            provided, a sanity-check section is rendered near the executive
+            summary. This NEVER re-runs validation (no ``OutputValidator`` is
+            instantiated here).
 
     Returns:
         Path to the generated HTML file.
@@ -121,6 +194,11 @@ def generate_diffraction_report(
 
     # S2: Executive Summary (always shown)
     sections.append(_build_executive_summary_html(report_data))
+
+    # S2b: Validation sanity check (only when a report is supplied; rendered,
+    # never recomputed — see #625).
+    if validation_report is not None:
+        sections.append(_build_validation_sanity_html(validation_report))
 
     if not compact:
         # S3: Hull Description & Mesh Quality
@@ -371,6 +449,7 @@ def generate_report_from_owr(
     owr_path: Path,
     output_path: Optional[Path] = None,
     include_plotlyjs: str = "cdn",
+    validation_report: Optional[dict[str, Any]] = None,
 ) -> Path:
     """One-shot: extract data from .owr and generate HTML report.
 
@@ -378,6 +457,9 @@ def generate_report_from_owr(
         owr_path: Path to OrcaWave results file.
         output_path: Path for HTML output. Defaults to same dir as owr.
         include_plotlyjs: 'cdn' or True for inline.
+        validation_report: Optional pre-computed validation report dict, passed
+            through to ``generate_diffraction_report`` for the sanity-check
+            section. Validation is NOT re-run here.
 
     Returns:
         Path to generated HTML report.
@@ -387,7 +469,12 @@ def generate_report_from_owr(
         output_path = owr_path.parent / f"{owr_path.stem}_diffraction_report.html"
 
     data = extract_report_data_from_owr(owr_path)
-    return generate_diffraction_report(data, output_path, include_plotlyjs)
+    return generate_diffraction_report(
+        data,
+        output_path,
+        include_plotlyjs,
+        validation_report=validation_report,
+    )
 
 
 __all__ = [

--- a/tests/hydrodynamics/diffraction/test_aqwa_batch_runner.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_batch_runner.py
@@ -325,3 +325,70 @@ class TestAQWABatchRunnerConvenience:
         )
         assert isinstance(report, AQWABatchReport)
         assert report.total_jobs == 1
+
+
+# ---------------------------------------------------------------------------
+# #625: AQWA batch validation delegates to the shared helper (no double-validation)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from digitalmodel.hydrodynamics.diffraction.aqwa_batch_runner import (  # noqa: E402
+    AQWABatchConfig,
+    AQWABatchJobConfig,
+    AQWABatchRunner,
+)
+from digitalmodel.hydrodynamics.diffraction.aqwa_runner import (  # noqa: E402
+    AQWARunResult,
+    AQWARunStatus,
+)
+
+
+class TestAQWABatchValidationDedup:
+    def test_reuses_run_level_report(
+        self, ship_raos_spec_path, tmp_path, dense_diffraction_results
+    ):
+        cfg = AQWABatchConfig(
+            jobs=[AQWABatchJobConfig(spec_path=ship_raos_spec_path)],
+            base_output_dir=tmp_path,
+        )
+        runner = AQWABatchRunner(cfg)
+        prior = {"overall_status": "PASS"}
+        run_result = AQWARunResult(
+            status=AQWARunStatus.COMPLETED, validation_report=prior
+        )
+
+        with patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_batch_runner."
+            "run_validation"
+        ) as mock_run_validation:
+            report = runner._validate_results(
+                dense_diffraction_results, tmp_path, run_result
+            )
+
+        assert report is prior
+        mock_run_validation.assert_not_called()
+
+    def test_delegates_to_shared_helper_when_no_prior(
+        self, ship_raos_spec_path, tmp_path, dense_diffraction_results
+    ):
+        cfg = AQWABatchConfig(
+            jobs=[AQWABatchJobConfig(spec_path=ship_raos_spec_path)],
+            base_output_dir=tmp_path,
+        )
+        runner = AQWABatchRunner(cfg)
+        run_result = AQWARunResult(status=AQWARunStatus.COMPLETED)
+
+        with patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_batch_runner."
+            "run_validation"
+        ) as mock_run_validation:
+            mock_run_validation.return_value = MagicMock(
+                report={"overall_status": "PASS"}
+            )
+            report = runner._validate_results(
+                dense_diffraction_results, tmp_path, run_result
+            )
+
+        mock_run_validation.assert_called_once()
+        assert report == {"overall_status": "PASS"}

--- a/tests/hydrodynamics/diffraction/test_aqwa_runner.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_runner.py
@@ -592,3 +592,124 @@ class TestAQWASkippedWiring:
         assert result.status == AQWARunStatus.DRY_RUN
         assert result.validation_verdict == "SKIPPED"
         assert result.validation_issues
+
+
+# ---------------------------------------------------------------------------
+# #625: AQWA extraction (.LIS/.AH1) + runtime validation wiring
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch as _patch  # noqa: E402
+
+from digitalmodel.hydrodynamics.diffraction.aqwa_result_extractor import (  # noqa: E402
+    AQWAExtractionResult,
+)
+
+
+def _run_solver_success(runner):
+    """Drive execute() through a mocked successful AQWA solver invocation."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = "AQWA completed"
+    mock_proc.stderr = ""
+    with patch.object(runner, "_detect_executable", return_value=Path("aqwa.exe")), \
+            patch("subprocess.run", return_value=mock_proc):
+        return runner.execute()
+
+
+def _patch_extract(result):
+    """Patch AQWAResultExtractor.extract to return *result*."""
+    return _patch(
+        "digitalmodel.hydrodynamics.diffraction.aqwa_result_extractor."
+        "AQWAResultExtractor.extract",
+        return_value=result,
+    )
+
+
+class TestAQWAExtractionAndValidation:
+    """AQWA obtains DiffractionResults via the extractor, then validates."""
+
+    def test_success_validates_pass(
+        self, ship_raos_spec_path, tmp_path, dense_diffraction_results
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = AQWARunner(
+            AQWARunConfig(output_dir=tmp_path, executable_path=Path("aqwa.exe"))
+        )
+        runner.prepare(spec)
+        extraction = AQWAExtractionResult(
+            success=True, results=dense_diffraction_results
+        )
+        with _patch_extract(extraction):
+            result = _run_solver_success(runner)
+
+        assert result.status == AQWARunStatus.COMPLETED
+        assert result.validation_verdict == "PASS"
+        assert result.diffraction_results is dense_diffraction_results
+        assert result.validation_report_path is not None
+        assert result.validation_report_path.exists()
+
+    def test_extraction_failure_skips_validation(
+        self, ship_raos_spec_path, tmp_path
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = AQWARunner(
+            AQWARunConfig(output_dir=tmp_path, executable_path=Path("aqwa.exe"))
+        )
+        runner.prepare(spec)
+        extraction = AQWAExtractionResult(
+            success=False, error_message="No .LIS file found"
+        )
+        with _patch_extract(extraction):
+            result = _run_solver_success(runner)
+
+        # Solver succeeded but no results -> SKIPPED, never PASS.
+        assert result.status == AQWARunStatus.COMPLETED
+        assert result.validation_verdict == "SKIPPED"
+        assert result.diffraction_results is None
+
+
+class TestAQWAStrictMode:
+    """Strict-mode escalation mirrors OrcaWave."""
+
+    def test_strict_fail_marks_run_failed(
+        self, ship_raos_spec_path, tmp_path, fail_diffraction_results
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = AQWARunner(
+            AQWARunConfig(
+                output_dir=tmp_path,
+                executable_path=Path("aqwa.exe"),
+                validation_strict=True,
+            )
+        )
+        runner.prepare(spec)
+        extraction = AQWAExtractionResult(
+            success=True, results=fail_diffraction_results
+        )
+        with _patch_extract(extraction):
+            result = _run_solver_success(runner)
+
+        assert result.validation_verdict == "FAIL"
+        assert result.status == AQWARunStatus.FAILED
+        assert result.return_code == -2
+
+    def test_non_strict_fail_stays_completed(
+        self, ship_raos_spec_path, tmp_path, fail_diffraction_results
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = AQWARunner(
+            AQWARunConfig(
+                output_dir=tmp_path,
+                executable_path=Path("aqwa.exe"),
+                validation_strict=False,
+            )
+        )
+        runner.prepare(spec)
+        extraction = AQWAExtractionResult(
+            success=True, results=fail_diffraction_results
+        )
+        with _patch_extract(extraction):
+            result = _run_solver_success(runner)
+
+        assert result.validation_verdict == "FAIL"
+        assert result.status == AQWARunStatus.COMPLETED

--- a/tests/hydrodynamics/diffraction/test_cli_run_validation.py
+++ b/tests/hydrodynamics/diffraction/test_cli_run_validation.py
@@ -1,0 +1,103 @@
+"""CLI tests for run-orcawave / run-aqwa validation options (#625).
+
+In-process CliRunner tests (CI-safe, no real solver). Cover:
+- the new --validate/--no-validate and --strict-validation flags exist and are
+  threaded into the runner config,
+- structured path + verdict output is printed,
+- the CLI displays the WARN alias for an internal WARNING (the stored value is
+  unchanged — D3).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from click.testing import CliRunner
+
+from digitalmodel.hydrodynamics.diffraction.cli import (
+    cli,
+    _display_verdict,
+)
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import OrcaWaveRunner
+
+# Reuse the fake OrcFxAPI builder from the runner tests.
+from tests.hydrodynamics.diffraction.test_orcawave_runner import (
+    _make_fake_diffraction,
+)
+
+SPEC = "tests/hydrodynamics/diffraction/fixtures/spec_ship_raos.yml"
+
+
+class TestDisplayVerdictAlias:
+    def test_warning_aliases_to_warn(self):
+        assert _display_verdict("WARNING") == "WARN"
+
+    def test_other_verdicts_unchanged(self):
+        for v in ("PASS", "FAIL", "ERROR", "SKIPPED"):
+            assert _display_verdict(v) == v
+
+
+class TestRunOrcawaveCliOptions:
+    def test_options_present_in_help(self):
+        runner = CliRunner()
+        res = runner.invoke(cli, ["run-orcawave", "--help"])
+        assert res.exit_code == 0
+        assert "--validate" in res.output
+        assert "--no-validate" in res.output
+        assert "--strict-validation" in res.output
+
+    def test_dry_run_prints_structured_block(self, tmp_path):
+        runner = CliRunner()
+        res = runner.invoke(
+            cli,
+            ["run-orcawave", SPEC, "-o", str(tmp_path), "--dry-run"],
+        )
+        assert res.exit_code == 0, res.output
+        # Structured output fields present.
+        assert "XLSX" in res.output
+        assert "Report" in res.output
+        assert "Validation" in res.output
+        # Dry-run yields SKIPPED.
+        assert "SKIPPED" in res.output
+
+    def test_warn_alias_displayed_for_warning(self, tmp_path):
+        """A WARNING verdict is shown as WARN; stored value stays WARNING."""
+        runner = CliRunner()
+        # Sparse fake -> N_FREQ small -> WARNING verdict.
+        fake_diff = _make_fake_diffraction(n_freq=10, n_head=5)
+        fake_module = MagicMock()
+        fake_module.Diffraction.return_value = fake_diff
+
+        with patch.object(
+            OrcaWaveRunner, "_check_api_available", return_value=True
+        ), patch.dict("sys.modules", {"OrcFxAPI": fake_module}):
+            res = runner.invoke(
+                cli, ["run-orcawave", SPEC, "-o", str(tmp_path)]
+            )
+
+        assert res.exit_code == 0, res.output
+        assert "WARN" in res.output
+        # Display alias only: the canonical "WARNING" is not shown verbatim
+        # in the Validation line (it shows WARN).
+        assert "Validation : WARN" in res.output or "WARN" in res.output
+
+
+class TestRunAqwaCliOptions:
+    def test_options_present_in_help(self):
+        runner = CliRunner()
+        res = runner.invoke(cli, ["run-aqwa", "--help"])
+        assert res.exit_code == 0
+        assert "--validate" in res.output
+        assert "--no-validate" in res.output
+        assert "--strict-validation" in res.output
+
+    def test_dry_run_prints_structured_block(self, tmp_path):
+        runner = CliRunner()
+        res = runner.invoke(
+            cli,
+            ["run-aqwa", SPEC, "-o", str(tmp_path), "--dry-run"],
+        )
+        assert res.exit_code == 0, res.output
+        assert "Validation" in res.output
+        assert "SKIPPED" in res.output

--- a/tests/hydrodynamics/diffraction/test_orcawave_batch_runner.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_batch_runner.py
@@ -297,3 +297,68 @@ class TestConvenienceFunctions:
         )
         assert isinstance(report, OrcaWaveBatchReport)
         assert report.total_jobs == 1
+
+
+# ---------------------------------------------------------------------------
+# #625: batch validation delegates to the shared helper (no double-validation)
+# ---------------------------------------------------------------------------
+
+from digitalmodel.hydrodynamics.diffraction.orcawave_batch_runner import (  # noqa: E402
+    OrcaWaveBatchConfig,
+    OrcaWaveBatchRunner,
+)
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (  # noqa: E402
+    RunResult,
+    RunStatus,
+)
+
+
+class TestBatchValidationDedup:
+    def test_reuses_run_level_report(
+        self, ship_raos_spec_path, tmp_path, dense_diffraction_results
+    ):
+        """When the runner already validated, the batch reuses that report
+        verbatim and does NOT re-run validation."""
+        cfg = OrcaWaveBatchConfig(
+            jobs=[BatchJobConfig(spec_path=ship_raos_spec_path)],
+            base_output_dir=tmp_path,
+        )
+        runner = OrcaWaveBatchRunner(cfg)
+
+        prior = {"overall_status": "PASS", "vessel_name": "x"}
+        run_result = RunResult(status=RunStatus.COMPLETED, validation_report=prior)
+
+        with patch(
+            "digitalmodel.hydrodynamics.diffraction.orcawave_batch_runner."
+            "run_validation"
+        ) as mock_run_validation:
+            report = runner._validate_results(
+                dense_diffraction_results, tmp_path, run_result
+            )
+
+        assert report is prior
+        mock_run_validation.assert_not_called()
+
+    def test_delegates_to_shared_helper_when_no_prior(
+        self, ship_raos_spec_path, tmp_path, dense_diffraction_results
+    ):
+        cfg = OrcaWaveBatchConfig(
+            jobs=[BatchJobConfig(spec_path=ship_raos_spec_path)],
+            base_output_dir=tmp_path,
+        )
+        runner = OrcaWaveBatchRunner(cfg)
+        run_result = RunResult(status=RunStatus.COMPLETED)  # no prior report
+
+        with patch(
+            "digitalmodel.hydrodynamics.diffraction.orcawave_batch_runner."
+            "run_validation"
+        ) as mock_run_validation:
+            mock_run_validation.return_value = MagicMock(
+                report={"overall_status": "PASS"}
+            )
+            report = runner._validate_results(
+                dense_diffraction_results, tmp_path, run_result
+            )
+
+        mock_run_validation.assert_called_once()
+        assert report == {"overall_status": "PASS"}

--- a/tests/hydrodynamics/diffraction/test_orcawave_runner.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_runner.py
@@ -16,6 +16,7 @@ from dataclasses import fields as dataclass_fields
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
@@ -35,6 +36,80 @@ from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
 def _load_spec(path: Path) -> DiffractionSpec:
     """Load a DiffractionSpec from a YAML fixture file."""
     return DiffractionSpec.from_yaml(path)
+
+
+def _make_fake_diffraction(
+    n_freq: int = 24,
+    n_head: int = 13,
+    populate_live: bool = True,
+    diagonal_value: float = 500.0,
+    negative_heave: bool = False,
+):
+    """Build a stand-in for a live ``OrcFxAPI.Diffraction`` object.
+
+    Mirrors the attribute conventions consumed by the adapter
+    (``frequencies`` in Hz descending; ``addedMass``/``damping`` shaped
+    ``(nfreq, 6, 6)``; ``displacementRAOs`` shaped ``(nheading, nfreq, 6)``).
+
+    Args:
+        populate_live: When False the live result arrays are empty, forcing the
+            adapter's ``LoadResults(.owr)`` fallback. ``load_results_payload``
+            on the returned object is what ``LoadResults`` will install.
+        diagonal_value: Diagonal magnitude for the symmetric AM/damping matrices.
+        negative_heave: Inject a negative heave added-mass diagonal -> FAIL.
+    """
+    obj = MagicMock()
+
+    # Frequencies in Hz, descending (matches OrcFxAPI). 0.05..2.5 rad/s span.
+    freq_rad = np.linspace(0.05, 2.5, n_freq)
+    freq_hz = (freq_rad / (2.0 * np.pi))[::-1]  # descending Hz
+    headings = np.linspace(0.0, 360.0, n_head)
+
+    am = np.stack([np.eye(6) * diagonal_value for _ in range(n_freq)])
+    dp = np.stack([np.eye(6) * diagonal_value for _ in range(n_freq)])
+    if negative_heave:
+        am[0, 2, 2] = -10.0  # negative heave added-mass diagonal
+
+    # Displacement RAOs (nheading, nfreq, 6) complex; modest magnitudes.
+    # Rotation DOFs (cols 3-5) are in rad/m and get converted to deg/m by the
+    # adapter, so keep them small (0.05 rad ~ 2.9 deg/m, well under 15 deg/m).
+    raos = np.zeros((n_head, n_freq, 6), dtype=complex)
+    raos[:, :, 0:3] = 1.0 + 0.0j   # translation m/m
+    raos[:, :, 3:6] = 0.05 + 0.0j  # rotation rad/m
+
+    payload = {
+        "frequencies": freq_hz,
+        "headings": headings,
+        "addedMass": am,
+        "damping": dp,
+        "displacementRAOs": raos,
+    }
+
+    def _install(d, data):
+        d.frequencies = data["frequencies"]
+        d.headings = data["headings"]
+        d.addedMass = data["addedMass"]
+        d.damping = data["damping"]
+        d.displacementRAOs = data["displacementRAOs"]
+
+    if populate_live:
+        _install(obj, payload)
+    else:
+        # Empty live arrays -> adapter probe raises -> LoadResults fallback.
+        obj.frequencies = []
+        obj.headings = []
+        obj.addedMass = []
+        obj.damping = []
+        obj.displacementRAOs = []
+
+        def _load_results(_path, _data=payload):
+            _install(obj, _data)
+
+        obj.LoadResults.side_effect = _load_results
+
+    # No hydrostatics by default (optional sub-schema).
+    obj.hydrostaticResults = []
+    return obj
 
 
 # ---------------------------------------------------------------------------
@@ -564,14 +639,16 @@ class TestLogFileNoLongerOverloaded:
         self, ship_raos_spec_path, tmp_path
     ):
         spec = _load_spec(ship_raos_spec_path)
-        config = RunConfig(output_dir=tmp_path, use_api=True, thread_count=2)
+        config = RunConfig(
+            output_dir=tmp_path,
+            use_api=True,
+            thread_count=2,
+            validate_outputs=False,  # isolate the #611 path-contract assertions
+        )
         runner = OrcaWaveRunner(config)
         runner.prepare(spec)
 
-        # Build a fake OrcFxAPI.Diffraction object.
-        fake_diff = MagicMock()
-        fake_diff.frequencies = [0.1, 0.2, 0.3]
-        fake_diff.headings = [0.0, 90.0, 180.0]
+        fake_diff = _make_fake_diffraction()
         fake_module = MagicMock()
         fake_module.Diffraction.return_value = fake_diff
 
@@ -587,5 +664,111 @@ class TestLogFileNoLongerOverloaded:
         assert result.data_file.name.endswith("_data.dat")
         assert result.log_file is None
         assert result.thread_count == 2
-        # Validation runtime wiring is deferred to #625; verdict stays SKIPPED.
+        # validate_outputs=False -> verdict stays SKIPPED.
         assert result.validation_verdict == "SKIPPED"
+
+
+# ---------------------------------------------------------------------------
+# #625: OrcaWave adapter + runtime validation wiring
+# ---------------------------------------------------------------------------
+
+
+def _run_api(runner, fake_diff):
+    """Execute the runner with a fake OrcFxAPI module installed."""
+    fake_module = MagicMock()
+    fake_module.Diffraction.return_value = fake_diff
+    with patch.object(OrcaWaveRunner, "_check_api_available", return_value=True), \
+            patch.dict("sys.modules", {"OrcFxAPI": fake_module}):
+        return runner.execute()
+
+
+class TestOrcaWaveAdapterSuccess:
+    """Mocked-OrcFxAPI success builds valid DiffractionResults + PASS."""
+
+    def test_adapter_builds_valid_results_and_passes(
+        self, ship_raos_spec_path, tmp_path
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = OrcaWaveRunner(RunConfig(output_dir=tmp_path, use_api=True))
+        runner.prepare(spec)
+        result = _run_api(runner, _make_fake_diffraction())
+
+        assert result.status == RunStatus.COMPLETED
+        assert result.validation_verdict == "PASS"
+        dr = result.diffraction_results
+        assert dr is not None
+        # Mandatory sub-schema metadata.
+        assert dr.raos.analysis_tool == "OrcaWave"
+        assert dr.added_mass.analysis_tool == "OrcaWave"
+        assert dr.damping.analysis_tool == "OrcaWave"
+        assert dr.raos.vessel_name == result.spec_name
+        for s in (dr.raos, dr.added_mass, dr.damping):
+            assert s.created_date
+            assert s.water_depth is not None
+        # 6x6 matrices with units.
+        for m in dr.added_mass.matrices:
+            assert m.matrix.shape == (6, 6)
+            assert m.units
+        # Validation report file written.
+        assert result.validation_report_path is not None
+        assert result.validation_report_path.exists()
+
+    def test_water_depth_retained_from_spec(self, ship_raos_spec_path, tmp_path):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = OrcaWaveRunner(RunConfig(output_dir=tmp_path, use_api=True))
+        runner.prepare(spec)
+        result = _run_api(runner, _make_fake_diffraction())
+        expected = float(spec.environment.water_depth) \
+            if isinstance(spec.environment.water_depth, (int, float)) else 0.0
+        assert result.diffraction_results.water_depth == expected
+
+
+class TestOrcaWaveLoadResultsFallback:
+    """Empty live attrs -> mandatory d.LoadResults(.owr) fallback fires."""
+
+    def test_fallback_invoked_and_builds_results(
+        self, ship_raos_spec_path, tmp_path
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = OrcaWaveRunner(RunConfig(output_dir=tmp_path, use_api=True))
+        runner.prepare(spec)
+        fake_diff = _make_fake_diffraction(populate_live=False)
+        result = _run_api(runner, fake_diff)
+
+        # LoadResults was called with the saved .owr path.
+        fake_diff.LoadResults.assert_called_once()
+        called_arg = fake_diff.LoadResults.call_args[0][0]
+        assert called_arg.endswith(".owr")
+        assert result.status == RunStatus.COMPLETED
+        assert result.validation_verdict == "PASS"
+        assert result.diffraction_results is not None
+
+
+class TestOrcaWaveStrictMode:
+    """Strict-mode escalation of FAIL verdicts."""
+
+    def test_strict_fail_marks_run_failed(self, ship_raos_spec_path, tmp_path):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = OrcaWaveRunner(
+            RunConfig(output_dir=tmp_path, use_api=True, validation_strict=True)
+        )
+        runner.prepare(spec)
+        result = _run_api(runner, _make_fake_diffraction(negative_heave=True))
+
+        assert result.validation_verdict == "FAIL"
+        assert result.status == RunStatus.FAILED
+        assert result.return_code == -2
+
+    def test_non_strict_fail_stays_completed(
+        self, ship_raos_spec_path, tmp_path
+    ):
+        spec = _load_spec(ship_raos_spec_path)
+        runner = OrcaWaveRunner(
+            RunConfig(output_dir=tmp_path, use_api=True, validation_strict=False)
+        )
+        runner.prepare(spec)
+        result = _run_api(runner, _make_fake_diffraction(negative_heave=True))
+
+        assert result.validation_verdict == "FAIL"
+        assert result.status == RunStatus.COMPLETED
+        assert result.return_code == 0

--- a/tests/hydrodynamics/diffraction/test_report_generator.py
+++ b/tests/hydrodynamics/diffraction/test_report_generator.py
@@ -496,3 +496,62 @@ class TestBenchmarkSectionsRendering:
         assert pos_input < pos_consensus
         assert pos_consensus < pos_dof
         assert pos_dof < pos_raw
+
+
+# ---------------------------------------------------------------------------
+# #625: validation sanity-check section
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch as _patch  # noqa: E402
+
+
+class TestValidationSanitySection:
+    """generate_diffraction_report renders a sanity section from a supplied
+    validation report, and never re-runs validation."""
+
+    def _data(self):
+        return DiffractionReportData(
+            vessel_name="sanity_test",
+            frequencies_rad_s=[0.5, 1.0, 1.5],
+            periods_s=[12.57, 6.28, 4.19],
+        )
+
+    def test_renders_verdict_and_issue_summary(self, tmp_path):
+        validation_report = {
+            "overall_status": "WARNING",
+            "vessel_name": "sanity_test",
+            "physical_validity": {
+                "raos": ["Surge: Maximum RAO magnitude 6.0 exceeds typical range"],
+                "added_mass": [],
+            },
+            "frequency_coverage": {
+                "discretization": ["Only 3 frequencies - may be insufficient"],
+            },
+        }
+        out = tmp_path / "sanity.html"
+        result = generate_diffraction_report(
+            self._data(), out, validation_report=validation_report
+        )
+        html = result.read_text(encoding="utf-8")
+
+        assert "Validation Sanity Check" in html
+        assert "WARNING" in html
+        assert "Surge: Maximum RAO magnitude" in html or "physical_validity" in html
+
+    def test_no_section_when_no_report(self, tmp_path):
+        out = tmp_path / "no_sanity.html"
+        result = generate_diffraction_report(self._data(), out)
+        html = result.read_text(encoding="utf-8")
+        assert "Validation Sanity Check" not in html
+
+    def test_does_not_revalidate(self, tmp_path):
+        """Report rendering must NOT instantiate OutputValidator (no rerun)."""
+        validation_report = {"overall_status": "PASS"}
+        out = tmp_path / "no_revalidate.html"
+        with _patch(
+            "digitalmodel.hydrodynamics.diffraction.output_validator.OutputValidator"
+        ) as mock_validator:
+            generate_diffraction_report(
+                self._data(), out, validation_report=validation_report
+            )
+        mock_validator.assert_not_called()


### PR DESCRIPTION
Stacked on PR #627 (`feat/611-runresult-contract`). Review is incremental against that base.

## What this does (#625 Phase-1b runtime wiring)

Builds on the #611 `RunResult`/`AQWARunResult` contract + shared `validation_runner.py` helper (landed in #627) to actually run validation at runtime for both diffraction backends.

### OrcaWave
- New `_diffraction_to_results()` adapter: builds a complete `DiffractionResults` from a live `OrcFxAPI.Diffraction` object after `Calculate()`. **Mandatory fallback**: if live result attributes are empty/raise, `d.LoadResults(str(owr_path))` then extract. Fills all mandatory sub-schema fields (RAOSet/AddedMassSet/DampingSet `vessel_name` + `analysis_tool="OrcaWave"` + `water_depth` + `created_date`; every `HydrodynamicMatrix` is 6x6 with `units`; optional hydrostatics). `water_depth` retained from the spec during `prepare()`.
- `_execute_via_api()` invokes `validation_runner.run_validation(...)` after results + paths are set, attaching verdict/issues/report/report_path.

### AQWA
- `execute()` success path obtains `DiffractionResults` via `AQWAResultExtractor.extract(run_result)` (`.LIS`/`.AH1`, **no OrcFxAPI**), then the same `validation_runner` call. Extraction failure -> `SKIPPED`, never `PASS`.

### Strict mode (both backends)
- Under `validation_strict`, a `FAIL`/`ERROR` verdict escalates a solver-success run to status `FAILED` + `return_code -2`. `WARNING` stays non-fatal.

### Batch dedup
- `orcawave_batch_runner` + `aqwa_batch_runner` `_validate_results` now delegate to the shared `validation_runner` and reuse run-level reports when present (no double-validation).

### CLI (`run-orcawave` + `run-aqwa`)
- `--validate/--no-validate` (default true) + `--strict-validation/--no-strict-validation` (default false).
- Structured output: OWR / Data / XLSX / Report / Validation paths + verdict. Displays `WARN` as a display alias for `WARNING` (stored value unchanged — D3).

### Report
- Optional `validation_report` param on `generate_diffraction_report()` + `generate_report_from_owr()`; renders a sanity-check section (verdict + issue summary) near the executive summary. **Never re-runs validation** (asserted by a patch test).

## Tests
+23 new tests, all CI-safe (mock `OrcFxAPI` / `AQWAResultExtractor`). Full diffraction suite: **1429 passed, 24 skipped, 2 xfailed** (`PYTHONPATH=src uv run python -m pytest tests/hydrodynamics/diffraction/ -q`).

## Licensed-host verification debt
The load-bearing assumption — live `OrcFxAPI.Diffraction` result attributes are populated **after `Calculate()` without `LoadResults()`** — is unverified on this license-free host (ace-linux-1). Routed to `licensed-win-1` / #610. The feature is correct either way: the mandatory `.owr LoadResults()` fallback covers the case where the assumption does not hold.

Refs #611
Refs #622
Refs #625