### PR TITLE
feat(orcaflex): M-shaped jumper library specs from published geometries (#722)

### DIFF
--- a/docs/domains/orcaflex/MODEL_CLAIM_INVENTORY.yaml
+++ b/docs/domains/orcaflex/MODEL_CLAIM_INVENTORY.yaml
@@ -35,7 +35,7 @@
 #       blocked_on: <optional — what's blocking the proof>
 
 schema_version: "1.0.0"
-last_updated: "2026-05-11"
+last_updated: "2026-06-12"
 purpose: "inventory_not_claim"
 
 inventory:
@@ -67,14 +67,54 @@ inventory:
       Companion to c06_calm_buoy. The #2472 plan focuses on CALM buoys;
       SPM-specific proof remains TBD.
 
+  # --------------------------------------------------------------------
+  # Literature-derived M-shaped jumper family (digitalmodel #722).
+  # Geometry from published sources; spec headers carry per-dimension
+  # stated-vs-assumed provenance. L1 enforced by
+  # tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py.
+  # L2/L3 proof = published natural frequencies (recorded in spec headers)
+  # vs licensed OrcaFlex modal/statics runs — #718/#719 sitting.
+  # --------------------------------------------------------------------
+
+  - name: mj01_exxonmobil_m_jumper_viv
+    family: jumper
+    builder_track: generic
+    proof_plan: "digitalmodel issue #722"
+    blocked_on: "L2/L3 require licensed OrcaFlex (modal comparison vs measured 0.863/2.149/2.194/2.542 Hz)"
+    notes: |
+      ExxonMobil M-jumper VIV towing-tank benchmark (Wang OMAE2013 /
+      Zheng OMAE2015; dimensions from Igeh UiS MSc thesis 2017, CC-BY).
+      Only published M-jumper with full dimension chain AND measured
+      multi-speed/multi-heading VIV response.
+
+  - name: mj02_zhu2022_m_jumper_fullscale
+    family: jumper
+    builder_track: generic
+    proof_plan: "digitalmodel issue #722"
+    blocked_on: "L2/L3 require licensed OrcaFlex (out-of-plane f1 ~ 1.464 Hz target)"
+    notes: |
+      Full-scale gas-oil M-jumper slug FIV case (Zhu et al. 2022,
+      Processes 10:2133). Only full-scale published M geometry with
+      explicit dimensions including bend radii; pipe size near-identical
+      to Ballymore 10.75in jumpers.
+
+  - name: mj03_li2024_m_jumper_lab
+    family: jumper
+    builder_track: generic
+    proof_plan: "digitalmodel issue #722"
+    blocked_on: "L2/L3 require licensed OrcaFlex (13 tabulated modes, f1=8.520 Hz target)"
+    notes: |
+      Lab-scale M-jumper combined internal/external flow case (Li et al.
+      2024, JMSE 12:1261). Geometry resolved from paper Figure 1 +
+      Table 1 ("total length" is the X-envelope, not arc length — see
+      spec header).
+
 # Roll-up:
-#   Total entries: 3
-#   By family: 1 riser, 1 buoy, 1 mooring
-#   By builder_track: 1 riser, 2 generic
-#   All entries have proof_plan references but no test_enforcing path.
+#   Total entries: 6
+#   By family: 1 riser, 1 buoy, 1 mooring, 3 jumper
+#   By builder_track: 1 riser, 5 generic
 #
 # Coverage gap (informational): MODEL_CLAIM_REGISTRY.yaml lists 3 attested
-# L1 entries; this inventory lists 3 pending. Together they describe 6 of
-# 20 model_library/ directories (30%). The remaining 14 models are not
-# inventoried here — adding them would imply intent-to-prove, which has
-# not been established.
+# L1 entries; this inventory lists 6 pending. The remaining model_library/
+# directories are not inventoried here — adding them would imply
+# intent-to-prove, which has not been established.

--- a/docs/domains/orcaflex/library/model_library/README.md
+++ b/docs/domains/orcaflex/library/model_library/README.md
@@ -1,0 +1,36 @@
+# OrcaFlex Model Library
+
+Each subdirectory is one model: a `spec.yml` (the high-level, human-authored
+source of truth consumed by the modular generator) and, for models extracted
+from existing OrcaFlex files, `modular/` and `monolithic/` reference outputs.
+
+**Claim status** — what each model is *proven* to do — lives in
+[`../../MODEL_CLAIM_REGISTRY.yaml`](../../MODEL_CLAIM_REGISTRY.yaml)
+(attested claims, enforced by tests) and
+[`../../MODEL_CLAIM_INVENTORY.yaml`](../../MODEL_CLAIM_INVENTORY.yaml)
+(pending entries). Directory presence alone implies **no** claim: L1 =
+validator-clean YAML generation, L2 = loads in licensed OrcaFlex, L3 =
+statics/dynamics run without errors.
+
+## Naming
+
+- `a*`–`e*` prefixes follow the Orcina example lettering for models extracted
+  from the standard OrcaFlex example set.
+- `mj*` — M-shaped jumper models reconstructed from published literature
+  (digitalmodel [#722](https://github.com/vamseeachanta/digitalmodel/issues/722)).
+
+## Literature-derived models
+
+Geometry provenance, stated-vs-inferred confidence flags, and published
+dynamic responses (the L2/L3 validation targets) for the `mj*` family are
+documented in the
+[M-shaped jumper literature geometry survey](../../subsea/jumper/m_shaped/LITERATURE_GEOMETRY_SURVEY.md).
+
+| Model | Source | Scale | Validation targets |
+|-------|--------|-------|--------------------|
+| `mj01_exxonmobil_m_jumper_viv` | Wang OMAE2013 / Zheng OMAE2015 / Igeh UiS 2017 | model (1:~4.5 of 10″ FS) | measured modes 0.863/2.149/2.194/2.542 Hz; VIV response 0.05–1.24 m/s |
+| `mj02_zhu2022_m_jumper_fullscale` | Zhu et al. 2022, *Processes* 10:2133 | full scale (OD 270 mm) | out-of-plane f₁ ≈ 1.464 Hz; slug-FIV lock-in at 2.5 Hz |
+| `mj03_li2024_m_jumper_lab` | Li et al. 2024, *JMSE* 12:1261 | lab (OD 60 mm) | 13 tabulated modes, f₁ = 8.520 Hz |
+
+L1 regression for the `mj*` family:
+`tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py`.

--- a/docs/domains/orcaflex/library/model_library/mj01_exxonmobil_m_jumper_viv/spec.yml
+++ b/docs/domains/orcaflex/library/model_library/mj01_exxonmobil_m_jumper_viv/spec.yml
@@ -1,0 +1,201 @@
+# M-shaped rigid jumper — ExxonMobil VIV model test (industry benchmark)
+#
+# Provenance (see docs/domains/orcaflex/subsea/jumper/m_shaped/LITERATURE_GEOMETRY_SURVEY.md
+# Case 1, and digitalmodel issue #722):
+#   - Wang et al., "VIV Response of a Subsea Jumper in Uniform Current", OMAE2013 V04BT04A043
+#   - Zheng et al., "Numerical Analysis of Experimental Data of Subsea Jumper VIV", OMAE2015
+#   - Igeh, "VIV Fatigue Investigation for Subsea Planar Rigid Spools and Jumpers",
+#     MSc thesis, Univ. of Stavanger 2017 (CC-BY), Tables 1-4 — dimension source:
+#     https://core.ac.uk/download/249952931.pdf
+#
+# Model-scale planar M jumper, 7 welded segments, both ends fully clamped.
+# Segment chain (Igeh Table 1, explicit): V1 1.495 | H1 1.000 | V2 2.323 |
+# H2 4.327 | V3 2.326 | H3 1.000 | V4 1.495  (total 13.966 m)
+#
+# Validation targets (measured, towing tank): natural frequencies
+# f1=0.863 Hz, f2=2.149 Hz, f3=2.194 Hz, f4=2.542 Hz; mode 3 first excited
+# at tow speed ~0.18 m/s. Tow speeds 0.05-1.241 m/s at 10/45/90 deg.
+#
+# Modeling assumptions (NOT from source — flagged per #722):
+#   A1: corner bend radii not published; sharp corners (source FEM did the same)
+#   A2: towing-tank water depth not published; 10 m assumed, jumper hubs at z=-9
+#   A3: spline statics starting shape control points at corner coordinates;
+#       licensed statics refinement is #718/#719 scope
+# Derived (not verbatim from source): mass_per_length and axial_stiffness
+# computed from published OD/ID/rho/E; consistency check: structural+contents
+# mass ratio reproduces published m*=2.33.
+
+metadata:
+  name: mj01_exxonmobil_m_jumper_viv
+  description: ExxonMobil M-jumper VIV towing-tank benchmark (Wang OMAE2013 / Igeh UiS 2017)
+  structure: jumper
+  operation: generic
+  project: model_library
+
+environment:
+  water:
+    depth: 10.0        # A2: assumed (towing tank depth not published)
+    density: 1.025
+  seabed:
+    slope: 0
+    stiffness:
+      normal: 100
+      shear: 100
+  waves:
+    type: airy
+    height: 0.0        # still water — VIV test under tow/current only
+    period: 8
+    direction: 0
+  current:
+    direction: 0       # tow speed sweep applied per-run (0.05-1.241 m/s)
+  wind:
+    speed: 0
+    direction: 0
+
+generic:
+  line_types:
+    - name: mj01_jumper_pipe_aluminium
+      category: General
+      outer_diameter: 0.0605          # m (published)
+      inner_diameter: 0.055           # m (published; WT 2.77 mm)
+      mass_per_length: 0.0013471      # te/m — derived: A=4.9893e-4 m2 x 2.70 te/m3
+      bending_stiffness:              # EI = 1.44e4 N.m2 (published) = 14.4 kN.m2
+        - 14.4
+        - ~
+      axial_stiffness: 34426.0        # kN — derived: E=6.90e10 Pa x A
+      properties:
+        BulkModulus: Infinity
+        CompressionIsLimited: false
+        PoissonRatio: 0.33
+        ExpansionTable: None
+        GJ: 10.8                      # kN.m2 — published 1.08e4 N.m2
+        TensionTorqueCoupling: 0
+        ClashStiffness: 0
+        Ca:                           # added mass coefficient (published Ca=1.0)
+          - 1.0
+          - ~
+          - 0
+        Cd:                           # drag coefficient (published Cd=1.1, drag dia 0.0605)
+          - 1.1
+          - ~
+          - 0.008
+        Cl: 0
+        SeabedLateralFrictionCoefficient: 0.5
+        SeabedAxialFrictionCoefficient: ~
+        RayleighDampingCoefficients: (no damping)
+
+  lines:
+    - name: mj01_m_jumper
+      line_type_refs:
+        - mj01_jumper_pipe_aluminium
+      properties:
+        IncludeTorsion: true          # torsional fatigue significant (Liu et al. 2020)
+        TopEnd: End A
+        LengthAndEndOrientations: Explicit
+        Representation: Finite element
+        DragFormulation: Standard
+        StaticsVIV: None
+        DynamicsVIV: None
+        WaveCalculationMethod: Specified by environment
+        # Both ends fully clamped at hub elevations (test: force dynamometers,
+        # built-in ends). End A at origin; End B 6.327 m along X, +0.003 m
+        # closure from the published 3 mm V2/V3 asymmetry.
+        ? Connection, ConnectionX, ConnectionY, ConnectionZ, ConnectionAzimuth,
+          ConnectionDeclination, ConnectionGamma, ConnectionReleaseStage, ConnectionzRelativeTo
+        : - - Fixed
+            - 0.0
+            - 0.0
+            - -9.0
+            - 0
+            - 0          # line leaves End A vertically up (V1)
+            - 0
+            - ~
+            - ~
+          - - Fixed
+            - 6.327
+            - 0.0
+            - -8.997
+            - 0
+            - 180        # line arrives at End B vertically down (V4)
+            - 0
+            - ~
+            - ~
+        ConnectionxBendingStiffness, ConnectionyBendingStiffness:
+          - - Infinity
+            - ~
+          - - Infinity
+            - ~
+        # One section per published segment — dimension chain traceable to
+        # Igeh Table 1 (V1 H1 V2 H2 V3 H3 V4).
+        LineType, Length, TargetSegmentLength:
+          - - mj01_jumper_pipe_aluminium
+            - 1.495
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 1.0
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 2.323
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 4.327
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 2.326
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 1.0
+            - 0.1
+          - - mj01_jumper_pipe_aluminium
+            - 1.495
+            - 0.1
+        ContentsMethod: Uniform
+        IncludeAxialContentsInertia: true
+        # Equivalent internal-fluid density used in the source VIVANA FEM
+        # (SG 1.4 fluid + distributed lead ballast): 2328.45 kg/m3.
+        # Consistency: contents 5.532 kg/m + aluminium 1.347 kg/m = 6.879 kg/m
+        # vs displaced 2.947 kg/m -> m* = 2.334 (published mass ratio: 2.33).
+        ContentsDensity: 2.32845
+        ContentsTemperature: ~
+        ContentsPressureRefZ: ~
+        ContentsPressure: 0
+        ContentsFlowRate: 0
+        IncludedInStatics: true
+        StaticsStep1: Spline
+        StaticsStep2: Full statics
+        StaticsSeabedFrictionPolicy: None
+        AsLaidTension: 0
+        SplineOrder: 3
+        # M-shape corner coordinates (A3): hubs z=-9, shoulders z=-7.505/-7.502,
+        # mid-span dip z=-9.828.
+        SplineControlPointX, SplineControlPointY, SplineControlPointZ:
+          - - 0.0
+            - 0.0
+            - -9.0
+          - - 0.0
+            - 0.0
+            - -7.505
+          - - 1.0
+            - 0.0
+            - -7.505
+          - - 1.0
+            - 0.0
+            - -9.828
+          - - 5.327
+            - 0.0
+            - -9.828
+          - - 5.327
+            - 0.0
+            - -7.502
+          - - 6.327
+            - 0.0
+            - -7.502
+          - - 6.327
+            - 0.0
+            - -8.997
+
+simulation:
+  time_step: 0.01
+  stages:
+    - 10.0
+    - 60.0

--- a/docs/domains/orcaflex/library/model_library/mj02_zhu2022_m_jumper_fullscale/spec.yml
+++ b/docs/domains/orcaflex/library/model_library/mj02_zhu2022_m_jumper_fullscale/spec.yml
@@ -1,0 +1,219 @@
+# M-shaped rigid jumper — full-scale gas-oil production jumper (Zhu et al. 2022)
+#
+# Provenance (see docs/domains/orcaflex/subsea/jumper/m_shaped/LITERATURE_GEOMETRY_SURVEY.md
+# Case 2, and digitalmodel issue #722):
+#   - Zhu, Hu, Tang, Ji, Zhou, "Evolution of Gas-Liquid Two-Phase Flow in an
+#     M-Shaped Jumper and the Resultant Flow-Induced Vibration Response",
+#     Processes 10(10):2133, 2022 (open access):
+#     https://www.mdpi.com/2227-9717/10/10/2133
+#
+# Full-scale planar M, 6 bends (Table 1 of paper, all explicit):
+#   inlet/outlet verticals L1 = 4 m | top horizontals L2 = 3 m |
+#   inner verticals L3 = 6 m | bottom horizontal L4 = 10 m |
+#   bend radius R = 2D = 0.54 m
+# Corner-to-corner chain: 4 | 3 | 6 | 10 | 6 | 3 | 4 (36 m); centerline arc
+# length with 6 x 90 deg bends = 36 - 6*(2*0.54) + 6*(pi/2*0.54) = 34.609 m.
+# Pipe size near-identical to Ballymore 10.75in jumpers (OD 0.273 m).
+#
+# Validation targets (computed, two-way FSI): fundamental out-of-plane
+# f1 ~ 1.464 Hz; FIV response locked to 2.5 Hz slug frequency; max structural
+# stress at Bend 5, max pressure stress at Bend 3.
+#
+# Modeling assumptions (NOT from source — flagged per #722):
+#   A1: water depth not published; 100 m assumed, jumper flanges at z=-95
+#       (mid-span dip 3 m above seabed)
+#   A2: end fixity assumed clamped (flanged connections to subsea equipment)
+#   A3: drag/added-mass coefficients not published (paper is internal-flow
+#       FIV); Cd=1.2 / Ca=1.0 standard bare-pipe values assumed
+#   A4: contents density not tabulated (gas-oil multiphase at 6 MPa);
+#       ContentsDensity 0 placeholder — set per analysis load case
+# Derived (not verbatim): mass_per_length, EA, EI, GJ computed from published
+# OD/ID, steel rho 7.85 te/m3, E=2.068e11 Pa, nu=0.303.
+
+metadata:
+  name: mj02_zhu2022_m_jumper_fullscale
+  description: Full-scale M-jumper gas-oil slug FIV case (Zhu et al. 2022, Processes 10:2133)
+  structure: jumper
+  operation: generic
+  project: model_library
+
+environment:
+  water:
+    depth: 100.0       # A1: assumed (not published)
+    density: 1.025
+  seabed:
+    slope: 0
+    stiffness:
+      normal: 100
+      shear: 100
+  waves:
+    type: airy
+    height: 0.0        # still water — internal slug FIV case
+    period: 8
+    direction: 0
+  current:
+    direction: 0
+  wind:
+    speed: 0
+    direction: 0
+
+generic:
+  line_types:
+    - name: mj02_jumper_pipe_steel
+      category: General
+      outer_diameter: 0.27            # m (published)
+      inner_diameter: 0.21            # m (published; WT 30 mm)
+      mass_per_length: 0.17756        # te/m — derived: A=2.26195e-2 m2 x 7.85 te/m3
+      bending_stiffness:              # EI — derived: E=2.068e11 Pa x I=1.65416e-4 m4
+        - 34208.0
+        - ~
+      axial_stiffness: 4677700.0      # kN — derived: E x A
+      properties:
+        BulkModulus: Infinity
+        CompressionIsLimited: false
+        PoissonRatio: 0.303           # published
+        ExpansionTable: None
+        GJ: 26253.0                   # kN.m2 — derived: G=E/2(1+nu) x J=2I
+        TensionTorqueCoupling: 0
+        ClashStiffness: 0
+        Ca:                           # A3: assumed
+          - 1.0
+          - ~
+          - 0
+        Cd:                           # A3: assumed
+          - 1.2
+          - ~
+          - 0.008
+        Cl: 0
+        SeabedLateralFrictionCoefficient: 0.5
+        SeabedAxialFrictionCoefficient: ~
+        RayleighDampingCoefficients: (no damping)
+
+  lines:
+    - name: mj02_m_jumper
+      line_type_refs:
+        - mj02_jumper_pipe_steel
+      properties:
+        IncludeTorsion: false
+        TopEnd: End A
+        LengthAndEndOrientations: Explicit
+        Representation: Finite element
+        DragFormulation: Standard
+        StaticsVIV: None
+        DynamicsVIV: None
+        WaveCalculationMethod: Specified by environment
+        # A2: both ends clamped at flange elevations. End A at origin,
+        # End B 16 m along X (overall span).
+        ? Connection, ConnectionX, ConnectionY, ConnectionZ, ConnectionAzimuth,
+          ConnectionDeclination, ConnectionGamma, ConnectionReleaseStage, ConnectionzRelativeTo
+        : - - Fixed
+            - 0.0
+            - 0.0
+            - -95.0
+            - 0
+            - 0          # line leaves End A vertically up (inlet riser leg)
+            - 0
+            - ~
+            - ~
+          - - Fixed
+            - 16.0
+            - 0.0
+            - -95.0
+            - 0
+            - 180        # line arrives at End B vertically down (outlet leg)
+            - 0
+            - ~
+            - ~
+        ConnectionxBendingStiffness, ConnectionyBendingStiffness:
+          - - Infinity
+            - ~
+          - - Infinity
+            - ~
+        # Section chain: straights shortened by R=0.54 at each bend end,
+        # 90-deg arcs (pi/2 x 0.54 = 0.84823 m) between them. Sum = 34.609 m.
+        LineType, Length, TargetSegmentLength:
+          - - mj02_jumper_pipe_steel    # inlet vertical (L1=4, less bend cut)
+            - 3.46
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 1 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # top horizontal (L2=3)
+            - 1.92
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 2 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # inner vertical down (L3=6)
+            - 4.92
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 3 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # bottom span (L4=10)
+            - 8.92
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 4 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # inner vertical up (L3=6)
+            - 4.92
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 5 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # top horizontal (L2=3)
+            - 1.92
+            - 0.5
+          - - mj02_jumper_pipe_steel    # bend 6 arc
+            - 0.84823
+            - 0.25
+          - - mj02_jumper_pipe_steel    # outlet vertical (L1=4)
+            - 3.46
+            - 0.5
+        ContentsMethod: Uniform
+        IncludeAxialContentsInertia: true
+        ContentsDensity: 0.0            # A4: multiphase gas-oil, set per load case
+        ContentsTemperature: ~
+        ContentsPressureRefZ: ~
+        ContentsPressure: 6000.0        # kPa — published 6 MPa back pressure
+        ContentsFlowRate: 0
+        IncludedInStatics: true
+        StaticsStep1: Spline
+        StaticsStep2: Full statics
+        StaticsSeabedFrictionPolicy: None
+        AsLaidTension: 0
+        SplineOrder: 3
+        # M-shape corner coordinates: flanges z=-95, shoulders z=-91,
+        # mid-span dip z=-97.
+        SplineControlPointX, SplineControlPointY, SplineControlPointZ:
+          - - 0.0
+            - 0.0
+            - -95.0
+          - - 0.0
+            - 0.0
+            - -91.0
+          - - 3.0
+            - 0.0
+            - -91.0
+          - - 3.0
+            - 0.0
+            - -97.0
+          - - 13.0
+            - 0.0
+            - -97.0
+          - - 13.0
+            - 0.0
+            - -91.0
+          - - 16.0
+            - 0.0
+            - -91.0
+          - - 16.0
+            - 0.0
+            - -95.0
+
+simulation:
+  time_step: 0.05
+  stages:
+    - 10.0
+    - 120.0

--- a/docs/domains/orcaflex/library/model_library/mj03_li2024_m_jumper_lab/spec.yml
+++ b/docs/domains/orcaflex/library/model_library/mj03_li2024_m_jumper_lab/spec.yml
@@ -1,0 +1,236 @@
+# M-shaped rigid jumper — lab-scale combined internal/external flow case
+# (Li et al. 2024)
+#
+# Provenance (see docs/domains/orcaflex/subsea/jumper/m_shaped/LITERATURE_GEOMETRY_SURVEY.md
+# Case 3, and digitalmodel issue #722):
+#   - Li, Li, Lin, Han, Zhou (Dalian Maritime Univ.), "Dynamic Response
+#     Analysis of a Subsea Rigid M-Shaped Jumper under Combined Internal and
+#     External Flows", J. Mar. Sci. Eng. 12(8):1261, 2024 (open access):
+#     https://www.mdpi.com/2077-1312/12/8/1261
+#
+# Geometry resolved from paper Figure 1 + Table 1 (2026-06-12 figure review):
+#   - 8 bends, 3 horizontal + 4 vertical segments, left-right symmetric,
+#     vertical overhang clamped to equipment at both ends
+#   - L1 = 800 mm: inlet/outlet vertical legs (segments 1 and 7)
+#   - L2 = 800 mm: top horizontals (segments 2 and 6)
+#   - L3 = 1000 mm: inner verticals (segments 3 and 5), dipping 200 mm
+#     below flange level
+#   - L4 = 2000 mm: bottom span (segment 4)
+#   - bend radius 1.5d = 72 mm; bends 1/8 are the inlet/outlet flange bends
+#   - "Total length 3744 mm" in Table 1 is the overall X-envelope
+#     (800 + 2000 + 800 + 2*72 = 3744), NOT centerline arc length.
+#   Centerline arc length = 6.192 m straights + 8 x (pi/2 x 0.072) arcs
+#   = 7.0968 m.
+#
+# Validation targets (computed, FEA): 13 modes < 100 Hz; f1 = 8.520 Hz
+# (out-of-plane), f2 = 13.825 Hz (in-plane), f3 = 17.473 Hz, f4 = 20.628 Hz.
+# External current 0.50 / 1.00 m/s normal to plane; internal air-water
+# stratified flow 0.02-0.90 m/s.
+#
+# Modeling assumptions (NOT from source — flagged per #722):
+#   A1: numerical/lab case has no site; 5 m water depth assumed, flanges z=-4
+#   A2: line ends placed at the bend-1/bend-8 corner points; flange stub
+#       offsets (72 mm) folded into the end arcs
+#   A3: end orientations horizontal (inlet flow enters +X per Figure 1);
+#       outlet orientation mirrored — flange facing not fully legible in figure
+#   A4: drag/added-mass coefficients not published (paper uses CFD pressure
+#       mapping); Cd=1.2 / Ca=1.0 assumed
+#   A5: contents density 0 placeholder (air-water mix varies per case);
+#       structural damping 1.2% (published Rayleigh a=1.160, b=4.368e-5)
+#       to be applied at analysis level on licensed runs
+# Derived (not verbatim): mass_per_length, EA, EI, GJ from published OD/ID,
+# rho=7850 kg/m3, E=2.1e11 Pa, nu=0.3.
+
+metadata:
+  name: mj03_li2024_m_jumper_lab
+  description: Lab-scale M-jumper combined internal/external flow case (Li et al. 2024, JMSE 12:1261)
+  structure: jumper
+  operation: generic
+  project: model_library
+
+environment:
+  water:
+    depth: 5.0         # A1: assumed (lab/numerical case)
+    density: 1.025
+  seabed:
+    slope: 0
+    stiffness:
+      normal: 100
+      shear: 100
+  waves:
+    type: airy
+    height: 0.0
+    period: 8
+    direction: 0
+  current:
+    direction: 90      # published external flow is normal to jumper plane (+Y)
+  wind:
+    speed: 0
+    direction: 0
+
+generic:
+  line_types:
+    - name: mj03_jumper_pipe_steel
+      category: General
+      outer_diameter: 0.060           # m (published)
+      inner_diameter: 0.048           # m (published; WT 6 mm)
+      mass_per_length: 0.0079904      # te/m — derived: A=1.01788e-3 m2 x 7.85 te/m3
+      bending_stiffness:              # EI — derived: E=2.1e11 Pa x I=3.75625e-7 m4
+        - 78.88
+        - ~
+      axial_stiffness: 213754.0       # kN — derived: E x A
+      properties:
+        BulkModulus: Infinity
+        CompressionIsLimited: false
+        PoissonRatio: 0.3             # published
+        ExpansionTable: None
+        GJ: 60.68                     # kN.m2 — derived: G=E/2(1+nu) x J=2I
+        TensionTorqueCoupling: 0
+        ClashStiffness: 0
+        Ca:                           # A4: assumed
+          - 1.0
+          - ~
+          - 0
+        Cd:                           # A4: assumed
+          - 1.2
+          - ~
+          - 0.008
+        Cl: 0
+        SeabedLateralFrictionCoefficient: 0.5
+        SeabedAxialFrictionCoefficient: ~
+        RayleighDampingCoefficients: (no damping)
+
+  lines:
+    - name: mj03_m_jumper
+      line_type_refs:
+        - mj03_jumper_pipe_steel
+      properties:
+        IncludeTorsion: false
+        TopEnd: End A
+        LengthAndEndOrientations: Explicit
+        Representation: Finite element
+        DragFormulation: Standard
+        StaticsVIV: None
+        DynamicsVIV: None
+        WaveCalculationMethod: Specified by environment
+        # Clamped at both flanges (vertical overhang, no other support).
+        # End A at bend-1 corner (origin); End B at bend-8 corner, 3.6 m
+        # along X. A3: end no-moment directions horizontal along +/-X.
+        ? Connection, ConnectionX, ConnectionY, ConnectionZ, ConnectionAzimuth,
+          ConnectionDeclination, ConnectionGamma, ConnectionReleaseStage, ConnectionzRelativeTo
+        : - - Fixed
+            - 0.0
+            - 0.0
+            - -4.0
+            - 0
+            - 90         # inlet flange faces -X, flow enters along +X
+            - 0
+            - ~
+            - ~
+          - - Fixed
+            - 3.6
+            - 0.0
+            - -4.0
+            - 180
+            - 90         # A3: outlet mirrored
+            - 0
+            - ~
+            - ~
+        ConnectionxBendingStiffness, ConnectionyBendingStiffness:
+          - - Infinity
+            - ~
+          - - Infinity
+            - ~
+        # Section chain from Figure 1: 8 x 90-deg arcs (pi/2 x 0.072 =
+        # 0.11310 m) alternating with corner-cut straights. Sum = 7.0968 m.
+        LineType, Length, TargetSegmentLength:
+          - - mj03_jumper_pipe_steel    # bend 1 (inlet flange bend)
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 1: inlet vertical (L1=800)
+            - 0.656
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 2
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 2: top horizontal (L2=800)
+            - 0.656
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 3
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 3: inner vertical down (L3=1000)
+            - 0.856
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 4
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 4: bottom span (L4=2000)
+            - 1.856
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 5
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 5: inner vertical up (L3=1000)
+            - 0.856
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 6
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 6: top horizontal (L2=800)
+            - 0.656
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 7
+            - 0.11310
+            - 0.025
+          - - mj03_jumper_pipe_steel    # segment 7: outlet vertical (L1=800)
+            - 0.656
+            - 0.05
+          - - mj03_jumper_pipe_steel    # bend 8 (outlet flange bend)
+            - 0.11310
+            - 0.025
+        ContentsMethod: Uniform
+        IncludeAxialContentsInertia: true
+        ContentsDensity: 0.0            # A5: air-water mix, set per load case
+        ContentsTemperature: ~
+        ContentsPressureRefZ: ~
+        ContentsPressure: 0
+        ContentsFlowRate: 0
+        IncludedInStatics: true
+        StaticsStep1: Spline
+        StaticsStep2: Full statics
+        StaticsSeabedFrictionPolicy: None
+        AsLaidTension: 0
+        SplineOrder: 3
+        # Corner coordinates: flanges z=-4, shoulders z=-3.2, dip z=-4.2.
+        SplineControlPointX, SplineControlPointY, SplineControlPointZ:
+          - - 0.0
+            - 0.0
+            - -4.0
+          - - 0.0
+            - 0.0
+            - -3.2
+          - - 0.8
+            - 0.0
+            - -3.2
+          - - 0.8
+            - 0.0
+            - -4.2
+          - - 2.8
+            - 0.0
+            - -4.2
+          - - 2.8
+            - 0.0
+            - -3.2
+          - - 3.6
+            - 0.0
+            - -3.2
+          - - 3.6
+            - 0.0
+            - -4.0
+
+simulation:
+  time_step: 0.001
+  stages:
+    - 5.0
+    - 30.0

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/cli.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/cli.py
@@ -126,13 +126,26 @@ def cmd_validate(args: argparse.Namespace) -> int:
     print(f"  Current speed:     {spec.environment.current.speed} m/s")
     print(f"  Wind speed:        {spec.environment.wind.speed} m/s")
     print()
-    print("Pipeline:")
-    print(f"  Name:              {spec.pipeline.name}")
-    print(f"  Material:          {spec.pipeline.material}")
-    print(f"  Outer diameter:    {spec.pipeline.dimensions.outer_diameter} m")
-    print(f"  Wall thickness:    {spec.pipeline.dimensions.wall_thickness} m")
-    print(f"  Total length:      {spec.get_total_pipeline_length()} m")
-    print(f"  Segments:          {len(spec.pipeline.segments)}")
+    if spec.pipeline is not None:
+        print("Pipeline:")
+        print(f"  Name:              {spec.pipeline.name}")
+        print(f"  Material:          {spec.pipeline.material}")
+        print(f"  Outer diameter:    {spec.pipeline.dimensions.outer_diameter} m")
+        print(f"  Wall thickness:    {spec.pipeline.dimensions.wall_thickness} m")
+        print(f"  Total length:      {spec.get_total_pipeline_length()} m")
+        print(f"  Segments:          {len(spec.pipeline.segments)}")
+    elif spec.riser is not None:
+        print("Riser:")
+        print(f"  Line types:        {len(spec.riser.line_types)}")
+        print(f"  Lines:             {len(spec.riser.lines)}")
+    elif spec.mooring is not None:
+        print("Mooring:")
+        print(f"  Lines:             {len(spec.mooring.lines)}")
+    elif spec.generic is not None:
+        print("Generic model:")
+        print(f"  Line types:        {len(spec.generic.line_types)}")
+        print(f"  Lines:             {len(spec.generic.lines)}")
+        print(f"  Vessels:           {len(spec.generic.vessels)}")
     print()
     print("Equipment:")
     if spec.equipment.tugs:
@@ -211,6 +224,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
         from .builders.registry import BuilderRegistry
 
         context = BuilderContext()
+        written_files: list[str] = []
 
         for file_name, builder_class in BuilderRegistry.get_ordered_builders():
             builder_name = builder_class.__name__
@@ -229,6 +243,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
             with open(file_path, 'w', encoding='utf-8') as f:
                 yaml.dump(data, f, Dumper=_NoAliasDumper, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
+            written_files.append(file_name)
             print_success(f"Generated: includes/{file_name}")
 
         # Generate parameters.yml
@@ -260,7 +275,9 @@ def cmd_generate(args: argparse.Namespace) -> int:
             '',
             '---',
         ]
-        for file_name in BuilderRegistry.get_include_order():
+        # Only reference include files actually written — skipped builders
+        # produce no file and a dangling includefile fails OrcFxAPI load.
+        for file_name in written_files:
             master_lines.append(f'- includefile: includes/{file_name}')
 
         master_path = output_dir / 'master.yml'
@@ -282,7 +299,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
     print(f"  {output_dir}/")
     print(f"    master.yml")
     print(f"    includes/")
-    for file_name in BuilderRegistry.get_include_order():
+    for file_name in written_files:
         print(f"      {file_name}")
     print(f"    inputs/")
     print(f"      parameters.yml")

--- a/tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py
+++ b/tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py
@@ -1,0 +1,121 @@
+"""L1 regression tests for the literature-derived M-shaped jumper library
+specs (issue #722).
+
+Locks, for each mj* model_library entry:
+  - the spec validates against ProjectInputSpec (generic track)
+  - generation produces master.yml + includes with no OrcFxAPI/license
+  - every generated YAML file is strict-YAML validator clean
+  - master.yml references only include files that actually exist
+    (regression for the CLI master.yml dangling-includefile bug)
+  - the line section chain matches the published dimension chain
+    (section count and total centerline length)
+
+Published natural frequencies (the L2/L3 validation targets) are recorded
+in each spec header — comparing them against licensed OrcaFlex runs is
+#718/#719 scope, deliberately NOT asserted here.
+
+CI command:
+    uv run pytest tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py -q
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema.root import ProjectInputSpec
+from digitalmodel.solvers.orcaflex.yaml_validator import validate_orcaflex_yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LIBRARY = REPO_ROOT / "docs/domains/orcaflex/library/model_library"
+
+# (dir name, expected section count, expected centerline length, tolerance)
+MJ_CASES = [
+    ("mj01_exxonmobil_m_jumper_viv", 13.966, 7),
+    ("mj02_zhu2022_m_jumper_fullscale", 34.609, 13),
+    ("mj03_li2024_m_jumper_lab", 7.0968, 15),
+]
+IDS = [c[0] for c in MJ_CASES]
+
+
+def _load_spec_dict(name: str) -> dict:
+    spec_path = LIBRARY / name / "spec.yml"
+    assert spec_path.exists(), f"missing spec: {spec_path}"
+    return yaml.safe_load(spec_path.read_text())
+
+
+@pytest.mark.parametrize("name,total_length,n_sections", MJ_CASES, ids=IDS)
+def test_spec_validates_as_generic_project_input(name, total_length, n_sections):
+    spec = ProjectInputSpec(**_load_spec_dict(name))
+    assert spec.generic is not None
+    assert len(spec.generic.line_types) == 1
+    assert len(spec.generic.lines) == 1
+
+
+@pytest.mark.parametrize("name,total_length,n_sections", MJ_CASES, ids=IDS)
+def test_generation_is_validator_clean(name, total_length, n_sections, tmp_path):
+    out_dir = tmp_path / name
+    generator = ModularModelGenerator(LIBRARY / name / "spec.yml")
+    generator.generate(out_dir)
+
+    master = out_dir / "master.yml"
+    assert master.exists()
+
+    for f in sorted(out_dir.rglob("*.yml")):
+        result = validate_orcaflex_yaml(f)
+        errors = [i.message for i in result.errors]
+        assert not errors, f"{f.relative_to(out_dir)}: {errors}"
+
+    # master.yml must reference only include files that exist
+    for entry in yaml.safe_load(master.read_text()):
+        ref = out_dir / entry["includefile"]
+        assert ref.exists(), f"dangling includefile: {entry['includefile']}"
+
+
+@pytest.mark.parametrize("name,total_length,n_sections", MJ_CASES, ids=IDS)
+def test_section_chain_matches_published_dimensions(
+    name, total_length, n_sections, tmp_path
+):
+    out_dir = tmp_path / name
+    ModularModelGenerator(LIBRARY / name / "spec.yml").generate(out_dir)
+
+    objects = yaml.safe_load((out_dir / "includes/20_generic_objects.yml").read_text())
+    lines = objects["Lines"]
+    assert len(lines) == 1
+    line = lines[0]
+
+    section_key = next(k for k in line if k.startswith("LineType,"))
+    sections = line[section_key]
+    assert len(sections) == n_sections
+    assert sum(row[1] for row in sections) == pytest.approx(total_length, abs=1e-3)
+
+    # every section's line type resolves to a LineType definition
+    type_names = {lt["Name"] for lt in objects["LineTypes"]}
+    assert {row[0] for row in sections} <= type_names
+
+
+def test_cli_generate_master_has_no_dangling_includes(tmp_path):
+    """The CLI generate path must list only includes it actually wrote.
+
+    Regression: cmd_generate previously wrote master.yml from the full
+    builder registry, so generic-track models referenced ~16 include
+    files that were never created — a guaranteed OrcFxAPI load failure.
+    (The ModularModelGenerator API path was always correct; the CLI
+    duplicated the logic.)
+    """
+    import argparse
+
+    from digitalmodel.solvers.orcaflex.modular_generator.cli import cmd_generate
+
+    out_dir = tmp_path / "mj01_cli"
+    args = argparse.Namespace(
+        input=str(LIBRARY / "mj01_exxonmobil_m_jumper_viv/spec.yml"),
+        output=str(out_dir),
+    )
+    assert cmd_generate(args) == 0
+
+    master_entries = yaml.safe_load((out_dir / "master.yml").read_text())
+    assert master_entries, "master.yml lists no includes"
+    for entry in master_entries:
+        ref = out_dir / entry["includefile"]
+        assert ref.exists(), f"dangling includefile: {entry['includefile']}"


### PR DESCRIPTION
Implements the build targets of #722. Survey: `docs/domains/orcaflex/subsea/jumper/m_shaped/LITERATURE_GEOMETRY_SURVEY.md` (PR #723).

## Library entries (generic track, L1 proven)

| Entry | Source | Chain | Centerline |
|---|---|---|---|
| `mj01_exxonmobil_m_jumper_viv` | Wang OMAE2013 / Zheng OMAE2015 / Igeh UiS 2017 (CC-BY) | 7 sections (sharp corners, as source FEM) | 13.966 m |
| `mj02_zhu2022_m_jumper_fullscale` | Zhu 2022, *Processes* 10:2133 | 13 sections incl. 6 bend arcs (R=0.54 m) | 34.609 m |
| `mj03_li2024_m_jumper_lab` | Li 2024, *JMSE* 12:1261 | 15 sections incl. 8 bend arcs (R=72 mm) | 7.0968 m |

Every dimension in the specs is comment-traceable to the cited table/figure; assumptions (water depth, end fixity, Cd/Ca where unpublished) are explicitly flagged `A1..A5` in each header. Published natural frequencies are recorded in the headers as the **L2/L3 validation targets** for the licensed sitting (#718/#719) — e.g. mj01's measured 0.863/2.149/2.194/2.542 Hz.

Notable geometry findings while building:
- **mj01 consistency check**: published equivalent contents density (2328.45 kg/m³) reproduces the published mass ratio m\*=2.33 exactly from the published OD/ID/ρ — strong confidence in the dataset.
- **mj03 "Total length 3744 mm" is NOT arc length** — Figure 1 review shows it's the overall X-envelope (800+2000+800+2×72). The survey's "consult Figure 1" flag is now resolved and documented in the spec header.

## Generator bugs found and fixed (both pre-existing on main)

1. **`validate` CLI crashed on every non-pipeline spec** — `cmd_validate` printed `spec.pipeline.name` unconditionally (`AttributeError` on generic/riser/mooring). Now prints per-track summaries. The documented validate command worked for 0 of the ~50 generic library specs.
2. **CLI `generate` wrote a guaranteed-unloadable `master.yml`** — it listed the full builder registry (~19 includefiles) instead of the includes actually written (3 for generic specs). Dangling includefiles fail OrcFxAPI load. The `ModularModelGenerator` API path was always correct; the CLI duplicated the logic badly. Directly relevant to #716/#718.

## Verification

```
uv run pytest tests/solvers/orcaflex/modular_generator/test_m_jumper_library_specs.py -q   # 10 passed
uv run pytest tests/solvers/orcaflex/modular_generator/ -q                                  # 662 passed, 45 skipped, 4 failed
```
The 4 failures (`test_builder_registry` ×2, `test_legacy_compat`, `test_schema_compat`) reproduce identically on bare `origin/main` (checked in a clean worktree) — pre-existing, not from this PR. All generated YAML for the three specs is strict-validator clean including `master.yml`.

Registry hygiene: entries added to `MODEL_CLAIM_INVENTORY.yaml` as **pending** (no claim inflation; L1 enforced by the new test, L2/L3 explicitly blocked on licensed runs). New `model_library/README.md` cross-links the survey per the #722 acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)