### PR TITLE
feat(workflows): wellpath (minimum-curvature) + wave_spectrum (JONSWAP/PM)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -110,6 +110,14 @@ workflows:
       - examples/workflows/pipe-ovality/results/input_ovality.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pipe-ovality]
     runtime: offline
+  - id: wave-spectrum
+    basename: wave_spectrum
+    title: Offline JONSWAP and Pierson-Moskowitz wave energy spectrum
+    input: examples/workflows/wave-spectrum/input.yml
+    outputs:
+      - examples/workflows/wave-spectrum/results/input_spectrum.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[wave-spectrum]
+    runtime: offline
   - id: rao-tabulation
     basename: rao_tabulation
     title: Offline 6-DOF vessel RAO amplitude and phase tabulation
@@ -418,6 +426,14 @@ workflows:
       - examples/workflows/well-hydraulics/results/input.yml
       - examples/workflows/well-hydraulics/results/well_hydraulics/well_hydraulics_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[well-hydraulics]
+    runtime: offline
+  - id: wellpath
+    basename: wellpath
+    title: Minimum-curvature directional survey interpolation
+    input: examples/workflows/wellpath/input.yml
+    outputs:
+      - examples/workflows/wellpath/results/input_wellpath.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[wellpath]
     runtime: offline
   - id: rop-analysis
     basename: rop_analysis

--- a/examples/workflows/wave-spectrum/input.yml
+++ b/examples/workflows/wave-spectrum/input.yml
@@ -1,0 +1,20 @@
+basename: wave_spectrum
+
+wave_spectrum:
+  spectrum: jonswap
+  Hs: 3.0
+  Tp: 10.0
+  gamma: 3.3
+  # Frequency grid units are rad/s. Use units: hz to provide cycles/s input.
+  frequency_grid:
+    units: rad_s
+    start: 0.2
+    stop: 2.0
+    num: 181
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/examples/workflows/wellpath/input.yml
+++ b/examples/workflows/wellpath/input.yml
@@ -1,0 +1,27 @@
+basename: wellpath
+
+wellpath:
+  stations:
+    - measured_depth_m: 0.0
+      inclination_deg: 0.0
+      azimuth_deg: 0.0
+    - measured_depth_m: 100.0
+      inclination_deg: 0.0
+      azimuth_deg: 0.0
+    - measured_depth_m: 200.0
+      inclination_deg: 15.0
+      azimuth_deg: 0.0
+    - measured_depth_m: 300.0
+      inclination_deg: 30.0
+      azimuth_deg: 0.0
+    - measured_depth_m: 400.0
+      inclination_deg: 30.0
+      azimuth_deg: 0.0
+  dls_normalization: 30.0
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/wave_spectrum/wave_spectrum.yml
+++ b/src/digitalmodel/base_configs/modules/wave_spectrum/wave_spectrum.yml
@@ -1,0 +1,19 @@
+basename: wave_spectrum
+
+wave_spectrum:
+  spectrum: jonswap
+  Hs: 3.0
+  Tp: 10.0
+  gamma: 3.3
+  frequency_grid:
+    units: rad_s
+    start: 0.2
+    stop: 2.0
+    num: 181
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/wellpath/wellpath.yml
+++ b/src/digitalmodel/base_configs/modules/wellpath/wellpath.yml
@@ -1,0 +1,18 @@
+basename: wellpath
+
+wellpath:
+  stations:
+    - measured_depth_m: 0.0
+      inclination_deg: 0.0
+      azimuth_deg: 0.0
+    - measured_depth_m: 100.0
+      inclination_deg: 30.0
+      azimuth_deg: 0.0
+  dls_normalization: 30.0
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -258,6 +258,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.structural.ovality.workflow import router as pipe_ovality
 
         cfg_base = pipe_ovality(cfg_base)
+    elif basename == "wave_spectrum":
+        from digitalmodel.hydrodynamics.wave_spectrum.workflow import router as wave_spectrum
+
+        cfg_base = wave_spectrum(cfg_base)
     elif basename == "von_mises":
         from digitalmodel.structural.fe.von_mises_workflow import router as von_mises
 
@@ -394,6 +398,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.well.workflow import run_well_hydraulics
 
         cfg_base = run_well_hydraulics(cfg_base)
+    elif basename == "wellpath":
+        from digitalmodel.well.wellpath.workflow import router as wellpath
+
+        cfg_base = wellpath(cfg_base)
     elif basename == "rop_analysis":
         from digitalmodel.well.workflow import run_rop_analysis
 

--- a/src/digitalmodel/hydrodynamics/wave_spectrum/__init__.py
+++ b/src/digitalmodel/hydrodynamics/wave_spectrum/__init__.py
@@ -1,0 +1,2 @@
+"""Wave-spectrum workflow."""
+

--- a/src/digitalmodel/hydrodynamics/wave_spectrum/workflow.py
+++ b/src/digitalmodel/hydrodynamics/wave_spectrum/workflow.py
@@ -1,0 +1,180 @@
+"""UV-workflow router for offline wave energy spectra."""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.hydrodynamics.wave_spectra import WaveSpectra
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("wave_spectrum") or {}
+    spectrum = _spectrum_name(settings)
+    significant_height = _positive_float(settings, "Hs")
+    peak_period = _positive_float(settings, "Tp")
+    gamma = _positive_float(settings, "gamma", 3.3)
+    frequency_grid = _frequency_grid(settings)
+
+    generator = WaveSpectra()
+    if spectrum == "jonswap":
+        frequencies, spectral_density = generator.jonswap(
+            hs=significant_height,
+            tp=peak_period,
+            gamma=gamma,
+            freq_min=frequency_grid["start"],
+            freq_max=frequency_grid["stop"],
+            n_points=frequency_grid["num"],
+        )
+    elif spectrum == "pierson_moskowitz":
+        frequencies, spectral_density = generator.pierson_moskowitz(
+            hs=significant_height,
+            tp=peak_period,
+            freq_min=frequency_grid["start"],
+            freq_max=frequency_grid["stop"],
+            n_points=frequency_grid["num"],
+        )
+    else:
+        raise ValueError(f"Unsupported wave_spectrum spectrum: {spectrum}")
+
+    rows = [
+        {"frequency": float(frequency), "S": float(density)}
+        for frequency, density in zip(frequencies, spectral_density)
+    ]
+    csv_path = _spectrum_csv_path(cfg, settings)
+    _write_spectrum_csv(csv_path, rows)
+
+    m0 = generator.spectral_moment(frequencies, spectral_density, n=0)
+    peak_frequency = float(generator.peak_frequency_from_spectrum(
+        frequencies, spectral_density
+    ))
+    cfg["wave_spectrum"] = {
+        "spectrum": spectrum,
+        "Hs_input": significant_height,
+        "Hs_check": 4.0 * math.sqrt(m0),
+        "Tp": peak_period,
+        "gamma": gamma if spectrum == "jonswap" else None,
+        "m0": m0,
+        "peak_frequency": peak_frequency,
+        "frequency_units": "rad_s",
+        "points": len(rows),
+        "spectrum_csv": _display_path(csv_path),
+    }
+    return cfg
+
+
+def _spectrum_name(settings: dict[str, Any]) -> str:
+    raw_value = (
+        settings.get("spectrum")
+        or settings.get("spectrum_type")
+        or settings.get("type")
+    )
+    if raw_value is None:
+        raise ValueError("wave_spectrum spectrum is required")
+    normalized = str(raw_value).strip().lower().replace("-", "_")
+    aliases = {
+        "pm": "pierson_moskowitz",
+        "p_m": "pierson_moskowitz",
+        "pierson_moskowitz": "pierson_moskowitz",
+        "piersonmoskowitz": "pierson_moskowitz",
+        "jonswap": "jonswap",
+    }
+    if normalized not in aliases:
+        raise ValueError(f"Unsupported wave_spectrum spectrum: {raw_value}")
+    return aliases[normalized]
+
+
+def _frequency_grid(settings: dict[str, Any]) -> dict[str, float | int]:
+    grid = settings.get("frequency_grid")
+    if not isinstance(grid, dict):
+        raise ValueError("wave_spectrum frequency_grid must be a mapping")
+
+    start = _required_positive_float(grid, "start", "frequency_grid")
+    stop = _required_positive_float(grid, "stop", "frequency_grid")
+    num = int(grid.get("num", 0))
+    if num < 2:
+        raise ValueError("wave_spectrum frequency_grid.num must be at least 2")
+    if stop <= start:
+        raise ValueError("wave_spectrum frequency_grid.stop must be greater than start")
+
+    units = str(grid.get("units", "rad_s")).strip().lower().replace("/", "_")
+    units = units.replace("rad_per_s", "rad_s").replace("radian_s", "rad_s")
+    if units in {"hz", "hertz", "cycles_s", "cycles_per_s"}:
+        start *= 2.0 * math.pi
+        stop *= 2.0 * math.pi
+    elif units not in {"rad_s", "rad_sec", "omega"}:
+        raise ValueError("wave_spectrum frequency_grid.units must be rad_s or hz")
+
+    return {"start": start, "stop": stop, "num": num}
+
+
+def _spectrum_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    stem = _input_stem(cfg)
+    return output_dir / f"{stem}_spectrum.csv"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "wave_spectrum"))
+
+
+def _write_spectrum_csv(path: Path, rows: list[dict[str, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=["frequency", "S"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _positive_float(
+    settings: dict[str, Any],
+    name: str,
+    default: float | None = None,
+) -> float:
+    value = settings.get(name, default)
+    if value is None:
+        raise ValueError(f"wave_spectrum {name} is required")
+    value = float(value)
+    if value <= 0.0 or not math.isfinite(value):
+        raise ValueError(f"wave_spectrum {name} must be positive")
+    return value
+
+
+def _required_positive_float(
+    settings: dict[str, Any],
+    name: str,
+    context: str,
+) -> float:
+    value = settings.get(name)
+    if value is None:
+        raise ValueError(f"wave_spectrum {context}.{name} is required")
+    value = float(value)
+    if value <= 0.0 or not math.isfinite(value):
+        raise ValueError(f"wave_spectrum {context}.{name} must be positive")
+    return value
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)
+

--- a/src/digitalmodel/well/wellpath/__init__.py
+++ b/src/digitalmodel/well/wellpath/__init__.py
@@ -1,0 +1,2 @@
+"""Minimum-curvature wellpath workflow."""
+

--- a/src/digitalmodel/well/wellpath/workflow.py
+++ b/src/digitalmodel/well/wellpath/workflow.py
@@ -1,0 +1,215 @@
+"""UV-workflow router for minimum-curvature directional surveys."""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("wellpath") or {}
+    stations = _stations(settings)
+    dls_normalization = _positive_float(settings, "dls_normalization", 30.0)
+
+    rows = _minimum_curvature_survey(stations, dls_normalization)
+    csv_path = _results_csv_path(cfg, settings)
+    _write_results_csv(csv_path, rows)
+
+    max_dls_row = max(rows, key=lambda row: float(row["dls"]))
+    cfg["wellpath"] = {
+        "points": len(rows),
+        "total_depth": float(rows[-1]["md"]),
+        "total_tvd": float(rows[-1]["tvd"]),
+        "max_dls": float(max_dls_row["dls"]),
+        "max_dls_depth": float(max_dls_row["md"]),
+        "dls_normalization": dls_normalization,
+        "wellpath_csv": _display_path(csv_path),
+    }
+    return cfg
+
+
+def _minimum_curvature_survey(
+    stations: list[dict[str, float]],
+    dls_normalization: float,
+) -> list[dict[str, float]]:
+    rows = [
+        {
+            "md": stations[0]["measured_depth_m"],
+            "inc": stations[0]["inclination_deg"],
+            "azi": stations[0]["azimuth_deg"],
+            "tvd": 0.0,
+            "north": 0.0,
+            "east": 0.0,
+            "dls": 0.0,
+        }
+    ]
+
+    tvd = north = east = 0.0
+    for previous, current in zip(stations, stations[1:]):
+        delta_md = current["measured_depth_m"] - previous["measured_depth_m"]
+        inc_1 = math.radians(previous["inclination_deg"])
+        inc_2 = math.radians(current["inclination_deg"])
+        azi_1 = math.radians(previous["azimuth_deg"])
+        azi_2 = math.radians(current["azimuth_deg"])
+
+        dogleg = _dogleg_angle(inc_1, inc_2, azi_1, azi_2)
+        ratio_factor = _ratio_factor(dogleg)
+        tvd += (
+            delta_md
+            * 0.5
+            * (math.cos(inc_1) + math.cos(inc_2))
+            * ratio_factor
+        )
+        north += (
+            delta_md
+            * 0.5
+            * (
+                math.sin(inc_1) * math.cos(azi_1)
+                + math.sin(inc_2) * math.cos(azi_2)
+            )
+            * ratio_factor
+        )
+        east += (
+            delta_md
+            * 0.5
+            * (
+                math.sin(inc_1) * math.sin(azi_1)
+                + math.sin(inc_2) * math.sin(azi_2)
+            )
+            * ratio_factor
+        )
+
+        rows.append(
+            {
+                "md": current["measured_depth_m"],
+                "inc": current["inclination_deg"],
+                "azi": current["azimuth_deg"],
+                "tvd": tvd,
+                "north": north,
+                "east": east,
+                "dls": math.degrees(dogleg) * dls_normalization / delta_md,
+            }
+        )
+    return rows
+
+
+def _dogleg_angle(
+    inc_1: float,
+    inc_2: float,
+    azi_1: float,
+    azi_2: float,
+) -> float:
+    cosine = (
+        math.sin(inc_1) * math.sin(inc_2) * math.cos(azi_2 - azi_1)
+        + math.cos(inc_1) * math.cos(inc_2)
+    )
+    return math.acos(max(-1.0, min(1.0, cosine)))
+
+
+def _ratio_factor(dogleg: float) -> float:
+    if abs(dogleg) <= 1.0e-12:
+        return 1.0
+    return (2.0 / dogleg) * math.tan(dogleg / 2.0)
+
+
+def _stations(settings: dict[str, Any]) -> list[dict[str, float]]:
+    raw_stations = settings.get("stations")
+    if not isinstance(raw_stations, list) or not raw_stations:
+        raise ValueError("wellpath stations must be a non-empty list")
+
+    stations = []
+    for index, station in enumerate(raw_stations):
+        if not isinstance(station, dict):
+            raise ValueError(f"wellpath stations[{index}] must be a mapping")
+        stations.append(
+            {
+                "measured_depth_m": _required_float(
+                    station, "measured_depth_m", f"stations[{index}]"
+                ),
+                "inclination_deg": _required_float(
+                    station, "inclination_deg", f"stations[{index}]"
+                ),
+                "azimuth_deg": _required_float(
+                    station, "azimuth_deg", f"stations[{index}]"
+                ),
+            }
+        )
+
+    previous_md = None
+    for index, station in enumerate(stations):
+        measured_depth = station["measured_depth_m"]
+        inclination = station["inclination_deg"]
+        if measured_depth < 0.0:
+            raise ValueError(f"wellpath stations[{index}].measured_depth_m must be >= 0")
+        if previous_md is not None and measured_depth <= previous_md:
+            raise ValueError("wellpath measured_depth_m values must be increasing")
+        if not 0.0 <= inclination <= 180.0:
+            raise ValueError(
+                f"wellpath stations[{index}].inclination_deg must be between 0 and 180"
+            )
+        previous_md = measured_depth
+    return stations
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    stem = _input_stem(cfg)
+    return output_dir / f"{stem}_wellpath.csv"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "wellpath"))
+
+
+def _write_results_csv(path: Path, rows: list[dict[str, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(
+            stream, fieldnames=["md", "inc", "azi", "tvd", "north", "east", "dls"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _required_float(source: dict[str, Any], name: str, context: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"wellpath {context}.{name} is required")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"wellpath {context}.{name} must be finite")
+    return value
+
+
+def _positive_float(settings: dict[str, Any], name: str, default: float) -> float:
+    value = settings.get(name, default)
+    value = float(value)
+    if value <= 0.0 or not math.isfinite(value):
+        raise ValueError(f"wellpath {name} must be positive")
+    return value
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)
+

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -161,6 +161,20 @@ def test_workflow_registry(workflow):
             expected_out_of_roundness
         )
         assert bool(results.loc[0, "passes"]) is True
+    elif workflow["id"] == "wave-spectrum":
+        summary = cfg["wave_spectrum"]
+        results_path = Path(summary["spectrum_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        spectrum = pd.read_csv(results_path)
+        omega_p = 2.0 * math.pi / summary["Tp"]
+
+        assert summary["spectrum"] == "jonswap"
+        assert summary["Hs_input"] == pytest.approx(3.0)
+        assert summary["Hs_check"] == pytest.approx(3.0, rel=0.05)
+        assert summary["peak_frequency"] == pytest.approx(omega_p, abs=0.02)
+        assert len(spectrum) == 181
+        assert (spectrum["S"] >= 0.0).all()
     elif workflow["id"] == "rao-tabulation":
         summary = cfg["rao_tabulation"]
         results_path = Path(summary["rao_csv"])
@@ -618,6 +632,20 @@ def test_workflow_registry(workflow):
         assert result["pressure_drop_annulus_psi"] == pytest.approx(127.087912088)
         assert result["ecd_ppg"] == pytest.approx(10.805499789)
         assert result["cuttings_transport_ratio"] == pytest.approx(1.0)
+    elif workflow["id"] == "wellpath":
+        summary = cfg["wellpath"]
+        results_path = Path(summary["wellpath_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        survey = pd.read_csv(results_path)
+
+        assert summary["total_depth"] == pytest.approx(400.0)
+        assert summary["total_tvd"] < summary["total_depth"]
+        assert summary["max_dls"] > 0.0
+        assert summary["max_dls_depth"] == pytest.approx(200.0)
+        assert len(survey) == 5
+        assert survey["tvd"].iloc[-1] < survey["md"].iloc[-1]
+        assert survey["dls"].iloc[2] > 0.0
     elif workflow["id"] == "rop-analysis":
         result = cfg["rop_analysis"]["result"]
         by = result["bourgoyne_young"]
@@ -651,3 +679,80 @@ def test_workflow_registry(workflow):
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:
         raise AssertionError(f"Missing workflow assertion for {workflow['id']}")
+
+
+def test_wellpath_minimum_curvature_textbook_case(tmp_path):
+    input_path = tmp_path / "wellpath.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "wellpath",
+                "wellpath": {
+                    "stations": [
+                        {
+                            "measured_depth_m": 0.0,
+                            "inclination_deg": 0.0,
+                            "azimuth_deg": 0.0,
+                        },
+                        {
+                            "measured_depth_m": 100.0,
+                            "inclination_deg": 30.0,
+                            "azimuth_deg": 0.0,
+                        },
+                    ],
+                    "output_dir": "results",
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    cfg = engine(inputfile=str(input_path))
+    survey = pd.read_csv(tmp_path / "results" / "wellpath_wellpath.csv")
+
+    assert cfg["wellpath"]["total_depth"] == pytest.approx(100.0)
+    assert survey.loc[1, "tvd"] == pytest.approx(95.4929658551)
+    assert survey.loc[1, "north"] == pytest.approx(25.5872630837)
+    assert survey.loc[1, "east"] == pytest.approx(0.0, abs=1.0e-12)
+    assert survey.loc[1, "dls"] == pytest.approx(9.0)
+
+
+def test_wave_spectrum_pierson_moskowitz_engine_textbook_check(tmp_path):
+    input_path = tmp_path / "wave_spectrum.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "wave_spectrum",
+                "wave_spectrum": {
+                    "spectrum": "pierson_moskowitz",
+                    "Hs": 2.5,
+                    "Tp": 8.0,
+                    "frequency_grid": {
+                        "units": "rad_s",
+                        "start": 0.2,
+                        "stop": 2.5,
+                        "num": 231,
+                    },
+                    "output_dir": "results",
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    cfg = engine(inputfile=str(input_path))
+    spectrum = pd.read_csv(tmp_path / "results" / "wave_spectrum_spectrum.csv")
+    omega_p = 2.0 * math.pi / 8.0
+
+    assert cfg["wave_spectrum"]["spectrum"] == "pierson_moskowitz"
+    assert cfg["wave_spectrum"]["Hs_check"] == pytest.approx(2.5, rel=0.05)
+    assert cfg["wave_spectrum"]["peak_frequency"] == pytest.approx(omega_p, abs=0.02)
+    assert spectrum.loc[spectrum["S"].idxmax(), "frequency"] == pytest.approx(
+        cfg["wave_spectrum"]["peak_frequency"]
+    )


### PR DESCRIPTION
## Summary
Two new pure-python **offline** workflows (parallel-worktree batch).

- **`wellpath`** — directional survey via the **minimum-curvature method**: TVD, north, east, dogleg severity per station. Validated against a textbook RF case (RF=1.0235); example build-up well has TVD 377.6 < MD 400 with max DLS 4.5 deg/30m. New `src/digitalmodel/well/wellpath/`.
- **`wave_spectrum`** — **JONSWAP** + **Pierson-Moskowitz** wave energy spectra over a frequency grid; reports `m0` and `Hs_check = 4·√m0`. Example JONSWAP Hs=3.0/Tp=10 → Hs_check=3.0, peak 0.63 rad/s ≈ 2π/Tp. New `src/digitalmodel/hydrodynamics/wave_spectrum/`.

Each: thin router (cfg-in/CSV-out), base_config, offline example, registry row, durable assertions, inputfile-path unit test. `engine.py`: two fail-closed dispatch branches only. Durable suite: **58 passed + 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)