### PR TITLE
fix(diffraction): stop dropping body-level control surfaces (#609)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/input_schemas.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/input_schemas.py
@@ -656,6 +656,19 @@ class BodySpec(BaseModel):
         ),
     )
 
+    def resolve_control_surface(self) -> Optional["ControlSurfaceSpec"]:
+        """Resolve this body's control surface (#609).
+
+        Precedence: a body-level ``BodySpec.control_surface`` overrides the
+        vessel-level ``VesselSpec.control_surface``. This is the single
+        resolution rule shared by backend generation, mesh packaging, and
+        validation — multi-body specs with per-body control surfaces must
+        never be silently ignored.
+        """
+        if self.control_surface is not None:
+            return self.control_surface
+        return self.vessel.control_surface
+
 
 # ---------------------------------------------------------------------------
 # Top-level spec

--- a/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/mesh_packaging.py
@@ -63,7 +63,7 @@ def _iter_mesh_slots(spec: DiffractionSpec) -> Iterator[_MeshSlot]:
         yield _MeshSlot("Damping lid mesh", damping_lid.mesh_file, damping_lid)
 
     for body in bodies:
-        control_surface = getattr(body.vessel, "control_surface", None)
+        control_surface = body.resolve_control_surface()
         if control_surface is not None and control_surface.mesh_file:
             yield _MeshSlot(
                 f"Body '{body.vessel.name}' control surface mesh",

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_backend.py
@@ -257,8 +257,9 @@ def _build_body_dict(
     if add_interior:
         body["BodyInteriorSurfacePanelMethod"] = "Triangulation method"
 
-    # Control surface mesh (for mean drift loads)
-    cs = getattr(vessel, "control_surface", None)
+    # Control surface mesh (for mean drift loads). Body-level definitions
+    # take precedence over vessel-level (#609).
+    cs = body_spec.resolve_control_surface()
     if cs is not None and cs.mesh_file is not None:
         body["BodyControlSurfaceType"] = "Defined by mesh file"
         body["BodyControlSurfaceMeshFileName"] = Path(cs.mesh_file).name
@@ -427,16 +428,12 @@ def _build_general_section(spec: DiffractionSpec) -> dict[str, Any]:
                 solver.qtf_calculation
             )
     # Check if any body has an explicit control surface defined
-    has_body_control_surface = False
-    bodies = getattr(spec, "bodies", None)
-    if bodies:
-        for b in bodies:
-            if getattr(b, "control_surface", None) is not None:
-                has_body_control_surface = True
-                break
-    elif getattr(spec, "vessel", None) is not None:
-        if getattr(spec.vessel, "control_surface", None) is not None:
-            has_body_control_surface = True
+    # Same resolution rule as per-body emission: body-level overrides
+    # vessel-level (#609).
+    has_body_control_surface = any(
+        body.resolve_control_surface() is not None
+        for body in spec.get_bodies()
+    )
 
     if is_qtf:
         section["QuadraticLoadControlSurface"] = "No"

--- a/tests/hydrodynamics/diffraction/test_body_level_control_surfaces.py
+++ b/tests/hydrodynamics/diffraction/test_body_level_control_surfaces.py
@@ -1,0 +1,171 @@
+"""Body-level control surface resolution (#609).
+
+``BodySpec.control_surface`` must never be silently ignored: backend
+emission, mesh packaging, and preflight all share one resolution rule —
+body-level overrides vessel-level.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.hydrodynamics.diffraction.input_schemas import (
+    BodySpec,
+    ControlSurfaceSpec,
+    DiffractionSpec,
+    VesselSpec,
+)
+from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
+    iter_mesh_references,
+)
+from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+MESH_FIXTURE = (
+    Path(__file__).parents[1] / "bemrosetta" / "fixtures" / "sample_box.gdf"
+)
+
+BODY_CS = """\
+    control_surface:
+      type: mesh
+      mesh_file: "cs_body.gdf"
+"""
+
+VESSEL_CS = """\
+      control_surface:
+        type: mesh
+        mesh_file: "cs_vessel.gdf"
+"""
+
+
+def _multibody_spec(
+    tmp_path: Path, body_level: bool = True, vessel_level: bool = False
+) -> Path:
+    """FPSO+turret fixture in tmp_path with control surfaces injected.
+
+    Body-level CS goes on the Turret body; vessel-level CS on the Turret
+    vessel. Body meshes are localized so the spec is self-contained.
+    """
+    text = (FIXTURES_DIR / "spec_fpso_turret.yml").read_text()
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.gdf"',
+        'mesh_file: "hull.gdf"',
+    )
+    text = text.replace(
+        'mesh_file: "../../bemrosetta/fixtures/sample_box.dat"',
+        'mesh_file: "turret.gdf"',
+    ).replace("mesh_format: dat", "mesh_format: gdf")
+    if vessel_level:
+        text = text.replace(
+            "      fixed_dofs: [surge, sway, yaw]",
+            VESSEL_CS + "      fixed_dofs: [surge, sway, yaw]",
+        )
+    if body_level:
+        text = text.replace(
+            '    connection_parent: "FPSO_Hull"',
+            BODY_CS + '    connection_parent: "FPSO_Hull"',
+        )
+    spec_path = tmp_path / "spec.yml"
+    spec_path.write_text(text)
+    for name in ("hull.gdf", "turret.gdf", "cs_body.gdf", "cs_vessel.gdf"):
+        shutil.copy2(MESH_FIXTURE, tmp_path / name)
+    return spec_path
+
+
+def _bodies_from(result: Path) -> list[dict]:
+    documents = [d for d in yaml.safe_load_all(result.read_text()) if d]
+    return documents[0]["Bodies"]
+
+
+class TestResolutionRule:
+    def _vessel(self, control_surface=None) -> VesselSpec:
+        data = DiffractionSpec.from_yaml(
+            FIXTURES_DIR / "spec_ship_raos.yml"
+        ).vessel.model_dump()
+        data["control_surface"] = control_surface
+        return VesselSpec.model_validate(data)
+
+    def test_body_level_wins(self):
+        body = BodySpec(
+            vessel=self._vessel({"type": "mesh", "mesh_file": "vessel.gdf"}),
+            control_surface=ControlSurfaceSpec(type="mesh", mesh_file="body.gdf"),
+        )
+        assert body.resolve_control_surface().mesh_file == "body.gdf"
+
+    def test_falls_back_to_vessel_level(self):
+        body = BodySpec(
+            vessel=self._vessel({"type": "mesh", "mesh_file": "vessel.gdf"})
+        )
+        assert body.resolve_control_surface().mesh_file == "vessel.gdf"
+
+    def test_none_when_neither(self):
+        assert BodySpec(vessel=self._vessel()).resolve_control_surface() is None
+
+
+class TestBackendEmission:
+    def test_body_level_cs_emitted_for_its_body_only(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=True)
+        out = tmp_path / "out"
+        result = SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=out, quality_gates=False
+        )
+        hull, turret = _bodies_from(result)
+        assert "BodyControlSurfaceMeshFileName" not in hull
+        assert turret["BodyControlSurfaceMeshFileName"] == "cs_body.gdf"
+        assert turret["BodyControlSurfaceType"] == "Defined by mesh file"
+
+    def test_body_level_overrides_vessel_level(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=True, vessel_level=True)
+        result = SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=tmp_path / "out", quality_gates=False
+        )
+        _, turret = _bodies_from(result)
+        assert turret["BodyControlSurfaceMeshFileName"] == "cs_body.gdf"
+
+    def test_vessel_level_still_works(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=False, vessel_level=True)
+        result = SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=tmp_path / "out", quality_gates=False
+        )
+        _, turret = _bodies_from(result)
+        assert turret["BodyControlSurfaceMeshFileName"] == "cs_vessel.gdf"
+
+    def test_general_section_flag_sees_body_level(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=True)
+        result = SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=tmp_path / "out", quality_gates=False
+        )
+        documents = [d for d in yaml.safe_load_all(result.read_text()) if d]
+        # PyYAML (YAML 1.1) parses OrcaWave's "Yes" as boolean True
+        assert documents[0]["QuadraticLoadControlSurface"] is True
+
+
+class TestPackagingAndPreflight:
+    def test_body_level_cs_collected_and_packaged(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=True)
+        spec = DiffractionSpec.from_yaml(spec_path)
+        files = [r.mesh_file for r in iter_mesh_references(spec)]
+        assert "cs_body.gdf" in files
+
+        out = tmp_path / "out"
+        SpecConverter(spec_path).convert(
+            solver="orcawave", output_dir=out, quality_gates=False
+        )
+        assert (out / "cs_body.gdf").is_file()
+
+    def test_missing_body_level_cs_fails_preflight(self, tmp_path):
+        spec_path = _multibody_spec(tmp_path, body_level=True)
+        (tmp_path / "cs_body.gdf").unlink()
+        converter = SpecConverter(spec_path)
+        with pytest.raises(FileNotFoundError, match="cs_body.gdf"):
+            converter.convert(
+                solver="orcawave",
+                output_dir=tmp_path / "out",
+                quality_gates=False,
+            )
+        issue = next(i for i in converter.validate() if "cs_body.gdf" in i)
+        assert "Turret" in issue


### PR DESCRIPTION
Closes #609. Last auxiliary-mesh gap after #731 (packaging+preflight of lid/CS/fsz) and #734 (quality gates).

## What

The central defect the issue names: `BodySpec.control_surface` existed in the schema but the backend (`_build_body_dict`) and packaging read only `vessel.control_surface`, so per-body control surfaces in multi-body specs were silently dropped.

- **`BodySpec.resolve_control_surface()`** — the single resolution rule: body-level overrides vessel-level, falls back to vessel-level, else None. Docstring states the precedence.
- All three readers now use it: backend per-body emission, the backend general-section `QuadraticLoadControlSurface` flag (replacing a hand-rolled getattr walk), and `mesh_packaging._iter_mesh_slots` — so a body-level CS mesh is emitted, packaged, existence-preflighted, and quality-gated identically to every other mesh.

## Acceptance criteria → status

- body-level CS not silently ignored → emitted per body, packaged, preflighted (tested)
- vessel + body behavior documented & tested → precedence in docstring; tests cover body-wins, vessel-fallback, neither
- backend/runner/validation share resolution rules → all flow through the one method (runner packages via `mesh_packaging` since #731)
- damping lid + free-surface packaged & preflighted → already done in #731 (`test_spec_converter_packaging.py`)
- multi-body per-body aux-mesh tests → FPSO+turret fixture: CS on Turret only → emitted on Turret's body block only; missing body-level CS mesh fails preflight naming the body

## Verification (ace-linux-2)

- New tests: **9 passed** (`test_body_level_control_surfaces.py`)
- Full diffraction domain suite: **1514 passed, 24 skipped, 2 xfailed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)