### PR TITLE
fix(orcaflex): preserve jumper line-section YAML in pipeline outputs (#601)

### DIFF
--- a/src/digitalmodel/marine_ops/installation/jumper_installation.py
+++ b/src/digitalmodel/marine_ops/installation/jumper_installation.py
@@ -205,7 +205,8 @@ def stage_4_generate_yaml(results: Dict) -> str:
         YAML string defining line sections.
     """
     if isinstance(results, dict):
-        return results.get("orcaflex_yaml", "")
+        # Key contract with jumper_lift.run_jumper_analysis() — see issue #601.
+        return results.get("orcaflex_sections_yaml", "")
     return ""
 
 

--- a/src/digitalmodel/marine_ops/installation/jumper_lift.py
+++ b/src/digitalmodel/marine_ops/installation/jumper_lift.py
@@ -21,6 +21,7 @@ Units  : SI unless noted (inch inputs converted internally)
 
 from __future__ import annotations
 
+import json
 import math
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
@@ -1025,9 +1026,11 @@ def generate_orcaflex_line_sections_yaml(
     sections = compute_orcaflex_sections(pipe_geom, pipe_props)
 
     yaml_lines = ["line_sections:"]
-    for i, sec in enumerate(sections):
-        yaml_lines.append(f"  - name: \"{sec['name']}\"")
-        yaml_lines.append(f"    line_type: \"{sec['line_type']}\"")
+    for sec in sections:
+        # Section names embed inch marks (e.g. 10.75"Jumper_wCoat); JSON
+        # string encoding is valid YAML and escapes them correctly.
+        yaml_lines.append(f"  - name: {json.dumps(sec['name'])}")
+        yaml_lines.append(f"    line_type: {json.dumps(sec['line_type'])}")
         yaml_lines.append(f"    length_m: {sec['length_m']:.6f}")
     return "\n".join(yaml_lines)
 

--- a/tests/solvers/orcaflex/modular_generator/test_jumper_pipeline_line_sections.py
+++ b/tests/solvers/orcaflex/modular_generator/test_jumper_pipeline_line_sections.py
@@ -1,0 +1,82 @@
+"""Regression tests for jumper pipeline line-section YAML output (issue #601).
+
+The jumper calculation layer returns generated OrcaFlex line-section YAML
+under the key ``orcaflex_sections_yaml``; the pipeline's stage 4 must read
+that same key or the 27 line sections are silently dropped and
+``line_sections.yml`` is never written.
+
+No OrcaFlex license or OrcFxAPI import is required.
+
+CI command:
+    uv run pytest tests/solvers/orcaflex/modular_generator/test_jumper_pipeline_line_sections.py -q
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.marine_ops.installation.jumper_installation import (
+    run_pipeline,
+    stage_4_generate_yaml,
+)
+from digitalmodel.marine_ops.installation.jumper_lift import run_jumper_analysis
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPEC_DIR = REPO_ROOT / "docs/domains/orcaflex/subsea/jumper/installation"
+
+BALLYMORE_SPECS = [
+    SPEC_DIR / "ballymore_mf_plet" / "spec.yml",
+    SPEC_DIR / "ballymore_plet_plem" / "spec.yml",
+]
+
+EXPECTED_SECTION_COUNT = 27
+
+
+def test_run_jumper_analysis_exposes_sections_yaml_key():
+    """Lock the producer-side key contract (jumper_lift)."""
+    results = run_jumper_analysis()
+    assert "orcaflex_sections_yaml" in results
+    assert results["orcaflex_sections_yaml"].strip()
+
+
+def test_stage_4_reads_producer_key():
+    """Lock the consumer-side key contract (jumper_installation stage 4).
+
+    Guards the #601 drift: stage 4 must return exactly what the
+    calculation layer produced, not an empty fallback from a stale key.
+    """
+    results = run_jumper_analysis()
+    assert stage_4_generate_yaml(results) == results["orcaflex_sections_yaml"]
+
+
+def test_stage_4_yaml_parses_with_expected_sections():
+    parsed = yaml.safe_load(stage_4_generate_yaml(run_jumper_analysis()))
+    assert isinstance(parsed, dict)
+    assert len(parsed["line_sections"]) == EXPECTED_SECTION_COUNT
+
+
+@pytest.mark.parametrize(
+    "spec_path", BALLYMORE_SPECS, ids=[p.parent.name for p in BALLYMORE_SPECS]
+)
+def test_pipeline_writes_line_sections_yml(spec_path, tmp_path):
+    """run_pipeline(..., run_go_no_go=False) persists line_sections.yml."""
+    assert spec_path.exists(), f"missing spec fixture: {spec_path}"
+
+    out_dir = tmp_path / spec_path.parent.name
+    output = run_pipeline(
+        str(spec_path),
+        output_dir=str(out_dir),
+        run_go_no_go=False,
+    )
+
+    yaml_path = out_dir / "line_sections.yml"
+    assert yaml_path.exists(), "line_sections.yml was not written (issue #601)"
+    assert str(yaml_path) in output.output_files
+
+    parsed = yaml.safe_load(yaml_path.read_text())
+    sections = parsed["line_sections"]
+    assert len(sections) == EXPECTED_SECTION_COUNT
+    for section in sections:
+        assert section["name"]
+        assert section["line_type"]
+        assert section["length_m"] > 0


### PR DESCRIPTION
Closes #601.

## What

Two fixes so `run_pipeline()` actually persists a parseable `line_sections.yml`:

1. **Key-contract drift (the #601 bug):** `stage_4_generate_yaml()` read `results["orcaflex_yaml"]` but `jumper_lift.run_jumper_analysis()` returns the YAML under `"orcaflex_sections_yaml"` — stage 5 silently wrote nothing. Now reads the producer's key.
2. **Invalid YAML emitter (found by the new regression test):** `generate_orcaflex_line_sections_yaml()` built YAML by string concatenation, and section names embed inch marks (`10.75"Jumper_wCoat`), producing `line_type: "10.75"Jumper_wCoat"` — never parseable. String scalars are now encoded with `json.dumps` (valid YAML, correct escaping, no new dependency, float formatting unchanged).

## Acceptance criteria from #601

- ✅ `run_pipeline(..., run_go_no_go=False)` writes `line_sections.yml` for both Ballymore specs (parametrized test)
- ✅ Written file parses with `yaml.safe_load` and contains exactly 27 entries under `line_sections`
- ✅ Producer/consumer key contract locked by tests so the drift cannot recur
- ✅ No claim that this output is a full OrcaFlex model — that remains #478/#602

## Verification

```
uv run pytest tests/solvers/orcaflex/modular_generator/test_jumper_pipeline_line_sections.py -q
# 5 passed
uv run pytest tests/marine_ops/installation/ tests/solvers/orcaflex/modular_generator/test_jumper_plet_to_plem_semantic.py -q
# 189 passed
```

Note: main CI baseline is red (engine + native segfault) — compare check set vs. bare main, not absolute green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)