### PR TITLE
fix(orcawave): repair 2 pre-existing diffraction-domain test failures

### DIFF
--- a/src/digitalmodel/orcawave/reporting/builder.py
+++ b/src/digitalmodel/orcawave/reporting/builder.py
@@ -65,6 +65,14 @@ class OrcaWaveReportBuilder:
             raise ImportError(
                 "OrcFxAPI is required to generate OrcaWave reports."
             ) from exc
+        # The solver subpackage imports successfully even when OrcFxAPI is
+        # absent, deliberately binding the name to ``None`` (see
+        # diffraction/solver/__init__.py). Guard against that so callers get a
+        # clean ImportError instead of an ``AttributeError`` on ``None``.
+        if OrcFxAPI is None:
+            raise ImportError(
+                "OrcFxAPI is required to generate OrcaWave reports."
+            )
         diff = OrcFxAPI.Diffraction(str(self.owr_path))
         return diff
 

--- a/tests/orcawave/test_section_rao_plots.py
+++ b/tests/orcawave/test_section_rao_plots.py
@@ -81,9 +81,13 @@ class TestRAOPlotsWithPlotly:
         """Heading filter selects only specified headings."""
         result = build_rao_plots(mock_diff_single_body, heading_filter_config)
         assert isinstance(result, str)
-        # Should contain 0° and 180° traces but not 90°
-        assert "0°" in result
-        assert "180°" in result
+        # Heading labels become Plotly trace names. fig.to_html() serializes the
+        # figure to JSON with ensure_ascii=True, so the degree sign (U+00B0) is
+        # emitted as the escape sequence "°" rather than a literal "°".
+        # Should contain 0° and 180° traces but not 90°.
+        assert '"0\\u00b0"' in result
+        assert '"180\\u00b0"' in result
+        assert '"90\\u00b0"' not in result
 
     def test_include_phase_adds_phase_traces(self, mock_diff_single_body, phase_config):
         result = build_rao_plots(mock_diff_single_body, phase_config)


### PR DESCRIPTION
## Summary

Repairs **2 pre-existing baseline test failures** in the `tests-hydrodynamics-diffraction` CI domain (the OrcaWave reporting tests run under that domain). These greens the domain, unblocking the diffraction check for PR #627 / #628.

## These are baseline failures — NOT caused by #627

Both failures reproduce on a clean `origin/main` checkout:

```
PYTHONPATH=src uv run python -m pytest \
  tests/orcawave/test_report_builder.py::TestLoadDiffraction::test_raises_import_error_without_orcfxapi \
  tests/orcawave/test_section_rao_plots.py -q
# => 2 failed, 17 passed
```

The touched files (`src/digitalmodel/orcawave/...`, `tests/orcawave/...`) are **not** part of #627's changeset, which is entirely under `src/digitalmodel/hydrodynamics/diffraction/` + `tests/hydrodynamics/diffraction/`. #627 itself is clean.

## Root causes & fixes

**1. `test_raises_import_error_without_orcfxapi`** — `AttributeError: 'NoneType' object has no attribute 'Diffraction'` at `builder.py:68`.

The diffraction `solver` subpackage imports successfully even when `OrcFxAPI` is absent — it deliberately binds the name to `None` (see `diffraction/solver/__init__.py`) so OrcFxAPI-free helpers stay importable on Linux. Consequently `builder._load_diffraction()`'s `try/except ImportError` never fired, and `None.Diffraction(...)` raised an `AttributeError` instead of the expected `ImportError`.

*Fix:* add an explicit `if OrcFxAPI is None:` guard that raises the `ImportError("OrcFxAPI is required ...")` the test (and callers) expect. **Real code fix**, not assertion deletion.

**2. `test_heading_filter`** — `assert "0°" in <html>` failed; HTML rendered as `nav nav-tabs`.

The renderer is correct: it sets each Plotly trace `name=f"{heading_deg:.0f}°"` (→ `"0°"`, `"180°"`). But `fig.to_html()` serializes the figure JSON with `ensure_ascii=True`, so the degree sign (U+00B0) is emitted as the escape sequence `°`, e.g. `"0°"`. The literal `0°` never appears in the HTML — Plotly renders the degree symbol in-browser from the escape. The **test assertion was stale** (checking the wrong representation), so this is a test fix, not a renderer change.

*Fix:* update the assertions to match Plotly's actual escaped output (`"0°"`, `"180°"`) and add a check that the filtered-out `90°` heading is absent (`"90°"` not in result) — matching the test's own comment, which previously asserted nothing about 90°.

## Verification

```
PYTHONPATH=src uv run python -m pytest tests/orcawave/ -q
# => 347 passed
```

No neighboring tests broken. Scope is diffraction-domain only; repo-wide baseline red in other domains is untouched.

Refs #627
Refs #628