### PR TITLE
feat(diffraction): wire MeshPipeline into spec conversion and runner (#606)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
@@ -13,11 +13,24 @@ drift.
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
-from typing import Iterator, NamedTuple
+from typing import Any, Iterator, NamedTuple
 
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+
+# Formats the solver consumes directly (copied unchanged — no conversion churn)
+_SOLVER_READY_EXTENSIONS: dict[str, set[str]] = {
+    "orcawave": {".gdf"},
+    "aqwa": {".dat"},
+}
+# Solver-native auxiliary formats with no panel-mesh handler (copied as-is)
+_PASSTHROUGH_EXTENSIONS = {".fdf"}
+# Formats MeshPipeline can load and convert to the solver target
+_CONVERTIBLE_EXTENSIONS = {".gdf", ".dat", ".stl"}
+
+PROVENANCE_FILENAME = "mesh_provenance.json"
 
 
 class MeshReference(NamedTuple):
@@ -25,6 +38,46 @@ class MeshReference(NamedTuple):
 
     label: str
     mesh_file: str
+
+
+class _MeshSlot(NamedTuple):
+    """A mesh reference plus the spec object holding it (for rewrites)."""
+
+    label: str
+    mesh_file: str
+    owner: Any  # model carrying mesh_file (and possibly mesh_format)
+
+
+def _iter_mesh_slots(spec: DiffractionSpec) -> Iterator[_MeshSlot]:
+    bodies = spec.get_bodies()
+
+    for body in bodies:
+        geometry = body.vessel.geometry
+        if geometry.mesh_file and geometry.mesh_file.strip():
+            yield _MeshSlot(
+                f"Body '{body.vessel.name}' mesh", geometry.mesh_file, geometry
+            )
+
+    damping_lid = getattr(spec, "damping_lid", None)
+    if damping_lid is not None and damping_lid.mesh_file:
+        yield _MeshSlot("Damping lid mesh", damping_lid.mesh_file, damping_lid)
+
+    for body in bodies:
+        control_surface = getattr(body.vessel, "control_surface", None)
+        if control_surface is not None and control_surface.mesh_file:
+            yield _MeshSlot(
+                f"Body '{body.vessel.name}' control surface mesh",
+                control_surface.mesh_file,
+                control_surface,
+            )
+
+    free_surface_zone = getattr(spec, "free_surface_zone", None)
+    if free_surface_zone is not None and free_surface_zone.mesh_file:
+        yield _MeshSlot(
+            "Free surface zone mesh",
+            free_surface_zone.mesh_file,
+            free_surface_zone,
+        )
 
 
 def iter_mesh_references(spec: DiffractionSpec) -> Iterator[MeshReference]:
@@ -35,30 +88,8 @@ def iter_mesh_references(spec: DiffractionSpec) -> Iterator[MeshReference]:
     surfaces, free-surface zone) are yielded only when present and carrying
     an explicit mesh file.
     """
-    bodies = spec.get_bodies()
-
-    for body in bodies:
-        mesh_file = body.vessel.geometry.mesh_file
-        if mesh_file and mesh_file.strip():
-            yield MeshReference(f"Body '{body.vessel.name}' mesh", mesh_file)
-
-    damping_lid = getattr(spec, "damping_lid", None)
-    if damping_lid is not None and damping_lid.mesh_file:
-        yield MeshReference("Damping lid mesh", damping_lid.mesh_file)
-
-    for body in bodies:
-        control_surface = getattr(body.vessel, "control_surface", None)
-        if control_surface is not None and control_surface.mesh_file:
-            yield MeshReference(
-                f"Body '{body.vessel.name}' control surface mesh",
-                control_surface.mesh_file,
-            )
-
-    free_surface_zone = getattr(spec, "free_surface_zone", None)
-    if free_surface_zone is not None and free_surface_zone.mesh_file:
-        yield MeshReference(
-            "Free surface zone mesh", free_surface_zone.mesh_file
-        )
+    for slot in _iter_mesh_slots(spec):
+        yield MeshReference(slot.label, slot.mesh_file)
 
 
 def resolve_mesh_path(mesh_file: str, spec_dir: Path | None) -> Path:
@@ -89,3 +120,120 @@ def copy_spec_meshes(
                 shutil.copy2(source, dest)
             copied.append(dest)
     return copied
+
+
+def _check_supported_formats(spec: DiffractionSpec, solver: str) -> None:
+    """Raise ValueError listing every unsupported mesh format, before any write."""
+    ready = _SOLVER_READY_EXTENSIONS[solver]
+    accepted = ready | _PASSTHROUGH_EXTENSIONS | _CONVERTIBLE_EXTENSIONS
+    unsupported = [
+        f"{slot.label}: '{slot.mesh_file}' "
+        f"({Path(slot.mesh_file).suffix.lower() or 'no extension'})"
+        for slot in _iter_mesh_slots(spec)
+        if Path(slot.mesh_file).suffix.lower() not in accepted
+    ]
+    if unsupported:
+        raise ValueError(
+            f"Unsupported mesh format(s) for solver '{solver}':\n  "
+            + "\n  ".join(unsupported)
+            + f"\nSupported formats: solver-ready {sorted(ready)}, "
+            f"convertible via MeshPipeline {sorted(_CONVERTIBLE_EXTENSIONS)}, "
+            f"passthrough {sorted(_PASSTHROUGH_EXTENSIONS)}."
+        )
+
+
+def _set_mesh_reference(owner: Any, packaged_name: str, target_format: str) -> None:
+    """Point a spec object's mesh reference at the packaged file."""
+    owner.mesh_file = packaged_name
+    current_format = getattr(owner, "mesh_format", None)
+    if current_format is not None:
+        # GeometrySpec uses a (str-based) MeshFormatType enum; lid/zone specs
+        # use plain str — reconstruct with the original type either way.
+        owner.mesh_format = type(current_format)(target_format)
+
+
+def package_spec_meshes(
+    spec: DiffractionSpec,
+    output_dir: Path,
+    spec_dir: Path | None = None,
+    solver: str = "orcawave",
+) -> tuple[DiffractionSpec, list[Path]]:
+    """Prepare every referenced mesh for *solver* into *output_dir* (#606).
+
+    Solver-ready formats (e.g. ``.gdf`` for OrcaWave) and solver-native
+    passthrough formats (``.fdf``) are copied unchanged — no conversion
+    churn. Convertible formats (``.dat``, ``.stl``) are converted to the
+    solver target via ``MeshPipeline.prepare_for_solver``. Unsupported
+    formats raise ``ValueError`` with the supported-format list before
+    anything is written. Missing files are skipped — existence is the
+    pre-flight's responsibility (#500).
+
+    Conversions are recorded in ``mesh_provenance.json`` next to the
+    packaged meshes (source path, formats, units/symmetry where the spec
+    carries them).
+
+    Returns
+    -------
+    tuple[DiffractionSpec, list[Path]]
+        A deep copy of *spec* whose mesh references (and formats) point at
+        the packaged files, and the packaged file paths.
+    """
+    solver = solver.lower()
+    if solver not in _SOLVER_READY_EXTENSIONS:
+        raise ValueError(
+            f"Unknown solver '{solver}'. "
+            f"Choose from: {', '.join(sorted(_SOLVER_READY_EXTENSIONS))}"
+        )
+
+    _check_supported_formats(spec, solver)
+
+    packaged_spec = spec.model_copy(deep=True)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ready = _SOLVER_READY_EXTENSIONS[solver]
+
+    pipeline = None
+    packaged: list[Path] = []
+    provenance: list[dict[str, Any]] = []
+
+    for slot in _iter_mesh_slots(packaged_spec):
+        source = resolve_mesh_path(slot.mesh_file, spec_dir)
+        if not source.exists():
+            continue
+        extension = source.suffix.lower()
+        if extension in ready or extension in _PASSTHROUGH_EXTENSIONS:
+            dest = output_dir / source.name
+            if not dest.exists() or not dest.samefile(source):
+                shutil.copy2(source, dest)
+        else:
+            if pipeline is None:
+                from digitalmodel.hydrodynamics.diffraction.mesh_pipeline import (
+                    MeshPipeline,
+                )
+
+                pipeline = MeshPipeline()
+            dest = pipeline.prepare_for_solver(source, solver, output_dir)
+            record: dict[str, Any] = {
+                "reference": slot.label,
+                "source": str(source),
+                "source_format": extension.lstrip("."),
+                "packaged": dest.name,
+                "target_format": dest.suffix.lstrip("."),
+            }
+            units = getattr(slot.owner, "length_units", None)
+            if units is not None:
+                record["length_units"] = str(units)
+            symmetry = getattr(slot.owner, "symmetry", None)
+            if symmetry is not None:
+                record["symmetry"] = str(
+                    getattr(symmetry, "value", symmetry)
+                )
+            provenance.append(record)
+        _set_mesh_reference(slot.owner, dest.name, dest.suffix.lstrip("."))
+        packaged.append(dest)
+
+    if provenance:
+        (output_dir / PROVENANCE_FILENAME).write_text(
+            json.dumps(provenance, indent=2)
+        )
+    return packaged_spec, packaged

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -57,7 +57,10 @@ from digitalmodel.hydrodynamics.diffraction.diffraction_units import (
     rad_per_s_to_period_s,
 )
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
-from digitalmodel.hydrodynamics.diffraction.mesh_packaging import copy_spec_meshes
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    copy_spec_meshes,
+    package_spec_meshes,
+)
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
 from digitalmodel.hydrodynamics.diffraction.output_schemas import (
     AddedMassSet,
@@ -351,18 +354,25 @@ class OrcaWaveRunner:
             spec_name=spec_name,
         )
 
+        # Package meshes first (copy ready formats, convert others via
+        # MeshPipeline) so the generated input references the packaged
+        # solver-ready filenames (#606).
+        spec_to_generate = spec
+        if self._config.copy_mesh_files:
+            spec_to_generate, mesh_files = package_spec_meshes(
+                spec, output_dir, spec_dir=spec_dir, solver="orcawave"
+            )
+            self._result.mesh_files = mesh_files
+
         # Generate single input file (required for solver)
-        input_file, modular_files = self._generate_input_files(spec, output_dir)
+        input_file, modular_files = self._generate_input_files(
+            spec_to_generate, output_dir
+        )
         self._result.input_file = input_file
         self._result.modular_files = modular_files
 
-        # Copy mesh files
-        if self._config.copy_mesh_files:
-            mesh_files = self._copy_mesh_files(spec, output_dir, spec_dir=spec_dir)
-            self._result.mesh_files = mesh_files
-
         # Validate mesh references
-        warnings = self._validate_mesh_references(spec, output_dir)
+        warnings = self._validate_mesh_references(spec_to_generate, output_dir)
         if warnings:
             self._result.error_message = "; ".join(warnings)
 

--- a/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
@@ -24,8 +24,8 @@ from pathlib import Path
 from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
-    copy_spec_meshes,
     iter_mesh_references,
+    package_spec_meshes,
     resolve_mesh_path,
 )
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
@@ -115,28 +115,35 @@ class SpecConverter:
         backend = self.backends[solver]
         output_dir = Path(output_dir)
 
+        # OrcaWave inputs reference meshes by basename. Package every
+        # referenced mesh into the output directory first — copying
+        # solver-ready formats unchanged and converting others via
+        # MeshPipeline — and generate from the rewritten spec so the YAML
+        # references the packaged filenames (#605, #606). AQWA needs no
+        # packaging: its backend embeds parsed mesh geometry in the .dat deck.
+        spec_to_generate = self.spec
+        if solver == "orcawave":
+            spec_to_generate, _ = package_spec_meshes(
+                self.spec,
+                output_dir,
+                spec_dir=self.spec_path.parent,
+                solver=solver,
+            )
+
         spec_dir = self.spec_path.parent if solver == "aqwa" else None
         if format == "single":
             if spec_dir is not None:
                 result = backend.generate_single(
-                    self.spec, output_dir, spec_dir=spec_dir
+                    spec_to_generate, output_dir, spec_dir=spec_dir
                 )
             else:
-                result = backend.generate_single(self.spec, output_dir)
+                result = backend.generate_single(spec_to_generate, output_dir)
         elif spec_dir is not None:
-            result = backend.generate_modular(self.spec, output_dir, spec_dir=spec_dir)
-        else:
-            result = backend.generate_modular(self.spec, output_dir)
-
-        # OrcaWave inputs reference meshes by basename; copy them alongside so
-        # the output directory is a self-contained, runnable package (#605).
-        # AQWA needs no copy: its backend embeds parsed mesh geometry in the
-        # generated .dat deck.
-        if solver == "orcawave":
-            package_dir = result if result.is_dir() else result.parent
-            copy_spec_meshes(
-                self.spec, package_dir, spec_dir=self.spec_path.parent
+            result = backend.generate_modular(
+                spec_to_generate, output_dir, spec_dir=spec_dir
             )
+        else:
+            result = backend.generate_modular(spec_to_generate, output_dir)
 
         return result
 

--- a/tests/hydrodynamics/diffraction/test_mesh_pipeline_integration.py
+++ b/tests/hydrodynamics/diffraction/test_mesh_pipeline_integration.py
@@ -1,0 +1,159 @@
+"""MeshPipeline integration into spec conversion and runner (#606).
+
+Non-GDF meshes must be converted to OrcaWave's GDF target during packaging,
+with the generated YAML referencing the converted filename; already-ready GDF
+meshes copy unchanged (no conversion churn); unsupported formats fail with
+the supported-format list before anything is written.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    PROVENANCE_FILENAME,
+    package_spec_meshes,
+)
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
+    OrcaWaveRunner,
+    RunConfig,
+    RunStatus,
+)
+from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+BEMROSETTA_FIXTURES = Path(__file__).parents[1] / "bemrosetta" / "fixtures"
+
+
+def _spec_with_mesh(tmp_path: Path, mesh_name: str, source: str | None) -> Path:
+    """Ship fixture spec in tmp_path referencing *mesh_name*.
+
+    *source* names a bemrosetta fixture to copy in as the mesh (None = don't
+    create the file).
+    """
+    text = (FIXTURES_DIR / "spec_ship_raos.yml").read_text()
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.gdf"',
+        f'mesh_file: "{mesh_name}"',
+    )
+    fmt = Path(mesh_name).suffix.lstrip(".")
+    if fmt in ("gdf", "dat", "stl"):
+        text = text.replace("mesh_format: gdf", f"mesh_format: {fmt}")
+    spec_path = tmp_path / "spec.yml"
+    spec_path.write_text(text)
+    if source is not None:
+        shutil.copy2(BEMROSETTA_FIXTURES / source, tmp_path / mesh_name)
+    return spec_path
+
+
+def _body_mesh_name(input_file: Path) -> str:
+    documents = [d for d in yaml.safe_load_all(input_file.read_text()) if d]
+    return documents[0]["Bodies"][0]["BodyMeshFileName"]
+
+
+class TestGdfPassthrough:
+    def test_ready_gdf_copied_byte_identical(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.gdf", "sample_box.gdf")
+        out = tmp_path / "out"
+        SpecConverter(spec_path).convert(solver="orcawave", output_dir=out)
+        assert (out / "body.gdf").read_bytes() == (tmp_path / "body.gdf").read_bytes()
+
+    def test_no_provenance_file_without_conversion(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.gdf", "sample_box.gdf")
+        out = tmp_path / "out"
+        SpecConverter(spec_path).convert(solver="orcawave", output_dir=out)
+        assert not (out / PROVENANCE_FILENAME).exists()
+
+
+class TestDatConversion:
+    @pytest.fixture()
+    def converted(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.dat", "sample_box.dat")
+        out = tmp_path / "out"
+        result = SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=out
+        )
+        return result, out
+
+    def test_dat_mesh_converted_to_gdf(self, converted):
+        _, out = converted
+        assert (out / "body.gdf").is_file()
+
+    def test_generated_yml_references_converted_name(self, converted):
+        result, out = converted
+        mesh_ref = _body_mesh_name(result)
+        assert mesh_ref == "body.gdf"
+        assert (out / mesh_ref).is_file()
+
+    def test_provenance_recorded(self, converted):
+        _, out = converted
+        records = json.loads((out / PROVENANCE_FILENAME).read_text())
+        assert records[0]["source_format"] == "dat"
+        assert records[0]["packaged"] == "body.gdf"
+        assert "length_units" in records[0]
+        assert "symmetry" in records[0]
+
+    def test_source_spec_not_mutated(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.dat", "sample_box.dat")
+        converter = SpecConverter(spec_path)
+        converter.convert(solver="orcawave", output_dir=tmp_path / "out")
+        assert converter.spec.vessel.geometry.mesh_file == "body.dat"
+
+
+class TestUnsupportedFormat:
+    def test_fails_with_supported_format_list(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.obj", None)
+        (tmp_path / "body.obj").write_text("o box\n")
+        out = tmp_path / "out"
+        with pytest.raises(ValueError, match=r"Unsupported mesh format"):
+            SpecConverter(spec_path).convert(solver="orcawave", output_dir=out)
+
+    def test_fails_before_writing_anything(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.obj", None)
+        (tmp_path / "body.obj").write_text("o box\n")
+        out = tmp_path / "out"
+        with pytest.raises(ValueError):
+            SpecConverter(spec_path).convert(solver="orcawave", output_dir=out)
+        assert not out.exists() or not any(out.iterdir())
+
+    def test_message_lists_supported_formats(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.obj", None)
+        (tmp_path / "body.obj").write_text("o box\n")
+        with pytest.raises(ValueError, match=r"\.gdf") as exc_info:
+            package_spec_meshes(
+                DiffractionSpec.from_yaml(spec_path),
+                tmp_path / "out",
+                spec_dir=tmp_path,
+            )
+        assert ".stl" in str(exc_info.value)
+
+
+class TestRunnerIntegration:
+    def test_dry_run_converts_dat_and_references_gdf(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.dat", "sample_box.dat")
+        out = tmp_path / "out"
+        runner = OrcaWaveRunner(RunConfig(output_dir=out, dry_run=True))
+        result = runner.run(
+            DiffractionSpec.from_yaml(spec_path), spec_path=spec_path
+        )
+        assert result.status == RunStatus.DRY_RUN
+        assert any(p.name == "body.gdf" for p in result.mesh_files)
+        assert _body_mesh_name(result.input_file) == "body.gdf"
+        assert result.error_message is None
+
+    def test_dry_run_gdf_passthrough_unchanged(self, tmp_path):
+        spec_path = _spec_with_mesh(tmp_path, "body.gdf", "sample_box.gdf")
+        out = tmp_path / "out"
+        runner = OrcaWaveRunner(RunConfig(output_dir=out, dry_run=True))
+        result = runner.run(
+            DiffractionSpec.from_yaml(spec_path), spec_path=spec_path
+        )
+        assert result.status == RunStatus.DRY_RUN
+        assert _body_mesh_name(result.input_file) == "body.gdf"
+        assert not (out / PROVENANCE_FILENAME).exists()


### PR DESCRIPTION
Closes #606. Continues the #622 critical path on top of #731's shared `mesh_packaging` module.

## What

New `package_spec_meshes(spec, output_dir, spec_dir, solver)` in `mesh_packaging.py`, now the single packaging step for both `SpecConverter.convert` and `OrcaWaveRunner.prepare`:

1. **Format policy** (documented in the module): `.gdf` is solver-ready for OrcaWave and copies unchanged; `.fdf` (free-surface zone) is solver-native passthrough; `.dat`/`.stl` convert to GDF via `MeshPipeline.prepare_for_solver`; anything else raises `ValueError` with the full supported-format list **before any file is written**.
2. **Generated YAML references packaged names**: packaging now runs *before* generation on a `model_copy(deep=True)` of the spec whose `mesh_file`/`mesh_format` fields are rewritten to the packaged basenames (str-enum-safe). The caller's spec is never mutated (tested).
3. **Provenance**: conversions are recorded in `mesh_provenance.json` next to the package — source path, source/target formats, and `length_units`/`symmetry` where the spec slot carries them. No file is written for pure-passthrough packages.

## Acceptance criteria → status

- non-GDF spec → OrcaWave-ready package → `.dat` body mesh converts to `.gdf`, packaged + referenced (tested)
- ready GDF avoids conversion churn → byte-identical copy, no provenance file (tested)
- converted filenames reflected in generated YAML → `BodyMeshFileName: body.gdf` from a `body.dat` spec (tested)
- unsupported formats fail with supported list → `.obj` raises before writing anything (tested)
- unit tests: GDF passthrough + ≥1 conversion path → 11 tests in `test_mesh_pipeline_integration.py`, covering both converter and runner (dry-run) paths

## Verification (ace-linux-2)

- New integration tests: **11 passed**
- Full diffraction domain suite: **1492 passed, 24 skipped, 2 xfailed** — #605 packaging, #500 preflight, runner, converter, semantic-roundtrip all unchanged

## Notes

- One real bug caught during TDD: `MeshFormatType` is a str-based enum, so a naive `isinstance(x, str)` branch silently replaced the enum with a plain string and broke the backend's `.value` access — fixed by reconstructing with the original type.
- Mesh *quality* gating at this same seam is #608 (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)