### PR TITLE
[codex] Add B401 edition metadata foundation for cathodic protection

### DIFF
--- a/src/digitalmodel/cathodic_protection/_edition.py
+++ b/src/digitalmodel/cathodic_protection/_edition.py
@@ -8,6 +8,10 @@ import warnings
 
 Edition = Literal["2017", "2021"]
 DEFAULT_EDITION: Edition = "2021"
+STANDARD_BY_EDITION: dict[Edition, str] = {
+    "2017": "DNV-RP-B401 (Oct 2017)",
+    "2021": "DNV-RP-B401 (May 2021)",
+}
 
 _ALIASES: dict[str, Edition] = {
     "2017": "2017",
@@ -26,7 +30,7 @@ _ALIASES: dict[str, Edition] = {
 }
 
 
-def normalize_edition(edition: str | None) -> Edition:
+def normalize_edition(edition: str | None, *, stacklevel: int = 2) -> Edition:
     """Return the canonical DNV-RP-B401 edition token.
 
     ``None`` keeps the P1 transition additive by warning and defaulting to the
@@ -36,7 +40,7 @@ def normalize_edition(edition: str | None) -> Edition:
         warnings.warn(
             "No DNV-RP-B401 edition supplied; defaulting to DNV-RP-B401 2021.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=stacklevel,
         )
         return DEFAULT_EDITION
 
@@ -48,3 +52,8 @@ def normalize_edition(edition: str | None) -> Edition:
             f"Unsupported DNV-RP-B401 edition {edition!r}. "
             "Supported editions are '2017' and '2021'."
         ) from exc
+
+
+def standard_for_edition(edition: Edition) -> str:
+    """Return the report-facing DNV-RP-B401 standard string for an edition."""
+    return STANDARD_BY_EDITION[edition]

--- a/src/digitalmodel/cathodic_protection/anode_sizing.py
+++ b/src/digitalmodel/cathodic_protection/anode_sizing.py
@@ -16,8 +16,16 @@ from __future__ import annotations
 
 import math
 from enum import Enum
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.cathodic_protection._edition import (
+    DEFAULT_EDITION,
+    Edition,
+    normalize_edition,
+    standard_for_edition,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +131,28 @@ class AnodeSizingResult(BaseModel):
     mass_check_ok: bool = Field(
         ..., description="Whether anode count provides sufficient total mass"
     )
+    edition_used: Edition = Field(
+        ..., description="DNV-RP-B401 edition used for the design"
+    )
+    standard: str = Field(
+        ..., description="Standards reference matching the selected edition"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_legacy_metadata(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        edition = values.get("edition_used") or DEFAULT_EDITION
+        values["edition_used"] = edition
+        if not values.get("standard"):
+            try:
+                values["standard"] = standard_for_edition(edition)
+            except KeyError:
+                pass
+        return values
 
 
 def calculate_current_demand(
@@ -243,7 +273,10 @@ def calculate_anode_resistance(
     return R_a
 
 
-def design_cp_system(input_params: AnodeSizingInput) -> AnodeSizingResult:
+def design_cp_system(
+    input_params: AnodeSizingInput,
+    edition: Edition | None = None,
+) -> AnodeSizingResult:
     """Design a complete sacrificial anode CP system.
 
     End-to-end calculation: current demand → anode mass → anode count →
@@ -259,6 +292,8 @@ def design_cp_system(input_params: AnodeSizingInput) -> AnodeSizingResult:
     AnodeSizingResult
         Complete CP system design result.
     """
+    ed = normalize_edition(edition, stacklevel=3)
+
     # Step 1: Current demand
     i_demand = calculate_current_demand(
         surface_area_m2=input_params.surface_area_m2,
@@ -308,4 +343,6 @@ def design_cp_system(input_params: AnodeSizingInput) -> AnodeSizingResult:
         driving_voltage_V=input_params.driving_voltage_V,
         anode_type=input_params.anode_type.value,
         mass_check_ok=mass_check_ok,
+        edition_used=ed,
+        standard=standard_for_edition(ed),
     )

--- a/src/digitalmodel/cathodic_protection/coating.py
+++ b/src/digitalmodel/cathodic_protection/coating.py
@@ -15,9 +15,16 @@ References
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.cathodic_protection._edition import (
+    DEFAULT_EDITION,
+    Edition,
+    normalize_edition,
+    standard_for_edition,
+)
 
 
 class CoatingCategory(str, Enum):
@@ -76,6 +83,28 @@ class CoatingBreakdownResult(BaseModel):
         ..., ge=0.0, le=1.0, description="Breakdown factor at end of design life"
     )
     design_life_years: float = Field(..., gt=0, description="Design life [years]")
+    edition_used: Edition = Field(
+        ..., description="DNV-RP-B401 edition used for the coating calculation"
+    )
+    standard: str = Field(
+        ..., description="Standards reference matching the selected edition"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_legacy_metadata(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        edition = values.get("edition_used") or DEFAULT_EDITION
+        values["edition_used"] = edition
+        if not values.get("standard"):
+            try:
+                values["standard"] = standard_for_edition(edition)
+            except KeyError:
+                pass
+        return values
 
 
 class CoatingLifeResult(BaseModel):
@@ -100,6 +129,7 @@ def coating_breakdown_factors(
     design_life_years: float = 25.0,
     depth_m: float = 0.0,
     temperature_c: float = 20.0,
+    edition: Edition | None = None,
 ) -> CoatingBreakdownResult:
     """Calculate initial, mean, and final coating breakdown factors.
 
@@ -127,6 +157,7 @@ def coating_breakdown_factors(
     CoatingBreakdownResult
         Initial, mean, and final breakdown factors.
     """
+    ed = normalize_edition(edition, stacklevel=3)
     a, b = COATING_CONSTANTS[coating_type]
 
     # Temperature correction: increase degradation rate by 2% per °C above 25°C
@@ -149,6 +180,8 @@ def coating_breakdown_factors(
         mean_factor=fc_mean,
         final_factor=fc_final,
         design_life_years=design_life_years,
+        edition_used=ed,
+        standard=standard_for_edition(ed),
     )
 
 

--- a/src/digitalmodel/cathodic_protection/dnv_rp_b401.py
+++ b/src/digitalmodel/cathodic_protection/dnv_rp_b401.py
@@ -67,7 +67,7 @@ def current_demand(
     float
         Current demand [A].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     return surface_area_m2 * current_density_A_m2 * breakdown_factor
 
 
@@ -98,7 +98,7 @@ def anode_mass_requirement(
     float
         Required net anode mass [kg].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     return (I_mean_A * T_design_years * 8760.0) / (E_capacity * u_f)
 
 
@@ -126,7 +126,7 @@ def coating_breakdown_factor(
     float
         Coating breakdown factor at time t (dimensionless).
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     return a + b * t_years
 
 
@@ -158,7 +158,7 @@ def anode_resistance_slender_standoff(
     float
         Anode-to-electrolyte resistance [ohm].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     R_a = (rho / (2.0 * math.pi * L_a)) * (
         math.log(4.0 * L_a / r_a) - 1.0
     )
@@ -195,7 +195,7 @@ def anode_current_output(
     float
         Anode current output [A].
     """
-    ed = normalize_edition(edition)
+    ed = normalize_edition(edition, stacklevel=3)
     R_a = anode_resistance_slender_standoff(
         rho, L_a, r_a, proximity_factor, edition=ed
     )
@@ -229,7 +229,7 @@ def equivalent_radius_from_mass(
     float
         Equivalent radius [m].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     return math.sqrt(net_mass_kg / (math.pi * L_a * density))
 
 
@@ -256,7 +256,7 @@ def number_of_anodes(
     int
         Number of anodes (rounded up to nearest integer or even integer).
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     n = math.ceil(total_mass_kg / anode_net_mass_kg)
     if round_to_even and n % 2 != 0:
         n += 1
@@ -296,7 +296,7 @@ def protected_length(
     float
         Protected length [m].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     return math.sqrt(
         (delta_E_me * WT * (D - WT)) / (rho_me * D * f_cf * i_cm)
     )
@@ -338,7 +338,7 @@ def flush_anode_resistance(
     float
         Anode-to-electrolyte resistance [ohm].
     """
-    _ = normalize_edition(edition)
+    _ = normalize_edition(edition, stacklevel=3)
     # W_in and H_in are accepted for compatibility with standard CP
     # spreadsheet call signatures; the slender-body formula only needs
     # L and r_eq (all cross-section information is collapsed into r_eq).

--- a/src/digitalmodel/cathodic_protection/marine_cp.py
+++ b/src/digitalmodel/cathodic_protection/marine_cp.py
@@ -17,8 +17,16 @@ from __future__ import annotations
 
 import math
 from enum import Enum
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.cathodic_protection._edition import (
+    DEFAULT_EDITION,
+    Edition,
+    normalize_edition,
+    standard_for_edition,
+)
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -123,6 +131,28 @@ class MarineCPResult(BaseModel):
     design_life_years: float = Field(
         ..., description="Design life used [years]"
     )
+    edition_used: Edition = Field(
+        ..., description="DNV-RP-B401 edition used for the marine CP design"
+    )
+    standard: str = Field(
+        ..., description="Standards reference matching the selected edition"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_legacy_metadata(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        edition = values.get("edition_used") or DEFAULT_EDITION
+        values["edition_used"] = edition
+        if not values.get("standard"):
+            try:
+                values["standard"] = standard_for_edition(edition)
+            except KeyError:
+                pass
+        return values
 
 
 def get_seawater_current_density(
@@ -242,6 +272,7 @@ def calculate_zone_demand(
 
 def design_marine_cp(
     input_params: MarineCPInput,
+    edition: Edition | None = None,
 ) -> MarineCPResult:
     """Design multi-zone CP system for a marine structure.
 
@@ -258,6 +289,8 @@ def design_marine_cp(
     MarineCPResult
         Complete CP design result with per-zone breakdown.
     """
+    ed = normalize_edition(edition, stacklevel=3)
+
     zone_demands: list[dict] = []
     total_demand = 0.0
 
@@ -292,4 +325,6 @@ def design_marine_cp(
         number_of_anodes=n_anodes,
         zone_demands=zone_demands,
         design_life_years=input_params.design_life_years,
+        edition_used=ed,
+        standard=standard_for_edition(ed),
     )

--- a/src/digitalmodel/cathodic_protection/marine_structure_cp.py
+++ b/src/digitalmodel/cathodic_protection/marine_structure_cp.py
@@ -16,9 +16,16 @@ from __future__ import annotations
 
 import math
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.cathodic_protection._edition import (
+    DEFAULT_EDITION,
+    Edition,
+    normalize_edition,
+    standard_for_edition,
+)
 
 
 class ExposureZone(str, Enum):
@@ -102,6 +109,29 @@ class MarineCPResult(BaseModel):
         default_factory=list,
         description="Per-zone breakdown of current demands",
     )
+    edition_used: Edition = Field(
+        ...,
+        description="DNV-RP-B401 edition used for the marine-structure CP design",
+    )
+    standard: str = Field(
+        ..., description="Standards reference matching the selected edition"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_legacy_metadata(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        edition = values.get("edition_used") or DEFAULT_EDITION
+        values["edition_used"] = edition
+        if not values.get("standard"):
+            try:
+                values["standard"] = standard_for_edition(edition)
+            except KeyError:
+                pass
+        return values
 
 
 class RetrofitAssessment(BaseModel):
@@ -131,6 +161,7 @@ def marine_structure_current_demand(
     anode_net_mass_kg: float = 200.0,
     anode_capacity_Ah_kg: float = 2000.0,
     utilization_factor: float = 0.90,
+    edition: Edition | None = None,
 ) -> MarineCPResult:
     """Calculate current demand and anode requirements for an offshore structure.
 
@@ -157,6 +188,8 @@ def marine_structure_current_demand(
     MarineCPResult
         Total current demand, anode mass, and number of anodes.
     """
+    ed = normalize_edition(edition, stacklevel=3)
+
     total_initial = 0.0
     total_mean = 0.0
     total_final = 0.0
@@ -201,6 +234,8 @@ def marine_structure_current_demand(
         total_anode_mass_kg=round(total_mass, 2),
         number_of_anodes=n_anodes,
         zone_details=zone_details,
+        edition_used=ed,
+        standard=standard_for_edition(ed),
     )
 
 

--- a/tests/cathodic_protection/test_edition_api_foundation.py
+++ b/tests/cathodic_protection/test_edition_api_foundation.py
@@ -403,3 +403,123 @@ def test_marine_cp_result_schema_requires_metadata_fields():
 
     assert "edition_used" in required
     assert "standard" in required
+
+
+def _sample_marine_structure_zones():
+    from digitalmodel.cathodic_protection.marine_structure_cp import (
+        ExposureZone,
+        StructuralZone,
+    )
+
+    return [
+        StructuralZone(
+            zone_name="submerged_legs",
+            exposure_zone=ExposureZone.SUBMERGED,
+            surface_area_m2=2000.0,
+            coating_breakdown_factor=0.05,
+        ),
+        StructuralZone(
+            zone_name="buried_piles",
+            exposure_zone=ExposureZone.BURIED_MUDLINE,
+            surface_area_m2=500.0,
+            coating_breakdown_factor=1.0,
+        ),
+    ]
+
+
+def test_marine_structure_current_demand_accepts_edition_kwarg():
+    from digitalmodel.cathodic_protection.marine_structure_cp import (
+        marine_structure_current_demand,
+    )
+
+    signature = inspect.signature(marine_structure_current_demand)
+
+    assert "edition" in signature.parameters
+
+
+def test_marine_structure_result_carries_explicit_edition_metadata():
+    from digitalmodel.cathodic_protection.marine_structure_cp import (
+        marine_structure_current_demand,
+    )
+
+    result = marine_structure_current_demand(
+        _sample_marine_structure_zones(),
+        edition="2017",
+    )
+
+    assert result.edition_used == "2017"
+    assert result.standard == "DNV-RP-B401 (Oct 2017)"
+
+
+def test_marine_structure_missing_edition_warns_and_defaults_metadata():
+    from digitalmodel.cathodic_protection.marine_structure_cp import (
+        marine_structure_current_demand,
+    )
+
+    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021") as warnings:
+        result = marine_structure_current_demand(_sample_marine_structure_zones())
+
+    assert Path(warnings[0].filename).name == "test_edition_api_foundation.py"
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_marine_structure_explicit_edition_preserves_p1_numerics():
+    from digitalmodel.cathodic_protection.marine_structure_cp import (
+        marine_structure_current_demand,
+    )
+
+    legacy = marine_structure_current_demand(
+        _sample_marine_structure_zones(), edition="2017"
+    )
+    current = marine_structure_current_demand(
+        _sample_marine_structure_zones(), edition="2021"
+    )
+
+    assert current.total_initial_current_A == pytest.approx(
+        legacy.total_initial_current_A
+    )
+    assert current.total_mean_current_A == pytest.approx(legacy.total_mean_current_A)
+    assert current.total_final_current_A == pytest.approx(legacy.total_final_current_A)
+    assert current.total_anode_mass_kg == pytest.approx(legacy.total_anode_mass_kg)
+    assert current.zone_details == legacy.zone_details
+
+
+def test_marine_structure_result_defaults_metadata_for_legacy_dicts():
+    from digitalmodel.cathodic_protection.marine_structure_cp import MarineCPResult
+
+    result = MarineCPResult(
+        total_initial_current_A=40.0,
+        total_mean_current_A=20.0,
+        total_final_current_A=24.0,
+        total_anode_mass_kg=2433.33,
+        number_of_anodes=13,
+        zone_details=[],
+    )
+
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_marine_structure_result_rejects_invalid_metadata_with_validation_error():
+    from digitalmodel.cathodic_protection.marine_structure_cp import MarineCPResult
+
+    with pytest.raises(ValidationError, match="edition_used"):
+        MarineCPResult(
+            total_initial_current_A=40.0,
+            total_mean_current_A=20.0,
+            total_final_current_A=24.0,
+            total_anode_mass_kg=2433.33,
+            number_of_anodes=13,
+            zone_details=[],
+            edition_used="2025",
+        )
+
+
+def test_marine_structure_result_schema_requires_metadata_fields():
+    from digitalmodel.cathodic_protection.marine_structure_cp import MarineCPResult
+
+    required = set(MarineCPResult.model_json_schema()["required"])
+
+    assert "edition_used" in required
+    assert "standard" in required

--- a/tests/cathodic_protection/test_edition_api_foundation.py
+++ b/tests/cathodic_protection/test_edition_api_foundation.py
@@ -203,3 +203,89 @@ def test_anode_sizing_result_schema_requires_metadata_fields():
 
     assert "edition_used" in required
     assert "standard" in required
+
+
+def test_coating_breakdown_factors_accepts_edition_kwarg():
+    from digitalmodel.cathodic_protection.coating import coating_breakdown_factors
+
+    signature = inspect.signature(coating_breakdown_factors)
+
+    assert "edition" in signature.parameters
+
+
+def test_coating_breakdown_result_carries_explicit_edition_metadata():
+    from digitalmodel.cathodic_protection.coating import (
+        CoatingCategory,
+        coating_breakdown_factors,
+    )
+
+    result = coating_breakdown_factors(CoatingCategory.FBE, edition="2017")
+
+    assert result.edition_used == "2017"
+    assert result.standard == "DNV-RP-B401 (Oct 2017)"
+
+
+def test_coating_breakdown_missing_edition_warns_and_defaults_metadata():
+    from digitalmodel.cathodic_protection.coating import (
+        CoatingCategory,
+        coating_breakdown_factors,
+    )
+
+    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021") as warnings:
+        result = coating_breakdown_factors(CoatingCategory.FBE)
+
+    assert Path(warnings[0].filename).name == "test_edition_api_foundation.py"
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_coating_breakdown_explicit_edition_preserves_p1_numerics():
+    from digitalmodel.cathodic_protection.coating import (
+        CoatingCategory,
+        coating_breakdown_factors,
+    )
+
+    legacy = coating_breakdown_factors(CoatingCategory.FBE, edition="2017")
+    current = coating_breakdown_factors(CoatingCategory.FBE, edition="2021")
+
+    assert current.initial_factor == pytest.approx(legacy.initial_factor)
+    assert current.mean_factor == pytest.approx(legacy.mean_factor)
+    assert current.final_factor == pytest.approx(legacy.final_factor)
+
+
+def test_coating_breakdown_result_defaults_metadata_for_legacy_dicts():
+    from digitalmodel.cathodic_protection.coating import CoatingBreakdownResult
+
+    result = CoatingBreakdownResult(
+        coating_type="fbe",
+        initial_factor=0.02,
+        mean_factor=0.0575,
+        final_factor=0.095,
+        design_life_years=25.0,
+    )
+
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_coating_breakdown_result_rejects_invalid_metadata_with_validation_error():
+    from digitalmodel.cathodic_protection.coating import CoatingBreakdownResult
+
+    with pytest.raises(ValidationError, match="edition_used"):
+        CoatingBreakdownResult(
+            coating_type="fbe",
+            initial_factor=0.02,
+            mean_factor=0.0575,
+            final_factor=0.095,
+            design_life_years=25.0,
+            edition_used="2025",
+        )
+
+
+def test_coating_breakdown_result_schema_requires_metadata_fields():
+    from digitalmodel.cathodic_protection.coating import CoatingBreakdownResult
+
+    required = set(CoatingBreakdownResult.model_json_schema()["required"])
+
+    assert "edition_used" in required
+    assert "standard" in required

--- a/tests/cathodic_protection/test_edition_api_foundation.py
+++ b/tests/cathodic_protection/test_edition_api_foundation.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
+import warnings
 
+from pydantic import ValidationError
 import pytest
 
 
@@ -76,5 +79,127 @@ def test_dnv_b401_explicit_edition_preserves_current_demand_numeric():
 def test_dnv_b401_missing_edition_warns_and_preserves_numeric():
     from digitalmodel.cathodic_protection.dnv_rp_b401 import current_demand
 
-    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021"):
+    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021") as warnings:
         assert current_demand(100.0, 0.05, 0.2) == pytest.approx(1.0)
+
+    assert Path(warnings[0].filename).name == "test_edition_api_foundation.py"
+
+
+def _sample_anode_sizing_input():
+    from digitalmodel.cathodic_protection.anode_sizing import (
+        AnodeSizingInput,
+        AnodeType,
+    )
+
+    return AnodeSizingInput(
+        surface_area_m2=3000.0,
+        coating_breakdown_factor=0.05,
+        current_density_mA_m2=100.0,
+        design_life_years=25.0,
+        anode_type=AnodeType.STAND_OFF,
+        anode_length_m=1.0,
+        anode_radius_m=0.08,
+        anode_net_mass_kg=200.0,
+        resistivity_ohm_m=0.30,
+        anode_capacity_Ah_kg=2000.0,
+        utilization_factor=0.90,
+    )
+
+
+def test_design_cp_system_result_carries_explicit_edition_metadata():
+    from digitalmodel.cathodic_protection.anode_sizing import design_cp_system
+
+    result = design_cp_system(_sample_anode_sizing_input(), edition="2017")
+
+    assert result.edition_used == "2017"
+    assert result.standard == "DNV-RP-B401 (Oct 2017)"
+
+
+def test_design_cp_system_missing_edition_warns_and_defaults_metadata():
+    from digitalmodel.cathodic_protection.anode_sizing import design_cp_system
+
+    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021") as warnings:
+        result = design_cp_system(_sample_anode_sizing_input())
+
+    assert Path(warnings[0].filename).name == "test_edition_api_foundation.py"
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_design_cp_system_explicit_edition_preserves_p1_numerics():
+    from digitalmodel.cathodic_protection.anode_sizing import design_cp_system
+
+    legacy = design_cp_system(_sample_anode_sizing_input(), edition="2017")
+    current = design_cp_system(_sample_anode_sizing_input(), edition="2021")
+
+    assert current.current_demand_A == pytest.approx(legacy.current_demand_A)
+    assert current.total_anode_mass_kg == pytest.approx(legacy.total_anode_mass_kg)
+    assert current.number_of_anodes == legacy.number_of_anodes
+    assert current.anode_resistance_ohm == pytest.approx(legacy.anode_resistance_ohm)
+
+
+def test_design_cp_system_explicit_edition_emits_no_missing_edition_warning():
+    from digitalmodel.cathodic_protection.anode_sizing import design_cp_system
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        result = design_cp_system(_sample_anode_sizing_input(), edition="2017")
+
+    messages = [str(warning.message) for warning in captured]
+    assert not [
+        message
+        for message in messages
+        if "defaulting to DNV-RP-B401 2021" in message
+    ]
+    assert result.edition_used == "2017"
+
+
+def _legacy_anode_sizing_result_data(**overrides):
+    data = {
+        "current_demand_A": 15.0,
+        "total_anode_mass_kg": 1825.0,
+        "number_of_anodes": 10,
+        "anode_resistance_ohm": 0.139,
+        "anode_current_output_A": 1.8,
+        "driving_voltage_V": 0.25,
+        "anode_type": "stand_off",
+        "mass_check_ok": True,
+    }
+    data.update(overrides)
+    return data
+
+
+def test_anode_sizing_result_defaults_metadata_for_legacy_dicts():
+    from digitalmodel.cathodic_protection.anode_sizing import AnodeSizingResult
+
+    result = AnodeSizingResult(**_legacy_anode_sizing_result_data())
+
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_anode_sizing_result_treats_none_metadata_as_legacy_missing():
+    from digitalmodel.cathodic_protection.anode_sizing import AnodeSizingResult
+
+    result = AnodeSizingResult(
+        **_legacy_anode_sizing_result_data(edition_used=None, standard=None)
+    )
+
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_anode_sizing_result_rejects_invalid_metadata_with_validation_error():
+    from digitalmodel.cathodic_protection.anode_sizing import AnodeSizingResult
+
+    with pytest.raises(ValidationError, match="edition_used"):
+        AnodeSizingResult(**_legacy_anode_sizing_result_data(edition_used="2025"))
+
+
+def test_anode_sizing_result_schema_requires_metadata_fields():
+    from digitalmodel.cathodic_protection.anode_sizing import AnodeSizingResult
+
+    required = set(AnodeSizingResult.model_json_schema()["required"])
+
+    assert "edition_used" in required
+    assert "standard" in required

--- a/tests/cathodic_protection/test_edition_api_foundation.py
+++ b/tests/cathodic_protection/test_edition_api_foundation.py
@@ -289,3 +289,117 @@ def test_coating_breakdown_result_schema_requires_metadata_fields():
 
     assert "edition_used" in required
     assert "standard" in required
+
+
+def _sample_marine_cp_input():
+    from digitalmodel.cathodic_protection.marine_cp import (
+        MarineCPInput,
+        Zone,
+        ZoneType,
+    )
+
+    return MarineCPInput(
+        structure_name="Edition Test Jacket",
+        zones=[
+            Zone(
+                name="submerged",
+                zone_type=ZoneType.SUBMERGED,
+                surface_area_m2=3000.0,
+                coating_breakdown_factor=0.05,
+            ),
+            Zone(
+                name="mudline",
+                zone_type=ZoneType.MUDLINE,
+                surface_area_m2=800.0,
+                coating_breakdown_factor=1.0,
+            ),
+        ],
+        water_temperature_c=8.0,
+        water_depth_m=100.0,
+        design_life_years=25.0,
+        anode_net_mass_kg=250.0,
+        anode_capacity_Ah_kg=2000.0,
+        utilization_factor=0.90,
+    )
+
+
+def test_design_marine_cp_accepts_edition_kwarg():
+    from digitalmodel.cathodic_protection.marine_cp import design_marine_cp
+
+    signature = inspect.signature(design_marine_cp)
+
+    assert "edition" in signature.parameters
+
+
+def test_design_marine_cp_result_carries_explicit_edition_metadata():
+    from digitalmodel.cathodic_protection.marine_cp import design_marine_cp
+
+    result = design_marine_cp(_sample_marine_cp_input(), edition="2017")
+
+    assert result.edition_used == "2017"
+    assert result.standard == "DNV-RP-B401 (Oct 2017)"
+
+
+def test_design_marine_cp_missing_edition_warns_and_defaults_metadata():
+    from digitalmodel.cathodic_protection.marine_cp import design_marine_cp
+
+    with pytest.warns(UserWarning, match="defaulting to DNV-RP-B401 2021") as warnings:
+        result = design_marine_cp(_sample_marine_cp_input())
+
+    assert Path(warnings[0].filename).name == "test_edition_api_foundation.py"
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_design_marine_cp_explicit_edition_preserves_p1_numerics():
+    from digitalmodel.cathodic_protection.marine_cp import design_marine_cp
+
+    legacy = design_marine_cp(_sample_marine_cp_input(), edition="2017")
+    current = design_marine_cp(_sample_marine_cp_input(), edition="2021")
+
+    assert current.total_current_demand_A == pytest.approx(
+        legacy.total_current_demand_A
+    )
+    assert current.total_anode_mass_kg == pytest.approx(legacy.total_anode_mass_kg)
+    assert current.number_of_anodes == legacy.number_of_anodes
+    assert current.zone_demands == legacy.zone_demands
+
+
+def test_marine_cp_result_defaults_metadata_for_legacy_dicts():
+    from digitalmodel.cathodic_protection.marine_cp import MarineCPResult
+
+    result = MarineCPResult(
+        structure_name="legacy",
+        total_current_demand_A=31.0,
+        total_anode_mass_kg=3771.0,
+        number_of_anodes=16,
+        zone_demands=[],
+        design_life_years=25.0,
+    )
+
+    assert result.edition_used == "2021"
+    assert result.standard == "DNV-RP-B401 (May 2021)"
+
+
+def test_marine_cp_result_rejects_invalid_metadata_with_validation_error():
+    from digitalmodel.cathodic_protection.marine_cp import MarineCPResult
+
+    with pytest.raises(ValidationError, match="edition_used"):
+        MarineCPResult(
+            structure_name="invalid",
+            total_current_demand_A=31.0,
+            total_anode_mass_kg=3771.0,
+            number_of_anodes=16,
+            zone_demands=[],
+            design_life_years=25.0,
+            edition_used="2025",
+        )
+
+
+def test_marine_cp_result_schema_requires_metadata_fields():
+    from digitalmodel.cathodic_protection.marine_cp import MarineCPResult
+
+    required = set(MarineCPResult.model_json_schema()["required"])
+
+    assert "edition_used" in required
+    assert "standard" in required


### PR DESCRIPTION
## Summary
- Add B401 edition normalization metadata for cathodic-protection result objects in anode sizing, coating, marine CP, and marine-structure CP.
- Preserve P1 numeric behavior while adding `edition=` APIs, `edition_used` / `standard` result fields, legacy-dict compatibility, and schema-required metadata fields.
- Improve missing-edition warning attribution for public B401 helpers.

## Context
Workspace-hub control issue: https://github.com/vamseeachanta/workspace-hub/issues/2694

This PR intentionally stays in the additive P1 foundation scope. It does not implement P2 numeric divergence tables, splash-zone edition behavior, citation sidecars, router cleanup, or shim deletion.

## Validation
- `UV_NO_SYNC=1 PYTHONPATH=src uv run pytest tests/cathodic_protection -q` => 260 passed
- `git diff --check` clean before slice commits
- `scripts/legal/legal-sanity-scan.sh --repo=digitalmodel --diff-only` via sibling-worktree harness => PASS
- Gemini adversarial review => APPROVE for each committed slice

## Notes
- `pipeline_cp.py` was left unchanged because the live module is NACE SP0169 / ISO 15589-1 oriented; stamping DNV-RP-B401 edition metadata onto that API should be clarified before implementation.
- PR opened as draft for review and follow-up gating.