### PR TITLE
fix(hydro): KramersKronig bool, cubic-interp fallback, seaborn-free heatmap

### DIFF
--- a/src/digitalmodel/marine_ops/marine_analysis/hydrodynamic_coefficients/coefficients.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/hydrodynamic_coefficients/coefficients.py
@@ -123,7 +123,7 @@ class KramersKronigValidator:
             relative_error = np.abs((B - damping_reconstructed) / (B + 1e-10))
 
         max_error = np.max(relative_error[~np.isnan(relative_error)])
-        is_valid = max_error < tolerance
+        is_valid = bool(max_error < tolerance)
 
         return is_valid, max_error
 
@@ -217,6 +217,8 @@ class CoefficientDatabase:
         if self._interpolators_built:
             return
 
+        interp_kind = 'cubic' if len(self.frequencies) >= 4 else 'linear'
+
         # Build interpolators for each DOF pair
         for i in range(6):
             for j in range(6):
@@ -228,7 +230,7 @@ class CoefficientDatabase:
                 self._interpolators_added_mass[(i, j)] = interp1d(
                     self.frequencies,
                     added_mass_values,
-                    kind='cubic',
+                    kind=interp_kind,
                     bounds_error=False,
                     fill_value='extrapolate'
                 )
@@ -241,7 +243,7 @@ class CoefficientDatabase:
                 self._interpolators_damping[(i, j)] = interp1d(
                     self.frequencies,
                     damping_values,
-                    kind='cubic',
+                    kind=interp_kind,
                     bounds_error=False,
                     fill_value='extrapolate'
                 )

--- a/src/digitalmodel/marine_ops/marine_analysis/hydrodynamic_coefficients/plotting.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/hydrodynamic_coefficients/plotting.py
@@ -536,9 +536,13 @@ class HydrodynamicPlotter:
         # Plot correlation heatmap
         fig, ax = plt.subplots(figsize=figsize)
 
-        sns.heatmap(corr_matrix, annot=False, cmap='coolwarm', center=0,
-                   square=True, linewidths=0.5, cbar_kws={"shrink": 0.8},
-                   ax=ax, vmin=-1, vmax=1)
+        corr_values = np.nan_to_num(corr_matrix.to_numpy(dtype=float), nan=0.0)
+        im = ax.imshow(corr_values, cmap='coolwarm', vmin=-1, vmax=1, aspect='equal')
+        ax.set_xticks(range(len(corr_matrix.columns)))
+        ax.set_yticks(range(len(corr_matrix.index)))
+        ax.set_xticklabels(corr_matrix.columns, rotation=90, fontsize=6)
+        ax.set_yticklabels(corr_matrix.index, fontsize=6)
+        plt.colorbar(im, ax=ax, shrink=0.8)
 
         title = f'Coefficient Correlation Matrix - {coefficient_type.replace("_", " ").title()}'
         ax.set_title(title, fontsize=14, fontweight='bold', pad=15)

--- a/src/digitalmodel/marine_ops/marine_engineering/hydrodynamic_coefficients/coefficients.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/hydrodynamic_coefficients/coefficients.py
@@ -123,7 +123,7 @@ class KramersKronigValidator:
             relative_error = np.abs((B - damping_reconstructed) / (B + 1e-10))
 
         max_error = np.max(relative_error[~np.isnan(relative_error)])
-        is_valid = max_error < tolerance
+        is_valid = bool(max_error < tolerance)
 
         return is_valid, max_error
 
@@ -217,6 +217,8 @@ class CoefficientDatabase:
         if self._interpolators_built:
             return
 
+        interp_kind = 'cubic' if len(self.frequencies) >= 4 else 'linear'
+
         # Build interpolators for each DOF pair
         for i in range(6):
             for j in range(6):
@@ -228,7 +230,7 @@ class CoefficientDatabase:
                 self._interpolators_added_mass[(i, j)] = interp1d(
                     self.frequencies,
                     added_mass_values,
-                    kind='cubic',
+                    kind=interp_kind,
                     bounds_error=False,
                     fill_value='extrapolate'
                 )
@@ -241,7 +243,7 @@ class CoefficientDatabase:
                 self._interpolators_damping[(i, j)] = interp1d(
                     self.frequencies,
                     damping_values,
-                    kind='cubic',
+                    kind=interp_kind,
                     bounds_error=False,
                     fill_value='extrapolate'
                 )

--- a/src/digitalmodel/marine_ops/marine_engineering/hydrodynamic_coefficients/plotting.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/hydrodynamic_coefficients/plotting.py
@@ -536,9 +536,13 @@ class HydrodynamicPlotter:
         # Plot correlation heatmap
         fig, ax = plt.subplots(figsize=figsize)
 
-        sns.heatmap(corr_matrix, annot=False, cmap='coolwarm', center=0,
-                   square=True, linewidths=0.5, cbar_kws={"shrink": 0.8},
-                   ax=ax, vmin=-1, vmax=1)
+        corr_values = np.nan_to_num(corr_matrix.to_numpy(dtype=float), nan=0.0)
+        im = ax.imshow(corr_values, cmap='coolwarm', vmin=-1, vmax=1, aspect='equal')
+        ax.set_xticks(range(len(corr_matrix.columns)))
+        ax.set_yticks(range(len(corr_matrix.index)))
+        ax.set_xticklabels(corr_matrix.columns, rotation=90, fontsize=6)
+        ax.set_yticklabels(corr_matrix.index, fontsize=6)
+        plt.colorbar(im, ax=ax, shrink=0.8)
 
         title = f'Coefficient Correlation Matrix - {coefficient_type.replace("_", " ").title()}'
         ax.set_title(title, fontsize=14, fontweight='bold', pad=15)

--- a/tests/marine_ops/marine_engineering/integration/test_hydro_rao_integration.py
+++ b/tests/marine_ops/marine_engineering/integration/test_hydro_rao_integration.py
@@ -238,8 +238,10 @@ class TestHydroRAOIntegration:
         mass = 50000e3
         stiffness = 5e6
 
-        frequencies = np.linspace(0.3, 1.2, 100)
+        frequencies = np.linspace(0.2, 1.2, 120)
         phases = []
+        undamped_phases = []
+        dynamic_stiffness = []
 
         for omega in frequencies:
             A_heave = db.get_added_mass(omega, 'Heave', 'Heave')
@@ -247,23 +249,30 @@ class TestHydroRAOIntegration:
 
             total_mass = mass + A_heave
 
-            # Phase angle: φ = arctan(ωB / (k - ω²m))
+            # Response phase is the phase of 1 / (k - omega^2 m + i omega B).
             numerator = omega * B_heave
             denominator = stiffness - omega**2 * total_mass
 
-            phase = np.arctan2(numerator, denominator)
-            phases.append(np.degrees(phase))
+            phase = -np.degrees(np.arctan2(numerator, denominator))
+            undamped_phase = -np.degrees(np.arctan2(0.0, denominator))
+            phases.append(phase)
+            undamped_phases.append(undamped_phase)
+            dynamic_stiffness.append(denominator)
 
         phases = np.array(phases)
+        undamped_phases = np.array(undamped_phases)
+        dynamic_stiffness = np.array(dynamic_stiffness)
 
         # Phase should transition through -90° at resonance
         # Below resonance: phase ≈ 0°
         # At resonance: phase ≈ -90°
         # Above resonance: phase ≈ -180°
 
-        min_phase_idx = np.argmin(phases)
-        assert -120 <= phases[min_phase_idx] <= -60, \
-            f"Phase at resonance {phases[min_phase_idx]:.1f}° should be near -90°"
+        resonance_idx = np.argmin(np.abs(dynamic_stiffness))
+        assert -120 <= phases[resonance_idx] <= -60, \
+            f"Phase at resonance {phases[resonance_idx]:.1f}° should be near -90°"
+        assert abs(phases[resonance_idx] - undamped_phases[resonance_idx]) > 20, \
+            "Radiation damping should shift response phase near resonance"
 
         # Create phase chart
         fig, ax = plt.subplots(figsize=(10, 6))
@@ -296,14 +305,28 @@ class TestHydroRAOIntegration:
         # Coupling term should be non-zero
         assert abs(A_heave_pitch) > 0, "Heave-pitch coupling should be non-zero"
 
-        # Coupling should be smaller than diagonal terms
-        A_heave_heave = db.get_added_mass(freq_test, 'Heave', 'Heave')
-        A_pitch_pitch = db.get_added_mass(freq_test, 'Pitch', 'Pitch')
+        # Coupling terms should change the solved response versus diagonal-only.
+        omega = freq_test
+        mass_matrix = np.diag([50000e3, 2.5e6])
+        stiffness_matrix = np.diag([5e6, 5e5])
 
-        assert abs(A_heave_pitch) < abs(A_heave_heave), \
-            "Coupling term should be smaller than diagonal term"
-        assert abs(A_heave_pitch) < abs(A_pitch_pitch), \
-            "Coupling term should be smaller than diagonal term"
+        A_coupled = db.get_added_mass_matrix(freq_test)[np.ix_([2, 4], [2, 4])]
+        B_coupled = db.get_damping_matrix(freq_test)[np.ix_([2, 4], [2, 4])]
+        A_diagonal = np.diag(np.diag(A_coupled))
+        B_diagonal = np.diag(np.diag(B_coupled))
+
+        excitation = np.array([1.0, 0.0], dtype=complex)
+        response_coupled = np.linalg.solve(
+            stiffness_matrix - omega**2 * (mass_matrix + A_coupled) + 1j * omega * B_coupled,
+            excitation,
+        )
+        response_diagonal = np.linalg.solve(
+            stiffness_matrix - omega**2 * (mass_matrix + A_diagonal) + 1j * omega * B_diagonal,
+            excitation,
+        )
+
+        assert not np.allclose(response_coupled, response_diagonal), \
+            "Off-diagonal hydrodynamic coupling should change the solved response"
 
     def test_full_matrix_interpolation(self, sample_database, output_dir):
         """Test interpolation of full 6×6 matrices."""
@@ -323,12 +346,26 @@ class TestHydroRAOIntegration:
         assert np.allclose(B_matrix, B_matrix.T, rtol=1e-3), \
             "Damping matrix should be symmetric"
 
-        # Check diagonal dominance (diagonal > off-diagonal)
+        # Full-matrix interpolation should be consistent with every scalar DOF-pair lookup.
         for i in range(6):
             for j in range(6):
-                if i != j:
-                    assert abs(A_matrix[i, i]) > abs(A_matrix[i, j]), \
-                        f"Added mass should be diagonally dominant at ({i},{j})"
+                assert A_matrix[i, j] == pytest.approx(db.get_added_mass(freq_test, i, j))
+                assert B_matrix[i, j] == pytest.approx(db.get_damping(freq_test, i, j))
+
+        # At tabulated frequencies, interpolation must reproduce the stored matrices exactly.
+        node_freq = 0.8
+        np.testing.assert_allclose(
+            db.get_added_mass_matrix(node_freq),
+            db.added_mass_matrices[node_freq].matrix,
+            rtol=1e-12,
+            atol=1e-6,
+        )
+        np.testing.assert_allclose(
+            db.get_damping_matrix(node_freq),
+            db.damping_matrices[node_freq].matrix,
+            rtol=1e-12,
+            atol=1e-6,
+        )
 
         # Create heatmap visualization
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))


### PR DESCRIPTION
## Summary
Parallel fix-pass (stream 3). Real bugs from the #755 finding.

**Production fixes** (`hydrodynamic_coefficients/coefficients.py`, mirrored in both `marine_analysis` and `marine_engineering` copies):
- KramersKronig validator returned `numpy.bool_` → now `bool(max_error < tolerance)`.
- Interpolation requested scipy `'cubic'` unconditionally, but cubic needs ≥4 nodes → **fall back to `'linear'` when fewer** (root cause of the full-matrix interpolation failure).
- `plotting.py` (both copies): replaced the seaborn heatmap with a matplotlib `imshow` equivalent (removes the optional seaborn dependency / regression).

**Test physics corrections** (`test_hydro_rao_integration.py`): phase from the response of `1/(k − ω²m + iωB)`; coupled vs diagonal-only response; full-matrix interpolation now verifies every DOF pair + exact table-node recovery.

**73 passed** (hydro-RAO integration + hydro coefficients + BEMRosetta validators). Regenerated chart PNGs excluded (test artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)