### PR TITLE
docs(orcaflex): add Orcina L07 reference

### DIFF
--- a/.claude/agents/orcaflex/README.md
+++ b/.claude/agents/orcaflex/README.md
@@ -72,14 +72,14 @@ vessel = model.CreateObject(OrcFxAPI.otVessel, "FPSO")
 ## Internal Resources
 - `src/modules/hydrodynamics/` - Hydrodynamic calculation modules
 - `specs/modules/marine-engineering/` - Engineering specifications
-- `context/examples_knowledge.json` - Knowledge base from 54 OrcaFlex examples
+- `context/examples_knowledge.json` - Knowledge base from 55 OrcaFlex examples
 - `context/examples_index.json` - Searchable index for finding relevant examples
 - `context/examples_knowledge_summary.md` - Human-readable summary of examples
 
 ## Examples Knowledge Base
 
-The agent now has access to analyzed metadata from 54 official OrcaFlex examples:
-- **15 unique features** demonstrated (lazy wave, steep wave, SHEAR7 interface, etc.)
+The agent now has access to analyzed metadata from 55 official OrcaFlex examples:
+- **20 unique features** demonstrated (lazy wave, wave drift damping, full QTF loads, SHEAR7 interface, etc.)
 - **Multiple analysis types** covered (static, dynamic, fatigue, VIV, installation)
 - **Various components** modeled (vessels, risers, moorings, buoys)
 - **Searchable index** for finding relevant examples by criteria

--- a/.claude/agents/orcaflex/context/examples_index.json
+++ b/.claude/agents/orcaflex/context/examples_index.json
@@ -16,21 +16,25 @@
       "E02 Rigid hinged stinger with piggyback line.sim",
       "A05 Catenary with semisub.sim",
       "A05 Catenary with spar.sim",
-      "A05 Lazy wave with FPSO.sim"
+      "A05 Lazy wave with FPSO.sim",
+      "L07 Wave drift load analysis.sim"
     ],
     "buoys": [
       "C07 Metocean buoy in deep water.sim",
       "C06 CALM buoy.sim",
       "C06 Discretised CALM buoy.sim",
-      "H03 Floating and stowed lines.sim"
+      "H03 Floating and stowed lines.sim",
+      "L07 Wave drift load analysis.sim"
     ],
     "winches": [
-      "HeaveCompensatedWinch.sim"
+      "HeaveCompensatedWinch.sim",
+      "L07 Wave drift load analysis.sim"
     ],
     "vessels": [
       "L01 Default vessel.sim",
       "Z09 Vessel time history.sim",
-      "A05 Lazy wave with FPSO.sim"
+      "A05 Lazy wave with FPSO.sim",
+      "L07 Wave drift load analysis.sim"
     ]
   },
   "by_analysis": {
@@ -88,7 +92,8 @@
       "K01 5MW spar FOWT.sim",
       "F01 Lowered cone.sim",
       "F01 Manifold block.sim",
-      "F01 Trapped water.sim"
+      "F01 Trapped water.sim",
+      "L07 Wave drift load analysis.sim"
     ],
     "fatigue_analysis": [
       "A06 SHEAR7 import drag amplification.sim",
@@ -101,6 +106,9 @@
     "installation_analysis": [
       "D02 Pull in analysis.sim",
       "D04 J-tube pull in.sim"
+    ],
+    "dynamic_analysis": [
+      "L07 Wave drift load analysis.sim"
     ]
   },
   "by_feature": {
@@ -156,6 +164,21 @@
     ],
     "BOP handling": [
       "B06 Running BOP.sim"
+    ],
+    "Full QTF wave drift loads": [
+      "L07 Wave drift load analysis.sim"
+    ],
+    "Wave drift damping": [
+      "L07 Wave drift load analysis.sim"
+    ],
+    "Manoeuvring load": [
+      "L07 Wave drift load analysis.sim"
+    ],
+    "CALM buoy mooring": [
+      "L07 Wave drift load analysis.sim"
+    ],
+    "Shallow water diffraction": [
+      "L07 Wave drift load analysis.sim"
     ]
   },
   "by_category": {}

--- a/.claude/agents/orcaflex/context/examples_knowledge.json
+++ b/.claude/agents/orcaflex/context/examples_knowledge.json
@@ -1,7 +1,7 @@
 {
-  "last_updated": "2025-08-20T13:10:22.009915",
+  "last_updated": "2026-06-10T19:21:24-05:00",
   "source": "Orcina Examples Portal - Complete Download",
-  "total_examples": 54,
+  "total_examples": 55,
   "examples": {
     "A06 SHEAR7 import drag amplification.sim": {
       "metadata": {
@@ -2958,6 +2958,88 @@
         }
       },
       "features": []
+    },
+    "L07 Wave drift load analysis.sim": {
+      "metadata": {
+        "name": "L07 Wave drift load analysis.sim",
+        "category": "l",
+        "category_title": "Diffraction",
+        "file_type": ".sim",
+        "size_bytes": 132134586,
+        "source": "Orcina Examples Portal - Category L Diffraction",
+        "source_page_url": "https://www.orcina.com/resources/examples/?key=l",
+        "news_url": "https://www.orcina.com/news/new-wave-drift-load-analysis-example/",
+        "description_pdf_url": "https://www.orcina.com/wp-content/uploads/examples/l/l07/L07%20Wave%20drift%20load%20analysis.pdf",
+        "example_zip_url": "https://www.orcina.com/wp-content/uploads/examples/l/l07/L07%20Wave%20drift%20load%20analysis.zip",
+        "posted_date": "2026-06-08",
+        "local_pdf_share_path": "digitalmodel/docs/orcaflex/literature/examples/raw/L07/docs/L07 Wave drift load analysis.pdf",
+        "local_zip_share_path": "digitalmodel/docs/orcaflex/data/examples/raw/L07/L07 Wave drift load analysis.zip",
+        "pdf_sha256": "8a0db4bae9bfb79c9bb12727a004893f45b923df948c917c5dc60e91832b6157",
+        "zip_sha256": "b796e76899eb7a723787a833f2f314620d81f2843efdabd51a4b71f6bd1fb2cd",
+        "zip_contents": [
+          "L07 body mesh.gdf",
+          "L07 Wave drift load analysis.owr",
+          "L07 Wave drift load analysis.owr.sig",
+          "L07 Wave drift load analysis.pdf",
+          "L07 Wave drift load analysis.sim",
+          "L07 Wave drift load analysis.sim.sig"
+        ]
+      },
+      "components": {
+        "vessels": {
+          "count": 1,
+          "types": [
+            "Vessel"
+          ]
+        },
+        "lines": {
+          "count": 1,
+          "types": [
+            "Hawser/mooring lines"
+          ]
+        },
+        "buoys": {
+          "count": 1,
+          "types": [
+            "CALM buoy"
+          ]
+        },
+        "winches": {
+          "count": 1
+        },
+        "constraints": {
+          "count": 0
+        }
+      },
+      "analysis": {
+        "static_analysis": true,
+        "dynamic_analysis": true,
+        "fatigue_analysis": false,
+        "installation_analysis": false,
+        "viv_analysis": false
+      },
+      "environment": {
+        "water_depth": 20.0,
+        "waves": {
+          "type": "JONSWAP",
+          "height": 3.0,
+          "period": 6.0
+        },
+        "current": {
+          "profile": null,
+          "speed": 0.25
+        },
+        "wind": {
+          "speed": 5.0
+        }
+      },
+      "features": [
+        "Full QTF wave drift loads",
+        "Wave drift damping",
+        "Manoeuvring load",
+        "CALM buoy mooring",
+        "Shallow water diffraction"
+      ]
     }
   },
   "patterns": {
@@ -2967,25 +3049,32 @@
       "winches": 1,
       "vessels": 2,
       "buoys+lines": 1,
-      "lines+vessels": 1
+      "lines+vessels": 1,
+      "buoys+lines+vessels+winches": 1
     },
     "analysis_combinations": {
       "fatigue_analysis+static_analysis+viv_analysis": 2,
       "static_analysis": 50,
-      "installation_analysis+static_analysis": 2
+      "installation_analysis+static_analysis": 2,
+      "dynamic_analysis+static_analysis": 1
     },
     "configuration_types": {
       "Catenary configuration": 3,
       "Lazy wave configuration": 4,
       "Pliant wave configuration": 2,
       "Steep wave configuration": 2,
-      "Chinese lantern configuration": 1
+      "Chinese lantern configuration": 1,
+      "Full QTF wave drift loads": 1,
+      "Wave drift damping": 1,
+      "Manoeuvring load": 1,
+      "CALM buoy mooring": 1,
+      "Shallow water diffraction": 1
     }
   },
   "best_practices": [
     "Most common setup: lines",
-    "Examples cover 1 distinct application categories",
-    "15 unique features/configurations demonstrated"
+    "Examples cover 2 distinct application categories",
+    "20 unique features/configurations demonstrated"
   ],
   "common_configurations": {
     "riser_types": {
@@ -2996,14 +3085,15 @@
     },
     "mooring_types": {},
     "vessel_types": {
-      "Vessel": 2,
+      "Vessel": 3,
       "FPSO": 1
     },
     "analysis_types": {
-      "static_analysis": 54,
+      "static_analysis": 55,
       "fatigue_analysis": 2,
       "viv_analysis": 2,
-      "installation_analysis": 2
+      "installation_analysis": 2,
+      "dynamic_analysis": 1
     }
   },
   "categories": {
@@ -3063,7 +3153,8 @@
         "K01 5MW spar FOWT.sim",
         "F01 Lowered cone.sim",
         "F01 Manifold block.sim",
-        "F01 Trapped water.sim"
+        "F01 Trapped water.sim",
+        "L07 Wave drift load analysis.sim"
       ]
     }
   },
@@ -3085,21 +3176,25 @@
         "E02 Rigid hinged stinger with piggyback line.sim",
         "A05 Catenary with semisub.sim",
         "A05 Catenary with spar.sim",
-        "A05 Lazy wave with FPSO.sim"
+        "A05 Lazy wave with FPSO.sim",
+        "L07 Wave drift load analysis.sim"
       ],
       "buoys": [
         "C07 Metocean buoy in deep water.sim",
         "C06 CALM buoy.sim",
         "C06 Discretised CALM buoy.sim",
-        "H03 Floating and stowed lines.sim"
+        "H03 Floating and stowed lines.sim",
+        "L07 Wave drift load analysis.sim"
       ],
       "winches": [
-        "HeaveCompensatedWinch.sim"
+        "HeaveCompensatedWinch.sim",
+        "L07 Wave drift load analysis.sim"
       ],
       "vessels": [
         "L01 Default vessel.sim",
         "Z09 Vessel time history.sim",
-        "A05 Lazy wave with FPSO.sim"
+        "A05 Lazy wave with FPSO.sim",
+        "L07 Wave drift load analysis.sim"
       ]
     },
     "by_analysis": {
@@ -3157,7 +3252,8 @@
         "K01 5MW spar FOWT.sim",
         "F01 Lowered cone.sim",
         "F01 Manifold block.sim",
-        "F01 Trapped water.sim"
+        "F01 Trapped water.sim",
+        "L07 Wave drift load analysis.sim"
       ],
       "fatigue_analysis": [
         "A06 SHEAR7 import drag amplification.sim",
@@ -3170,6 +3266,9 @@
       "installation_analysis": [
         "D02 Pull in analysis.sim",
         "D04 J-tube pull in.sim"
+      ],
+      "dynamic_analysis": [
+        "L07 Wave drift load analysis.sim"
       ]
     },
     "by_feature": {
@@ -3225,6 +3324,21 @@
       ],
       "BOP handling": [
         "B06 Running BOP.sim"
+      ],
+      "Full QTF wave drift loads": [
+        "L07 Wave drift load analysis.sim"
+      ],
+      "Wave drift damping": [
+        "L07 Wave drift load analysis.sim"
+      ],
+      "Manoeuvring load": [
+        "L07 Wave drift load analysis.sim"
+      ],
+      "CALM buoy mooring": [
+        "L07 Wave drift load analysis.sim"
+      ],
+      "Shallow water diffraction": [
+        "L07 Wave drift load analysis.sim"
       ]
     },
     "by_category": {}

--- a/.claude/agents/orcaflex/context/examples_knowledge_summary.md
+++ b/.claude/agents/orcaflex/context/examples_knowledge_summary.md
@@ -1,38 +1,40 @@
 # OrcaFlex Examples Knowledge Base
 
-**Last Updated:** 2025-08-20T13:10:22.009915
-**Total Examples:** 54
+**Last Updated:** 2026-06-10T19:21:24-05:00
+**Total Examples:** 55
 **Source:** Orcina Examples Portal - Complete Download
 
 ## Overview
 
-This knowledge base contains analyzed metadata from 54 official OrcaFlex examples 
-downloaded from the Orcina resources portal. The examples cover 13 categories 
+This knowledge base contains analyzed metadata from 55 official OrcaFlex examples
+downloaded from the Orcina resources portal. The examples cover 13 categories
 spanning various offshore engineering applications.
 
 ## Categories
 
-- **UNKNOWN**: Unknown (54 examples)
+- **UNKNOWN**: Unknown (55 examples)
 
 ## Best Practices Identified
 
 - Most common setup: lines
-- Examples cover 1 distinct application categories
-- 15 unique features/configurations demonstrated
+- Examples cover 2 distinct application categories
+- 20 unique features/configurations demonstrated
 
 ## Common Patterns
 
 ### Component Combinations
 
 - lines: 14 examples
-- buoys: 3 examples
-- vessels: 2 examples
-- winches: 1 examples
+- buoys: 4 examples
+- vessels: 3 examples
+- winches: 2 examples
 - buoys + lines: 1 examples
+- buoys + lines + vessels + winches: 1 examples
 
 ### Analysis Types
 
-- Static Analysis: 54 examples
+- Static Analysis: 55 examples
+- Dynamic Analysis: 1 examples
 - Fatigue Analysis: 2 examples
 - Viv Analysis: 2 examples
 - Installation Analysis: 2 examples
@@ -48,26 +50,31 @@ spanning various offshore engineering applications.
 
 ### Vessel Types
 
-- Vessel: 2 examples
+- Vessel: 3 examples
 - FPSO: 1 examples
 
 ## Unique Features Demonstrated
 
 - Aquaculture application (1 examples)
 - BOP handling (1 examples)
+- CALM buoy mooring (1 examples)
 - Catenary configuration (3 examples)
 - Chinese lantern configuration (1 examples)
 - Disconnectable system (1 examples)
 - Drag amplification modeling (1 examples)
 - Drilling operations (1 examples)
+- Full QTF wave drift loads (1 examples)
 - Heave compensation (1 examples)
 - J-tube pull-in (1 examples)
 - Lazy wave configuration (4 examples)
+- Manoeuvring load (1 examples)
 - Multibody dynamics (1 examples)
 - Pliant wave configuration (2 examples)
 - SHEAR7 VIV analysis interface (2 examples)
+- Shallow water diffraction (1 examples)
 - Steep wave configuration (2 examples)
 - Turret mooring system (1 examples)
+- Wave drift damping (1 examples)
 
 ## Usage
 
@@ -80,4 +87,4 @@ This knowledge base can be queried to find relevant examples for specific:
 Use the `examples_index.json` for programmatic access to find examples by criteria.
 
 ---
-*Generated from downloaded OrcaFlex examples on 2025-08-20 13:10:22*
+*Updated with Orcina L07 Wave drift load analysis on 2026-06-10 19:21:24 -05:00*

--- a/.claude/agents/orcaflex/context/external/web/web_resources.yaml
+++ b/.claude/agents/orcaflex/context/external/web/web_resources.yaml
@@ -18,6 +18,12 @@ user_added_links:
   type: user_added
   url: https://www.orcina.com/resources/examples/
 - added_by: user
+  date_added: '2026-06-10T19:21:24-05:00'
+  notes: L07 Wave drift load analysis; new Orcina diffraction example posted 2026-06-08
+  title: L07 Wave drift load analysis
+  type: user_added
+  url: https://www.orcina.com/resources/examples/?key=l#50
+- added_by: user
   date_added: '2025-08-10T18:00:55.124906'
   notes: OrcaFlex Python API documentation
   title: https://www.orcina.com/SoftwareProducts/OrcaFlex/Documentation/Help/htm/index.htm

--- a/.claude/agents/orcaflex/context/web_resources_review.md
+++ b/.claude/agents/orcaflex/context/web_resources_review.md
@@ -1,6 +1,6 @@
 # Web Resources Review
 
-Generated: 2025-08-10 18:01:42
+Generated: 2026-06-10 19:21:24
 
 Module: orcaflex
 
@@ -12,6 +12,9 @@ Module: orcaflex
 - ✅ https://www.orcina.com/resources/examples/
   Notes: OrcaFlex example models and case studies
   Added: 2025-08-10T18:00:50.834108
+- ✅ https://www.orcina.com/resources/examples/?key=l#50
+  Notes: L07 Wave drift load analysis; new Orcina diffraction example posted 2026-06-08
+  Added: 2026-06-10T19:21:24-05:00
 - ✅ https://www.orcina.com/SoftwareProducts/OrcaFlex/Documentation/Help/htm/index.htm
   Notes: OrcaFlex Python API documentation
   Added: 2025-08-10T18:00:55.124906

--- a/.claude/skills/engineering/orcaflex-agents/orcaflex/SKILL.md
+++ b/.claude/skills/engineering/orcaflex-agents/orcaflex/SKILL.md
@@ -83,14 +83,14 @@ vessel = model.CreateObject(OrcFxAPI.otVessel, "FPSO")
 ## Internal Resources
 - `src/modules/hydrodynamics/` - Hydrodynamic calculation modules
 - `specs/modules/marine-engineering/` - Engineering specifications
-- `context/examples_knowledge.json` - Knowledge base from 54 OrcaFlex examples
+- `context/examples_knowledge.json` - Knowledge base from 55 OrcaFlex examples
 - `context/examples_index.json` - Searchable index for finding relevant examples
 - `context/examples_knowledge_summary.md` - Human-readable summary of examples
 
 ## Examples Knowledge Base
 
-The agent now has access to analyzed metadata from 54 official OrcaFlex examples:
-- **15 unique features** demonstrated (lazy wave, steep wave, SHEAR7 interface, etc.)
+The agent now has access to analyzed metadata from 55 official OrcaFlex examples:
+- **20 unique features** demonstrated (lazy wave, wave drift damping, full QTF loads, SHEAR7 interface, etc.)
 - **Multiple analysis types** covered (static, dynamic, fatigue, VIV, installation)
 - **Various components** modeled (vessels, risers, moorings, buoys)
 - **Searchable index** for finding relevant examples by criteria
@@ -347,39 +347,41 @@ python -m pytest tests/domains/orcaflex/mooring_tension_iteration/batch_processi
 
 # OrcaFlex Examples Knowledge Base
 
-**Last Updated:** 2025-08-20T13:10:22.009915
-**Total Examples:** 54
+**Last Updated:** 2026-06-10T19:21:24-05:00
+**Total Examples:** 55
 **Source:** Orcina Examples Portal - Complete Download
 
 ## Overview
 
-This knowledge base contains analyzed metadata from 54 official OrcaFlex examples 
-downloaded from the Orcina resources portal. The examples cover 13 categories 
+This knowledge base contains analyzed metadata from 55 official OrcaFlex examples
+downloaded from the Orcina resources portal. The examples cover 13 categories
 spanning various offshore engineering applications.
 
 ## Categories
 
-- **UNKNOWN**: Unknown (54 examples)
+- **UNKNOWN**: Unknown (55 examples)
 
 ## Best Practices Identified
 
 - Most common setup: lines
-- Examples cover 1 distinct application categories
-- 15 unique features/configurations demonstrated
+- Examples cover 2 distinct application categories
+- 20 unique features/configurations demonstrated
 
 ## Common Patterns
 
 ### Component Combinations
 
 - lines: 14 examples
-- buoys: 3 examples
-- vessels: 2 examples
-- winches: 1 examples
+- buoys: 4 examples
+- vessels: 3 examples
+- winches: 2 examples
 - buoys + lines: 1 examples
+- buoys + lines + vessels + winches: 1 examples
 
 ### Analysis Types
 
-- Static Analysis: 54 examples
+- Static Analysis: 55 examples
+- Dynamic Analysis: 1 examples
 - Fatigue Analysis: 2 examples
 - Viv Analysis: 2 examples
 - Installation Analysis: 2 examples
@@ -395,26 +397,31 @@ spanning various offshore engineering applications.
 
 ### Vessel Types
 
-- Vessel: 2 examples
+- Vessel: 3 examples
 - FPSO: 1 examples
 
 ## Unique Features Demonstrated
 
 - Aquaculture application (1 examples)
 - BOP handling (1 examples)
+- CALM buoy mooring (1 examples)
 - Catenary configuration (3 examples)
 - Chinese lantern configuration (1 examples)
 - Disconnectable system (1 examples)
 - Drag amplification modeling (1 examples)
 - Drilling operations (1 examples)
+- Full QTF wave drift loads (1 examples)
 - Heave compensation (1 examples)
 - J-tube pull-in (1 examples)
 - Lazy wave configuration (4 examples)
+- Manoeuvring load (1 examples)
 - Multibody dynamics (1 examples)
 - Pliant wave configuration (2 examples)
 - SHEAR7 VIV analysis interface (2 examples)
+- Shallow water diffraction (1 examples)
 - Steep wave configuration (2 examples)
 - Turret mooring system (1 examples)
+- Wave drift damping (1 examples)
 
 ## Usage
 
@@ -427,7 +434,7 @@ This knowledge base can be queried to find relevant examples for specific:
 Use the `examples_index.json` for programmatic access to find examples by criteria.
 
 ---
-*Generated from downloaded OrcaFlex examples on 2025-08-20 13:10:22*
+*Updated with Orcina L07 Wave drift load analysis on 2026-06-10 19:21:24 -05:00*
 
 
 ---
@@ -436,7 +443,7 @@ Use the `examples_index.json` for programmatic access to find examples by criter
 
 # Web Resources Review
 
-Generated: 2025-08-10 18:01:42
+Generated: 2026-06-10 19:21:24
 
 Module: orcaflex
 
@@ -448,6 +455,9 @@ Module: orcaflex
 - ✅ https://www.orcina.com/resources/examples/
   Notes: OrcaFlex example models and case studies
   Added: 2025-08-10T18:00:50.834108
+- ✅ https://www.orcina.com/resources/examples/?key=l#50
+  Notes: L07 Wave drift load analysis; new Orcina diffraction example posted 2026-06-08
+  Added: 2026-06-10T19:21:24-05:00
 - ✅ https://www.orcina.com/SoftwareProducts/OrcaFlex/Documentation/Help/htm/index.htm
   Notes: OrcaFlex Python API documentation
   Added: 2025-08-10T18:00:55.124906
@@ -511,4 +521,3 @@ You are a specialized AI agent for {module_name} with expertise in {domain}.
 **Resources:**
 - [Resource 1]
 - [Resource 2]
-

--- a/docs/domains/orcaflex/MANUALS_AND_REFERENCES.md
+++ b/docs/domains/orcaflex/MANUALS_AND_REFERENCES.md
@@ -179,12 +179,12 @@ model.SaveSimulation("output.sim")
 | File requirements | `docs/domains/orcaflex/FILE_REQUIREMENTS.md` | Format specs |
 | Human-friendly YAML | `docs/domains/orcaflex/HUMAN_FRIENDLY_YAML_FORMAT.md` | Readable format guide |
 | Batch YAML | `docs/domains/orcaflex/orcaflex-batch-yml.md` | Batch config format |
-| Examples catalog | `docs/domains/orcaflex/examples/catalog/` | 54 analyzed examples |
+| Examples catalog | `docs/domains/orcaflex/examples/catalog/` | 55 analyzed examples |
 | OrcaWave examples | `docs/domains/orcawave/examples/` | L01-L04 worked examples |
 | Batch processing notes | SKILL.md (orcaflex agent) | API integration learnings |
 
 ### Examples Knowledge Base
-- 54 official OrcaFlex examples analyzed
+- 55 official OrcaFlex examples analyzed
 - Index: `.claude/skills/engineering/orcaflex-agents/orcaflex/context/examples_index.json`
 - Knowledge: `.claude/skills/engineering/orcaflex-agents/orcaflex/context/examples_knowledge.json`
 - Summary: `.claude/skills/engineering/orcaflex-agents/orcaflex/context/examples_knowledge_summary.md`

--- a/docs/domains/orcaflex/examples/README.md
+++ b/docs/domains/orcaflex/examples/README.md
@@ -16,9 +16,9 @@ examples/
 
 ## Collection Status
 
-- **Total Examples**: [To be populated]
-- **Categories**: [To be populated]
-- **Last Updated**: 2024-12-19
+- **Total Examples**: 55 indexed examples
+- **Categories**: 13 portal categories
+- **Last Updated**: 2026-06-10
 
 ## Usage
 

--- a/docs/domains/orcaflex/examples/catalog/complete_catalog.md
+++ b/docs/domains/orcaflex/examples/catalog/complete_catalog.md
@@ -1,12 +1,12 @@
 # Complete OrcaFlex Examples Catalog
 
-Generated: 2025-08-20T12:13:39.823814
+Generated: 2026-06-10T19:21:24-05:00
 
 ## Download Statistics
-- Total ZIP files: 39
-- Successfully downloaded: 39
-- Total OrcaFlex files: 54
-- Total size: 823.0MB
+- Total ZIP files: 40
+- Successfully downloaded: 40
+- Total OrcaFlex files: 55
+- Total size: 953.0MB
 
 ## By Letter Category
 - **A**: 5 ZIPs, 14 files
@@ -20,7 +20,7 @@ Generated: 2025-08-20T12:13:39.823814
 - **I**: 1 ZIPs, 1 files
 - **J**: 1 ZIPs, 1 files
 - **K**: 1 ZIPs, 1 files
-- **L**: 3 ZIPs, 3 files
+- **L**: 4 ZIPs, 4 files
 - **Z**: 2 ZIPs, 2 files
 
 ## Examples by Category
@@ -257,6 +257,12 @@ Generated: 2025-08-20T12:13:39.823814
 - Size: 18.0MB
 - Files:
   - L03 Semi-sub multibody analysis.sim
+
+#### L07 - Wave drift load analysis
+- Size: 130.0MB
+- Storage: ace share `digitalmodel/docs/orcaflex/data/examples/raw/L07/L07 Wave drift load analysis.zip`
+- Files:
+  - L07 Wave drift load analysis.sim
 
 
 ### Category Z

--- a/docs/domains/orcaflex/examples/metadata/complete_manifest.json
+++ b/docs/domains/orcaflex/examples/metadata/complete_manifest.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2025-08-20T12:13:39.819860",
+  "last_updated": "2026-06-10T19:21:24-05:00",
   "letter_categories": {
     "a": {
       "url": "https://www.orcina.com/resources/examples/?key=a",
@@ -58,8 +58,8 @@
     },
     "l": {
       "url": "https://www.orcina.com/resources/examples/?key=l",
-      "zip_count": 5,
-      "last_checked": "2025-08-20T12:12:14.805597"
+      "zip_count": 7,
+      "last_checked": "2026-06-10T19:21:24-05:00"
     },
     "z": {
       "url": "https://www.orcina.com/resources/examples/?key=z",
@@ -463,6 +463,17 @@
       "checksum": "5c51f300a91e605518d40c504355be78",
       "downloaded": "2025-08-20T12:13:38.838867",
       "path": "downloads/F01 Lowering hydrodynamics.zip"
+    },
+    "L07 Wave drift load analysis.zip": {
+      "url": "https://www.orcina.com/wp-content/uploads/examples/l/l07/L07 Wave drift load analysis.zip",
+      "category_code": "L07",
+      "category_letter": "L",
+      "source_letter": "L",
+      "description": "Wave drift load analysis",
+      "size_mb": 130.0,
+      "checksum": "b796e76899eb7a723787a833f2f314620d81f2843efdabd51a4b71f6bd1fb2cd",
+      "downloaded": "2026-06-10T19:21:24-05:00",
+      "path": "ace-share:digitalmodel/docs/orcaflex/data/examples/raw/L07/L07 Wave drift load analysis.zip"
     }
   },
   "examples": {
@@ -897,14 +908,22 @@
       "original_path": "F01 Trapped water.sim",
       "extracted_path": "raw/F01/F01 Trapped water.sim",
       "extracted": "2025-08-20T12:13:39.810629"
+    },
+    "L07 Wave drift load analysis.sim": {
+      "category": "L07",
+      "category_letter": "L",
+      "zip_file": "L07 Wave drift load analysis.zip",
+      "original_path": "L07 Wave drift load analysis.sim",
+      "extracted_path": "ace-share:digitalmodel/docs/orcaflex/data/examples/raw/L07/L07 Wave drift load analysis.zip!L07 Wave drift load analysis.sim",
+      "extracted": "2026-06-10T19:21:24-05:00"
     }
   },
   "statistics": {
-    "total_zips": 39,
-    "successful_downloads": 39,
+    "total_zips": 40,
+    "successful_downloads": 40,
     "failed_downloads": 0,
-    "total_extracted": 54,
-    "total_size_mb": 823.0,
+    "total_extracted": 55,
+    "total_size_mb": 953.0,
     "by_category": {
       "E": {
         "zips": 6,
@@ -923,8 +942,8 @@
         "files": 1
       },
       "L": {
-        "zips": 3,
-        "files": 3
+        "zips": 4,
+        "files": 4
       },
       "Z": {
         "zips": 2,

--- a/docs/domains/orcaflex/reference/INDEX.md
+++ b/docs/domains/orcaflex/reference/INDEX.md
@@ -28,6 +28,12 @@
 | [winches-data.md](winches-data.md) | Winch data properties |
 | [winches-wire-properties.md](winches-wire-properties.md) | Winch wire properties |
 
+## Related Orcina Examples
+
+| File | Description |
+|------|-------------|
+| [Orcina L07 wave drift load analysis](../../orcawave/reference/orcina-l07-wave-drift-load-analysis.md) | Full QTF wave drift load example using OrcaWave and OrcaFlex |
+
 ## Not Yet Available
 
 These pages could not be fetched. Run the script again or download manually:

--- a/docs/domains/orcawave/reference/INDEX.md
+++ b/docs/domains/orcawave/reference/INDEX.md
@@ -18,3 +18,9 @@
 | [data-qtfs.md](data-qtfs.md) | QTF calculation settings |
 | [data-wave-spectrum.md](data-wave-spectrum.md) | Wave spectrum configuration |
 | [text-data-files.md](text-data-files.md) | OrcaWave text data file format |
+
+## Related Orcina Examples
+
+| File | Description |
+|------|-------------|
+| [orcina-l07-wave-drift-load-analysis.md](orcina-l07-wave-drift-load-analysis.md) | Full QTF wave drift load example using OrcaWave and OrcaFlex |

--- a/docs/domains/orcawave/reference/orcina-l07-wave-drift-load-analysis.md
+++ b/docs/domains/orcawave/reference/orcina-l07-wave-drift-load-analysis.md
@@ -1,0 +1,37 @@
+# Orcina L07 Wave Drift Load Analysis
+
+Source: https://www.orcina.com/resources/examples/?key=l
+
+News post: https://www.orcina.com/news/new-wave-drift-load-analysis-example/
+
+Posted: 2026-06-08
+
+## Scope
+
+Official Orcina diffraction example L07 models wave drift effects for a ship-shaped body in shallow water. The example uses OrcaWave to calculate full quadratic transfer function wave drift load data, then uses OrcaFlex to analyse the vessel response with a CALM buoy mooring system.
+
+## Local References
+
+All paths are share-relative. On ace-linux-1 prepend `/mnt/ace/`; on ace-linux-2 prepend `/mnt/remote/ace-linux-1/ace/`.
+
+| Artifact | Share-relative path | Size | SHA-256 |
+|---|---:|---:|---|
+| Description PDF | `digitalmodel/docs/orcaflex/literature/examples/raw/L07/docs/L07 Wave drift load analysis.pdf` | 1,450,491 bytes | `8a0db4bae9bfb79c9bb12727a004893f45b923df948c917c5dc60e91832b6157` |
+| Example ZIP | `digitalmodel/docs/orcaflex/data/examples/raw/L07/L07 Wave drift load analysis.zip` | 135,966,395 bytes | `b796e76899eb7a723787a833f2f314620d81f2843efdabd51a4b71f6bd1fb2cd` |
+
+## ZIP Manifest
+
+- `L07 body mesh.gdf`
+- `L07 Wave drift load analysis.owr`
+- `L07 Wave drift load analysis.owr.sig`
+- `L07 Wave drift load analysis.pdf`
+- `L07 Wave drift load analysis.sim`
+- `L07 Wave drift load analysis.sim.sig`
+
+## Search Tags
+
+- full QTF wave drift loads
+- wave drift damping
+- manoeuvring load
+- CALM buoy mooring
+- shallow water diffraction


### PR DESCRIPTION
## Summary

- Adds the official Orcina L07 Wave drift load analysis reference page under OrcaWave docs.
- Updates OrcaFlex example knowledge, index, catalog, manifest, README, and web resource review to include L07 as the 55th indexed example.
- Records the ace-share ZIP/PDF artifact paths, SHA-256 checksums, ZIP manifest, and L07 search tags.

## Validation

- `python3 -m json.tool` on OrcaFlex examples knowledge, index, and complete manifest.
- `yaml.safe_load` on OrcaFlex web resources YAML.
- `git diff --check` on touched L07 reference/index paths.
- Source ZIP/PDF checksums verified during download.

## Notes

- Direct push to `main` was rejected by repo rule requiring PRs, so this branch preserves the local commit `ba07d1af`.
- Workspace-hub registry currently does not contain the L07 row; that is recorded as a closeout gap because active parallel workspace-hub work was detected.
- Follow-up YAML export work is tracked in https://github.com/vamseeachanta/digitalmodel/issues/691 and ingestion of the exported YAML in https://github.com/vamseeachanta/digitalmodel/issues/692.