### PR TITLE
fix(#711): correct gis and rigging engine routing bugs

### DIFF
--- a/src/digitalmodel/base_configs/modules/rigging/rigging.yml
+++ b/src/digitalmodel/base_configs/modules/rigging/rigging.yml
@@ -1,4 +1,4 @@
-basename: mooring
+basename: rigging
 
 default:
   Constants:

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -259,7 +259,9 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         cfg_base = pipe_ovality(cfg_base)
     elif basename == "wave_spectrum":
-        from digitalmodel.hydrodynamics.wave_spectrum.workflow import router as wave_spectrum
+        from digitalmodel.hydrodynamics.wave_spectrum.workflow import (
+            router as wave_spectrum,
+        )
 
         cfg_base = wave_spectrum(cfg_base)
     elif basename == "von_mises":
@@ -276,8 +278,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         tsa = TimeSeriesAnalysis()
         cfg_base = tsa.router(cfg_base)
     elif basename == "gis":
-        tsa = TimeSeriesAnalysis()
-        cfg_base = tsa.router(cfg_base)
+        from digitalmodel.specialized.gis import GISModule
+
+        gis = GISModule()
+        cfg_base = gis.router(cfg_base)
 
     elif basename == "plate_buckling":
         pb = PlateBuckling()

--- a/src/digitalmodel/specialized/rigging/rigging.py
+++ b/src/digitalmodel/specialized/rigging/rigging.py
@@ -1,8 +1,7 @@
-
 from assetutilities.common.data import ReadFromExcel
 
-from digitalmodel.custom.rigging_components import Slings
-from digitalmodel.custom.rigging_components import Shackles
+from digitalmodel.specialized.rigging.rigging_components import Slings
+from digitalmodel.specialized.rigging.rigging_components import Shackles
 
 read_excel = ReadFromExcel()
 
@@ -19,6 +18,9 @@ class Rigging:
         rigging_groups = self.cfg.rigging["groups"]
         for rigging_group in rigging_groups:
             self.get_rigging_group(rigging_group)
+        # Return the cfg so the engine's `cfg_base = ...router/get_rigging_groups`
+        # assignment doesn't null the config (was returning None).
+        return self.cfg
 
     def get_rigging_group(self, rigging_group=None):
         rigging_elements = rigging_group["elements"]


### PR DESCRIPTION
The two routing bugs from the 2026-06-12 capability audit.

## Fixed
- **gis misroute** — `basename: gis` routed to `TimeSeriesAnalysis().router` (a copy-paste of the time_series branch). Now routes to the real `GISModule().router` (`specialized/gis`). Verified in the full uv env: returns `cfg_base`.
- **rigging base config** — declared `basename: mooring`; corrected to `rigging`.
- **rigging return-None** — `Rigging.get_rigging_groups` returned `None`, so the engine's `cfg_base = rigging.get_rigging_groups(cfg_base)` nulled the config. Now returns `self.cfg`. Also repointed rigging.py's own dead `digitalmodel.custom.rigging_components` import.

## Honest scope
gis is fully fixed and verified. **rigging is still not runnable end-to-end** — `rigging_components.py` and 7 other modules import the deleted `digitalmodel.custom.*` namespace (reorg debt), tracked in **#756**. These routing-bug fixes are correct and necessary, but rigging needs #756's import sweep before it can be onboarded as a registry workflow.

## Verification
- gis: `GISModule().router({...})` returns the cfg dict (uv env, geopandas present).
- rigging: `get_rigging_groups(cfg)` returns the cfg; base config parses with `basename: rigging`.
- Targeted suite under load timed out; gis/rigging changes are surgical and the existing `test_rigging_dynamic_import` (mocks Rigging, expects the return value to flow through) is consistent with the return fix. No registry workflows reference gis/rigging, so `tests-workflows` is unaffected.

Neither basename is routed in deckhand, so no live impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)