### PR TITLE
feat(#711): registry wave 4 geotech — anchor (E302/E303), pile, scour

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -276,3 +276,30 @@ workflows:
       - examples/workflows/nodal-analysis-ipr-vlp/results/nodal_analysis/nodal_analysis_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[nodal-analysis-ipr-vlp]
     runtime: offline
+  - id: anchor-capacity
+    basename: anchor_capacity
+    title: Anchor drag + suction holding capacity screen (DNV-RP-E302 / E303)
+    input: examples/workflows/anchor-capacity/input.yml
+    outputs:
+      - examples/workflows/anchor-capacity/results/input.yml
+      - examples/workflows/anchor-capacity/results/anchor_capacity/anchor_capacity_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[anchor-capacity]
+    runtime: offline
+  - id: pile-capacity
+    basename: pile_capacity
+    title: API RP 2GEO alpha-method pile capacity in firm clay
+    input: examples/workflows/pile-capacity/input.yml
+    outputs:
+      - examples/workflows/pile-capacity/results/input.yml
+      - examples/workflows/pile-capacity/results/pile_capacity/pile_capacity_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pile-capacity]
+    runtime: offline
+  - id: scour-assessment
+    basename: scour
+    title: DNV-RP-F107 pipeline, monopile, and rock armour scour assessment
+    input: examples/workflows/scour-assessment/input.yml
+    outputs:
+      - examples/workflows/scour-assessment/results/input.yml
+      - examples/workflows/scour-assessment/results/scour/scour_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[scour-assessment]
+    runtime: offline

--- a/examples/workflows/anchor-capacity/input.yml
+++ b/examples/workflows/anchor-capacity/input.yml
@@ -1,0 +1,35 @@
+basename: anchor_capacity
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+anchor_capacity:
+  case:
+    id: registry_anchor_capacity_e305
+    description: Drag-anchor and suction-caisson capacity screen over existing anchor calculators
+  drag_anchor:
+    anchor_type: stevpris
+    soil_type: soft_clay
+    weight_kn: 120.0
+    design:
+      factor_of_safety: 1.5
+      required_holding_kn: 2000.0
+  suction_anchor:
+    caisson:
+      diameter_m: 5.0
+      length_m: 15.0
+      wall_thickness_m: 0.04
+    soil:
+      Su_kpa: 30.0
+      alpha: 0.65
+      Nc: 9.0
+    design:
+      factor_of_safety: 1.5
+      required_capacity_kn: 9000.0
+  outputs:
+    directory: results/anchor_capacity
+    summary_json: anchor_capacity_summary.json

--- a/examples/workflows/pile-capacity/input.yml
+++ b/examples/workflows/pile-capacity/input.yml
@@ -1,0 +1,26 @@
+basename: pile_capacity
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+pile_capacity:
+  case:
+    id: registry_pile_capacity
+    description: API RP 2GEO alpha-method pile axial capacity in firm clay
+  pile:
+    diameter_m: 1.0
+    embedded_length_m: 30.0
+    Nc: 9.0
+  soil:
+    Su_kpa: 60.0
+    sigma_v_kpa: 150.0
+  design:
+    factor_of_safety: 2.0
+    applied_load_kn: 2000.0
+  outputs:
+    directory: results/pile_capacity
+    summary_json: pile_capacity_summary.json

--- a/examples/workflows/scour-assessment/input.yml
+++ b/examples/workflows/scour-assessment/input.yml
@@ -1,0 +1,32 @@
+basename: scour
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+scour:
+  case:
+    id: registry_scour_assessment
+    description: DNV-RP-F107 pipeline, monopile, and rock armour scour screen
+  pipeline:
+    pipe_od_m: 0.5
+    current_velocity_ms: 0.8
+    wave_orbital_velocity_ms: 0.3
+    sediment_d50_mm: 0.3
+    burial_ratio: 0.25
+    wave_period_s: 8.0
+  monopile:
+    pile_diameter_m: 6.0
+    current_velocity_ms: 1.0
+    water_depth_m: 30.0
+  rock_armour:
+    current_velocity_ms: 1.0
+    rock_density_kg_m3: 2650.0
+    water_density_kg_m3: 1025.0
+    rock_d50_m: 0.3
+  outputs:
+    directory: results/scour
+    summary_json: scour_summary.json

--- a/src/digitalmodel/base_configs/modules/anchor_capacity/anchor_capacity.yml
+++ b/src/digitalmodel/base_configs/modules/anchor_capacity/anchor_capacity.yml
@@ -1,0 +1,10 @@
+basename: anchor_capacity
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+anchor_capacity: {}

--- a/src/digitalmodel/base_configs/modules/pile_capacity/pile_capacity.yml
+++ b/src/digitalmodel/base_configs/modules/pile_capacity/pile_capacity.yml
@@ -1,0 +1,10 @@
+basename: pile_capacity
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+pile_capacity: {}

--- a/src/digitalmodel/base_configs/modules/scour/scour.yml
+++ b/src/digitalmodel/base_configs/modules/scour/scour.yml
@@ -1,0 +1,10 @@
+basename: scour
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+scour: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -297,7 +297,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         diffraction = DiffractionWorkflow()
         cfg_base = diffraction.router(cfg_base)
     elif basename == "fpso_mooring":
-        from digitalmodel.subsea.mooring_analysis.fpso_workflow import FPSOMooringWorkflow
+        from digitalmodel.subsea.mooring_analysis.fpso_workflow import (
+            FPSOMooringWorkflow,
+        )
+
         fmw = FPSOMooringWorkflow()
         cfg_base = fmw.router(cfg_base)
     elif basename == "jacket_checks":
@@ -322,6 +325,21 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         geotechnical = GeotechnicalWorkflow()
         cfg_base = geotechnical.router(cfg_base)
+    elif basename == "anchor_capacity":
+        from digitalmodel.geotechnical.cfg_workflows import AnchorCapacityWorkflow
+
+        anchor_capacity = AnchorCapacityWorkflow()
+        cfg_base = anchor_capacity.router(cfg_base)
+    elif basename == "pile_capacity":
+        from digitalmodel.geotechnical.cfg_workflows import PileCapacityWorkflow
+
+        pile_capacity = PileCapacityWorkflow()
+        cfg_base = pile_capacity.router(cfg_base)
+    elif basename == "scour":
+        from digitalmodel.geotechnical.cfg_workflows import ScourWorkflow
+
+        scour = ScourWorkflow()
+        cfg_base = scour.router(cfg_base)
     elif basename == "production":
         from digitalmodel.production_engineering.workflow import (
             ProductionEngineeringWorkflow,

--- a/src/digitalmodel/geotechnical/cfg_workflows.py
+++ b/src/digitalmodel/geotechnical/cfg_workflows.py
@@ -1,0 +1,209 @@
+# ABOUTME: Thin engine-routed wrappers for geotechnical registry workflows.
+# ABOUTME: Converts cfg blocks into existing pure geotechnical calculator calls.
+"""Configuration-routed geotechnical workflows."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_dir(cfg: dict[str, Any], value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(cfg.get("_config_dir_path", Path.cwd())) / path
+
+
+def _write_summary(
+    cfg: dict[str, Any],
+    output_cfg: dict[str, Any],
+    default_directory: str,
+    default_filename: str,
+    payload: dict[str, Any],
+) -> Path:
+    directory = _resolve_dir(cfg, output_cfg.get("directory", default_directory))
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get("summary_json", default_filename)
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    cfg.setdefault("outputs", {})["directory"] = str(directory)
+    cfg["outputs"]["summary_json"] = str(summary_path)
+    return summary_path
+
+
+def _design_status(required: float | None, allowable: float) -> dict[str, Any]:
+    design: dict[str, Any] = {"allowable_capacity_kn": allowable}
+    if required is not None:
+        design["required_capacity_kn"] = required
+        design["utilization"] = required / allowable
+        design["status"] = "PASS" if required <= allowable else "FAIL"
+    return design
+
+
+class AnchorCapacityWorkflow:
+    """Run drag-anchor and suction-caisson capacity calculators from cfg."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        from digitalmodel.geotechnical.anchors import (
+            drag_anchor_capacity,
+            suction_anchor_capacity,
+        )
+
+        workflow_cfg = cfg.get("anchor_capacity", {})
+        results: dict[str, Any] = {}
+        design: dict[str, Any] = {}
+
+        if "drag_anchor" in workflow_cfg:
+            drag = workflow_cfg["drag_anchor"]
+            result = drag_anchor_capacity(
+                anchor_weight_kn=float(drag["weight_kn"]),
+                soil_type=str(drag["soil_type"]),
+                anchor_type=str(drag["anchor_type"]),
+            )
+            fos = float(drag.get("design", {}).get("factor_of_safety", 1.5))
+            required = drag.get("design", {}).get("required_holding_kn")
+            results["drag_anchor"] = asdict(result)
+            drag_design = _design_status(
+                None if required is None else float(required),
+                result.holding_capacity_kn / fos,
+            )
+            drag_design["factor_of_safety"] = fos
+            design["drag_anchor"] = drag_design
+
+        if "suction_anchor" in workflow_cfg:
+            suction = workflow_cfg["suction_anchor"]
+            caisson = suction["caisson"]
+            soil = suction["soil"]
+            result = suction_anchor_capacity(
+                diameter_m=float(caisson["diameter_m"]),
+                length_m=float(caisson["length_m"]),
+                su_kpa=float(soil["Su_kpa"]),
+                alpha=float(soil.get("alpha", 0.65)),
+                nc=float(soil.get("Nc", 9.0)),
+                wall_thickness_m=float(caisson.get("wall_thickness_m", 0.04)),
+            )
+            fos = float(suction.get("design", {}).get("factor_of_safety", 1.5))
+            required = suction.get("design", {}).get("required_capacity_kn")
+            results["suction_anchor"] = asdict(result)
+            suction_design = _design_status(
+                None if required is None else float(required),
+                result.total_capacity_kn / fos,
+            )
+            suction_design["factor_of_safety"] = fos
+            design["suction_anchor"] = suction_design
+
+        statuses = [item.get("status") for item in design.values()]
+        design["status"] = (
+            "PASS" if all(status == "PASS" for status in statuses) else "FAIL"
+        )
+        payload = {**workflow_cfg, "results": results, "design": design}
+        payload["summary_json"] = str(
+            _write_summary(
+                cfg,
+                workflow_cfg.get("outputs", {}),
+                "results/anchor_capacity",
+                "anchor_capacity_summary.json",
+                payload,
+            )
+        )
+        cfg["anchor_capacity"] = payload
+        return cfg
+
+
+class PileCapacityWorkflow:
+    """Run API RP 2GEO alpha-method pile capacity from cfg."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        from digitalmodel.geotechnical.pile_capacity import (
+            alpha_method_capacity,
+            alpha_method_capacity_multilayer,
+        )
+
+        workflow_cfg = cfg.get("pile_capacity", {})
+        pile = workflow_cfg["pile"]
+        nc = float(pile.get("Nc", 9.0))
+        if workflow_cfg.get("soil_layers"):
+            layers = [
+                (
+                    float(layer["thickness_m"]),
+                    float(layer["Su_kpa"]),
+                    float(layer["sigma_v_kpa"]),
+                )
+                for layer in workflow_cfg["soil_layers"]
+            ]
+            result = alpha_method_capacity_multilayer(
+                D=float(pile["diameter_m"]), layers=layers, Nc=nc
+            )
+        else:
+            soil = workflow_cfg["soil"]
+            result = alpha_method_capacity(
+                D=float(pile["diameter_m"]),
+                L=float(pile["embedded_length_m"]),
+                Su=float(soil["Su_kpa"]),
+                sigma_v=float(soil["sigma_v_kpa"]),
+                Nc=nc,
+            )
+
+        design_cfg = workflow_cfg.get("design", {})
+        fos = float(design_cfg.get("factor_of_safety", 2.0))
+        applied = design_cfg.get("applied_load_kn")
+        design = _design_status(
+            None if applied is None else float(applied),
+            result.total_capacity_kn / fos,
+        )
+        design["factor_of_safety"] = fos
+        payload = {
+            **workflow_cfg,
+            "standard": result.standard,
+            "result": asdict(result),
+        }
+        payload["design"] = design
+        payload["summary_json"] = str(
+            _write_summary(
+                cfg,
+                workflow_cfg.get("outputs", {}),
+                "results/pile_capacity",
+                "pile_capacity_summary.json",
+                payload,
+            )
+        )
+        cfg["pile_capacity"] = payload
+        return cfg
+
+
+class ScourWorkflow:
+    """Run DNV-RP-F107 scour calculators from cfg."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        from digitalmodel.geotechnical.scour import (
+            monopile_scour_depth,
+            pipeline_scour_depth,
+            rock_armour_thickness,
+        )
+
+        workflow_cfg = cfg.get("scour", {})
+        results: dict[str, Any] = {}
+        if "pipeline" in workflow_cfg:
+            pipeline = workflow_cfg["pipeline"]
+            results["pipeline"] = asdict(pipeline_scour_depth(**pipeline))
+        if "monopile" in workflow_cfg:
+            monopile = workflow_cfg["monopile"]
+            results["monopile"] = asdict(monopile_scour_depth(**monopile))
+        if "rock_armour" in workflow_cfg:
+            armour = workflow_cfg["rock_armour"]
+            results["rock_armour"] = asdict(rock_armour_thickness(**armour))
+
+        payload = {**workflow_cfg, "results": results}
+        payload["summary_json"] = str(
+            _write_summary(
+                cfg,
+                workflow_cfg.get("outputs", {}),
+                "results/scour",
+                "scour_summary.json",
+                payload,
+            )
+        )
+        cfg["scour"] = payload
+        return cfg

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -78,8 +78,9 @@ def test_workflow_registry(workflow):
             REPO_ROOT / "examples/workflows/viv-parametric/results/cases.csv"
         )
         case_0 = yaml.safe_load(
-            (REPO_ROOT / "examples/workflows/viv-parametric/results/case_0.yml")
-            .read_text()
+            (
+                REPO_ROOT / "examples/workflows/viv-parametric/results/case_0.yml"
+            ).read_text()
         )
 
         assert len(cases) == 6
@@ -182,9 +183,7 @@ def test_workflow_registry(workflow):
         assert result["anchor_length"]["end"] == pytest.approx(1368.5)
         assert result["min_critical_buckling_load"] == pytest.approx(-64701.045412)
         assert result["effective_axial_load"]["anchor_start"] == pytest.approx(-33.26)
-        assert result["fully_restrained_axial_force"]["L=0"] == pytest.approx(
-            -253.575
-        )
+        assert result["fully_restrained_axial_force"]["L=0"] == pytest.approx(-253.575)
     elif workflow["id"] == "pipeline-upheaval-buckling":
         result = cfg["pipeline"]["upheaval_buckling"]
         assert result["cover_check"] == "Pass"
@@ -218,9 +217,7 @@ def test_workflow_registry(workflow):
         assert "could not be loaded" not in content
     elif workflow["id"] == "dynacard-diagnostics":
         results = cfg["results"]
-        assert results["diagnostic_message"].startswith(
-            "Classification: PUMP_TAGGING."
-        )
+        assert results["diagnostic_message"].startswith("Classification: PUMP_TAGGING.")
         assert results["pump_fillage"] == pytest.approx(75.909653)
         assert results["inferred_production"] == pytest.approx(338.041470)
 
@@ -238,8 +235,7 @@ def test_workflow_registry(workflow):
         assert props["I"]["Ix"] == pytest.approx(19.471869)
 
         model_path = (
-            REPO_ROOT
-            / "examples/workflows/orcaflex-6dbuoy-dnvrph103/results/"
+            REPO_ROOT / "examples/workflows/orcaflex-6dbuoy-dnvrph103/results/"
             "dnvrph103_demo_6dbuoy_deep.yml"
         )
         model = yaml.safe_load(model_path.read_text())
@@ -258,9 +254,7 @@ def test_workflow_registry(workflow):
         assert summary["n_results"] == 8
         assert summary["min_safety_factor"] == pytest.approx(2.08)
         assert summary["max_utilization"] == pytest.approx(0.48)
-        assert result["environmental_loads"]["total_force"] == pytest.approx(
-            2280.94225
-        )
+        assert result["environmental_loads"]["total_force"] == pytest.approx(2280.94225)
 
         summary_path = Path(cfg["outputs"]["summary_json"])
         if not summary_path.is_absolute():
@@ -353,7 +347,9 @@ def test_workflow_registry(workflow):
         assert row["speed_kn"] == pytest.approx(12.0)
         assert row["rudder_angle_deg"] == pytest.approx(35.0)
         assert row["scalar_normal_force_N"] == pytest.approx(722870.905140)
-        assert row["hydrodynamic_rudder_stock_torque_Nm"] == pytest.approx(542153.178855)
+        assert row["hydrodynamic_rudder_stock_torque_Nm"] == pytest.approx(
+            542153.178855
+        )
         assert row["required_steering_gear_holding_torque_Nm"] == pytest.approx(
             -542153.178855
         )
@@ -388,5 +384,22 @@ def test_workflow_registry(workflow):
         assert op["confidence"] == "Green"
         assert op["q_uncertainty_fraction"] == pytest.approx(0.05)
         assert op["q_low_bopd"] < op["q_bopd"] < op["q_high_bopd"]
+    elif workflow["id"] == "anchor-capacity":
+        result = cfg["anchor_capacity"]["results"]
+        assert result["drag_anchor"]["holding_capacity_kn"] == pytest.approx(3600.0)
+        assert result["suction_anchor"]["total_capacity_kn"] == pytest.approx(
+            14417.082847
+        )
+        assert cfg["anchor_capacity"]["design"]["status"] == "PASS"
+    elif workflow["id"] == "pile-capacity":
+        result = cfg["pile_capacity"]["result"]
+        assert result["total_capacity_kn"] == pytest.approx(4894.679728)
+        assert result["alpha"] == pytest.approx(0.790569415)
+        assert cfg["pile_capacity"]["design"]["status"] == "PASS"
+    elif workflow["id"] == "scour-assessment":
+        result = cfg["scour"]["results"]
+        assert result["pipeline"]["scour_depth_m"] == pytest.approx(0.225)
+        assert result["monopile"]["scour_depth_m"] == pytest.approx(7.8)
+        assert result["rock_armour"]["thickness_m"] == pytest.approx(0.6)
     else:
         raise AssertionError(f"Missing workflow assertion for {workflow['id']}")

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "assetutilities"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../assetutilities" }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Part of #711, wave 4 (geotechnical). Thin cfg runners over the existing `geotechnical/` calculators — no new engineering. Registry +3 rows.

| Workflow | Verified |
|---|---|
| anchor-capacity | drag holding 3600 kN + suction 14417 kN, combined design PASS — **DNV-RP-E302/E303** (honest: the module has no E305 impl, so slug/title say E302/E303, not E305) |
| pile-capacity | total 4894.68 kN, alpha 0.7906, design PASS |
| scour-assessment | pipeline scour 0.225 m, monopile 7.8 m, rock-armour 0.6 m |

## Verified (real uv, outside codex sandbox)
- all 3 exit 0 via `uv run python -m digitalmodel <input.yml>`
- `tests/workflows/ + tests/contracts/` → 51 passed; `tests/geotechnical/` → 73 passed (no pre-existing geotech failures)

Merge-order note: wave-4 lanes (geotech / well-drilling / field-dev) all append to engine.py + registry — merge any order, later ones rebase. Companion PRs incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)