### PR TITLE
feat(workflows): register 4 dm#711 backlog capability lanes (workspace-hub#3065)

### DIFF
--- a/.github/workflows/quality-gates-by-domain.yml
+++ b/.github/workflows/quality-gates-by-domain.yml
@@ -76,6 +76,7 @@ jobs:
           uv run --no-sources --with-editable . python -m pytest \
             tests/scripts/test_detect_touched_domains.py \
             tests/workflows/automation/test_quality_gates.py \
+            tests/workflows/test_durable_workflows.py \
             -q --tb=line
 
   domain-tests:

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -197,3 +197,40 @@ workflows:
       - examples/workflows/naval-arch-yaw-moment/results/naval_arch_yaw_moment/yaw_moment_sweep.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[naval-arch-yaw-moment]
     runtime: offline
+  - id: rudder-stock-torque
+    basename: naval_arch
+    title: Preliminary rudder-stock torque and steering-gear holding-torque screen
+    input: examples/workflows/rudder-stock-torque/input.yml
+    outputs:
+      - examples/workflows/rudder-stock-torque/results/input.yml
+      - examples/workflows/rudder-stock-torque/results/rudder_stock_torque/rudder_stock_torque_sweep.csv
+      - examples/workflows/rudder-stock-torque/results/rudder_stock_torque/rudder_stock_torque_sweep.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rudder-stock-torque]
+    runtime: offline
+  - id: pile-axial-capacity
+    basename: geotechnical
+    title: API RP 2GEO alpha-method axial pile capacity in clay
+    input: examples/workflows/pile-axial-capacity/input.yml
+    outputs:
+      - examples/workflows/pile-axial-capacity/results/input.yml
+      - examples/workflows/pile-axial-capacity/results/pile_axial_capacity/pile_axial_capacity_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pile-axial-capacity]
+    runtime: offline
+  - id: drag-anchor-holding
+    basename: geotechnical
+    title: DNV-RP-E302 / API RP 2SK empirical drag-anchor holding capacity
+    input: examples/workflows/drag-anchor-holding/input.yml
+    outputs:
+      - examples/workflows/drag-anchor-holding/results/input.yml
+      - examples/workflows/drag-anchor-holding/results/drag_anchor_holding/drag_anchor_holding_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[drag-anchor-holding]
+    runtime: offline
+  - id: nodal-analysis-ipr-vlp
+    basename: production
+    title: Well operating point from Vogel IPR / Hagedorn-Brown VLP intersection
+    input: examples/workflows/nodal-analysis-ipr-vlp/input.yml
+    outputs:
+      - examples/workflows/nodal-analysis-ipr-vlp/results/input.yml
+      - examples/workflows/nodal-analysis-ipr-vlp/results/nodal_analysis/nodal_analysis_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[nodal-analysis-ipr-vlp]
+    runtime: offline

--- a/examples/workflows/drag-anchor-holding/input.yml
+++ b/examples/workflows/drag-anchor-holding/input.yml
@@ -1,0 +1,25 @@
+basename: geotechnical
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+geotechnical:
+  calculation: drag_anchor
+  drag_anchor:
+    case:
+      id: registry_drag_anchor_holding
+      description: DNV-RP-E302 / API RP 2SK empirical drag-anchor holding capacity in soft clay
+    anchor:
+      anchor_type: stevpris
+      soil_type: soft_clay
+      weight_kn: 120.0
+    design:
+      factor_of_safety: 1.5
+      required_holding_kn: 2000.0
+    outputs:
+      directory: results/drag_anchor_holding
+      summary_json: drag_anchor_holding_summary.json

--- a/examples/workflows/nodal-analysis-ipr-vlp/input.yml
+++ b/examples/workflows/nodal-analysis-ipr-vlp/input.yml
@@ -1,0 +1,35 @@
+basename: production
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+production:
+  calculation: nodal_analysis
+  nodal_analysis:
+    case:
+      id: registry_nodal_analysis
+      description: Well operating point from Vogel IPR / Hagedorn-Brown VLP intersection
+    reservoir:
+      ipr_model: vogel
+      reservoir_pressure_psi: 3000.0
+      bubble_point_psi: 2500.0
+      productivity_index_bopd_psi: 2.0
+    tubing:
+      depth_ft: 8000.0
+      tubing_id_in: 2.992
+    fluid:
+      oil_api: 35.0
+      gas_gravity: 0.65
+      temperature_f: 180.0
+    surface:
+      whp_psi: 200.0
+      watercut: 0.2
+      gor_scf_per_bbl: 400.0
+      test_quality_score: 85.0
+    outputs:
+      directory: results/nodal_analysis
+      summary_json: nodal_analysis_summary.json

--- a/examples/workflows/pile-axial-capacity/input.yml
+++ b/examples/workflows/pile-axial-capacity/input.yml
@@ -1,0 +1,28 @@
+basename: geotechnical
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+geotechnical:
+  calculation: pile_axial_capacity
+  pile_axial_capacity:
+    case:
+      id: registry_pile_axial_capacity
+      description: API RP 2GEO alpha-method axial capacity for an open-ended steel pile in clay
+    pile:
+      diameter_m: 1.8
+      embedded_length_m: 40.0
+      Nc: 9.0
+    soil:
+      Su_kpa: 80.0
+      sigma_v_kpa: 200.0
+    design:
+      factor_of_safety: 2.0
+      applied_load_kn: 5000.0
+    outputs:
+      directory: results/pile_axial_capacity
+      summary_json: pile_axial_capacity_summary.json

--- a/examples/workflows/rudder-stock-torque/input.yml
+++ b/examples/workflows/rudder-stock-torque/input.yml
@@ -1,0 +1,40 @@
+basename: naval_arch
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+naval_arch:
+  calculation: rudder_stock_torque
+  rudder_stock_torque:
+    case:
+      id: registry_rudder_stock_torque
+      description: Registry preliminary rudder-stock torque screen
+    vessel:
+      type: typical_single_screw_ship
+      length_between_perpendiculars_m: 120.0
+      beam_m: 20.0
+      draft_m: 7.0
+      design_speed_kn: 12.0
+    rudder:
+      area_m2: 20.0
+      span_m: 5.0
+      behind_hull: true
+    stock:
+      stock_to_center_of_pressure_arm_m: 0.75
+    environment:
+      rho_kg_m3: 1025.0
+    sweep:
+      speeds:
+        units: kn
+        values: [12.0]
+      rudder_angles_deg: [35.0]
+    outputs:
+      directory: results/rudder_stock_torque
+      tables: [csv, json]
+      charts:
+        enabled: false
+        formats: []

--- a/src/digitalmodel/base_configs/modules/geotechnical/geotechnical.yml
+++ b/src/digitalmodel/base_configs/modules/geotechnical/geotechnical.yml
@@ -1,0 +1,10 @@
+basename: geotechnical
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+geotechnical: {}

--- a/src/digitalmodel/base_configs/modules/production/production.yml
+++ b/src/digitalmodel/base_configs/modules/production/production.yml
@@ -1,0 +1,10 @@
+basename: production
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+production: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -301,6 +301,18 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         naval_arch = NavalArchitectureWorkflow()
         cfg_base = naval_arch.router(cfg_base)
+    elif basename == "geotechnical":
+        from digitalmodel.geotechnical.workflow import GeotechnicalWorkflow
+
+        geotechnical = GeotechnicalWorkflow()
+        cfg_base = geotechnical.router(cfg_base)
+    elif basename == "production":
+        from digitalmodel.production_engineering.workflow import (
+            ProductionEngineeringWorkflow,
+        )
+
+        production = ProductionEngineeringWorkflow()
+        cfg_base = production.router(cfg_base)
     else:
         raise (Exception(f"Analysis for basename: {basename} not found. ... FAIL"))
 

--- a/src/digitalmodel/geotechnical/workflow.py
+++ b/src/digitalmodel/geotechnical/workflow.py
@@ -1,0 +1,188 @@
+# ABOUTME: Engine-routed geotechnical screeners (pile axial capacity, anchor holding).
+# ABOUTME: Routes the `geotechnical` basename to existing offline calculators and writes a JSON summary.
+"""Engine-routed geotechnical screeners.
+
+Supported `geotechnical.calculation` values:
+- ``pile_axial_capacity``  -> API RP 2GEO alpha-method axial pile capacity (single or multilayer clay)
+- ``drag_anchor``          -> DNV-RP-E302 / API RP 2SK empirical drag-anchor holding capacity
+- ``suction_anchor``       -> DNV-RP-E303 suction-caisson capacity in clay
+
+Each calculation wraps the matching pure-function calculator, applies a user
+supplied design factor of safety, and writes a JSON summary sidecar.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.geotechnical.anchors import (
+    drag_anchor_capacity,
+    suction_anchor_capacity,
+)
+from digitalmodel.geotechnical.pile_capacity import (
+    alpha_method_capacity,
+    alpha_method_capacity_multilayer,
+)
+
+
+def _resolve_dir(cfg: dict[str, Any], value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(cfg.get("_config_dir_path", Path.cwd())) / path
+
+
+def _write_summary(cfg: dict[str, Any], output_cfg: dict[str, Any], payload: dict[str, Any]) -> Path:
+    directory = _resolve_dir(cfg, output_cfg.get("directory", "results/geotechnical"))
+    directory.mkdir(parents=True, exist_ok=True)
+    filename = output_cfg.get("summary_json", "geotechnical_summary.json")
+    summary_path = directory / filename
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    cfg.setdefault("outputs", {})["directory"] = str(directory)
+    cfg["outputs"]["summary_json"] = str(summary_path)
+    return summary_path
+
+
+class GeotechnicalWorkflow:
+    """Route selected geotechnical calculations through existing helpers."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        workflow_cfg = cfg.get("geotechnical", {})
+        calculation = workflow_cfg.get("calculation")
+        if calculation == "pile_axial_capacity":
+            return self._run_pile_axial_capacity(cfg, workflow_cfg)
+        if calculation == "drag_anchor":
+            return self._run_drag_anchor(cfg, workflow_cfg)
+        if calculation == "suction_anchor":
+            return self._run_suction_anchor(cfg, workflow_cfg)
+        raise ValueError(f"Unsupported geotechnical calculation: {calculation}")
+
+    def _run_pile_axial_capacity(
+        self, cfg: dict[str, Any], workflow_cfg: dict[str, Any]
+    ) -> dict[str, Any]:
+        params = workflow_cfg["pile_axial_capacity"]
+        pile = params["pile"]
+        design = params.get("design", {})
+        nc = float(pile.get("Nc", 9.0))
+
+        layers = params.get("soil_layers")
+        if layers:
+            tuple_layers = [
+                (float(layer["thickness_m"]), float(layer["Su_kpa"]), float(layer["sigma_v_kpa"]))
+                for layer in layers
+            ]
+            result = alpha_method_capacity_multilayer(
+                D=float(pile["diameter_m"]), layers=tuple_layers, Nc=nc
+            )
+        else:
+            soil = params["soil"]
+            result = alpha_method_capacity(
+                D=float(pile["diameter_m"]),
+                L=float(pile["embedded_length_m"]),
+                Su=float(soil["Su_kpa"]),
+                sigma_v=float(soil["sigma_v_kpa"]),
+                Nc=nc,
+            )
+
+        fos = float(design.get("factor_of_safety", 2.0))
+        applied_load_kn = design.get("applied_load_kn")
+        allowable_kn = result.total_capacity_kn / fos
+        summary = {
+            "calculation": "pile_axial_capacity",
+            "standard": result.standard,
+            "result": asdict(result),
+            "design": {
+                "factor_of_safety": fos,
+                "allowable_capacity_kn": allowable_kn,
+            },
+        }
+        if applied_load_kn is not None:
+            applied = float(applied_load_kn)
+            summary["design"]["applied_load_kn"] = applied
+            summary["design"]["utilization"] = applied / allowable_kn
+            summary["design"]["status"] = "PASS" if applied <= allowable_kn else "FAIL"
+
+        summary["summary_json"] = str(
+            _write_summary(cfg, params.get("outputs", {}), summary)
+        )
+        cfg["geotechnical"] = {
+            "calculation": "pile_axial_capacity",
+            "pile_axial_capacity": {**params, **summary},
+        }
+        return cfg
+
+    def _run_drag_anchor(
+        self, cfg: dict[str, Any], workflow_cfg: dict[str, Any]
+    ) -> dict[str, Any]:
+        params = workflow_cfg["drag_anchor"]
+        anchor = params["anchor"]
+        design = params.get("design", {})
+        result = drag_anchor_capacity(
+            anchor_weight_kn=float(anchor["weight_kn"]),
+            soil_type=str(anchor["soil_type"]),
+            anchor_type=str(anchor["anchor_type"]),
+        )
+        fos = float(design.get("factor_of_safety", 1.5))
+        allowable_kn = result.holding_capacity_kn / fos
+        summary = {
+            "calculation": "drag_anchor",
+            "standard": result.standard,
+            "result": asdict(result),
+            "design": {
+                "factor_of_safety": fos,
+                "allowable_holding_kn": allowable_kn,
+            },
+        }
+        required = design.get("required_holding_kn")
+        if required is not None:
+            req = float(required)
+            summary["design"]["required_holding_kn"] = req
+            summary["design"]["utilization"] = req / allowable_kn
+            summary["design"]["status"] = "PASS" if req <= allowable_kn else "FAIL"
+
+        summary["summary_json"] = str(
+            _write_summary(cfg, params.get("outputs", {}), summary)
+        )
+        cfg["geotechnical"] = {
+            "calculation": "drag_anchor",
+            "drag_anchor": {**params, **summary},
+        }
+        return cfg
+
+    def _run_suction_anchor(
+        self, cfg: dict[str, Any], workflow_cfg: dict[str, Any]
+    ) -> dict[str, Any]:
+        params = workflow_cfg["suction_anchor"]
+        caisson = params["caisson"]
+        soil = params["soil"]
+        design = params.get("design", {})
+        result = suction_anchor_capacity(
+            diameter_m=float(caisson["diameter_m"]),
+            length_m=float(caisson["length_m"]),
+            su_kpa=float(soil["Su_kpa"]),
+            alpha=float(soil.get("alpha", 0.65)),
+            nc=float(soil.get("Nc", 9.0)),
+            wall_thickness_m=float(caisson.get("wall_thickness_m", 0.04)),
+        )
+        fos = float(design.get("factor_of_safety", 1.5))
+        allowable_kn = result.total_capacity_kn / fos
+        summary = {
+            "calculation": "suction_anchor",
+            "standard": result.standard,
+            "result": asdict(result),
+            "design": {
+                "factor_of_safety": fos,
+                "allowable_capacity_kn": allowable_kn,
+            },
+        }
+        summary["summary_json"] = str(
+            _write_summary(cfg, params.get("outputs", {}), summary)
+        )
+        cfg["geotechnical"] = {
+            "calculation": "suction_anchor",
+            "suction_anchor": {**params, **summary},
+        }
+        return cfg

--- a/src/digitalmodel/naval_architecture/workflow.py
+++ b/src/digitalmodel/naval_architecture/workflow.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from digitalmodel.naval_architecture.rudder_stock_torque import (
+    run_rudder_stock_torque_sweep,
+    validate_rudder_stock_torque_input,
+    write_rudder_stock_torque_results,
+)
 from digitalmodel.naval_architecture.yaw_moment import (
     run_yaw_moment_sweep,
     validate_yaw_moment_input,
@@ -37,6 +42,8 @@ class NavalArchitectureWorkflow:
         calculation = workflow_cfg.get("calculation")
         if calculation == "yaw_moment":
             return self._run_yaw_moment(cfg, workflow_cfg)
+        if calculation == "rudder_stock_torque":
+            return self._run_rudder_stock_torque(cfg, workflow_cfg)
         raise ValueError(f"Unsupported naval_arch calculation: {calculation}")
 
     def _run_yaw_moment(
@@ -58,6 +65,33 @@ class NavalArchitectureWorkflow:
         cfg["naval_arch"] = {
             "calculation": "yaw_moment",
             "yaw_moment": {
+                **input_payload,
+                "result": result,
+                "artifacts": _stringify_paths(manifest),
+            },
+        }
+        cfg.setdefault("outputs", {})["directory"] = str(output_dir)
+        return cfg
+
+    def _run_rudder_stock_torque(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+    ) -> dict[str, Any]:
+        input_payload = workflow_cfg["rudder_stock_torque"]
+        config = validate_rudder_stock_torque_input(input_payload)
+        result = run_rudder_stock_torque_sweep(config)
+        chart_formats = config.chart_formats if config.chart_enabled else ()
+        output_dir = _resolve_dir(cfg, config.output_directory)
+        manifest = write_rudder_stock_torque_results(
+            result,
+            output_dir,
+            table_formats=config.table_formats,
+            chart_formats=chart_formats,
+        )
+        cfg["naval_arch"] = {
+            "calculation": "rudder_stock_torque",
+            "rudder_stock_torque": {
                 **input_payload,
                 "result": result,
                 "artifacts": _stringify_paths(manifest),

--- a/src/digitalmodel/production_engineering/workflow.py
+++ b/src/digitalmodel/production_engineering/workflow.py
@@ -1,0 +1,122 @@
+# ABOUTME: Engine-routed production-engineering nodal analysis (IPR/VLP operating point).
+# ABOUTME: Routes the `production` basename to the existing nodal solver and IPR/VLP correlations.
+"""Engine-routed production-engineering screeners.
+
+Supported ``production.calculation`` values:
+- ``nodal_analysis`` -> solve the IPR/VLP intersection (well operating point) using the
+  Vogel or Linear IPR model and the Hagedorn-Brown VLP correlation.
+
+The result is the operating point (rate, flowing bottom-hole pressure) with
+confidence bounds derived from an optional well-test quality score. A JSON
+summary sidecar is written for offline delivery.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.production_engineering.ipr_models import (
+    LinearIpr,
+    ReservoirConditions,
+    VogelIpr,
+)
+from digitalmodel.production_engineering.nodal_solver import NodalSolver
+from digitalmodel.production_engineering.vlp_correlations import (
+    FluidProperties,
+    TubingConfig,
+)
+
+
+def _resolve_dir(cfg: dict[str, Any], value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(cfg.get("_config_dir_path", Path.cwd())) / path
+
+
+def _build_ipr(reservoir_cfg: dict[str, Any]):
+    reservoir = ReservoirConditions(
+        reservoir_pressure_psi=float(reservoir_cfg["reservoir_pressure_psi"]),
+        bubble_point_psi=float(reservoir_cfg["bubble_point_psi"]),
+        productivity_index_bopd_psi=float(reservoir_cfg["productivity_index_bopd_psi"]),
+    )
+    model = str(reservoir_cfg.get("ipr_model", "vogel")).lower()
+    pi = reservoir.productivity_index_bopd_psi
+    if model == "vogel":
+        return VogelIpr.from_productivity_index(reservoir, pi), model
+    if model == "linear":
+        return LinearIpr(reservoir, pi), model
+    raise ValueError(f"Unsupported ipr_model: {reservoir_cfg.get('ipr_model')}")
+
+
+class ProductionEngineeringWorkflow:
+    """Route selected production-engineering calculations through existing helpers."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        workflow_cfg = cfg.get("production", {})
+        calculation = workflow_cfg.get("calculation")
+        if calculation == "nodal_analysis":
+            return self._run_nodal_analysis(cfg, workflow_cfg)
+        raise ValueError(f"Unsupported production calculation: {calculation}")
+
+    def _run_nodal_analysis(
+        self, cfg: dict[str, Any], workflow_cfg: dict[str, Any]
+    ) -> dict[str, Any]:
+        params = workflow_cfg["nodal_analysis"]
+        ipr, ipr_model = _build_ipr(params["reservoir"])
+
+        tubing_cfg = params["tubing"]
+        tubing = TubingConfig(
+            depth_ft=float(tubing_cfg["depth_ft"]),
+            tubing_id_in=float(tubing_cfg["tubing_id_in"]),
+            roughness_in=float(tubing_cfg.get("roughness_in", 0.0006)),
+        )
+        fluid_cfg = params.get("fluid", {})
+        fluid = FluidProperties(
+            oil_api=float(fluid_cfg.get("oil_api", 35.0)),
+            gas_gravity=float(fluid_cfg.get("gas_gravity", 0.65)),
+            temperature_f=float(fluid_cfg.get("temperature_f", 150.0)),
+        )
+        surface = params["surface"]
+
+        operating_point = NodalSolver().solve(
+            ipr=ipr,
+            tubing=tubing,
+            fluid=fluid,
+            watercut=float(surface.get("watercut", 0.0)),
+            gor_scf_per_bbl=float(surface["gor_scf_per_bbl"]),
+            whp_psi=float(surface["whp_psi"]),
+            test_quality_score=surface.get("test_quality_score"),
+        )
+
+        summary = {
+            "calculation": "nodal_analysis",
+            "ipr_model": ipr_model,
+            "operating_point": {
+                "q_bopd": operating_point.q_bopd,
+                "pwf_psi": operating_point.pwf_psi,
+                "confidence": operating_point.confidence.value,
+                "q_uncertainty_fraction": operating_point.q_uncertainty_fraction,
+                "q_low_bopd": operating_point.q_low_bopd,
+                "q_high_bopd": operating_point.q_high_bopd,
+            },
+        }
+
+        output_cfg = params.get("outputs", {})
+        directory = _resolve_dir(cfg, output_cfg.get("directory", "results/nodal_analysis"))
+        directory.mkdir(parents=True, exist_ok=True)
+        summary_path = directory / output_cfg.get(
+            "summary_json", "nodal_analysis_summary.json"
+        )
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+        summary["summary_json"] = str(summary_path)
+        cfg["production"] = {
+            "calculation": "nodal_analysis",
+            "nodal_analysis": {**params, **summary},
+        }
+        cfg.setdefault("outputs", {})["directory"] = str(directory)
+        cfg["outputs"]["summary_json"] = str(summary_path)
+        return cfg

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -269,5 +269,47 @@ def test_workflow_registry(workflow):
         assert row["transverse_force_N"] == pytest.approx(97417.402886)
         assert row["yaw_moment_Nm"] == pytest.approx(-4383783.129880)
         assert row["sign_convention"] == "port"
+    elif workflow["id"] == "rudder-stock-torque":
+        row = cfg["naval_arch"]["rudder_stock_torque"]["result"]["rows"][0]
+        assert cfg["naval_arch"]["calculation"] == "rudder_stock_torque"
+        assert len(cfg["naval_arch"]["rudder_stock_torque"]["result"]["rows"]) == 1
+        assert row["speed_kn"] == pytest.approx(12.0)
+        assert row["rudder_angle_deg"] == pytest.approx(35.0)
+        assert row["scalar_normal_force_N"] == pytest.approx(722870.905140)
+        assert row["hydrodynamic_rudder_stock_torque_Nm"] == pytest.approx(542153.178855)
+        assert row["required_steering_gear_holding_torque_Nm"] == pytest.approx(
+            -542153.178855
+        )
+        assert row["rudder_stock_torque_abs_kNm"] == pytest.approx(542.153178855)
+    elif workflow["id"] == "pile-axial-capacity":
+        block = cfg["geotechnical"]["pile_axial_capacity"]
+        result = block["result"]
+        design = block["design"]
+        assert block["standard"] == "API RP 2GEO"
+        assert result["total_capacity_kn"] == pytest.approx(16137.983938)
+        assert result["skin_friction_kn"] == pytest.approx(14305.807103)
+        assert result["end_bearing_kn"] == pytest.approx(1832.176836)
+        assert result["alpha"] == pytest.approx(0.790569415)
+        assert design["allowable_capacity_kn"] == pytest.approx(8068.991969)
+        assert design["utilization"] == pytest.approx(0.619656088)
+        assert design["status"] == "PASS"
+    elif workflow["id"] == "drag-anchor-holding":
+        block = cfg["geotechnical"]["drag_anchor"]
+        result = block["result"]
+        design = block["design"]
+        assert block["standard"] == "DNV-RP-E302"
+        assert result["holding_capacity_kn"] == pytest.approx(3600.0)
+        assert result["efficiency"] == pytest.approx(30.0)
+        assert design["allowable_holding_kn"] == pytest.approx(2400.0)
+        assert design["status"] == "PASS"
+    elif workflow["id"] == "nodal-analysis-ipr-vlp":
+        block = cfg["production"]["nodal_analysis"]
+        op = block["operating_point"]
+        assert block["ipr_model"] == "vogel"
+        assert op["q_bopd"] == pytest.approx(996.727220, rel=1e-4)
+        assert op["pwf_psi"] == pytest.approx(2458.137610, rel=1e-4)
+        assert op["confidence"] == "Green"
+        assert op["q_uncertainty_fraction"] == pytest.approx(0.05)
+        assert op["q_low_bopd"] < op["q_bopd"] < op["q_high_bopd"]
     else:
         raise AssertionError(f"Missing workflow assertion for {workflow['id']}")


### PR DESCRIPTION
## Summary

Progresses [workspace-hub#3065](https://github.com/vamseeachanta/workspace-hub/issues/3065) by onboarding the first batch of unrouted engine capabilities from the [dm#711](https://github.com/vamseeachanta/digitalmodel/issues/711) capability audit into the durable UV-workflow contract.

digitalmodel was already at example↔registry parity (22 rows ↔ 22 example dirs). The real gap is the dm#711 backlog of ~35 capability lanes the engine *could* compute but had no example/registry row. This PR registers **4 high-value, non-license-gated lanes**, growing the registry **22 → 26 rows**.

Each lane follows the established pattern: an `examples/workflows/<slug>/input.yml` runnable via `uv run python -m digitalmodel <input.yml>`, a `docs/registry/workflows.yaml` row, and a value-pinned assertion in `tests/workflows/test_durable_workflows.py`.

## Lanes in this batch (all `runtime: offline`)

| Lane | Basename | Standard | Wiring |
|---|---|---|---|
| `rudder-stock-torque` | `naval_arch` | preliminary constant-arm | extends existing `NavalArchitectureWorkflow` router (STABLE `rudder_stock_torque` helpers) |
| `pile-axial-capacity` | `geotechnical` *(new)* | API RP 2GEO §7.3 alpha method | new router → `alpha_method_capacity` |
| `drag-anchor-holding` | `geotechnical` *(new)* | DNV-RP-E302 / API RP 2SK | same router → `drag_anchor_capacity` |
| `nodal-analysis-ipr-vlp` | `production` *(new)* | Vogel IPR / Hagedorn-Brown VLP | new router → `NodalSolver` |

New base configs added for the `geotechnical` and `production` basenames. Two new thin workflow routers (`geotechnical/workflow.py`, `production_engineering/workflow.py`) wrap existing pure-function calculators — no calculator logic changed.

## Verification

All 26 registry rows run green:

```
$ uv run --no-sync python -m pytest tests/workflows/test_durable_workflows.py -q
26 passed in 9.67s
```

Each new workflow verified to run green standalone via `uv run python -m digitalmodel examples/workflows/<slug>/input.yml` (exit 0).

## CI widening

The registry test (invariant: registry row == working example == green test) is now asserted on **every PR** via the `ci-harness-tests` job in `quality-gates-by-domain.yml`. Previously it only ran when a matching domain was touched. Low-risk addition (the job already exists and runs the quality-gate harness tests). Note: digitalmodel main CI baseline is red on unrelated jobs (engine + native segfault) — only the workflow/harness assertions are meaningful here.

## Backlog still open (future batches)

Remaining dm#711 lanes, prioritized: suction-anchor (geotech, trivial add to this router), naval-arch damage-stability (SOLAS) + platform stability + Holtrop-Mennen resistance, well/drilling (wellbore design, ECD hydraulics, ROP), field development (capex/opex/concept). License-gated rows (ansys/OrcaWave/AQWA post-processors) need a licensed Windows host and are **not** doable on this Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)