### PR TITLE
feat(diffraction): hard-fail mesh pre-flight in SpecConverter (#500)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
@@ -29,6 +29,13 @@ from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBack
 class SpecConverter:
     """Main entry point for spec -> solver input conversion.
 
+    Mesh path convention: ``vessel.geometry.mesh_file`` entries are resolved
+    relative to the directory containing the spec file (absolute paths are
+    used as-is). ``convert``/``convert_all`` hard-fail with
+    ``FileNotFoundError`` when any referenced mesh does not resolve, so
+    missing meshes surface at conversion time rather than as cryptic
+    solver-time errors (#500).
+
     Parameters
     ----------
     spec_path : Path
@@ -88,6 +95,13 @@ class SpecConverter:
         if format not in ("single", "modular"):
             raise ValueError(
                 f"Unknown format '{format}'. Choose 'single' or 'modular'."
+            )
+
+        mesh_issues = self._validate_mesh_files()
+        if mesh_issues:
+            raise FileNotFoundError(
+                "Mesh pre-flight validation failed:\n  "
+                + "\n  ".join(mesh_issues)
             )
 
         backend = self.backends[solver]
@@ -169,4 +183,35 @@ class SpecConverter:
             if body.vessel.inertia.mass <= 0:
                 issues.append(f"Body '{body.vessel.name}' has non-positive mass.")
 
+        # Pre-flight mesh existence (#500): convert() refuses to run on these.
+        issues.extend(self._validate_mesh_files())
+
+        return issues
+
+    def _resolve_mesh_path(self, mesh_file: str) -> Path:
+        """Resolve a mesh reference per the spec-relative convention."""
+        mesh_path = Path(mesh_file)
+        if mesh_path.is_absolute():
+            return mesh_path
+        return (self.spec_path.parent / mesh_path).resolve()
+
+    def _validate_mesh_files(self) -> list[str]:
+        """Return an issue per body whose mesh file does not resolve.
+
+        Mesh references are resolved relative to the spec file's directory;
+        absolute paths are checked as-is. Bodies with no mesh specified are
+        reported separately by :meth:`validate` and skipped here.
+        """
+        issues: list[str] = []
+        for body in self.spec.get_bodies():
+            mesh_file = body.vessel.geometry.mesh_file
+            if not mesh_file or mesh_file.strip() == "":
+                continue
+            resolved = self._resolve_mesh_path(mesh_file)
+            if not resolved.is_file():
+                issues.append(
+                    f"Body '{body.vessel.name}': mesh file '{mesh_file}' not "
+                    f"found (resolved to '{resolved}'; relative paths resolve "
+                    f"against the spec file directory '{self.spec_path.parent}')."
+                )
         return issues

--- a/tests/hydrodynamics/diffraction/test_spec_converter_mesh_preflight.py
+++ b/tests/hydrodynamics/diffraction/test_spec_converter_mesh_preflight.py
@@ -1,0 +1,107 @@
+"""Mesh pre-flight validation in SpecConverter (#500).
+
+Missing or unresolvable mesh references must surface as validate() issues and
+hard-fail convert()/convert_all() with FileNotFoundError before any solver
+input is generated — never as cryptic solver-time errors.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+MESH_FIXTURE = (
+    Path(__file__).parents[1] / "bemrosetta" / "fixtures" / "sample_box.gdf"
+)
+
+
+def _spec_in_tmp(tmp_path: Path, mesh_file: str, with_mesh: bool = False) -> Path:
+    """Copy the ship fixture spec to tmp_path with a rewritten mesh reference."""
+    text = (FIXTURES_DIR / "spec_ship_raos.yml").read_text()
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.gdf"',
+        f'mesh_file: "{mesh_file}"',
+    )
+    spec_path = tmp_path / "spec.yml"
+    spec_path.write_text(text)
+    if with_mesh:
+        shutil.copy2(MESH_FIXTURE, tmp_path / Path(mesh_file).name)
+    return spec_path
+
+
+class TestValidateReportsMissingMesh:
+    def test_missing_mesh_is_an_issue(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        issues = converter.validate()
+        assert any("no_such_mesh.gdf" in issue for issue in issues)
+
+    def test_issue_names_resolved_path_and_convention(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        issue = next(i for i in converter.validate() if "no_such_mesh.gdf" in i)
+        assert str(tmp_path) in issue  # resolved location
+        assert "spec file directory" in issue  # convention statement
+
+    def test_present_mesh_yields_no_issues(self, tmp_path):
+        converter = SpecConverter(
+            _spec_in_tmp(tmp_path, "sample_box.gdf", with_mesh=True)
+        )
+        assert converter.validate() == []
+
+    def test_original_fixture_still_validates_clean(self):
+        assert SpecConverter(FIXTURES_DIR / "spec_ship_raos.yml").validate() == []
+
+
+class TestConvertHardFails:
+    def test_convert_raises_file_not_found(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        with pytest.raises(FileNotFoundError, match="no_such_mesh.gdf"):
+            converter.convert(solver="orcawave", output_dir=tmp_path / "out")
+
+    def test_convert_fails_before_writing_output(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        out_dir = tmp_path / "out"
+        with pytest.raises(FileNotFoundError):
+            converter.convert(solver="orcawave", output_dir=out_dir)
+        assert not out_dir.exists() or not any(out_dir.iterdir())
+
+    def test_convert_all_raises_too(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        with pytest.raises(FileNotFoundError):
+            converter.convert_all(output_dir=tmp_path / "out")
+
+    def test_aqwa_path_also_guarded(self, tmp_path):
+        converter = SpecConverter(_spec_in_tmp(tmp_path, "no_such_mesh.gdf"))
+        with pytest.raises(FileNotFoundError):
+            converter.convert(solver="aqwa", output_dir=tmp_path / "out")
+
+    def test_convert_succeeds_with_present_mesh(self, tmp_path):
+        converter = SpecConverter(
+            _spec_in_tmp(tmp_path, "sample_box.gdf", with_mesh=True)
+        )
+        result = converter.convert(solver="orcawave", output_dir=tmp_path / "out")
+        assert result.is_file()
+
+
+class TestPathResolution:
+    def test_absolute_mesh_path_is_used_as_is(self, tmp_path):
+        mesh_abs = tmp_path / "abs_box.gdf"
+        shutil.copy2(MESH_FIXTURE, mesh_abs)
+        converter = SpecConverter(
+            _spec_in_tmp(tmp_path / "specs_elsewhere", str(mesh_abs))
+        )
+        assert converter.validate() == []
+
+    def test_relative_path_resolves_from_spec_dir_not_cwd(self, tmp_path, monkeypatch):
+        spec_path = _spec_in_tmp(tmp_path, "sample_box.gdf", with_mesh=True)
+        monkeypatch.chdir(tmp_path.parent)  # cwd != spec dir
+        assert SpecConverter(spec_path).validate() == []
+
+
+@pytest.fixture(autouse=True)
+def _mkdir_for_nested_spec(tmp_path):
+    (tmp_path / "specs_elsewhere").mkdir(exist_ok=True)


### PR DESCRIPTION
Closes #500. Next critical-path item on epic #622 after #720/#727/#728 (see the 2026-06-12 review comment on the epic).

## What

Per the issue's approved plan and the 2026-05-27 completeness audit (55%), the one missing criterion was pre-flight mesh validation that hard-fails — the runner auto-copy leg was already done and tested.

- **`SpecConverter._validate_mesh_files()`**: resolves each body's `mesh_file` per the convention (absolute as-is; relative against the spec file's directory) and reports every non-existent mesh with both the raw reference and the resolved path, plus the convention itself, so the error is self-explanatory.
- **`convert()` / `convert_all()`** raise `FileNotFoundError` before writing any output. `diffraction convert-spec` already wraps exceptions → exits 1 with the message.
- **`validate()`** appends the same findings to its issues list (contract unchanged), so `diffraction validate-spec` now exits non-zero on missing meshes.
- Convention documented in the class docstring; user-facing docs were already updated in #728.

Bodies with *no* mesh specified keep their existing dedicated issue message and are skipped by the new check (no duplicate reporting).

## Verification (ace-linux-2)

- New: `tests/hydrodynamics/diffraction/test_spec_converter_mesh_preflight.py` — **11 tests**: validate-reports-missing (with resolved path + convention text), convert/convert_all/AQWA-path hard-fail, fails-before-writing-output, success paths with present mesh, absolute-path honored, spec-dir-not-cwd resolution.
- Existing `test_spec_converter.py`: **18/18 pass** unchanged.
- Full diffraction domain suite: **1471 passed, 24 skipped, 2 xfailed** — no regressions.

## Notes

- Scope deliberately excludes the runner's warn-and-skip behavior for auxiliary meshes — control-surface/damping-lid preflight is #609, and quality gates are #608.
- Relabeled lane:codex → lane:claude on the issue (remaining scope was light, license-free engineering; noted in the claim comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)