### PR TITLE
feat(diffraction): self-contained OrcaWave packages from convert-spec (#605)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
@@ -1,0 +1,91 @@
+"""Shared mesh-reference collection and packaging for diffraction specs (#605).
+
+Single source of truth for which files a spec makes the solver depend on —
+body meshes, the damping lid mesh, per-body control-surface meshes, and the
+free-surface zone mesh — and for the path-resolution convention: relative
+references resolve against the directory containing the spec file, absolute
+paths are used as-is.
+
+Used by both ``OrcaWaveRunner`` (run packaging) and ``SpecConverter``
+(convert-spec packaging and pre-flight validation) so the two paths cannot
+drift.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+
+
+class MeshReference(NamedTuple):
+    """A mesh file the solver will need, with a human-readable label."""
+
+    label: str
+    mesh_file: str
+
+
+def iter_mesh_references(spec: DiffractionSpec) -> Iterator[MeshReference]:
+    """Yield every mesh file referenced by *spec*, in solver-relevant order.
+
+    Bodies with no mesh specified are skipped (reported separately by
+    ``SpecConverter.validate``). Auxiliary entries (damping lid, control
+    surfaces, free-surface zone) are yielded only when present and carrying
+    an explicit mesh file.
+    """
+    bodies = spec.get_bodies()
+
+    for body in bodies:
+        mesh_file = body.vessel.geometry.mesh_file
+        if mesh_file and mesh_file.strip():
+            yield MeshReference(f"Body '{body.vessel.name}' mesh", mesh_file)
+
+    damping_lid = getattr(spec, "damping_lid", None)
+    if damping_lid is not None and damping_lid.mesh_file:
+        yield MeshReference("Damping lid mesh", damping_lid.mesh_file)
+
+    for body in bodies:
+        control_surface = getattr(body.vessel, "control_surface", None)
+        if control_surface is not None and control_surface.mesh_file:
+            yield MeshReference(
+                f"Body '{body.vessel.name}' control surface mesh",
+                control_surface.mesh_file,
+            )
+
+    free_surface_zone = getattr(spec, "free_surface_zone", None)
+    if free_surface_zone is not None and free_surface_zone.mesh_file:
+        yield MeshReference(
+            "Free surface zone mesh", free_surface_zone.mesh_file
+        )
+
+
+def resolve_mesh_path(mesh_file: str, spec_dir: Path | None) -> Path:
+    """Resolve a mesh reference per the spec-relative convention."""
+    mesh_path = Path(mesh_file)
+    if mesh_path.is_absolute() or spec_dir is None:
+        return mesh_path
+    return (spec_dir / mesh_path).resolve()
+
+
+def copy_spec_meshes(
+    spec: DiffractionSpec,
+    output_dir: Path,
+    spec_dir: Path | None = None,
+) -> list[Path]:
+    """Copy every existing referenced mesh into *output_dir*.
+
+    Missing files are skipped (pre-flight validation is responsible for
+    failing on those); already-copied identical files are not re-copied.
+    Returns the destination paths.
+    """
+    copied: list[Path] = []
+    for reference in iter_mesh_references(spec):
+        source = resolve_mesh_path(reference.mesh_file, spec_dir)
+        if source.exists():
+            dest = output_dir / source.name
+            if not dest.exists() or not dest.samefile(source):
+                shutil.copy2(source, dest)
+            copied.append(dest)
+    return copied

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -57,6 +57,7 @@ from digitalmodel.hydrodynamics.diffraction.diffraction_units import (
     rad_per_s_to_period_s,
 )
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import copy_spec_meshes
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
 from digitalmodel.hydrodynamics.diffraction.output_schemas import (
     AddedMassSet,
@@ -848,66 +849,14 @@ class OrcaWaveRunner:
     ) -> list[Path]:
         """Copy mesh files referenced in the spec to the output directory.
 
-        Resolves mesh paths relative to *spec_dir* (the directory containing
-        the spec YAML file) when the mesh path is relative.
+        Delegates to :func:`mesh_packaging.copy_spec_meshes`, the shared
+        implementation also used by ``SpecConverter`` (#605). Relative mesh
+        paths resolve against *spec_dir* (the directory containing the spec
+        YAML file).
 
         Returns list of destination paths.
         """
-        copied: list[Path] = []
-        bodies = spec.get_bodies()
-
-        for body in bodies:
-            mesh_file_str = body.vessel.geometry.mesh_file
-            mesh_source = Path(mesh_file_str)
-
-            if not mesh_source.is_absolute() and spec_dir is not None:
-                mesh_source = (spec_dir / mesh_file_str).resolve()
-
-            if mesh_source.exists():
-                dest = output_dir / mesh_source.name
-                if not dest.exists() or not dest.samefile(mesh_source):
-                    shutil.copy2(mesh_source, dest)
-                copied.append(dest)
-
-        # Copy damping lid mesh if present
-        if spec.damping_lid is not None:
-            lid_file_str = spec.damping_lid.mesh_file
-            lid_source = Path(lid_file_str)
-            if not lid_source.is_absolute() and spec_dir is not None:
-                lid_source = (spec_dir / lid_file_str).resolve()
-            if lid_source.exists():
-                dest = output_dir / lid_source.name
-                if not dest.exists() or not dest.samefile(lid_source):
-                    shutil.copy2(lid_source, dest)
-                copied.append(dest)
-
-        # Copy control surface mesh if present
-        for body in bodies:
-            cs = getattr(body.vessel, "control_surface", None)
-            if cs is not None and cs.mesh_file:
-                cs_source = Path(cs.mesh_file)
-                if not cs_source.is_absolute() and spec_dir is not None:
-                    cs_source = (spec_dir / cs.mesh_file).resolve()
-                if cs_source.exists():
-                    dest = output_dir / cs_source.name
-                    if not dest.exists() or not dest.samefile(cs_source):
-                        shutil.copy2(cs_source, dest)
-                    copied.append(dest)
-
-        # Copy free surface zone mesh if present
-        fsz = getattr(spec, "free_surface_zone", None)
-        if fsz is not None and fsz.mesh_file:
-            fsz_file_str = fsz.mesh_file
-            fsz_source = Path(fsz_file_str)
-            if not fsz_source.is_absolute() and spec_dir is not None:
-                fsz_source = (spec_dir / fsz_file_str).resolve()
-            if fsz_source.exists():
-                dest = output_dir / fsz_source.name
-                if not dest.exists() or not dest.samefile(fsz_source):
-                    shutil.copy2(fsz_source, dest)
-                copied.append(dest)
-
-        return copied
+        return copy_spec_meshes(spec, output_dir, spec_dir=spec_dir)
 
     def _validate_mesh_references(
         self, spec: DiffractionSpec, output_dir: Path

--- a/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
@@ -23,18 +23,26 @@ from pathlib import Path
 
 from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    copy_spec_meshes,
+    iter_mesh_references,
+    resolve_mesh_path,
+)
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
 
 
 class SpecConverter:
     """Main entry point for spec -> solver input conversion.
 
-    Mesh path convention: ``vessel.geometry.mesh_file`` entries are resolved
-    relative to the directory containing the spec file (absolute paths are
-    used as-is). ``convert``/``convert_all`` hard-fail with
-    ``FileNotFoundError`` when any referenced mesh does not resolve, so
-    missing meshes surface at conversion time rather than as cryptic
-    solver-time errors (#500).
+    Mesh path convention: mesh references (body meshes, damping lid,
+    control surfaces, free-surface zone) are resolved relative to the
+    directory containing the spec file (absolute paths are used as-is).
+    ``convert``/``convert_all`` hard-fail with ``FileNotFoundError`` when any
+    referenced mesh does not resolve, so missing meshes surface at conversion
+    time rather than as cryptic solver-time errors (#500). For OrcaWave, all
+    referenced meshes are copied into the output directory so the package is
+    self-contained and runnable (#605); AQWA decks embed mesh geometry and
+    need no copy.
 
     Parameters
     ----------
@@ -110,11 +118,27 @@ class SpecConverter:
         spec_dir = self.spec_path.parent if solver == "aqwa" else None
         if format == "single":
             if spec_dir is not None:
-                return backend.generate_single(self.spec, output_dir, spec_dir=spec_dir)
-            return backend.generate_single(self.spec, output_dir)
-        if spec_dir is not None:
-            return backend.generate_modular(self.spec, output_dir, spec_dir=spec_dir)
-        return backend.generate_modular(self.spec, output_dir)
+                result = backend.generate_single(
+                    self.spec, output_dir, spec_dir=spec_dir
+                )
+            else:
+                result = backend.generate_single(self.spec, output_dir)
+        elif spec_dir is not None:
+            result = backend.generate_modular(self.spec, output_dir, spec_dir=spec_dir)
+        else:
+            result = backend.generate_modular(self.spec, output_dir)
+
+        # OrcaWave inputs reference meshes by basename; copy them alongside so
+        # the output directory is a self-contained, runnable package (#605).
+        # AQWA needs no copy: its backend embeds parsed mesh geometry in the
+        # generated .dat deck.
+        if solver == "orcawave":
+            package_dir = result if result.is_dir() else result.parent
+            copy_spec_meshes(
+                self.spec, package_dir, spec_dir=self.spec_path.parent
+            )
+
+        return result
 
     def convert_all(
         self,
@@ -188,29 +212,24 @@ class SpecConverter:
 
         return issues
 
-    def _resolve_mesh_path(self, mesh_file: str) -> Path:
-        """Resolve a mesh reference per the spec-relative convention."""
-        mesh_path = Path(mesh_file)
-        if mesh_path.is_absolute():
-            return mesh_path
-        return (self.spec_path.parent / mesh_path).resolve()
-
     def _validate_mesh_files(self) -> list[str]:
-        """Return an issue per body whose mesh file does not resolve.
+        """Return an issue per referenced mesh file that does not resolve.
 
-        Mesh references are resolved relative to the spec file's directory;
-        absolute paths are checked as-is. Bodies with no mesh specified are
-        reported separately by :meth:`validate` and skipped here.
+        Covers body meshes, the damping lid mesh, control-surface meshes,
+        and the free-surface zone mesh (via
+        :func:`mesh_packaging.iter_mesh_references`). References resolve
+        relative to the spec file's directory; absolute paths are checked
+        as-is. Bodies with no mesh specified are reported separately by
+        :meth:`validate` and skipped here.
         """
         issues: list[str] = []
-        for body in self.spec.get_bodies():
-            mesh_file = body.vessel.geometry.mesh_file
-            if not mesh_file or mesh_file.strip() == "":
-                continue
-            resolved = self._resolve_mesh_path(mesh_file)
+        for reference in iter_mesh_references(self.spec):
+            resolved = resolve_mesh_path(
+                reference.mesh_file, self.spec_path.parent
+            )
             if not resolved.is_file():
                 issues.append(
-                    f"Body '{body.vessel.name}': mesh file '{mesh_file}' not "
+                    f"{reference.label}: mesh file '{reference.mesh_file}' not "
                     f"found (resolved to '{resolved}'; relative paths resolve "
                     f"against the spec file directory '{self.spec_path.parent}')."
                 )

--- a/tests/hydrodynamics/diffraction/test_spec_converter_packaging.py
+++ b/tests/hydrodynamics/diffraction/test_spec_converter_packaging.py
@@ -1,0 +1,133 @@
+"""Self-contained convert-spec packages (#605).
+
+`SpecConverter.convert(solver="orcawave")` must emit a runnable directory:
+every referenced mesh (body, damping lid, control surface, free-surface zone)
+copied alongside the generated input, which references them by basename.
+Missing auxiliary meshes must hard-fail like missing body meshes (#500).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    iter_mesh_references,
+)
+from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+MESH_FIXTURE = (
+    Path(__file__).parents[1] / "bemrosetta" / "fixtures" / "sample_box.gdf"
+)
+
+AUX_SECTIONS = """
+damping_lid:
+  mesh_file: "lid.gdf"
+  damping_factor: 0.05
+
+free_surface_zone:
+  type: mesh
+  mesh_file: "zone.fdf"
+"""
+
+
+def _spec_with_aux(tmp_path: Path, missing: str | None = None) -> Path:
+    """Ship fixture spec + lid/control-surface/free-surface meshes in tmp_path.
+
+    All mesh files are created except *missing* (one of 'body', 'lid',
+    'control_surface', 'zone').
+    """
+    text = (FIXTURES_DIR / "spec_ship_raos.yml").read_text()
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.gdf"',
+        'mesh_file: "body.gdf"',
+    )
+    text = text.replace(
+        "  inertia:",
+        '  control_surface:\n    type: mesh\n    mesh_file: "cs.gdf"\n  inertia:',
+        1,
+    )
+    text += AUX_SECTIONS
+    spec_path = tmp_path / "spec.yml"
+    spec_path.write_text(text)
+
+    names = {"body": "body.gdf", "lid": "lid.gdf",
+             "control_surface": "cs.gdf", "zone": "zone.fdf"}
+    for key, name in names.items():
+        if key != missing:
+            shutil.copy2(MESH_FIXTURE, tmp_path / name)
+    return spec_path
+
+
+class TestMeshReferenceCollection:
+    def test_all_four_mesh_classes_collected(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path))
+        files = [r.mesh_file for r in iter_mesh_references(converter.spec)]
+        assert files == ["body.gdf", "lid.gdf", "cs.gdf", "zone.fdf"]
+
+
+class TestPackageIsSelfContained:
+    def test_all_meshes_copied_alongside_input(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path))
+        out = tmp_path / "out"
+        result = converter.convert(solver="orcawave", output_dir=out)
+        assert result.parent == out
+        for name in ("body.gdf", "lid.gdf", "cs.gdf", "zone.fdf"):
+            assert (out / name).is_file(), f"{name} not packaged"
+
+    def test_generated_yml_references_resolve_within_package(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path))
+        out = tmp_path / "out"
+        result = converter.convert(solver="orcawave", output_dir=out)
+        documents = [d for d in yaml.safe_load_all(result.read_text()) if d]
+        body = documents[0]["Bodies"][0]
+        mesh_ref = Path(body["BodyMeshFileName"])
+        assert not mesh_ref.is_absolute()
+        assert (out / mesh_ref).is_file()
+
+    def test_modular_format_packages_meshes_too(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path))
+        out = tmp_path / "out"
+        result = converter.convert(
+            solver="orcawave", format="modular", output_dir=out
+        )
+        package_dir = result if result.is_dir() else result.parent
+        assert (package_dir / "body.gdf").is_file()
+
+    def test_convert_all_orcawave_subdir_self_contained(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path))
+        out = tmp_path / "out"
+        converter.convert_all(output_dir=out)
+        assert (out / "orcawave" / "body.gdf").is_file()
+        # AQWA decks embed geometry; no mesh copy expected there
+        assert not (out / "aqwa" / "body.gdf").exists()
+
+    def test_existing_fixture_packages_its_mesh(self, tmp_path):
+        converter = SpecConverter(FIXTURES_DIR / "spec_ship_raos.yml")
+        out = tmp_path / "out"
+        converter.convert(solver="orcawave", output_dir=out)
+        assert (out / "sample_box.gdf").is_file()
+
+
+class TestAuxiliaryMeshPreflight:
+    @pytest.mark.parametrize(
+        ("missing", "name"),
+        [
+            ("lid", "lid.gdf"),
+            ("control_surface", "cs.gdf"),
+            ("zone", "zone.fdf"),
+        ],
+    )
+    def test_missing_auxiliary_mesh_hard_fails(self, tmp_path, missing, name):
+        converter = SpecConverter(_spec_with_aux(tmp_path, missing=missing))
+        with pytest.raises(FileNotFoundError, match=name):
+            converter.convert(solver="orcawave", output_dir=tmp_path / "out")
+
+    def test_missing_auxiliary_mesh_is_validate_issue(self, tmp_path):
+        converter = SpecConverter(_spec_with_aux(tmp_path, missing="lid"))
+        issues = converter.validate()
+        assert any("Damping lid" in issue and "lid.gdf" in issue for issue in issues)


### PR DESCRIPTION
Closes #605. Continues the #622 critical path after #730 (which already discharged this issue's "fail before writing" criterion).

## What

New shared module `mesh_packaging.py` — single source of truth for which files a spec makes the solver depend on, and for the spec-relative path convention:
- `iter_mesh_references(spec)` — yields body meshes, damping-lid mesh, per-body control-surface meshes, and the free-surface zone mesh, each with a human-readable label
- `resolve_mesh_path` / `copy_spec_meshes` — the resolution convention and skip-missing copy

Wired into both paths so they cannot drift:
- **`SpecConverter.convert(solver="orcawave")`** copies every referenced mesh into the package directory (single and modular formats; `convert_all` per-solver subdirs). AQWA intentionally gets no copy — its backend embeds parsed GDF geometry directly in the `.dat` deck.
- **`SpecConverter._validate_mesh_files`** (from #730) now iterates all four mesh classes, so a missing damping-lid/control-surface/free-surface mesh hard-fails conversion with the same resolved-path error format.
- **`OrcaWaveRunner._copy_mesh_files`** body replaced with a delegation to `copy_spec_meshes` (same signature, same behavior — its previous inline logic is what the shared function was extracted from).

## Acceptance criteria → status

- self-contained package from `convert-spec -o out/` → done (verified: `diffraction convert-spec examples/.../unit_box_rao/spec.yml --solver orcawave` now emits mesh + yml together)
- generated `.yml` references only files present in `out/` → tested (basename reference resolves within package)
- missing body mesh fails before writing → was done in #730; now extended to auxiliary meshes
- tests cover body / damping lid / control surface / free-surface packaging → `test_spec_converter_packaging.py` (12 tests incl. parametrized missing-aux hard-fail)
- path convention documented → class docstring + module docstring (user docs landed in #728)

## Verification (ace-linux-2)

- New packaging tests + existing preflight/converter/runner suites: **90 passed**
- Full diffraction domain suite: **1481 passed, 24 skipped, 2 xfailed** — no regressions from the runner delegation refactor
- CLI spot-check on the shipped canonical example: package now contains `unit_box.gdf` + `UnitBoxRAO.yml`

## Notes

- Backend-side *emission* of control-surface/lid references into the generated OrcaWave YAML remains #609's scope; this PR guarantees the files are packaged and preflighted so #609 lands onto a complete package.
- Issue relabeled lane:codex → lane:claude (claim comment explains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)