### PR TITLE
chore(orcaflex): refresh spec-library audit — 100% pass, parallel runner (#716)

### DIFF
--- a/docs/domains/orcaflex/SECTION_FIDELITY_ANALYSIS.md
+++ b/docs/domains/orcaflex/SECTION_FIDELITY_ANALYSIS.md
@@ -1,5 +1,12 @@
 # OrcaFlex Section Fidelity Analysis
 
+> **SUPERSEDED (failure counts):** the per-spec failure inventory below is a
+> 2026-04-10 snapshot and is obsolete — every failure category it lists has
+> since been fixed. Current pass rates and regeneration instructions live in
+> [`SPEC_AUDIT_SNAPSHOT.md`](SPEC_AUDIT_SNAPSHOT.md) (2026-06-12: 91/91
+> OrcaFlex, 13/13 OrcaWave all-stages pass). The builder-track architecture
+> and section-coverage matrix below remain valid reference material.
+
 **Date:** 2026-04-10
 **Scope:** Modular generator builders vs OrcaFlex YAML-strict sections
 

--- a/docs/domains/orcaflex/SPEC_AUDIT_SNAPSHOT.md
+++ b/docs/domains/orcaflex/SPEC_AUDIT_SNAPSHOT.md
@@ -1,0 +1,67 @@
+# Spec Library Audit Snapshot
+
+> Generated 2026-06-12 on current main + #716 branch (`scripts/audit_all_specs.py`).
+> Supersedes the failure inventory in `SECTION_FIDELITY_ANALYSIS.md`
+> (2026-04-10), whose builder-fidelity *matrix* remains useful but whose
+> failure counts are obsolete. Regenerate this snapshot with:
+>
+> ```bash
+> uv run python scripts/audit_all_specs.py --json /tmp/audit.json
+> ```
+>
+> Tracking issue: [#716](https://github.com/vamseeachanta/digitalmodel/issues/716).
+
+## Results (2026-06-12)
+
+| Stage | OrcaFlex | OrcaWave |
+|-------|----------|----------|
+| YAML parseable | 91/91 | 13/13 |
+| Schema validation (`ProjectInputSpec` / `DiffractionSpec`) | 91/91 | 13/13 |
+| Generation (master.yml + includes) | 91/91 | 13/13 |
+| YAML-strict validator | 91/91 | n/a |
+| Post-validation (cross-references) | 91/91 | n/a |
+| **ALL STAGES PASS** | **91/91 (100%)** | **13/13 (100%)** |
+
+3 additional OrcaFlex specs use intentionally different schemas and are
+excluded from the `ProjectInputSpec` denominator (1 passing-ship, 2 jumper
+installation — see #506; the jumper specs convert via
+`jumper_to_modular_spec.build_modular_spec()`, #602).
+
+Model-type distribution: 77 generic, 8 riser, 5 pipeline, 1 minimal.
+
+## Disposition of the 2026-04-10 failure inventory
+
+Every failure category in the old fidelity analysis is resolved on current
+main; none required new work in #716 except the last item:
+
+| Old category (count) | Status | Where fixed |
+|---|---|---|
+| Schema: `seabed.stiffness.shear` null (≈11) | fixed | `environment.py` `_coerce_none_to_zero` validator |
+| Generation: `equipment.ramp` vs `ramps` (≈5) | fixed | `shapes_builder.py:39` uses `ramps` |
+| YAML-strict: `ImplicitVariableMaxTimeStep` (≈2) | fixed | `generic_builder.py` `_SKIP_GENERAL_KEYS` |
+| Post-validator reference gaps (≈7 specs / 34 errors) | not reproducible | 91/91 post-validation pass; #717 should re-verify against its own fresh list before doing any work |
+| `frps_ssr_global_riser`: placeholder `period: 0.0` rejected by `gt=0` | **fixed in #716** | spec placeholder set to 8.0 s ("SET per load case" comment retained) |
+
+## Audit runtime
+
+| Mode | Wall time | Notes |
+|------|-----------|-------|
+| Sequential (`--workers 1`, legacy behavior) | ~662 s | dominated by multi-MB extracted specs |
+| Parallel (default, 31 workers on ace-linux-2) | 324 s | wall-bounded by the single slowest spec (~5.4 min for the largest extracted model) |
+| `--changed-only` (pre-commit / PR gate) | seconds–90 s | audits only spec.yml files differing from origin/main; the #509 hook should use this |
+
+The issue's aspirational <60 s full-library target is not reachable by
+parallelism alone — the floor is per-spec Pydantic validation time on the
+multi-MB extracted specs. That is the per-iteration `model_validate`
+performance problem already tracked in
+[#536](https://github.com/vamseeachanta/digitalmodel/issues/536); if #536
+lands, rerun and update this table.
+
+## CLI
+
+```
+--domain {all,orcaflex,orcawave}   restrict to one solver domain
+--workers N                        parallel processes (1 = sequential)
+--changed-only                     only specs changed vs origin/main
+--json PATH                        machine-readable results
+```

--- a/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/spec.yml
+++ b/docs/domains/orcaflex/library/model_library/frps_ssr_global_riser/spec.yml
@@ -77,7 +77,7 @@ environment:
   waves:
     type: JONSWAP                               # storm spectrum (PLACEHOLDER - see metocean matrix)
     height: 0.0                                 # Hs (m) - SET per load case
-    period: 0.0                                 # Tp (s) - SET per load case
+    period: 8.0                                 # Tp (s) PLACEHOLDER (schema requires >0) - SET per load case
     direction: 180
     gamma: 2.4                                  # GoM hurricane (PLACEHOLDER)
   current:

--- a/scripts/audit_all_specs.py
+++ b/scripts/audit_all_specs.py
@@ -2,9 +2,25 @@
 """Audit all spec.yml files for OrcaFlex and OrcaWave readiness.
 
 Reports pass/fail/error for each spec across multiple validation stages.
+
+Usage:
+    uv run python scripts/audit_all_specs.py                 # full audit
+    uv run python scripts/audit_all_specs.py --domain orcaflex
+    uv run python scripts/audit_all_specs.py --changed-only  # vs origin/main
+    uv run python scripts/audit_all_specs.py --workers 8 --json /tmp/audit.json
+
+Specs run in parallel worker processes (default: cpu_count - 1); use
+--workers 1 to force the legacy sequential behavior. --changed-only audits
+only spec.yml files that differ from origin/main (suitable for the #509
+pre-commit hook).
 """
 
+import argparse
+import json
+import multiprocessing
+import subprocess
 import sys
+import time
 from pathlib import Path
 import yaml
 import traceback
@@ -208,7 +224,52 @@ def audit_orcawave_spec(spec_path: Path) -> dict:
     return result
 
 
+def _changed_spec_paths() -> set[Path]:
+    """spec.yml files changed vs origin/main (working tree + staged)."""
+    repo_root = Path(__file__).parent.parent
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main", "--", "*spec.yml"],
+        capture_output=True, text=True, cwd=repo_root,
+    )
+    return {
+        (repo_root / line).resolve()
+        for line in out.stdout.splitlines()
+        if line.strip()
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--domain", choices=["all", "orcaflex", "orcawave"], default="all",
+        help="Restrict the audit to one solver domain",
+    )
+    parser.add_argument(
+        "--workers", type=int, default=max(1, multiprocessing.cpu_count() - 1),
+        help="Parallel worker processes (1 = sequential)",
+    )
+    parser.add_argument(
+        "--changed-only", action="store_true",
+        help="Audit only spec.yml files changed vs origin/main",
+    )
+    parser.add_argument(
+        "--json", type=Path, default=None, metavar="PATH",
+        help="Also write full results as JSON to PATH",
+    )
+    return parser.parse_args()
+
+
+def _run_audits(audit_fn, specs: list[Path], workers: int) -> list[dict]:
+    if workers <= 1 or len(specs) <= 1:
+        return [audit_fn(p) for p in specs]
+    with multiprocessing.Pool(workers) as pool:
+        return pool.map(audit_fn, specs)
+
+
 def main():
+    args = _parse_args()
+    started = time.monotonic()
+
     print("=" * 80)
     print("OrcaFlex & OrcaWave Spec Readiness Audit")
     print("=" * 80)
@@ -217,17 +278,29 @@ def main():
     orcaflex_specs = sorted(ORCAFLEX_SPEC_DIR.rglob("spec.yml"))
     orcawave_specs = sorted(ORCAWAVE_SPEC_DIR.rglob("spec.yml"))
 
-    print(f"\nFound {len(orcaflex_specs)} OrcaFlex specs, {len(orcawave_specs)} OrcaWave specs\n")
+    if args.domain == "orcaflex":
+        orcawave_specs = []
+    elif args.domain == "orcawave":
+        orcaflex_specs = []
+
+    if args.changed_only:
+        changed = _changed_spec_paths()
+        orcaflex_specs = [p for p in orcaflex_specs if p.resolve() in changed]
+        orcawave_specs = [p for p in orcawave_specs if p.resolve() in changed]
+        if not orcaflex_specs and not orcawave_specs:
+            print("\nNo spec.yml changes vs origin/main — nothing to audit.")
+            return [], []
+
+    print(f"\nFound {len(orcaflex_specs)} OrcaFlex specs, {len(orcawave_specs)} OrcaWave specs"
+          f" (workers={args.workers})\n")
 
     # Audit OrcaFlex
     print("=" * 80)
     print("ORCAFLEX SPECS")
     print("=" * 80)
 
-    ofx_results = []
-    for i, spec_path in enumerate(orcaflex_specs, 1):
-        r = audit_orcaflex_spec(spec_path)
-        ofx_results.append(r)
+    ofx_results = _run_audits(audit_orcaflex_spec, orcaflex_specs, args.workers)
+    for i, r in enumerate(ofx_results, 1):
         is_alt = r["schema_valid"] == "different_schema"
         all_pass = is_alt or all(
             v == "pass"
@@ -250,10 +323,8 @@ def main():
     print("ORCAWAVE SPECS")
     print("=" * 80)
 
-    ow_results = []
-    for i, spec_path in enumerate(orcawave_specs, 1):
-        r = audit_orcawave_spec(spec_path)
-        ow_results.append(r)
+    ow_results = _run_audits(audit_orcawave_spec, orcawave_specs, args.workers)
+    for i, r in enumerate(ow_results, 1):
         all_pass = all(
             v == "pass" for k, v in r.items() if k not in ("path", "errors")
         )
@@ -352,6 +423,17 @@ def main():
             patterns[prefix] = patterns.get(prefix, 0) + 1
         for pattern, count in sorted(patterns.items(), key=lambda x: -x[1])[:15]:
             print(f"  {count:3d}x {pattern}")
+
+    elapsed = time.monotonic() - started
+    print(f"\nAudit wall time: {elapsed:.1f} s (workers={args.workers})")
+
+    if args.json:
+        args.json.write_text(json.dumps(
+            {"orcaflex": ofx_results, "orcawave": ow_results,
+             "elapsed_seconds": round(elapsed, 1)},
+            indent=2,
+        ))
+        print(f"JSON results written: {args.json}")
 
     # Return results for report generation
     return ofx_results, ow_results


### PR DESCRIPTION
Closes #716.

## Headline

Fresh audit on current main: **91/91 OrcaFlex + 13/13 OrcaWave specs pass ALL stages** (schema → generation → YAML-strict → post-validation). The stale 2026-04-10 failure inventory (≈25 failures across 4 categories) is fully obsolete — every category was already fixed on main by intervening work. The re-verify-before-fixing rule in the issue paid off: the planned "fix" work was already done; what remained was one real spec defect, the doc refresh, and the audit speed work.

## Changes

1. **One real fix**: `frps_ssr_global_riser` used a placeholder `period: 0.0` rejected by the schema's `gt=0` (correctly — OrcaFlex also rejects Tp=0). Set to a valid 8.0 s placeholder, "SET per load case" intent retained. Verified via the new `--changed-only` mode: PASS all stages.
2. **`SPEC_AUDIT_SNAPSHOT.md`** (new): dated results table, disposition of every old failure category with where-fixed references, runtime table, regeneration command. `SECTION_FIDELITY_ANALYSIS.md` gets a superseded notice (its builder-track matrix stays as reference).
3. **`audit_all_specs.py`**: parallel workers (full audit **662 s → 324 s**, now wall-bounded by the slowest multi-MB extracted spec — the remaining floor is #536's `model_validate` perf), `--changed-only` (the fast gate #509's pre-commit hook should call), `--domain`, `--json`, wall-time print. Default behavior unchanged apart from parallelism; `--workers 1` restores legacy sequential.

## Acceptance criteria → proof

- Fresh audit committed with date + per-category counts → `SPEC_AUDIT_SNAPSHOT.md`
- shear-null / ramps / ImplicitVariableMaxTimeStep → verified already fixed on main; disposition table cites the fix sites
- All previously-failing specs pass or filed → 91/91 after the frps fix; nothing left to file
- Fast mode documented + runtime recorded → runtime table; <60 s full-library target explicitly marked unreachable without #536 (honest gap, not silently dropped)
- Registry/inventory untouched → no claim changes

## Follow-up signal for #717

The post-validator failures (~7 specs / 34 errors in the old doc) are **not reproducible** — 91/91 post-validation pass. #717 should start by re-deriving its own failure list; the built-in-connections/arc-length gaps may already be closed. Commenting there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)