### PR TITLE
fix(catenary): correct general 2D catenary solver (18 mooring failures)

### DIFF
--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/solver.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/solver.py
@@ -24,8 +24,7 @@ Author: Digital Model Project
 from dataclasses import dataclass
 from typing import Optional, Tuple
 import numpy as np
-from scipy.optimize import fsolve, brentq
-import warnings
+from scipy.optimize import brentq
 
 
 @dataclass
@@ -108,112 +107,116 @@ class CatenarySolver:
         if params.length < straight_dist:
             raise ValueError(f"Length {params.length}m < straight distance {straight_dist:.2f}m")
 
-        # Solve for H and geometry
-        H_solution, converged, iterations = self._solve_general_catenary(params)
+        # Solve for H and signed low-point geometry.
+        H_solution, u_anchor, u_fairlead, converged, iterations = (
+            self._solve_general_catenary(params)
+        )
 
         # Compute all results
-        return self._compute_results(params, H_solution, converged, iterations)
+        return self._compute_results(
+            params, H_solution, u_anchor, u_fairlead, converged, iterations
+        )
 
-    def _solve_general_catenary(self, params: CatenaryInput) -> Tuple[float, bool, int]:
+    def _solve_general_catenary(
+        self, params: CatenaryInput
+    ) -> Tuple[float, float, float, bool, int]:
         """
-        Solve general catenary BVP for H, x1, x2.
+        Solve the general catenary BVP for H and endpoint positions.
 
-        Uses system of 3 equations:
-        1. x2 - x1 = X (horizontal span)
-        2. h2 - h1 = Y (vertical span)
-        3. s2 - s1 + elongation = L (length)
+        Coordinates are signed distances from the catenary low point. This
+        allows the low point to lie left of the anchor, between endpoints, or
+        right of the fairlead.
 
-        Where:
-          x1, x2 = horizontal distances from low point to anchor/fairlead
-          h1, h2 = heights above low point at anchor/fairlead
-          s1, s2 = arc lengths from low point to anchor/fairlead
+        Midpoint identities reduce the geometry to a one-variable solve in
+        ``a = H / w``. When elastic stretch creates a second very high-tension
+        root, the first bracketed root is the physically relevant sagging line.
 
         Returns
         -------
         H : float
             Horizontal tension
+        u_anchor : float
+            Signed coordinate of the anchor from the low point.
+        u_fairlead : float
+            Signed coordinate of the fairlead from the low point.
         converged : bool
             Convergence flag
         iterations : int
             Number of iterations
         """
+        scale = max(
+            params.length,
+            params.horizontal_span,
+            abs(params.vertical_span),
+            1.0
+        )
+        a_low = max(scale * 1e-3, 1e-9)
+        f_low = self._length_error_for_a(a_low, params)
+        iterations = 1
+        while np.isfinite(f_low) and f_low < 0.0:
+            a_low *= 0.5
+            f_low = self._length_error_for_a(a_low, params)
+            iterations += 1
 
-        def system_equations(vars):
-            """System of equations for catenary BVP."""
-            H, x1, x2 = vars
+        a_high = a_low
+        f_high = f_low
+        for _ in range(max(self.max_iterations, 200)):
+            a_high *= 2.0
+            f_high = self._length_error_for_a(a_high, params)
+            iterations += 1
+            if np.isfinite(f_low) and np.isfinite(f_high) and f_low * f_high <= 0:
+                break
+            a_low = a_high
+            f_low = f_high
+        else:
+            raise ValueError("Failed to bracket catenary solution")
 
-            if H <= 0 or x1 < 0 or x2 <= x1:
-                return [1e10, 1e10, 1e10]
-
-            a = H / params.weight_per_length
-
-            # Catenary equations from low point
-            h1 = a * np.cosh(x1 / a)
-            h2 = a * np.cosh(x2 / a)
-            s1 = a * np.sinh(x1 / a)
-            s2 = a * np.sinh(x2 / a)
-
-            # Elongation (use average tension approximation)
-            # More accurate would integrate tension along line
-            T_avg = H  # Conservative: use horizontal tension
-            elongation = T_avg * params.length / params.ea_stiffness
-
-            # System of equations
-            eq1 = (x2 - x1) - params.horizontal_span
-            eq2 = (h2 - h1) - params.vertical_span
-            eq3 = (s2 - s1 + elongation) - params.length
-
-            return [eq1, eq2, eq3]
-
-        # Initial guess strategy
-        # For mooring: low point typically below anchor
-        # Estimate x1 from sag: for small angles, x1 ≈ sqrt(2*a*h1)
-        # Where h1 (height of anchor above low point) relates to sag
-
-        # Simple heuristic:  start with x1 ≈ L/4, x2 ≈ x1 + X
-        x1_guess = params.length / 4
-        x2_guess = x1_guess + params.horizontal_span
-
-        # Estimate H from geometry
-        # For catenary: a ≈ L² / (8 * max_sag) for parabolic approximation
-        # Assume max_sag ≈ (L - X) (excess length drops as sag)
-        sag_estimate = max(params.length - params.horizontal_span, 10)
-        a_estimate = params.horizontal_span**2 / (8 * sag_estimate)
-        H_guess = params.weight_per_length * a_estimate
-
-        initial_guess = [H_guess, x1_guess, x2_guess]
-
-        # Solve using fsolve
-        try:
-            solution = fsolve(
-                system_equations,
-                initial_guess,
-                full_output=True,
-                xtol=self.tolerance
-            )
-
-            vars_sol, info, ier, msg = solution
-
-            if ier == 1:
-                H_sol = vars_sol[0]
-                converged = True
-                iterations = info['nfev']
-
-                # Verify solution is physical
-                if H_sol > 0:
-                    return H_sol, converged, iterations
-
-        except:
-            pass
-
-        # If fsolve failed, try simpler 1D approach
-        # Assume low point at anchor (x1=0), solve for H only
-        warnings.warn(
-            "General catenary BVP failed to converge. Using simplified formulation with low point at anchor.",
-            UserWarning
+        root, result = brentq(
+            lambda a: self._length_error_for_a(a, params),
+            a_low,
+            a_high,
+            xtol=self.tolerance,
+            maxiter=self.max_iterations,
+            full_output=True
         )
 
-        return self._solve_simplified(params)
+        _, u_anchor, u_fairlead = self._geometry_for_a(root, params)
+        H_sol = root * params.weight_per_length
+        return (
+            H_sol,
+            u_anchor,
+            u_fairlead,
+            result.converged,
+            iterations + result.iterations
+        )
+
+    def _length_error_for_a(self, a: float, params: CatenaryInput) -> float:
+        """Return length error for a catenary parameter."""
+        arc_length, _, _ = self._geometry_for_a(a, params)
+        if not np.isfinite(arc_length):
+            return np.inf
+
+        horizontal_tension = a * params.weight_per_length
+        elongation = horizontal_tension * params.length / params.ea_stiffness
+        return arc_length + elongation - params.length
+
+    def _geometry_for_a(
+        self, a: float, params: CatenaryInput
+    ) -> Tuple[float, float, float]:
+        """Return arc length and signed endpoint coordinates for ``a``."""
+        half_span_over_a = params.horizontal_span / (2.0 * a)
+        if half_span_over_a > 350.0:
+            return np.inf, -np.inf, np.inf
+
+        sinh_half_span = np.sinh(half_span_over_a)
+        midpoint_sinh = params.vertical_span / (2.0 * a * sinh_half_span)
+        midpoint = np.arcsinh(midpoint_sinh)
+        midpoint_cosh = np.sqrt(1.0 + midpoint_sinh**2)
+
+        arc_length = 2.0 * a * midpoint_cosh * sinh_half_span
+        u_anchor = a * (midpoint - half_span_over_a)
+        u_fairlead = a * (midpoint + half_span_over_a)
+        return arc_length, u_anchor, u_fairlead
 
     def _solve_simplified(self, params: CatenaryInput) -> Tuple[float, bool, int]:
         """
@@ -273,18 +276,20 @@ class CatenarySolver:
         self,
         params: CatenaryInput,
         H: float,
+        u_anchor: float,
+        u_fairlead: float,
         converged: bool,
         iterations: int
     ) -> CatenaryResults:
         """Compute all catenary results from solved H."""
 
         a = H / params.weight_per_length
-        X = params.horizontal_span
 
-        # Tensions (assuming low point at or near anchor)
-        V_fairlead = H * np.sinh(X / a)
+        # Endpoint tensions from signed low-point coordinates.
+        V_fairlead = H * np.sinh(u_fairlead / a)
+        V_anchor = H * np.sinh(u_anchor / a)
         T_fairlead = np.sqrt(H**2 + V_fairlead**2)
-        T_anchor = H  # At low point, V=0
+        T_anchor = np.sqrt(H**2 + V_anchor**2)
 
         # Elongation
         elongation = H * params.length / params.ea_stiffness
@@ -292,17 +297,24 @@ class CatenarySolver:
         # Touchdown
         touchdown = None
         if params.water_depth is not None:
-            arg = params.water_depth / a + 1
-            if arg > 1.0:
-                touchdown = a * np.arccosh(arg)
+            target = params.water_depth / a + np.cosh(u_anchor / a)
+            if target >= 1.0:
+                root = a * np.arccosh(target)
+                candidates = []
+                for u_touchdown in (-root, root):
+                    if u_anchor <= u_touchdown <= u_fairlead:
+                        candidates.append(u_touchdown - u_anchor)
+                touchdown = min(candidates) if candidates else None
 
         # Line shape
         n_points = 100
-        x = np.linspace(0, X, n_points)
-        y = a * (np.cosh(x / a) - 1)
+        u = np.linspace(u_anchor, u_fairlead, n_points)
+        x = u - u_anchor
+        y = a * (np.cosh(u / a) - np.cosh(u_anchor / a))
 
         # Tension distribution
-        tension_dist = np.sqrt(H**2 + (H * np.sinh(x / a))**2)
+        vertical_tension = H * np.sinh(u / a)
+        tension_dist = np.sqrt(H**2 + vertical_tension**2)
 
         return CatenaryResults(
             horizontal_tension=H,

--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/utils.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/utils.py
@@ -35,17 +35,17 @@ def safe_sinh(x: Union[float, np.ndarray], max_arg: float = 700.0) -> Union[floa
         mask_large_neg = x < -max_arg
 
         result[mask_small] = np.sinh(x[mask_small])
-        result[mask_large_pos] = np.exp(x[mask_large_pos]) / 2.0
-        result[mask_large_neg] = -np.exp(-x[mask_large_neg]) / 2.0
+        result[mask_large_pos] = np.finfo(float).max
+        result[mask_large_neg] = -np.finfo(float).max
 
         return result
     else:
         if abs(x) <= max_arg:
             return np.sinh(x)
         elif x > 0:
-            return np.exp(x) / 2.0
+            return np.finfo(float).max
         else:
-            return -np.exp(-x) / 2.0
+            return -np.finfo(float).max
 
 
 def safe_cosh(x: Union[float, np.ndarray], max_arg: float = 700.0) -> Union[float, np.ndarray]:
@@ -73,14 +73,14 @@ def safe_cosh(x: Union[float, np.ndarray], max_arg: float = 700.0) -> Union[floa
         mask_large = np.abs(x) > max_arg
 
         result[mask_small] = np.cosh(x[mask_small])
-        result[mask_large] = np.exp(np.abs(x[mask_large])) / 2.0
+        result[mask_large] = np.finfo(float).max
 
         return result
     else:
         if abs(x) <= max_arg:
             return np.cosh(x)
         else:
-            return np.exp(abs(x)) / 2.0
+            return np.finfo(float).max
 
 
 def validate_catenary_inputs(

--- a/tests/marine_ops/marine_engineering/legacy/test_mooring_catenary.py
+++ b/tests/marine_ops/marine_engineering/legacy/test_mooring_catenary.py
@@ -238,6 +238,23 @@ class CatenarySolver:
             return 0.0  # Line doesn't reach seabed
 
 
+from digitalmodel.marine_ops.marine_analysis.catenary.solver import (  # noqa: E402
+    CatenaryInput,
+    CatenaryResults,
+    CatenarySolver,
+)
+
+
+def _signed_anchor_coordinate(a: float, params: CatenaryInput) -> float:
+    """Return anchor coordinate from the catenary low point."""
+    half_span_over_a = params.horizontal_span / (2.0 * a)
+    midpoint_sinh = params.vertical_span / (
+        2.0 * a * np.sinh(half_span_over_a)
+    )
+    midpoint = np.arcsinh(midpoint_sinh)
+    return a * (midpoint - half_span_over_a)
+
+
 # ============================================================================
 # TEST SUITE
 # ============================================================================
@@ -254,12 +271,12 @@ class TestCatenarySolver:
         """
         Test Case 1: Single Chain Segment (Excel "Poly Mooring" reference)
 
-        Excel Reference Values:
+        Closed-form general catenary values for the stated inputs:
         - Input: L=1000m, span=800m, w=1962 N/m, EA=64e9 N
-        - Expected H_tension ≈ 785,000 N (±1% tolerance)
-        - Expected V_tension ≈ 196,200 N
-        - Expected Total_tension ≈ 809,000 N
-        - Expected elongation ≈ 12.3 m
+        - Expected H_tension ≈ 671,495 N (±1% tolerance)
+        - Expected V_tension ≈ 1,100,062 N
+        - Expected Total_tension ≈ 1,288,814 N
+        - Expected elongation ≈ 0.0105 m
         """
         params = CatenaryInput(
             length=1000,
@@ -274,33 +291,41 @@ class TestCatenarySolver:
         # Validate convergence
         assert results.converged, "Solver failed to converge"
 
-        # Excel reference values with ±1% tolerance
-        excel_H_tension = 785_000  # N
-        excel_V_tension = 196_200  # N
-        excel_total_tension = 809_000  # N
-        excel_elongation = 12.3  # m
+        expected_H_tension = 671_494.5846  # N
+        expected_V_tension = 1_100_062.3837  # N
+        expected_total_tension = 1_288_814.2710  # N
+        expected_elongation = 0.0104921029  # m
 
         # Horizontal tension validation (±1%)
-        H_error = abs(results.horizontal_tension - excel_H_tension) / excel_H_tension
+        H_error = (
+            abs(results.horizontal_tension - expected_H_tension)
+            / expected_H_tension
+        )
         assert H_error < 0.01, (
             f"Horizontal tension error {H_error*100:.2f}% exceeds 1% tolerance. "
-            f"Got {results.horizontal_tension:.0f} N, expected {excel_H_tension:.0f} N"
+            f"Got {results.horizontal_tension:.0f} N, expected {expected_H_tension:.0f} N"
         )
 
         # Vertical tension validation (±1%)
-        V_error = abs(results.vertical_tension_fairlead - excel_V_tension) / excel_V_tension
+        V_error = (
+            abs(results.vertical_tension_fairlead - expected_V_tension)
+            / expected_V_tension
+        )
         assert V_error < 0.01, (
             f"Vertical tension error {V_error*100:.2f}% exceeds 1% tolerance"
         )
 
         # Total tension validation (±1%)
-        T_error = abs(results.total_tension_fairlead - excel_total_tension) / excel_total_tension
+        T_error = (
+            abs(results.total_tension_fairlead - expected_total_tension)
+            / expected_total_tension
+        )
         assert T_error < 0.01, (
             f"Total tension error {T_error*100:.2f}% exceeds 1% tolerance"
         )
 
         # Elongation validation (±5% - more tolerance due to EA uncertainty)
-        E_error = abs(results.elongation - excel_elongation) / excel_elongation
+        E_error = abs(results.elongation - expected_elongation) / expected_elongation
         assert E_error < 0.05, (
             f"Elongation error {E_error*100:.2f}% exceeds 5% tolerance"
         )
@@ -317,20 +342,22 @@ class TestCatenarySolver:
 
         results = solver.solve(params)
 
-        # Tension should be minimum at anchor (horizontal only)
+        # Tension should match the endpoint totals.
         assert results.tension_distribution[0] == pytest.approx(
             results.total_tension_anchor, rel=1e-6
         )
-
-        # Tension should be maximum at fairlead
         assert results.tension_distribution[-1] == pytest.approx(
             results.total_tension_fairlead, rel=1e-6
         )
 
-        # Tension should increase monotonically
-        assert np.all(np.diff(results.tension_distribution) >= 0), (
-            "Tension distribution is not monotonically increasing"
+        # For this geometry the low point lies between endpoints.
+        min_index = int(np.argmin(results.tension_distribution))
+        assert 0 < min_index < len(results.tension_distribution) - 1
+        assert results.tension_distribution[min_index] == pytest.approx(
+            results.horizontal_tension, rel=1e-4
         )
+        assert np.all(np.diff(results.tension_distribution[:min_index + 1]) <= 0)
+        assert np.all(np.diff(results.tension_distribution[min_index:]) >= 0)
 
     def test_catenary_parameter(self, solver):
         """Validate catenary parameter a = H/w calculation."""
@@ -367,10 +394,12 @@ class TestCatenarySolver:
         # Shape should end at horizontal span
         assert results.shape_x[-1] == pytest.approx(params.horizontal_span, rel=1e-6)
 
-        # Verify catenary equation: y(x) = a * (cosh(x/a) - 1)
+        # Verify general catenary equation from the signed low-point coordinate.
         a = results.catenary_parameter
+        u_anchor = _signed_anchor_coordinate(a, params)
         for x, y in zip(results.shape_x, results.shape_y):
-            expected_y = a * (np.cosh(x / a) - 1)
+            u = x + u_anchor
+            expected_y = a * (np.cosh(u / a) - np.cosh(u_anchor / a))
             assert y == pytest.approx(expected_y, rel=1e-6)
 
     def test_convergence_iterations(self, solver):
@@ -455,10 +484,8 @@ class TestCatenarySolver:
 
         results = solver.solve(params)
 
-        # Calculate center of mass elevation
-        # For catenary: y_cm = (1/L) ∫ y ds
-        # This is approximate - full calculation requires integration along arc
-        y_cm_approx = np.mean(results.shape_y)
+        # Potential energy is reference-level dependent; measure above low point.
+        y_cm_approx = np.mean(results.shape_y - np.min(results.shape_y))
 
         # Potential energy (approximate)
         PE = params.weight_per_length * params.length * y_cm_approx

--- a/tests/marine_ops/marine_engineering/test_catenary_adapter.py
+++ b/tests/marine_ops/marine_engineering/test_catenary_adapter.py
@@ -32,7 +32,7 @@ class TestCatenaryEquationForceMethod:
     def test_basic_force_calculation(self):
         """Test basic force-based calculation with known values."""
         data = {
-            "F": 10000.0,
+            "F": 100000.0,
             "w": 500.0,
             "d": 100.0,
             "X": None,
@@ -72,7 +72,7 @@ class TestCatenaryEquationForceMethod:
         """Test that results exactly match legacy implementation."""
         # These expected values come from running original catenaryMethods.py
         data = {
-            "F": 5000.0,
+            "F": 50000.0,
             "w": 250.0,
             "d": 50.0,
             "X": None,
@@ -102,9 +102,9 @@ class TestCatenaryEquationForceMethod:
     def test_force_method_multiple_scenarios(self):
         """Test force method with various parameter combinations."""
         test_cases = [
-            {"F": 15000.0, "w": 600.0, "d": 120.0},
-            {"F": 3000.0, "w": 150.0, "d": 30.0},
-            {"F": 50000.0, "w": 2000.0, "d": 200.0},
+            {"F": 150000.0, "w": 600.0, "d": 120.0},
+            {"F": 15000.0, "w": 150.0, "d": 30.0},
+            {"F": 500000.0, "w": 2000.0, "d": 200.0},
         ]
 
         for params in test_cases:
@@ -437,7 +437,7 @@ class TestIntegration:
         """Test using catenaryEquation then catenaryForces."""
         # First calculate catenary geometry
         catenary_data = {
-            "F": 8000.0,
+            "F": 80000.0,
             "w": 400.0,
             "d": 90.0,
             "X": None,

--- a/tests/marine_ops/marine_engineering/test_mooring_catenary.py
+++ b/tests/marine_ops/marine_engineering/test_mooring_catenary.py
@@ -238,6 +238,23 @@ class CatenarySolver:
             return 0.0  # Line doesn't reach seabed
 
 
+from digitalmodel.marine_ops.marine_analysis.catenary.solver import (  # noqa: E402
+    CatenaryInput,
+    CatenaryResults,
+    CatenarySolver,
+)
+
+
+def _signed_anchor_coordinate(a: float, params: CatenaryInput) -> float:
+    """Return anchor coordinate from the catenary low point."""
+    half_span_over_a = params.horizontal_span / (2.0 * a)
+    midpoint_sinh = params.vertical_span / (
+        2.0 * a * np.sinh(half_span_over_a)
+    )
+    midpoint = np.arcsinh(midpoint_sinh)
+    return a * (midpoint - half_span_over_a)
+
+
 # ============================================================================
 # TEST SUITE
 # ============================================================================
@@ -254,12 +271,12 @@ class TestCatenarySolver:
         """
         Test Case 1: Single Chain Segment (Excel "Poly Mooring" reference)
 
-        Excel Reference Values:
+        Closed-form general catenary values for the stated inputs:
         - Input: L=1000m, span=800m, w=1962 N/m, EA=64e9 N
-        - Expected H_tension ≈ 785,000 N (±1% tolerance)
-        - Expected V_tension ≈ 196,200 N
-        - Expected Total_tension ≈ 809,000 N
-        - Expected elongation ≈ 12.3 m
+        - Expected H_tension ≈ 671,495 N (±1% tolerance)
+        - Expected V_tension ≈ 1,100,062 N
+        - Expected Total_tension ≈ 1,288,814 N
+        - Expected elongation ≈ 0.0105 m
         """
         params = CatenaryInput(
             length=1000,
@@ -274,33 +291,41 @@ class TestCatenarySolver:
         # Validate convergence
         assert results.converged, "Solver failed to converge"
 
-        # Excel reference values with ±1% tolerance
-        excel_H_tension = 785_000  # N
-        excel_V_tension = 196_200  # N
-        excel_total_tension = 809_000  # N
-        excel_elongation = 12.3  # m
+        expected_H_tension = 671_494.5846  # N
+        expected_V_tension = 1_100_062.3837  # N
+        expected_total_tension = 1_288_814.2710  # N
+        expected_elongation = 0.0104921029  # m
 
         # Horizontal tension validation (±1%)
-        H_error = abs(results.horizontal_tension - excel_H_tension) / excel_H_tension
+        H_error = (
+            abs(results.horizontal_tension - expected_H_tension)
+            / expected_H_tension
+        )
         assert H_error < 0.01, (
             f"Horizontal tension error {H_error*100:.2f}% exceeds 1% tolerance. "
-            f"Got {results.horizontal_tension:.0f} N, expected {excel_H_tension:.0f} N"
+            f"Got {results.horizontal_tension:.0f} N, expected {expected_H_tension:.0f} N"
         )
 
         # Vertical tension validation (±1%)
-        V_error = abs(results.vertical_tension_fairlead - excel_V_tension) / excel_V_tension
+        V_error = (
+            abs(results.vertical_tension_fairlead - expected_V_tension)
+            / expected_V_tension
+        )
         assert V_error < 0.01, (
             f"Vertical tension error {V_error*100:.2f}% exceeds 1% tolerance"
         )
 
         # Total tension validation (±1%)
-        T_error = abs(results.total_tension_fairlead - excel_total_tension) / excel_total_tension
+        T_error = (
+            abs(results.total_tension_fairlead - expected_total_tension)
+            / expected_total_tension
+        )
         assert T_error < 0.01, (
             f"Total tension error {T_error*100:.2f}% exceeds 1% tolerance"
         )
 
         # Elongation validation (±5% - more tolerance due to EA uncertainty)
-        E_error = abs(results.elongation - excel_elongation) / excel_elongation
+        E_error = abs(results.elongation - expected_elongation) / expected_elongation
         assert E_error < 0.05, (
             f"Elongation error {E_error*100:.2f}% exceeds 5% tolerance"
         )
@@ -317,20 +342,22 @@ class TestCatenarySolver:
 
         results = solver.solve(params)
 
-        # Tension should be minimum at anchor (horizontal only)
+        # Tension should match the endpoint totals.
         assert results.tension_distribution[0] == pytest.approx(
             results.total_tension_anchor, rel=1e-6
         )
-
-        # Tension should be maximum at fairlead
         assert results.tension_distribution[-1] == pytest.approx(
             results.total_tension_fairlead, rel=1e-6
         )
 
-        # Tension should increase monotonically
-        assert np.all(np.diff(results.tension_distribution) >= 0), (
-            "Tension distribution is not monotonically increasing"
+        # For this geometry the low point lies between endpoints.
+        min_index = int(np.argmin(results.tension_distribution))
+        assert 0 < min_index < len(results.tension_distribution) - 1
+        assert results.tension_distribution[min_index] == pytest.approx(
+            results.horizontal_tension, rel=1e-4
         )
+        assert np.all(np.diff(results.tension_distribution[:min_index + 1]) <= 0)
+        assert np.all(np.diff(results.tension_distribution[min_index:]) >= 0)
 
     def test_catenary_parameter(self, solver):
         """Validate catenary parameter a = H/w calculation."""
@@ -367,10 +394,12 @@ class TestCatenarySolver:
         # Shape should end at horizontal span
         assert results.shape_x[-1] == pytest.approx(params.horizontal_span, rel=1e-6)
 
-        # Verify catenary equation: y(x) = a * (cosh(x/a) - 1)
+        # Verify general catenary equation from the signed low-point coordinate.
         a = results.catenary_parameter
+        u_anchor = _signed_anchor_coordinate(a, params)
         for x, y in zip(results.shape_x, results.shape_y):
-            expected_y = a * (np.cosh(x / a) - 1)
+            u = x + u_anchor
+            expected_y = a * (np.cosh(u / a) - np.cosh(u_anchor / a))
             assert y == pytest.approx(expected_y, rel=1e-6)
 
     def test_convergence_iterations(self, solver):
@@ -455,10 +484,8 @@ class TestCatenarySolver:
 
         results = solver.solve(params)
 
-        # Calculate center of mass elevation
-        # For catenary: y_cm = (1/L) ∫ y ds
-        # This is approximate - full calculation requires integration along arc
-        y_cm_approx = np.mean(results.shape_y)
+        # Potential energy is reference-level dependent; measure above low point.
+        y_cm_approx = np.mean(results.shape_y - np.min(results.shape_y))
 
         # Potential energy (approximate)
         PE = params.weight_per_length * params.length * y_cm_approx


### PR DESCRIPTION
## Summary
Parallel fix-pass (stream 1) — the largest cluster (18 failures). Real production bug in the mooring/catenary solver.

## Root cause
`catenary/solver.py` advertised a general 2D catenary BVP but effectively fell back to a low-point-at-anchor solve → vertical-span cases were wrong or non-converging (the convergence/overflow/speed failures). Rewrote with **signed low-point geometry**, **1D bracketing on a = H/w** (lower physical root), and endpoint tensions/shape from the same geometry. Overflow-saturated `safe_sinh/safe_cosh` in `utils.py`.

## Tests were testing a copy, not production
The two `test_mooring_catenary.py` files carried **copied test-local solver code** — they never exercised production. Rebound them to the production solver and corrected the stale expectations.

## Ground truth — independently verified
For L=1000, X=800, Y=100 m, w=1962 N/m, an independent from-scratch catenary BVP solve gives **a=342.24 m, H=671.5 kN, V_fairlead=1100.1 kN, T_fairlead=1288.8 kN** — matching the new solver to 4+ sig figs. The old `785 kN / 12.3 m` expectation was inconsistent with those inputs. Also fixed invalid adapter fixtures where `F/w ≤ d`.

**45 passed** (both mooring-catenary files + adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)