### PR TITLE
FrPS/SSR free-standing riser — global dynamic model scaffold (input YAML, no run)

### DIFF
--- a/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/README.md
+++ b/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/README.md
@@ -1,0 +1,123 @@
+# FrPS / SSR Free-Standing Riser — Global Dynamic Model (Input Scaffold)
+
+> **Status: INPUT SCAFFOLD — not solved, no results.**
+> This directory contains the *model-input definition* for the global dynamic
+> analysis the FDAS riser-buckling screening campaign concluded it needs. It is
+> **not a run** and produces **no engineering results**. A licensed solver
+> (OrcaFlex / Flexcom / Abaqus-Aqua) is required to execute it and is almost
+> certainly **not installed or licensed** in the environment where this was
+> scaffolded (cf. workspace-hub #2849, "solver-license availability").
+
+## What this model is
+
+A parameterized OrcaFlex model of a **free-standing, dry-tree riser** landed on
+a surface SSR / wellhead. It is the engineering follow-on to the FDAS screening
+campaign (`github.com/vamseeachanta/llm-wiki-fdas` issues **#2–#7**), whose
+conservative hand-screens (unrestrained Euler #2/#3, survival-pushdown stress
+#4, tendon tension #7) all fail — and whose verdict pivots on inputs the screens
+cannot manufacture. The global-model scope is **FDAS issue #2**; this scaffold
+mirrors that scope as reviewable YAML.
+
+### Geometry
+- Concentric **16 in / 11.75 in / 7 in** strings.
+- **810 ft (246.888 m)** bare-pipe "slick" section carrying the dry tree.
+- Centralizers at **~30 ft (9.144 m)** spacing.
+- Set-down stops, surface wellhead landing.
+- Water depths **6,000 / 8,000 / 10,000 ft** (1828.8 / 2438.4 / 3048.0 m).
+
+### Top boundary (per FDAS #2, Jun-4 Chuck↔Roy exchange)
+Axially sliding on UHMW pads (μ < 0.1) but **restrained against rotation** (no
+articulation) — modeled as guided / rotation-fixed with stroke limits at the
+set-down stops. Baseline assumes the **7-in tubing is always installed and
+pre-tensioned** when the tree is on the SSR; the *no-tubing* case is carried as
+a robustness/abnormal sensitivity, not the baseline.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `spec.yml` | Human-authored, parameterized model definition (geometry, strings, slick section, restraints, boundaries). Consumed by the `modular_generator`. Section properties are **placeholders** pending the section-basis decision. |
+| `inputs/parameters.yml` | Parametric matrix: section-basis variants, demand/set-down variants, water-depth cases, restraint-stiffness placeholders, metocean/load-case matrix, analysis-type toggles, sensitivity cases, tooling/license note. |
+| `README.md` | This file. |
+
+> `modular/` (the OrcaFlex-loadable `master.yml` + `includes/*.yml`) is
+> **generator output and is intentionally not committed**. Generate it on a
+> licensed solver host (see below) after the two open inputs are resolved.
+
+## The two OPEN inputs that must be set before build
+
+Both are unresolved in the screening campaign and are carried as explicit
+**variants** in `inputs/parameters.yml` — they are deliberate engineering
+decisions, not values to guess:
+
+1. **Section basis** (`section_basis`, FDAS #3) —
+   **82.51 in²** (two-casing, tubing not structural) **vs ~97 in²**
+   (three-string, 7-in WT 0.50→0.75 in). This sets the buckling demand the
+   screens flagged. Pick one variant; derive EA/EI for the concentric stack
+   and write it into `spec.yml` line types before build. *Do not average.*
+
+2. **Roy demand / set-down definition** (`demand.setdown_definition`, FDAS #4/#7) —
+   Roy's "5–10 ft pushdown": does it **net the slip-joint stroke**?
+   Variants `gross_pushdown` vs `net_of_stroke` bound it. The preferred
+   resolution per #2 is to derive imposed set-down + heave from the **coupled
+   vessel/riser RAO response**, not a quoted figure; the variants bound it
+   until that coupled run exists.
+
+Additional values marked `~` / `TBD` / `PLACEHOLDER` (restraint stiffnesses,
+metocean magnitudes, S-N class, RAOs) are **not results** — they are slots for
+project data and calibration.
+
+## Analyses the model is structured to support
+
+Each closes a specific open screening item (`inputs/parameters.yml → analyses`):
+
+| Analysis | Closes | Output |
+|---|---|---|
+| **Static** | #4/#7 | set-down, stop reaction, tendon tension, effective-tension profile |
+| **Modal/eigenvalue** | #3/#5 | mode shapes/frequencies, restraint efficiency, VIV lock-in screen |
+| **Dynamic time-domain** | storm combos | max tension/stress, snap loads, dynamic stop reaction |
+| **Fatigue** | #4/#5 | VIV + wave stress-range spectra → S-N life |
+
+## Hydrodynamics / RAOs
+
+Vessel RAOs (and QTFs) are to be sourced from the **digitalmodel OrcaWave /
+diffraction capability** for the actual SSR hull and linked into the vessel
+type in `spec.yml`. The placeholder vessel type is **not populated** and must
+not be used as-is.
+
+## How to generate the OrcaFlex model (on a licensed host)
+
+```bash
+# 1. Resolve the two open inputs in inputs/parameters.yml
+#    (set section_basis.selected and demand.setdown_definition; derive EA/EI).
+# 2. Generate the OrcaFlex-loadable include tree:
+uv run python -m digitalmodel.solvers.orcaflex.modular_generator generate \
+    --input spec.yml --output modular/
+```
+
+This follows the same convention as the other entries under
+`docs/domains/orcaflex/library/model_library/` (e.g. `b01_drilling_riser`).
+
+## What is scaffolded vs. what is needed
+
+**Scaffolded (this commit):**
+- Geometry, concentric strings, slick section, boundaries/restraint structure.
+- Parametric matrix: section-basis & demand variants, water-depth cases,
+  metocean/load-case matrix, analysis toggles, sensitivity (no-tubing) case.
+- Honest placeholders for every value the screening could not settle.
+
+**Still needed (NOT in this commit):**
+- A **licensed solver** (OrcaFlex primary; Flexcom / Abaqus-Aqua alternatives)
+  on a host where it is installed — none assumed here.
+- Resolution of the **two open inputs** (section basis; Roy demand definition).
+- Project **metocean** data, **restraint-stiffness calibration**, **S-N class**,
+  and **OrcaWave-sourced RAOs/QTFs**.
+- The generated `modular/` tree, then static → modal → dynamic → fatigue runs.
+
+## Provenance
+
+- Screening campaign: `llm-wiki-fdas` #3–#7.
+- Global-model scope: `llm-wiki-fdas` #2.
+- Basis page: `llm-wiki-fdas pages/frps-fsr-global-riser-model.md` (PR #9, unmerged).
+- No raw vendor files are committed; off-repo raw data should be referenced by
+  sha256 pointer per the house method.

--- a/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/inputs/parameters.yml
+++ b/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/inputs/parameters.yml
@@ -1,0 +1,198 @@
+# FrPS / SSR Free-Standing Riser - GLOBAL DYNAMIC MODEL
+# Parametric matrix (variants, load cases, analysis toggles, restraint placeholders)
+#
+# Status: INPUT SCAFFOLD - values marked PLACEHOLDER / TBD are NOT engineering
+#         results. They exist so the parametric structure is reviewable and the
+#         two pivotal open inputs are explicit. Resolve before any solver run.
+#
+# Units: SI (m, te, kN, te/m^3) unless a field-unit original is noted.
+
+# ===========================================================================
+# OPEN INPUT 1 - SECTION BASIS  (#3)
+#   The screening left the as-built concentric section area unresolved. Build
+#   ONE variant; do not average. The choice sets the buckling demand the
+#   screens flagged, so it must be a deliberate engineering decision.
+# ===========================================================================
+section_basis:
+  selected: ~                                    # MUST SET: two_casing | three_string
+  variants:
+    two_casing:
+      description: "16 + 11.75 in only; 7-in tubing not counted structurally"
+      effective_area_in2: 82.51                  # in^2 (screening figure)
+      effective_area_m2: 0.053232                 # 82.51 in^2 -> m^2
+      tubing_structural: false
+    three_string:
+      description: "16 + 11.75 + 7 in tubing, tubing WT 0.50->0.75 in"
+      effective_area_in2: 97.0                    # in^2 (~, upper basis)
+      effective_area_m2: 0.062581                 # ~97 in^2 -> m^2
+      tubing_structural: true
+      tubing_wt_in: [0.50, 0.75]                  # WT swing driving the area range
+  # Effective EA/EI for the chosen variant MUST be derived from the concentric
+  # stack (per-string A, I, E) and written into spec.yml line types before build.
+  derived_properties_status: "TBD - derive EA/EI from chosen variant"
+
+# ===========================================================================
+# OPEN INPUT 2 - DEMAND / SET-DOWN DEFINITION  (#4 / #7)
+#   Roy's "5-10 ft pushdown" - does it net the slip-joint stroke? The model
+#   resolves demand from coupled vessel/riser RAO response, but the imposed
+#   set-down case definition must state the convention.
+# ===========================================================================
+demand:
+  setdown_definition: ~                          # MUST SET: gross_pushdown | net_of_stroke
+  variants:
+    gross_pushdown:
+      description: "5-10 ft is total platform pushdown; stroke NOT subtracted"
+      pushdown_ft: [5, 10]
+      pushdown_m: [1.524, 3.048]
+      nets_stroke: false
+    net_of_stroke:
+      description: "5-10 ft is set-down remaining AFTER slip-joint stroke taken up"
+      setdown_ft: [5, 10]
+      setdown_m: [1.524, 3.048]
+      nets_stroke: true
+  slip_joint_stroke_m: ~                          # TBD - needed to relate the two variants
+  # Preferred resolution per #2: derive imposed set-down + heave from coupled
+  # vessel/riser RAO response rather than a quoted figure. These variants bound
+  # it until the coupled run exists.
+
+# ===========================================================================
+# WATER-DEPTH CASES  (geometry sweep)
+# ===========================================================================
+water_depth_cases:
+  selected: [wd_6000]                            # build set; extend to 8k/10k as needed
+  cases:
+    wd_6000: { depth_ft: 6000, depth_m: 1828.8 }
+    wd_8000: { depth_ft: 8000, depth_m: 2438.4 }
+    wd_10000: { depth_ft: 10000, depth_m: 3048.0 }
+
+# ===========================================================================
+# GEOMETRY (fixed across cases)
+# ===========================================================================
+geometry:
+  slick_length_ft: 810
+  slick_length_m: 246.888
+  centralizer_spacing_ft: 30
+  centralizer_spacing_m: 9.144
+  strings:                                       # OD only fixed; WT per section_basis
+    outer_casing_in: 16.0
+    intermediate_casing_in: 11.75
+    tubing_in: 7.0
+  dry_tree: true                                 # slick section carries the dry tree
+  surface_wellhead_landing: true
+
+# ===========================================================================
+# RESTRAINT STIFFNESS PLACEHOLDERS  (CALIBRATE - #2/#3)
+#   "The hinge." Actual modal restraint vs the K-factor bounds is the open
+#   question. All values PLACEHOLDER pending calibration against modal results.
+# ===========================================================================
+restraint:
+  top_boundary:
+    type: "axial-slide, rotation-fixed"          # UHMW pads mu<0.1, no articulation (#2)
+    axial_friction_mu: 0.1                        # < 0.1 per #2
+    rotational: fixed
+  bottom_boundary:
+    type: "wellhead landing - pinned/tensioned"
+    lateral_stiffness_kN_per_m: ~                 # PLACEHOLDER - calibrate
+    rotational_stiffness_kNm_per_deg: ~           # PLACEHOLDER - calibrate
+  centralizer_stiffness:
+    lateral_stiffness_kN_per_m: ~                 # PLACEHOLDER per centralizer - calibrate
+    spacing_m: 9.144
+    efficiency_note: "modal restraint efficiency = open #2/#3 deliverable"
+  setdown_stop:
+    contact_stiffness_kN_per_m: ~                 # PLACEHOLDER
+    gap_m: ~                                       # PLACEHOLDER - coupled to demand.setdown_definition
+    reaction_capacity_kN: ~                        # PLACEHOLDER - stop reaction limit
+
+# ===========================================================================
+# METOCEAN / LOAD-CASE MATRIX
+#   Loop Current + storm combos; platform offsets drive set-down. Values are
+#   PLACEHOLDER return-period magnitudes - replace with project metocean.
+# ===========================================================================
+metocean:
+  load_cases:
+    - id: LC1_loop_current
+      description: "Loop Current dominant"
+      current_ref_speed_m_s: ~                    # PLACEHOLDER (e.g. 1-yr Loop Current)
+      wave_hs_m: ~
+      wave_tp_s: ~
+      platform_offset_pct_wd: ~
+    - id: LC2_1yr_hurricane
+      description: "1-yr hurricane wave (H) + associated wind/current"
+      current_ref_speed_m_s: ~
+      wave_hs_m: ~
+      wave_tp_s: ~
+      platform_offset_pct_wd: ~
+    - id: LC3_10yr_winter_storm
+      description: "10-yr winter storm (WS)"
+      current_ref_speed_m_s: ~
+      wave_hs_m: ~
+      wave_tp_s: ~
+      platform_offset_pct_wd: ~
+    - id: LC4_combo_max_setdown
+      description: "Combo driving the set-down envelope (max platform offset)"
+      current_ref_speed_m_s: ~
+      wave_hs_m: ~
+      wave_tp_s: ~
+      platform_offset_pct_wd: ~                    # max offset -> max set-down (#4/#5/#7 driver)
+  platform_offsets:
+    note: "platform offset = set-down driver; enumerate near/far/cross per LC"
+    cases_pct_wd: ~                               # PLACEHOLDER (e.g. [0, 5, 8] % of WD)
+  raos_source:
+    tool: "OrcaWave (digitalmodel diffraction capability)"
+    status: "TBD - vessel RAOs + QTFs to be generated and linked"
+
+# ===========================================================================
+# ANALYSIS TYPES (toggles + per-type settings)
+#   Mirrors the analysis-driver convention (cf. config/fatigue_analysis,
+#   config/viv_analysis). Each closes a specific open screening item.
+# ===========================================================================
+analyses:
+  static:
+    enabled: true
+    closes: "#4/#7 - equilibrium, set-down, stop engagement, tendon tension"
+    outputs: [setdown, stop_reaction, tendon_tension, effective_tension_profile]
+  modal:
+    enabled: true
+    closes: "#3/#5 - restraint efficiency + VIV lock-in screen"
+    n_modes: 30                                   # PLACEHOLDER
+    outputs: [mode_shapes, natural_frequencies, restraint_efficiency]
+  dynamic_time_domain:
+    enabled: true
+    closes: "storm combos, stop snap loads, max tension/stress"
+    solution: "Implicit time domain"
+    storm_window_s: 10800                         # 3 h (PLACEHOLDER)
+    outputs: [max_tension, max_stress, snap_loads, stop_reaction_dynamic]
+  fatigue:
+    enabled: true
+    closes: "#4/#5 - VIV + wave stress-range -> S-N life"
+    viv:
+      solver: "shear7 | wave"                     # cf. config/viv_analysis pattern
+      enabled: true
+    wave:
+      sn_curve: ~                                  # PLACEHOLDER (e.g. DNV-RP-C203 class)
+      enabled: true
+    outputs: [stress_range_spectra, sn_damage, fatigue_life]
+
+# ===========================================================================
+# SENSITIVITY / ABNORMAL CASES
+# ===========================================================================
+sensitivity:
+  no_tubing:
+    description: >-
+      Chuck's original concern: tree supported with NO tubing structural
+      contribution (arguably outer riser only). Robustness/abnormal case, NOT
+      baseline (baseline = tubing always pre-tensioned, per FDAS #2).
+    tubing_structural: false
+    classification: abnormal
+
+# ===========================================================================
+# SOLVER / TOOLING
+# ===========================================================================
+tooling:
+  primary: "OrcaFlex (line + 6D buoy + stop/contact elements)"
+  alternatives: ["Flexcom", "Abaqus-Aqua"]
+  hydro_raos: "OrcaWave (digitalmodel)"
+  license_status: >-
+    Solver license availability is the gating question (workspace-hub #2849).
+    OrcaFlex is almost certainly NOT installed/licensed in the scaffolding
+    environment - this matrix is model INPUT only, not a run.

--- a/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/spec.yml
+++ b/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/spec.yml
@@ -1,0 +1,267 @@
+# OrcaFlex Modular Model Generator - Model Specification
+# FrPS / SSR Free-Standing Riser - GLOBAL DYNAMIC MODEL (INPUT SCAFFOLD)
+#
+# Model Type:   Free-standing (dry-tree) riser on a Surface SSR / wellhead landing
+# Source basis: FDAS riser-buckling screening campaign
+#               (github.com/vamseeachanta/llm-wiki-fdas issues #2-#7;
+#                global-model scope = issue #2)
+# Status:       INPUT SCAFFOLD ONLY - not solved. See README.md.
+# Version:      0.1 (scaffold)
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS IS
+#   A parameterized OrcaFlex model-input definition for the global dynamic
+#   analysis the FDAS screening (#3-#7) concluded it needs. The screens fail
+#   every conservative hand-check; the verdict pivots on inputs the screens
+#   cannot manufacture (restraint efficiency, demand definition, section
+#   basis). This file captures the model geometry and a parametric matrix so
+#   those inputs are settled at model build, then handed to a solver.
+#
+# WHAT THIS IS NOT
+#   This is not a run and not a result. OrcaFlex (and Flexcom / Abaqus-Aqua)
+#   is a licensed solver and is almost certainly NOT installed/licensed in
+#   this environment (cf. workspace-hub #2849, "solver-license availability").
+#   No results are produced or implied here. Hydro/RAOs are to be sourced from
+#   the digitalmodel OrcaWave/diffraction capability - placeholders below.
+#
+# TWO OPEN INPUTS THAT MUST BE SET BEFORE BUILD (see README.md):
+#   1. SECTION BASIS  - 82.51 in^2 (two-casing) vs ~97 in^2 (three-string,
+#                       7-in WT 0.50->0.75). Carried as variants in
+#                       inputs/parameters.yml -> section_basis.
+#   2. ROY DEMAND     - "5-10 ft pushdown": does it net the slip-joint stroke?
+#                       Carried as variants -> demand.setdown_definition.
+#
+# USAGE (when a licensed solver host is available):
+#   Resolve the two open inputs in inputs/parameters.yml, then generate the
+#   OrcaFlex-loadable include tree:
+#     uv run python -m digitalmodel.solvers.orcaflex.modular_generator generate \
+#         --input spec.yml --output modular/
+#   (modular/ is intentionally NOT committed here - it is generator output.)
+#
+# UNITS: SI per OrcaFlex model library convention (te, m, kN, te/m^3).
+#   Field-unit originals from the screening basis are kept in comments.
+# ---------------------------------------------------------------------------
+
+metadata:
+  name: "frps_ssr_global_riser"
+  description: "Free-standing dry-tree riser on SSR/wellhead landing - global dynamic model input scaffold (FDAS #2)"
+  structure: riser                              # riser | pipeline | mooring | installation | vessel
+  operation: in-place                           # in-place | installation | production | drilling
+  project: "FrPS SSR Global Riser (FDAS)"
+  version: "0.1"
+  provenance:
+    screening_campaign: "llm-wiki-fdas #3-#7"
+    global_model_scope: "llm-wiki-fdas #2"
+    basis_page: "llm-wiki-fdas pages/frps-fsr-global-riser-model.md (PR #9, unmerged)"
+    status: "input-scaffold-not-solved"
+  open_inputs:                                  # MUST be resolved before build
+    - section_basis                             # 82.51 vs ~97 in^2 (see parameters.yml)
+    - demand_setdown_definition                 # Roy "5-10 ft pushdown" net-of-stroke? (see parameters.yml)
+
+# ---------------------------------------------------------------------------
+# ENVIRONMENT
+#   Base (single) case shown here for schema validity. The real load matrix
+#   (water-depth cases x metocean combos) lives in inputs/parameters.yml and
+#   is expanded per-case at generation time. Values below = placeholder
+#   defaults at the 6,000 ft (1828.8 m) datum; OVERRIDE via parameters.yml.
+# ---------------------------------------------------------------------------
+environment:
+  water:
+    depth: 1828.8                               # 6,000 ft datum (PLACEHOLDER - see water_depth_cases)
+    density: 1.025                              # te/m^3
+  seabed:
+    slope: 0
+    stiffness:
+      normal: 100                               # kN/m/m^2 (PLACEHOLDER - GoM clay TBD)
+      shear: 100
+  waves:
+    type: JONSWAP                               # storm spectrum (PLACEHOLDER - see metocean matrix)
+    height: 0.0                                 # Hs (m) - SET per load case
+    period: 0.0                                 # Tp (s) - SET per load case
+    direction: 180
+    gamma: 2.4                                  # GoM hurricane (PLACEHOLDER)
+  current:
+    speed: 0.0                                  # Loop Current ref speed (m/s) - SET per load case
+    direction: 180
+    profile:                                    # [depth_m, factor] - Loop Current shear (PLACEHOLDER)
+    - - 0
+      - 1
+    - - 300
+      - 0.3
+  wind:
+    speed: 0.0                                  # m/s - SET per load case
+    direction: 180
+
+# ---------------------------------------------------------------------------
+# SIMULATION
+#   Per analysis-type. Toggles + per-type settings live in
+#   inputs/parameters.yml -> analyses. Defaults below are the dynamic-storm
+#   placeholder; static/modal/fatigue override.
+# ---------------------------------------------------------------------------
+simulation:
+  stages:
+  - 16                                          # build-up (PLACEHOLDER)
+  - 10800                                       # 3 h storm window (PLACEHOLDER)
+  time_step: 0.1
+
+# ---------------------------------------------------------------------------
+# GENERIC OBJECTS
+#   Concentric 16 / 11.75 / 7-in strings + 810-ft bare-pipe slick section
+#   carrying the dry tree, centralizers @ ~30 ft, set-down stops, surface
+#   wellhead landing. Section properties below are PLACEHOLDERS pending the
+#   section-basis decision (parameters.yml -> section_basis) and as-built
+#   wall-thickness schedule. Line types are expressed as homogeneous-pipe
+#   approximations of the concentric stack; the equivalent EA/EI/area MUST be
+#   replaced by validated concentric section properties before build.
+# ---------------------------------------------------------------------------
+generic:
+
+  vessel_types:
+  - name: "SSR Platform"                        # Surface platform / SSR providing motions
+    properties:
+      # RAOs + hydrodynamics to be sourced from digitalmodel OrcaWave /
+      # diffraction capability for the actual hull. PLACEHOLDER vessel type:
+      # populate Draughts / DisplacementRAOs / LoadRAOs from OrcaWave output
+      # (see README "OrcaWave-sourced hydro"). Do NOT use as-is.
+      RAOResponseUnits: degrees
+      RAOWaveUnit: amplitude
+      WavesReferredToBy: frequency (Hz)
+      RAOPhaseConvention: lags
+      Symmetry: xz and yz planes
+      hydro_source: "OrcaWave (TBD) - placeholder, not populated"
+
+  vessels:
+  - name: "SSR Platform"
+    vessel_type: "SSR Platform"
+    connection: Free
+    initial_position: [0, 0, 0]
+    properties:
+      # Platform offset drives the set-down envelope (#4/#5/#7 driver).
+      # Offset cases enumerated in parameters.yml -> metocean.platform_offsets.
+      PrimaryMotion: Prescribed
+      SuperimposedMotion: RAOs + harmonics
+      offset_note: "platform offset = set-down driver; enumerated in parameters.yml"
+
+  line_types:
+  # --- Concentric strings (homogeneous-pipe approximations; SI) ---------
+  - name: "16in Outer Casing"                   # 16 in OD outer string
+    category: Homogeneous pipe
+    outer_diameter: 0.4064                       # 16.000 in
+    inner_diameter: 0.3620                        # PLACEHOLDER WT - set from as-built schedule
+    properties:
+      MaterialDensity: 7.85                       # te/m^3
+      E: 207e6                                     # kN/m^2 (steel)
+      PoissonRatio: 0.3
+      Cdn: 1.2
+      Can: 1.0
+      basis_note: "WT/area PLACEHOLDER - resolve via section_basis variant"
+
+  - name: "11.75in Intermediate Casing"          # 11-3/4 in OD intermediate string
+    category: Homogeneous pipe
+    outer_diameter: 0.29845                        # 11.750 in
+    inner_diameter: 0.2600                          # PLACEHOLDER WT
+    properties:
+      MaterialDensity: 7.85
+      E: 207e6
+      PoissonRatio: 0.3
+      Cdn: 1.2
+      Can: 1.0
+      basis_note: "WT/area PLACEHOLDER - resolve via section_basis variant"
+
+  - name: "7in Tubing"                            # 7 in OD tubing (always pre-tensioned baseline)
+    category: Homogeneous pipe
+    outer_diameter: 0.1778                          # 7.000 in
+    inner_diameter: 0.1524                            # PLACEHOLDER (WT 0.50->0.75 in is the section-basis swing)
+    properties:
+      MaterialDensity: 7.85
+      E: 207e6
+      PoissonRatio: 0.3
+      Cdn: 1.2
+      Can: 1.0
+      pretension_note: >-
+        BASELINE per FDAS #2 (Jun-4 Chuck<->Roy): 7-in tubing ALWAYS installed
+        and pre-tensioned when tree is on the SSR. Sensitivity case = no tubing
+        structural contribution (parameters.yml -> sensitivity.no_tubing).
+      basis_note: "7-in WT 0.50->0.75 in is the section_basis swing (82.51 vs ~97 in^2)"
+
+  - name: "Slick Equivalent"                      # 810-ft bare-pipe slick section carrying dry tree
+    category: Homogeneous pipe
+    outer_diameter: 0.4064                          # outer-string OD governs slick OD (PLACEHOLDER)
+    inner_diameter: 0.3620                            # PLACEHOLDER
+    properties:
+      MaterialDensity: 7.85
+      E: 207e6
+      PoissonRatio: 0.3
+      Cdn: 1.2
+      Can: 1.0
+      slick_note: >-
+        810 ft (246.888 m) bare-pipe "slick" joint carrying the dry tree.
+        Equivalent concentric EA/EI/area to be set from validated section
+        basis - THIS is where the 82.51-vs-97 in^2 decision bites hardest
+        (it sets the buckling demand the screens flagged).
+
+  lines:
+  # --- Main free-standing column ----------------------------------------
+  - name: "Riser Column"
+    line_type_refs: ["Slick Equivalent"]
+    properties:
+      IncludeTorsion: true
+      TopEnd: End A                              # top at SSR / surface wellhead landing
+      Representation: Finite element
+      # Top boundary (FDAS #2, Jun-4): axially sliding on UHMW pads (mu<0.1)
+      # but RESTRAINED AGAINST ROTATION (no articulation). Model as guided /
+      # rotation-fixed with stroke limits at the set-down stops.
+      top_boundary_note: "axially sliding (mu<0.1), rotation-fixed; stroke-limited at stops"
+      # Bottom boundary: wellhead landing - pinned/tensioned (calibrate).
+      bottom_boundary_note: "wellhead landing - pinned/tensioned; restraint stiffness TBD"
+      LineType, Length, TargetSegmentLength:
+      - - "Slick Equivalent"
+        - 246.888                                # 810 ft slick section
+        - 5
+      - - "16in Outer Casing"
+        - 1581.912                               # remainder to 6,000 ft datum (PLACEHOLDER - per water-depth case)
+        - 10
+      # Centralizer restraints @ ~30 ft (9.144 m) - represented as lateral
+      # restraint stiffness at attachment points. Stiffness is a PLACEHOLDER
+      # to be CALIBRATED (this is "the hinge" - #2/#3 restraint efficiency).
+      centralizer_note: >-
+        centralizers @ ~30 ft (9.144 m) spacing -> lateral restraint stiffness
+        placeholders in parameters.yml -> restraint.centralizer_stiffness;
+        modal restraint efficiency is the open #2/#3 question to calibrate.
+      ContentsMethod: Uniform
+      ContentsDensity: 0.0                        # SET per case (production fluid / completion brine)
+      IncludedInStatics: true
+
+  buoys_6d:
+  # --- Set-down stop / contact (6D buoy + stop kinematics) ---------------
+  - name: "Set-Down Stop"
+    buoy_type: Lumped buoy
+    connection: Free
+    initial_position: [0, 0, 0]                  # at landing datum (PLACEHOLDER)
+    mass: 0.001
+    properties:
+      # Stop engagement load path (#4/#7): set-down stop reaction + tendon
+      # tension. Contact stiffness + gap (stroke) are PLACEHOLDERS tied to the
+      # Roy-demand decision (does 5-10 ft net the slip-joint stroke?).
+      stop_note: >-
+        set-down stop / contact element. Gap (engagement stroke) and contact
+        stiffness in parameters.yml -> restraint.setdown_stop; gap definition
+        is coupled to demand.setdown_definition (the Roy open input).
+      DegreesOfFreedomInStatics: All
+
+  constraints:
+  - name: "Surface Wellhead Landing"
+    in_frame_connection: "SSR Platform"
+    constraint_type: Calculated DOFs
+    properties:
+      # Top landing: axially free (sliding), rotation-fixed (per #2). Heave/
+      # stroke DOF free between stops; lateral + rotational locked.
+      landing_note: "axial-slide free (stroke-limited), rotation-fixed per FDAS #2"
+      InFrameInitialPosition: [0, 0, 0]
+
+# ---------------------------------------------------------------------------
+# NOTE ON GENERATOR OUTPUT
+#   `modular/` (master.yml + includes/*.yml) is generator OUTPUT and is NOT
+#   committed in this scaffold. Generate it on a licensed solver host with the
+#   modular_generator command above AFTER resolving the two open inputs.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## FrPS/SSR free-standing riser — global dynamic model scaffold

Model **input scaffold** (YAML, no run) for the FrPS/SSR free-standing riser global dynamic analysis — the engineering follow-on to the FDAS riser-buckling **screening campaign** (private wiki `llm-wiki-fdas` #2–#7), which concluded the riser fails every conservative hand-screen and needs a validated global model.

### What's here
Under the existing `model_library/<id>/` convention (mirrors `b01_drilling_riser`):
- `frps_ssr_global_riser/spec.yml` — parameterized model definition (concentric 16/11.75/7-in strings, 810-ft slick section, centralizers @~30 ft, set-down stops, surface wellhead; water depths 6k/8k/10k; metocean/load-case matrix; static/modal/dynamic/fatigue toggles each mapped to the screen it closes).
- `frps_ssr_global_riser/inputs/parameters.yml`
- `frps_ssr_global_riser/README.md`

### Honest status (not a run)
- **Scaffold only** — OrcaFlex (primary) is a licensed solver, not assumed installed here (cf. workspace-hub #2849). RAOs/QTFs to come from digitalmodel's OrcaWave/diffraction capability (vessel-type placeholder).
- **Two open inputs carried as explicit variants, not fabricated:** `section_basis` (82.51 in² two-casing vs ~97 in² three-string — FDAS #3) and `demand.setdown_definition` (`gross_pushdown` vs `net_of_stroke` — the open Roy question, FDAS #4/#7).

### Tracking
Model-build phase of the FDAS global-model work breakdown (`llm-wiki-fdas` #2 → child issues #16–#22). Settle the two open inputs at/before build. Left for review.
