### PR TITLE
fix(cli): route python -m digitalmodel subcommands to console-script CLIs (#713)

### DIFF
--- a/src/digitalmodel/__main__.py
+++ b/src/digitalmodel/__main__.py
@@ -3,7 +3,15 @@
 Usage:
 ------
 
+Run an analysis from an input file (the engine contract)::
 
+    python -m digitalmodel <input.yml>
+
+or invoke any of the package's console-script CLIs through the module
+entry point (#713)::
+
+    python -m digitalmodel diffraction run-orcawave spec.yml --dry-run
+    python -m digitalmodel aqwa --help
 
 Contact:
 --------
@@ -20,10 +28,44 @@ Version:
 - digitalmodel v0.0.9
 """
 
+import sys
+from importlib import metadata
+from pathlib import Path
+
 from digitalmodel.engine import engine
+
+# Entry points that would re-enter this module rather than dispatch to a CLI.
+_SELF_NAMES = {"digital_model", "digitalmodel"}
+
+
+def _resolve_cli(name: str):
+    """Return this distribution's console-script entry point called ``name``.
+
+    Looks up ``[project.scripts]`` via package metadata so the routing table
+    cannot drift from pyproject.toml. Returns None for unknown names, for
+    this module's own entry point, or when distribution metadata is
+    unavailable — callers then fall through to the engine contract.
+    """
+    if name in _SELF_NAMES:
+        return None
+    try:
+        entry_points = metadata.distribution("digitalmodel").entry_points
+    except metadata.PackageNotFoundError:
+        return None
+    for entry_point in entry_points:
+        if entry_point.group == "console_scripts" and entry_point.name == name:
+            return entry_point
+    return None
 
 
 def main():
+    # An existing file always wins: `python -m digitalmodel <input.yml>` is
+    # the engine contract and must stay unchanged (durable-workflow callers).
+    if len(sys.argv) > 1 and not Path(sys.argv[1]).exists():
+        entry_point = _resolve_cli(sys.argv[1])
+        if entry_point is not None:
+            sys.argv = sys.argv[1:]
+            sys.exit(entry_point.load()())
     engine()
 
 

--- a/tests/test_main_module_routing.py
+++ b/tests/test_main_module_routing.py
@@ -1,0 +1,60 @@
+"""Tests for `python -m digitalmodel <subcommand>` routing (#713).
+
+The module entry point must dispatch known console-script CLIs while leaving
+the engine input-yml contract untouched: an existing file path as argv[1]
+always goes to engine(), and unknown non-file arguments keep today's engine
+behavior.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from digitalmodel.__main__ import _resolve_cli, main
+
+
+class TestResolveCli:
+    def test_known_console_script_resolves(self):
+        entry_point = _resolve_cli("diffraction")
+        assert entry_point is not None
+        assert entry_point.value == "digitalmodel.hydrodynamics.diffraction.cli:cli"
+
+    def test_unknown_name_returns_none(self):
+        assert _resolve_cli("definitely-not-a-cli") is None
+
+    def test_own_entry_point_is_not_dispatched(self):
+        assert _resolve_cli("digital_model") is None
+        assert _resolve_cli("digitalmodel") is None
+
+
+class TestMainRouting:
+    def test_known_subcommand_dispatches(self):
+        with patch.object(sys, "argv", ["digitalmodel", "diffraction", "--help"]):
+            with patch("digitalmodel.__main__.engine") as mock_engine:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+        assert exc_info.value.code == 0
+        mock_engine.assert_not_called()
+
+    def test_existing_file_goes_to_engine(self, tmp_path):
+        input_file = tmp_path / "diffraction"  # file named like a CLI still wins
+        input_file.write_text("basename: test\n")
+        with patch.object(sys, "argv", ["digitalmodel", str(input_file)]):
+            with patch("digitalmodel.__main__.engine") as mock_engine:
+                main()
+        mock_engine.assert_called_once()
+
+    def test_unknown_non_file_arg_keeps_engine_contract(self):
+        with patch.object(sys, "argv", ["digitalmodel", "no-such-thing.yml"]):
+            with patch("digitalmodel.__main__.engine") as mock_engine:
+                main()
+        mock_engine.assert_called_once()
+
+    def test_no_args_goes_to_engine(self):
+        with patch.object(sys, "argv", ["digitalmodel"]):
+            with patch("digitalmodel.__main__.engine") as mock_engine:
+                main()
+        mock_engine.assert_called_once()


### PR DESCRIPTION
Closes #713 (option 1 from the issue, as flagged in the claim comment).

## What

`python -m digitalmodel <name>` now resolves `<name>` against the distribution's own `[project.scripts]` entry points (via `importlib.metadata` — no static registry to drift from pyproject) and dispatches to that CLI. Precedence rules keep both contracts intact:

1. **Existing file path always wins** → `engine()` (the durable-workflow input-yml contract), even for a file literally named `diffraction`.
2. Known console-script name → dispatched with remaining argv.
3. Unknown non-file argument → `engine()` exactly as today.
4. `digital_model`/`digitalmodel` are excluded from dispatch (no self-recursion).

## Verification (ace-linux-2)

- The originally-failing command now works end-to-end:
  `uv run python -m digitalmodel diffraction run-orcawave .../acceptance_610/spec.yml --dry-run` → `[DRY_RUN]`, 9 modular files, 1 mesh copied, exit 0
- Engine contract spot-check: `python -m digitalmodel no-such-input.yml` still raises the same `FileNotFoundError`
- New tests: `tests/test_main_module_routing.py` — **7 passed** (resolution, dispatch, file-wins precedence, unknown-arg fallthrough, no-args)
- `tests/test_engine.py` + `tests/test_engine_isolated.py`: **10 failed / 54 passed / 1 skipped — byte-identical to unmodified main** (pre-existing red engine baseline; verified by stash/rerun/pop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)