### PR TITLE
feat(diffraction): orcawave-doctor environment readiness command (#613)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/cli.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/cli.py
@@ -684,6 +684,65 @@ def resolve_cmd(
 # ---------------------------------------------------------------------------
 
 
+@cli.command("orcawave-doctor")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output directory to test for writability (default: cwd)",
+)
+@click.option(
+    "--executable",
+    type=click.Path(),
+    default=None,
+    help="Explicit OrcaWave executable path to verify.",
+)
+@click.option(
+    "--require-solver",
+    is_flag=True,
+    default=False,
+    help="Exit nonzero if the host cannot actually solve (dry-run only).",
+)
+def orcawave_doctor_cmd(output, executable, require_solver):
+    """Diagnose OrcaWave runtime readiness on this host.
+
+    Reports PASS/WARN/FAIL for the OrcFxAPI binding, executable detection,
+    ORCAWAVE_PATH, output-directory writability, and thread/memory guidance,
+    then states whether the host is solver-capable or dry-run only.
+
+    Exit policy: 0 = host usable (dry-run-only is a supported mode);
+    nonzero = any FAIL check, or dry-run-only with --require-solver.
+    """
+    from digitalmodel.hydrodynamics.diffraction.orcawave_doctor import run_doctor
+
+    click.echo("=" * 80)
+    click.echo("OrcaWave Doctor")
+    click.echo("=" * 80)
+
+    checks, capability = run_doctor(
+        output_dir=Path(output) if output else None,
+        executable=Path(executable) if executable else None,
+    )
+    colors = {"PASS": "green", "WARN": "yellow", "FAIL": "red"}
+    for check in checks:
+        click.echo(
+            click.style(f"[{check.status:4}] ", fg=colors[check.status])
+            + f"{check.name}: {check.detail}"
+        )
+
+    failed = any(c.status == "FAIL" for c in checks)
+    if failed:
+        click.echo(click.style("\n[FAIL] Hard failures present.", fg="red"))
+        sys.exit(1)
+    if require_solver and capability == "dry-run-only":
+        click.echo(click.style(
+            "\n[FAIL] --require-solver: host is dry-run only.", fg="red"
+        ))
+        sys.exit(1)
+    click.echo(click.style(f"\n[OK] Host usable ({capability}).", fg="green"))
+
+
 @cli.command("run-orcawave")
 @click.argument("spec_path", type=click.Path(exists=True))
 @click.option(

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_doctor.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_doctor.py
@@ -1,0 +1,181 @@
+"""OrcaWave environment and license readiness diagnostics (#613).
+
+Surfaces the runner's existing detection logic (OrcFxAPI import, executable
+search, ``ORCAWAVE_PATH``) as a PASS/WARN/FAIL report so users know whether a
+host can actually solve before preparing a large run, instead of discovering
+a silent dry-run fallback afterwards.
+
+Exit-code policy (enforced by the CLI command):
+- ``0`` — host usable, including dry-run-only hosts (a supported mode);
+- nonzero — any FAIL check (e.g. unwritable output directory), or a
+  dry-run-only host when ``--require-solver`` was passed.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class DoctorCheck:
+    """One diagnostic line: PASS / WARN / FAIL plus human detail."""
+
+    name: str
+    status: str
+    detail: str
+
+
+def _orcfxapi_info() -> tuple[bool, str]:
+    """(available, detail) for the OrcFxAPI Python binding."""
+    try:
+        import OrcFxAPI  # noqa: F401
+    except ImportError:
+        return False, "OrcFxAPI not importable - API solve unavailable"
+    detail = "OrcFxAPI importable"
+    try:
+        detail += f" (DLL version {OrcFxAPI.DLLVersion()})"
+    except Exception:
+        try:
+            detail += f" (version {OrcFxAPI.Version()})"
+        except Exception:
+            pass
+    return True, detail
+
+
+def _detect_executable(executable: Path | None) -> Path | None:
+    """Reuse the runner's executable search order."""
+    from digitalmodel.hydrodynamics.diffraction.orcawave_runner import (
+        OrcaWaveRunner,
+        RunConfig,
+    )
+
+    runner = OrcaWaveRunner(RunConfig(executable_path=executable))
+    return runner._detect_executable()
+
+
+def _memory_gb() -> float | None:
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                return round(int(line.split()[1]) / 1024 / 1024, 1)
+    except OSError:
+        pass
+    return None
+
+
+def run_doctor(
+    output_dir: Path | None = None,
+    executable: Path | None = None,
+) -> tuple[list[DoctorCheck], str]:
+    """Run all readiness checks.
+
+    Returns ``(checks, capability)`` where capability is one of
+    ``"api-solve"``, ``"subprocess-solve"``, or ``"dry-run-only"``.
+    """
+    checks: list[DoctorCheck] = []
+
+    api_available, api_detail = _orcfxapi_info()
+    checks.append(
+        DoctorCheck(
+            "OrcFxAPI binding",
+            "PASS" if api_available else "WARN",
+            api_detail,
+        )
+    )
+    if api_available:
+        checks.append(
+            DoctorCheck(
+                "OrcaWave license",
+                "PASS",
+                "API present; the license itself is claimed at solve time "
+                "(Calculate) - a licensed dongle/server must be reachable then",
+            )
+        )
+
+    env_path = os.environ.get("ORCAWAVE_PATH")
+    if env_path:
+        exists = Path(env_path).exists()
+        checks.append(
+            DoctorCheck(
+                "ORCAWAVE_PATH",
+                "PASS" if exists else "WARN",
+                f"set to '{env_path}'"
+                + ("" if exists else " (path does not exist)"),
+            )
+        )
+    else:
+        checks.append(DoctorCheck("ORCAWAVE_PATH", "WARN", "not set"))
+
+    detected = _detect_executable(executable)
+    if executable is not None:
+        checks.append(
+            DoctorCheck(
+                "Explicit executable",
+                "PASS" if detected else "FAIL",
+                f"'{executable}'"
+                + ("" if detected else " does not exist"),
+            )
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                "OrcaWave executable",
+                "PASS" if detected else "WARN",
+                f"detected at '{detected}'"
+                if detected
+                else "not found (explicit path, ORCAWAVE_PATH, standard "
+                "install dirs, PATH all empty)",
+            )
+        )
+
+    target = Path(output_dir) if output_dir is not None else Path.cwd()
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(dir=target, prefix=".doctor_"):
+            pass
+        checks.append(
+            DoctorCheck("Output directory", "PASS", f"'{target}' is writable")
+        )
+    except OSError as error:
+        checks.append(
+            DoctorCheck(
+                "Output directory", "FAIL", f"'{target}' not writable: {error}"
+            )
+        )
+
+    cpu = os.cpu_count() or 1
+    mem = _memory_gb()
+    guidance = f"{cpu} CPUs"
+    if mem is not None:
+        guidance += f", {mem} GB RAM"
+    guidance += (
+        ". Moderate thread counts are safer: very high thread counts have "
+        "produced out-of-memory failures on large cases (see #714)."
+    )
+    checks.append(DoctorCheck("Threads/memory", "PASS", guidance))
+
+    if api_available:
+        capability = "api-solve"
+    elif detected is not None:
+        capability = "subprocess-solve"
+    else:
+        capability = "dry-run-only"
+    checks.append(
+        DoctorCheck(
+            "Host capability",
+            "PASS" if capability != "dry-run-only" else "WARN",
+            {
+                "api-solve": "solver-capable via OrcFxAPI (preferred)",
+                "subprocess-solve": "solver-capable via OrcaWave executable",
+                "dry-run-only": (
+                    f"dry-run only on this {platform.system()} host - runs "
+                    "will generate input packages but not solve"
+                ),
+            }[capability],
+        )
+    )
+    return checks, capability

--- a/tests/hydrodynamics/diffraction/test_orcawave_doctor.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_doctor.py
@@ -1,0 +1,109 @@
+"""OrcaWave doctor diagnostics (#613).
+
+Covers the unlicensed-Linux behavior (real on this host) and mocked-OrcFxAPI
+behavior, plus the documented exit-code policy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from digitalmodel.hydrodynamics.diffraction import orcawave_doctor
+from digitalmodel.hydrodynamics.diffraction.cli import cli
+from digitalmodel.hydrodynamics.diffraction.orcawave_doctor import run_doctor
+
+
+def _by_name(checks, name):
+    return next(c for c in checks if c.name == name)
+
+
+class TestRunDoctorUnlicensedHost:
+    """Real behavior on this Linux box (no OrcFxAPI, no OrcaWave.exe)."""
+
+    def test_no_stack_trace_and_dry_run_capability(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ORCAWAVE_PATH", raising=False)
+        checks, capability = run_doctor(output_dir=tmp_path)
+        assert capability == "dry-run-only"
+        api = _by_name(checks, "OrcFxAPI binding")
+        assert api.status == "WARN"
+        assert "not importable" in api.detail
+
+    def test_capability_check_mentions_dry_run(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ORCAWAVE_PATH", raising=False)
+        checks, _ = run_doctor(output_dir=tmp_path)
+        host = _by_name(checks, "Host capability")
+        assert host.status == "WARN"
+        assert "dry-run only" in host.detail
+
+    def test_output_dir_writable_pass(self, tmp_path):
+        checks, _ = run_doctor(output_dir=tmp_path / "new")
+        assert _by_name(checks, "Output directory").status == "PASS"
+
+    def test_orcawave_path_env_reported(self, tmp_path, monkeypatch):
+        exe = tmp_path / "orcawave"
+        exe.write_text("")
+        monkeypatch.setenv("ORCAWAVE_PATH", str(exe))
+        checks, capability = run_doctor(output_dir=tmp_path)
+        env = _by_name(checks, "ORCAWAVE_PATH")
+        assert env.status == "PASS"
+        assert str(exe) in env.detail
+        assert capability == "subprocess-solve"
+
+    def test_explicit_executable_missing_is_fail(self, tmp_path):
+        checks, _ = run_doctor(
+            output_dir=tmp_path, executable=tmp_path / "nope.exe"
+        )
+        assert _by_name(checks, "Explicit executable").status == "FAIL"
+
+
+class TestRunDoctorMockedApi:
+    def test_api_present_gives_api_solve(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ORCAWAVE_PATH", raising=False)
+        with patch.object(
+            orcawave_doctor,
+            "_orcfxapi_info",
+            return_value=(True, "OrcFxAPI importable (DLL version 11.6)"),
+        ):
+            checks, capability = run_doctor(output_dir=tmp_path)
+        assert capability == "api-solve"
+        assert _by_name(checks, "OrcFxAPI binding").status == "PASS"
+        license_check = _by_name(checks, "OrcaWave license")
+        assert "solve time" in license_check.detail
+
+
+class TestCliExitPolicy:
+    def test_default_exit_zero_on_dry_run_host(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ORCAWAVE_PATH", raising=False)
+        result = CliRunner().invoke(
+            cli, ["orcawave-doctor", "-o", str(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "dry-run only" in result.output
+        assert "[OK] Host usable (dry-run-only)" in result.output
+
+    def test_require_solver_exits_nonzero_on_dry_run_host(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("ORCAWAVE_PATH", raising=False)
+        result = CliRunner().invoke(
+            cli, ["orcawave-doctor", "-o", str(tmp_path), "--require-solver"]
+        )
+        assert result.exit_code == 1
+        assert "--require-solver" in result.output
+
+    def test_explicit_missing_executable_exits_nonzero(self, tmp_path):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "orcawave-doctor",
+                "-o",
+                str(tmp_path),
+                "--executable",
+                str(tmp_path / "nope.exe"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Hard failures" in result.output


### PR DESCRIPTION
Closes #613. The "surfacing job" the 15% audit described: the runner's `_check_api_available` / `_detect_executable` / `ORCAWAVE_PATH` logic, presented as a readiness report.

## What

`diffraction orcawave-doctor [-o DIR] [--executable PATH] [--require-solver]` — new `orcawave_doctor.py` module + CLI command:

- **OrcFxAPI binding** — PASS with DLL/version detail, or WARN "not importable - API solve unavailable" (never a stack trace)
- **License** — honest note: the API's presence is checkable, the license itself is claimed at `Calculate()` time
- **ORCAWAVE_PATH** — reported set/unset, existence-checked
- **Executable** — the runner's exact search order; explicit `--executable` that doesn't exist is a hard FAIL
- **Output directory** — writability probe (FAIL if not writable)
- **Threads/memory** — CPU/RAM report with guidance citing the #714 high-thread-count OOM finding
- **Host capability verdict** — `api-solve` / `subprocess-solve` / `dry-run-only`

**Exit policy (documented in `--help`)**: 0 = host usable, including dry-run-only (a supported mode); nonzero = any FAIL check, or dry-run-only when `--require-solver` is passed. Useful as a session preflight on licensed boxes: `diffraction orcawave-doctor --require-solver` before committing to a big run.

## Verification (ace-linux-2)

- New tests: **9 passed** — real unlicensed-Linux behavior (WARN + dry-run-only + exit 0), mocked-OrcFxAPI behavior (api-solve), and all three exit-policy branches via Click's CliRunner
- Full diffraction domain suite: **1514 passed, 24 skipped, 2 xfailed**
- Live run on this box produces the expected report (3 WARNs, dry-run-only, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)