### PR TITLE
fix(fatigue): rainflow ASTM handling, CLI import surface, seastate tie-break, api contract

### DIFF
--- a/src/digitalmodel/structural/fatigue_apps/__main__.py
+++ b/src/digitalmodel/structural/fatigue_apps/__main__.py
@@ -28,10 +28,20 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 import json
+import numpy as np
 
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
+from digitalmodel.structural.fatigue_apps.fatigue_damage_calculator import (
+    FatigueDamageCalculator,
+)
+from digitalmodel.structural.fatigue_apps.integrated_processor import (
+    FatigueCondition as IntegratedFatigueCondition,
+    IntegratedFatigueProcessor,
+    ProductionDataHandler,
+    main as run_integrated_analysis,
+)
 from digitalmodel.structural.fatigue_apps.reference_seastate_processor import (
     ReferenceSeaStateProcessor,
     FatigueCondition,
@@ -257,11 +267,6 @@ def run_analysis(args):
     
     # Initialize processor
     try:
-        from .integrated_processor import (
-            IntegratedFatigueProcessor,
-            ProductionDataHandler
-        )
-        
         # Create data handler
         data_handler = ProductionDataHandler(
             base_path=data_path,
@@ -282,7 +287,6 @@ def run_analysis(args):
         
         # Override S-N curve if specified
         if args.sn_curve != 'ABS_E_AIR':
-            from .fatigue_damage_calculator import FatigueDamageCalculator
             processor.fatigue_calculator = FatigueDamageCalculator(
                 sn_curve=FatigueDamageCalculator.CURVES[args.sn_curve],
                 scf=args.scf,
@@ -297,8 +301,7 @@ def run_analysis(args):
             # Convert to FatigueCondition objects
             conditions = []
             for _, row in df.iterrows():
-                from .integrated_processor import FatigueCondition
-                conditions.append(FatigueCondition(
+                conditions.append(IntegratedFatigueCondition(
                     id=int(row.get('Row', len(conditions) + 1)),
                     wind_speed=float(row.get('Wind Speed (m/s)', 5.0)),
                     wind_dir=float(row.get('Wind Dir (°)', 0.0)),
@@ -345,9 +348,16 @@ def run_analysis(args):
         logging.info("\n" + "="*60)
         logging.info("STARTING FATIGUE ANALYSIS")
         logging.info("="*60)
-        
+
+        parallel_workers = getattr(args, 'parallel', 1)
+        if not isinstance(parallel_workers, int):
+            parallel_workers = 1
+        adaptive_processing = getattr(args, 'adaptive', False)
+        if not isinstance(adaptive_processing, bool):
+            adaptive_processing = False
+
         # Check if parallel processing is requested
-        if args.parallel and args.parallel > 1:
+        if parallel_workers > 1:
             # Use parallel processor
             from .parallel_processor import (
                 ParallelFatigueProcessor,
@@ -367,20 +377,20 @@ def run_analysis(args):
             )
             
             # Create appropriate parallel processor
-            if args.adaptive:
+            if adaptive_processing:
                 parallel_processor = AdaptiveParallelProcessor(
                     base_processor=base_processor,
-                    num_workers=args.parallel if args.parallel > 0 else None,
+                    num_workers=parallel_workers if parallel_workers > 0 else None,
                     show_progress=not args.verbose
                 )
                 logging.info("Using adaptive parallel processing")
             else:
                 parallel_processor = ParallelFatigueProcessor(
                     base_processor=base_processor,
-                    num_workers=args.parallel,
+                    num_workers=parallel_workers,
                     show_progress=not args.verbose
                 )
-                logging.info(f"Using parallel processing with {args.parallel} workers")
+                logging.info(f"Using parallel processing with {parallel_workers} workers")
             
             # Get configurations to process
             if config_list:
@@ -442,7 +452,7 @@ def run_analysis(args):
                 }
             
             # Save performance report
-            if args.parallel > 1:
+            if parallel_workers > 1:
                 parallel_processor.save_performance_report()
                 logging.info(f"Parallel processing metrics:")
                 logging.info(f"  Total tasks: {metrics['total_tasks']}")
@@ -453,8 +463,7 @@ def run_analysis(args):
             results = results_data
         else:
             # Use sequential processing (original method)
-            from .integrated_processor import main
-            results, summary = main(data_path)
+            results, summary = run_integrated_analysis(data_path)
         
         # Save results
         if results:

--- a/src/digitalmodel/structural/fatigue_apps/rainflow_counter.py
+++ b/src/digitalmodel/structural/fatigue_apps/rainflow_counter.py
@@ -63,15 +63,14 @@ class RainflowCounter:
         reversals, reversal_indices = self._extract_reversals(time_series)
         logger.debug(f"Extracted {len(reversals)} reversal points")
         
-        # Apply gate filter if specified
-        if self.gate_value is not None:
-            reversals, reversal_indices = self._apply_gate_filter(
-                reversals, reversal_indices
-            )
-            logger.debug(f"After gate filter: {len(reversals)} reversals remain")
-        
         # Perform rainflow counting
         self.cycles = self._rainflow_algorithm(reversals, reversal_indices)
+        if self.gate_value is not None:
+            self.cycles = [
+                cycle for cycle in self.cycles
+                if cycle.range_value >= self.gate_value
+            ]
+            logger.debug(f"After gate filter: {len(self.cycles)} cycles remain")
         logger.info(f"Identified {len(self.cycles)} cycles")
         
         # Convert to range-count format
@@ -176,65 +175,47 @@ class RainflowCounter:
         """
         cycles = []
         stack = []
-        
-        # Push first two reversals onto stack
-        for i in range(min(2, len(reversals))):
-            stack.append((reversals[i], indices[i]))
-        
-        # Process remaining reversals
-        for i in range(2, len(reversals)):
-            stack.append((reversals[i], indices[i]))
-            
-            # Check for cycles
+
+        for reversal, index in zip(reversals, indices):
+            stack.append((reversal, index))
+
             while len(stack) >= 3:
-                # Get last three points
-                X = abs(stack[-2][0] - stack[-1][0])  # Range X-Y
-                Y = abs(stack[-3][0] - stack[-2][0])  # Range S-X
-                
-                if X >= Y:
-                    # Found a cycle
-                    if len(stack) == 3:
-                        # Half cycle
-                        cycle_range = Y
-                        cycle_mean = (stack[-3][0] + stack[-2][0]) / 2
-                        cycles.append(RainflowCycle(
-                            range_value=cycle_range,
-                            mean_value=cycle_mean,
-                            count=0.5,
-                            start_index=stack[-3][1],
-                            end_index=stack[-2][1]
-                        ))
-                        # Remove middle point
-                        del stack[-2]
-                        break
-                    else:
-                        # Full cycle
-                        cycle_range = Y
-                        cycle_mean = (stack[-3][0] + stack[-2][0]) / 2
-                        cycles.append(RainflowCycle(
-                            range_value=cycle_range,
-                            mean_value=cycle_mean,
-                            count=1.0,
-                            start_index=stack[-3][1],
-                            end_index=stack[-2][1]
-                        ))
-                        # Remove the two points that formed the cycle
-                        del stack[-3:-1]  # Remove S and X, keep Y
-                else:
+                new_range = abs(stack[-2][0] - stack[-1][0])
+                prior_range = abs(stack[-3][0] - stack[-2][0])
+
+                if new_range < prior_range:
                     break
+
+                cycle_range = prior_range
+                if cycle_range > 0:
+                    cycles.append(RainflowCycle(
+                        range_value=cycle_range,
+                        mean_value=(stack[-3][0] + stack[-2][0]) / 2,
+                        count=0.5 if len(stack) == 3 else 1.0,
+                        start_index=stack[-3][1],
+                        end_index=stack[-2][1]
+                    ))
+
+                if len(stack) == 3:
+                    stack.pop(0)
+                else:
+                    last = stack.pop()
+                    stack.pop()
+                    stack.pop()
+                    stack.append(last)
         
         # Process remaining points in stack as half cycles
-        while len(stack) >= 2:
-            cycle_range = abs(stack[0][0] - stack[1][0])
-            cycle_mean = (stack[0][0] + stack[1][0]) / 2
+        for i in range(len(stack) - 1):
+            cycle_range = abs(stack[i][0] - stack[i + 1][0])
+            if cycle_range == 0:
+                continue
             cycles.append(RainflowCycle(
                 range_value=cycle_range,
-                mean_value=cycle_mean,
+                mean_value=(stack[i][0] + stack[i + 1][0]) / 2,
                 count=0.5,
-                start_index=stack[0][1],
-                end_index=stack[1][1]
+                start_index=stack[i][1],
+                end_index=stack[i + 1][1]
             ))
-            stack.pop(0)
         
         return cycles
     

--- a/src/digitalmodel/structural/fatigue_apps/reference_seastate_processor.py
+++ b/src/digitalmodel/structural/fatigue_apps/reference_seastate_processor.py
@@ -312,27 +312,27 @@ class ReferenceSeaStateProcessor:
         """Find reference with closest direction"""
         if not refs:
             return ""
-        
-        best_ref = ""
-        best_diff = float('inf')
-        
+
+        candidates = []
+        target_dir = target_dir % 360
+
         for ref in refs:
             # Extract direction from name (e.g., "wind_045deg_...")
             parts = ref.split('_')
             if len(parts) >= 2:
                 try:
-                    ref_dir = float(parts[1].replace('deg', ''))
+                    ref_dir = float(parts[1].replace('deg', '')) % 360
                     diff = abs(ref_dir - target_dir)
                     if diff > 180:
                         diff = 360 - diff
-                    
-                    if diff < best_diff:
-                        best_diff = diff
-                        best_ref = ref
+                    candidates.append((diff, -ref_dir, ref))
                 except ValueError:
                     continue
-        
-        return best_ref
+
+        if not candidates:
+            return ""
+
+        return min(candidates)[2]
     
     def _find_closest_wave(self, refs: List[str], target_dir: float, target_tp: float) -> str:
         """Find wave reference with closest direction and Tp"""

--- a/tests/infrastructure/contracts/test_api_contracts.py
+++ b/tests/infrastructure/contracts/test_api_contracts.py
@@ -152,6 +152,40 @@ class APIContractValidator:
                     }
                 },
                 "additionalProperties": False
+            },
+            "analysis_response": {
+                "type": "object",
+                "required": ["status_code", "data"],
+                "properties": {
+                    "status_code": {"type": "integer", "minimum": 200, "maximum": 599},
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "analysis_id": {"type": "string", "pattern": "^[a-zA-Z0-9-]+$"},
+                            "status": {
+                                "type": "string",
+                                "enum": ["queued", "running", "completed", "failed", "cancelled"]
+                            },
+                            "results": {
+                                "type": "object",
+                                "properties": {
+                                    "summary": {"type": "object", "additionalProperties": True},
+                                    "details": {
+                                        "type": "array",
+                                        "items": {"type": "object", "additionalProperties": True}
+                                    }
+                                },
+                                "additionalProperties": True
+                            },
+                            "metadata": {"type": "object"}
+                        },
+                        "required": ["analysis_id", "status", "results"]
+                    },
+                    "message": {"type": ["string", "null"]},
+                    "timestamp": {"type": ["string", "null"]},
+                    "version": {"type": "string", "pattern": "^\\d+\\.\\d+$"}
+                },
+                "additionalProperties": False
             }
         }
 
@@ -524,11 +558,12 @@ class TestEndToEndContracts:
         result = contract_runner.test_endpoint_contract(
             "/api/v1/analysis/run",
             request_data,
-            "simulation_response"
+            "analysis_response"
         )
 
         assert result['schema_valid'], f"Contract validation failed: {result['errors']}"
         assert result['response']['status_code'] == 200
+        assert 'analysis_id' in result['response']['data']
 
     def test_error_handling_contracts(self, contract_runner):
         """Test error handling contracts."""

--- a/tests/structural/fatigue_analysis/test_fatigue_cli.py
+++ b/tests/structural/fatigue_analysis/test_fatigue_cli.py
@@ -227,8 +227,8 @@ class TestAnalysisExecution:
         
         with patch('digitalmodel.structural.fatigue_apps.__main__.IntegratedFatigueProcessor') as MockProcessor:
             with patch('digitalmodel.structural.fatigue_apps.__main__.ProductionDataHandler') as MockHandler:
-                with patch('digitalmodel.structural.fatigue_apps.__main__.main') as mock_main:
-                    mock_main.return_value = ([], {})
+                with patch('digitalmodel.structural.fatigue_apps.__main__.run_integrated_analysis') as mock_analysis:
+                    mock_analysis.return_value = ([], {})
                     
                     result = run_analysis(args)
                     
@@ -262,8 +262,23 @@ class TestAnalysisExecution:
         
         with patch('digitalmodel.structural.fatigue_apps.__main__.IntegratedFatigueProcessor') as MockProcessor:
             with patch('digitalmodel.structural.fatigue_apps.__main__.ProductionDataHandler') as MockHandler:
-                with patch('digitalmodel.structural.fatigue_apps.__main__.main') as mock_main:
-                    mock_main.return_value = ([{"test": "result"}], {"summary": "data"})
+                mock_handler = MagicMock()
+                mock_handler.configurations = {
+                    'fsts_l015': MagicMock(description="Test Config", weight=100.0)
+                }
+                MockHandler.return_value = mock_handler
+
+                with patch('digitalmodel.structural.fatigue_apps.__main__.run_integrated_analysis') as mock_analysis:
+                    mock_analysis.return_value = (
+                        [{"test": "result"}],
+                        {
+                            "fsts_l015": {
+                                "weight_pct": 100.0,
+                                "critical_strut": "Strut1",
+                                "min_fatigue_life": 25.0,
+                            }
+                        },
+                    )
                     
                     result = run_analysis(args)
                     
@@ -345,10 +360,10 @@ class TestAnalysisExecution:
         
         with patch('digitalmodel.structural.fatigue_apps.__main__.IntegratedFatigueProcessor') as MockProcessor:
             with patch('digitalmodel.structural.fatigue_apps.__main__.ProductionDataHandler') as MockHandler:
-                with patch('digitalmodel.structural.fatigue_apps.__main__.main') as mock_main:
+                with patch('digitalmodel.structural.fatigue_apps.__main__.run_integrated_analysis') as mock_analysis:
                     mock_processor = MagicMock()
                     MockProcessor.return_value = mock_processor
-                    mock_main.return_value = ([], {})
+                    mock_analysis.return_value = ([], {})
                     
                     result = run_analysis(args)
                     

--- a/tests/structural/fatigue_analysis/test_rainflow_counter.py
+++ b/tests/structural/fatigue_analysis/test_rainflow_counter.py
@@ -196,7 +196,7 @@ class TestRainflowValidation:
     def test_astm_example_1(self):
         """Test against ASTM E1049 Example 1"""
         # Standard ASTM test sequence
-        stress = np.array([0, -2, 1, -3, 5, -1, 3, -4, 4, -2, 0])
+        stress = np.array([-2, 1, -3, 5, -1, 3, -4, 4, -2])
         
         counter = RainflowCounter()
         ranges, counts = counter.count_cycles(stress)
@@ -210,12 +210,8 @@ class TestRainflowValidation:
             9: 0.5    # Range 9, half cycle
         }
         
-        # Verify against expected (allowing for algorithm variations)
-        total_expected = sum(expected_ranges.values())
-        total_actual = np.sum(counts)
-        
-        # Total counts should match
-        assert abs(total_actual - total_expected) < 1.0
+        actual_ranges = dict(zip(ranges, counts))
+        assert actual_ranges == expected_ranges
     
     def test_repeating_pattern(self):
         """Test with repeating load pattern"""

--- a/tests/structural/fatigue_analysis/test_reference_seastate_processor.py
+++ b/tests/structural/fatigue_analysis/test_reference_seastate_processor.py
@@ -201,7 +201,7 @@ class TestReferenceSeaStateProcessor:
             wind_speed=10,
             wind_dir=45,  # Closest to 90
             hs=1.0,
-            tp=3.0,  # Closest to 3.47
+            tp=3.2,  # Closest to 3.47
             wave_dir=45,  # Closest to 90
             occurrence=5.0
         )


### PR DESCRIPTION
## Summary
Parallel fix-pass (round 2, stream 4). Fatigue cluster + 1 API-contract failure.

- **rainflow_counter** — production bug: wrong stack-point deletion for 3-point half cycles + gate filtering *before* cycle extraction → bogus zero ranges. Fixed ASTM E1049 stack handling + post-cycle gating. **Independently verified**: on the canonical ASTM series the output `{3:0.5, 4:1.5, 6:0.5, 8:1.0, 9:0.5}` matches the `rainflow` PyPI package oracle exactly.
- **fatigue CLI** (`__main__`) — deps imported inside `run_analysis` so tests couldn't patch the import surface; integrated `main` collided with CLI `main`. Module-level aliases + robust parallel/adaptive handling.
- **reference_seastate_processor** — direction tie-break selected first-seen instead of the nearer numeric direction; fixed circular tie-break. Corrected a test fixture (`tp` 3.0→3.2 to match its "closest to 3.47" claim).
- **api_contracts** — `/api/v1/analysis/run` returns analysis-shaped data but was validated against `simulation_response`; added an `analysis_response` schema.

**69 passed** combined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)