### PR TITLE
feat(#711): registry wave 4 well/drilling — wellbore, hydraulics, ROP, tubular envelope

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -276,3 +276,40 @@ workflows:
       - examples/workflows/nodal-analysis-ipr-vlp/results/nodal_analysis/nodal_analysis_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[nodal-analysis-ipr-vlp]
     runtime: offline
+  - id: well-bore-design
+    basename: well_bore_design
+    title: Standard offshore wellbore casing/cost/risk screen
+    input: examples/workflows/well-bore-design/input.yml
+    outputs:
+      - examples/workflows/well-bore-design/results/input.yml
+      - examples/workflows/well-bore-design/results/well_bore_design/well_bore_design_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[well-bore-design]
+    runtime: offline
+  - id: well-hydraulics
+    basename: well_hydraulics
+    title: 8.5 inch hole annular hydraulics ECD and cleaning screen
+    input: examples/workflows/well-hydraulics/input.yml
+    outputs:
+      - examples/workflows/well-hydraulics/results/input.yml
+      - examples/workflows/well-hydraulics/results/well_hydraulics/well_hydraulics_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[well-hydraulics]
+    runtime: offline
+  - id: rop-analysis
+    basename: rop_analysis
+    title: Bourgoyne-Young and Warren ROP model comparison
+    input: examples/workflows/rop-analysis/input.yml
+    outputs:
+      - examples/workflows/rop-analysis/results/input.yml
+      - examples/workflows/rop-analysis/results/rop_analysis/rop_analysis_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rop-analysis]
+    runtime: offline
+  - id: tubular-design-envelope
+    basename: tubular_design
+    title: 7 inch L80 casing API/VME tubular design envelope
+    input: examples/workflows/tubular-design-envelope/input.yml
+    outputs:
+      - examples/workflows/tubular-design-envelope/results/input.yml
+      - examples/workflows/tubular-design-envelope/results/tubular_design/tubular_design_summary.json
+      - examples/workflows/tubular-design-envelope/results/tubular_design/tubular_design_envelope.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[tubular-design-envelope]
+    runtime: offline

--- a/examples/workflows/rop-analysis/input.yml
+++ b/examples/workflows/rop-analysis/input.yml
@@ -1,0 +1,42 @@
+basename: rop_analysis
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+rop_analysis:
+  case:
+    id: registry_rop_analysis
+    description: Bourgoyne-Young and Warren ROP comparison
+  bourgoyne_young:
+    parameters:
+      a1: 0.5
+      a2: 0.0
+      a3: 0.0
+      a4: 0.3
+      a5: 0.5
+      a6: 0.6
+      a7: 0.5
+      a8: 0.3
+    inputs:
+      depth_ft: 5000.0
+      wob_klb: 20.0
+      rpm: 100.0
+      bit_dia_in: 8.5
+      overbalance_kpsi: 0.5
+      bit_wear: 0.0
+  warren:
+    parameters:
+      K: 10.0
+      a: 0.6
+      b: 0.5
+    inputs:
+      wob_klb: 20.0
+      rpm: 100.0
+      bit_dia_in: 8.5
+  outputs:
+    directory: results/rop_analysis
+    summary_json: rop_analysis_summary.json

--- a/examples/workflows/tubular-design-envelope/input.yml
+++ b/examples/workflows/tubular-design-envelope/input.yml
@@ -1,0 +1,25 @@
+basename: tubular_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+tubular_design:
+  case:
+    id: registry_tubular_design_envelope
+    description: 7 inch 26 ppf L80 casing API/VME design envelope
+  geometry:
+    od_in: 7.0
+    id_in: 6.276
+    smys_psi: 80000.0
+    burst_rating_psi: 5180.0
+    collapse_rating_psi: 5550.0
+  design_factor: 1.2
+  n_points: 80
+  outputs:
+    directory: results/tubular_design
+    summary_json: tubular_design_summary.json
+    envelope_csv: tubular_design_envelope.csv

--- a/examples/workflows/well-bore-design/input.yml
+++ b/examples/workflows/well-bore-design/input.yml
@@ -1,0 +1,19 @@
+basename: well_bore_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+well_bore_design:
+  case:
+    id: registry_well_bore_design
+    description: Standard offshore wellbore design comparison
+  hole_type: standard_hole
+  water_depth_m: 500.0
+  objective: development
+  outputs:
+    directory: results/well_bore_design
+    summary_json: well_bore_design_summary.json

--- a/examples/workflows/well-hydraulics/input.yml
+++ b/examples/workflows/well-hydraulics/input.yml
@@ -1,0 +1,25 @@
+basename: well_hydraulics
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+well_hydraulics:
+  case:
+    id: registry_well_hydraulics
+    description: Field hydraulics for an 8.5 inch hole section
+  section:
+    pipe_od: 4.5
+    pipe_id: 3.826
+    hole_diameter: 8.5
+    mud_weight: 10.5
+    flow_rate: 400.0
+    tvd: 8000.0
+    plastic_viscosity: 18.0
+    yield_point: 12.0
+  outputs:
+    directory: results/well_hydraulics
+    summary_json: well_hydraulics_summary.json

--- a/src/digitalmodel/base_configs/modules/rop_analysis/rop_analysis.yml
+++ b/src/digitalmodel/base_configs/modules/rop_analysis/rop_analysis.yml
@@ -1,0 +1,10 @@
+basename: rop_analysis
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+rop_analysis: {}

--- a/src/digitalmodel/base_configs/modules/tubular_design/tubular_design.yml
+++ b/src/digitalmodel/base_configs/modules/tubular_design/tubular_design.yml
@@ -1,0 +1,10 @@
+basename: tubular_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+tubular_design: {}

--- a/src/digitalmodel/base_configs/modules/well_bore_design/well_bore_design.yml
+++ b/src/digitalmodel/base_configs/modules/well_bore_design/well_bore_design.yml
@@ -1,0 +1,10 @@
+basename: well_bore_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+well_bore_design: {}

--- a/src/digitalmodel/base_configs/modules/well_hydraulics/well_hydraulics.yml
+++ b/src/digitalmodel/base_configs/modules/well_hydraulics/well_hydraulics.yml
@@ -1,0 +1,10 @@
+basename: well_hydraulics
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+well_hydraulics: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -297,7 +297,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         diffraction = DiffractionWorkflow()
         cfg_base = diffraction.router(cfg_base)
     elif basename == "fpso_mooring":
-        from digitalmodel.subsea.mooring_analysis.fpso_workflow import FPSOMooringWorkflow
+        from digitalmodel.subsea.mooring_analysis.fpso_workflow import (
+            FPSOMooringWorkflow,
+        )
+
         fmw = FPSOMooringWorkflow()
         cfg_base = fmw.router(cfg_base)
     elif basename == "jacket_checks":
@@ -329,6 +332,22 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         production = ProductionEngineeringWorkflow()
         cfg_base = production.router(cfg_base)
+    elif basename == "well_bore_design":
+        from digitalmodel.well.workflow import run_well_bore_design
+
+        cfg_base = run_well_bore_design(cfg_base)
+    elif basename == "well_hydraulics":
+        from digitalmodel.well.workflow import run_well_hydraulics
+
+        cfg_base = run_well_hydraulics(cfg_base)
+    elif basename == "rop_analysis":
+        from digitalmodel.well.workflow import run_rop_analysis
+
+        cfg_base = run_rop_analysis(cfg_base)
+    elif basename == "tubular_design":
+        from digitalmodel.well.workflow import run_tubular_design
+
+        cfg_base = run_tubular_design(cfg_base)
     else:
         raise (Exception(f"Analysis for basename: {basename} not found. ... FAIL"))
 

--- a/src/digitalmodel/well/workflow.py
+++ b/src/digitalmodel/well/workflow.py
@@ -1,0 +1,247 @@
+# ABOUTME: Engine-routed well and drilling workflow adapters for registry examples.
+# ABOUTME: Wraps existing wellbore, hydraulics, ROP, and tubular envelope logic.
+"""Engine-routed well and drilling workflow adapters."""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.well.drilling.hydraulics import WellboreHydraulics
+from digitalmodel.well.drilling.rop_models import BourgoineYoungROP, WarrenROP
+from digitalmodel.well.drilling.well_bore_design import WellDesign
+from digitalmodel.well.tubulars.design_envelope import (
+    TubularGeometry,
+    design_envelope_points,
+)
+
+
+def _resolve_dir(cfg: dict[str, Any], value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(cfg.get("_config_dir_path", Path.cwd())) / path
+
+
+def _write_summary(
+    cfg: dict[str, Any],
+    output_cfg: dict[str, Any],
+    payload: dict[str, Any],
+    default_directory: str,
+    default_filename: str,
+) -> Path:
+    directory = _resolve_dir(cfg, output_cfg.get("directory", default_directory))
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get("summary_json", default_filename)
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    cfg.setdefault("outputs", {})["directory"] = str(directory)
+    cfg["outputs"]["summary_json"] = str(summary_path)
+    return summary_path
+
+
+def run_well_bore_design(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Run the configured wellbore design screen."""
+    params = cfg.get("well_bore_design", {})
+    design = WellDesign(
+        hole_type=str(params["hole_type"]),
+        water_depth_m=float(params["water_depth_m"]),
+    )
+    casing_program = [asdict(casing) for casing in design.casing_program()]
+    cost = asdict(design.estimate_cost())
+    risk = design.risk_assessment()
+    objective = str(params.get("objective", "development"))
+    recommended = design.recommend_hole_type(
+        water_depth_m=float(params["water_depth_m"]),
+        objective=objective,
+    )
+
+    summary = {
+        "calculation": "well_bore_design",
+        "hole_type": design.hole_type,
+        "water_depth_m": design.water_depth_m,
+        "objective": objective,
+        "casing_count": len(casing_program),
+        "total_cost_usd": cost["total_usd"],
+        "production_potential_bopd": design.production_potential(),
+        "risk": risk,
+        "recommended_hole_type": recommended,
+    }
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            params.get("outputs", {}),
+            summary,
+            "results/well_bore_design",
+            "well_bore_design_summary.json",
+        )
+    )
+    cfg["well_bore_design"] = {
+        **params,
+        "casing_program": casing_program,
+        "cost": cost,
+        "risk": risk,
+        "summary": summary,
+    }
+    return cfg
+
+
+def run_well_hydraulics(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Run the configured annular hydraulics screen."""
+    params = cfg.get("well_hydraulics", {})
+    section = params["section"]
+    hydraulics = WellboreHydraulics(
+        pipe_od=float(section["pipe_od"]),
+        pipe_id=float(section["pipe_id"]),
+        hole_diameter=float(section["hole_diameter"]),
+        mud_weight=float(section["mud_weight"]),
+        flow_rate=float(section["flow_rate"]),
+        tvd=float(section["tvd"]),
+        plastic_viscosity=float(section["plastic_viscosity"]),
+        yield_point=float(section["yield_point"]),
+    )
+    pressure_drop = hydraulics.pressure_drop_annulus()
+    result = {
+        "annular_velocity_ft_min": hydraulics.annular_velocity(),
+        "pressure_drop_annulus_psi": pressure_drop,
+        "ecd_ppg": hydraulics.ecd(pressure_drop),
+        "cuttings_transport_ratio": hydraulics.cuttings_transport_ratio(),
+    }
+    summary = {
+        "calculation": "well_hydraulics",
+        "section": dict(section),
+        "result": result,
+    }
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            params.get("outputs", {}),
+            summary,
+            "results/well_hydraulics",
+            "well_hydraulics_summary.json",
+        )
+    )
+    cfg["well_hydraulics"] = {**params, "result": result, "summary": summary}
+    return cfg
+
+
+def run_rop_analysis(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Run configured Bourgoyne-Young and Warren ROP predictions."""
+    params = cfg.get("rop_analysis", {})
+
+    by_cfg = params["bourgoyne_young"]
+    by_params = {key: float(value) for key, value in by_cfg["parameters"].items()}
+    by_model = BourgoineYoungROP(**by_params)
+    by_inputs = {key: float(value) for key, value in by_cfg["inputs"].items()}
+    by_prediction = by_model.predict(**by_inputs)
+
+    warren_cfg = params["warren"]
+    warren_model = WarrenROP(
+        K=float(warren_cfg["parameters"]["K"]),
+        a=float(warren_cfg["parameters"]["a"]),
+        b=float(warren_cfg["parameters"]["b"]),
+    )
+    warren_inputs = {key: float(value) for key, value in warren_cfg["inputs"].items()}
+    warren_prediction = warren_model.predict(**warren_inputs)
+
+    result = {
+        "bourgoyne_young": {
+            "rop_ft_hr": by_prediction.rop_ft_hr,
+            "model": by_prediction.model,
+            "sensitivity_wob_ft_hr_per_klb": by_model.sensitivity_wob(**by_inputs),
+            "sensitivity_rpm_ft_hr_per_rpm": by_model.sensitivity_rpm(**by_inputs),
+        },
+        "warren": {
+            "rop_ft_hr": warren_prediction.rop_ft_hr,
+            "model": warren_prediction.model,
+        },
+    }
+    summary = {"calculation": "rop_analysis", "result": result}
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            params.get("outputs", {}),
+            summary,
+            "results/rop_analysis",
+            "rop_analysis_summary.json",
+        )
+    )
+    cfg["rop_analysis"] = {**params, "result": result, "summary": summary}
+    return cfg
+
+
+def run_tubular_design(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Run the configured tubular design-envelope sweep."""
+    params = cfg.get("tubular_design", {})
+    geometry = TubularGeometry(
+        od_in=float(params["geometry"]["od_in"]),
+        id_in=float(params["geometry"]["id_in"]),
+        smys_psi=float(params["geometry"]["smys_psi"]),
+        burst_rating_psi=float(params["geometry"]["burst_rating_psi"]),
+        collapse_rating_psi=float(params["geometry"]["collapse_rating_psi"]),
+    )
+    n_points = int(params.get("n_points", 100))
+    design_factor = float(params.get("design_factor", 1.0))
+    yield_hoop_ratio = params.get("yield_hoop_ratio")
+    if yield_hoop_ratio is not None:
+        yield_hoop_ratio = float(yield_hoop_ratio)
+
+    envelopes = design_envelope_points(
+        geometry=geometry,
+        design_factor=design_factor,
+        n_points=n_points,
+        yield_hoop_ratio=yield_hoop_ratio,
+    )
+
+    output_cfg = params.get("outputs", {})
+    directory = _resolve_dir(cfg, output_cfg.get("directory", "results/tubular_design"))
+    directory.mkdir(parents=True, exist_ok=True)
+    csv_path = directory / output_cfg.get("envelope_csv", "tubular_design_envelope.csv")
+    with csv_path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(
+            ["envelope", "point_index", "axial_force_lbf", "differential_pressure_psi"]
+        )
+        for envelope_name, points in envelopes.items():
+            for index, point in enumerate(points):
+                writer.writerow(
+                    [envelope_name, index, float(point[0]), float(point[1])]
+                )
+
+    summary = {
+        "calculation": "tubular_design",
+        "design_factor": design_factor,
+        "n_points": n_points,
+        "geometry": {
+            **params["geometry"],
+            "wall_thickness_in": geometry.wall_thickness_in,
+            "cross_section_area_in2": geometry.cross_section_area_in2,
+            "yield_force_lbf": geometry.yield_force_lbf,
+        },
+        "envelopes": {
+            name: {
+                "point_count": int(points.shape[0]),
+                "min_axial_force_lbf": float(points[:, 0].min()),
+                "max_axial_force_lbf": float(points[:, 0].max()),
+                "min_pressure_psi": float(points[:, 1].min()),
+                "max_pressure_psi": float(points[:, 1].max()),
+            }
+            for name, points in envelopes.items()
+        },
+    }
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            output_cfg,
+            summary,
+            "results/tubular_design",
+            "tubular_design_summary.json",
+        )
+    )
+
+    cfg.setdefault("outputs", {})["directory"] = str(directory)
+    cfg["outputs"]["envelope_csv"] = str(csv_path)
+    cfg["tubular_design"] = {**params, "summary": summary}
+    return cfg

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -78,8 +78,9 @@ def test_workflow_registry(workflow):
             REPO_ROOT / "examples/workflows/viv-parametric/results/cases.csv"
         )
         case_0 = yaml.safe_load(
-            (REPO_ROOT / "examples/workflows/viv-parametric/results/case_0.yml")
-            .read_text()
+            (
+                REPO_ROOT / "examples/workflows/viv-parametric/results/case_0.yml"
+            ).read_text()
         )
 
         assert len(cases) == 6
@@ -182,9 +183,7 @@ def test_workflow_registry(workflow):
         assert result["anchor_length"]["end"] == pytest.approx(1368.5)
         assert result["min_critical_buckling_load"] == pytest.approx(-64701.045412)
         assert result["effective_axial_load"]["anchor_start"] == pytest.approx(-33.26)
-        assert result["fully_restrained_axial_force"]["L=0"] == pytest.approx(
-            -253.575
-        )
+        assert result["fully_restrained_axial_force"]["L=0"] == pytest.approx(-253.575)
     elif workflow["id"] == "pipeline-upheaval-buckling":
         result = cfg["pipeline"]["upheaval_buckling"]
         assert result["cover_check"] == "Pass"
@@ -218,9 +217,7 @@ def test_workflow_registry(workflow):
         assert "could not be loaded" not in content
     elif workflow["id"] == "dynacard-diagnostics":
         results = cfg["results"]
-        assert results["diagnostic_message"].startswith(
-            "Classification: PUMP_TAGGING."
-        )
+        assert results["diagnostic_message"].startswith("Classification: PUMP_TAGGING.")
         assert results["pump_fillage"] == pytest.approx(75.909653)
         assert results["inferred_production"] == pytest.approx(338.041470)
 
@@ -238,8 +235,7 @@ def test_workflow_registry(workflow):
         assert props["I"]["Ix"] == pytest.approx(19.471869)
 
         model_path = (
-            REPO_ROOT
-            / "examples/workflows/orcaflex-6dbuoy-dnvrph103/results/"
+            REPO_ROOT / "examples/workflows/orcaflex-6dbuoy-dnvrph103/results/"
             "dnvrph103_demo_6dbuoy_deep.yml"
         )
         model = yaml.safe_load(model_path.read_text())
@@ -258,9 +254,7 @@ def test_workflow_registry(workflow):
         assert summary["n_results"] == 8
         assert summary["min_safety_factor"] == pytest.approx(2.08)
         assert summary["max_utilization"] == pytest.approx(0.48)
-        assert result["environmental_loads"]["total_force"] == pytest.approx(
-            2280.94225
-        )
+        assert result["environmental_loads"]["total_force"] == pytest.approx(2280.94225)
 
         summary_path = Path(cfg["outputs"]["summary_json"])
         if not summary_path.is_absolute():
@@ -353,7 +347,9 @@ def test_workflow_registry(workflow):
         assert row["speed_kn"] == pytest.approx(12.0)
         assert row["rudder_angle_deg"] == pytest.approx(35.0)
         assert row["scalar_normal_force_N"] == pytest.approx(722870.905140)
-        assert row["hydrodynamic_rudder_stock_torque_Nm"] == pytest.approx(542153.178855)
+        assert row["hydrodynamic_rudder_stock_torque_Nm"] == pytest.approx(
+            542153.178855
+        )
         assert row["required_steering_gear_holding_torque_Nm"] == pytest.approx(
             -542153.178855
         )
@@ -388,5 +384,49 @@ def test_workflow_registry(workflow):
         assert op["confidence"] == "Green"
         assert op["q_uncertainty_fraction"] == pytest.approx(0.05)
         assert op["q_low_bopd"] < op["q_bopd"] < op["q_high_bopd"]
+    elif workflow["id"] == "well-bore-design":
+        block = cfg["well_bore_design"]
+        summary = block["summary"]
+        assert block["hole_type"] == "standard_hole"
+        assert summary["casing_count"] == 5
+        assert summary["total_cost_usd"] == pytest.approx(21500000.0)
+        assert summary["production_potential_bopd"] == pytest.approx(15000.0)
+        assert summary["risk"]["overall_score"] == pytest.approx(4.0)
+        assert summary["recommended_hole_type"] == "standard_hole"
+    elif workflow["id"] == "well-hydraulics":
+        result = cfg["well_hydraulics"]["result"]
+        assert result["annular_velocity_ft_min"] == pytest.approx(188.538461538)
+        assert result["pressure_drop_annulus_psi"] == pytest.approx(127.087912088)
+        assert result["ecd_ppg"] == pytest.approx(10.805499789)
+        assert result["cuttings_transport_ratio"] == pytest.approx(1.0)
+    elif workflow["id"] == "rop-analysis":
+        result = cfg["rop_analysis"]["result"]
+        by = result["bourgoyne_young"]
+        warren = result["warren"]
+        assert by["rop_ft_hr"] == pytest.approx(5.636893157)
+        assert by["sensitivity_wob_ft_hr_per_klb"] == pytest.approx(0.140933341)
+        assert by["sensitivity_rpm_ft_hr_per_rpm"] == pytest.approx(0.033829259)
+        assert warren["rop_ft_hr"] == pytest.approx(167.096226327)
+    elif workflow["id"] == "tubular-design-envelope":
+        summary = cfg["tubular_design"]["summary"]
+        assert summary["geometry"]["yield_force_lbf"] == pytest.approx(603928.713320)
+        assert summary["envelopes"]["vme_isotropic"]["max_pressure_psi"] == (
+            pytest.approx(7224.808854)
+        )
+        assert summary["envelopes"]["vme_isotropic"]["min_pressure_psi"] == (
+            pytest.approx(-7224.808854)
+        )
+        assert summary["envelopes"]["api_ellipse"]["max_pressure_psi"] == (
+            pytest.approx(4984.071753)
+        )
+        assert summary["envelopes"]["api_ellipse"]["min_pressure_psi"] == (
+            pytest.approx(-5340.076878)
+        )
+        envelope_csv = Path(cfg["outputs"]["envelope_csv"])
+        if not envelope_csv.is_absolute():
+            envelope_csv = REPO_ROOT / envelope_csv
+        envelope = pd.read_csv(envelope_csv)
+        assert len(envelope) == 160
+        assert set(envelope["envelope"]) == {"vme_isotropic", "api_ellipse"}
     else:
         raise AssertionError(f"Missing workflow assertion for {workflow['id']}")


### PR DESCRIPTION
Part of #711, wave 4 (well/drilling). Thin cfg runner over existing `well/` logic — no new engineering. Registry +4 rows.

| Workflow | Verified |
|---|---|
| well-bore-design | 5 casing strings, total cost 21.5M, 15000 bopd, risk 4.0, standard_hole |
| well-hydraulics | annular velocity 188.54 ft/min, ΔP 127.09 psi, ECD 10.81 ppg |
| rop-analysis | Bourgoyne-Young 5.637 ft/hr, Warren 167.10 ft/hr |
| tubular-design-envelope | yield 603929 lbf, VME ±7224.8 psi, API 4984.07 psi, 160-row envelope CSV |

## Verified (real uv)
- all 4 exit 0 via the module CLI
- `tests/workflows/ + tests/contracts/` → 52 passed; `tests/well/` → 180 passed (no pre-existing failures)

Merge-order: wave-4 lanes append to engine.py + registry; merge any order, later rebase. Companions: geotech #745, field-dev incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)