### PR TITLE
feat(workflows): elastic_buckling workflow + ElasticBucklingSolver correctness fix

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -102,6 +102,14 @@ workflows:
       - examples/workflows/api-2sk-mooring/results/input_code_check.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[api-2sk-mooring]
     runtime: offline
+  - id: pipe-ovality
+    basename: pipe_ovality
+    title: DNV-OS-F101 pipe out-of-roundness geometry check
+    input: examples/workflows/pipe-ovality/input.yml
+    outputs:
+      - examples/workflows/pipe-ovality/results/input_ovality.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pipe-ovality]
+    runtime: offline
   - id: von-mises
     basename: von_mises
     title: Two-element cantilever beam Von Mises stress check
@@ -143,6 +151,14 @@ workflows:
     outputs:
       - examples/workflows/riser-stackup/results/input_riser_stackup.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[riser-stackup]
+    runtime: offline
+  - id: tsj-sizing
+    basename: tsj_sizing
+    title: API RP 2RD taper stress joint membrane sizing
+    input: examples/workflows/tsj-sizing/input.yml
+    outputs:
+      - examples/workflows/tsj-sizing/results/input_tsj.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[tsj-sizing]
     runtime: offline
   - id: riser-stackup-parametric
     basename: parametric_run

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -110,6 +110,14 @@ workflows:
       - examples/workflows/von-mises/results/input_von_mises.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[von-mises]
     runtime: offline
+  - id: elastic-buckling
+    basename: elastic_buckling
+    title: Pinned-pinned Euler column elastic buckling check
+    input: examples/workflows/elastic-buckling/input.yml
+    outputs:
+      - examples/workflows/elastic-buckling/results/input_elastic_buckling.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[elastic-buckling]
+    runtime: offline
   - id: stress-strain-parametric
     basename: parametric_run
     title: Ramberg-Osgood material grade sweep for offshore pipeline steels

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -110,6 +110,14 @@ workflows:
       - examples/workflows/pipe-ovality/results/input_ovality.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pipe-ovality]
     runtime: offline
+  - id: rao-tabulation
+    basename: rao_tabulation
+    title: Offline 6-DOF vessel RAO amplitude and phase tabulation
+    input: examples/workflows/rao-tabulation/input.yml
+    outputs:
+      - examples/workflows/rao-tabulation/results/input_rao.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rao-tabulation]
+    runtime: offline
   - id: von-mises
     basename: von_mises
     title: Two-element cantilever beam Von Mises stress check

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -118,6 +118,14 @@ workflows:
       - examples/workflows/elastic-buckling/results/input_elastic_buckling.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[elastic-buckling]
     runtime: offline
+  - id: orcaflex-strength-post
+    basename: orcaflex_post_process
+    title: OrcaFlex strength post-processing (tension/moment/curvature) — needs OrcaFlex license
+    input: examples/workflows/orcaflex-strength-post/input.yml
+    outputs:
+      - examples/workflows/orcaflex-strength-post/results/strength_loadcase_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[orcaflex-strength-post]
+    runtime: requires-license
   - id: stress-strain-parametric
     basename: parametric_run
     title: Ramberg-Osgood material grade sweep for offshore pipeline steels

--- a/examples/workflows/elastic-buckling/input.yml
+++ b/examples/workflows/elastic-buckling/input.yml
@@ -1,0 +1,106 @@
+basename: elastic_buckling
+
+elastic_buckling:
+  nodes:
+    - id: 0
+      x: 0.0
+      y: 0.0
+    - id: 1
+      x: 0.375
+      y: 0.0
+    - id: 2
+      x: 0.75
+      y: 0.0
+    - id: 3
+      x: 1.125
+      y: 0.0
+    - id: 4
+      x: 1.5
+      y: 0.0
+    - id: 5
+      x: 1.875
+      y: 0.0
+    - id: 6
+      x: 2.25
+      y: 0.0
+    - id: 7
+      x: 2.625
+      y: 0.0
+    - id: 8
+      x: 3.0
+      y: 0.0
+  elements:
+    - id: 0
+      node1: 0
+      node2: 1
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 1
+      node1: 1
+      node2: 2
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 2
+      node1: 2
+      node2: 3
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 3
+      node1: 3
+      node2: 4
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 4
+      node1: 4
+      node2: 5
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 5
+      node1: 5
+      node2: 6
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 6
+      node1: 6
+      node2: 7
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 7
+      node1: 7
+      node2: 8
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+  boundary_conditions:
+    pinned_nodes:
+      - 0
+      - 8
+  loads:
+    - node: 8
+      direction: x
+      magnitude: -1.0
+  material:
+    E: 2.10e11
+    nu: 0.3
+    rho: 7850.0
+    sigma_y: 4.48e8
+  axial_force: 1.0
+  num_modes: 3
+  reference:
+    length: 3.0
+    effective_length_factor: 1.0
+    euler_tolerance: 0.05
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/examples/workflows/orcaflex-strength-post/input.yml
+++ b/examples/workflows/orcaflex-strength-post/input.yml
@@ -1,0 +1,51 @@
+# OrcaFlex strength post-processing — REQUIRES-LICENSE workflow.
+#
+# This workflow post-processes an OrcaFlex .sim (effective/wall tension, bend
+# moment, curvature range graphs + summary statistics) and therefore needs a
+# licensed OrcaFlex install (OrcFxAPI) plus the referenced .sim file. It is
+# registered with `runtime: requires-license` and is SKIPPED by the offline
+# durable-workflows test (which only executes `runtime: offline` rows). It is
+# intended to run where OrcaFlex is licensed (e.g. a dedicated licensed-run
+# channel), not in offline CI.
+basename: orcaflex_post_process
+
+orcaflex_post_process: {}
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: True
+
+orcaflex:
+  postprocess:
+    visualization:
+      flag: False
+    summary:
+      flag: True
+      statistics:
+        Minimum: True
+        Maximum: True
+        Mean: True
+        StdDev: True
+      min: True
+      max: True
+      mean: True
+    RangeGraph:
+      flag: True
+    time_series:
+      flag: False
+
+parameters:
+  VarNames:
+    Line: [Effective tension, Wall tension, Bend moment, Curvature, Bend radius]
+
+file_management:
+  flag: True
+  files:
+    files_in_current_directory:
+      flag: False
+      directory: data
+    data_source: yml
+    data:
+      - Name: data/strength_loadcase.sim

--- a/examples/workflows/pipe-ovality/input.yml
+++ b/examples/workflows/pipe-ovality/input.yml
@@ -1,0 +1,15 @@
+basename: pipe_ovality
+
+pipe_ovality:
+  nominal_OD: 323.85
+  max_OD: 325.0
+  min_OD: 322.7
+  allowable: 0.03
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+

--- a/examples/workflows/rao-tabulation/input.yml
+++ b/examples/workflows/rao-tabulation/input.yml
@@ -1,0 +1,41 @@
+basename: rao_tabulation
+
+rao_tabulation:
+  # Periods are converted internally with omega_rad_s = 2*pi/period_s.
+  rao_database:
+    vessel_name: offline_demo_vessel
+    periods_s: [6.0, 10.0, 14.0, 18.0]
+    headings_deg: [0.0, 90.0]
+    amplitudes:
+      - - [0.03, 0.01, 0.35, 0.006, 0.012, 0.003]
+        - [0.02, 0.02, 0.30, 0.012, 0.010, 0.004]
+      - - [0.06, 0.02, 0.75, 0.012, 0.020, 0.006]
+        - [0.05, 0.03, 0.70, 0.020, 0.017, 0.007]
+      - - [0.09, 0.03, 0.95, 0.017, 0.027, 0.008]
+        - [0.07, 0.04, 0.90, 0.026, 0.022, 0.009]
+      - - [0.11, 0.04, 1.02, 0.022, 0.032, 0.010]
+        - [0.09, 0.05, 0.98, 0.032, 0.027, 0.011]
+    phases_deg:
+      - - [0.0, 4.0, 8.0, 0.0, 2.0, 1.0]
+        - [1.0, 5.0, 10.0, 1.0, 3.0, 2.0]
+      - - [2.0, 6.0, 13.0, 2.0, 4.0, 3.0]
+        - [3.0, 7.0, 15.0, 3.0, 5.0, 4.0]
+      - - [4.0, 8.0, 18.0, 4.0, 6.0, 5.0]
+        - [5.0, 9.0, 20.0, 5.0, 7.0, 6.0]
+      - - [6.0, 10.0, 22.0, 6.0, 8.0, 7.0]
+        - [7.0, 11.0, 24.0, 7.0, 9.0, 8.0]
+  query_points:
+    - period_s: 8.0
+      heading_deg: 45.0
+    - period_s: 14.0
+      heading_deg: 90.0
+    - period_s: 18.0
+      heading_deg: 0.0
+  interpolation_method: linear
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/examples/workflows/tsj-sizing/input.yml
+++ b/examples/workflows/tsj-sizing/input.yml
@@ -1,0 +1,29 @@
+basename: tsj_sizing
+
+tsj_sizing:
+  effective_tension_N: 2500000.0
+  internal_pressure_Pa: 12000000.0
+  external_pressure_Pa: 1000000.0
+  SMYS_Pa: 552000000.0
+  design_factor: 0.67
+  taper:
+    - position_m: 0.0
+      outer_diameter_mm: 508.0
+      wall_thickness_mm: 38.0
+    - position_m: 10.0
+      outer_diameter_mm: 457.0
+      wall_thickness_mm: 32.0
+    - position_m: 20.0
+      outer_diameter_mm: 406.0
+      wall_thickness_mm: 25.0
+    - position_m: 30.0
+      outer_diameter_mm: 356.0
+      wall_thickness_mm: 20.0
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+

--- a/src/digitalmodel/base_configs/modules/elastic_buckling/elastic_buckling.yml
+++ b/src/digitalmodel/base_configs/modules/elastic_buckling/elastic_buckling.yml
@@ -1,0 +1,106 @@
+basename: elastic_buckling
+
+elastic_buckling:
+  nodes:
+    - id: 0
+      x: 0.0
+      y: 0.0
+    - id: 1
+      x: 0.375
+      y: 0.0
+    - id: 2
+      x: 0.75
+      y: 0.0
+    - id: 3
+      x: 1.125
+      y: 0.0
+    - id: 4
+      x: 1.5
+      y: 0.0
+    - id: 5
+      x: 1.875
+      y: 0.0
+    - id: 6
+      x: 2.25
+      y: 0.0
+    - id: 7
+      x: 2.625
+      y: 0.0
+    - id: 8
+      x: 3.0
+      y: 0.0
+  elements:
+    - id: 0
+      node1: 0
+      node2: 1
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 1
+      node1: 1
+      node2: 2
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 2
+      node1: 2
+      node2: 3
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 3
+      node1: 3
+      node2: 4
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 4
+      node1: 4
+      node2: 5
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 5
+      node1: 5
+      node2: 6
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 6
+      node1: 6
+      node2: 7
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+    - id: 7
+      node1: 7
+      node2: 8
+      E: 2.10e11
+      I: 8.10e-6
+      A: 1.0e-2
+  boundary_conditions:
+    pinned_nodes:
+      - 0
+      - 8
+  loads:
+    - node: 8
+      direction: x
+      magnitude: -1.0
+  material:
+    E: 2.10e11
+    nu: 0.3
+    rho: 7850.0
+    sigma_y: 4.48e8
+  axial_force: 1.0
+  num_modes: 3
+  reference:
+    length: 3.0
+    effective_length_factor: 1.0
+    euler_tolerance: 0.05
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/pipe_ovality/pipe_ovality.yml
+++ b/src/digitalmodel/base_configs/modules/pipe_ovality/pipe_ovality.yml
@@ -1,0 +1,15 @@
+basename: pipe_ovality
+
+pipe_ovality:
+  nominal_OD: 323.85
+  max_OD: 325.0
+  min_OD: 322.7
+  allowable: 0.03
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+

--- a/src/digitalmodel/base_configs/modules/rao_tabulation/rao_tabulation.yml
+++ b/src/digitalmodel/base_configs/modules/rao_tabulation/rao_tabulation.yml
@@ -1,0 +1,29 @@
+basename: rao_tabulation
+
+rao_tabulation:
+  # Periods are converted internally with omega_rad_s = 2*pi/period_s.
+  rao_database:
+    vessel_name: demo_vessel
+    periods_s: [8.0, 12.0]
+    headings_deg: [0.0, 90.0]
+    amplitudes:
+      - - [0.05, 0.02, 0.60, 0.010, 0.020, 0.005]
+        - [0.04, 0.03, 0.55, 0.020, 0.015, 0.006]
+      - - [0.08, 0.03, 0.90, 0.015, 0.025, 0.007]
+        - [0.06, 0.04, 0.85, 0.025, 0.020, 0.008]
+    phases_deg:
+      - - [0.0, 5.0, 10.0, 0.0, 2.0, 1.0]
+        - [1.0, 6.0, 12.0, 1.0, 3.0, 2.0]
+      - - [2.0, 7.0, 15.0, 2.0, 4.0, 3.0]
+        - [3.0, 8.0, 17.0, 3.0, 5.0, 4.0]
+  query_points:
+    - period_s: 10.0
+      heading_deg: 45.0
+  interpolation_method: linear
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/tsj_sizing/tsj_sizing.yml
+++ b/src/digitalmodel/base_configs/modules/tsj_sizing/tsj_sizing.yml
@@ -1,0 +1,29 @@
+basename: tsj_sizing
+
+tsj_sizing:
+  effective_tension_N: 2500000.0
+  internal_pressure_Pa: 12000000.0
+  external_pressure_Pa: 1000000.0
+  SMYS_Pa: 552000000.0
+  design_factor: 0.67
+  taper:
+    - position_m: 0.0
+      outer_diameter_mm: 508.0
+      wall_thickness_mm: 38.0
+    - position_m: 10.0
+      outer_diameter_mm: 457.0
+      wall_thickness_mm: 32.0
+    - position_m: 20.0
+      outer_diameter_mm: 406.0
+      wall_thickness_mm: 25.0
+    - position_m: 30.0
+      outer_diameter_mm: 356.0
+      wall_thickness_mm: 20.0
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+

--- a/src/digitalmodel/drilling_riser/tsj_workflow.py
+++ b/src/digitalmodel/drilling_riser/tsj_workflow.py
@@ -1,0 +1,250 @@
+"""UV-workflow router for taper stress joint membrane sizing.
+
+This is a minimal offline API RP 2RD-style screening calculation for a tapered
+riser stress joint. It evaluates true wall tension and von Mises membrane stress
+at each taper station; it does not depend on OrcaFlex or dynamic analysis.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("tsj_sizing") or {}
+    effective_tension_n = _effective_tension_n(settings)
+    internal_pressure_pa = _pressure_pa(
+        settings,
+        ("internal_pressure_Pa", "internal_pressure_pa"),
+        ("internal_pressure_MPa", "internal_pressure_mpa"),
+        0.0,
+    )
+    external_pressure_pa = _pressure_pa(
+        settings,
+        ("external_pressure_Pa", "external_pressure_pa"),
+        ("external_pressure_MPa", "external_pressure_mpa"),
+        0.0,
+    )
+    smys_pa = _required_positive_float(settings, ("SMYS_Pa", "smys_Pa", "SMYS", "smys"))
+    design_factor = _required_positive_float(settings, ("design_factor",))
+    allowable_stress_pa = design_factor * smys_pa
+    sections = _sections(settings)
+
+    rows = [
+        _section_result(
+            section,
+            effective_tension_n,
+            internal_pressure_pa,
+            external_pressure_pa,
+            allowable_stress_pa,
+        )
+        for section in sections
+    ]
+    csv_path = _results_csv_path(cfg, settings)
+    _write_results_csv(csv_path, rows)
+
+    governing = max(rows, key=lambda row: float(row["utilisation"]))
+    cfg["tsj_sizing"] = {
+        "effective_tension_N": effective_tension_n,
+        "internal_pressure_Pa": internal_pressure_pa,
+        "external_pressure_Pa": external_pressure_pa,
+        "SMYS_Pa": smys_pa,
+        "design_factor": design_factor,
+        "allowable_stress_Pa": allowable_stress_pa,
+        "sections": len(rows),
+        "max_utilisation": float(governing["utilisation"]),
+        "governing_section": {
+            "position_m": governing["position_m"],
+            "OD_mm": governing["OD_mm"],
+            "WT_mm": governing["WT_mm"],
+            "utilisation": governing["utilisation"],
+        },
+        "passes": float(governing["utilisation"]) <= 1.0,
+        "results_csv": _display_path(csv_path),
+    }
+    return cfg
+
+
+def _section_result(
+    section: dict[str, float],
+    effective_tension_n: float,
+    internal_pressure_pa: float,
+    external_pressure_pa: float,
+    allowable_stress_pa: float,
+) -> dict[str, float]:
+    od_m = section["OD_mm"] / 1000.0
+    wt_m = section["WT_mm"] / 1000.0
+    id_m = od_m - 2.0 * wt_m
+    area_m2 = math.pi / 4.0 * (od_m**2 - id_m**2)
+    inner_area_m2 = math.pi / 4.0 * id_m**2
+    outer_area_m2 = math.pi / 4.0 * od_m**2
+    inertia_m4 = math.pi / 64.0 * (od_m**4 - id_m**4)
+    section_modulus_m3 = inertia_m4 / (od_m / 2.0)
+    true_wall_tension_n = (
+        effective_tension_n
+        + internal_pressure_pa * inner_area_m2
+        - external_pressure_pa * outer_area_m2
+    )
+    axial_stress_pa = true_wall_tension_n / area_m2
+    hoop_stress_pa = (internal_pressure_pa - external_pressure_pa) * od_m / (2.0 * wt_m)
+    vm_stress_pa = math.sqrt(
+        axial_stress_pa**2 - axial_stress_pa * hoop_stress_pa + hoop_stress_pa**2
+    )
+
+    return {
+        "position_m": section["position_m"],
+        "OD_mm": section["OD_mm"],
+        "WT_mm": section["WT_mm"],
+        "area_m2": area_m2,
+        "section_modulus_m3": section_modulus_m3,
+        "true_wall_tension_N": true_wall_tension_n,
+        "axial_stress_Pa": axial_stress_pa,
+        "hoop_stress_Pa": hoop_stress_pa,
+        "vm_stress_Pa": vm_stress_pa,
+        "utilisation": vm_stress_pa / allowable_stress_pa,
+    }
+
+
+def _sections(settings: dict[str, Any]) -> list[dict[str, float]]:
+    raw_sections = settings.get("taper")
+    if not isinstance(raw_sections, list) or not raw_sections:
+        raise ValueError("tsj_sizing taper must be a non-empty list")
+
+    sections = []
+    for index, raw_section in enumerate(raw_sections):
+        if not isinstance(raw_section, dict):
+            raise ValueError("tsj_sizing taper sections must be mappings")
+        position_m = _required_positive_or_zero_float(raw_section, ("position_m",))
+        od_mm = _required_positive_float(
+            raw_section,
+            ("outer_diameter_mm", "OD_mm", "od_mm"),
+        )
+        wt_mm = _required_positive_float(
+            raw_section,
+            ("wall_thickness_mm", "WT_mm", "wt_mm"),
+        )
+        if od_mm <= 2.0 * wt_mm:
+            raise ValueError(
+                f"tsj_sizing taper[{index}] wall_thickness_mm leaves no bore"
+            )
+        sections.append({"position_m": position_m, "OD_mm": od_mm, "WT_mm": wt_mm})
+
+    if any(
+        sections[index]["position_m"] <= sections[index - 1]["position_m"]
+        for index in range(1, len(sections))
+    ):
+        raise ValueError("tsj_sizing taper positions must be strictly increasing")
+    return sections
+
+
+def _effective_tension_n(settings: dict[str, Any]) -> float:
+    value = _first_value(settings, ("effective_tension_N", "effective_tension_n"))
+    if value is not None:
+        value = float(value)
+    else:
+        value = _first_value(
+            settings,
+            ("effective_tension_kN", "effective_tension_kn"),
+        )
+        if value is None:
+            raise ValueError("tsj_sizing effective_tension_N is required")
+        value = float(value) * 1000.0
+    if value <= 0.0:
+        raise ValueError("tsj_sizing effective_tension_N must be positive")
+    return value
+
+
+def _pressure_pa(
+    settings: dict[str, Any],
+    pa_aliases: tuple[str, ...],
+    mpa_aliases: tuple[str, ...],
+    default: float,
+) -> float:
+    value = _first_value(settings, pa_aliases)
+    if value is not None:
+        pressure = float(value)
+    else:
+        value = _first_value(settings, mpa_aliases)
+        if value is None:
+            return default
+        pressure = float(value) * 1.0e6
+    if pressure < 0.0:
+        raise ValueError(f"tsj_sizing {pa_aliases[0]} must be non-negative")
+    return pressure
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    stem = _input_stem(cfg)
+    return output_dir / f"{stem}_tsj.csv"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "tsj_sizing"))
+
+
+def _write_results_csv(path: Path, rows: list[dict[str, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _required_positive_float(
+    values: dict[str, Any],
+    aliases: tuple[str, ...],
+) -> float:
+    value = _first_value(values, aliases)
+    if value is None:
+        raise ValueError(f"tsj_sizing {aliases[0]} is required")
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"tsj_sizing {aliases[0]} must be positive")
+    return value
+
+
+def _required_positive_or_zero_float(
+    values: dict[str, Any],
+    aliases: tuple[str, ...],
+) -> float:
+    value = _first_value(values, aliases)
+    if value is None:
+        raise ValueError(f"tsj_sizing {aliases[0]} is required")
+    value = float(value)
+    if value < 0.0:
+        raise ValueError(f"tsj_sizing {aliases[0]} must be non-negative")
+    return value
+
+
+def _first_value(values: dict[str, Any], aliases: tuple[str, ...]) -> Any:
+    for alias in aliases:
+        if values.get(alias) is not None:
+            return values[alias]
+    return None
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -175,6 +175,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
     elif basename == "rao_analysis":
         rao = RAOAnalysis()
         cfg_base = rao.read_orcaflex_displacement_raos(cfg_base)
+    elif basename == "rao_tabulation":
+        from digitalmodel.hydrodynamics.rao_tabulation.workflow import (
+            router as rao_tabulation,
+        )
+
+        cfg_base = rao_tabulation(cfg_base)
     elif basename == "installation":
         orc_install = OrcInstallation()
         if cfg_base["structure"]["flag"]:

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -232,6 +232,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.drilling_riser.workflow import router as riser_stackup
 
         cfg_base = riser_stackup(cfg_base)
+    elif basename == "tsj_sizing":
+        from digitalmodel.drilling_riser.tsj_workflow import router as tsj_sizing
+
+        cfg_base = tsj_sizing(cfg_base)
     elif basename == "sn_curve":
         from digitalmodel.fatigue.workflow import router as sn_curve
 
@@ -244,6 +248,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.code_checks.workflow import router as code_check
 
         cfg_base = code_check(cfg_base)
+    elif basename == "pipe_ovality":
+        from digitalmodel.structural.ovality.workflow import router as pipe_ovality
+
+        cfg_base = pipe_ovality(cfg_base)
     elif basename == "von_mises":
         from digitalmodel.structural.fe.von_mises_workflow import router as von_mises
 

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -248,6 +248,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.structural.fe.von_mises_workflow import router as von_mises
 
         cfg_base = von_mises(cfg_base)
+    elif basename == "elastic_buckling":
+        from digitalmodel.structural.fe.elastic_buckling_workflow import (
+            router as elastic_buckling,
+        )
+
+        cfg_base = elastic_buckling(cfg_base)
     elif basename == "time_series":
         tsa = TimeSeriesAnalysis()
         cfg_base = tsa.router(cfg_base)

--- a/src/digitalmodel/hydrodynamics/rao_tabulation/__init__.py
+++ b/src/digitalmodel/hydrodynamics/rao_tabulation/__init__.py
@@ -1,0 +1,2 @@
+"""Offline RAO tabulation workflow."""
+

--- a/src/digitalmodel/hydrodynamics/rao_tabulation/workflow.py
+++ b/src/digitalmodel/hydrodynamics/rao_tabulation/workflow.py
@@ -1,0 +1,313 @@
+"""UV-workflow router for offline 6-DOF RAO tabulation.
+
+Period inputs use the hydrodynamics convention omega_rad_s = 2*pi/period_s.
+Frequency inputs are angular frequencies in rad/s.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from digitalmodel.hydrodynamics.interpolator import CoefficientsInterpolator
+from digitalmodel.hydrodynamics.models import MatrixDOF, RAOData
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DOFS = tuple(dof.name.lower() for dof in MatrixDOF)
+PHASE_COLUMNS = tuple(f"{name}_phase_deg" for name in DOFS)
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("rao_tabulation") or {}
+    rao_data = _rao_data(settings)
+    queries = _query_points(settings)
+    method = _interpolation_method(settings)
+    rows = _interpolated_rows(rao_data, queries, method)
+    csv_path = _results_csv_path(cfg, settings)
+    _write_results_csv(csv_path, rows)
+
+    peak = max(rows, key=lambda row: float(row["heave"]))
+    cfg["rao_tabulation"] = {
+        "vessel_name": rao_data.vessel_name,
+        "frequency_convention": "omega_rad_s = 2*pi/period_s",
+        "interpolation_method": method,
+        "n_query_points": len(rows),
+        "dofs": list(DOFS),
+        "rao_csv": _display_path(csv_path),
+        "peak_heave_amplitude": float(peak["heave"]),
+        "peak_heave_period_s": float(peak["period_s"]),
+        "peak_heave_heading_deg": float(peak["heading_deg"]),
+    }
+    return cfg
+
+
+def _rao_data(settings: dict[str, Any]) -> RAOData:
+    database = _database(settings)
+    frequencies = _frequency_axis(database)
+    directions = _directions_axis(database)
+    amplitudes = _rao_array(database, "amplitudes", frequencies, directions)
+    phases = _rao_array(database, "phases_deg", frequencies, directions)
+
+    freq_order = _sorted_indices(frequencies, "rao_tabulation frequencies")
+    dir_order = _sorted_indices(directions, "rao_tabulation headings")
+    return RAOData(
+        frequencies=frequencies[freq_order],
+        directions=directions[dir_order],
+        amplitudes=amplitudes[freq_order][:, dir_order, :],
+        phases=phases[freq_order][:, dir_order, :],
+        vessel_name=str(
+            database.get("vessel_name", settings.get("vessel_name", "Vessel"))
+        ),
+    )
+
+
+def _database(settings: dict[str, Any]) -> dict[str, Any]:
+    database = settings.get("rao_database", settings.get("database", settings))
+    if not isinstance(database, dict):
+        raise ValueError("rao_tabulation rao_database must be a mapping")
+    return database
+
+
+def _frequency_axis(database: dict[str, Any]) -> np.ndarray:
+    periods = _first_value(database, ("periods_s", "periods", "period_s"))
+    freqs = _first_value(
+        database, ("frequencies_rad_s", "frequencies", "frequency_rad_s")
+    )
+    if (periods is None) == (freqs is None):
+        raise ValueError(
+            "rao_tabulation requires exactly one of periods_s or frequencies_rad_s"
+        )
+    if periods is not None:
+        period_values = _float_vector(periods, "rao_tabulation periods_s")
+        if np.any(period_values <= 0.0):
+            raise ValueError("rao_tabulation periods_s must be positive")
+        return (2.0 * math.pi) / period_values
+
+    frequency_values = _float_vector(freqs, "rao_tabulation frequencies_rad_s")
+    if np.any(frequency_values <= 0.0):
+        raise ValueError("rao_tabulation frequencies_rad_s must be positive")
+    return frequency_values
+
+
+def _directions_axis(database: dict[str, Any]) -> np.ndarray:
+    directions = _first_value(
+        database, ("headings_deg", "directions_deg", "headings", "directions")
+    )
+    if directions is None:
+        raise ValueError("rao_tabulation headings_deg is required")
+    return _float_vector(directions, "rao_tabulation headings_deg")
+
+
+def _rao_array(
+    database: dict[str, Any],
+    name: str,
+    frequencies: np.ndarray,
+    directions: np.ndarray,
+) -> np.ndarray:
+    value = _first_value(database, (name, "phases" if name == "phases_deg" else name))
+    if value is None:
+        raise ValueError(f"rao_tabulation rao_database.{name} is required")
+    values = np.asarray(value, dtype=float)
+    expected_shape = (len(frequencies), len(directions), len(DOFS))
+    if values.shape != expected_shape:
+        raise ValueError(
+            f"rao_tabulation rao_database.{name} shape {values.shape} "
+            f"does not match expected {expected_shape}"
+        )
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"rao_tabulation rao_database.{name} must be finite")
+    return values
+
+
+def _query_points(settings: dict[str, Any]) -> list[dict[str, float]]:
+    raw_queries = settings.get("query_points", settings.get("queries"))
+    if not isinstance(raw_queries, list) or not raw_queries:
+        raise ValueError("rao_tabulation query_points must be a non-empty list")
+    queries = []
+    for index, raw_query in enumerate(raw_queries):
+        if not isinstance(raw_query, dict):
+            raise ValueError(f"rao_tabulation query_points[{index}] must be a mapping")
+        period_s, frequency = _query_period_and_frequency(raw_query, index)
+        heading = _query_heading(raw_query, index)
+        queries.append(
+            {"period_s": period_s, "frequency": frequency, "heading_deg": heading}
+        )
+    return queries
+
+
+def _query_period_and_frequency(
+    query: dict[str, Any], index: int
+) -> tuple[float, float]:
+    period = _first_value(query, ("period_s", "period", "periods_s"))
+    frequency = _first_value(
+        query, ("frequency_rad_s", "frequency", "frequencies_rad_s")
+    )
+    if period is None and frequency is None:
+        raise ValueError(
+            f"rao_tabulation query_points[{index}] requires period_s or frequency_rad_s"
+        )
+    if period is not None:
+        period_s = float(period)
+        if period_s <= 0.0:
+            raise ValueError(
+                f"rao_tabulation query_points[{index}].period_s must be positive"
+            )
+        frequency_from_period = (2.0 * math.pi) / period_s
+    if frequency is not None:
+        frequency_value = float(frequency)
+        if frequency_value <= 0.0:
+            raise ValueError(
+                f"rao_tabulation query_points[{index}].frequency_rad_s must be positive"
+            )
+        period_from_frequency = (2.0 * math.pi) / frequency_value
+    if period is not None and frequency is not None:
+        if not math.isclose(frequency_value, frequency_from_period, rel_tol=1.0e-9):
+            raise ValueError(
+                f"rao_tabulation query_points[{index}] period_s and frequency_rad_s disagree"
+            )
+    if period is not None:
+        return period_s, frequency_from_period
+    return period_from_frequency, frequency_value
+
+
+def _query_heading(query: dict[str, Any], index: int) -> float:
+    heading = _first_value(
+        query, ("heading_deg", "direction_deg", "heading", "direction")
+    )
+    if heading is None:
+        raise ValueError(
+            f"rao_tabulation query_points[{index}].heading_deg is required"
+        )
+    heading_value = float(heading)
+    if not math.isfinite(heading_value):
+        raise ValueError(
+            f"rao_tabulation query_points[{index}].heading_deg must be finite"
+        )
+    return heading_value
+
+
+def _interpolation_method(settings: dict[str, Any]) -> str:
+    method = str(settings.get("interpolation_method", "linear")).strip().lower()
+    if method not in {"linear", "nearest"}:
+        raise ValueError(
+            "rao_tabulation interpolation_method must be linear or nearest"
+        )
+    return method
+
+
+def _interpolated_rows(
+    rao_data: RAOData,
+    queries: list[dict[str, float]],
+    method: str,
+) -> list[dict[str, float]]:
+    interpolator = CoefficientsInterpolator()
+    interpolator.load_raos(rao_data)
+    rows = []
+    for query in queries:
+        _check_query_bounds(rao_data, query)
+        interpolated = interpolator.interpolate_all_dofs(
+            np.array([query["frequency"]], dtype=float),
+            np.array([query["heading_deg"]], dtype=float),
+            method=method,
+        )
+        rows.append(_result_row(query, interpolated))
+    return rows
+
+
+def _check_query_bounds(rao_data: RAOData, query: dict[str, float]) -> None:
+    frequency = query["frequency"]
+    heading = query["heading_deg"]
+    if frequency < np.min(rao_data.frequencies) or frequency > np.max(
+        rao_data.frequencies
+    ):
+        raise ValueError(
+            "rao_tabulation query frequency is outside the RAO database range"
+        )
+    if heading < np.min(rao_data.directions) or heading > np.max(rao_data.directions):
+        raise ValueError(
+            "rao_tabulation query heading is outside the RAO database range"
+        )
+
+
+def _result_row(query: dict[str, float], interpolated: RAOData) -> dict[str, float]:
+    amplitudes = interpolated.amplitudes[0, 0, :]
+    phases = interpolated.phases[0, 0, :]
+    if not np.all(np.isfinite(amplitudes)) or not np.all(np.isfinite(phases)):
+        raise ValueError("rao_tabulation interpolation returned non-finite values")
+    row = {
+        "period_s": float(query["period_s"]),
+        "heading_deg": float(query["heading_deg"]),
+    }
+    row.update({dof: float(amplitudes[index]) for index, dof in enumerate(DOFS)})
+    row.update(
+        {phase: float(phases[index]) for index, phase in enumerate(PHASE_COLUMNS)}
+    )
+    return row
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    stem = _input_stem(cfg)
+    return output_dir / f"{stem}_rao.csv"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "rao_tabulation"))
+
+
+def _write_results_csv(path: Path, rows: list[dict[str, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["period_s", "heading_deg", *DOFS, *PHASE_COLUMNS]
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _float_vector(value: Any, name: str) -> np.ndarray:
+    values = np.asarray(value, dtype=float)
+    if values.ndim != 1 or len(values) == 0:
+        raise ValueError(f"{name} must be a non-empty list")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must be finite")
+    return values
+
+
+def _sorted_indices(values: np.ndarray, name: str) -> np.ndarray:
+    order = np.argsort(values)
+    sorted_values = values[order]
+    if np.any(np.diff(sorted_values) <= 0.0):
+        raise ValueError(f"{name} must contain unique values")
+    return order
+
+
+def _first_value(source: dict[str, Any], aliases: tuple[str, ...]) -> Any:
+    for alias in aliases:
+        if source.get(alias) is not None:
+            return source[alias]
+    return None
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/src/digitalmodel/infrastructure/base_solvers/structural/buckling/elastic_buckling.py
+++ b/src/digitalmodel/infrastructure/base_solvers/structural/buckling/elastic_buckling.py
@@ -127,12 +127,14 @@ class ElasticBucklingSolver(StructuralSolver):
 
             # Apply boundary conditions
             logger.info("Applying boundary conditions")
-            K_mod, _ = self.apply_boundary_conditions(K, np.zeros(K.shape[0]))
-            Kg_mod, _ = self.apply_boundary_conditions(Kg, np.zeros(Kg.shape[0]))
+            K_mod, Kg_mod, free_dofs = self._reduce_buckling_matrices(K, Kg)
 
             # Solve eigenvalue problem
             logger.info("Solving eigenvalue problem: (K - λKg)φ = 0")
             eigenvalues, eigenvectors = self._solve_eigenvalue_problem(K_mod, Kg_mod)
+            eigenvectors = self._expand_eigenvectors(
+                eigenvectors, free_dofs, K.shape[0]
+            )
 
             # Store results
             self._store_results(eigenvalues, eigenvectors)
@@ -213,6 +215,9 @@ class ElasticBucklingSolver(StructuralSolver):
         Returns:
             Estimated axial force (N)
         """
+        if hasattr(element, "axial_force"):
+            return float(element.axial_force)
+
         # Compute total load magnitude
         total_load = sum(abs(load['magnitude']) for load in self.loads)
 
@@ -231,11 +236,13 @@ class ElasticBucklingSolver(StructuralSolver):
         """
         Compute element geometric stiffness matrix.
 
-        For a beam element:
-        Kg = (N/L) * [0, 0, 0, 0]
-                      [0, 6/5, 0, 1/10]
-                      [0, 0, 0, 0]
-                      [0, 1/10, 0, 6/5]
+        For a Euler-Bernoulli beam-column element with transverse displacement
+        and rotation DOFs, positive axial_force is compressive reference load:
+
+        Kg = N/(30L) * [ 36,   3L, -36,   3L]
+                      [ 3L, 4L², -3L,  -L²]
+                      [-36,  -3L,  36,  -3L]
+                      [ 3L, -L², -3L, 4L²]
 
         Args:
             element: Element object
@@ -245,17 +252,83 @@ class ElasticBucklingSolver(StructuralSolver):
             4×4 element geometric stiffness matrix
         """
         L = element.L
-        N_over_L = axial_force / L
+        L2 = L * L
 
-        # Simplified geometric stiffness (for bending)
-        kg = N_over_L * np.array([
-            [0.0, 0.0, 0.0, 0.0],
-            [0.0, 6.0/5.0, 0.0, 1.0/10.0],
-            [0.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0/10.0, 0.0, 6.0/5.0]
+        kg = (axial_force / (30.0 * L)) * np.array([
+            [36.0, 3.0 * L, -36.0, 3.0 * L],
+            [3.0 * L, 4.0 * L2, -3.0 * L, -L2],
+            [-36.0, -3.0 * L, 36.0, -3.0 * L],
+            [3.0 * L, -L2, -3.0 * L, 4.0 * L2],
         ])
 
         return kg
+
+    def _reduce_buckling_matrices(
+        self, K: np.ndarray, Kg: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, List[int]]:
+        """
+        Reduce K and Kg to free DOFs for a generalized buckling eigenproblem.
+
+        Constrained DOFs must be removed rather than identity-stamped into both
+        matrices; otherwise fixed DOFs create artificial eigenvalues of 1.0.
+        """
+        n_dof = K.shape[0]
+        constrained = self._constrained_dof_indices(n_dof)
+        free_dofs = [index for index in range(n_dof) if index not in constrained]
+        if not free_dofs:
+            raise ValueError("All DOFs are constrained; buckling eigenproblem is empty")
+
+        selector = np.ix_(free_dofs, free_dofs)
+        return K[selector], Kg[selector], free_dofs
+
+    def _constrained_dof_indices(self, n_dof: int) -> set[int]:
+        constrained: set[int] = set()
+        dofs_per_node = 2
+
+        for node in self.boundary_conditions.get("fixed_nodes", []):
+            node_id = int(node)
+            constrained.update(
+                index
+                for index in range(
+                    node_id * dofs_per_node,
+                    node_id * dofs_per_node + dofs_per_node,
+                )
+                if 0 <= index < n_dof
+            )
+
+        for node in self.boundary_conditions.get("pinned_nodes", []):
+            dof_index = int(node) * dofs_per_node
+            if 0 <= dof_index < n_dof:
+                constrained.add(dof_index)
+
+        for item in self.boundary_conditions.get("fixed_dofs", []):
+            node_id = int(item["node"])
+            for dof_name in item["dofs"]:
+                offset = self._dof_offset(str(dof_name))
+                dof_index = node_id * dofs_per_node + offset
+                if 0 <= dof_index < n_dof:
+                    constrained.add(dof_index)
+
+        return constrained
+
+    def _dof_offset(self, dof_name: str) -> int:
+        normalized = dof_name.lower()
+        if normalized in {"y", "uy", "translation", "transverse"}:
+            return 0
+        if normalized in {"theta", "rotation", "rz"}:
+            return 1
+        raise ValueError(f"Unsupported beam DOF name for buckling BC: {dof_name}")
+
+    def _expand_eigenvectors(
+        self,
+        eigenvectors: np.ndarray,
+        free_dofs: List[int],
+        n_dof: int,
+    ) -> np.ndarray:
+        expanded = np.zeros((n_dof, eigenvectors.shape[1]))
+        for reduced_index, dof_index in enumerate(free_dofs):
+            expanded[dof_index, :] = eigenvectors[reduced_index, :]
+        return expanded
 
     def _solve_eigenvalue_problem(
         self,
@@ -286,7 +359,11 @@ class ElasticBucklingSolver(StructuralSolver):
 
             # Filter to real positive eigenvalues
             # (complex eigenvalues indicate numerical issues)
-            real_mask = np.isreal(eigenvalues) & (np.real(eigenvalues) > 0)
+            real_mask = (
+                np.isreal(eigenvalues)
+                & np.isfinite(np.real(eigenvalues))
+                & (np.real(eigenvalues) > 0)
+            )
             eigenvalues = np.real(eigenvalues[real_mask])
             eigenvectors = np.real(eigenvectors[:, real_mask])
 
@@ -299,6 +376,9 @@ class ElasticBucklingSolver(StructuralSolver):
             n_modes = min(self.num_modes, len(eigenvalues))
             eigenvalues = eigenvalues[:n_modes]
             eigenvectors = eigenvectors[:, :n_modes]
+
+            if len(eigenvalues) == 0:
+                raise ValueError("No finite positive buckling eigenvalues found")
 
             logger.debug("Eigenvalue problem solved - %d modes found", len(eigenvalues))
             logger.debug("Eigenvalues (critical load factors): %s", eigenvalues)

--- a/src/digitalmodel/structural/fe/elastic_buckling_workflow.py
+++ b/src/digitalmodel/structural/fe/elastic_buckling_workflow.py
@@ -1,0 +1,109 @@
+"""UV-workflow router for elastic beam-column buckling analysis."""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.infrastructure.base_solvers.structural.buckling.elastic_buckling import (
+    ElasticBucklingSolver,
+)
+from digitalmodel.structural.fe.model_builder import (
+    BeamModel,
+    build_beam_model,
+    display_path,
+    results_csv_path,
+)
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("elastic_buckling") or {}
+    model = build_beam_model(settings, "elastic_buckling")
+    axial_force = _reference_axial_force(settings)
+    for element in model.elements:
+        element.axial_force = axial_force
+
+    solver = ElasticBucklingSolver()
+    solver.set_num_modes(int(settings.get("num_modes", 5)))
+    solver.set_nodes(model.nodes)
+    solver.set_elements(model.elements)
+    solver.set_boundary_conditions(model.boundary_conditions)
+    solver.set_loads(model.loads)
+    solver.set_material_properties(model.material)
+    results = solver.solve()
+    if results.get("status") != "completed":
+        raise ValueError(f"elastic_buckling solver failed: {results.get('error')}")
+
+    load_factors = [float(value) for value in results["eigenvalues"]]
+    critical_loads = [factor * axial_force for factor in load_factors]
+    _validate_distinct_modes(critical_loads)
+
+    euler_reference = _euler_reference_load(settings, model)
+    relative_error = abs(critical_loads[0] - euler_reference) / euler_reference
+    tolerance = settings.get("reference", {}).get("euler_tolerance")
+    if tolerance is not None and relative_error > float(tolerance):
+        raise ValueError(
+            "elastic_buckling first critical load "
+            f"{critical_loads[0]:.6g} differs from Euler reference "
+            f"{euler_reference:.6g} by {relative_error:.3%}"
+        )
+
+    csv_path = results_csv_path(cfg, settings, "elastic_buckling")
+    _write_mode_results_csv(csv_path, load_factors, critical_loads)
+
+    cfg["elastic_buckling"] = {
+        "status": results["status"],
+        "num_elements": results["num_elements"],
+        "num_nodes": results["num_nodes"],
+        "num_modes": len(critical_loads),
+        "axial_reference_load": axial_force,
+        "first_load_factor": load_factors[0],
+        "first_critical_load": critical_loads[0],
+        "euler_reference_load": euler_reference,
+        "euler_relative_error": relative_error,
+        "results_csv": display_path(csv_path),
+    }
+    return cfg
+
+
+def _reference_axial_force(settings: dict[str, Any]) -> float:
+    axial_force = float(settings.get("axial_force", 0.0))
+    if axial_force <= 0.0:
+        raise ValueError("elastic_buckling axial_force must be positive compression")
+    return axial_force
+
+
+def _validate_distinct_modes(critical_loads: list[float]) -> None:
+    if not critical_loads or critical_loads[0] <= 0.0:
+        raise ValueError("elastic_buckling produced no positive critical loads")
+    if len(critical_loads) > 1 and critical_loads[1] <= critical_loads[0]:
+        raise ValueError("elastic_buckling modes are not distinct and increasing")
+
+
+def _euler_reference_load(settings: dict[str, Any], model: BeamModel) -> float:
+    reference = settings.get("reference", {})
+    length = float(reference.get("length", sum(element.L for element in model.elements)))
+    effective_length_factor = float(reference.get("effective_length_factor", 1.0))
+    if length <= 0.0 or effective_length_factor <= 0.0:
+        raise ValueError("Euler reference length and effective length factor must be positive")
+
+    element = model.elements[0]
+    return math.pi**2 * element.E * element.I / (effective_length_factor * length) ** 2
+
+
+def _write_mode_results_csv(
+    path: Path,
+    load_factors: list[float],
+    critical_loads: list[float],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["mode", "eigenvalue", "critical_load"])
+        for mode_index, (load_factor, critical_load) in enumerate(
+            zip(load_factors, critical_loads),
+            start=1,
+        ):
+            writer.writerow([mode_index, load_factor, critical_load])

--- a/src/digitalmodel/structural/ovality/__init__.py
+++ b/src/digitalmodel/structural/ovality/__init__.py
@@ -1,0 +1,2 @@
+"""Pipe ovality workflow package."""
+

--- a/src/digitalmodel/structural/ovality/workflow.py
+++ b/src/digitalmodel/structural/ovality/workflow.py
@@ -1,0 +1,139 @@
+"""UV-workflow router for pipe out-of-roundness checks.
+
+The DNV-OS-F101 initial ovality parameter is O0 = (Dmax - Dmin) / D.
+This workflow reports that geometry value and compares it with a configurable
+allowable fraction.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("pipe_ovality") or {}
+    nominal_od = _required_positive_float(settings, "nominal_OD")
+    allowable = _optional_positive_float(settings, "allowable", 0.03)
+    max_od = _optional_float(settings, "max_OD")
+    min_od = _optional_float(settings, "min_OD")
+
+    if max_od is not None or min_od is not None:
+        if max_od is None or min_od is None:
+            raise ValueError("pipe_ovality requires both max_OD and min_OD")
+        out_of_roundness = _out_of_roundness(nominal_od, max_od, min_od)
+    else:
+        out_of_roundness = _required_ovality_fraction(settings)
+        max_od = nominal_od * (1.0 + out_of_roundness / 2.0)
+        min_od = nominal_od * (1.0 - out_of_roundness / 2.0)
+
+    row = {
+        "nominal_OD": nominal_od,
+        "max_OD": max_od,
+        "min_OD": min_od,
+        "out_of_roundness": out_of_roundness,
+        "ovality_percent": out_of_roundness * 100.0,
+        "allowable": allowable,
+        "passes": out_of_roundness <= allowable,
+    }
+    csv_path = _results_csv_path(cfg, settings)
+    _write_results_csv(csv_path, row)
+
+    cfg["pipe_ovality"] = {
+        **row,
+        "results_csv": _display_path(csv_path),
+    }
+    return cfg
+
+
+def _out_of_roundness(nominal_od: float, max_od: float, min_od: float) -> float:
+    if max_od <= 0.0:
+        raise ValueError("pipe_ovality max_OD must be positive")
+    if min_od <= 0.0:
+        raise ValueError("pipe_ovality min_OD must be positive")
+    if max_od < min_od:
+        raise ValueError("pipe_ovality max_OD must be greater than or equal to min_OD")
+    return (max_od - min_od) / nominal_od
+
+
+def _required_ovality_fraction(settings: dict[str, Any]) -> float:
+    for key in ("ovality_fraction", "out_of_roundness", "ovality"):
+        if settings.get(key) is not None:
+            value = float(settings[key])
+            if value < 0.0:
+                raise ValueError(f"pipe_ovality {key} must be non-negative")
+            return value
+    raise ValueError("pipe_ovality requires max_OD/min_OD or ovality_fraction")
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    stem = _input_stem(cfg)
+    return output_dir / f"{stem}_ovality.csv"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "pipe_ovality"))
+
+
+def _write_results_csv(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(row.keys()))
+        writer.writeheader()
+        writer.writerow(row)
+
+
+def _required_positive_float(settings: dict[str, Any], name: str) -> float:
+    value = settings.get(name)
+    if value is None:
+        raise ValueError(f"pipe_ovality {name} is required")
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"pipe_ovality {name} must be positive")
+    return value
+
+
+def _optional_positive_float(
+    settings: dict[str, Any],
+    name: str,
+    default: float,
+) -> float:
+    value = settings.get(name)
+    if value is None:
+        return default
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"pipe_ovality {name} must be positive")
+    return value
+
+
+def _optional_float(settings: dict[str, Any], name: str) -> float | None:
+    value = settings.get(name)
+    if value is None:
+        return None
+    return float(value)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/drilling_riser/test_tsj_workflow.py
+++ b/tests/drilling_riser/test_tsj_workflow.py
@@ -1,0 +1,64 @@
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.engine import engine
+
+
+def test_tsj_sizing_workflow_writes_section_utilisation_next_to_input(tmp_path):
+    cfg = {
+        "basename": "tsj_sizing",
+        "tsj_sizing": {
+            "effective_tension_N": 2_500_000.0,
+            "internal_pressure_Pa": 12_000_000.0,
+            "external_pressure_Pa": 1_000_000.0,
+            "SMYS_Pa": 552_000_000.0,
+            "design_factor": 0.67,
+            "taper": [
+                {
+                    "position_m": 0.0,
+                    "outer_diameter_mm": 508.0,
+                    "wall_thickness_mm": 38.0,
+                },
+                {
+                    "position_m": 10.0,
+                    "outer_diameter_mm": 457.0,
+                    "wall_thickness_mm": 32.0,
+                },
+                {
+                    "position_m": 20.0,
+                    "outer_diameter_mm": 406.0,
+                    "wall_thickness_mm": 25.0,
+                },
+                {
+                    "position_m": 30.0,
+                    "outer_diameter_mm": 356.0,
+                    "wall_thickness_mm": 20.0,
+                },
+            ],
+            "output_dir": "results",
+        },
+        "default": {"log_level": "INFO", "config": {"overwrite": {"output": True}}},
+    }
+    input_path = tmp_path / "case.yml"
+    input_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    result = engine(inputfile=str(input_path))
+
+    summary = result["tsj_sizing"]
+    results_csv = Path(summary["results_csv"])
+    table = pd.read_csv(results_csv)
+
+    assert results_csv.resolve() == (tmp_path / "results" / "case_tsj.csv").resolve()
+    assert len(table) == 4
+    assert summary["passes"] is True
+    assert 0.0 < summary["max_utilisation"] < 1.0
+    assert math.isfinite(summary["max_utilisation"])
+    assert summary["governing_section"]["position_m"] == pytest.approx(30.0)
+    assert (table["utilisation"] > 0.0).all()
+    assert table["utilisation"].map(math.isfinite).all()
+    assert table["utilisation"].iloc[-1] == pytest.approx(summary["max_utilisation"])
+    assert table["vm_stress_Pa"].iloc[-1] > table["vm_stress_Pa"].iloc[0]

--- a/tests/hydrodynamics/test_rao_tabulation_workflow.py
+++ b/tests/hydrodynamics/test_rao_tabulation_workflow.py
@@ -1,0 +1,130 @@
+import copy
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.engine import engine
+
+
+EXPECTED_COLUMNS = [
+    "period_s",
+    "heading_deg",
+    "surge",
+    "sway",
+    "heave",
+    "roll",
+    "pitch",
+    "yaw",
+    "surge_phase_deg",
+    "sway_phase_deg",
+    "heave_phase_deg",
+    "roll_phase_deg",
+    "pitch_phase_deg",
+    "yaw_phase_deg",
+]
+
+
+def _base_cfg():
+    return {
+        "basename": "rao_tabulation",
+        "rao_tabulation": {
+            "rao_database": {
+                "periods_s": [8.0, 12.0, 16.0],
+                "headings_deg": [0.0, 90.0],
+                "amplitudes": [
+                    [
+                        [0.05, 0.02, 0.60, 0.010, 0.020, 0.005],
+                        [0.04, 0.03, 0.55, 0.020, 0.015, 0.006],
+                    ],
+                    [
+                        [0.08, 0.03, 0.90, 0.015, 0.025, 0.007],
+                        [0.06, 0.04, 0.85, 0.025, 0.020, 0.008],
+                    ],
+                    [
+                        [0.10, 0.04, 1.00, 0.020, 0.030, 0.009],
+                        [0.08, 0.05, 0.95, 0.030, 0.025, 0.010],
+                    ],
+                ],
+                "phases_deg": [
+                    [[0.0, 5.0, 10.0, 0.0, 2.0, 1.0], [1.0, 6.0, 12.0, 1.0, 3.0, 2.0]],
+                    [[2.0, 7.0, 15.0, 2.0, 4.0, 3.0], [3.0, 8.0, 17.0, 3.0, 5.0, 4.0]],
+                    [[4.0, 9.0, 20.0, 4.0, 6.0, 5.0], [5.0, 10.0, 22.0, 5.0, 7.0, 6.0]],
+                ],
+            },
+            "query_points": [
+                {"period_s": 10.0, "heading_deg": 45.0},
+                {"period_s": 16.0, "heading_deg": 0.0},
+            ],
+            "output_dir": "results",
+        },
+        "default": {"log_level": "INFO", "config": {"overwrite": {"output": True}}},
+    }
+
+
+def _run_case(tmp_path, cfg):
+    input_path = tmp_path / "case.yml"
+    input_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+    return engine(inputfile=str(input_path))
+
+
+def test_rao_tabulation_workflow_writes_interpolated_6dof_table(tmp_path):
+    result = _run_case(tmp_path, _base_cfg())
+
+    summary = result["rao_tabulation"]
+    results_csv = Path(summary["rao_csv"])
+    table = pd.read_csv(results_csv)
+
+    assert results_csv.resolve() == (tmp_path / "results" / "case_rao.csv").resolve()
+    assert summary["n_query_points"] == 2
+    assert summary["dofs"] == ["surge", "sway", "heave", "roll", "pitch", "yaw"]
+    assert summary["peak_heave_amplitude"] == pytest.approx(1.0)
+    assert summary["peak_heave_period_s"] == pytest.approx(16.0)
+    assert summary["peak_heave_heading_deg"] == pytest.approx(0.0)
+
+    assert list(table.columns) == EXPECTED_COLUMNS
+    assert len(table) == 2
+    interpolated_heave = table.loc[0, "heave"]
+    assert interpolated_heave == pytest.approx(0.755)
+    assert 0.55 < interpolated_heave < 0.90
+    assert table.loc[1, "heave"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda cfg: cfg["rao_tabulation"]["rao_database"].update(
+                {"amplitudes": cfg["rao_tabulation"]["rao_database"]["amplitudes"][:-1]}
+            ),
+            "shape",
+        ),
+        (
+            lambda cfg: cfg["rao_tabulation"].update({"query_points": []}),
+            "query_points",
+        ),
+        (
+            lambda cfg: cfg["rao_tabulation"]["query_points"][0].update(
+                {"frequency_rad_s": 1.0}
+            ),
+            "disagree",
+        ),
+        (
+            lambda cfg: cfg["rao_tabulation"]["query_points"][0].update(
+                {"period_s": 4.0}
+            ),
+            "outside the RAO database range",
+        ),
+    ],
+)
+def test_rao_tabulation_workflow_fails_closed_on_malformed_inputs(
+    tmp_path,
+    mutator,
+    message,
+):
+    cfg = copy.deepcopy(_base_cfg())
+    mutator(cfg)
+
+    with pytest.raises(ValueError, match=message):
+        _run_case(tmp_path, cfg)

--- a/tests/infrastructure/unit/test_structural_solvers_week2.py
+++ b/tests/infrastructure/unit/test_structural_solvers_week2.py
@@ -188,45 +188,63 @@ class TestElasticBucklingSolver:
         """Setup simple column for buckling analysis."""
         solver = buckling_solver
 
-        # Nodes: {0: [0, 0], 1: [0, 1]} (1m vertical column) - dictionary format required
-        solver.set_nodes({
-            0: np.array([0.0, 0.0]),
-            1: np.array([0.0, 1.0])
-        })
+        length = 1.0
+        num_elements = 8
+        axial_reference_load = 1.0
+        E = 2.1e11
+        I = 1.0e-5
+        A = 1.0e-3
 
-        # Single beam element
-        elem = BeamElement(
-            elem_id=0,
-            node1=0, node2=1,
-            coord1=np.array([0.0, 0.0]),
-            coord2=np.array([0.0, 1.0]),
-            E=2.1e11,
-            I=1.0e-5,
-            A=1.0e-3
-        )
-        solver.set_elements([elem])
+        # 1m beam-column aligned with the axial load direction.
+        nodes = {
+            node_id: np.array([length * node_id / num_elements, 0.0])
+            for node_id in range(num_elements + 1)
+        }
+        solver.set_nodes(nodes)
 
-        # Boundary conditions: pinned-pinned
+        elements = []
+        for elem_id in range(num_elements):
+            elem = BeamElement(
+                elem_id=elem_id,
+                node1=elem_id,
+                node2=elem_id + 1,
+                coord1=nodes[elem_id],
+                coord2=nodes[elem_id + 1],
+                E=E,
+                I=I,
+                A=A
+            )
+            elem.axial_force = axial_reference_load
+            elements.append(elem)
+        solver.set_elements(elements)
+
+        # Pinned-pinned: constrain end transverse DOFs only; rotations remain free.
         solver.set_boundary_conditions({
-            'fixed_nodes': [0, 1],
-            'pinned_nodes': [],
+            'fixed_nodes': [],
+            'pinned_nodes': [0, num_elements],
             'prescribed_displacements': {}
         })
 
-        # Axial load at top
+        # Nonzero load record keeps validation honest; element.axial_force supplies Kg.
         solver.set_loads([
-            {'node': 1, 'direction': 'y', 'magnitude': -100000.0}
+            {'node': num_elements, 'direction': 'x', 'magnitude': -axial_reference_load}
         ])
 
         # Material properties
         solver.set_material_properties({
-            'E': 2.1e11,
+            'E': E,
             'nu': 0.3,
             'rho': 7850,
             'sigma_y': 2.5e8
         })
 
         return solver
+
+    def _euler_pinned_pinned_load(self, solver):
+        """Euler critical load for the pinned-pinned test column."""
+        length = sum(element.L for element in solver.elements)
+        element = solver.elements[0]
+        return np.pi**2 * element.E * element.I / length**2
 
     def test_initialization(self, buckling_solver):
         """Test buckling solver initialization."""
@@ -274,12 +292,14 @@ class TestElasticBucklingSolver:
         solver = setup_column
         solver.set_num_modes(1)  # Only first mode
         result = solver.solve()
+        euler_load = self._euler_pinned_pinned_load(solver)
 
         assert result['status'] == 'completed'
         assert 'critical_loads' in result
         assert 'mode_shapes' in result
         assert 'eigenvalues' in result
-        assert result['first_critical_load'] > 0
+        assert result['num_modes'] == 1
+        assert result['first_critical_load'] == pytest.approx(euler_load, rel=0.05)
 
     def test_critical_loads_positive(self, setup_column):
         """Test critical loads are positive."""
@@ -287,7 +307,10 @@ class TestElasticBucklingSolver:
         solver.set_num_modes(3)
         result = solver.solve()
 
-        assert all(load > 0 for load in result['critical_loads'].values())
+        assert result['status'] == 'completed'
+        critical_loads = list(result['critical_loads'].values())
+        assert len(critical_loads) == 3
+        assert all(np.isfinite(load) and load > 0 for load in critical_loads)
 
     def test_first_mode_lowest_load(self, setup_column):
         """Test first buckling load is lowest."""
@@ -295,9 +318,13 @@ class TestElasticBucklingSolver:
         solver.set_num_modes(3)
         result = solver.solve()
 
+        assert result['status'] == 'completed'
         critical_loads = list(result['critical_loads'].values())
-        for i in range(len(critical_loads) - 1):
-            assert critical_loads[i] <= critical_loads[i + 1]
+        assert len(critical_loads) == 3
+        assert all(
+            critical_loads[i] < critical_loads[i + 1]
+            for i in range(len(critical_loads) - 1)
+        )
 
     def test_mode_shapes_vectors(self, setup_column):
         """Test mode shapes are vectors."""
@@ -305,10 +332,13 @@ class TestElasticBucklingSolver:
         solver.set_num_modes(2)
         result = solver.solve()
 
+        assert result['status'] == 'completed'
+        expected_dofs = len(solver.nodes) * 2
         assert len(result['mode_shapes']) == 2
         for mode_id, shape in result['mode_shapes'].items():
             assert isinstance(shape, np.ndarray)
-            assert len(shape) > 0
+            assert shape.shape == (expected_dofs,)
+            assert np.linalg.norm(shape) > 0.0
 
     def test_solver_metadata(self, buckling_solver):
         """Test buckling solver metadata."""

--- a/tests/structural/fe/test_elastic_buckling_workflow.py
+++ b/tests/structural/fe/test_elastic_buckling_workflow.py
@@ -1,0 +1,88 @@
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.engine import engine
+
+
+def test_elastic_buckling_workflow_matches_euler_column(tmp_path):
+    length = 3.0
+    elements = 8
+    youngs_modulus = 2.10e11
+    inertia = 8.10e-6
+    area = 1.0e-2
+    euler_load = math.pi**2 * youngs_modulus * inertia / length**2
+    nodes = [
+        {"id": index, "x": length * index / elements, "y": 0.0}
+        for index in range(elements + 1)
+    ]
+    beam_elements = [
+        {
+            "id": index,
+            "node1": index,
+            "node2": index + 1,
+            "E": youngs_modulus,
+            "I": inertia,
+            "A": area,
+        }
+        for index in range(elements)
+    ]
+    cfg = {
+        "basename": "elastic_buckling",
+        "elastic_buckling": {
+            "nodes": nodes,
+            "elements": beam_elements,
+            "boundary_conditions": {"pinned_nodes": [0, elements]},
+            "loads": [{"node": elements, "direction": "x", "magnitude": -1.0}],
+            "material": {
+                "E": youngs_modulus,
+                "nu": 0.3,
+                "rho": 7850.0,
+                "sigma_y": 4.48e8,
+            },
+            "axial_force": 1.0,
+            "num_modes": 3,
+            "reference": {
+                "effective_length_factor": 1.0,
+                "euler_tolerance": 0.05,
+            },
+            "output_dir": "results",
+        },
+        "default": {"log_level": "INFO", "config": {"overwrite": {"output": True}}},
+    }
+    input_path = tmp_path / "case.yml"
+    input_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    result = engine(inputfile=str(input_path))
+
+    summary = result["elastic_buckling"]
+    csv_path = Path(summary["results_csv"])
+    if not csv_path.is_absolute():
+        csv_path = Path.cwd() / csv_path
+    mode_results = pd.read_csv(csv_path)
+
+    assert csv_path.resolve() == (
+        tmp_path / "results" / "case_elastic_buckling.csv"
+    ).resolve()
+    assert summary["status"] == "completed"
+    assert summary["num_modes"] == 3
+    assert summary["first_critical_load"] > 0.0
+    assert summary["euler_reference_load"] == pytest.approx(euler_load)
+    assert summary["first_critical_load"] == pytest.approx(euler_load, rel=0.05)
+
+    assert len(mode_results) == 3
+    assert mode_results["critical_load"].iloc[0] == pytest.approx(
+        summary["first_critical_load"]
+    )
+    assert mode_results["critical_load"].iloc[1] > mode_results["critical_load"].iloc[0]
+    assert mode_results["critical_load"].iloc[1] == pytest.approx(
+        4.0 * euler_load,
+        rel=0.05,
+    )
+    assert not math.isclose(
+        mode_results["critical_load"].iloc[0],
+        mode_results["critical_load"].iloc[1],
+    )

--- a/tests/structural/ovality/test_ovality_workflow.py
+++ b/tests/structural/ovality/test_ovality_workflow.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.engine import engine
+
+
+def test_pipe_ovality_workflow_writes_geometry_check_next_to_input(tmp_path):
+    cfg = {
+        "basename": "pipe_ovality",
+        "pipe_ovality": {
+            "nominal_OD": 323.85,
+            "max_OD": 325.0,
+            "min_OD": 322.7,
+            "allowable": 0.03,
+            "output_dir": "results",
+        },
+        "default": {"log_level": "INFO", "config": {"overwrite": {"output": True}}},
+    }
+    input_path = tmp_path / "case.yml"
+    input_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    result = engine(inputfile=str(input_path))
+
+    summary = result["pipe_ovality"]
+    results_csv = Path(summary["results_csv"])
+    table = pd.read_csv(results_csv)
+
+    expected_out_of_roundness = (325.0 - 322.7) / 323.85
+    assert (
+        results_csv.resolve() == (tmp_path / "results" / "case_ovality.csv").resolve()
+    )
+    assert summary["out_of_roundness"] == pytest.approx(expected_out_of_roundness)
+    assert summary["ovality_percent"] == pytest.approx(
+        expected_out_of_roundness * 100.0
+    )
+    assert summary["passes"] is True
+    assert len(table) == 1
+    assert table.loc[0, "out_of_roundness"] == pytest.approx(expected_out_of_roundness)

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -162,6 +162,32 @@ def test_workflow_registry(workflow):
         assert len(element_results) == summary["num_elements"]
         assert (element_results["von_mises_stress"] > 0.0).all()
         assert (element_results["safety_factor"] > 0.0).all()
+    elif workflow["id"] == "elastic-buckling":
+        summary = cfg["elastic_buckling"]
+        results_path = Path(summary["results_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        mode_results = pd.read_csv(results_path)
+
+        assert summary["status"] == "completed"
+        assert summary["first_critical_load"] > 0.0
+        assert math.isfinite(summary["first_critical_load"])
+        assert summary["num_modes"] >= 2
+        assert len(mode_results) == summary["num_modes"]
+        assert mode_results["critical_load"].iloc[0] == pytest.approx(
+            summary["first_critical_load"]
+        )
+        assert mode_results["critical_load"].iloc[1] > mode_results[
+            "critical_load"
+        ].iloc[0]
+        assert not math.isclose(
+            mode_results["critical_load"].iloc[0],
+            mode_results["critical_load"].iloc[1],
+        )
+        assert summary["first_critical_load"] == pytest.approx(
+            summary["euler_reference_load"],
+            rel=0.05,
+        )
     elif workflow["id"] == "stress-strain-parametric":
         cases = cfg["parametric_run"]["cases"]
         manifest = pd.read_csv(

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -144,6 +144,23 @@ def test_workflow_registry(workflow):
         assert (results["code"] == expected_codes[workflow["id"]]).all()
         assert (results["utilisation"] > 0.0).all()
         assert results["utilisation"].map(math.isfinite).all()
+    elif workflow["id"] == "pipe-ovality":
+        summary = cfg["pipe_ovality"]
+        results_path = Path(summary["results_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        results = pd.read_csv(results_path)
+        expected_out_of_roundness = (325.0 - 322.7) / 323.85
+
+        assert summary["out_of_roundness"] == pytest.approx(expected_out_of_roundness)
+        assert summary["ovality_percent"] == pytest.approx(
+            expected_out_of_roundness * 100.0
+        )
+        assert summary["passes"] is True
+        assert results.loc[0, "out_of_roundness"] == pytest.approx(
+            expected_out_of_roundness
+        )
+        assert bool(results.loc[0, "passes"]) is True
     elif workflow["id"] == "von-mises":
         summary = cfg["von_mises"]
         results_path = Path(summary["results_csv"])
@@ -177,9 +194,10 @@ def test_workflow_registry(workflow):
         assert mode_results["critical_load"].iloc[0] == pytest.approx(
             summary["first_critical_load"]
         )
-        assert mode_results["critical_load"].iloc[1] > mode_results[
-            "critical_load"
-        ].iloc[0]
+        assert (
+            mode_results["critical_load"].iloc[1]
+            > mode_results["critical_load"].iloc[0]
+        )
         assert not math.isclose(
             mode_results["critical_load"].iloc[0],
             mode_results["critical_load"].iloc[1],
@@ -206,13 +224,11 @@ def test_workflow_registry(workflow):
             ).read_text()
         )
         low_yield = pd.read_csv(
-            REPO_ROOT
-            / "examples/workflows/stress-strain-parametric/results/"
+            REPO_ROOT / "examples/workflows/stress-strain-parametric/results/"
             "results/case_0_stress_strain.csv"
         )
         high_yield = pd.read_csv(
-            REPO_ROOT
-            / "examples/workflows/stress-strain-parametric/results/"
+            REPO_ROOT / "examples/workflows/stress-strain-parametric/results/"
             "results/case_2_stress_strain.csv"
         )
 
@@ -241,6 +257,22 @@ def test_workflow_registry(workflow):
         assert profile["effective_tension_kn"].iloc[0] > (
             profile["effective_tension_kn"].iloc[-1]
         )
+    elif workflow["id"] == "tsj-sizing":
+        summary = cfg["tsj_sizing"]
+        results_path = Path(summary["results_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        results = pd.read_csv(results_path)
+
+        assert summary["max_utilisation"] > 0.0
+        assert math.isfinite(summary["max_utilisation"])
+        assert summary["passes"] is True
+        assert summary["governing_section"]["position_m"] == pytest.approx(30.0)
+        assert len(results) == 4
+        assert (results["utilisation"] > 0.0).all()
+        assert results["utilisation"].map(math.isfinite).all()
+        assert results["utilisation"].max() == pytest.approx(summary["max_utilisation"])
+        assert results["vm_stress_Pa"].iloc[-1] > results["vm_stress_Pa"].iloc[0]
     elif workflow["id"] == "riser-stackup-parametric":
         cases = cfg["parametric_run"]["cases"]
         manifest = pd.read_csv(

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -161,6 +161,25 @@ def test_workflow_registry(workflow):
             expected_out_of_roundness
         )
         assert bool(results.loc[0, "passes"]) is True
+    elif workflow["id"] == "rao-tabulation":
+        summary = cfg["rao_tabulation"]
+        results_path = Path(summary["rao_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        results = pd.read_csv(results_path)
+
+        assert summary["n_query_points"] == 3
+        assert summary["dofs"] == ["surge", "sway", "heave", "roll", "pitch", "yaw"]
+        assert summary["peak_heave_amplitude"] == pytest.approx(1.02)
+        assert summary["peak_heave_period_s"] == pytest.approx(18.0)
+        assert summary["peak_heave_heading_deg"] == pytest.approx(0.0)
+        assert len(results) == 3
+        assert (results["heave"] > 0.0).all()
+        assert results["heave"].map(math.isfinite).all()
+
+        interpolated_heave = results.loc[0, "heave"]
+        assert interpolated_heave == pytest.approx(0.575)
+        assert 0.30 < interpolated_heave < 0.75
     elif workflow["id"] == "von-mises":
         summary = cfg["von_mises"]
         results_path = Path(summary["results_csv"])


### PR DESCRIPTION
## Summary
Ships `elastic_buckling` (deferred from #748 because the solver produced degenerate results) after **fixing the underlying solver**, then exposing it offline via the UV-workflow contract.

## Solver correctness fix — `ElasticBucklingSolver`
The earlier degeneracy (all modes = 1.0) was an artifact, not buckling:
- The eigenproblem **identity-stamped constrained DOFs** into both K and Kg, fabricating eigenvalues of exactly 1.0. Now **reduces to free DOFs** before solving `(K − λKg)φ = 0` and expands eigenvectors back.
- Replaced the simplified rotational-only geometric stiffness with the **standard consistent beam-column** `Kg = N/(30L)·[[36,3L,−36,3L],…]`.
- Added an explicit `element.axial_force` preload path + robustness filters.
- **Validated:** pinned-pinned column first mode within **0.003%** of Euler `P_cr = π²EI/L²`; modes scale **1:4:9**.

## Workflow
- `structural/fe/elastic_buckling_workflow.py` (reuses `fe/model_builder`)
- engine.py fail-closed dispatch branch (branch only)
- `examples/workflows/elastic-buckling` + registry row + durable assertions (distinct modes, Euler-validated) + inputfile-path unit test

## Test repair (disclosed)
`tests/infrastructure/unit/test_structural_solvers_week2.py::TestElasticBucklingSolver` — the old fixture **fully-clamped a 1-element column** (zero free DOFs → physically cannot buckle) and only "passed" on the fabricated 1.0 artifact. Replaced with a valid **8-element pinned-pinned column** and Euler-correct assertions.

## Verification
- `tests/workflows/test_durable_workflows.py` → **51 passed** (rebased on current main incl. #711 waves)
- `tests/infrastructure/unit/test_structural_solvers_week2.py` → **32 passed**
- Pre-existing unrelated failures (`tests/structural/fatigue/test_sn_curves_yaml.py` collection errors; plate/member-capacity) are **untouched** — they fail on origin/main independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)