### PR TITLE
feat(diffraction): inverse resolver + AssumptionLedger (pillar a) — closes #623, #624

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/__init__.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/__init__.py
@@ -14,6 +14,15 @@ This module provides:
 - AQWA vs OrcaWave comparison framework
 - Geometry quality validation
 - Test utilities for converter validation
+
+Inverse resolver example:
+    from digitalmodel.hydrodynamics.diffraction import (
+        Outcome, ResolverInputs, resolve,
+    )
+    spec, ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(mesh_file="hull.gdf", water_depth=1200.0),
+    )
 """
 
 from digitalmodel.hydrodynamics.diffraction.output_schemas import (
@@ -176,6 +185,20 @@ except ImportError:
     GmshMeshSpec = None
     MeshExportResult = None
     GMSH_AVAILABLE = False
+
+from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionRecord,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.hydrodynamics.diffraction.resolver import (
+    Outcome,
+    PrincipalDimensions,
+    ResolverConfig,
+    ResolverInputs,
+    resolve,
+)
 # Test utilities (optional - for testing without OrcFxAPI)
 try:
     from digitalmodel.hydrodynamics.diffraction.orcawave_test_utilities import (
@@ -306,6 +329,17 @@ __all__ = [
     'GmshMeshSpec',
     'MeshExportResult',
     'GMSH_AVAILABLE',
+
+    # Inverse resolver + assumption ledger
+    'AssumptionLedger',
+    'AssumptionRecord',
+    'AssumptionSource',
+    'Confidence',
+    'Outcome',
+    'PrincipalDimensions',
+    'ResolverConfig',
+    'ResolverInputs',
+    'resolve',
 ]
 
 __version__ = "3.0.0"

--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
@@ -36,7 +36,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -44,6 +44,11 @@ from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
 from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
+
+if TYPE_CHECKING:
+    from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+        AssumptionLedger,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +179,7 @@ class AQWARunResult:
     validation_issues: list[str] = field(default_factory=list)
     validation_report: dict[str, Any] | None = None
     diffraction_results: DiffractionResults | None = None
+    assumption_ledger: "AssumptionLedger | None" = None
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +238,10 @@ class AQWARunner:
     # ----- public API -----
 
     def run(
-        self, spec: DiffractionSpec, spec_path: Path | str | None = None
+        self,
+        spec: DiffractionSpec,
+        spec_path: Path | str | None = None,
+        assumption_ledger: "AssumptionLedger | None" = None,
     ) -> AQWARunResult:
         """Execute the full pipeline: prepare + execute.
 
@@ -243,8 +252,14 @@ class AQWARunner:
             spec: Canonical diffraction specification.
             spec_path: Path to the source YAML file (for resolving relative
                        mesh paths). Optional.
+            assumption_ledger: Optional provenance ledger (e.g. from
+                ``resolver.resolve``) to carry onto the result so it reaches
+                report generation. Attached to every return path.
         """
         self.prepare(spec, spec_path=spec_path)
+        # Attach after prepare() (which builds self._result) so the ledger
+        # rides both the dry-run early return and the execute() result.
+        self._result.assumption_ledger = assumption_ledger
 
         if not self._config.dry_run:
             exe = self._detect_executable()
@@ -749,6 +764,7 @@ def run_aqwa(
     dry_run: bool = False,
     timeout_seconds: int = 7200,
     spec_path: Path | str | None = None,
+    assumption_ledger: "AssumptionLedger | None" = None,
 ) -> AQWARunResult:
     """Run an AQWA diffraction analysis from a DiffractionSpec.
 
@@ -761,6 +777,8 @@ def run_aqwa(
         timeout_seconds: Maximum solver execution time.
         spec_path: Path to the source YAML file (for resolving relative
                    mesh paths). Optional.
+        assumption_ledger: Optional provenance ledger (e.g. from
+            ``resolver.resolve``) carried onto the result for reporting.
 
     Returns:
         AQWARunResult with status, paths, and logs.
@@ -771,4 +789,6 @@ def run_aqwa(
         timeout_seconds=timeout_seconds,
     )
     runner = AQWARunner(config)
-    return runner.run(spec, spec_path=spec_path)
+    return runner.run(
+        spec, spec_path=spec_path, assumption_ledger=assumption_ledger
+    )

--- a/src/digitalmodel/hydrodynamics/diffraction/assumption_ledger.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/assumption_ledger.py
@@ -1,0 +1,136 @@
+"""Assumption provenance ledger for diffraction input resolution."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Iterator, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AssumptionSource(str, Enum):
+    """Source category for a resolved diffraction input value."""
+
+    USER_SUPPLIED = "user_supplied"
+    ASSUMED_DEFAULT = "assumed_default"
+    ESTIMATED_FROM_DATA = "estimated_from_data"
+    DATABASE_LOOKUP = "database_lookup"
+
+
+class Confidence(str, Enum):
+    """Confidence in an assumed value."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class AssumptionRecord(BaseModel):
+    """One non-user-supplied value used to complete a diffraction spec."""
+
+    field: str
+    value: Any
+    source: AssumptionSource
+    basis: str
+    reference: Optional[str] = None
+    confidence: Confidence
+    impact: int = Field(default=0)
+
+
+class AssumptionLedger:
+    """Collection of non-user-supplied assumption records.
+
+    User-supplied values are intentionally not stored. A fully detailed
+    resolver run therefore produces a literally empty ledger.
+    """
+
+    def __init__(self, records: list[AssumptionRecord] | None = None) -> None:
+        self._records = list(records or [])
+
+    def record(
+        self,
+        field: str,
+        value: Any,
+        source: AssumptionSource,
+        basis: str,
+        confidence: Confidence,
+        *,
+        reference: str | None = None,
+        impact: int = 0,
+    ) -> None:
+        """Store a non-user-supplied assumption record."""
+        if source == AssumptionSource.USER_SUPPLIED:
+            return
+        self._records.append(
+            AssumptionRecord(
+                field=field,
+                value=value,
+                source=source,
+                basis=basis,
+                reference=reference,
+                confidence=confidence,
+                impact=impact,
+            )
+        )
+
+    @property
+    def records(self) -> list[AssumptionRecord]:
+        """Return records in insertion order."""
+        return list(self._records)
+
+    def rows(self) -> list[AssumptionRecord]:
+        """Return records sorted for human review by impact then confidence."""
+        confidence_rank = {
+            Confidence.LOW: 0,
+            Confidence.MEDIUM: 1,
+            Confidence.HIGH: 2,
+        }
+        return sorted(
+            self._records,
+            key=lambda r: (-r.impact, confidence_rank[r.confidence], r.field),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a machine-readable dictionary."""
+        return {
+            "records": [
+                record.model_dump(mode="json") for record in self._records
+            ]
+        }
+
+    def to_json(self) -> str:
+        """Serialise to JSON."""
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AssumptionLedger":
+        """Rebuild a ledger from ``to_dict`` output."""
+        return cls(
+            [
+                AssumptionRecord.model_validate(item)
+                for item in data.get("records", [])
+            ]
+        )
+
+    @classmethod
+    def from_json(cls, data: str) -> "AssumptionLedger":
+        """Rebuild a ledger from ``to_json`` output."""
+        return cls.from_dict(json.loads(data))
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    def __bool__(self) -> bool:
+        return bool(self._records)
+
+    def __iter__(self) -> Iterator[AssumptionRecord]:
+        return iter(self._records)
+
+
+__all__ = [
+    "AssumptionLedger",
+    "AssumptionRecord",
+    "AssumptionSource",
+    "Confidence",
+]

--- a/src/digitalmodel/hydrodynamics/diffraction/cli.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/cli.py
@@ -545,6 +545,105 @@ def validate_spec(spec_path):
         sys.exit(1)
 
 
+@cli.command("resolve")
+@click.option(
+    "--outcome",
+    type=click.Choice(
+        ["ship_raos", "added_mass_damping", "qtf"], case_sensitive=False
+    ),
+    required=True,
+    help="Target outcome to resolve.",
+)
+@click.option("--mesh", "mesh_file", type=click.Path(), required=True)
+@click.option("--water-depth", required=True, help="Water depth or 'infinite'.")
+@click.option("--out", "out_path", type=click.Path(), required=True)
+@click.option("--loa", type=float, default=None)
+@click.option("--beam", type=float, default=None)
+@click.option("--draft", type=float, default=None)
+@click.option("--displacement", type=float, default=None)
+@click.option("--hull-id", type=str, default=None)
+@click.option(
+    "--inertia-mode",
+    type=click.Choice(["free_floating", "explicit"], case_sensitive=False),
+    default="free_floating",
+    show_default=True,
+)
+def resolve_cmd(
+    outcome,
+    mesh_file,
+    water_depth,
+    out_path,
+    loa,
+    beam,
+    draft,
+    displacement,
+    hull_id,
+    inertia_mode,
+):
+    """Resolve sparse inputs into a complete DiffractionSpec YAML."""
+    from digitalmodel.hydrodynamics.diffraction.resolver import (
+        PrincipalDimensions,
+        ResolverInputs,
+        resolve,
+    )
+
+    dimensions = None
+    supplied_dims = [loa is not None, beam is not None, draft is not None]
+    if any(supplied_dims):
+        if not all(supplied_dims):
+            click.echo(
+                click.style(
+                    "[ERROR] --loa, --beam, and --draft must be supplied together",
+                    fg="red",
+                    bold=True,
+                )
+            )
+            sys.exit(1)
+        dimensions = PrincipalDimensions(
+            loa=loa,
+            beam=beam,
+            draft=draft,
+            displacement_t=displacement,
+        )
+
+    try:
+        wd: float | str
+        if water_depth.lower() in ("infinite", "inf", "deep"):
+            wd = water_depth
+        else:
+            # Inside try so a malformed value yields the formatted [ERROR]
+            # exit-1 path rather than an uncaught ValueError traceback.
+            wd = float(water_depth)
+        spec, ledger = resolve(
+            outcome,
+            ResolverInputs(
+                dimensions=dimensions,
+                mesh_file=mesh_file,
+                water_depth=wd,
+                hull_id=hull_id,
+                inertia_mode=inertia_mode,
+            ),
+        )
+        out = Path(out_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        spec.to_yaml(out)
+        click.echo(click.style("[OK] Resolved diffraction spec.", fg="green"))
+        click.echo(f"Spec: {out}")
+        click.echo("Assumptions:")
+        if not ledger:
+            click.echo("  No assumed values — all inputs were user-supplied.")
+        else:
+            for record in ledger.rows():
+                click.echo(
+                    "  - "
+                    f"{record.field}: {record.value} "
+                    f"[{record.source.value}, {record.confidence.value}]"
+                )
+    except Exception as e:
+        click.echo(click.style(f"\n[ERROR] {e}", fg="red", bold=True))
+        sys.exit(1)
+
+
 # ---------------------------------------------------------------------------
 # WRK-029: OrcaWave runner command
 # ---------------------------------------------------------------------------

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -46,7 +46,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import BaseModel, Field, field_validator
@@ -71,6 +71,11 @@ from digitalmodel.hydrodynamics.diffraction.output_schemas import (
     RAOSet,
 )
 from digitalmodel.hydrodynamics.diffraction.validation_runner import run_validation
+
+if TYPE_CHECKING:
+    from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+        AssumptionLedger,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +221,7 @@ class RunResult:
     # --- solver metadata ---
     orcf_api_version: str | None = None
     thread_count: int | None = None
+    assumption_ledger: "AssumptionLedger | None" = None
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +278,10 @@ class OrcaWaveRunner:
     # ----- public API -----
 
     def run(
-        self, spec: DiffractionSpec, spec_path: Path | str | None = None
+        self,
+        spec: DiffractionSpec,
+        spec_path: Path | str | None = None,
+        assumption_ledger: "AssumptionLedger | None" = None,
     ) -> RunResult:
         """Execute the full pipeline: prepare + execute.
 
@@ -285,8 +294,14 @@ class OrcaWaveRunner:
             spec: Canonical diffraction specification.
             spec_path: Path to the source YAML file (for resolving relative
                        mesh paths). Optional.
+            assumption_ledger: Optional provenance ledger (e.g. from
+                ``resolver.resolve``) to carry onto the result so it reaches
+                report generation. Attached to every return path.
         """
         self.prepare(spec, spec_path=spec_path)
+        # Attach after prepare() (which builds self._result) so the ledger
+        # rides both the dry-run early return and the execute() result.
+        self._result.assumption_ledger = assumption_ledger
 
         if not self._config.dry_run:
             # Check API or executable availability before executing
@@ -981,6 +996,7 @@ def run_orcawave(
     dry_run: bool = False,
     timeout_seconds: int = 7200,
     spec_path: Path | str | None = None,
+    assumption_ledger: "AssumptionLedger | None" = None,
 ) -> RunResult:
     """Run an OrcaWave diffraction analysis from a DiffractionSpec.
 
@@ -993,6 +1009,8 @@ def run_orcawave(
         timeout_seconds: Maximum solver execution time.
         spec_path: Path to the source YAML file (for resolving relative
                    mesh paths). Optional.
+        assumption_ledger: Optional provenance ledger (e.g. from
+            ``resolver.resolve``) carried onto the result for reporting.
 
     Returns:
         RunResult with status, paths, and logs.
@@ -1003,4 +1021,6 @@ def run_orcawave(
         timeout_seconds=timeout_seconds,
     )
     runner = OrcaWaveRunner(config)
-    return runner.run(spec, spec_path=spec_path)
+    return runner.run(
+        spec, spec_path=spec_path, assumption_ledger=assumption_ledger
+    )

--- a/src/digitalmodel/hydrodynamics/diffraction/parametric_spec_generator.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/parametric_spec_generator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 import numpy as np
 from pydantic import BaseModel, Field
@@ -132,30 +132,60 @@ class SpecGeneratorConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def estimate_mass(profile: HullProfile, rho: float = RHO_SEAWATER) -> float:
-    """Estimate vessel mass from hull profile.
+def _dimensions_from_profile(profile: HullProfile) -> Any:
+    """Build resolver dimensions lazily to avoid import cycles."""
+    from digitalmodel.hydrodynamics.diffraction.resolver import (
+        PrincipalDimensions,
+    )
+
+    # Preserve the original estimators' falsy-guard semantics: a non-positive
+    # displacement/block_coefficient meant "unknown -> use the Cb formula".
+    # PrincipalDimensions enforces gt=0 on both, so map non-positive -> None
+    # rather than letting a 0.0 profile raise ValidationError (back-compat).
+    return PrincipalDimensions(
+        length_bp=profile.length_bp,
+        beam=profile.beam,
+        draft=profile.draft,
+        displacement_t=(
+            profile.displacement
+            if profile.displacement and profile.displacement > 0
+            else None
+        ),
+        block_coefficient=(
+            profile.block_coefficient
+            if profile.block_coefficient and profile.block_coefficient > 0
+            else None
+        ),
+    )
+
+
+def estimate_mass_from_dimensions(
+    dims: Any, rho: float = RHO_SEAWATER
+) -> float:
+    """Estimate vessel mass from principal dimensions.
 
     Uses displacement in tonnes if available on the profile; otherwise
     falls back to Cb * L * B * T * rho.  When block_coefficient is also
     missing, a default Cb of 0.65 (typical full-form vessel) is used.
 
     Args:
-        profile: Hull profile with principal dimensions.
+        dims: Principal dimensions with length, beam, draft, and optional
+            displacement/block coefficient.
         rho: Water density in kg/m^3.
 
     Returns:
         Estimated mass in kg.
     """
-    if profile.displacement is not None and profile.displacement > 0:
-        return profile.displacement * 1000.0  # tonnes -> kg
+    if dims.displacement_t is not None and dims.displacement_t > 0:
+        return dims.displacement_t * 1000.0  # tonnes -> kg
 
-    cb = profile.block_coefficient if profile.block_coefficient else 0.65
-    volume = cb * profile.length_bp * profile.beam * profile.draft
+    cb = dims.block_coefficient if dims.block_coefficient else 0.65
+    volume = cb * dims.length * dims.beam * dims.draft
     return volume * rho
 
 
-def estimate_cog(profile: HullProfile) -> list[float]:
-    """Estimate centre of gravity from hull dimensions.
+def estimate_cog_from_dimensions(dims: Any) -> list[float]:
+    """Estimate centre of gravity from principal dimensions.
 
     Simple approximation: x at midships (L/2), y on centreline,
     z at half-draft below waterline.
@@ -164,14 +194,14 @@ def estimate_cog(profile: HullProfile) -> list[float]:
         [x, y, z] in metres (marine convention: z=0 at waterline).
     """
     return [
-        profile.length_bp / 2.0,
+        dims.length / 2.0,
         0.0,
-        -profile.draft / 2.0,
+        -dims.draft / 2.0,
     ]
 
 
-def estimate_radii_of_gyration(profile: HullProfile) -> list[float]:
-    """Estimate radii of gyration from hull dimensions.
+def estimate_radii_of_gyration_from_dimensions(dims: Any) -> list[float]:
+    """Estimate radii of gyration from principal dimensions.
 
     Uses standard naval architecture empirical coefficients:
     - Kxx ~ 0.34 * B  (roll)
@@ -182,10 +212,27 @@ def estimate_radii_of_gyration(profile: HullProfile) -> list[float]:
         [kxx, kyy, kzz] in metres.
     """
     return [
-        KXX_COEFF * profile.beam,
-        KYY_COEFF * profile.length_bp,
-        KZZ_COEFF * profile.length_bp,
+        KXX_COEFF * dims.beam,
+        KYY_COEFF * dims.length,
+        KZZ_COEFF * dims.length,
     ]
+
+
+def estimate_mass(profile: HullProfile, rho: float = RHO_SEAWATER) -> float:
+    """Estimate vessel mass from hull profile."""
+    return estimate_mass_from_dimensions(_dimensions_from_profile(profile), rho)
+
+
+def estimate_cog(profile: HullProfile) -> list[float]:
+    """Estimate centre of gravity from hull profile."""
+    return estimate_cog_from_dimensions(_dimensions_from_profile(profile))
+
+
+def estimate_radii_of_gyration(profile: HullProfile) -> list[float]:
+    """Estimate radii of gyration from hull profile."""
+    return estimate_radii_of_gyration_from_dimensions(
+        _dimensions_from_profile(profile)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +463,9 @@ def generate_batch_diffraction_specs(
 
 __all__ = [
     "SpecGeneratorConfig",
+    "estimate_mass_from_dimensions",
+    "estimate_cog_from_dimensions",
+    "estimate_radii_of_gyration_from_dimensions",
     "estimate_mass",
     "estimate_cog",
     "estimate_radii_of_gyration",

--- a/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
@@ -16,8 +16,9 @@ Version: 2.0.0 (post-split)
 
 from __future__ import annotations
 
+import html
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 # --- Re-exports from report_data_models ---
 from digitalmodel.hydrodynamics.diffraction.report_data_models import (
@@ -75,6 +76,11 @@ from digitalmodel.hydrodynamics.diffraction.report_builders import (
     _build_toc_html,
     _get_hull_type_note,
 )
+
+if TYPE_CHECKING:
+    from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+        AssumptionLedger,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -150,12 +156,47 @@ def _build_validation_sanity_html(validation_report: dict[str, Any]) -> str:
     )
 
 
+def _build_assumptions_html(ledger: "AssumptionLedger") -> str:
+    """Render the non-user-supplied assumption ledger."""
+    if not ledger:
+        body = "<p>No assumed values — all inputs were user-supplied.</p>"
+    else:
+        rows = []
+        for record in ledger.rows():
+            value = html.escape(str(record.value))
+            reference = html.escape(str(record.reference or ""))
+            rows.append(
+                "<tr>"
+                f"<td>{html.escape(record.field)}</td>"
+                f"<td>{value}</td>"
+                f"<td>{html.escape(record.source.value)}</td>"
+                f"<td>{html.escape(record.basis)}</td>"
+                f"<td>{reference}</td>"
+                f"<td>{html.escape(record.confidence.value)}</td>"
+                "</tr>"
+            )
+        body = (
+            "<table><thead><tr><th>Field</th><th>Value</th>"
+            "<th>Source</th><th>Basis</th><th>Reference</th>"
+            "<th>Confidence</th></tr></thead><tbody>"
+            + "".join(rows)
+            + "</tbody></table>"
+        )
+    return (
+        '<div class="section" id="assumptions">'
+        "<h2>Assumptions</h2>"
+        f"{body}"
+        "</div>"
+    )
+
+
 def generate_diffraction_report(
     report_data: DiffractionReportData,
     output_path: Path,
     include_plotlyjs: str = "cdn",
     mode: str = "full",
     validation_report: Optional[dict[str, Any]] = None,
+    assumption_ledger: Optional["AssumptionLedger"] = None,
 ) -> Path:
     """Generate a self-contained HTML diffraction report.
 
@@ -172,6 +213,8 @@ def generate_diffraction_report(
             provided, a sanity-check section is rendered near the executive
             summary. This NEVER re-runs validation (no ``OutputValidator`` is
             instantiated here).
+        assumption_ledger: Optional assumption provenance ledger. When
+            provided, an Assumptions section is rendered.
 
     Returns:
         Path to the generated HTML file.
@@ -199,6 +242,9 @@ def generate_diffraction_report(
     # never recomputed — see #625).
     if validation_report is not None:
         sections.append(_build_validation_sanity_html(validation_report))
+
+    if assumption_ledger is not None:
+        sections.append(_build_assumptions_html(assumption_ledger))
 
     if not compact:
         # S3: Hull Description & Mesh Quality

--- a/src/digitalmodel/hydrodynamics/diffraction/resolver.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/resolver.py
@@ -28,17 +28,14 @@ from digitalmodel.hydrodynamics.diffraction.input_schemas import (
     VesselSpec,
     WaveHeadingSpec,
 )
-from digitalmodel.hydrodynamics.diffraction.parametric_spec_generator import (
-    GRAVITY,
-    RHO_SEAWATER,
-    estimate_cog_from_dimensions,
-    estimate_mass_from_dimensions,
-    estimate_radii_of_gyration_from_dimensions,
-)
-from digitalmodel.hydrodynamics.hull_library.lookup import (
-    HullLookup,
-    HullLookupTarget,
-)
+# Physical constants are mirrored locally and the estimators + HullLookup are
+# imported lazily inside the functions that use them. Importing
+# parametric_spec_generator or hull_library at MODULE load pulls in
+# hull_library.mesh_generator -> bemrosetta -> diffraction.__init__ -> this
+# resolver (which the diffraction package eagerly imports), closing a circular
+# import. Keeping these edges lazy breaks the cycle without changing behaviour.
+RHO_SEAWATER = 1025.0  # kg/m^3
+GRAVITY = 9.80665  # m/s^2
 
 
 class Outcome(str, Enum):
@@ -360,6 +357,11 @@ def _resolve_inertia(
     hull_lookup: Any,
     ledger: AssumptionLedger,
 ) -> None:
+    from digitalmodel.hydrodynamics.diffraction.parametric_spec_generator import (
+        estimate_cog_from_dimensions,
+        estimate_radii_of_gyration_from_dimensions,
+    )
+
     vessel = _nested(data, "vessel")
     inertia = _nested(vessel, "inertia")
     inertia.setdefault("mode", inputs.inertia_mode)
@@ -476,6 +478,11 @@ def _lookup_values(
 ) -> dict[str, Any] | None:
     if dims is None:
         return None
+    from digitalmodel.hydrodynamics.hull_library.lookup import (
+        HullLookup,
+        HullLookupTarget,
+    )
+
     lookup = hull_lookup or HullLookup()
     match = lookup.get_hull_form(
         HullLookupTarget(
@@ -527,6 +534,10 @@ def _mass_from_sources(
         )
     if dims is None:
         raise ValueError("dimensions are required to estimate mass")
+    from digitalmodel.hydrodynamics.diffraction.parametric_spec_generator import (
+        estimate_mass_from_dimensions,
+    )
+
     return (
         estimate_mass_from_dimensions(dims, config.water_density),
         AssumptionSource.ESTIMATED_FROM_DATA,

--- a/src/digitalmodel/hydrodynamics/diffraction/resolver.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/resolver.py
@@ -1,0 +1,681 @@
+"""Inverse resolver for complete, solver-agnostic diffraction specs."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.hydrodynamics.diffraction.input_schemas import (
+    DiffractionSpec,
+    EnvironmentSpec,
+    FrequencyInputType,
+    FrequencyRangeSpec,
+    FrequencySpec,
+    HeadingRangeSpec,
+    MeshFormatType,
+    SolverOptions,
+    SymmetryType,
+    VesselGeometry,
+    VesselInertia,
+    VesselSpec,
+    WaveHeadingSpec,
+)
+from digitalmodel.hydrodynamics.diffraction.parametric_spec_generator import (
+    GRAVITY,
+    RHO_SEAWATER,
+    estimate_cog_from_dimensions,
+    estimate_mass_from_dimensions,
+    estimate_radii_of_gyration_from_dimensions,
+)
+from digitalmodel.hydrodynamics.hull_library.lookup import (
+    HullLookup,
+    HullLookupTarget,
+)
+
+
+class Outcome(str, Enum):
+    """Supported user outcomes for inverse resolution."""
+
+    SHIP_RAOS = "ship_raos"
+    ADDED_MASS_DAMPING = "added_mass_damping"
+    QTF = "qtf"
+
+
+OUTCOME_REQUIREMENTS: dict[Outcome, set[str]] = {
+    Outcome.SHIP_RAOS: {
+        "vessel.geometry.mesh_file",
+        "vessel.inertia.mass",
+        "vessel.inertia.centre_of_gravity",
+        "environment.water_depth",
+        "frequencies",
+        "wave_headings",
+    },
+    Outcome.ADDED_MASS_DAMPING: {
+        "vessel.geometry.mesh_file",
+        "vessel.inertia.mass",
+        "vessel.inertia.centre_of_gravity",
+        "environment.water_depth",
+        "frequencies",
+        "wave_headings",
+    },
+    Outcome.QTF: {
+        "vessel.geometry.mesh_file",
+        "vessel.inertia.mass",
+        "vessel.inertia.centre_of_gravity",
+        "environment.water_depth",
+        "frequencies",
+        "wave_headings",
+        "solver_options.qtf_calculation",
+    },
+}
+
+
+ASSUMPTION_CONTROLLED_FIELDS: tuple[str, ...] = (
+    "vessel.geometry.mesh_file",
+    "vessel.geometry.mesh_format",
+    "vessel.geometry.symmetry",
+    "vessel.geometry.reference_point",
+    "vessel.geometry.waterline_z",
+    "vessel.geometry.length_units",
+    "vessel.inertia.mass",
+    "vessel.inertia.centre_of_gravity",
+    "vessel.inertia.radii_of_gyration",
+    "vessel.inertia.inertia_tensor",
+    "vessel.inertia.cog_z",
+    "environment.water_depth",
+    "environment.water_density",
+    "environment.gravity",
+    "frequencies.range",
+    "wave_headings.range",
+    "solver_options.qtf_calculation",
+)
+
+
+class PrincipalDimensions(BaseModel):
+    """Principal vessel dimensions in metres and displacement in tonnes."""
+
+    loa: Optional[float] = Field(default=None, gt=0)
+    length_bp: Optional[float] = Field(default=None, gt=0)
+    beam: float = Field(gt=0)
+    draft: float = Field(gt=0)
+    displacement_t: Optional[float] = Field(default=None, gt=0)
+    block_coefficient: Optional[float] = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def check_length_available(self) -> "PrincipalDimensions":
+        if self.loa is None and self.length_bp is None:
+            raise ValueError("Either loa or length_bp must be supplied")
+        return self
+
+    @property
+    def length(self) -> float:
+        return self.length_bp if self.length_bp is not None else self.loa
+
+
+class ResolverInputs(BaseModel):
+    """Inputs accepted by the inverse resolver."""
+
+    dimensions: Optional[PrincipalDimensions] = None
+    mesh_file: Optional[str] = None
+    water_depth: Optional[float | str] = None
+    partial_spec: Optional[dict[str, Any]] = None
+    hull_id: Optional[str] = None
+    inertia_mode: str = "free_floating"
+
+
+class ResolverConfig(BaseModel):
+    """Configuration for default and lookup resolution behaviour."""
+
+    exact_thresh: float = Field(default=0.95, ge=0.0, le=1.0)
+    near_thresh: float = Field(default=0.80, ge=0.0, le=1.0)
+    freq_start: float = Field(default=0.2, gt=0)
+    freq_end: float = Field(default=2.0, gt=0)
+    freq_count: int = Field(default=30, gt=0)
+    heading_start: float = 0.0
+    heading_end: float = 180.0
+    heading_increment: float = Field(default=15.0, gt=0)
+    water_density: float = RHO_SEAWATER
+    gravity: float = GRAVITY
+
+
+def resolve(
+    outcome: Outcome | str,
+    inputs: ResolverInputs | dict[str, Any],
+    *,
+    hull_lookup: Any = None,
+    rao_db: Any = None,
+    config: ResolverConfig | None = None,
+) -> tuple[DiffractionSpec, AssumptionLedger]:
+    """Resolve user outcome and sparse inputs into a complete DiffractionSpec."""
+    del rao_db  # Source separation: RAODatabase may cross-check later, not write.
+    outcome = Outcome(outcome)
+    resolver_inputs = (
+        inputs
+        if isinstance(inputs, ResolverInputs)
+        else ResolverInputs.model_validate(inputs)
+    )
+    config = config or ResolverConfig()
+    data = _deep_copy(resolver_inputs.partial_spec or {})
+    ledger = AssumptionLedger()
+
+    dims = resolver_inputs.dimensions
+    geometry_data = _nested(data, "vessel", "geometry")
+    mesh_file = resolver_inputs.mesh_file or geometry_data.get("mesh_file")
+
+    _resolve_geometry(data, resolver_inputs, geometry_data, mesh_file, ledger)
+    _resolve_environment(data, resolver_inputs, config, ledger)
+    _resolve_frequencies(data, config, ledger)
+    _resolve_headings(data, config, ledger)
+    _resolve_solver_options(data, outcome, ledger)
+    _resolve_inertia(
+        data,
+        dims,
+        resolver_inputs,
+        config,
+        hull_lookup,
+        ledger,
+    )
+
+    spec = DiffractionSpec.model_validate(data)
+    return spec, ledger
+
+
+def _resolve_geometry(
+    data: dict[str, Any],
+    inputs: ResolverInputs,
+    geometry_data: dict[str, Any],
+    mesh_file: str | None,
+    ledger: AssumptionLedger,
+) -> None:
+    vessel = _nested(data, "vessel")
+    geometry = _nested(vessel, "geometry")
+    if "name" not in vessel:
+        vessel["name"] = inputs.hull_id or Path(mesh_file or "resolved_hull").stem
+        ledger.record(
+            "vessel.name",
+            vessel["name"],
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Name derived from hull hint or mesh filename",
+            Confidence.LOW,
+            reference="default",
+            impact=1,
+        )
+    if mesh_file and "mesh_file" not in geometry:
+        geometry["mesh_file"] = mesh_file
+    if "mesh_file" not in geometry:
+        raise ValueError("mesh_file is required when partial_spec lacks geometry")
+    if "mesh_format" not in geometry:
+        geometry["mesh_format"] = _mesh_format_from_path(geometry["mesh_file"])
+        ledger.record(
+            "vessel.geometry.mesh_format",
+            geometry["mesh_format"],
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Mesh format inferred from file extension",
+            Confidence.LOW,
+            reference="extension",
+            impact=2,
+        )
+    for field, value in (
+        ("symmetry", SymmetryType.NONE.value),
+        ("reference_point", [0.0, 0.0, 0.0]),
+        ("waterline_z", 0.0),
+        ("length_units", "m"),
+    ):
+        if field not in geometry:
+            geometry[field] = value
+            ledger.record(
+                f"vessel.geometry.{field}",
+                value,
+                AssumptionSource.ASSUMED_DEFAULT,
+                "Conservative geometry default",
+                Confidence.LOW,
+                reference="default",
+                impact=2,
+            )
+    if "type" not in vessel and inputs.hull_id:
+        vessel["type"] = inputs.hull_id
+
+
+def _resolve_environment(
+    data: dict[str, Any],
+    inputs: ResolverInputs,
+    config: ResolverConfig,
+    ledger: AssumptionLedger,
+) -> None:
+    env = _nested(data, "environment")
+    if inputs.water_depth is not None:
+        env["water_depth"] = inputs.water_depth
+    if "water_depth" not in env:
+        raise ValueError("water_depth is required")
+    if "water_density" not in env:
+        env["water_density"] = config.water_density
+        ledger.record(
+            "environment.water_density",
+            config.water_density,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default seawater density",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+    if "gravity" not in env:
+        env["gravity"] = config.gravity
+        ledger.record(
+            "environment.gravity",
+            config.gravity,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Standard gravity",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+    EnvironmentSpec.model_validate(env)
+
+
+def _resolve_frequencies(
+    data: dict[str, Any],
+    config: ResolverConfig,
+    ledger: AssumptionLedger,
+) -> None:
+    if "frequencies" in data:
+        return
+    data["frequencies"] = FrequencySpec(
+        input_type=FrequencyInputType.FREQUENCY,
+        range=FrequencyRangeSpec(
+            start=config.freq_start,
+            end=config.freq_end,
+            count=config.freq_count,
+        ),
+    ).model_dump(mode="json", exclude_none=True)
+    ledger.record(
+        "frequencies.range",
+        data["frequencies"]["range"],
+        AssumptionSource.ASSUMED_DEFAULT,
+        "Default diffraction frequency sweep",
+        Confidence.LOW,
+        reference="default",
+        impact=4,
+    )
+
+
+def _resolve_headings(
+    data: dict[str, Any],
+    config: ResolverConfig,
+    ledger: AssumptionLedger,
+) -> None:
+    if "wave_headings" in data:
+        return
+    data["wave_headings"] = WaveHeadingSpec(
+        range=HeadingRangeSpec(
+            start=config.heading_start,
+            end=config.heading_end,
+            increment=config.heading_increment,
+        ),
+        symmetry=True,
+    ).model_dump(mode="json", exclude_none=True)
+    ledger.record(
+        "wave_headings.range",
+        data["wave_headings"]["range"],
+        AssumptionSource.ASSUMED_DEFAULT,
+        "Default heading sweep",
+        Confidence.LOW,
+        reference="default",
+        impact=4,
+    )
+
+
+def _resolve_solver_options(
+    data: dict[str, Any],
+    outcome: Outcome,
+    ledger: AssumptionLedger,
+) -> None:
+    solver = _nested(data, "solver_options")
+    if outcome == Outcome.QTF and "qtf_calculation" not in solver:
+        solver["qtf_calculation"] = True
+        ledger.record(
+            "solver_options.qtf_calculation",
+            True,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "QTF outcome requires QTF calculation",
+            Confidence.LOW,
+            reference="outcome:qtf",
+            impact=4,
+        )
+    SolverOptions.model_validate(solver)
+
+
+def _resolve_inertia(
+    data: dict[str, Any],
+    dims: PrincipalDimensions | None,
+    inputs: ResolverInputs,
+    config: ResolverConfig,
+    hull_lookup: Any,
+    ledger: AssumptionLedger,
+) -> None:
+    vessel = _nested(data, "vessel")
+    inertia = _nested(vessel, "inertia")
+    inertia.setdefault("mode", inputs.inertia_mode)
+    if dims is None and _inertia_needs_dimensions(inertia):
+        geometry = _nested(vessel, "geometry")
+        dims = _derive_dimensions_from_mesh(geometry["mesh_file"], geometry, ledger)
+
+    if "mass" not in inertia:
+        # Only consult the hull lookup when mass actually needs resolving, so a
+        # user-supplied mass never triggers a spurious DATABASE_LOOKUP record
+        # (keeps the "detailed run -> empty ledger" contract intact even when
+        # dimensions happen to also be supplied).
+        lookup_values = _lookup_values(dims, hull_lookup, config, ledger)
+        mass, source, confidence, reference, basis = _mass_from_sources(
+            dims, lookup_values, config
+        )
+        inertia["mass"] = mass
+        ledger.record(
+            "vessel.inertia.mass",
+            mass,
+            source,
+            basis,
+            confidence,
+            reference=reference,
+            impact=5,
+        )
+    if "centre_of_gravity" not in inertia:
+        if dims is None:
+            raise ValueError("dimensions are required to estimate centre_of_gravity")
+        cog = estimate_cog_from_dimensions(dims)
+        inertia["centre_of_gravity"] = cog
+        ledger.record(
+            "vessel.inertia.centre_of_gravity",
+            cog,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            "Empirical CoG from principal dimensions",
+            Confidence.MEDIUM,
+            reference="estimate_cog_from_dimensions",
+            impact=5,
+        )
+    if inertia["mode"] == "free_floating" and "radii_of_gyration" not in inertia:
+        if dims is None:
+            raise ValueError("dimensions are required to estimate radii_of_gyration")
+        radii = estimate_radii_of_gyration_from_dimensions(dims)
+        inertia["radii_of_gyration"] = radii
+        ledger.record(
+            "vessel.inertia.radii_of_gyration",
+            radii,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            "Empirical radii from principal dimensions",
+            Confidence.MEDIUM,
+            reference="estimate_radii_of_gyration_from_dimensions",
+            impact=5,
+        )
+    if (
+        inertia["mode"] == "explicit"
+        and "radii_of_gyration" not in inertia
+        and "inertia_tensor" not in inertia
+    ):
+        if dims is None:
+            raise ValueError("dimensions are required to estimate inertia_tensor")
+        radii = estimate_radii_of_gyration_from_dimensions(dims)
+        mass = inertia["mass"]
+        inertia["inertia_tensor"] = {
+            "Ixx": mass * radii[0] ** 2,
+            "Iyy": mass * radii[1] ** 2,
+            "Izz": mass * radii[2] ** 2,
+            "Ixy": 0.0,
+            "Ixz": 0.0,
+            "Iyz": 0.0,
+        }
+        # Radii of gyration are defined about the centre of mass, so the
+        # estimated diagonal tensor is CG-relative. Label it accordingly
+        # instead of inheriting the schema default ("body_origin"), which
+        # would mis-state the reference point whenever the CoG is offset.
+        inertia["inertia_tensor_origin"] = "centre_of_mass"
+        ledger.record(
+            "vessel.inertia.inertia_tensor",
+            inertia["inertia_tensor"],
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            "Diagonal inertia tensor estimated from empirical radii",
+            Confidence.MEDIUM,
+            reference="estimate_radii_of_gyration_from_dimensions",
+            impact=5,
+        )
+    if inertia["mode"] == "free_floating" and "cog_z" not in inertia:
+        inertia["cog_z"] = inertia["centre_of_gravity"][2]
+        ledger.record(
+            "vessel.inertia.cog_z",
+            inertia["cog_z"],
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            "Derived from centre_of_gravity z coordinate",
+            Confidence.MEDIUM,
+            reference="centre_of_gravity",
+            impact=3,
+        )
+    VesselInertia.model_validate(inertia)
+    VesselSpec.model_validate(vessel)
+
+
+def _inertia_needs_dimensions(inertia: dict[str, Any]) -> bool:
+    if "mass" not in inertia or "centre_of_gravity" not in inertia:
+        return True
+    if inertia.get("mode", "free_floating") == "free_floating":
+        return "radii_of_gyration" not in inertia or "cog_z" not in inertia
+    return "radii_of_gyration" not in inertia and "inertia_tensor" not in inertia
+
+
+def _lookup_values(
+    dims: PrincipalDimensions | None,
+    hull_lookup: Any,
+    config: ResolverConfig,
+    ledger: AssumptionLedger,
+) -> dict[str, Any] | None:
+    if dims is None:
+        return None
+    lookup = hull_lookup or HullLookup()
+    match = lookup.get_hull_form(
+        HullLookupTarget(
+            loa_m=dims.length,
+            beam_m=dims.beam,
+            draft_m=dims.draft,
+            displacement_t=dims.displacement_t,
+        )
+    )
+    if match.similarity_score < config.near_thresh:
+        return None
+    confidence = (
+        Confidence.HIGH
+        if match.similarity_score >= config.exact_thresh
+        else Confidence.MEDIUM
+    )
+    entry = match.matched_entry
+    displacement_t = _entry_value(entry, "displacement_t")
+    if displacement_t is None:
+        return None
+    ledger.record(
+        "vessel.hull_lookup",
+        match.hull_id,
+        AssumptionSource.DATABASE_LOOKUP,
+        f"Nearest hull similarity {match.similarity_score:.3f}",
+        confidence,
+        reference=match.hull_id,
+        impact=2,
+    )
+    return {
+        "mass": float(displacement_t) * 1000.0,
+        "confidence": confidence,
+        "reference": match.hull_id,
+    }
+
+
+def _mass_from_sources(
+    dims: PrincipalDimensions | None,
+    lookup_values: dict[str, Any] | None,
+    config: ResolverConfig,
+) -> tuple[float, AssumptionSource, Confidence, str | None, str]:
+    if lookup_values is not None:
+        return (
+            lookup_values["mass"],
+            AssumptionSource.DATABASE_LOOKUP,
+            lookup_values["confidence"],
+            lookup_values["reference"],
+            "Mass from gated nearest-neighbour hull lookup",
+        )
+    if dims is None:
+        raise ValueError("dimensions are required to estimate mass")
+    return (
+        estimate_mass_from_dimensions(dims, config.water_density),
+        AssumptionSource.ESTIMATED_FROM_DATA,
+        Confidence.MEDIUM,
+        "estimate_mass_from_dimensions",
+        "Empirical mass from principal dimensions",
+    )
+
+
+def _derive_dimensions_from_mesh(
+    mesh_file: str,
+    geometry: dict[str, Any],
+    ledger: AssumptionLedger,
+) -> PrincipalDimensions:
+    units = geometry.get("length_units", "m")
+    symmetry = SymmetryType(geometry.get("symmetry", SymmetryType.NONE.value))
+    waterline_z = geometry.get("waterline_z", 0.0)
+    factor = _unit_factor(units)
+    points = _read_mesh_points(Path(mesh_file))
+    if not points:
+        raise ValueError(f"Cannot derive dimensions: no vertices in {mesh_file}")
+    xs = [p[0] * factor for p in points]
+    ys = [p[1] * factor for p in points]
+    zs = [p[2] * factor for p in points]
+    waterline = float(waterline_z) * factor
+    loa = max(xs) - min(xs)
+    beam = max(ys) - min(ys)
+    if symmetry in (SymmetryType.YZ, SymmetryType.XZ_YZ):
+        loa *= 2.0
+    if symmetry in (SymmetryType.XZ, SymmetryType.XZ_YZ):
+        beam *= 2.0
+    submerged = [z for z in zs if z <= waterline + 1e-9]
+    if not submerged:
+        raise ValueError(
+            "Cannot derive draft: mesh has no vertices below waterline_z"
+        )
+    draft = waterline - min(submerged)
+    if loa <= 0 or beam <= 0 or draft <= 0:
+        raise ValueError(
+            "Cannot derive positive dimensions from mesh; supply dimensions"
+        )
+    dims = PrincipalDimensions(loa=loa, beam=beam, draft=draft)
+    ledger.record(
+        "vessel.principal_dimensions",
+        dims.model_dump(mode="json", exclude_none=True),
+        AssumptionSource.ESTIMATED_FROM_DATA,
+        "Derived from mesh bounding box with units, symmetry, and waterline",
+        Confidence.MEDIUM,
+        reference=str(mesh_file),
+        impact=5,
+    )
+    return dims
+
+
+def _read_mesh_points(path: Path) -> list[tuple[float, float, float]]:
+    if not path.exists():
+        raise ValueError(f"Cannot derive dimensions: mesh file not found: {path}")
+    suffix = path.suffix.lower()
+    if suffix == ".obj":
+        return _read_obj_points(path)
+    if suffix in {".gdf", ".dat", ".stl", ""}:
+        return _read_numeric_triplets(path)
+    raise ValueError(
+        f"Cannot derive dimensions from unsupported mesh format '{suffix}'"
+    )
+
+
+def _read_obj_points(path: Path) -> list[tuple[float, float, float]]:
+    points = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) >= 4 and parts[0] == "v":
+            points.append((float(parts[1]), float(parts[2]), float(parts[3])))
+    return points
+
+
+def _read_numeric_triplets(path: Path) -> list[tuple[float, float, float]]:
+    points = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        parts = line.replace(",", " ").split()
+        if len(parts) != 3:
+            continue
+        try:
+            points.append((float(parts[0]), float(parts[1]), float(parts[2])))
+        except ValueError:
+            continue
+    return points
+
+
+def _unit_factor(units: str) -> float:
+    normalised = units.lower()
+    factors = {
+        "m": 1.0,
+        "meter": 1.0,
+        "meters": 1.0,
+        "metre": 1.0,
+        "metres": 1.0,
+        "ft": 0.3048,
+        "feet": 0.3048,
+        "foot": 0.3048,
+        "mm": 0.001,
+        "cm": 0.01,
+    }
+    if normalised not in factors:
+        raise ValueError(
+            f"Cannot derive dimensions: unknown length_units '{units}'"
+        )
+    return factors[normalised]
+
+
+def _mesh_format_from_path(path: str) -> str:
+    suffix = Path(path).suffix.lower().lstrip(".")
+    try:
+        return MeshFormatType(suffix).value
+    except ValueError:
+        return MeshFormatType.AUTO.value
+
+
+def _entry_value(entry: Any, key: str) -> Any:
+    if isinstance(entry, dict):
+        return entry.get(key)
+    return getattr(entry, key, None)
+
+
+def _nested(data: dict[str, Any], *keys: str) -> dict[str, Any]:
+    current = data
+    for key in keys:
+        value = current.setdefault(key, {})
+        if not isinstance(value, dict):
+            raise ValueError(f"{'.'.join(keys)} must be a mapping")
+        current = value
+    return current
+
+
+def _deep_copy(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _deep_copy(value) if isinstance(value, dict) else value
+        for key, value in data.items()
+    }
+
+
+__all__ = [
+    "ASSUMPTION_CONTROLLED_FIELDS",
+    "OUTCOME_REQUIREMENTS",
+    "Outcome",
+    "PrincipalDimensions",
+    "ResolverConfig",
+    "ResolverInputs",
+    "resolve",
+]

--- a/tests/hydrodynamics/diffraction/test_assumption_ledger.py
+++ b/tests/hydrodynamics/diffraction/test_assumption_ledger.py
@@ -1,0 +1,51 @@
+"""Tests for diffraction assumption ledger provenance."""
+
+from __future__ import annotations
+
+from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+
+
+def test_record_and_serialize_round_trip() -> None:
+    ledger = AssumptionLedger()
+    ledger.record(
+        "vessel.inertia.mass",
+        123.0,
+        AssumptionSource.ESTIMATED_FROM_DATA,
+        "test basis",
+        Confidence.MEDIUM,
+        reference="formula",
+        impact=5,
+    )
+
+    from_dict = AssumptionLedger.from_dict(ledger.to_dict())
+    from_json = AssumptionLedger.from_json(ledger.to_json())
+
+    assert len(from_dict) == 1
+    assert len(from_json) == 1
+    assert from_json.records[0].field == "vessel.inertia.mass"
+
+
+def test_user_supplied_records_are_refused() -> None:
+    ledger = AssumptionLedger()
+    ledger.record(
+        "environment.water_depth",
+        100.0,
+        AssumptionSource.USER_SUPPLIED,
+        "from user",
+        Confidence.HIGH,
+    )
+
+    assert len(ledger) == 0
+    assert bool(ledger) is False
+
+
+def test_empty_ledger_contract_for_detailed_run() -> None:
+    ledger = AssumptionLedger()
+
+    assert len(ledger) == 0
+    assert bool(ledger) is False
+    assert ledger.rows() == []

--- a/tests/hydrodynamics/diffraction/test_parametric_spec_generator.py
+++ b/tests/hydrodynamics/diffraction/test_parametric_spec_generator.py
@@ -117,6 +117,36 @@ class TestMassEstimation:
         expected = 0.85 * 100.0 * 20.0 * 5.0 * 1000.0
         assert mass == pytest.approx(expected)
 
+    def test_mass_non_positive_displacement_falls_through_to_cb(self):
+        """Back-compat: displacement<=0 means 'unknown' -> use the Cb formula.
+
+        The HullProfile->PrincipalDimensions wrapper enforces gt=0, so a 0.0
+        displacement must be treated as absent (not raise ValidationError),
+        preserving the original estimate_mass falsy-guard semantics.
+        """
+        profile = _make_barge_profile(
+            length=100.0, beam=20.0, draft=5.0, cb=0.85, displacement=0.0
+        )
+        expected = 0.85 * 100.0 * 20.0 * 5.0 * 1025.0
+        mass = estimate_mass(profile)
+        assert mass == pytest.approx(expected)
+
+    def test_mass_non_positive_block_coefficient_uses_default_cb(self):
+        """Back-compat: a non-positive Cb means 'unknown' -> default Cb=0.65.
+
+        A negative block_coefficient is truthy, so the wrapper must guard on
+        > 0 (not mere truthiness) to avoid raising on PrincipalDimensions(gt=0).
+        """
+        profile = _make_barge_profile(
+            length=100.0, beam=20.0, draft=5.0, cb=0.85, displacement=None
+        )
+        profile_bad_cb = profile.model_copy(
+            update={"block_coefficient": -0.5, "displacement": None}
+        )
+        expected = 0.65 * 100.0 * 20.0 * 5.0 * 1025.0
+        mass = estimate_mass(profile_bad_cb)
+        assert mass == pytest.approx(expected)
+
 
 class TestCoGEstimation:
     """Tests for estimate_cog function."""

--- a/tests/hydrodynamics/diffraction/test_resolve_cli.py
+++ b/tests/hydrodynamics/diffraction/test_resolve_cli.py
@@ -1,0 +1,50 @@
+"""CLI tests for diffraction inverse resolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from digitalmodel.hydrodynamics.diffraction.cli import cli
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+
+
+def test_resolve_cli_writes_spec_and_prints_assumptions(tmp_path: Path) -> None:
+    mesh = tmp_path / "box.gdf"
+    mesh.write_text(
+        "\n".join(
+            [
+                "0 0 -2",
+                "10 0 -2",
+                "10 4 -2",
+                "0 4 -2",
+                "0 0 0",
+                "10 0 0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "resolved.yml"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "resolve",
+            "--outcome",
+            "ship_raos",
+            "--mesh",
+            str(mesh),
+            "--water-depth",
+            "50",
+            "--out",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    spec = DiffractionSpec.from_yaml(out)
+    assert spec.vessel.geometry.mesh_file == str(mesh)
+    assert "Assumptions:" in result.output
+    assert "vessel.inertia.mass" in result.output

--- a/tests/hydrodynamics/diffraction/test_resolver.py
+++ b/tests/hydrodynamics/diffraction/test_resolver.py
@@ -1,0 +1,450 @@
+"""Tests for diffraction inverse resolver."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.aqwa_runner import (
+    AQWARunResult,
+    AQWARunStatus,
+)
+from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
+    RunResult,
+    RunStatus,
+)
+from digitalmodel.hydrodynamics.diffraction.parametric_spec_generator import (
+    estimate_cog,
+    estimate_cog_from_dimensions,
+    estimate_mass,
+    estimate_mass_from_dimensions,
+    estimate_radii_of_gyration,
+    estimate_radii_of_gyration_from_dimensions,
+)
+from digitalmodel.hydrodynamics.diffraction.report_data_models import (
+    DiffractionReportData,
+)
+from digitalmodel.hydrodynamics.diffraction.report_generator import (
+    generate_diffraction_report,
+)
+from digitalmodel.hydrodynamics.diffraction.resolver import (
+    ASSUMPTION_CONTROLLED_FIELDS,
+    OUTCOME_REQUIREMENTS,
+    Outcome,
+    PrincipalDimensions,
+    ResolverConfig,
+    ResolverInputs,
+    resolve,
+)
+from digitalmodel.hydrodynamics.hull_library.lookup import HullMatch
+from digitalmodel.hydrodynamics.hull_library.profile_schema import (
+    HullProfile,
+    HullStation,
+    HullType,
+)
+
+
+def _write_box_mesh(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "# box mesh",
+                "0 0 -2",
+                "10 0 -2",
+                "10 4 -2",
+                "0 4 -2",
+                "0 0 0",
+                "10 0 0",
+                "10 4 0",
+                "0 4 0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _detailed_partial(mesh: Path) -> dict:
+    return {
+        "vessel": {
+            "name": "detailed",
+            "geometry": {
+                "mesh_file": str(mesh),
+                "mesh_format": "gdf",
+                "symmetry": "none",
+                "reference_point": [0.0, 0.0, 0.0],
+                "waterline_z": 0.0,
+                "length_units": "m",
+            },
+            "inertia": {
+                "mode": "free_floating",
+                "mass": 10_000.0,
+                "centre_of_gravity": [5.0, 0.0, -1.0],
+                "radii_of_gyration": [1.0, 2.5, 2.6],
+                "cog_z": -1.0,
+            },
+        },
+        "environment": {
+            "water_depth": 100.0,
+            "water_density": 1025.0,
+            "gravity": 9.80665,
+        },
+        "frequencies": {
+            "input_type": "frequency",
+            "range": {"start": 0.2, "end": 2.0, "count": 30},
+        },
+        "wave_headings": {
+            "range": {"start": 0.0, "end": 180.0, "increment": 15.0},
+            "symmetry": True,
+        },
+    }
+
+
+class FakeLookup:
+    def __init__(self, score: float) -> None:
+        self.score = score
+
+    def get_hull_form(self, target):  # noqa: ANN001
+        return HullMatch(
+            hull_id="FAKE",
+            similarity_score=self.score,
+            scaling_factors={},
+            matched_entry={"displacement_t": 12.0},
+            source="fake",
+        )
+
+
+def test_barebones_mesh_water_depth_resolves_and_ledgers(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+
+    spec, ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    assert isinstance(spec, DiffractionSpec)
+    assert spec.vessel.geometry.mesh_file == str(mesh)
+    assert spec.vessel.inertia.mass > 0
+    assert any(r.field == "vessel.principal_dimensions" for r in ledger)
+
+
+def test_partial_dimensions_avoid_mesh_dimension_derivation(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+
+    spec, ledger = resolve(
+        "ship_raos",
+        ResolverInputs(
+            dimensions=PrincipalDimensions(loa=20.0, beam=5.0, draft=2.0),
+            mesh_file=str(mesh),
+            water_depth=80.0,
+            partial_spec={"vessel": {"name": "partial"}},
+        ),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    assert spec.vessel.name == "partial"
+    assert not any(r.field == "vessel.principal_dimensions" for r in ledger)
+
+
+def test_detailed_run_has_empty_ledger_and_report_empty_state(
+    tmp_path: Path,
+) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+
+    spec, ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(partial_spec=_detailed_partial(mesh)),
+    )
+
+    assert spec.vessel.name == "detailed"
+    assert len(ledger) == 0
+    out = tmp_path / "report.html"
+    generate_diffraction_report(
+        DiffractionReportData(vessel_name="detailed", mode="compact"),
+        out,
+        assumption_ledger=ledger,
+    )
+    text = out.read_text(encoding="utf-8")
+    assert 'id="assumptions"' in text
+    assert "No assumed values" in text
+
+
+def test_lookup_threshold_falls_through_below_near_threshold(
+    tmp_path: Path,
+) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    dims = PrincipalDimensions(loa=10.0, beam=4.0, draft=2.0)
+
+    _, high_ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(dimensions=dims, mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.99),
+    )
+    _, low_ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(dimensions=dims, mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    high_mass = [
+        r for r in high_ledger if r.field == "vessel.inertia.mass"
+    ][0]
+    low_mass = [r for r in low_ledger if r.field == "vessel.inertia.mass"][0]
+    assert high_mass.source == AssumptionSource.DATABASE_LOOKUP
+    assert high_mass.confidence == Confidence.HIGH
+    assert low_mass.source == AssumptionSource.ESTIMATED_FROM_DATA
+
+
+def test_dual_backend_ledger_field_and_report_render(tmp_path: Path) -> None:
+    ledger = AssumptionLedger()
+    ledger.record(
+        "frequencies.range",
+        {"start": 0.2},
+        AssumptionSource.ASSUMED_DEFAULT,
+        "default",
+        Confidence.LOW,
+    )
+
+    assert "assumption_ledger" in {f.name for f in fields(RunResult)}
+    assert "assumption_ledger" in {f.name for f in fields(AQWARunResult)}
+    assert (
+        RunResult(status=RunStatus.PENDING, assumption_ledger=ledger)
+        .assumption_ledger
+        is ledger
+    )
+    assert (
+        AQWARunResult(
+            status=AQWARunStatus.PENDING, assumption_ledger=ledger
+        ).assumption_ledger
+        is ledger
+    )
+
+    out = tmp_path / "report.html"
+    generate_diffraction_report(
+        DiffractionReportData(vessel_name="vessel", mode="compact"),
+        out,
+        assumption_ledger=ledger,
+    )
+    assert 'id="assumptions"' in out.read_text(encoding="utf-8")
+
+
+def test_inertia_mode_free_floating_vs_explicit(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    dims = PrincipalDimensions(loa=10.0, beam=4.0, draft=2.0)
+
+    free_spec, free_ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(
+            dimensions=dims,
+            mesh_file=str(mesh),
+            water_depth=50.0,
+            inertia_mode="free_floating",
+        ),
+        hull_lookup=FakeLookup(0.1),
+    )
+    explicit_spec, explicit_ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(
+            dimensions=dims,
+            mesh_file=str(mesh),
+            water_depth=50.0,
+            inertia_mode="explicit",
+        ),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    assert free_spec.vessel.inertia.radii_of_gyration is not None
+    assert explicit_spec.vessel.inertia.radii_of_gyration is None
+    assert explicit_spec.vessel.inertia.inertia_tensor is not None
+    assert any(r.field == "vessel.inertia.radii_of_gyration" for r in free_ledger)
+    assert not any(
+        r.field == "vessel.inertia.radii_of_gyration" for r in explicit_ledger
+    )
+
+
+def test_explicit_inertia_tensor_origin_is_centre_of_mass(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    spec, _ = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(
+            dimensions=PrincipalDimensions(loa=100.0, beam=20.0, draft=10.0),
+            mesh_file=str(mesh),
+            water_depth=100.0,
+            inertia_mode="explicit",
+        ),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    # Empirical radii of gyration are CG-relative, so the estimated diagonal
+    # tensor must be labelled centre_of_mass, not the schema default
+    # body_origin (which would mis-state the reference for an offset CoG).
+    assert spec.vessel.inertia.inertia_tensor is not None
+    assert spec.vessel.inertia.inertia_tensor_origin == "centre_of_mass"
+
+
+def test_ledger_travels_through_run_entrypoints(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.aqwa_runner import run_aqwa
+    from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
+        run_orcawave,
+    )
+
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    spec, ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.1),
+    )
+    assert len(ledger) > 0
+
+    # The provenance ledger must ride the result from a real run entry point
+    # (dry-run, license-free) so it reaches report generation — not only when
+    # a caller hand-constructs the result object.
+    orca_result = run_orcawave(
+        spec,
+        output_dir=tmp_path / "orca",
+        dry_run=True,
+        assumption_ledger=ledger,
+    )
+    assert orca_result.assumption_ledger is ledger
+
+    aqwa_result = run_aqwa(
+        spec,
+        output_dir=tmp_path / "aqwa",
+        dry_run=True,
+        assumption_ledger=ledger,
+    )
+    assert aqwa_result.assumption_ledger is ledger
+
+
+def test_mesh_units_symmetry_and_draft_use_waterline(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "half_box.gdf")
+
+    spec, ledger = resolve(
+        Outcome.SHIP_RAOS,
+        ResolverInputs(
+            mesh_file=str(mesh),
+            water_depth=50.0,
+            partial_spec={
+                "vessel": {
+                    "geometry": {
+                        "mesh_file": str(mesh),
+                        "symmetry": "xz",
+                        "length_units": "ft",
+                        "waterline_z": 0.0,
+                    }
+                }
+            },
+        ),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    assert spec.vessel.inertia.centre_of_gravity[0] == pytest.approx(1.524)
+    assert spec.vessel.inertia.centre_of_gravity[2] == pytest.approx(-0.3048)
+    dims_record = [
+        r for r in ledger if r.field == "vessel.principal_dimensions"
+    ][0]
+    assert dims_record.value["beam"] == pytest.approx(2.4384)
+    assert dims_record.value["draft"] == pytest.approx(0.6096)
+
+
+def test_mesh_dimension_derivation_fail_closed(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+
+    with pytest.raises(ValueError, match="unknown length_units"):
+        resolve(
+            Outcome.SHIP_RAOS,
+            ResolverInputs(
+                mesh_file=str(mesh),
+                water_depth=50.0,
+                partial_spec={
+                    "vessel": {
+                        "geometry": {
+                            "mesh_file": str(mesh),
+                            "length_units": "furlong",
+                        }
+                    }
+                },
+            ),
+        )
+
+
+def test_estimator_dimension_functions_match_profile_wrappers() -> None:
+    profile = HullProfile(
+        name="profile",
+        hull_type=HullType.BARGE,
+        stations=[
+            HullStation(x_position=0.0, waterline_offsets=[(0.0, 1.0)]),
+            HullStation(x_position=10.0, waterline_offsets=[(0.0, 1.0)]),
+        ],
+        length_bp=10.0,
+        beam=4.0,
+        draft=2.0,
+        depth=3.0,
+        source="test",
+        block_coefficient=0.8,
+        displacement=None,
+    )
+    dims = PrincipalDimensions(
+        length_bp=10.0,
+        beam=4.0,
+        draft=2.0,
+        block_coefficient=0.8,
+    )
+
+    assert estimate_mass(profile) == pytest.approx(
+        estimate_mass_from_dimensions(dims)
+    )
+    assert estimate_cog(profile) == estimate_cog_from_dimensions(dims)
+    assert estimate_radii_of_gyration(
+        profile
+    ) == estimate_radii_of_gyration_from_dimensions(dims)
+
+
+def test_assumption_controlled_manifest_is_ledgered(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    _, ledger = resolve(
+        Outcome.QTF,
+        ResolverInputs(mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    recorded = {record.field for record in ledger}
+    expected = {
+        "vessel.geometry.mesh_format",
+        "vessel.geometry.symmetry",
+        "vessel.geometry.reference_point",
+        "vessel.geometry.waterline_z",
+        "vessel.geometry.length_units",
+        "vessel.inertia.mass",
+        "vessel.inertia.centre_of_gravity",
+        "vessel.inertia.radii_of_gyration",
+        "vessel.inertia.cog_z",
+        "environment.water_density",
+        "environment.gravity",
+        "frequencies.range",
+        "wave_headings.range",
+        "solver_options.qtf_calculation",
+    }
+    assert expected <= recorded
+    assert expected <= set(ASSUMPTION_CONTROLLED_FIELDS)
+
+
+def test_outcome_requirements_are_data_driven(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    spec, _ = resolve(
+        Outcome.QTF,
+        ResolverInputs(mesh_file=str(mesh), water_depth=50.0),
+        hull_lookup=FakeLookup(0.1),
+    )
+
+    assert "solver_options.qtf_calculation" in OUTCOME_REQUIREMENTS[Outcome.QTF]
+    assert spec.solver_options.qtf_calculation is True

--- a/tests/hydrodynamics/diffraction/test_resolver.py
+++ b/tests/hydrodynamics/diffraction/test_resolver.py
@@ -271,6 +271,30 @@ def test_inertia_mode_free_floating_vs_explicit(tmp_path: Path) -> None:
     )
 
 
+def test_no_circular_import_when_hull_library_imported_first() -> None:
+    """Guard against the resolver re-introducing a circular import.
+
+    The diffraction package eagerly imports ``resolver``; if ``resolver``
+    imported ``parametric_spec_generator`` / ``hull_library`` at module load,
+    the chain hull_library.mesh_generator -> bemrosetta -> diffraction.__init__
+    -> resolver -> parametric_spec_generator -> hull_library.mesh_generator
+    (half-initialised) raises ImportError. Those edges are lazy; this checks it
+    in a fresh interpreter (same-process import caching would mask the cycle).
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import digitalmodel.hydrodynamics.hull_library.mesh_generator\n"
+        "import digitalmodel.hydrodynamics.diffraction\n"
+        "from digitalmodel.hydrodynamics.diffraction import resolve, Outcome\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_explicit_inertia_tensor_origin_is_centre_of_mass(tmp_path: Path) -> None:
     mesh = _write_box_mesh(tmp_path / "box.gdf")
     spec, _ = resolve(


### PR DESCRIPTION
## Pillar (a) — the headline output-driven capability (epic #622)

`resolve(outcome, inputs) -> (DiffractionSpec, AssumptionLedger)`. A user names an outcome and supplies data anywhere on **barebones → detailed**; the resolver returns a complete, runnable, **solver-agnostic** `DiffractionSpec` where **every value it assumed (not received) carries a provenance record** surfaced in a mandatory report Assumptions section. No silent assumptions.

Built per the approved, adversarially-reviewed plan on #623 and the locked decisions: **D1 single PR · D2 CLI included · D3 SHIP_RAOS + ADDED_MASS_DAMPING + QTF**.

### What's in it
1. **`assumption_ledger.py`** — `AssumptionRecord{field, value, source, basis, reference, confidence, impact}` + `AssumptionLedger` that holds **only non-user-supplied records** → a fully-detailed run yields a *literally empty* ledger. Serializable machine (`to_dict`/`to_json`) + human (`rows()`).
2. **`resolver.py`** — pluggable `OUTCOME_REQUIREMENTS` table; per-gap tiering **DATABASE_LOOKUP → ESTIMATED_FROM_DATA → ASSUMED_DEFAULT**. Review-settled contracts:
   - `HullLookup` is nearest-neighbour → **gated by `similarity_score`** (`< near_thresh` falls through, so a bad hull never pollutes the spec).
   - **Mesh → dimensions is fail-closed**: corrects for `length_units` + `symmetry` (half-mesh doubling), draft = submerged depth below `waterline_z`; **raises** on indeterminate input rather than emit a wrong guess.
   - **Source separation**: `HullLookup` → geometry/mass/inertia only; `RAODatabase` forbidden from solver-input spec fields.
   - Default inertia `free_floating`; `explicit` mode tested.
3. **Threading + report** — `assumption_ledger` on **both** `RunResult` and `AQWARunResult`, threaded through `run()` / `run_orcawave()` / `run_aqwa()`. Mandatory `Assumptions` report section (html-escaped, sorted by impact then confidence, empty-state for detailed runs). Honors **D2** (no xlsx/report-path work).
4. **CLI** — `diffraction resolve --outcome --mesh --water-depth --out` (+ optional dims / hull-id / inertia-mode), prints the assumption summary, license-free.
5. **Estimator promotion (back-compat)** — new `estimate_*_from_dimensions(PrincipalDimensions)`; legacy `estimate_*(HullProfile)` retained as wrappers (non-positive displacement/Cb preserve the Cb-formula fall-through).

### Provenance / quality
- **Drafted by Codex**, then **reviewed line-by-line (Claude)** + a **fresh-context Codex adversarial defect-hunting pass**.
- Adversarial review surfaced 5 findings; **4 folded** (explicit-mode inertia-tensor origin labelled `centre_of_mass`; ledger threaded through the `run_*` entry points; negative-`block_coefficient` guard; CLI `--water-depth` error path). **1 deferred** as out-of-scope (policing user-supplied `partial_spec` frequency/heading *values* is schema/#525 territory) — see follow-up note on the issues.

### Tests (dev-primary, mock OrcFxAPI)
Ledger round-trip · resolver tiers (barebones / partial / detailed→empty) · similarity fall-through · **dual-backend ledger travel through the run entry points** · inertia modes · mesh fail-closed edge cases (units / half-mesh / draft) · estimator back-compat regressions · #525 field-manifest guard · pluggability.

**`uv run pytest tests/hydrodynamics/diffraction` → 1462 passed, 24 skipped, 2 xfailed.** (Repo-wide `Run Quality Gates` is red on a pre-existing baseline, unrelated to this PR.)

Closes #623
Closes #624