### PR TITLE
feat(naval-arch): turning_circle (Nomoto) estimator — NEW FEATURE, needs review

### DIFF
--- a/docs/domains/marine-engineering/turning-circle-estimator.md
+++ b/docs/domains/marine-engineering/turning-circle-estimator.md
@@ -1,0 +1,23 @@
+# Turning Circle Estimator
+
+The turning-circle estimator is a preliminary first-order Nomoto workflow for
+constant-speed, constant-rudder sensitivity studies. It integrates
+`r_dot = (K * delta - r) / T`, then reports advance and transfer from the
+interpolated 90 degree heading crossing and tactical diameter from the
+interpolated 180 degree heading crossing.
+
+This is not MMG and not a full MMG maneuvering model. The packaged typical-ship
+YAML uses assumed Nomoto `K` and `T` values; it is not calibrated from sea-trial
+or telemetry evidence.
+
+The output may reference IMO turning-circle terminology and ABS/class context
+for reader orientation, but it is not an IMO maneuvering compliance assessment
+and it makes no ABS or class compliance conclusion.
+
+Primary artifacts:
+
+- `turning_circle_time_history.csv`
+- `turning_circle_metrics.csv`
+- `turning_circle_results.json`
+- `turning_circle_provenance.json`
+- chart files for trajectory, yaw rate, heading, and metrics sensitivity

--- a/src/digitalmodel/naval_architecture/__init__.py
+++ b/src/digitalmodel/naval_architecture/__init__.py
@@ -62,6 +62,12 @@ from digitalmodel.naval_architecture.rudder_stock_torque import (
     load_packaged_rudder_stock_torque_yaml,
     run_rudder_stock_torque_sweep,
 )
+from digitalmodel.naval_architecture.turning_circle import (
+    load_packaged_turning_circle_yaml,
+    run_turning_circle_sweep,
+    simulate_nomoto_turning_circle,
+    write_turning_circle_results,
+)
 from digitalmodel.naval_architecture.yaw_moment import (
     load_packaged_typical_ship_yaml,
     load_yaw_moment_input,
@@ -89,6 +95,7 @@ __all__ = [
     "load_packaged_b1528_time_trace_config",
     "load_packaged_b1528_yaw_config",
     "load_packaged_rudder_stock_torque_yaml",
+    "load_packaged_turning_circle_yaml",
     "load_packaged_typical_ship_yaml",
     "load_yaw_moment_input",
     "merge_template_into_registry",
@@ -105,8 +112,10 @@ __all__ = [
     "run_b1528_moored_current_report",
     "run_b1528_time_trace_report",
     "run_rudder_stock_torque_sweep",
+    "run_turning_circle_sweep",
     "run_yaw_moment_sweep",
     "simulate_b1528_time_trace",
+    "simulate_nomoto_turning_circle",
     "stability_curve_estimate",
     "summarize_drilling_rig_hull_validation",
     "validate_drilling_rig_fleet",
@@ -116,5 +125,6 @@ __all__ = [
     "write_b1528_current_heading_rudder_report",
     "write_b1528_moored_current_report",
     "write_b1528_time_trace_report",
+    "write_turning_circle_results",
     "write_yaw_moment_results",
 ]

--- a/src/digitalmodel/naval_architecture/data/turning_circle_typical_ship.yml
+++ b/src/digitalmodel/naval_architecture/data/turning_circle_typical_ship.yml
@@ -1,0 +1,52 @@
+# Typical single-screw ship preliminary Nomoto turning-circle sweep input.
+case:
+  id: typical_single_screw_turning_circle
+  description: >-
+    Typical ship preliminary first-order Nomoto turning-circle estimate for
+    advance, transfer, and tactical-diameter sensitivity.
+
+vessel:
+  type: typical_single_screw_ship
+  length_between_perpendiculars_m: 120.0
+  beam_m: 20.0
+  draft_m: 7.0
+  design_speed_kn: 12.0
+
+nomoto:
+  K_per_s: 0.12
+  T_s: 20.0
+  assumption: >-
+    Assumed first-order Nomoto gain and time constant for preliminary source-gap
+    sensitivity; not calibrated from trial or telemetry data.
+
+simulation:
+  duration_s: 240.0
+  dt_s: 1.0
+
+sweep:
+  speeds:
+    units: kn
+    values: [10.0, 15.0]
+  rudder_angles_deg: [-20.0, 20.0, 30.0]
+
+outputs:
+  directory: results/turning_circle
+  tables: [csv, json]
+  sidecars:
+    provenance: turning_circle_provenance.json
+    artifact_manifest: artifact_manifest.json
+  charts:
+    enabled: true
+    formats: [png, html]
+    required:
+      - trajectory_by_case
+      - yaw_rate_vs_time
+      - heading_vs_time
+      - turning_metrics_vs_rudder_angle
+
+warnings:
+  scope_limitations:
+    - Preliminary constant-speed first-order Nomoto estimate only.
+    - Not MMG and not a full MMG maneuvering model.
+    - Not an IMO maneuvering compliance assessment.
+    - No ABS or class compliance conclusion is made.

--- a/src/digitalmodel/naval_architecture/turning_circle.py
+++ b/src/digitalmodel/naval_architecture/turning_circle.py
@@ -1,0 +1,384 @@
+# ABOUTME: Preliminary Nomoto turning-circle sweeps, artifacts, and charts.
+# ABOUTME: Keeps the public API and packaged YAML used by the estimator tests.
+"""Preliminary first-order Nomoto turning-circle estimator.
+
+This module is a bounded estimating tool. It integrates
+``r_dot = (K * delta - r) / T`` for constant speed and rudder angle, then
+derives advance, transfer, and tactical-diameter estimates from heading
+crossings. It is not a full MMG model or class/IMO/ABS compliance proof.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any, Iterable
+
+import yaml
+
+from digitalmodel.naval_architecture.turning_circle_artifacts import (
+    METRICS_HEADERS as METRICS_HEADERS,
+    REQUIRED_CHARTS,
+    SUPPORTED_CHART_FORMATS,
+    SUPPORTED_TABLE_FORMATS,
+    TIME_HISTORY_HEADERS as TIME_HISTORY_HEADERS,
+    provenance_metadata,
+    units_metadata,
+    write_turning_circle_results as write_turning_circle_results,
+)
+
+KNOT_TO_M_PER_S = 0.514444
+M_PER_S_TO_KNOT = 1.0 / KNOT_TO_M_PER_S
+
+
+@dataclass(frozen=True)
+class TurningCircleInput:
+    """Validated packaged turning-circle sweep input."""
+
+    case_id: str
+    case_description: str
+    vessel: dict[str, Any]
+    speeds_m_s: list[float]
+    speeds_kn: list[float]
+    rudder_angles_deg: list[float]
+    K_per_s: float
+    T_s: float
+    duration_s: float
+    dt_s: float
+    output_directory: str
+    table_formats: tuple[str, ...]
+    provenance_filename: str
+    artifact_manifest_filename: str
+    chart_enabled: bool
+    chart_formats: tuple[str, ...]
+    required_charts: tuple[str, ...]
+    raw: dict[str, Any]
+
+
+def _finite(name: str, value: float) -> float:
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value}")
+    return value
+
+
+def _positive(name: str, value: float) -> float:
+    value = _finite(name, value)
+    if value <= 0:
+        raise ValueError(f"{name} must be > 0, got {value}")
+    return value
+
+
+def _nonnegative(name: str, value: float) -> float:
+    value = _finite(name, value)
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0, got {value}")
+    return value
+
+
+def simulate_nomoto_turning_circle(
+    *,
+    speed_m_s: float,
+    rudder_angle_deg: float,
+    K_per_s: float,
+    T_s: float,
+    duration_s: float,
+    dt_s: float,
+    case_id: str = "direct_nomoto_turning_circle",
+) -> dict[str, Any]:
+    """Simulate a constant-rudder first-order Nomoto turning circle."""
+
+    speed_m_s = _positive("speed_m_s", speed_m_s)
+    rudder_angle_deg = _finite("rudder_angle_deg", rudder_angle_deg)
+    K_per_s = _nonnegative("K_per_s", K_per_s)
+    T_s = _positive("T_s", T_s)
+    duration_s = _positive("duration_s", duration_s)
+    dt_s = _positive("dt_s", dt_s)
+    if duration_s <= dt_s:
+        raise ValueError("duration_s must be greater than dt_s")
+
+    rows = _integrate_nomoto(
+        case_id, speed_m_s, rudder_angle_deg, K_per_s, T_s, duration_s, dt_s
+    )
+    metrics, warnings = _turning_metrics(rows, rudder_angle_deg)
+    return {
+        "metadata": {
+            "case_id": case_id,
+            "speed_m_s": speed_m_s,
+            "speed_kn": speed_m_s * M_PER_S_TO_KNOT,
+            "rudder_angle_deg": rudder_angle_deg,
+            "nomoto": {"K_per_s": K_per_s, "T_s": T_s},
+            "duration_s": duration_s,
+            "dt_s": dt_s,
+            "equation": "r_dot = (K * delta - r) / T",
+        },
+        "metrics": metrics,
+        "time_history": rows,
+        "warnings": warnings,
+    }
+
+
+def _integrate_nomoto(
+    case_id: str,
+    speed_m_s: float,
+    rudder_angle_deg: float,
+    K_per_s: float,
+    T_s: float,
+    duration_s: float,
+    dt_s: float,
+) -> list[dict[str, float | str]]:
+    time_s = 0.0
+    x_m = 0.0
+    y_m = 0.0
+    heading_rad = 0.0
+    yaw_rate_rad_s = 0.0
+    delta_rad = math.radians(rudder_angle_deg)
+    steady_yaw_rate = K_per_s * delta_rad
+    speed_kn = speed_m_s * M_PER_S_TO_KNOT
+    rows = [
+        _history_row(
+            case_id,
+            speed_m_s,
+            speed_kn,
+            rudder_angle_deg,
+            time_s,
+            x_m,
+            y_m,
+            heading_rad,
+            yaw_rate_rad_s,
+        )
+    ]
+    while time_s < duration_s - 1e-12:
+        step_s = min(dt_s, duration_s - time_s)
+        decay = math.exp(-step_s / T_s)
+        next_yaw_rate = steady_yaw_rate + (yaw_rate_rad_s - steady_yaw_rate) * decay
+        delta_heading = steady_yaw_rate * step_s + (
+            yaw_rate_rad_s - steady_yaw_rate
+        ) * T_s * (1.0 - decay)
+        midpoint_heading = heading_rad + 0.5 * delta_heading
+        x_m += speed_m_s * math.cos(midpoint_heading) * step_s
+        y_m += speed_m_s * math.sin(midpoint_heading) * step_s
+        heading_rad += delta_heading
+        yaw_rate_rad_s = next_yaw_rate
+        time_s = round(time_s + step_s, 10)
+        rows.append(
+            _history_row(
+                case_id,
+                speed_m_s,
+                speed_kn,
+                rudder_angle_deg,
+                time_s,
+                x_m,
+                y_m,
+                heading_rad,
+                yaw_rate_rad_s,
+            )
+        )
+    return rows
+
+
+def _history_row(
+    case_id: str,
+    speed_m_s: float,
+    speed_kn: float,
+    rudder_angle_deg: float,
+    time_s: float,
+    x_m: float,
+    y_m: float,
+    heading_rad: float,
+    yaw_rate_rad_s: float,
+) -> dict[str, float | str]:
+    return {
+        "case_id": case_id,
+        "speed_m_s": speed_m_s,
+        "speed_kn": speed_kn,
+        "rudder_angle_deg": rudder_angle_deg,
+        "time_s": time_s,
+        "x_m": x_m,
+        "y_m": y_m,
+        "heading_deg": math.degrees(heading_rad),
+        "yaw_rate_rad_s": yaw_rate_rad_s,
+        "yaw_rate_deg_s": math.degrees(yaw_rate_rad_s),
+    }
+
+
+def _turning_metrics(
+    rows: list[dict[str, Any]], rudder_angle_deg: float
+) -> tuple[dict[str, Any], list[str]]:
+    sign = 1.0 if rudder_angle_deg >= 0 else -1.0
+    advance_transfer = _heading_crossing(rows, sign * 90.0)
+    tactical = _heading_crossing(rows, sign * 180.0)
+    warnings: list[str] = []
+    if advance_transfer is None:
+        warnings.append(
+            "Heading target 90 deg was not reached; metrics are incomplete."
+        )
+    if tactical is None:
+        warnings.append(
+            "Heading target 180 deg was not reached; tactical diameter is incomplete."
+        )
+    return {
+        "case_id": rows[0]["case_id"],
+        "speed_m_s": rows[0]["speed_m_s"],
+        "speed_kn": rows[0]["speed_kn"],
+        "rudder_angle_deg": rudder_angle_deg,
+        "advance_transfer_time_s": (
+            None if advance_transfer is None else advance_transfer["time_s"]
+        ),
+        "advance_m": None if advance_transfer is None else advance_transfer["x_m"],
+        "transfer_m": None if advance_transfer is None else advance_transfer["y_m"],
+        "tactical_diameter_time_s": None if tactical is None else tactical["time_s"],
+        "tactical_diameter_m": None if tactical is None else tactical["y_m"],
+        "metric_status": "ok" if not warnings else "warning",
+    }, warnings
+
+
+def _heading_crossing(
+    rows: list[dict[str, Any]], target_heading_deg: float
+) -> dict[str, float] | None:
+    for previous, current in zip(rows, rows[1:]):
+        prev_heading = float(previous["heading_deg"])
+        curr_heading = float(current["heading_deg"])
+        if target_heading_deg >= 0:
+            crossed = prev_heading < target_heading_deg <= curr_heading
+        else:
+            crossed = prev_heading > target_heading_deg >= curr_heading
+        if not crossed or curr_heading == prev_heading:
+            continue
+        fraction = (target_heading_deg - prev_heading) / (curr_heading - prev_heading)
+        return {
+            key: float(previous[key])
+            + fraction * (float(current[key]) - float(previous[key]))
+            for key in ("time_s", "x_m", "y_m", "yaw_rate_rad_s", "yaw_rate_deg_s")
+        } | {"heading_deg": target_heading_deg}
+    return None
+
+
+def load_packaged_turning_circle_yaml() -> TurningCircleInput:
+    """Load the packaged typical-ship turning-circle YAML."""
+
+    resource = resources.files("digitalmodel.naval_architecture.data").joinpath(
+        "turning_circle_typical_ship.yml"
+    )
+    with resource.open("r", encoding="utf-8") as stream:
+        return validate_turning_circle_input(yaml.safe_load(stream))
+
+
+def validate_turning_circle_input(payload: dict[str, Any]) -> TurningCircleInput:
+    """Validate the documented turning-circle input contract."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("turning circle input must be a YAML mapping")
+    required = {"case", "nomoto", "sweep", "outputs"}
+    missing = sorted(required - set(payload))
+    if missing:
+        raise ValueError(f"missing required top-level sections: {missing}")
+
+    speeds = payload["sweep"]["speeds"]
+    speed_values = [_positive("speed", value) for value in speeds["values"]]
+    if not speed_values:
+        raise ValueError("sweep.speeds.values must contain at least one value")
+    if speeds.get("units") == "kn":
+        speeds_kn = speed_values
+        speeds_m_s = [value * KNOT_TO_M_PER_S for value in speed_values]
+    elif speeds.get("units") == "m/s":
+        speeds_m_s = speed_values
+        speeds_kn = [value * M_PER_S_TO_KNOT for value in speed_values]
+    else:
+        raise ValueError("sweep.speeds.units must be 'kn' or 'm/s'")
+
+    outputs = payload["outputs"]
+    table_formats = tuple(outputs.get("tables", ("csv", "json")))
+    chart_cfg = outputs.get("charts", {})
+    chart_formats = tuple(chart_cfg.get("formats", ("png",)))
+    required_charts = tuple(chart_cfg.get("required", ()))
+    _validate_formats(table_formats, SUPPORTED_TABLE_FORMATS, "table")
+    _validate_formats(chart_formats, SUPPORTED_CHART_FORMATS, "chart")
+    _validate_formats(required_charts, set(REQUIRED_CHARTS), "required chart")
+    if required_charts and not bool(chart_cfg.get("enabled", False)):
+        raise ValueError(
+            "outputs.charts.required is invalid when charts.enabled is false"
+        )
+
+    sidecar_cfg = outputs.get("sidecars", {})
+    duration_s = _positive("simulation.duration_s", payload["simulation"]["duration_s"])
+    dt_s = _positive("simulation.dt_s", payload["simulation"]["dt_s"])
+    if duration_s <= dt_s:
+        raise ValueError("simulation.duration_s must be greater than simulation.dt_s")
+    rudder_angles_deg = [
+        _finite("rudder_angle_deg", value)
+        for value in payload["sweep"]["rudder_angles_deg"]
+    ]
+    if not rudder_angles_deg:
+        raise ValueError("sweep.rudder_angles_deg must contain at least one value")
+
+    return TurningCircleInput(
+        case_id=str(payload["case"]["id"]),
+        case_description=str(payload["case"].get("description", "")),
+        vessel=dict(payload.get("vessel", {})),
+        speeds_m_s=speeds_m_s,
+        speeds_kn=speeds_kn,
+        rudder_angles_deg=rudder_angles_deg,
+        K_per_s=_nonnegative("nomoto.K_per_s", payload["nomoto"]["K_per_s"]),
+        T_s=_positive("nomoto.T_s", payload["nomoto"]["T_s"]),
+        duration_s=duration_s,
+        dt_s=dt_s,
+        output_directory=str(outputs.get("directory", "results/turning_circle")),
+        table_formats=table_formats,
+        provenance_filename=str(
+            sidecar_cfg.get("provenance", "turning_circle_provenance.json")
+        ),
+        artifact_manifest_filename=str(
+            sidecar_cfg.get("artifact_manifest", "artifact_manifest.json")
+        ),
+        chart_enabled=bool(chart_cfg.get("enabled", False)),
+        chart_formats=chart_formats,
+        required_charts=required_charts,
+        raw=payload,
+    )
+
+
+def _validate_formats(values: Iterable[str], supported: set[str], label: str) -> None:
+    unsupported = sorted(set(values) - supported)
+    if unsupported:
+        raise ValueError(f"unsupported {label} formats: {unsupported}")
+
+
+def run_turning_circle_sweep(config: TurningCircleInput) -> dict[str, Any]:
+    """Run every speed/rudder-angle combination and return rows + metadata."""
+
+    cases: list[dict[str, Any]] = []
+    metrics: list[dict[str, Any]] = []
+    time_history: list[dict[str, Any]] = []
+    for speed_m_s, speed_kn in zip(config.speeds_m_s, config.speeds_kn):
+        for rudder_angle_deg in config.rudder_angles_deg:
+            case_id = f"{config.case_id}_{speed_kn:g}kn_{rudder_angle_deg:g}deg"
+            result = simulate_nomoto_turning_circle(
+                speed_m_s=speed_m_s,
+                rudder_angle_deg=rudder_angle_deg,
+                K_per_s=config.K_per_s,
+                T_s=config.T_s,
+                duration_s=config.duration_s,
+                dt_s=config.dt_s,
+                case_id=case_id,
+            )
+            cases.append(result["metadata"])
+            metrics.append(result["metrics"])
+            time_history.extend(result["time_history"])
+    return {
+        "metadata": {
+            "case_id": config.case_id,
+            "case_description": config.case_description,
+            "units": units_metadata(),
+            "required_charts": list(config.required_charts),
+            "sidecars": {
+                "provenance": config.provenance_filename,
+                "artifact_manifest": config.artifact_manifest_filename,
+            },
+        },
+        "provenance": provenance_metadata(),
+        "cases": cases,
+        "metrics": metrics,
+        "time_history": time_history,
+    }

--- a/src/digitalmodel/naval_architecture/turning_circle_artifacts.py
+++ b/src/digitalmodel/naval_architecture/turning_circle_artifacts.py
@@ -1,0 +1,353 @@
+# ABOUTME: Artifact and chart writers for preliminary turning-circle sweeps.
+# ABOUTME: Split from turning_circle.py to keep the public estimator module small.
+"""Writers for preliminary Nomoto turning-circle tables and charts."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable
+
+TIME_HISTORY_HEADERS = [
+    "case_id",
+    "speed_m_s",
+    "speed_kn",
+    "rudder_angle_deg",
+    "time_s",
+    "x_m",
+    "y_m",
+    "heading_deg",
+    "yaw_rate_rad_s",
+    "yaw_rate_deg_s",
+]
+
+METRICS_HEADERS = [
+    "case_id",
+    "speed_m_s",
+    "speed_kn",
+    "rudder_angle_deg",
+    "advance_transfer_time_s",
+    "advance_m",
+    "transfer_m",
+    "tactical_diameter_time_s",
+    "tactical_diameter_m",
+    "metric_status",
+]
+
+REQUIRED_CHARTS = [
+    "trajectory_by_case",
+    "yaw_rate_vs_time",
+    "heading_vs_time",
+    "turning_metrics_vs_rudder_angle",
+]
+
+SUPPORTED_TABLE_FORMATS = {"csv", "json"}
+SUPPORTED_CHART_FORMATS = {"png", "html"}
+
+
+def units_metadata() -> dict[str, str]:
+    return {
+        "speed_m_s": "m/s",
+        "speed_kn": "kn",
+        "rudder_angle_deg": "deg",
+        "time_s": "s",
+        "x_m": "m",
+        "y_m": "m",
+        "heading_deg": "deg",
+        "yaw_rate_rad_s": "rad/s",
+        "yaw_rate_deg_s": "deg/s",
+        "advance_m": "m",
+        "transfer_m": "m",
+        "tactical_diameter_m": "m",
+    }
+
+
+def provenance_metadata() -> dict[str, Any]:
+    return {
+        "calculation": "preliminary first-order Nomoto turning-circle estimate",
+        "nomoto_equation": "r_dot = (K * delta - r) / T",
+        "metric_basis": (
+            "advance and transfer use the interpolated 90 deg heading crossing; "
+            "tactical diameter uses the interpolated 180 deg heading crossing"
+        ),
+        "scope_limitations": [
+            "Preliminary constant-speed first-order Nomoto estimate only.",
+            "Not MMG and not a full MMG maneuvering model.",
+            "Not an IMO maneuvering compliance assessment.",
+            "No ABS or class compliance conclusion is made.",
+        ],
+    }
+
+
+def write_turning_circle_results(
+    result: dict[str, Any],
+    output_dir: str | Path,
+    table_formats: Iterable[str] = ("csv", "json"),
+    chart_formats: Iterable[str] = ("png",),
+) -> dict[str, Any]:
+    """Write CSV/JSON tables, provenance, manifest, and charts."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    table_formats = tuple(table_formats)
+    chart_formats = tuple(chart_formats)
+    _validate_formats(table_formats, SUPPORTED_TABLE_FORMATS, "table")
+    _validate_formats(chart_formats, SUPPORTED_CHART_FORMATS, "chart")
+
+    manifest: dict[str, Any] = {"tables": {}, "charts": {}, "sidecars": {}}
+    if "csv" in table_formats:
+        manifest["tables"].update(_write_csv_tables(result, output_path))
+    if "json" in table_formats:
+        manifest["tables"]["json"] = _write_json_table(result, output_path)
+
+    sidecar_names = result.get("metadata", {}).get("sidecars", {})
+    provenance_path = output_path / sidecar_names.get(
+        "provenance", "turning_circle_provenance.json"
+    )
+    provenance_path.write_text(
+        json.dumps(result["provenance"], indent=2), encoding="utf-8"
+    )
+    manifest["sidecars"]["provenance"] = provenance_path
+
+    manifest["charts"] = write_turning_circle_charts(result, output_path, chart_formats)
+    manifest_path = output_path / sidecar_names.get(
+        "artifact_manifest", "artifact_manifest.json"
+    )
+    manifest["sidecars"]["artifact_manifest"] = manifest_path
+    manifest_path.write_text(
+        json.dumps(_stringify(manifest), indent=2), encoding="utf-8"
+    )
+
+    if "json" in manifest["tables"]:
+        _attach_manifest_to_json(manifest["tables"]["json"], manifest)
+    return manifest
+
+
+def _write_csv_tables(result: dict[str, Any], output_path: Path) -> dict[str, Path]:
+    time_history_path = output_path / "turning_circle_time_history.csv"
+    metrics_path = output_path / "turning_circle_metrics.csv"
+    _write_csv(time_history_path, TIME_HISTORY_HEADERS, result["time_history"])
+    _write_csv(metrics_path, METRICS_HEADERS, result["metrics"])
+    return {"time_history_csv": time_history_path, "metrics_csv": metrics_path}
+
+
+def _write_csv(path: Path, headers: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=headers)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({header: row[header] for header in headers})
+
+
+def _write_json_table(result: dict[str, Any], output_path: Path) -> Path:
+    path = output_path / "turning_circle_results.json"
+    payload = {
+        "metadata": result["metadata"],
+        "provenance": result["provenance"],
+        "cases": result["cases"],
+        "metrics": result["metrics"],
+        "time_history": result["time_history"],
+        "artifacts": {},
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def write_turning_circle_charts(
+    result: dict[str, Any],
+    output_dir: Path,
+    chart_formats: Iterable[str] = ("png",),
+) -> dict[str, dict[str, Path]]:
+    """Write required PNG/HTML charts and return artifact paths."""
+
+    chart_formats = tuple(chart_formats)
+    _validate_formats(chart_formats, SUPPORTED_CHART_FORMATS, "chart")
+    if not chart_formats:
+        return {}
+
+    charts: dict[str, dict[str, Path]] = {}
+    required_charts = (
+        result.get("metadata", {}).get("required_charts") or REQUIRED_CHARTS
+    )
+    for chart_name in required_charts:
+        title = chart_name.replace("_", " ").title()
+        charts[chart_name] = {}
+        if "png" in chart_formats:
+            path = output_dir / f"{chart_name}.png"
+            _write_png_chart(result, chart_name, title, path)
+            charts[chart_name]["png"] = path
+        if "html" in chart_formats:
+            path = output_dir / f"{chart_name}.html"
+            _write_html_chart(result, chart_name, title, path)
+            charts[chart_name]["html"] = path
+    return charts
+
+
+def _write_png_chart(
+    result: dict[str, Any], chart_name: str, title: str, path: Path
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    if chart_name == "trajectory_by_case":
+        _plot_time_history(ax, result["time_history"], "x_m", "y_m", by_case=True)
+        ax.set_xlabel("Advance x (m)")
+        ax.set_ylabel("Transfer y (m)")
+    elif chart_name == "yaw_rate_vs_time":
+        _plot_time_history(ax, result["time_history"], "time_s", "yaw_rate_deg_s")
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Yaw rate (deg/s)")
+    elif chart_name == "heading_vs_time":
+        _plot_time_history(ax, result["time_history"], "time_s", "heading_deg")
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Heading (deg)")
+    elif chart_name == "turning_metrics_vs_rudder_angle":
+        _plot_metrics(ax, result["metrics"])
+        ax.set_xlabel("Rudder angle (deg)")
+        ax.set_ylabel("Distance (m)")
+    else:
+        raise ValueError(f"unsupported chart name: {chart_name}")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize="x-small")
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def _write_html_chart(
+    result: dict[str, Any], chart_name: str, title: str, path: Path
+) -> None:
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    if chart_name == "trajectory_by_case":
+        _add_time_history_traces(fig, result["time_history"], "x_m", "y_m")
+        x_title, y_title = "Advance x (m)", "Transfer y (m)"
+    elif chart_name == "yaw_rate_vs_time":
+        _add_time_history_traces(
+            fig, result["time_history"], "time_s", "yaw_rate_deg_s"
+        )
+        x_title, y_title = "Time (s)", "Yaw rate (deg/s)"
+    elif chart_name == "heading_vs_time":
+        _add_time_history_traces(fig, result["time_history"], "time_s", "heading_deg")
+        x_title, y_title = "Time (s)", "Heading (deg)"
+    elif chart_name == "turning_metrics_vs_rudder_angle":
+        _add_metric_traces(fig, result["metrics"])
+        x_title, y_title = "Rudder angle (deg)", "Distance (m)"
+    else:
+        raise ValueError(f"unsupported chart name: {chart_name}")
+    fig.update_layout(title_text=title)
+    fig.update_xaxes(title_text=x_title)
+    fig.update_yaxes(title_text=y_title)
+    fig.write_html(path, include_plotlyjs=True, full_html=True)
+
+
+def _plot_time_history(
+    ax: Any, rows: list[dict[str, Any]], x_key: str, y_key: str, by_case: bool = False
+) -> None:
+    group_key = "case_id" if by_case else "rudder_angle_deg"
+    for label, grouped in _group_rows(rows, group_key).items():
+        ordered = sorted(grouped, key=lambda row: row["time_s"])
+        ax.plot(
+            [row[x_key] for row in ordered],
+            [row[y_key] for row in ordered],
+            label=str(label),
+        )
+
+
+def _plot_metrics(ax: Any, rows: list[dict[str, Any]]) -> None:
+    for speed, grouped in _group_rows(rows, "speed_kn").items():
+        ordered = sorted(grouped, key=lambda row: row["rudder_angle_deg"])
+        x_values = [row["rudder_angle_deg"] for row in ordered]
+        ax.plot(
+            x_values,
+            [_chart_value(row["advance_m"]) for row in ordered],
+            marker="o",
+            label=f"{speed:g} kn advance",
+        )
+        ax.plot(
+            x_values,
+            [_chart_value(row["tactical_diameter_m"]) for row in ordered],
+            marker="s",
+            label=f"{speed:g} kn tactical",
+        )
+
+
+def _add_time_history_traces(
+    fig: Any, rows: list[dict[str, Any]], x_key: str, y_key: str
+) -> None:
+    import plotly.graph_objects as go
+
+    for case_id, grouped in _group_rows(rows, "case_id").items():
+        ordered = sorted(grouped, key=lambda row: row["time_s"])
+        fig.add_trace(
+            go.Scatter(
+                x=[row[x_key] for row in ordered],
+                y=[row[y_key] for row in ordered],
+                mode="lines",
+                name=str(case_id),
+            )
+        )
+
+
+def _add_metric_traces(fig: Any, rows: list[dict[str, Any]]) -> None:
+    import plotly.graph_objects as go
+
+    for speed, grouped in _group_rows(rows, "speed_kn").items():
+        ordered = sorted(grouped, key=lambda row: row["rudder_angle_deg"])
+        x_values = [row["rudder_angle_deg"] for row in ordered]
+        fig.add_trace(
+            go.Scatter(
+                x=x_values,
+                y=[row["advance_m"] for row in ordered],
+                mode="lines+markers",
+                name=f"{speed:g} kn advance",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=x_values,
+                y=[row["tactical_diameter_m"] for row in ordered],
+                mode="lines+markers",
+                name=f"{speed:g} kn tactical",
+            )
+        )
+
+
+def _group_rows(
+    rows: list[dict[str, Any]], key: str
+) -> dict[Any, list[dict[str, Any]]]:
+    grouped: dict[Any, list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(row[key], []).append(row)
+    return grouped
+
+
+def _chart_value(value: Any) -> float:
+    return math.nan if value is None else float(value)
+
+
+def _validate_formats(values: Iterable[str], supported: set[str], label: str) -> None:
+    unsupported = sorted(set(values) - supported)
+    if unsupported:
+        raise ValueError(f"unsupported {label} formats: {unsupported}")
+
+
+def _attach_manifest_to_json(path: Path, manifest: dict[str, Any]) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["artifacts"] = _stringify(manifest)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _stringify(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _stringify(item) for key, item in value.items()}
+    return value


### PR DESCRIPTION
## ⚠️ This is a FEATURE implementation, not a bug fix — please review the code

The 14 failing `test_turning_circle_estimator.py` tests were an **orphaned TDD spec**: the `digitalmodel.naval_architecture.turning_circle` module **never existed** in production (`git grep` on main finds nothing; the test imports are inside test bodies, so they reported as *failures* rather than collection errors).

A codex worker **implemented the spec** — **737 lines of new production code**:
- `turning_circle.py` — first-order **Nomoto** model (`ṙ = (K·δ − r)/T`), `simulate_nomoto_turning_circle`, packaged-YAML loader, advance/transfer (interpolated 90° crossing), tactical diameter (interpolated 180° crossing), input validation.
- `turning_circle_artifacts.py` — CSV/JSON/chart/provenance/manifest writer.
- `data/turning_circle_typical_ship.yml` — packaged parameters; `__init__.py` exports; docs page (explicitly *preliminary*, not MMG/IMO/ABS class-compliant).

**All 14 spec tests pass**, including the Nomoto physics checks (zero rudder → straight, rudder sign symmetry, dt-refinement stability, invalid inputs raise).

**Caveat:** this is auto-generated production code validated only by its own test spec — I could not fully independently verify 737 lines. Recommend a real review of the maneuvering model + artifacts writer before merge. If you'd rather not adopt the feature now, the alternative is to xfail/skip the spec instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)