### PR TITLE
Scope repo-local agent memory (epic #3084)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,7 +1,7 @@
-# wt-digitalmodel — repo-scoped memory
+# digitalmodel — repo-scoped memory
 
 Session context for THIS repo only (epic #3084 context-flow backbone).
-Keep entries scoped to wt-digitalmodel; cross-repo facts stay in workspace-hub memory.
+Keep entries scoped to digitalmodel; cross-repo facts stay in workspace-hub memory.
 
 ## Project
 - (repo mission summary — see config/mission/mission-map.yaml in workspace-hub)

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,10 @@
+# wt-digitalmodel — repo-scoped memory
+
+Session context for THIS repo only (epic #3084 context-flow backbone).
+Keep entries scoped to wt-digitalmodel; cross-repo facts stay in workspace-hub memory.
+
+## Project
+- (repo mission summary — see config/mission/mission-map.yaml in workspace-hub)
+
+## Feedback
+- (none yet — repo-scoped feedback accrues here instead of the workspace-hub blob)

--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,7 @@ specs/
 examples/workflows/*/results/
 examples/workflows/*/logs/
 src/digitalmodel/base_configs/modules/*/logs/
+
+# epic #3084: keep repo-scoped agent memory tracked despite blanket memory/ rule
+!.claude/memory/
+!.claude/memory/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,4 @@ Plans: `.planning/` (long-duration: `docs/plans/`) | Specs: `specs/`
 
 ## Repo Overrides
 Add repo-specific rules below without weakening required gates.
+> Memory: read THIS repo's `.claude/memory/` first; consult workspace-hub memory only for cross-repo concerns


### PR DESCRIPTION
Part of workspace-hub epic #3078 / #3084. Adds .claude/memory/ + CLAUDE.md precedence line so this repo's agent sessions get clean, on-topic context instead of the workspace-hub blob. Generated by scripts/memory/scope-repo-memory.sh.