### PR TITLE
feat(diffraction): mesh quality gates before diffraction solve (#608)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/cli.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/cli.py
@@ -470,7 +470,15 @@ def batch(config_file):
     default="output",
     help="Output directory (default: output)",
 )
-def convert_spec(spec_path, solver, fmt, output):
+@click.option(
+    "--quality-gates/--no-quality-gates",
+    default=True,
+    help=(
+        "Run geometry quality gates on packaged meshes; FAIL blocks "
+        "conversion (default: --quality-gates)"
+    ),
+)
+def convert_spec(spec_path, solver, fmt, output, quality_gates):
     """Convert a DiffractionSpec YAML to solver input files.
 
     SPEC_PATH: Path to a spec.yml file conforming to DiffractionSpec schema.
@@ -500,10 +508,15 @@ def convert_spec(spec_path, solver, fmt, output):
                 click.echo(f"  {name}: {path}")
         else:
             result_path = converter.convert(
-                solver=solver, format=fmt, output_dir=Path(output)
+                solver=solver,
+                format=fmt,
+                output_dir=Path(output),
+                quality_gates=quality_gates,
             )
             click.echo(click.style("[OK] Conversion complete:", fg="green"))
             click.echo(f"  {solver}: {result_path}")
+        for warning in converter.quality_warnings:
+            click.echo(click.style(f"  [QUALITY] {warning}", fg="yellow"))
 
     except Exception as e:
         click.echo(click.style(f"\n[ERROR] {e}", fg="red", bold=True))
@@ -537,8 +550,30 @@ def validate_spec(spec_path):
             for issue in issues:
                 click.echo(f"  - {issue}")
             sys.exit(1)
-        else:
-            click.echo(click.style("[OK] Spec is valid.", fg="green"))
+
+        # Mesh quality gates (#608): FAIL is blocking, warnings are not.
+        quality_failed = False
+        for gate in converter.check_mesh_quality():
+            if gate.status == "FAIL":
+                quality_failed = True
+                click.echo(click.style(
+                    f"[QUALITY FAIL] {gate.label} ('{gate.mesh}'):", fg="red"
+                ))
+                for issue in gate.blocking:
+                    click.echo(f"  - {issue}")
+            elif gate.status == "WARNING":
+                click.echo(click.style(
+                    f"[QUALITY WARN] {gate.label} ('{gate.mesh}'):", fg="yellow"
+                ))
+                for warning in gate.warnings:
+                    click.echo(f"  - {warning}")
+            elif gate.status == "PASS":
+                click.echo(click.style(
+                    f"[QUALITY PASS] {gate.label} ('{gate.mesh}')", fg="green"
+                ))
+        if quality_failed:
+            sys.exit(1)
+        click.echo(click.style("[OK] Spec is valid.", fg="green"))
 
     except Exception as e:
         click.echo(click.style(f"\n[ERROR] {e}", fg="red", bold=True))
@@ -695,6 +730,14 @@ def resolve_cmd(
         "(default: --no-strict-validation)"
     ),
 )
+@click.option(
+    "--quality-gates/--no-quality-gates",
+    default=True,
+    help=(
+        "Run geometry quality gates on packaged meshes; FAIL blocks the "
+        "run (default: --quality-gates)"
+    ),
+)
 def run_orcawave_cmd(
     spec_path,
     output,
@@ -704,6 +747,7 @@ def run_orcawave_cmd(
     modular,
     validate,
     strict_validation,
+    quality_gates,
 ):
     """Run an OrcaWave diffraction analysis from a DiffractionSpec YAML.
 
@@ -745,6 +789,7 @@ def run_orcawave_cmd(
             generate_modular=modular,
             validate_outputs=validate,
             validation_strict=strict_validation,
+            quality_gates=quality_gates,
         )
         runner = OrcaWaveRunner(config)
         result = runner.run(spec, spec_path=Path(spec_path))
@@ -756,6 +801,8 @@ def run_orcawave_cmd(
             click.echo(f"  Modular    : {len(result.modular_files)} section files")
         if result.mesh_files:
             click.echo(f"  Mesh files : {len(result.mesh_files)} copied")
+        for warning in getattr(result, "quality_warnings", []):
+            click.echo(click.style(f"  [QUALITY] {warning}", fg="yellow"))
         if result.duration_seconds is not None:
             click.echo(f"  Duration   : {result.duration_seconds:.2f}s")
         _echo_validation_block(result)
@@ -878,6 +925,8 @@ def run_aqwa_cmd(
         click.echo(f"  Output dir : {result.output_dir}")
         if result.mesh_files:
             click.echo(f"  Mesh files : {len(result.mesh_files)} copied")
+        for warning in getattr(result, "quality_warnings", []):
+            click.echo(click.style(f"  [QUALITY] {warning}", fg="yellow"))
         if result.lis_file:
             click.echo(f"  LIS file   : {result.lis_file}")
         if result.ah1_file:

--- a/src/digitalmodel/hydrodynamics/diffraction/geometry_quality.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/geometry_quality.py
@@ -244,11 +244,16 @@ class GeometryQualityChecker:
         min_aspect = float('inf')
 
         for panel in panels:
-            panel_nodes = nodes[panel[:3]]
+            indices = list(panel)
+            # Triangles are often stored as degenerate quads (last index
+            # repeated); drop the duplicate so every edge has real length.
+            if len(indices) == 4 and indices[3] == indices[2]:
+                indices = indices[:3]
+            panel_nodes = nodes[indices]
 
             # Calculate edge lengths
             edges = []
-            n = len(panel)
+            n = len(panel_nodes)
             for i in range(n):
                 edge_len = np.linalg.norm(panel_nodes[(i+1) % n] - panel_nodes[i])
                 edges.append(edge_len)
@@ -291,11 +296,16 @@ class GeometryQualityChecker:
         # Calculate characteristic size for each panel
         sizes = []
         for panel in panels:
-            panel_nodes = nodes[panel[:3]]
+            indices = list(panel)
+            # Triangles are often stored as degenerate quads (last index
+            # repeated); drop the duplicate so every edge has real length.
+            if len(indices) == 4 and indices[3] == indices[2]:
+                indices = indices[:3]
+            panel_nodes = nodes[indices]
 
             # Use edge lengths
             edges = []
-            n = len(panel)
+            n = len(panel_nodes)
             for i in range(n):
                 edge_len = np.linalg.norm(panel_nodes[(i+1) % n] - panel_nodes[i])
                 edges.append(edge_len)

--- a/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
@@ -157,7 +157,8 @@ def package_spec_meshes(
     output_dir: Path,
     spec_dir: Path | None = None,
     solver: str = "orcawave",
-) -> tuple[DiffractionSpec, list[Path]]:
+    quality_gates: bool = True,
+) -> tuple[DiffractionSpec, list[Path], list[str]]:
     """Prepare every referenced mesh for *solver* into *output_dir* (#606).
 
     Solver-ready formats (e.g. ``.gdf`` for OrcaWave) and solver-native
@@ -168,15 +169,22 @@ def package_spec_meshes(
     anything is written. Missing files are skipped — existence is the
     pre-flight's responsibility (#500).
 
+    With *quality_gates* enabled (#608), every packaged panel mesh runs the
+    geometry quality checks: a FAIL verdict raises ``MeshQualityError`` and
+    a machine-readable ``mesh_quality_report.json`` is written next to the
+    packaged meshes. Non-blocking warnings are returned for the caller to
+    surface.
+
     Conversions are recorded in ``mesh_provenance.json`` next to the
     packaged meshes (source path, formats, units/symmetry where the spec
     carries them).
 
     Returns
     -------
-    tuple[DiffractionSpec, list[Path]]
+    tuple[DiffractionSpec, list[Path], list[str]]
         A deep copy of *spec* whose mesh references (and formats) point at
-        the packaged files, and the packaged file paths.
+        the packaged files, the packaged file paths, and non-blocking
+        quality warnings.
     """
     solver = solver.lower()
     if solver not in _SOLVER_READY_EXTENSIONS:
@@ -195,6 +203,7 @@ def package_spec_meshes(
     pipeline = None
     packaged: list[Path] = []
     provenance: list[dict[str, Any]] = []
+    gate_results: list[Any] = []
 
     for slot in _iter_mesh_slots(packaged_spec):
         source = resolve_mesh_path(slot.mesh_file, spec_dir)
@@ -232,8 +241,24 @@ def package_spec_meshes(
         _set_mesh_reference(slot.owner, dest.name, dest.suffix.lstrip("."))
         packaged.append(dest)
 
+        if quality_gates:
+            from digitalmodel.hydrodynamics.diffraction.quality_gates import (
+                run_mesh_quality_gate,
+            )
+
+            gate_results.append(run_mesh_quality_gate(dest, label=slot.label))
+
     if provenance:
         (output_dir / PROVENANCE_FILENAME).write_text(
             json.dumps(provenance, indent=2)
         )
-    return packaged_spec, packaged
+
+    quality_warnings: list[str] = []
+    if quality_gates and gate_results:
+        from digitalmodel.hydrodynamics.diffraction.quality_gates import (
+            enforce_quality_gates,
+        )
+
+        quality_warnings = enforce_quality_gates(gate_results, output_dir)
+
+    return packaged_spec, packaged, quality_warnings

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -131,6 +131,13 @@ class RunConfig(BaseModel):
         default=True,
         description="Generate modular section files alongside the single input file.",
     )
+    quality_gates: bool = Field(
+        default=True,
+        description=(
+            "Run geometry quality gates on packaged meshes; FAIL blocks the "
+            "run, warnings are reported (#608)."
+        ),
+    )
     copy_mesh_files: bool = Field(
         default=True,
         description="Copy mesh files referenced by the spec into the output directory.",
@@ -217,6 +224,8 @@ class RunResult:
     xlsx_path: Path | None = None
     report_path: Path | None = None
     # --- #625 validation contract ---
+    quality_warnings: list[str] = field(default_factory=list)
+
     validation_report_path: Path | None = None
     validation_verdict: str = "SKIPPED"
     validation_issues: list[str] = field(default_factory=list)
@@ -359,10 +368,15 @@ class OrcaWaveRunner:
         # solver-ready filenames (#606).
         spec_to_generate = spec
         if self._config.copy_mesh_files:
-            spec_to_generate, mesh_files = package_spec_meshes(
-                spec, output_dir, spec_dir=spec_dir, solver="orcawave"
+            spec_to_generate, mesh_files, quality_warnings = package_spec_meshes(
+                spec,
+                output_dir,
+                spec_dir=spec_dir,
+                solver="orcawave",
+                quality_gates=self._config.quality_gates,
             )
             self._result.mesh_files = mesh_files
+            self._result.quality_warnings = quality_warnings
 
         # Generate single input file (required for solver)
         input_file, modular_files = self._generate_input_files(

--- a/src/digitalmodel/hydrodynamics/diffraction/quality_gates.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/quality_gates.py
@@ -1,0 +1,151 @@
+"""Pre-solve mesh quality gates for diffraction packaging (#608).
+
+Bridges ``MeshPipeline`` (mesh loading) and ``GeometryQualityChecker``
+(quality analysis) into a gate with a calibrated blocking policy:
+
+- ``FAIL`` (fewer than 3 of 5 checks pass) **blocks** solve/package
+  generation — the geometry is unusable.
+- ``WARNING`` is reported but never blocks. Calibration note: legitimate
+  diffraction hull meshes are open at the waterline, so the watertightness
+  check fails them by design; small meshes also trip the panel-count check.
+  Such meshes score WARNING and must pass through.
+
+Reports are written machine-readably to ``mesh_quality_report.json`` in the
+package directory and surfaced human-readably by the CLI.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from digitalmodel.hydrodynamics.diffraction.geometry_quality import (
+    GeometryQualityChecker,
+    GeometryQualityReport,
+)
+
+QUALITY_REPORT_FILENAME = "mesh_quality_report.json"
+
+# Quality checks apply to panel meshes the pipeline can load; solver-native
+# auxiliary formats (e.g. .fdf free-surface zones) have no panel topology.
+_CHECKABLE_EXTENSIONS = {".gdf", ".dat", ".stl"}
+
+
+class MeshQualityError(ValueError):
+    """A mesh failed blocking quality gates; solve/packaging must not proceed."""
+
+
+@dataclass
+class QualityGateResult:
+    """Outcome of the quality gate for a single mesh."""
+
+    label: str
+    mesh: str
+    status: str  # PASS / WARNING / FAIL / SKIPPED
+    blocking: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    report: GeometryQualityReport | None = None
+
+    def to_dict(self) -> dict:
+        data = {
+            "label": self.label,
+            "mesh": self.mesh,
+            "status": self.status,
+            "blocking": self.blocking,
+            "warnings": self.warnings,
+        }
+        if self.report is not None:
+            data["report"] = asdict(self.report)
+        return data
+
+
+def _collect_issues(report: GeometryQualityReport) -> list[str]:
+    return (
+        list(report.watertight_issues)
+        + list(report.normal_issues)
+        + list(report.panel_count_issues)
+        + list(report.aspect_ratio_issues)
+        + list(report.element_size_issues)
+    )
+
+
+def run_mesh_quality_gate(mesh_path: Path, label: str = "mesh") -> QualityGateResult:
+    """Run the geometry quality checks on one mesh file.
+
+    Non-panel formats are SKIPPED. The checker's console narration is
+    suppressed; callers present the result themselves.
+    """
+    mesh_path = Path(mesh_path)
+    if mesh_path.suffix.lower() not in _CHECKABLE_EXTENSIONS:
+        return QualityGateResult(
+            label=label, mesh=mesh_path.name, status="SKIPPED"
+        )
+
+    from digitalmodel.hydrodynamics.diffraction.mesh_pipeline import MeshPipeline
+
+    mesh = MeshPipeline().load(mesh_path)
+    checker = GeometryQualityChecker()
+    with contextlib.redirect_stdout(io.StringIO()):
+        report = checker.generate_report(
+            str(mesh_path), mesh.vertices, mesh.panels
+        )
+
+    issues = _collect_issues(report)
+    if report.overall_status == "FAIL":
+        return QualityGateResult(
+            label=label,
+            mesh=mesh_path.name,
+            status="FAIL",
+            blocking=issues,
+            report=report,
+        )
+    warnings = issues if report.overall_status == "WARNING" else []
+    return QualityGateResult(
+        label=label,
+        mesh=mesh_path.name,
+        status=report.overall_status,
+        warnings=warnings,
+        report=report,
+    )
+
+
+def enforce_quality_gates(
+    results: list[QualityGateResult], output_dir: Path | None = None
+) -> list[str]:
+    """Write the machine-readable report and raise on any blocking FAIL.
+
+    Returns the non-blocking warning lines (one per warning, prefixed with
+    the mesh label) for the caller to surface.
+    """
+    if output_dir is not None and any(r.status != "SKIPPED" for r in results):
+        report_path = Path(output_dir) / QUALITY_REPORT_FILENAME
+        report_path.write_text(
+            json.dumps(
+                [r.to_dict() for r in results],
+                indent=2,
+                # the checker stores numpy scalars (np.bool_, np.float64)
+                default=lambda o: o.item() if hasattr(o, "item") else str(o),
+            )
+        )
+
+    failed = [r for r in results if r.status == "FAIL"]
+    if failed:
+        lines = [
+            f"{r.label} ('{r.mesh}'): {issue}"
+            for r in failed
+            for issue in r.blocking
+        ]
+        raise MeshQualityError(
+            "Mesh quality gates failed (geometry unusable for diffraction):\n  "
+            + "\n  ".join(lines)
+            + f"\nFull report: {QUALITY_REPORT_FILENAME} in the output directory."
+        )
+
+    return [
+        f"{r.label} ('{r.mesh}') quality {r.status}: {w}"
+        for r in results
+        for w in r.warnings
+    ]

--- a/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_converter.py
@@ -58,6 +58,8 @@ class SpecConverter:
     def __init__(self, spec_path: Path) -> None:
         self.spec_path = Path(spec_path)
         self.spec = DiffractionSpec.from_yaml(self.spec_path)
+        # Non-blocking mesh quality warnings from the most recent convert()
+        self.quality_warnings: list[str] = []
         self.backends: dict[str, AQWABackend | OrcaWaveBackend] = {
             "aqwa": AQWABackend(),
             "orcawave": OrcaWaveBackend(),
@@ -68,6 +70,7 @@ class SpecConverter:
         solver: str,
         format: str = "single",
         output_dir: Path = Path("output"),
+        quality_gates: bool = True,
     ) -> Path:
         """Convert spec to solver-specific input files.
 
@@ -122,12 +125,14 @@ class SpecConverter:
         # references the packaged filenames (#605, #606). AQWA needs no
         # packaging: its backend embeds parsed mesh geometry in the .dat deck.
         spec_to_generate = self.spec
+        self.quality_warnings = []
         if solver == "orcawave":
-            spec_to_generate, _ = package_spec_meshes(
+            spec_to_generate, _, self.quality_warnings = package_spec_meshes(
                 self.spec,
                 output_dir,
                 spec_dir=self.spec_path.parent,
                 solver=solver,
+                quality_gates=quality_gates,
             )
 
         spec_dir = self.spec_path.parent if solver == "aqwa" else None
@@ -241,3 +246,24 @@ class SpecConverter:
                     f"against the spec file directory '{self.spec_path.parent}')."
                 )
         return issues
+
+    def check_mesh_quality(self) -> list["QualityGateResult"]:
+        """Run geometry quality gates on every resolvable mesh (#608).
+
+        Source meshes are checked in place (no packaging side effects);
+        missing files are skipped — existence is :meth:`validate`'s job.
+        """
+        from digitalmodel.hydrodynamics.diffraction.quality_gates import (
+            run_mesh_quality_gate,
+        )
+
+        results = []
+        for reference in iter_mesh_references(self.spec):
+            resolved = resolve_mesh_path(
+                reference.mesh_file, self.spec_path.parent
+            )
+            if resolved.is_file():
+                results.append(
+                    run_mesh_quality_gate(resolved, label=reference.label)
+                )
+        return results

--- a/tests/hydrodynamics/diffraction/test_quality_gates.py
+++ b/tests/hydrodynamics/diffraction/test_quality_gates.py
@@ -1,0 +1,184 @@
+"""Pre-solve mesh quality gates (#608).
+
+FAIL verdicts block solve/package generation; WARNING verdicts are surfaced
+but never block — calibrated so legitimate waterline-open hull meshes (which
+fail the watertightness check by design) pass through with warnings.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    package_spec_meshes,
+)
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
+    OrcaWaveRunner,
+    RunConfig,
+    RunStatus,
+)
+from digitalmodel.hydrodynamics.diffraction.quality_gates import (
+    QUALITY_REPORT_FILENAME,
+    MeshQualityError,
+    run_mesh_quality_gate,
+)
+from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SAMPLE_GDF = Path(__file__).parents[1] / "bemrosetta" / "fixtures" / "sample_box.gdf"
+
+# Two disjoint panels: a sliver (aspect ratio ~10000) and a large quad —
+# non-watertight, too few panels, terrible aspect ratio, wild element-size
+# variance. Fails enough checks to score FAIL.
+BAD_GDF = """\
+deliberately bad mesh for quality gate tests
+1.0  9.81
+0  0
+2
+0.000000  0.000000  -1.000000
+10.000000  0.000000  -1.000000
+10.000000  0.001000  -1.000000
+0.000000  0.001000  -1.000000
+0.000000  0.000000  -2.000000
+5.000000  0.000000  -2.000000
+5.000000  5.000000  -2.000000
+0.000000  5.000000  -2.000000
+"""
+
+
+def _spec_in_tmp(tmp_path: Path, mesh_name: str = "body.gdf") -> Path:
+    text = (FIXTURES_DIR / "spec_ship_raos.yml").read_text()
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.gdf"',
+        f'mesh_file: "{mesh_name}"',
+    )
+    spec_path = tmp_path / "spec.yml"
+    spec_path.write_text(text)
+    return spec_path
+
+
+@pytest.fixture
+def good_mesh_spec(tmp_path):
+    spec_path = _spec_in_tmp(tmp_path)
+    shutil.copy2(SAMPLE_GDF, tmp_path / "body.gdf")
+    return spec_path
+
+
+@pytest.fixture
+def bad_mesh_spec(tmp_path):
+    spec_path = _spec_in_tmp(tmp_path)
+    (tmp_path / "body.gdf").write_text(BAD_GDF)
+    return spec_path
+
+
+class TestGateVerdicts:
+    def test_legit_open_waterline_mesh_warns_not_blocks(self):
+        gate = run_mesh_quality_gate(SAMPLE_GDF, label="body")
+        assert gate.status == "WARNING"
+        assert gate.blocking == []
+        assert gate.warnings  # watertightness/panel-count surfaced
+
+    def test_bad_mesh_fails(self, tmp_path):
+        bad = tmp_path / "bad.gdf"
+        bad.write_text(BAD_GDF)
+        gate = run_mesh_quality_gate(bad, label="body")
+        assert gate.status == "FAIL"
+        assert gate.blocking
+
+    def test_fdf_skipped(self, tmp_path):
+        zone = tmp_path / "zone.fdf"
+        zone.write_text("not a panel mesh\n")
+        gate = run_mesh_quality_gate(zone, label="free surface zone")
+        assert gate.status == "SKIPPED"
+
+    def test_aspect_ratio_no_crash_on_quads(self):
+        """Regression: checker crashed on quad panels (nodes[panel[:3]])."""
+        gate = run_mesh_quality_gate(SAMPLE_GDF)
+        assert gate.report is not None
+        assert gate.report.total_checks == gate.report.passed_checks + (
+            gate.report.total_checks - gate.report.passed_checks
+        )
+
+
+class TestConvertGating:
+    def test_good_mesh_converts_with_warnings(self, good_mesh_spec, tmp_path):
+        converter = SpecConverter(good_mesh_spec)
+        out = tmp_path / "out"
+        result = converter.convert(solver="orcawave", output_dir=out)
+        assert result.is_file()
+        assert converter.quality_warnings
+        assert (out / QUALITY_REPORT_FILENAME).is_file()
+
+    def test_bad_mesh_blocks_conversion(self, bad_mesh_spec, tmp_path):
+        converter = SpecConverter(bad_mesh_spec)
+        with pytest.raises(MeshQualityError, match="quality gates failed"):
+            converter.convert(solver="orcawave", output_dir=tmp_path / "out")
+
+    def test_machine_readable_report_written_on_fail(self, bad_mesh_spec, tmp_path):
+        out = tmp_path / "out"
+        with pytest.raises(MeshQualityError):
+            SpecConverter(bad_mesh_spec).convert(solver="orcawave", output_dir=out)
+        records = json.loads((out / QUALITY_REPORT_FILENAME).read_text())
+        assert records[0]["status"] == "FAIL"
+        assert records[0]["blocking"]
+        assert "report" in records[0]
+
+    def test_no_quality_gates_escape_hatch(self, bad_mesh_spec, tmp_path):
+        converter = SpecConverter(bad_mesh_spec)
+        result = converter.convert(
+            solver="orcawave",
+            output_dir=tmp_path / "out",
+            quality_gates=False,
+        )
+        assert result.is_file()
+        assert converter.quality_warnings == []
+
+
+class TestRunnerGating:
+    def test_bad_mesh_blocks_run(self, bad_mesh_spec, tmp_path):
+        runner = OrcaWaveRunner(
+            RunConfig(output_dir=tmp_path / "out", dry_run=True)
+        )
+        spec = DiffractionSpec.from_yaml(bad_mesh_spec)
+        with pytest.raises(MeshQualityError):
+            runner.run(spec, spec_path=bad_mesh_spec)
+
+    def test_quality_gates_off_allows_run(self, bad_mesh_spec, tmp_path):
+        runner = OrcaWaveRunner(
+            RunConfig(
+                output_dir=tmp_path / "out", dry_run=True, quality_gates=False
+            )
+        )
+        spec = DiffractionSpec.from_yaml(bad_mesh_spec)
+        result = runner.run(spec, spec_path=bad_mesh_spec)
+        assert result.status == RunStatus.DRY_RUN
+
+    def test_warnings_surfaced_on_result(self, good_mesh_spec, tmp_path):
+        runner = OrcaWaveRunner(
+            RunConfig(output_dir=tmp_path / "out", dry_run=True)
+        )
+        spec = DiffractionSpec.from_yaml(good_mesh_spec)
+        result = runner.run(spec, spec_path=good_mesh_spec)
+        assert result.status == RunStatus.DRY_RUN
+        assert result.quality_warnings
+
+
+class TestValidateSpecQuality:
+    def test_check_mesh_quality_reports_per_mesh(self, good_mesh_spec):
+        results = SpecConverter(good_mesh_spec).check_mesh_quality()
+        assert len(results) == 1
+        assert results[0].status == "WARNING"
+
+    def test_package_spec_meshes_returns_warnings(self, good_mesh_spec, tmp_path):
+        spec = DiffractionSpec.from_yaml(good_mesh_spec)
+        _, _, warnings = package_spec_meshes(
+            spec,
+            tmp_path / "out",
+            spec_dir=good_mesh_spec.parent,
+        )
+        assert warnings


### PR DESCRIPTION
Closes #608. **Stacked on #733** (base branch is `feat/606-meshpipeline-integration`) — merge #733 first, then this lands on the same packaging seam. The diff shown here is #608-only.

## What

New `quality_gates.py` bridging `MeshPipeline` (loading) and `GeometryQualityChecker` (analysis) into a gate with an empirically calibrated policy:

- **FAIL blocks** (`MeshQualityError`), **WARNING reports** — calibration evidence: legitimate waterline-open hull meshes (repo fixture boxes) fail the watertightness check *by design* and score WARNING; they must pass through. A genuinely degenerate mesh (sliver panels, non-watertight, wild element variance) scores FAIL and blocks.
- Gates run on every packaged panel mesh inside `package_spec_meshes` → both `convert-spec` and `run-orcawave` are protected; `.fdf` zone meshes are SKIPPED (no panel topology).
- `validate-spec` now prints a per-mesh quality section (PASS green / WARN yellow / FAIL red + exit 1).
- Machine-readable `mesh_quality_report.json` (full checker report per mesh, numpy-safe) written next to the packaged meshes; human-readable warnings echoed by the CLI and carried on `RunResult.quality_warnings`.
- Escape hatches: `--no-quality-gates` on both commands, `RunConfig.quality_gates=False`.

## Two real bugs found and fixed in `GeometryQualityChecker`

`check_aspect_ratios` **and** `check_element_sizes` both did `nodes[panel[:3]]` (3 nodes) while looping `len(panel)` (4) edges → `IndexError` on any quad-panel mesh — i.e. the checker crashed on the most common WAMIT GDF meshes. Fixed with degenerate-quad-aware indexing; regression-covered.

## Acceptance criteria → status

- QA during validate-spec or preflight → validate-spec section + gates inside packaging (both)
- Blocking errors prevent solve/package → `MeshQualityError` from convert and run paths (tested)
- Non-blocking warnings reported clearly → CLI yellow `[QUALITY]` lines + `RunResult.quality_warnings` (tested)
- Machine- + human-readable report → `mesh_quality_report.json` + CLI output (tested)
- Tests with valid + invalid meshes → 13 tests: legit-open-hull WARNING, crafted bad-mesh FAIL, fdf SKIP, escape hatches, report content

## Verification (ace-linux-2)

- Quality gate tests: **13 passed**
- Full diffraction domain suite: **1505 passed, 24 skipped, 2 xfailed**
- `diffraction validate-spec` on the canonical example: warnings listed (watertight/panel-count), `[OK] Spec is valid.`
- Caught in-suite: the shared CLI echo also runs for `run-aqwa`, whose result type lacks the new field — guarded with `getattr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)