### PR TITLE
fix(tests): clear high-confidence pre-existing test failures

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -188,8 +188,8 @@ gates:
     order: 1
     description: "Domain tests for subsea"
     domain: "subsea"
-    test_roots: ["tests/subsea/", "tests/drilling_riser/", "tests/check_catenary_geometry.py", "tests/solve_catenary_correct.py", "tests/solve_general_catenary.py", "tests/test_catenary_debug.py", "tests/test_catenary_module.py", "tests/test_catenary_riser_summary.py", "tests/test_lazy_wave_catenary.py", "tests/test_lazy_wave_legacy_comparison.py", "tests/test_on_bottom_stability.py"]
-    command: "uv run --no-sources --with-editable . python -m pytest tests/subsea/ tests/drilling_riser/ tests/check_catenary_geometry.py tests/solve_catenary_correct.py tests/solve_general_catenary.py tests/test_catenary_debug.py tests/test_catenary_module.py tests/test_catenary_riser_summary.py tests/test_lazy_wave_catenary.py tests/test_lazy_wave_legacy_comparison.py tests/test_on_bottom_stability.py -rfE -p no:asyncio -p no:randomly -p no:sugar --no-header -q --tb=line"
+    test_roots: ["tests/subsea/", "tests/drilling_riser/", "tests/check_catenary_geometry.py", "tests/solve_catenary_correct.py", "tests/solve_general_catenary.py", "tests/test_catenary_module.py", "tests/test_catenary_riser_summary.py", "tests/test_lazy_wave_catenary.py", "tests/test_lazy_wave_legacy_comparison.py", "tests/test_on_bottom_stability.py"]
+    command: "uv run --no-sources --with-editable . python -m pytest tests/subsea/ tests/drilling_riser/ tests/check_catenary_geometry.py tests/solve_catenary_correct.py tests/solve_general_catenary.py tests/test_catenary_module.py tests/test_catenary_riser_summary.py tests/test_lazy_wave_catenary.py tests/test_lazy_wave_legacy_comparison.py tests/test_on_bottom_stability.py -rfE -p no:asyncio -p no:randomly -p no:sugar --no-header -q --tb=line"
     failure_action: "block"
     warning_action: "report"
 

--- a/data/fatigue/sn_curves.yaml
+++ b/data/fatigue/sn_curves.yaml
@@ -1,0 +1,181 @@
+metadata:
+  version: '1.0'
+  tier: 2
+  source: digitalmodel.structural.fatigue.sn_curves.StandardSNCurves
+  generated_from: production_curve_dictionaries
+standards:
+  DNV:
+    curves:
+      B1:
+        A: 4220000000000000.0
+        m: 4.0
+        fatigue_limit: 106.97
+      B2:
+        A: 1010000000000000.0
+        m: 3.5
+        fatigue_limit: 93.59
+      C:
+        A: 1080000000000.0
+        m: 3.0
+        fatigue_limit: 73.1
+      C1:
+        A: 423000000000.0
+        m: 3.0
+        fatigue_limit: 65.5
+      C2:
+        A: 108000000000.0
+        m: 3.0
+        fatigue_limit: 46.78
+      D:
+        A: 573000000000.0
+        m: 3.0
+        fatigue_limit: 52.63
+      E:
+        A: 329000000000.0
+        m: 3.0
+        fatigue_limit: 45.54
+      F:
+        A: 173000000000.0
+        m: 3.0
+        fatigue_limit: 36.84
+      F1:
+        A: 108000000000.0
+        m: 3.0
+        fatigue_limit: 36.58
+      F3:
+        A: 57300000000.0
+        m: 3.0
+        fatigue_limit: 29.64
+      G:
+        A: 28200000000.0
+        m: 3.0
+        fatigue_limit: 23.44
+      W1:
+        A: 21500000000.0
+        m: 3.0
+        fatigue_limit: 21.34
+      W2:
+        A: 10800000000.0
+        m: 3.0
+        fatigue_limit: 16.92
+      W3:
+        A: 5300000000.0
+        m: 3.0
+        fatigue_limit: 13.35
+    multislope:
+      D_MULTISLOPE:
+        slopes:
+        - 3.0
+        - 3.5
+        - 5.0
+        constants:
+        - 573000000000.0
+        - 108000000000.0
+        - 25000000000.0
+        transition_cycles:
+        - 2000000.0
+        - 10000000.0
+        fatigue_limit: 52.63
+      F_MULTISLOPE:
+        slopes:
+        - 3.0
+        - 4.0
+        - 5.0
+        constants:
+        - 173000000000.0
+        - 86000000000.0
+        - 21500000000.0
+        transition_cycles:
+        - 2000000.0
+        - 10000000.0
+        fatigue_limit: 36.84
+  API:
+    curves:
+      X:
+        A: 1010000000000.0
+        m: 3.0
+        fatigue_limit: 48.0
+      X_prime:
+        A: 152000000000.0
+        m: 3.0
+        fatigue_limit: 32.7
+      Y:
+        A: 356000000000.0
+        m: 3.0
+        fatigue_limit: 40.6
+      S-N1:
+        A: 621000000000.0
+        m: 3.0
+        fatigue_limit: 0.0
+      S-N2:
+        A: 124000000000.0
+        m: 3.0
+        fatigue_limit: 0.0
+  BS:
+    curves:
+      B:
+        A: 3900000000000.0
+        m: 3.0
+        fatigue_limit: 100.0
+      C:
+        A: 1000000000000.0
+        m: 3.0
+        fatigue_limit: 63.0
+      D:
+        A: 390000000000.0
+        m: 3.0
+        fatigue_limit: 50.0
+      E:
+        A: 160000000000.0
+        m: 3.0
+        fatigue_limit: 40.0
+      F:
+        A: 63000000000.0
+        m: 3.0
+        fatigue_limit: 32.0
+      F2:
+        A: 25000000000.0
+        m: 3.0
+        fatigue_limit: 25.0
+      G:
+        A: 10000000000.0
+        m: 3.0
+        fatigue_limit: 20.0
+      W:
+        A: 3900000000.0
+        m: 3.0
+        fatigue_limit: 16.0
+  AWS:
+    curves:
+      A:
+        A: 811000000000.0
+        m: 3.0
+        fatigue_limit: 165.0
+      B:
+        A: 391000000000.0
+        m: 3.0
+        fatigue_limit: 110.0
+      B1:
+        A: 263000000000.0
+        m: 3.0
+        fatigue_limit: 83.0
+      C:
+        A: 137000000000.0
+        m: 3.0
+        fatigue_limit: 69.0
+      C1:
+        A: 101000000000.0
+        m: 3.0
+        fatigue_limit: 55.0
+      D:
+        A: 72100000000.0
+        m: 3.0
+        fatigue_limit: 48.0
+      E:
+        A: 36100000000.0
+        m: 3.0
+        fatigue_limit: 31.0
+      E1:
+        A: 18100000000.0
+        m: 3.0
+        fatigue_limit: 18.0

--- a/src/digitalmodel/specialized/digitalmarketing/digitalmarketing.py
+++ b/src/digitalmodel/specialized/digitalmarketing/digitalmarketing.py
@@ -25,7 +25,10 @@ class DigitalMarketing:
         calculation_name = cfg.get("calculation", {}).get("name", "")
 
         if calculation_name == "seo_analysis":
-            from digitalmodel.digitalmarketing.seo.seo_analysis import SEOAnalysis
+            from digitalmodel.specialized.digitalmarketing.seo.seo_analysis import (
+                SEOAnalysis,
+            )
+
             seo_analysis = SEOAnalysis()
             cfg = seo_analysis.run(cfg)
         else:

--- a/tests/infrastructure/core/test_database_manager.py
+++ b/tests/infrastructure/core/test_database_manager.py
@@ -2,6 +2,7 @@
 # Tests connection pooling, retry logic, failover, and multi-database support
 
 import os
+import importlib.util
 import time
 from unittest.mock import MagicMock, Mock, patch, PropertyMock
 
@@ -81,7 +82,7 @@ class TestDatabaseManagerConfiguration:
 class TestConnectionPooling:
     """Test SQLAlchemy connection pooling functionality"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_creates_engine_with_queue_pool(self, mock_create_engine):
         """Should create engine with QueuePool configuration"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -93,7 +94,8 @@ class TestConnectionPooling:
             'password': 'pass'
         })
 
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         # Verify create_engine was called with pooling parameters
         call_kwargs = mock_create_engine.call_args[1]
@@ -101,18 +103,19 @@ class TestConnectionPooling:
         assert call_kwargs.get('pool_size') == 20  # PostgreSQL default
         assert 'pool_recycle' in call_kwargs
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_pool_pre_ping_enabled(self, mock_create_engine):
         """Should enable pool_pre_ping for auto-reconnect"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
 
         manager = DatabaseManager(db_type='postgresql')
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         call_kwargs = mock_create_engine.call_args[1]
         assert call_kwargs['pool_pre_ping'] is True
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_configurable_pool_size_and_overflow(self, mock_create_engine):
         """Should support custom pool size and max overflow"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -122,7 +125,8 @@ class TestConnectionPooling:
             pool_size=30,
             max_overflow=10
         )
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         call_kwargs = mock_create_engine.call_args[1]
         assert call_kwargs['pool_size'] == 30
@@ -133,7 +137,7 @@ class TestRetryLogic:
     """Test retry logic with exponential backoff"""
 
     @patch('time.sleep')
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_retry_on_operational_error(self, mock_create_engine, mock_sleep):
         """Should retry connection on OperationalError"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -148,14 +152,14 @@ class TestRetryLogic:
         mock_create_engine.return_value = mock_engine
 
         manager = DatabaseManager(db_type='postgresql')
-        connection = manager.get_connection()
+        with manager.get_connection() as connection:
+            assert connection is not None
 
         # Should have retried 2 times before success
         assert mock_engine.connect.call_count == 3
-        assert connection is not None
 
     @patch('time.sleep')
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_exponential_backoff(self, mock_create_engine, mock_sleep):
         """Should use exponential backoff: 1s, 2s, 4s"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -170,13 +174,14 @@ class TestRetryLogic:
         mock_create_engine.return_value = mock_engine
 
         manager = DatabaseManager(db_type='postgresql', max_retries=3)
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         # Verify sleep was called with exponential backoff
         sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
         assert sleep_calls == [1, 2, 4]
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_no_retry_on_authentication_error(self, mock_create_engine):
         """Should NOT retry on authentication failures"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -190,12 +195,13 @@ class TestRetryLogic:
         manager = DatabaseManager(db_type='postgresql')
 
         with pytest.raises(DatabaseError):
-            manager.get_connection()
+            with manager.get_connection():
+                pass
 
         # Should NOT retry authentication errors
         assert mock_engine.connect.call_count == 1
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_no_retry_on_permission_error(self, mock_create_engine):
         """Should NOT retry on permission errors"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -209,11 +215,12 @@ class TestRetryLogic:
         manager = DatabaseManager(db_type='postgresql')
 
         with pytest.raises(DatabaseError):
-            manager.get_connection()
+            with manager.get_connection():
+                pass
 
         assert mock_engine.connect.call_count == 1
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_max_retries_exceeded(self, mock_create_engine):
         """Should raise error after max retries exceeded"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -225,7 +232,8 @@ class TestRetryLogic:
         manager = DatabaseManager(db_type='postgresql', max_retries=3)
 
         with pytest.raises(OperationalError):
-            manager.get_connection()
+            with manager.get_connection():
+                pass
 
         # Should attempt initial + 3 retries = 4 total
         assert mock_engine.connect.call_count == 4
@@ -234,7 +242,7 @@ class TestRetryLogic:
 class TestHighAvailabilityFailover:
     """Test HA failover with primary and replica connection strings"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_supports_multiple_connection_strings(self, mock_create_engine):
         """Should accept list of connection strings for HA"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -254,7 +262,7 @@ class TestHighAvailabilityFailover:
         assert manager.primary_connection == connection_strings[0]
         assert manager.replica_connections == connection_strings[1:]
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_writes_go_to_primary(self, mock_create_engine):
         """Write connections should always use primary"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -272,13 +280,14 @@ class TestHighAvailabilityFailover:
             connection_strings=connection_strings
         )
 
-        manager.get_connection(read_only=False)
+        with manager.get_connection(read_only=False):
+            pass
 
         # Should use primary connection string
         call_args = mock_create_engine.call_args[0]
         assert "primary" in call_args[0]
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_reads_round_robin_across_all(self, mock_create_engine):
         """Read connections should round-robin across all servers"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -300,7 +309,8 @@ class TestHighAvailabilityFailover:
         # Get 3 read connections
         used_hosts = []
         for _ in range(3):
-            manager.get_connection(read_only=True)
+            with manager.get_connection(read_only=True):
+                pass
             call_args = mock_create_engine.call_args[0][0]
             used_hosts.append(call_args)
 
@@ -309,7 +319,7 @@ class TestHighAvailabilityFailover:
         assert "replica1" in used_hosts[1]
         assert "replica2" in used_hosts[2]
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_failover_to_replica_on_primary_failure(self, mock_create_engine):
         """Should failover to replica if primary fails"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -338,12 +348,17 @@ class TestHighAvailabilityFailover:
         )
 
         # Should failover to replica
-        connection = manager.get_connection(read_only=False)
-        assert connection is not None
+        with manager.get_connection(read_only=False) as connection:
+            assert connection is not None
 
 
 class TestMongoDBIntegration:
     """Test MongoDB-specific connection handling"""
+
+    pytestmark = pytest.mark.skipif(
+        importlib.util.find_spec("motor") is None,
+        reason="motor optional dependency not installed",
+    )
 
     @patch('motor.motor_asyncio.AsyncIOMotorClient')
     def test_uses_motor_for_async(self, mock_motor_client):
@@ -389,7 +404,7 @@ class TestMongoDBIntegration:
 class TestMSAccessHandling:
     """Test MS Access-specific handling (no pooling)"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_access_single_connection_only(self, mock_create_engine):
         """MS Access should use single connection (no pooling)"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -398,7 +413,7 @@ class TestMSAccessHandling:
 
         assert manager.pool_size == 1
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_access_warns_in_production(self, mock_create_engine):
         """Should warn when Access is used in production"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -407,7 +422,7 @@ class TestMSAccessHandling:
             with pytest.warns(UserWarning, match="MS Access.*production"):
                 manager = DatabaseManager(db_type='access')
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_access_ok_in_development(self, mock_create_engine):
         """Should not warn in development environment"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -420,7 +435,7 @@ class TestMSAccessHandling:
 class TestMetricsTracking:
     """Test connection metrics tracking"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_tracks_active_connections(self, mock_create_engine):
         """Should track number of active connections"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -431,14 +446,16 @@ class TestMetricsTracking:
         manager = DatabaseManager(db_type='postgresql')
 
         # Get connections
-        manager.get_connection()
-        manager.get_connection()
+        with manager.get_connection():
+            pass
+        with manager.get_connection():
+            pass
 
         metrics = manager.get_metrics()
         assert 'active_connections' in metrics
         assert metrics['active_connections'] >= 0
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_tracks_pool_size(self, mock_create_engine):
         """Should track configured pool size"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -448,7 +465,7 @@ class TestMetricsTracking:
         metrics = manager.get_metrics()
         assert metrics['pool_size'] == 25
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_tracks_connection_errors(self, mock_create_engine):
         """Should track connection error count"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -460,7 +477,8 @@ class TestMetricsTracking:
         manager = DatabaseManager(db_type='postgresql', max_retries=2)
 
         try:
-            manager.get_connection()
+            with manager.get_connection():
+                pass
         except OperationalError:
             pass
 
@@ -468,7 +486,7 @@ class TestMetricsTracking:
         assert 'connection_errors' in metrics
         assert metrics['connection_errors'] > 0
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     @patch('time.time')
     def test_tracks_query_times(self, mock_time, mock_create_engine):
         """Should track query execution times"""
@@ -491,7 +509,7 @@ class TestMetricsTracking:
         metrics = manager.get_metrics()
         assert 'avg_query_time' in metrics or 'total_queries' in metrics
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_tracks_failure_rate(self, mock_create_engine):
         """Should track connection failure rate"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -506,7 +524,8 @@ class TestMetricsTracking:
         mock_create_engine.return_value = mock_engine
 
         manager = DatabaseManager(db_type='postgresql', max_retries=3)
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         metrics = manager.get_metrics()
         assert 'failure_rate' in metrics
@@ -515,7 +534,7 @@ class TestMetricsTracking:
 class TestContextManager:
     """Test context manager for safe connection handling"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_context_manager_returns_connection(self, mock_create_engine):
         """Context manager should return valid connection"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -530,7 +549,7 @@ class TestContextManager:
         with manager.get_connection() as conn:
             assert conn == mock_connection
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_context_manager_closes_connection(self, mock_create_engine):
         """Context manager should close connection on exit"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -547,7 +566,7 @@ class TestContextManager:
 
         mock_connection.close.assert_called_once()
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_context_manager_closes_on_exception(self, mock_create_engine):
         """Context manager should close connection even on exception"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -608,7 +627,7 @@ class TestBackwardCompatibility:
         assert manager is not None
         assert isinstance(status, bool)
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_connection_string_compatibility(self, mock_create_engine):
         """Should work with existing connection_string parameter"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -620,7 +639,8 @@ class TestBackwardCompatibility:
             connection_string=connection_string
         )
 
-        manager.get_connection()
+        with manager.get_connection():
+            pass
 
         # Should use provided connection string
         call_args = mock_create_engine.call_args[0]
@@ -630,7 +650,7 @@ class TestBackwardCompatibility:
 class TestHealthCheck:
     """Test health check functionality"""
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_health_check_returns_status(self, mock_create_engine):
         """Health check should return connection status"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager
@@ -648,7 +668,7 @@ class TestHealthCheck:
         assert 'response_time' in status
         assert status['status'] in ['healthy', 'unhealthy']
 
-    @patch('sqlalchemy.create_engine')
+    @patch('digitalmodel.infrastructure.core.database_manager.create_engine')
     def test_health_check_detects_failure(self, mock_create_engine):
         """Health check should detect connection failures"""
         from digitalmodel.infrastructure.core.database_manager import DatabaseManager

--- a/tests/naval_architecture/test_b1528_sirocco_current_heading_rudder.py
+++ b/tests/naval_architecture/test_b1528_sirocco_current_heading_rudder.py
@@ -3,6 +3,7 @@
 
 import json
 import math
+import os
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,12 @@ from digitalmodel.naval_architecture.b1528_sirocco_current_heading_rudder_report
     run_b1528_current_heading_rudder_report,
     validate_b1528_current_heading_rudder_config,
     write_b1528_current_heading_rudder_report,
+)
+
+
+requires_ocimf_workbook = pytest.mark.skipif(
+    not os.environ.get("OCIMF_WORKBOOK_PATH"),
+    reason="OCIMF_WORKBOOK_PATH is not set; licensed OCIMF workbook is optional/off-repo",
 )
 
 
@@ -55,6 +62,7 @@ def test_package_level_exports_available():
     assert callable(naval_architecture.write_b1528_current_heading_rudder_report)
 
 
+@requires_ocimf_workbook
 def test_full_sweep_row_counts_and_default_plane_flags():
     result = run_b1528_current_heading_rudder_report()
     rows = result["rows"]
@@ -76,6 +84,7 @@ def test_full_sweep_row_counts_and_default_plane_flags():
     )
 
 
+@requires_ocimf_workbook
 def test_zero_effective_inflow_angle_identity_and_scope_wording():
     result = run_b1528_current_heading_rudder_report()
     row = _find_row(result["rows"], 3.08, 0.0, 0.0)
@@ -89,6 +98,7 @@ def test_zero_effective_inflow_angle_identity_and_scope_wording():
     assert "not total hull current load" in result["metadata"]["zero_effective_angle_note"].lower()
 
 
+@requires_ocimf_workbook
 def test_centerline_regression_matches_existing_fixed_report_formula():
     result = run_b1528_current_heading_rudder_report()
     row = _find_row(result["rows"], 3.08, 0.0, 28.0)
@@ -106,6 +116,7 @@ def test_centerline_regression_matches_existing_fixed_report_formula():
     assert row["moment_n_yaw_bow_port_kN_m"] == pytest.approx(expected_y * 135.3 / 1000.0)
 
 
+@requires_ocimf_workbook
 def test_sign_cases_for_port_rudder_and_zero_rudder():
     rows = run_b1528_current_heading_rudder_report()["rows"]
     port = _find_row(rows, 3.08, 0.0, 28.0)
@@ -118,6 +129,7 @@ def test_sign_cases_for_port_rudder_and_zero_rudder():
     assert port["force_x_local_downstream_N"] >= 0.0
 
 
+@requires_ocimf_workbook
 def test_heading_rudder_interaction_rotates_local_force_to_ship_frame():
     rows = run_b1528_current_heading_rudder_report()["rows"]
     oblique = _find_row(rows, 3.08, 4.0, 28.0)
@@ -136,6 +148,7 @@ def test_heading_rudder_interaction_rotates_local_force_to_ship_frame():
     assert oblique["force_y_ship_port_N"] != pytest.approx(centerline_equivalent_alpha["force_y_ship_port_N"])
 
 
+@requires_ocimf_workbook
 def test_ship_fixed_transform_independent_formula():
     rows = run_b1528_current_heading_rudder_report()["rows"]
     row = _find_row(rows, 2.0, -5.0, 10.0)
@@ -155,6 +168,7 @@ def test_ship_fixed_transform_independent_formula():
     assert row["mooring_reaction_n_Nm"] == pytest.approx(-row["total_moment_n_yaw_bow_port_Nm"])
 
 
+@requires_ocimf_workbook
 def test_speed_squared_scaling_for_same_heading_and_rudder():
     rows = run_b1528_current_heading_rudder_report()["rows"]
     slow = _find_row(rows, 2.0, -3.0, 10.0)
@@ -171,6 +185,7 @@ def test_speed_squared_scaling_for_same_heading_and_rudder():
         assert fast[key] / slow[key] == pytest.approx(4.0)
 
 
+@requires_ocimf_workbook
 def test_formula_sample_for_issue_2760_default_speed():
     result = run_b1528_current_heading_rudder_report()
     sample = result["sample_working_example"]
@@ -192,6 +207,7 @@ def test_formula_sample_for_issue_2760_default_speed():
     assert sample["moment_n_yaw_bow_port_kN_m"] == pytest.approx(expected_y * 135.3 / 1000.0)
 
 
+@requires_ocimf_workbook
 def test_ocimf_current_rudder_and_total_components_are_reported_about_cog():
     result = run_b1528_current_heading_rudder_report()
     row = _find_row(result["rows"], 3.08, 5.0, 28.0)
@@ -217,6 +233,7 @@ def test_ocimf_current_rudder_and_total_components_are_reported_about_cog():
     )
 
 
+@requires_ocimf_workbook
 def test_report_outputs_include_issue_2760_dropdown_chart_contract_and_provenance(tmp_path):
     result = run_b1528_current_heading_rudder_report()
     manifest = write_b1528_current_heading_rudder_report(result, tmp_path)
@@ -293,6 +310,7 @@ def test_report_outputs_include_issue_2760_dropdown_chart_contract_and_provenanc
     assert "scope_exclusions" in provenance
 
 
+@requires_ocimf_workbook
 def test_generated_csv_has_expected_rows(tmp_path):
     result = run_b1528_current_heading_rudder_report()
     manifest = write_b1528_current_heading_rudder_report(result, tmp_path)

--- a/tests/naval_architecture/test_issue_2760_sirocco_current_rudder_revision.py
+++ b/tests/naval_architecture/test_issue_2760_sirocco_current_rudder_revision.py
@@ -3,6 +3,7 @@
 
 import inspect
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,23 @@ from digitalmodel.naval_architecture.b1528_sirocco_current_heading_rudder_report
     KNOT_TO_M_PER_S,
     load_packaged_b1528_current_heading_rudder_config,
     run_b1528_current_heading_rudder_report,
+)
+
+
+requires_ocimf_workbook = pytest.mark.skipif(
+    not os.environ.get(report_module.OCIMF_WORKBOOK_PATH_ENV),
+    reason="OCIMF_WORKBOOK_PATH is not set; licensed OCIMF workbook is optional/off-repo",
+)
+requires_ocimf_provenance = pytest.mark.skipif(
+    not all(
+        (Path.cwd() / path).exists()
+        for path in (
+            report_module.OCIMF_PROVENANCE_README,
+            "wikis/marine-engineering/wiki/standards/ocimf-meg4.md",
+            "wikis/acma-projects/wiki/concepts/b1528-sirocco-rudder-yaw-moment-inputs.md",
+        )
+    ),
+    reason="OCIMF citation/provenance wiki artifacts are unavailable in this checkout",
 )
 
 
@@ -56,6 +74,7 @@ def test_issue_2760_placeholder_ocimf_constants_removed_from_source():
     assert "placeholder heading functions" not in source.lower()
 
 
+@requires_ocimf_workbook
 def test_issue_2760_default_ocimf_coefficients_are_interpolated_from_workbook():
     cfg = load_packaged_b1528_current_heading_rudder_config()
 
@@ -78,6 +97,7 @@ def test_issue_2760_default_ocimf_coefficients_are_interpolated_from_workbook():
     assert coeffs["source_workbook"] == "licensed-off-repo-ocimf-workbook"
 
 
+@requires_ocimf_workbook
 def test_issue_2760_cxyc_preserves_workbook_sign_in_negative_regime():
     """Sentinel for the latent abs() defect on Cxyc.
 
@@ -121,6 +141,7 @@ def test_issue_2760_cxyc_preserves_workbook_sign_in_negative_regime():
     assert stbd_far["cyc"] < 0.0
 
 
+@requires_ocimf_workbook
 def test_issue_2760_ocimf_source_gate_and_citation_sidecars_resolve():
     preflight = report_module.issue_2760_source_preflight()
 
@@ -153,6 +174,7 @@ def test_issue_2760_ocimf_source_gate_rejects_missing_workbook(monkeypatch, tmp_
         report_module.issue_2760_source_preflight()
 
 
+@requires_ocimf_provenance
 def test_issue_2760_ocimf_preflight_does_not_return_local_workbook_path(monkeypatch, tmp_path):
     workbook = tmp_path / "OCIMF Coef.xlsx"
     workbook.write_bytes(b"placeholder")
@@ -165,6 +187,7 @@ def test_issue_2760_ocimf_preflight_does_not_return_local_workbook_path(monkeypa
     assert preflight["ocimf"]["workbook_source_id"] == "licensed-off-repo-ocimf-workbook"
 
 
+@requires_ocimf_workbook
 def test_issue_2760_generated_provenance_emits_citation_sidecar(tmp_path):
     result = run_b1528_current_heading_rudder_report()
     manifest = report_module.write_b1528_current_heading_rudder_report(result, tmp_path)
@@ -204,6 +227,7 @@ def test_issue_2760_ocimf_basis_selection_is_geometry_documented():
     assert selection["rejected_alternatives"]
 
 
+@requires_ocimf_workbook
 def test_issue_2760_default_current_and_rudder_signs_are_port_positive():
     result = run_b1528_current_heading_rudder_report()
     row = _find_row(result["rows"], 3.08, 5.0, 28.0)
@@ -216,6 +240,7 @@ def test_issue_2760_default_current_and_rudder_signs_are_port_positive():
     assert row["force_component_basis"].startswith("issue #2760")
 
 
+@requires_ocimf_workbook
 def test_issue_2760_main_report_output_removes_resultants_and_heatmap(tmp_path):
     result = run_b1528_current_heading_rudder_report()
     manifest = report_module.write_b1528_current_heading_rudder_report(result, tmp_path)
@@ -230,6 +255,7 @@ def test_issue_2760_main_report_output_removes_resultants_and_heatmap(tmp_path):
         assert "total horizontal force" not in text
 
 
+@requires_ocimf_workbook
 def test_issue_2760_docx_output_opens_and_contains_required_sections(tmp_path):
     from docx import Document
 
@@ -267,6 +293,7 @@ def test_issue_2760_docx_output_opens_and_contains_required_sections(tmp_path):
     assert "Heading/rudder schematic" not in text  # superseded by per-section schematic references
 
 
+@requires_ocimf_workbook
 def test_issue_2760_canonical_section_layout_in_markdown(tmp_path):
     """Pass A contract: MD must follow the 6-section canonical layout from
     issue thread comment 4492317819 and approved plan §3.1.
@@ -295,6 +322,7 @@ def test_issue_2760_canonical_section_layout_in_markdown(tmp_path):
     )
 
 
+@requires_ocimf_workbook
 def test_issue_2760_canonical_section_layout_in_html(tmp_path):
     """Pass A contract: HTML must follow the same 6-section canonical layout."""
     result = run_b1528_current_heading_rudder_report()
@@ -317,6 +345,7 @@ def test_issue_2760_canonical_section_layout_in_html(tmp_path):
     )
 
 
+@requires_ocimf_workbook
 def test_issue_2760_per_section_schematic_anchors_exist(tmp_path):
     """Pass A→B handoff contract: each major calculation section has its own
     schematic placeholder/anchor. Pass B fills the SVG content; Pass A
@@ -336,6 +365,7 @@ def test_issue_2760_per_section_schematic_anchors_exist(tmp_path):
         assert f'id="{sid}"' in html, f"Missing per-section schematic anchor: {sid}"
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_b_schematic_svgs_have_real_content(tmp_path):
     """Pass B/G contract: per-section schematic SVGs (current-loading,
     current-moment, rudder-loading) must contain real ship+arrow markup,
@@ -385,6 +415,7 @@ def test_issue_2760_pass_b_schematic_svgs_have_real_content(tmp_path):
         )
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_h_docx_embeds_schematic_pictures(tmp_path):
     """Pass H "add pictures" contract: the DOCX embeds at least 4 inline
     pictures (one per OCIMF schematic — axes/sign, current loading,
@@ -405,6 +436,7 @@ def test_issue_2760_pass_h_docx_embeds_schematic_pictures(tmp_path):
         pass  # Playwright unavailable; DOCX correctly degrades to text-only
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_h_docx_has_sensitivity_and_appendix(tmp_path):
     """Pass H DOCX parity: the Word artifact must carry the same Pass H
     additions as HTML/PDF (was stripped at §5.1 / §6 only).
@@ -429,6 +461,7 @@ def test_issue_2760_pass_h_docx_has_sensitivity_and_appendix(tmp_path):
     assert "Key variables" in text or "Default case" in text
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_h_revisions(tmp_path):
     """Pass H contract: §4.2 transverse current force chart, §5.1 renamed to
     Whicker-Fehlner - Model A, §5.4/§5.5 lead-in key variables, §5.6
@@ -466,6 +499,7 @@ def test_issue_2760_pass_h_revisions(tmp_path):
     assert max(result["metadata"]["rudder_angles_deg"]) == pytest.approx(28.0)
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_g_schematics_have_ocimf_caption_block(tmp_path):
     """Pass G contract: each per-section schematic SVG is followed by a
     caption block (.schematic-caption div) carrying the full English
@@ -538,6 +572,7 @@ def test_issue_2760_pass_c_simple_plate_rudder_helper_exists_and_is_sane():
     assert f_60 <= f_28 + 1e-9
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_c_simple_plate_fields_in_row_dict():
     """Pass C contract: each row in the sweep carries simple-plate model
     fields alongside the existing Whicker-Fehlner fields, so the HTML
@@ -565,6 +600,7 @@ def test_issue_2760_pass_c_simple_plate_fields_in_row_dict():
     assert default_row["force_y_ship_port_N"] > 0
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_e_yaw_side_by_side_chart_and_field(tmp_path):
     """Pass E contract: §4.2 includes a side-by-side yaw chart comparing
     OCIMF direct yaw moment (Method A: Nc = q·A_l·LBP·Cxyc) with
@@ -595,6 +631,7 @@ def test_issue_2760_pass_e_yaw_side_by_side_chart_and_field(tmp_path):
     )
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_d_decimal_rounding_in_display_values(tmp_path):
     """Pass D contract: kN and kN·m display values are rounded to 0 decimals
     when |val| ≥ 1, and to 2 decimals otherwise (per plan §130 and user
@@ -621,6 +658,7 @@ def test_issue_2760_pass_d_decimal_rounding_in_display_values(tmp_path):
     assert ".toFixed(0)" in html, "Pass D needs at least one .toFixed(0) display rounder"
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_d_force_labels_use_english_terms(tmp_path):
     """Pass D contract: HTML uses English force labels
     "longitudinal" / "transverse" / "yaw moment" alongside the symbolic
@@ -641,6 +679,7 @@ def test_issue_2760_pass_d_force_labels_use_english_terms(tmp_path):
     assert "transverse y" in html or "transverse force" in html
 
 
+@requires_ocimf_workbook
 def test_issue_2760_pass_c_html_has_side_by_side_rudder_comparison(tmp_path):
     """Pass C contract: HTML §5 contains a Model A vs Model B side-by-side
     comparison table at the default case AND a chart comparing both
@@ -656,6 +695,7 @@ def test_issue_2760_pass_c_html_has_side_by_side_rudder_comparison(tmp_path):
     assert 'id="rudder-model-comparison-chart"' in html
 
 
+@requires_ocimf_workbook
 def test_issue_2760_html_javascript_uses_only_x_y_n_component_fields(tmp_path):
     result = run_b1528_current_heading_rudder_report()
     manifest = report_module.write_b1528_current_heading_rudder_report(result, tmp_path)

--- a/tests/structural/structural_analysis/test_structural_analysis_unit.py
+++ b/tests/structural/structural_analysis/test_structural_analysis_unit.py
@@ -125,8 +125,9 @@ class TestPlateBuckling:
         sigma_e = analyzer.elastic_buckling_stress(plate)
 
         assert sigma_e > 0
-        # Elastic buckling should be well above yield for thick plates
-        assert sigma_e > STEEL_S355.yield_strength
+        # A 10 mm x 1000 mm square plate is slender; elastic buckling is below yield.
+        assert sigma_e == pytest.approx(75.9200338545)
+        assert sigma_e < STEEL_S355.yield_strength
 
     def test_elastic_buckling_long_plate(self, analyzer):
         """Test elastic buckling for long plate"""
@@ -135,13 +136,16 @@ class TestPlateBuckling:
 
         assert sigma_e > 0
 
-    def test_johnson_ostenfeld_elastic(self, analyzer):
-        """Test Johnson-Ostenfeld in elastic range"""
+    def test_johnson_ostenfeld_inelastic_cap(self, analyzer):
+        """Test Johnson-Ostenfeld cap for high elastic buckling stress."""
         sigma_e = 1000.0  # High elastic stress
         sigma_cr = analyzer.johnson_ostenfeld(sigma_e)
 
-        # Should return elastic stress unchanged
-        assert abs(sigma_cr - sigma_e) < 0.1
+        expected = STEEL_S355.yield_strength * (
+            1 - STEEL_S355.yield_strength / (4 * sigma_e)
+        )
+        assert sigma_cr == pytest.approx(expected)
+        assert sigma_cr < STEEL_S355.yield_strength
 
     def test_johnson_ostenfeld_inelastic(self, analyzer):
         """Test Johnson-Ostenfeld in inelastic range"""
@@ -284,8 +288,8 @@ class TestMemberCapacity:
 
         assert result.governing_mode in ["plastic", "net_section"]
 
-    def test_combined_loading_passes(self, checker):
-        """Test combined loading check that passes"""
+    def test_combined_loading_slightly_overutilized(self, checker):
+        """Test combined loading check just above unity utilization."""
         result = checker.check_combined_loading(
             N=2e6,          # 2 MN axial
             M_y=500e6,      # 500 kNm
@@ -298,8 +302,8 @@ class TestMemberCapacity:
             gamma_m1=1.0
         )
 
-        assert result.passes
-        assert result.utilization < 1.0
+        assert not result.passes
+        assert result.utilization == pytest.approx(1.0328638498)
 
     def test_combined_loading_high_util(self, checker):
         """Test combined loading with high utilization"""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -169,7 +169,7 @@ class TestCacheClientRedisBackend:
     @pytest.fixture
     def cache_client(self):
         """Create cache client with fakeredis."""
-        import fakeredis
+        fakeredis = pytest.importorskip("fakeredis")
 
         config = CacheConfig(enable_redis=True)
         client = CacheClient(config)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -112,8 +112,8 @@ class TestEngineConfiguration:
         """Test engine with provided configuration."""
         cfg = AttributeDict(sample_config)
 
-        # Mock all external dependencies including the Mooring module
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        # Mock all external dependencies including the Pipeline module
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_instance = MagicMock()
             mock_instance.router.return_value = cfg
             mock_mooring.return_value = mock_instance
@@ -129,13 +129,13 @@ class TestEngineConfiguration:
     def test_engine_config_file_path_tracking(self, temp_config_file):
         """Test that engine tracks config file paths for relative path resolution."""
         config_data = {
-            "basename": "mooring",
+            "basename": "pipeline",
             "inputs": {"test": "value"},
             "_config_file_path": os.path.abspath(temp_config_file),
             "_config_dir_path": os.path.dirname(os.path.abspath(temp_config_file))
         }
 
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_instance = MagicMock()
             mock_instance.router.return_value = config_data
             mock_mooring.return_value = mock_instance
@@ -163,9 +163,9 @@ class TestEngineConfiguration:
 
     def test_basename_extraction_from_config(self):
         """Test basename extraction from different config structures."""
-        # Test basename in root - use valid mooring basename
-        cfg1 = {"basename": "mooring"}
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        # Test basename in root - use valid pipeline basename
+        cfg1 = {"basename": "pipeline"}
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_instance = MagicMock()
             mock_instance.router.return_value = cfg1
             mock_mooring.return_value = mock_instance
@@ -177,9 +177,9 @@ class TestEngineConfiguration:
                     result = engine(cfg=cfg1, config_flag=False)
                     assert "basename" in result
 
-        # Test basename in meta - use valid mooring basename
-        cfg2 = {"meta": {"basename": "mooring"}}
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        # Test basename in meta - use valid pipeline basename
+        cfg2 = {"meta": {"basename": "pipeline"}}
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_instance = MagicMock()
             mock_instance.router.return_value = cfg2
             mock_mooring.return_value = mock_instance
@@ -207,7 +207,7 @@ class TestEngineConfiguration:
             from digitalmodel.solvers.orcaflex.output_control import OutputController
             mock_output.return_value = OutputController.QUIET
 
-            with patch('digitalmodel.engine.Mooring') as mock_mooring:
+            with patch('digitalmodel.engine.Pipeline') as mock_mooring:
                 mock_instance = MagicMock()
                 mock_instance.router.return_value = cfg
                 mock_mooring.return_value = mock_instance
@@ -224,7 +224,7 @@ class TestEngineConfiguration:
         with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
             mock_output.return_value = OutputController.VERBOSE
 
-            with patch('digitalmodel.engine.Mooring') as mock_mooring:
+            with patch('digitalmodel.engine.Pipeline') as mock_mooring:
                 mock_instance = MagicMock()
                 mock_instance.router.return_value = cfg
                 mock_mooring.return_value = mock_instance
@@ -385,21 +385,15 @@ class TestModuleRouting:
                     mock_instance.router.assert_called_once_with(cfg)
 
     def test_mooring_routing(self):
-        """Test routing to mooring module."""
+        """Test current mooring route points callers to the CLI/API."""
         cfg = {"basename": "mooring"}
 
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
-            mock_instance = MagicMock()
-            mock_instance.router.return_value = cfg
-            mock_mooring.return_value = mock_instance
+        with patch('digitalmodel.engine.app_manager') as mock_app_manager:
+            mock_app_manager.save_cfg = MagicMock()
 
-            with patch('digitalmodel.engine.app_manager') as mock_app_manager:
-                mock_app_manager.save_cfg = MagicMock()
-
-                with patch('digitalmodel.engine.logger'):
-                    result = engine(cfg=cfg, config_flag=False)
-                    mock_mooring.assert_called_once()
-                    mock_instance.router.assert_called_once_with(cfg)
+            with patch('digitalmodel.engine.logger'):
+                with pytest.raises(NotImplementedError, match="mooring_analysis CLI"):
+                    engine(cfg=cfg, config_flag=False)
 
 
 class TestComplexModuleRouting:
@@ -652,7 +646,7 @@ class TestErrorHandling:
                 mock_fm_instance.router.return_value = cfg
                 mock_fm.return_value = mock_fm_instance
 
-                with patch('digitalmodel.engine.Mooring') as mock_mooring:
+                with patch('digitalmodel.engine.Pipeline') as mock_mooring:
                     mock_mooring_instance = MagicMock()
                     mock_mooring_instance.router.return_value = cfg
                     mock_mooring.return_value = mock_mooring_instance
@@ -671,11 +665,11 @@ class TestConfigurationManagement:
     def test_config_dir_path_preservation(self, temp_config_file):
         """Test that config directory paths are preserved through processing."""
         config_data = {
-            "basename": "mooring",
+            "basename": "pipeline",
             "inputs": {"test": "value"}
         }
 
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_mooring_instance = MagicMock()
             mock_mooring_instance.router.return_value = AttributeDict(config_data)
             mock_mooring.return_value = mock_mooring_instance
@@ -708,7 +702,7 @@ class TestConfigurationManagement:
         """Test that library name and basename are correctly used in configuration."""
         cfg = AttributeDict(sample_config)
 
-        with patch('digitalmodel.engine.Mooring') as mock_mooring:
+        with patch('digitalmodel.engine.Pipeline') as mock_mooring:
             mock_mooring_instance = MagicMock()
             mock_mooring_instance.router.return_value = cfg
             mock_mooring.return_value = mock_mooring_instance
@@ -729,7 +723,7 @@ class TestConfigurationManagement:
                         # Verify correct parameters passed to configure
                         call_args = mock_app_manager.configure.call_args[0]
                         assert call_args[1] == "digitalmodel"  # library_name
-                        assert call_args[2] == "mooring"       # basename
+                        assert call_args[2] == "pipeline"       # basename
 
 
 # Test fixtures
@@ -737,10 +731,10 @@ class TestConfigurationManagement:
 def sample_config():
     """Provide sample configuration for testing.
 
-    Uses 'mooring' as basename since it's a valid, simple handler in engine.py.
+    Uses 'pipeline' as basename since it's a valid, simple handler in engine.py.
     """
     return {
-        "basename": "mooring",
+        "basename": "pipeline",
         "inputs": {
             "test_parameter": "test_value",
             "shape": "rectangular"
@@ -1281,7 +1275,7 @@ class TestEngineComprehensiveIntegration:
     def test_engine_multiple_module_workflow(self):
         """Test engine handling multiple different modules in sequence."""
         test_modules = [
-            'transformation', 'pipeline', 'fatigue_analysis', 'mooring', 'time_series'
+            'transformation', 'pipeline', 'fatigue_analysis', 'time_series'
         ]
 
         for basename in test_modules:
@@ -1292,7 +1286,6 @@ class TestEngineComprehensiveIntegration:
                 'transformation': 'Transformation',
                 'pipeline': 'Pipeline',
                 'fatigue_analysis': 'FatigueAnalysis',
-                'mooring': 'Mooring',
                 'time_series': 'TimeSeriesAnalysis'
             }
 


### PR DESCRIPTION
## Summary
Triaged the pre-existing test failures on `main` (independent of the recent workflow PRs — those are green) and fixed the **high-confidence** set. **All collection errors eliminated** (113 → 0); affected suites **290 passed + 44 skipped**.

## Fixes
| Area | Category | Fix |
|---|---|---|
| `test_sn_curves_yaml.py` (85 errors) | missing data | Regenerated `data/fatigue/sn_curves.yaml` from production `StandardSNCurves` (provenance in file metadata) → 126 passed |
| subsea gate | stale config | Dropped dangling `tests/test_catenary_debug.py` ref from `.claude/quality-gates.yaml` |
| `digitalmarketing.py` | **real bug** | Fixed canonical SEO import (was importing legacy `digitalmodel.digitalmarketing.*` instead of `specialized.*`) |
| `test_structural_analysis_unit.py` | stale tests | Corrected to real physics — thin-plate `sigma_e ≈ 75.9 MPa < yield`; member util `1.033 → passes=False` |
| `test_database_manager.py` | stale + opt-dep | Fixed `create_engine` patch target; `importorskip` motor/psycopg2 |
| `test_engine.py` | stale | Updated to current mooring CLI-guidance routing |
| naval B1528/2760, `test_cache.py` | opt-dep | Honest skip guards (OCIMF workbook / fakeredis) instead of fails |

Durable-workflows suite unaffected: 54 passed + 1 skipped.

## Deferred — needs your decision (NOT in this PR)
`tests/infrastructure/core/test_cache.py` is a 617-line suite for a legacy `Cache` API **production doesn't have** (only `CacheClient` exists; nothing in `src/` imports `Cache`). The fix worker initially added ~175 lines of unused `Cache` facade to satisfy it — I **reverted that** rather than ship dead production code. Honest options: rewrite the tests against `CacheClient`, or delete the orphaned suite. Left failing pending that call.

## Scope note
This PR only fixes high-confidence items. Remaining `main` failures are optional-dep/environment (OrcFxAPI, rasterio, pygmt, matplotlib cache in sandbox) — candidates for skip-guards in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)