### PR TITLE
feat(#711): registry v2 lane A — wall-thickness quickcheck + API 579 FFS lattice workflows

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -61,3 +61,30 @@ workflows:
       - examples/workflows/plate-buckling/results/input.yml
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[plate-buckling]
     runtime: offline
+  - id: wall-thickness-quickcheck
+    basename: wall_thickness
+    title: DNV/API wall-thickness quickcheck cached deckhand report
+    input: examples/workflows/wall-thickness-quickcheck/input.yml
+    outputs:
+      - examples/workflows/wall-thickness-quickcheck/results/input.yml
+      - examples/workflows/wall-thickness-quickcheck/results/wall_thickness_quickcheck.html
+      - examples/workflows/wall-thickness-quickcheck/results/wall_thickness_quickcheck.json
+      - examples/workflows/wall-thickness-quickcheck/results/wall_thickness_quickcheck.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[wall-thickness-quickcheck]
+    runtime: offline
+  - id: api579-pipe-ffs-b314
+    basename: API579
+    title: API 579 FFS for a 12.75 inch B31.4 oil pipe
+    input: examples/workflows/api579-pipe-ffs-b314/input.yml
+    outputs:
+      - examples/workflows/api579-pipe-ffs-b314/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[api579-pipe-ffs-b314]
+    runtime: offline
+  - id: api579-pipe-ffs-b318
+    basename: API579
+    title: API 579 FFS for a 16 inch B31.8 gas pipe
+    input: examples/workflows/api579-pipe-ffs-b318/input.yml
+    outputs:
+      - examples/workflows/api579-pipe-ffs-b318/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[api579-pipe-ffs-b318]
+    runtime: offline

--- a/examples/structural/wall_thickness_quickcheck/quick_check.py
+++ b/examples/structural/wall_thickness_quickcheck/quick_check.py
@@ -332,10 +332,11 @@ def write_cache(payload: dict[str, Any]) -> None:
     CACHE_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def run_from_cache() -> dict[str, Any]:
-    if not CACHE_PATH.exists():
-        raise SystemExit(f"[ERROR] cache fixture not found: {CACHE_PATH}")
-    return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+def run_from_cache(cache_path: Path | None = None) -> dict[str, Any]:
+    path = cache_path or CACHE_PATH
+    if not path.exists():
+        raise SystemExit(f"[ERROR] cache fixture not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def print_summary(payload: dict[str, Any]) -> None:

--- a/examples/workflows/api579-pipe-ffs-b314/README.md
+++ b/examples/workflows/api579-pipe-ffs-b314/README.md
@@ -1,0 +1,10 @@
+# API579 Pipe FFS B314
+
+Runs an offline API 579 general/local metal loss assessment for a representative
+12.75 inch oil pipe case using inline wall-thickness measurements.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/api579-pipe-ffs-b314/input.yml
+```

--- a/examples/workflows/api579-pipe-ffs-b314/input.yml
+++ b/examples/workflows/api579-pipe-ffs-b314/input.yml
@@ -1,0 +1,186 @@
+basename: API579
+
+default:
+  Analysis:
+    GML:
+      data_source: inline
+      Circumference: true
+      Length: false
+      FCARate: Historical
+      FCA: [0.0, 0.02, 0.04, 0.06]
+    LML: true
+    B31G: false
+  Units: inch
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+  settings:
+    StartWTFactor: 1
+    AssessmentLengthCeilingFactor_Circumference: null
+    AssessmentLengthCeilingFactor_Length: 0.5
+    CorrosionAllowance: 0.0
+
+ReadingSets:
+  - DataCorrectionFactor: 1.0
+    Label: B314 CML31
+    FCARate: Historical
+    FCA: [0.0, 0.02, 0.04, 0.06]
+    Contour:
+      xlim: null
+      ylim: null
+      zlim: [0.20, 0.36]
+    grid:
+      index: [0, 1, 2, 3, 4, 5]
+      columns: [0, 1, 2, 3, 4, 5]
+      values:
+        - [0.350, 0.349, 0.348, 0.347, 0.348, 0.349]
+        - [0.348, 0.346, 0.342, 0.340, 0.343, 0.347]
+        - [0.346, 0.340, 0.322, 0.318, 0.334, 0.345]
+        - [0.345, 0.338, 0.316, 0.312, 0.331, 0.344]
+        - [0.347, 0.342, 0.336, 0.332, 0.340, 0.346]
+        - [0.349, 0.348, 0.346, 0.345, 0.347, 0.349]
+
+API579Parameters:
+  RSFa: 0.9
+  Age: 15
+  FCARateFloor: 0.00118
+  FoliasFactor:
+    FlawParameter: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0]
+    Mt:
+      Cylindrical: [1.001, 1.056, 1.199, 1.394, 1.618, 1.857, 2.103, 2.351, 2.600, 2.847, 3.091, 3.331, 3.568, 3.801, 4.032, 4.262, 4.492, 4.727, 4.970, 5.225, 5.497]
+      Conical: [1.001, 1.056, 1.199, 1.394, 1.618, 1.857, 2.103, 2.351, 2.600, 2.847, 3.091, 3.331, 3.568, 3.801, 4.032, 4.262, 4.492, 4.727, 4.970, 5.225, 5.497]
+      Spherical: []
+
+Geometry:
+  NominalID: null
+  NominalOD: 12.75
+  DesignWT: 0.350
+  StartWTFactor: 1
+  tmin: 0.300
+  AssessmentLengthCeilingFactor_Circumference: null
+  AssessmentLengthCeilingFactor_Length: 0.5
+  CorrosionAllowance: 0.0
+
+Outer_Pipe:
+  Geometry:
+    Nominal_ID: null
+    Nominal_OD: 12.75
+    Design_WT: 0.350
+    tmin: 0.300
+    Corrosion_Allowance: 0.0
+  Material:
+    Material: Steel
+    Material_Grade: API 5L X65
+    WeldFactor:
+      Seamless: 1.0
+    Insulation: null
+    Buoyancy: null
+  Manufacturing:
+    Coupling Mass Ratio: 0.0
+
+Inner_Pipe: null
+
+Design:
+  - Load Condition: {Outer_Pipe: internal_pressure}
+    InternalPressure: {Outer_Pipe: 285}
+    InternalFluid: {Outer_Pipe: 0.03703047}
+    ExternalPressure: {Outer_Pipe: 0}
+    ExternalFluid: {Outer_Pipe: 0.03703047}
+    Temperature:
+      Ambient: {Outer_Pipe: 50}
+      Operating: {Outer_Pipe: 82}
+      Maximum: null
+    BendingMoment: 0
+    AxialForce: 0
+    Torsion: 0
+    Condition: Restrained
+    Water_Depth: 2460.63
+    Code:
+      - {Outer_Pipe: ASME B31.4-2016 Chapter IX Platform Piping}
+
+Material:
+  E: 30000000.0
+  rho: 7800
+  Poissionsratio: 0.3
+  SMYS: 30000
+  SMUS: null
+  ThermalExpansionCoefficient: 6.5e-06
+  WeldFactor:
+    Seamless: 1.0
+  Steel:
+    E: 30000000.0
+    Rho: 0.2817929
+    Poissionsratio: 0.3
+    ThermalExpansionCoefficient: 6.5e-06
+    Grades:
+      API 5L X65:
+        SMYS: 30000
+        SMUS: null
+        Reference: null
+
+DesignFactors:
+  Pressure: 0.6
+  Longitudinal: 0.8
+  EquivalentStress: 0.9
+  Logitudinal: 0.8
+  TemperatureDerating: 1.0
+  ASME B31.4-2016 Chapter IX Platform Piping:
+    internal_pressure: 0.6
+    Longitudinal: 0.8
+    EquivalentStress: 0.9
+    D_over_T_Trasition_Ratio: 30
+
+LML:
+  LTA:
+    - DataCorrectionFactor: 1.0
+      Label: B314 CML31 flaw
+      sIndex: [2, 4]
+      cIndex: [2, 4]
+      s: null
+      c: null
+      Contour:
+        xlim: null
+        ylim: null
+        zlim: [0.20, 0.36]
+      FCA: [0.0, 0.02, 0.04, 0.06]
+      Lmsd: 6.0
+      MtType: Cylindrical
+      FCAs: null
+      FCAc: null
+      FCANonFlawRatio: 0.25
+      io: null
+      sheet_name: null
+      index_col: null
+      skiprows: 0
+      skipfooter: 0
+      grid:
+        index: [0, 1, 2, 3, 4, 5]
+        columns: [0, 1, 2, 3, 4, 5]
+        values:
+          - [0.350, 0.349, 0.348, 0.347, 0.348, 0.349]
+          - [0.348, 0.346, 0.342, 0.340, 0.343, 0.347]
+          - [0.346, 0.340, 0.322, 0.318, 0.334, 0.345]
+          - [0.345, 0.338, 0.316, 0.312, 0.331, 0.344]
+          - [0.347, 0.342, 0.336, 0.332, 0.340, 0.346]
+          - [0.349, 0.348, 0.346, 0.345, 0.347, 0.349]
+
+PlotSettings:
+  Data:
+    PltSupTitle: B314 pipe FFS
+    PltTitle: Inline wall thickness grid
+    PltXLabel: Circumference (inch)
+    PltYLabel: Length (inch)
+  LML:
+    PltSupTitle: B314 pipe FFS
+    PltTitle: Local Metal Loss, Levels 1 and 2
+    PltXLabel: Future Corrosion Allowance (inch)
+    PltYLabel: Maximum Allowable Working Pressure (psi)
+    ylim: [0, 4000]
+  GML:
+    PltSupTitle: B314 pipe FFS
+    PltTitle: General Metal Loss, Level 2
+    PltXLabel: Future Corrosion Allowance (inch)
+    PltYLabel: Maximum Allowable Working Pressure (psi)
+    ylim: [0, 4000]

--- a/examples/workflows/api579-pipe-ffs-b318/README.md
+++ b/examples/workflows/api579-pipe-ffs-b318/README.md
@@ -1,0 +1,10 @@
+# API579 Pipe FFS B318
+
+Runs an offline API 579 general/local metal loss assessment for a representative
+16 inch gas pipe case using inline wall-thickness measurements.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/api579-pipe-ffs-b318/input.yml
+```

--- a/examples/workflows/api579-pipe-ffs-b318/input.yml
+++ b/examples/workflows/api579-pipe-ffs-b318/input.yml
@@ -1,0 +1,186 @@
+basename: API579
+
+default:
+  Analysis:
+    GML:
+      data_source: inline
+      Circumference: true
+      Length: false
+      FCARate: Historical
+      FCA: [0.0, 0.04, 0.08, 0.12, 0.16]
+    LML: true
+    B31G: false
+  Units: inch
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+  settings:
+    StartWTFactor: 1
+    AssessmentLengthCeilingFactor_Circumference: null
+    AssessmentLengthCeilingFactor_Length: 0.5
+    CorrosionAllowance: 0.0
+
+ReadingSets:
+  - DataCorrectionFactor: 1.0
+    Label: B318 Feature 3
+    FCARate: Historical
+    FCA: [0.0, 0.04, 0.08, 0.12, 0.16]
+    Contour:
+      xlim: null
+      ylim: null
+      zlim: [0.50, 0.64]
+    grid:
+      index: [0, 1, 2, 3, 4, 5]
+      columns: [0, 1, 2, 3, 4, 5]
+      values:
+        - [0.625, 0.622, 0.620, 0.619, 0.621, 0.623]
+        - [0.621, 0.615, 0.600, 0.596, 0.611, 0.620]
+        - [0.618, 0.604, 0.556, 0.552, 0.592, 0.617]
+        - [0.617, 0.602, 0.550, 0.548, 0.590, 0.616]
+        - [0.620, 0.612, 0.598, 0.594, 0.610, 0.619]
+        - [0.623, 0.621, 0.618, 0.617, 0.620, 0.622]
+
+API579Parameters:
+  RSFa: 0.9
+  Age: 15
+  FCARateFloor: 0.00118
+  FoliasFactor:
+    FlawParameter: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0]
+    Mt:
+      Cylindrical: [1.001, 1.056, 1.199, 1.394, 1.618, 1.857, 2.103, 2.351, 2.600, 2.847, 3.091, 3.331, 3.568, 3.801, 4.032, 4.262, 4.492, 4.727, 4.970, 5.225, 5.497]
+      Conical: [1.001, 1.056, 1.199, 1.394, 1.618, 1.857, 2.103, 2.351, 2.600, 2.847, 3.091, 3.331, 3.568, 3.801, 4.032, 4.262, 4.492, 4.727, 4.970, 5.225, 5.497]
+      Spherical: []
+
+Geometry:
+  NominalID: null
+  NominalOD: 16
+  DesignWT: 0.625
+  StartWTFactor: 1
+  tmin: 0.526
+  AssessmentLengthCeilingFactor_Circumference: null
+  AssessmentLengthCeilingFactor_Length: 0.5
+  CorrosionAllowance: 0.0
+
+Outer_Pipe:
+  Geometry:
+    Nominal_ID: null
+    Nominal_OD: 16
+    Design_WT: 0.625
+    tmin: 0.526
+    Corrosion_Allowance: 0.0
+  Material:
+    Material: Steel
+    Material_Grade: API 5L X65
+    WeldFactor:
+      Seamless: 1.0
+    Insulation: null
+    Buoyancy: null
+  Manufacturing:
+    Coupling Mass Ratio: 0.0
+
+Inner_Pipe: null
+
+Design:
+  - Load Condition: {Outer_Pipe: internal_pressure}
+    InternalPressure: {Outer_Pipe: 2220}
+    InternalFluid: {Outer_Pipe: 0.03703047}
+    ExternalPressure: {Outer_Pipe: 0}
+    ExternalFluid: {Outer_Pipe: 0.03703047}
+    Temperature:
+      Ambient: {Outer_Pipe: 50}
+      Operating: {Outer_Pipe: 82}
+      Maximum: null
+    BendingMoment: 0
+    AxialForce: 0
+    Torsion: 0
+    Condition: Restrained
+    Water_Depth: 2460.63
+    Code:
+      - {Outer_Pipe: ASME B31.8-2016 Chapter VIII Pipeline}
+
+Material:
+  E: 30000000.0
+  rho: 7800
+  Poissionsratio: 0.3
+  SMYS: 65000
+  SMUS: null
+  ThermalExpansionCoefficient: 6.5e-06
+  WeldFactor:
+    Seamless: 1.0
+  Steel:
+    E: 30000000.0
+    Rho: 0.2817929
+    Poissionsratio: 0.3
+    ThermalExpansionCoefficient: 6.5e-06
+    Grades:
+      API 5L X65:
+        SMYS: 65000
+        SMUS: null
+        Reference: null
+
+DesignFactors:
+  Pressure: 0.5
+  Longitudinal: 0.9
+  EquivalentStress: 0.9
+  Logitudinal: 0.9
+  TemperatureDerating: 1.0
+  ASME B31.8-2016 Chapter VIII Pipeline:
+    internal_pressure: 0.72
+    Longitudinal: 0.8
+    EquivalentStress: 0.9
+    D_over_T_Trasition_Ratio: 30
+
+LML:
+  LTA:
+    - DataCorrectionFactor: 1.0
+      Label: B318 Feature 3 flaw
+      sIndex: [2, 4]
+      cIndex: [2, 4]
+      s: null
+      c: null
+      Contour:
+        xlim: null
+        ylim: null
+        zlim: [0.50, 0.64]
+      FCA: [0.0, 0.04, 0.08, 0.12, 0.16]
+      Lmsd: 15.0
+      MtType: Cylindrical
+      FCAs: null
+      FCAc: null
+      FCANonFlawRatio: 0.25
+      io: null
+      sheet_name: null
+      index_col: null
+      skiprows: 0
+      skipfooter: 0
+      grid:
+        index: [0, 1, 2, 3, 4, 5]
+        columns: [0, 1, 2, 3, 4, 5]
+        values:
+          - [0.625, 0.622, 0.620, 0.619, 0.621, 0.623]
+          - [0.621, 0.615, 0.600, 0.596, 0.611, 0.620]
+          - [0.618, 0.604, 0.556, 0.552, 0.592, 0.617]
+          - [0.617, 0.602, 0.550, 0.548, 0.590, 0.616]
+          - [0.620, 0.612, 0.598, 0.594, 0.610, 0.619]
+          - [0.623, 0.621, 0.618, 0.617, 0.620, 0.622]
+
+PlotSettings:
+  Data:
+    PltSupTitle: B318 pipe FFS
+    PltTitle: Inline wall thickness grid
+    PltXLabel: Circumference (inch)
+    PltYLabel: Length (inch)
+  LML:
+    PltSupTitle: B318 pipe FFS
+    PltTitle: Local Metal Loss, Levels 1 and 2
+    PltXLabel: Future Corrosion Allowance (inch)
+    PltYLabel: Maximum Allowable Working Pressure (psi)
+    ylim: [0, 4000]
+  GML:
+    PltSupTitle: B318 pipe FFS
+    PltTitle: General Metal Loss, Level 2
+    PltXLabel: Future Corrosion Allowance (inch)
+    PltYLabel: Maximum Allowable Working Pressure (psi)
+    ylim: [0, 4000]

--- a/examples/workflows/wall-thickness-quickcheck/README.md
+++ b/examples/workflows/wall-thickness-quickcheck/README.md
@@ -1,0 +1,12 @@
+# Wall Thickness Quickcheck
+
+Runs the deckhand wall-thickness quickcheck from the committed cache and writes
+the self-contained HTML report plus JSON/CSV result extracts.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/wall-thickness-quickcheck/input.yml
+```
+
+Expected outputs are written to `examples/workflows/wall-thickness-quickcheck/results/`.

--- a/examples/workflows/wall-thickness-quickcheck/data/quickcheck_cache.json
+++ b/examples/workflows/wall-thickness-quickcheck/data/quickcheck_cache.json
@@ -1,0 +1,1753 @@
+{
+  "buckle_arrestor_sizing": {
+    "additional_wall_mm": 8.025,
+    "arrestor_length_m": 0.648,
+    "arrestor_wall_mm": 25.5,
+    "crossover_pressure_mpa": 15.238,
+    "governing_code": "DNV-ST-F101",
+    "length_basis": "2.0D screening length for integral arrestor section",
+    "pipe_wall_mm": 17.475,
+    "type": "integral buckle arrestor"
+  },
+  "case": {
+    "buckle_arrestors": "with",
+    "codes": [
+      "DNV-ST-F101",
+      "API-RP-1111"
+    ],
+    "geometry": {
+      "corrosion_allowance": 0.003,
+      "outer_diameter": 0.3239
+    },
+    "label": "12.75 in OD X65 export line, 1500 m water depth",
+    "loads": {
+      "internal_pressure": 15000000.0
+    },
+    "material": {
+      "grade": "X65",
+      "smts": 531000000.0,
+      "smys": 448000000.0
+    },
+    "pressure_basis": "design",
+    "water_depth_m": 1500.0
+  },
+  "external_pressure_mpa": 15.082875,
+  "external_pressure_pa": 15082875.0,
+  "load_premises": "burst/containment checked at p_i = design pressure with zero external pressure (route minimum); collapse and propagation checked for the empty line (p_i = 0) at full water depth",
+  "schema_version": 3,
+  "selection": {
+    "with_arrestors": {
+      "governing_check": "DNV-ST-F101 collapse",
+      "governing_utilisation": 0.629046,
+      "include_propagation": false,
+      "nonstandard_minimum_wall_mm": 14.909,
+      "selected_standard_label": "SCH 80",
+      "selected_standard_wall_in": 0.688,
+      "selected_standard_wall_mm": 17.475
+    },
+    "without_arrestors": {
+      "governing_check": "DNV-ST-F101 propagation_buckling",
+      "governing_utilisation": 0.718566,
+      "include_propagation": true,
+      "nonstandard_minimum_wall_mm": 25.408,
+      "selected_standard_label": "SCH 140",
+      "selected_standard_wall_in": 1.125,
+      "selected_standard_wall_mm": 28.575
+    }
+  },
+  "standard_walls": [
+    {
+      "label": "SCH 20",
+      "wall_in": 0.25,
+      "wall_mm": 6.35
+    },
+    {
+      "label": "SCH 30",
+      "wall_in": 0.33,
+      "wall_mm": 8.382
+    },
+    {
+      "label": "STD",
+      "wall_in": 0.375,
+      "wall_mm": 9.525
+    },
+    {
+      "label": "SCH 40",
+      "wall_in": 0.406,
+      "wall_mm": 10.312
+    },
+    {
+      "label": "XS",
+      "wall_in": 0.5,
+      "wall_mm": 12.7
+    },
+    {
+      "label": "SCH 60",
+      "wall_in": 0.562,
+      "wall_mm": 14.275
+    },
+    {
+      "label": "SCH 80",
+      "wall_in": 0.688,
+      "wall_mm": 17.475
+    },
+    {
+      "label": "SCH 100",
+      "wall_in": 0.844,
+      "wall_mm": 21.438
+    },
+    {
+      "label": "SCH 120 / XXS",
+      "wall_in": 1.0,
+      "wall_mm": 25.4
+    },
+    {
+      "label": "SCH 140",
+      "wall_in": 1.125,
+      "wall_mm": 28.575
+    },
+    {
+      "label": "SCH 160",
+      "wall_in": 1.312,
+      "wall_mm": 33.325
+    }
+  ],
+  "sweep": [
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 40.248686,
+            "combined_loading": 30.754708,
+            "pressure_containment": 2.164176,
+            "propagation_buckling": 115.716031
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 1.182421,
+            "collapse": 5.603551,
+            "propagation": 21.990455
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 20"
+      ],
+      "wall_thickness_in": 0.25,
+      "wall_thickness_mm": 6.35
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 9.863592,
+            "combined_loading": 7.536939,
+            "pressure_containment": 1.339619,
+            "propagation_buckling": 35.370916
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.890041,
+            "collapse": 2.525713,
+            "propagation": 11.294234
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 30"
+      ],
+      "wall_thickness_in": 0.33,
+      "wall_thickness_mm": 8.382
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 5.589319,
+            "combined_loading": 4.270894,
+            "pressure_containment": 1.101493,
+            "propagation_buckling": 21.855173
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.780399,
+            "collapse": 1.779745,
+            "propagation": 8.310271
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "STD"
+      ],
+      "wall_thickness_in": 0.375,
+      "wall_thickness_mm": 9.525
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 4.546691,
+            "combined_loading": 3.474204,
+            "pressure_containment": 1.025407,
+            "propagation_buckling": 18.334136
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.742207,
+            "collapse": 1.564471,
+            "propagation": 7.3942
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.3937,
+      "wall_thickness_mm": 10.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 4.001098,
+            "combined_loading": 3.057307,
+            "pressure_containment": 0.98081,
+            "propagation_buckling": 16.440503
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.719035,
+            "collapse": 1.444315,
+            "propagation": 6.8686
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 40"
+      ],
+      "wall_thickness_in": 0.406,
+      "wall_thickness_mm": 10.312
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 3.714599,
+            "combined_loading": 2.838389,
+            "pressure_containment": 0.955729,
+            "propagation_buckling": 15.429519
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.705738,
+            "collapse": 1.378809,
+            "propagation": 6.577136
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.4134,
+      "wall_thickness_mm": 10.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 3.076704,
+            "combined_loading": 2.350962,
+            "pressure_containment": 0.894761,
+            "propagation_buckling": 13.130479
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.672584,
+            "collapse": 1.226082,
+            "propagation": 5.882321
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.4331,
+      "wall_thickness_mm": 11.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 2.579609,
+            "combined_loading": 1.971123,
+            "pressure_containment": 0.840965,
+            "propagation_buckling": 11.283874
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.642313,
+            "collapse": 1.099349,
+            "propagation": 5.287086
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.4528,
+      "wall_thickness_mm": 11.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 2.186677,
+            "combined_loading": 1.670877,
+            "pressure_containment": 0.793147,
+            "propagation_buckling": 9.781361
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.614565,
+            "collapse": 0.993327,
+            "propagation": 4.773712
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.4724,
+      "wall_thickness_mm": 12.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.872207,
+            "combined_loading": 1.430585,
+            "pressure_containment": 0.750362,
+            "propagation_buckling": 8.544694
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.589036,
+            "collapse": 0.903954,
+            "propagation": 4.328198
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.4921,
+      "wall_thickness_mm": 12.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.764082,
+            "combined_loading": 1.347965,
+            "pressure_containment": 0.734483,
+            "propagation_buckling": 8.111034
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.579388,
+            "collapse": 0.872134,
+            "propagation": 4.166412
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "XS"
+      ],
+      "wall_thickness_in": 0.5,
+      "wall_thickness_mm": 12.7
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.617812,
+            "combined_loading": 1.236198,
+            "pressure_containment": 0.711856,
+            "propagation_buckling": 7.516325
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.565472,
+            "collapse": 0.82807,
+            "propagation": 3.939373
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.5118,
+      "wall_thickness_mm": 13.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.410117,
+            "combined_loading": 1.077494,
+            "pressure_containment": 0.677017,
+            "propagation_buckling": 6.653226
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.543653,
+            "collapse": 0.763195,
+            "propagation": 3.59824
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.5315,
+      "wall_thickness_mm": 13.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.239244,
+            "combined_loading": 0.946927,
+            "pressure_containment": 0.645345,
+            "propagation_buckling": 5.922756
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.523392,
+            "collapse": 0.707365,
+            "propagation": 3.297493
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.5512,
+      "wall_thickness_mm": 14.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.158201,
+            "combined_loading": 0.885001,
+            "pressure_containment": 0.629123,
+            "propagation_buckling": 5.568192
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.512854,
+            "collapse": 0.679933,
+            "propagation": 3.147085
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 60"
+      ],
+      "wall_thickness_in": 0.562,
+      "wall_thickness_mm": 14.275
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 1.097801,
+            "combined_loading": 0.838848,
+            "pressure_containment": 0.616427,
+            "propagation_buckling": 5.299818
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.504529,
+            "collapse": 0.659014,
+            "propagation": 3.031154
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.5709,
+      "wall_thickness_mm": 14.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.980189,
+            "combined_loading": 0.748979,
+            "pressure_containment": 0.589919,
+            "propagation_buckling": 4.764885
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.486923,
+            "collapse": 0.616883,
+            "propagation": 2.794294
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.5906,
+      "wall_thickness_mm": 15.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.88211,
+            "combined_loading": 0.674036,
+            "pressure_containment": 0.565532,
+            "propagation_buckling": 4.302595
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.470453,
+            "collapse": 0.579955,
+            "propagation": 2.582826
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.6102,
+      "wall_thickness_mm": 15.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.800209,
+            "combined_loading": 0.611453,
+            "pressure_containment": 0.54302,
+            "propagation_buckling": 3.900741
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.455012,
+            "collapse": 0.547402,
+            "propagation": 2.393333
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.6299,
+      "wall_thickness_mm": 16.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.731798,
+            "combined_loading": 0.559179,
+            "pressure_containment": 0.522176,
+            "propagation_buckling": 3.549532
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.440508,
+            "collapse": 0.518547,
+            "propagation": 2.22295
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.6496,
+      "wall_thickness_mm": 16.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.674649,
+            "combined_loading": 0.515511,
+            "pressure_containment": 0.502821,
+            "propagation_buckling": 3.241048
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.426856,
+            "collapse": 0.492835,
+            "propagation": 2.069254
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.6693,
+      "wall_thickness_mm": 17.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.629046,
+            "combined_loading": 0.480665,
+            "pressure_containment": 0.485673,
+            "propagation_buckling": 2.981667
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.414611,
+            "collapse": 0.4709,
+            "propagation": 1.936823
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 80"
+      ],
+      "wall_thickness_in": 0.688,
+      "wall_thickness_mm": 17.475
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.626852,
+            "combined_loading": 0.478988,
+            "pressure_containment": 0.484801,
+            "propagation_buckling": 2.968831
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.413985,
+            "collapse": 0.469806,
+            "propagation": 1.930189
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.689,
+      "wall_thickness_mm": 17.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.586731,
+            "combined_loading": 0.448331,
+            "pressure_containment": 0.467982,
+            "propagation_buckling": 2.727579
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.401828,
+            "collapse": 0.449078,
+            "propagation": 1.804003
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.7087,
+      "wall_thickness_mm": 18.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.552824,
+            "combined_loading": 0.422423,
+            "pressure_containment": 0.452249,
+            "propagation_buckling": 2.512906
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.390329,
+            "collapse": 0.430335,
+            "propagation": 1.689192
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.7283,
+      "wall_thickness_mm": 18.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.523891,
+            "combined_loading": 0.400314,
+            "pressure_containment": 0.437498,
+            "propagation_buckling": 2.321163
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.379435,
+            "collapse": 0.413309,
+            "propagation": 1.584465
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.748,
+      "wall_thickness_mm": 19.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.498911,
+            "combined_loading": 0.381226,
+            "pressure_containment": 0.423642,
+            "propagation_buckling": 2.149293
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.3691,
+            "collapse": 0.397778,
+            "propagation": 1.488703
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.7677,
+      "wall_thickness_mm": 19.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.477076,
+            "combined_loading": 0.364542,
+            "pressure_containment": 0.4106,
+            "propagation_buckling": 1.994726
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.359281,
+            "collapse": 0.383553,
+            "propagation": 1.400939
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.7874,
+      "wall_thickness_mm": 20.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.457759,
+            "combined_loading": 0.349781,
+            "pressure_containment": 0.398304,
+            "propagation_buckling": 1.855284
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.349941,
+            "collapse": 0.370473,
+            "propagation": 1.320328
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.8071,
+      "wall_thickness_mm": 20.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.440478,
+            "combined_loading": 0.336577,
+            "pressure_containment": 0.386691,
+            "propagation_buckling": 1.729117
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.341046,
+            "collapse": 0.358403,
+            "propagation": 1.246134
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.8268,
+      "wall_thickness_mm": 21.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.426721,
+            "combined_loading": 0.326065,
+            "pressure_containment": 0.377036,
+            "propagation_buckling": 1.62825
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.333595,
+            "collapse": 0.348567,
+            "propagation": 1.185902
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 100"
+      ],
+      "wall_thickness_in": 0.844,
+      "wall_thickness_mm": 21.438
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.424866,
+            "combined_loading": 0.324647,
+            "pressure_containment": 0.375706,
+            "propagation_buckling": 1.614642
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.332565,
+            "collapse": 0.347226,
+            "propagation": 1.177711
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.8465,
+      "wall_thickness_mm": 21.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.41064,
+            "combined_loading": 0.313777,
+            "pressure_containment": 0.365299,
+            "propagation_buckling": 1.510503
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.323894,
+            "collapse": 0.336843,
+            "propagation": 1.114491
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.8661,
+      "wall_thickness_mm": 22.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.397583,
+            "combined_loading": 0.3038,
+            "pressure_containment": 0.355425,
+            "propagation_buckling": 1.41553
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.316144,
+            "collapse": 0.327168,
+            "propagation": 1.055974
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.8858,
+      "wall_thickness_mm": 22.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.385523,
+            "combined_loading": 0.294585,
+            "pressure_containment": 0.346046,
+            "propagation_buckling": 1.328711
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.308731,
+            "collapse": 0.318127,
+            "propagation": 1.001715
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.9055,
+      "wall_thickness_mm": 23.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.374325,
+            "combined_loading": 0.286028,
+            "pressure_containment": 0.337124,
+            "propagation_buckling": 1.249168
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.301632,
+            "collapse": 0.309655,
+            "propagation": 0.951324
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.9252,
+      "wall_thickness_mm": 23.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.363878,
+            "combined_loading": 0.278045,
+            "pressure_containment": 0.328626,
+            "propagation_buckling": 1.176135
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.294828,
+            "collapse": 0.301697,
+            "propagation": 0.904449
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.9449,
+      "wall_thickness_mm": 24.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.354095,
+            "combined_loading": 0.27057,
+            "pressure_containment": 0.320524,
+            "propagation_buckling": 1.108943
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.288302,
+            "collapse": 0.294203,
+            "propagation": 0.860781
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.9646,
+      "wall_thickness_mm": 24.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.344901,
+            "combined_loading": 0.263545,
+            "pressure_containment": 0.31279,
+            "propagation_buckling": 1.047005
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.282035,
+            "collapse": 0.287131,
+            "propagation": 0.82004
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 0.9843,
+      "wall_thickness_mm": 25.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.337928,
+            "combined_loading": 0.258217,
+            "pressure_containment": 0.306852,
+            "propagation_buckling": 1.000888
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.2772,
+            "collapse": 0.281751,
+            "propagation": 0.789387
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 120 / XXS"
+      ],
+      "wall_thickness_in": 1.0,
+      "wall_thickness_mm": 25.4
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.336235,
+            "combined_loading": 0.256923,
+            "pressure_containment": 0.3054,
+            "propagation_buckling": 0.989804
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.276014,
+            "collapse": 0.280443,
+            "propagation": 0.781978
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.0039,
+      "wall_thickness_mm": 25.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.328045,
+            "combined_loading": 0.250665,
+            "pressure_containment": 0.298331,
+            "propagation_buckling": 0.936884
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.270224,
+            "collapse": 0.274105,
+            "propagation": 0.746372
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.0236,
+      "wall_thickness_mm": 26.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.320286,
+            "combined_loading": 0.244736,
+            "pressure_containment": 0.291563,
+            "propagation_buckling": 0.887842
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.264652,
+            "collapse": 0.268089,
+            "propagation": 0.713019
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.0433,
+      "wall_thickness_mm": 26.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.312921,
+            "combined_loading": 0.239109,
+            "pressure_containment": 0.285077,
+            "propagation_buckling": 0.842321
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.259286,
+            "collapse": 0.262369,
+            "propagation": 0.681739
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.063,
+      "wall_thickness_mm": 27.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.305917,
+            "combined_loading": 0.233756,
+            "pressure_containment": 0.278856,
+            "propagation_buckling": 0.800001
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.254114,
+            "collapse": 0.25692,
+            "propagation": 0.652368
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.0827,
+      "wall_thickness_mm": 27.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.299243,
+            "combined_loading": 0.228657,
+            "pressure_containment": 0.272884,
+            "propagation_buckling": 0.760599
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.249126,
+            "collapse": 0.251722,
+            "propagation": 0.624758
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.1024,
+      "wall_thickness_mm": 28.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.292876,
+            "combined_loading": 0.223791,
+            "pressure_containment": 0.267145,
+            "propagation_buckling": 0.723861
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.244313,
+            "collapse": 0.246756,
+            "propagation": 0.598775
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.122,
+      "wall_thickness_mm": 28.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.291945,
+            "combined_loading": 0.22308,
+            "pressure_containment": 0.266304,
+            "propagation_buckling": 0.718566
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.243605,
+            "collapse": 0.24603,
+            "propagation": 0.59501
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 140"
+      ],
+      "wall_thickness_in": 1.125,
+      "wall_thickness_mm": 28.575
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.286791,
+            "combined_loading": 0.219142,
+            "pressure_containment": 0.261628,
+            "propagation_buckling": 0.68956
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.239665,
+            "collapse": 0.242006,
+            "propagation": 0.574296
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.1417,
+      "wall_thickness_mm": 29.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.280968,
+            "combined_loading": 0.214693,
+            "pressure_containment": 0.256319,
+            "propagation_buckling": 0.657493
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.235174,
+            "collapse": 0.237456,
+            "propagation": 0.551212
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.1614,
+      "wall_thickness_mm": 29.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.275391,
+            "combined_loading": 0.210431,
+            "pressure_containment": 0.251206,
+            "propagation_buckling": 0.627475
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.230832,
+            "collapse": 0.233093,
+            "propagation": 0.52942
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.1811,
+      "wall_thickness_mm": 30.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.270041,
+            "combined_loading": 0.206343,
+            "pressure_containment": 0.246279,
+            "propagation_buckling": 0.599341
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.226632,
+            "collapse": 0.228904,
+            "propagation": 0.508829
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2008,
+      "wall_thickness_mm": 30.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.264905,
+            "combined_loading": 0.202419,
+            "pressure_containment": 0.241529,
+            "propagation_buckling": 0.572942
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.222567,
+            "collapse": 0.224879,
+            "propagation": 0.489354
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2205,
+      "wall_thickness_mm": 31.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.259969,
+            "combined_loading": 0.198647,
+            "pressure_containment": 0.236944,
+            "propagation_buckling": 0.548142
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.218631,
+            "collapse": 0.221006,
+            "propagation": 0.470919
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2402,
+      "wall_thickness_mm": 31.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.255221,
+            "combined_loading": 0.195019,
+            "pressure_containment": 0.232518,
+            "propagation_buckling": 0.52482
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.214817,
+            "collapse": 0.217277,
+            "propagation": 0.453452
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2598,
+      "wall_thickness_mm": 32.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.250649,
+            "combined_loading": 0.191525,
+            "pressure_containment": 0.228242,
+            "propagation_buckling": 0.502864
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.21112,
+            "collapse": 0.213682,
+            "propagation": 0.436889
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2795,
+      "wall_thickness_mm": 32.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.246244,
+            "combined_loading": 0.188159,
+            "pressure_containment": 0.224109,
+            "propagation_buckling": 0.482172
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.207534,
+            "collapse": 0.210215,
+            "propagation": 0.42117
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.2992,
+      "wall_thickness_mm": 33.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.243465,
+            "combined_loading": 0.186036,
+            "pressure_containment": 0.221495,
+            "propagation_buckling": 0.469357
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.205261,
+            "collapse": 0.208025,
+            "propagation": 0.41138
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": true,
+      "standard_labels": [
+        "SCH 160"
+      ],
+      "wall_thickness_in": 1.312,
+      "wall_thickness_mm": 33.325
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.241996,
+            "combined_loading": 0.184913,
+            "pressure_containment": 0.220111,
+            "propagation_buckling": 0.462654
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.204055,
+            "collapse": 0.206867,
+            "propagation": 0.406241
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.3189,
+      "wall_thickness_mm": 33.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.237896,
+            "combined_loading": 0.18178,
+            "pressure_containment": 0.216242,
+            "propagation_buckling": 0.444223
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.200678,
+            "collapse": 0.203632,
+            "propagation": 0.39205
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.3386,
+      "wall_thickness_mm": 34.0
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.233936,
+            "combined_loading": 0.178755,
+            "pressure_containment": 0.212496,
+            "propagation_buckling": 0.426805
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.197398,
+            "collapse": 0.200505,
+            "propagation": 0.378552
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.3583,
+      "wall_thickness_mm": 34.5
+    },
+    {
+      "codes": [
+        {
+          "checks": {
+            "collapse": 0.23011,
+            "combined_loading": 0.175831,
+            "pressure_containment": 0.208867,
+            "propagation_buckling": 0.410327
+          },
+          "code_label": "DNV-ST-F101"
+        },
+        {
+          "checks": {
+            "burst": 0.194211,
+            "collapse": 0.197479,
+            "propagation": 0.365702
+          },
+          "code_label": "API-RP-1111"
+        }
+      ],
+      "is_standard": false,
+      "standard_labels": [],
+      "wall_thickness_in": 1.378,
+      "wall_thickness_mm": 35.0
+    }
+  ],
+  "wall_grid_mm": [
+    6.35,
+    8.382,
+    9.525,
+    10.0,
+    10.312,
+    10.5,
+    11.0,
+    11.5,
+    12.0,
+    12.5,
+    12.7,
+    13.0,
+    13.5,
+    14.0,
+    14.275,
+    14.5,
+    15.0,
+    15.5,
+    16.0,
+    16.5,
+    17.0,
+    17.475,
+    17.5,
+    18.0,
+    18.5,
+    19.0,
+    19.5,
+    20.0,
+    20.5,
+    21.0,
+    21.438,
+    21.5,
+    22.0,
+    22.5,
+    23.0,
+    23.5,
+    24.0,
+    24.5,
+    25.0,
+    25.4,
+    25.5,
+    26.0,
+    26.5,
+    27.0,
+    27.5,
+    28.0,
+    28.5,
+    28.575,
+    29.0,
+    29.5,
+    30.0,
+    30.5,
+    31.0,
+    31.5,
+    32.0,
+    32.5,
+    33.0,
+    33.325,
+    33.5,
+    34.0,
+    34.5,
+    35.0
+  ]
+}

--- a/examples/workflows/wall-thickness-quickcheck/input.yml
+++ b/examples/workflows/wall-thickness-quickcheck/input.yml
@@ -1,0 +1,15 @@
+basename: wall_thickness
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+wall_thickness:
+  quickcheck:
+    cache: data/quickcheck_cache.json
+    output_html: results/wall_thickness_quickcheck.html
+    output_json: results/wall_thickness_quickcheck.json
+    output_csv: results/wall_thickness_quickcheck.csv

--- a/src/digitalmodel/asset_integrity/common/API579_components.py
+++ b/src/digitalmodel/asset_integrity/common/API579_components.py
@@ -20,21 +20,50 @@ class API579_components():
     def __init__(self, cfg):
         self.cfg = cfg
 
+    def _generate_plots(self):
+        return self.cfg.get("default", {}).get("config", {}).get(
+            "generate_plots", True
+        )
+
+    def _to_builtin(self, value):
+        if isinstance(value, dict):
+            return {key: self._to_builtin(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._to_builtin(item) for item in value]
+        if isinstance(value, tuple):
+            return [self._to_builtin(item) for item in value]
+        if isinstance(value, np.generic):
+            return value.item()
+        return value
+
+    def _inline_grid_to_dataframe(self, data):
+        grid = data["grid"]
+        values = grid["values"]
+        index = grid.get("index", list(range(len(values))))
+        columns = grid.get("columns", list(range(len(values[0]))))
+        return pd.DataFrame(values, index=index, columns=columns)
+
     def gml(self):
         import numpy as np
         import pandas as pd
 
         self.cfg['Result'] = {}
         self.cfg['Result']['Circumference'] = []
+        self.cfg['Result']['GML_MAWP'] = []
+        self.cfg['Result']['GML_Acceptable_FCA'] = []
 
         self.read_gml_grids()
 
         for fileIndex in range(0, len(self.gml_wt_grids)):
             df = self.gml_wt_grids[fileIndex]
-            self.prepare_contour_plot_gml(df, fileIndex)
+            if self._generate_plots():
+                self.prepare_contour_plot_gml(df, fileIndex)
 
             summary, GMLMAWPResults = self.API579GML(df, fileIndex)
             self.cfg['Result']['Circumference'].append(summary)
+            self.cfg['Result']['GML_MAWP'].append(
+                self._to_builtin(GMLMAWPResults)
+            )
 
             GMLMAWPResultsDF = pd.DataFrame.from_dict(GMLMAWPResults)
             FileName = self.cfg['Analysis']['result_folder'] + self.cfg[
@@ -44,11 +73,15 @@ class API579_components():
                 self.cfg['Design'][0]['InternalPressure']['Outer_Pipe'],
                 GMLMAWPResultsDF['MAWP'].iloc[::-1].values,
                 GMLMAWPResultsDF['FCA'].iloc[::-1].values)
+            self.cfg['Result']['GML_Acceptable_FCA'].append(
+                self._to_builtin(Acceptable_FCA)
+            )
             print("Acceptable GML FCA for design condition 1 is : {0}".format(
                 Acceptable_FCA))
 
-            self.plot_and_save_gml_results(Acceptable_FCA, GMLMAWPResultsDF,
-                                           fileIndex)
+            if self._generate_plots():
+                self.plot_and_save_gml_results(Acceptable_FCA, GMLMAWPResultsDF,
+                                               fileIndex)
 
         return self.cfg
 
@@ -199,6 +232,8 @@ class API579_components():
 
         LMLSummaryDFArray = []
         LMLFileNameArray = []
+        self.cfg.setdefault('Result', {})
+        self.cfg['Result']['LML'] = []
         for fileIndex in range(0, len(self.cfg['LML']['LTA'])):
             customdata = {
                 "io": self.cfg['LML']['LTA'][fileIndex]['io'],
@@ -207,10 +242,16 @@ class API579_components():
                 "skipfooter": self.cfg['LML']['LTA'][fileIndex]['skipfooter'],
                 "index_col": self.cfg['LML']['LTA'][fileIndex]['index_col']
             }
-            df = ExcelRead(customdata)
+            if self.cfg['LML']['LTA'][fileIndex].get('grid') is not None:
+                df = self._inline_grid_to_dataframe(
+                    self.cfg['LML']['LTA'][fileIndex]
+                )
+            else:
+                df = ExcelRead(customdata)
             df = df * self.cfg['LML']['LTA'][fileIndex]['DataCorrectionFactor']
             LMLResults = self.API579LML(df, self.cfg, fileIndex)
             LMLSummaryDF = pd.DataFrame.from_dict(LMLResults)
+            self.cfg['Result']['LML'].append(self._to_builtin(LMLResults))
             FileName = self.cfg['Analysis']['result_folder'] + self.cfg[
                 'Analysis']['file_name'] + 'Summary_LML_' + str(fileIndex)
             LMLFileNameArray.append('LML_' + str(fileIndex) + '_')
@@ -219,9 +260,10 @@ class API579_components():
                 index=LMLSummaryDF.columns.values)
             LMLSummaryDF = LMLSummaryDF.round(decimalArray)
             LMLSummaryDFArray.append(LMLSummaryDF)
-            DataFrame_To_Image(LMLSummaryDF,
-                               FileName + '_TBL' + '.png',
-                               col_width=1.0)
+            if self._generate_plots():
+                DataFrame_To_Image(LMLSummaryDF,
+                                   FileName + '_TBL' + '.png',
+                                   col_width=1.0)
             # LMLSummaryDF.to_csv(FileName + '_TBL' +'.csv')
             # DataFrame_To_xlsx(LMLSummaryDF, customdata)
             no_of_design_conditions = len(self.cfg['Design'])
@@ -306,7 +348,8 @@ class API579_components():
                         self.cfg['Analysis']['file_name'] + 'Summary_LML_' +
                         str(fileIndex) + '_PLT' + '.png'
                 }
-                plotCustom(LMLSummaryDF, customdata)
+                if self._generate_plots():
+                    plotCustom(LMLSummaryDF, customdata)
 
                 #  For plot without the MAWP
                 customdata = {
@@ -379,7 +422,8 @@ class API579_components():
                         self.cfg['Analysis']['file_name'] + 'Summary_LML_' +
                         str(fileIndex) + '_PLT1' + '.png'
                 }
-                plotCustom(LMLSummaryDF, customdata)
+                if self._generate_plots():
+                    plotCustom(LMLSummaryDF, customdata)
 
             #  Send LML Data to Excel Sheet
             customdata = {
@@ -391,7 +435,8 @@ class API579_components():
                 "thin_border":
                     True
             }
-            DataFrameArray_To_xlsx_openpyxl(LMLSummaryDFArray, customdata)
+            if self._generate_plots():
+                DataFrameArray_To_xlsx_openpyxl(LMLSummaryDFArray, customdata)
 
         return self.cfg
 
@@ -452,6 +497,16 @@ class API579_components():
             self.read_gml_grids_from_excel()
         elif self.cfg.default['Analysis']['GML']['data_source'] == 'simulated':
             self.read_gml_grids_from_simulations()
+        elif self.cfg.default['Analysis']['GML']['data_source'] == 'inline':
+            self.read_gml_grids_from_inline()
+
+    def read_gml_grids_from_inline(self):
+        self.gml_wt_grids = []
+        for fileIndex in range(0, len(self.cfg['ReadingSets'])):
+            df = self._inline_grid_to_dataframe(self.cfg['ReadingSets'][fileIndex])
+            df = df * self.cfg['ReadingSets'][fileIndex]['DataCorrectionFactor']
+            if len(df) > 0:
+                self.gml_wt_grids.append(df)
 
     def read_gml_grids_from_simulations(self):
         self.gml_wt_grids = []
@@ -668,6 +723,8 @@ class API579_components():
                     'data_source'] == 'simulated':
                 custom_grid_data = self.cfg['gml_simulated_grid'][
                     fileIndex].copy()
+            elif self.cfg.default['Analysis']['GML']['data_source'] == 'inline':
+                custom_grid_data = self.cfg['ReadingSets'][fileIndex].copy()
 
             file_name = self.cfg['Analysis']['result_folder'] + self.cfg[
                 'Analysis']['file_name'] + '_' + custom_grid_data[
@@ -795,6 +852,10 @@ class API579_components():
         dfLTA = df.iloc[sIndex0:sIndex1, cIndex0:cIndex1].copy()
         print(dfLTA)
 
+        source_label = Path(
+            cfg['LML']['LTA'][fileIndex].get('io')
+            or cfg['LML']['LTA'][fileIndex]['Label']
+        ).stem
         customdata = {
             "Index_Name":
                 'Length',
@@ -802,7 +863,7 @@ class API579_components():
                 'Circumference',
             "FileName":
                 self.cfg.Analysis['result_folder'] + '\\Plot\\Flaw_' +
-                Path(cfg['LML']['LTA'][fileIndex]['io']).stem + '_' +
+                source_label + '_' +
                 cfg['LML']['LTA'][fileIndex]['Label'],
             "PltSupTitle":
                 cfg['PlotSettings']['Data']['PltSupTitle'],
@@ -828,7 +889,8 @@ class API579_components():
         }
         # plotHeatMap(df, customdata)
 
-        plotContourf(dfLTA, customdata)
+        if self._generate_plots():
+            plotContourf(dfLTA, customdata)
 
         dfrd = df.copy()
         dfrd.iloc[sIndex0:sIndex1, cIndex0:cIndex1] = np.nan

--- a/src/digitalmodel/base_configs/modules/API579/API579.yml
+++ b/src/digitalmodel/base_configs/modules/API579/API579.yml
@@ -1,0 +1,23 @@
+basename: API579
+
+default:
+  Analysis:
+    GML:
+      data_source: inline
+      Circumference: true
+      Length: false
+      FCARate: Historical
+      FCA: [0.0, 0.04, 0.08]
+    LML: true
+    B31G: false
+  Units: inch
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+  settings:
+    StartWTFactor: 1
+    AssessmentLengthCeilingFactor_Circumference: null
+    AssessmentLengthCeilingFactor_Length: 1.0
+    CorrosionAllowance: 0.0

--- a/src/digitalmodel/base_configs/modules/wall_thickness/wall_thickness.yml
+++ b/src/digitalmodel/base_configs/modules/wall_thickness/wall_thickness.yml
@@ -1,0 +1,15 @@
+basename: wall_thickness
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+wall_thickness:
+  quickcheck:
+    cache: data/quickcheck_cache.json
+    output_html: results/wall_thickness_quickcheck.html
+    output_json: results/wall_thickness_quickcheck.json
+    output_csv: results/wall_thickness_quickcheck.csv

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -190,6 +190,20 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
     elif basename == "pipe_capacity":
         pc = PipeCapacity()
         cfg_base = pc.router(cfg_base)
+    elif basename == "wall_thickness":
+        from digitalmodel.structural.wall_thickness_quickcheck import (
+            WallThicknessQuickCheck,
+        )
+
+        wt = WallThicknessQuickCheck()
+        cfg_base = wt.router(cfg_base)
+    elif basename == "API579":
+        from digitalmodel.asset_integrity.API579 import API579
+
+        result_folder = cfg_base.get("Analysis", {}).get("result_folder")
+        if result_folder and not str(result_folder).endswith(os.sep):
+            cfg_base["Analysis"]["result_folder"] = f"{result_folder}{os.sep}"
+        cfg_base = API579(cfg_base)
     elif basename == "ct_hydraulics":
         ct_hydraulics = CTHydraulics()
         cfg_base = ct_hydraulics.router(cfg_base)

--- a/src/digitalmodel/structural/wall_thickness_quickcheck.py
+++ b/src/digitalmodel/structural/wall_thickness_quickcheck.py
@@ -1,0 +1,100 @@
+"""Engine runner for the wall-thickness quickcheck workflow."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_quickcheck_module():
+    module_path = (
+        _repo_root()
+        / "examples"
+        / "structural"
+        / "wall_thickness_quickcheck"
+        / "quick_check.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "digitalmodel_wall_thickness_quick_check", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load wall-thickness quickcheck: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve_path(config_dir: Path, value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return config_dir / path
+
+
+def _selection_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for branch, selection in payload["selection"].items():
+        rows.append(
+            {
+                "branch": branch,
+                "selected_standard_label": selection["selected_standard_label"],
+                "selected_standard_wall_mm": selection["selected_standard_wall_mm"],
+                "selected_standard_wall_in": selection["selected_standard_wall_in"],
+                "nonstandard_minimum_wall_mm": selection[
+                    "nonstandard_minimum_wall_mm"
+                ],
+                "governing_check": selection["governing_check"],
+                "governing_utilisation": selection["governing_utilisation"],
+            }
+        )
+    return rows
+
+
+def _write_selection_csv(payload: dict[str, Any], output_path: Path) -> None:
+    rows = _selection_rows(payload)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class WallThicknessQuickCheck:
+    """Thin adapter around the existing deckhand quickcheck scripts."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        config_dir = Path(cfg.get("_config_dir_path", Path.cwd()))
+        quickcheck_cfg = cfg.get("wall_thickness", {}).get("quickcheck", {})
+        cache_path = _resolve_path(config_dir, quickcheck_cfg["cache"])
+        html_path = _resolve_path(config_dir, quickcheck_cfg["output_html"])
+        json_path = _resolve_path(config_dir, quickcheck_cfg["output_json"])
+        csv_path = _resolve_path(config_dir, quickcheck_cfg["output_csv"])
+
+        quick_check = _load_quickcheck_module()
+        payload = quick_check.run_from_cache(cache_path)
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        quick_check.write_report(payload, html_path)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _write_selection_csv(payload, csv_path)
+
+        cfg.setdefault("wall_thickness", {})
+        cfg["wall_thickness"]["quickcheck"] = {
+            **quickcheck_cfg,
+            "report_html": str(html_path),
+            "result_json": str(json_path),
+            "result_csv": str(csv_path),
+            "selection": payload["selection"],
+            "buckle_arrestor_sizing": payload["buckle_arrestor_sizing"],
+        }
+        return cfg

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -86,5 +86,47 @@ def test_workflow_registry(workflow):
             pytest.approx(0.236)
         )
         assert result["usage_factor_ultimate_check"]["usage_equivalent"] < 1
+    elif workflow["id"] == "wall-thickness-quickcheck":
+        result = cfg["wall_thickness"]["quickcheck"]
+        selection = result["selection"]["with_arrestors"]
+        assert selection["selected_standard_label"] == "SCH 80"
+        assert selection["selected_standard_wall_mm"] == pytest.approx(17.475)
+        assert selection["nonstandard_minimum_wall_mm"] == pytest.approx(14.909)
+        assert selection["governing_check"] == "DNV-ST-F101 collapse"
+        assert selection["governing_utilisation"] == pytest.approx(0.629046)
+        arrestor = result["buckle_arrestor_sizing"]
+        assert arrestor["arrestor_wall_mm"] == pytest.approx(25.5)
+    elif workflow["id"] == "api579-pipe-ffs-b314":
+        gml = cfg["Result"]["Circumference"][0]
+        gml_mawp = cfg["Result"]["GML_MAWP"][0][0]
+        lml = cfg["Result"]["LML"][0][0]
+        assert gml["Min WT (inch)"] == pytest.approx(0.312)
+        assert gml["Avg. WT (inch)"] == pytest.approx(0.329727273)
+        assert gml_mawp["MAWP"] == pytest.approx(930.994652)
+        assert cfg["Result"]["GML_Acceptable_FCA"][0] == pytest.approx(0.06)
+        assert lml["MAWP"] == pytest.approx(970.588235)
+        assert lml["RSF, L2"] == pytest.approx(1.0)
+        assert lml["RSF, L2"] >= cfg["API579Parameters"]["RSFa"]
+        assert lml["MAWPr, L2"] == pytest.approx(970.588235)
+        # The FFS verdict: measured-lattice MAWP must cover the design pressure
+        design_pressure = cfg["Design"][0]["InternalPressure"]["Outer_Pipe"]
+        assert gml_mawp["MAWP"] >= design_pressure
+        assert lml["MAWPr, L2"] >= design_pressure
+    elif workflow["id"] == "api579-pipe-ffs-b318":
+        gml = cfg["Result"]["Circumference"][0]
+        gml_mawp = cfg["Result"]["GML_MAWP"][0][0]
+        lml = cfg["Result"]["LML"][0][0]
+        assert gml["Min WT (inch)"] == pytest.approx(0.548)
+        assert gml["Avg. WT (inch)"] == pytest.approx(0.584454545)
+        assert gml_mawp["MAWP"] == pytest.approx(3548.686981)
+        assert cfg["Result"]["GML_Acceptable_FCA"][0] == pytest.approx(0.16)
+        assert lml["MAWP"] == pytest.approx(3726.454203)
+        assert lml["RSF, L2"] == pytest.approx(1.0)
+        assert lml["RSF, L2"] >= cfg["API579Parameters"]["RSFa"]
+        assert lml["MAWPr, L2"] == pytest.approx(3726.454203)
+        # The FFS verdict: measured-lattice MAWP must cover the design pressure
+        design_pressure = cfg["Design"][0]["InternalPressure"]["Outer_Pipe"]
+        assert gml_mawp["MAWP"] >= design_pressure
+        assert lml["MAWPr, L2"] >= design_pressure
     else:
         raise AssertionError(f"Missing workflow assertion for {workflow['id']}")


### PR DESCRIPTION
Part of #711 (registry v2), lane A. Operator contract encoded: API 579 workflows take a **wall-thickness measurement lattice** (inline CML grid) and check it **against design pressure** — tests assert `MAWP >= design pressure` (GML and LML) as the first-class FFS verdict, alongside pinned MAWP/FCA/RSF values.

## New registry workflows (offline, `uv run python -m digitalmodel <input.yml>`)
- **wall-thickness-quickcheck** — multi-code WT solve via new `wall_thickness` basename (thin runner over the existing quickcheck logic, offline from-cache, HTML report). Pinned: governing DNV-ST-F101 collapse, SCH 80 / 17.475 mm, U=0.629046, arrestor wall 25.5 mm. This restores the deckhand pipeline subdomain's flagship EXECUTE leg under the module-only contract (deckhand#275).
- **api579-pipe-ffs-b314** — 12in X65 B31.4 pipe, 6×6 measurement lattice: GML min WT 0.312 in, GML MAWP 930.99 psi vs design 285 psi (PASS), acceptable FCA 0.06 in, LML MAWPr 970.59 psi.
- **api579-pipe-ffs-b318** — 16in B31.8: GML MAWP 3548.69 psi, acceptable FCA 0.16 in, LML MAWPr 3726.45 psi (PASS vs design).

`API579` had NO engine route before this PR despite a production FFS engine and existing test configs.

## Verification (hand-verified via real uv outside the codex sandbox)
- All three workflows exit 0 via module CLI (wall-thickness takes ~1m47s wall; earlier apparent hangs were uv cache-lock contention between parallel lanes, not the workflow).
- `tests/workflows/` 345 passed · `tests/contracts/` 17 passed · `tests/asset_integrity/` 310 passed, 8 skipped.
- Fracture-mechanics stretch NOT onboarded: the asset-integrity route fails on missing package default data files (`src/digitalmodel/asset_integrity/tests/test_data/`) — needs a data-packaging fix first; noted for a later lane.

Merge-order note: lanes A/B/D all append to engine.py + the registry; merge any order, later ones rebase. Lane B = PR #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)