### PR TITLE
fix(catenary): restore solve_from_angle convention (fixes suite-wide collection abort)

### DIFF
--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/simplified.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/simplified.py
@@ -76,16 +76,17 @@ class SimplifiedCatenarySolver:
         """Calculate catenary from angle and vertical distance.
 
         This method solves the catenary equation when the departure angle
-        from horizontal (q) and vertical distance (d) are known.
+        (q, measured from vertical) and vertical distance (d) are known.
 
-        Mathematical formulation:
-        - slope = tan(q)
-        - a = d / (sqrt(1 + slope^2) - 1)
-        - S = a * slope
-        - X = a * asinh(slope)
+        Mathematical formulation (complementary-angle convention, consistent
+        with the canonical catenary workflow + legacy adapter):
+        - qc = 90 - q ; tanqc = tan(qc) ; coc = cos(qc)
+        - a (bend radius) = d * coc / (1 - coc)
+        - S = a * tanqc
+        - X = a * asinh(tanqc)
 
         Args:
-            angle_deg: Angle from horizontal at departure point [degrees]
+            angle_deg: Angle from vertical at departure point [degrees]
                       Valid range: 0° < angle_deg < 90°
             vertical_distance: Vertical distance between endpoints [m]
                              Must be positive
@@ -102,7 +103,7 @@ class SimplifiedCatenarySolver:
             >>> solver = SimplifiedCatenarySolver()
             >>> result = solver.solve_from_angle(30.0, 100.0)
             >>> result.arc_length
-            373.205...
+            173.205...
         """
         # Input validation
         if not (0 < angle_deg < 90):
@@ -114,24 +115,27 @@ class SimplifiedCatenarySolver:
                 f"vertical_distance must be positive, got {vertical_distance}"
             )
 
-        angle_rad = math.radians(angle_deg)
-        slope = math.tan(angle_rad)
-        cosh_at_fairlead = math.sqrt(1.0 + slope**2)
+        # Angle convention: complementary (q measured from vertical), kept
+        # consistent with the canonical `catenary` workflow (durable-tested at
+        # S=173.2050808 for q=30, d=100) and the legacy catenaryEquation adapter.
+        complementary_angle_rad = math.radians(90.0 - angle_deg)
+        tanq = math.tan(complementary_angle_rad)
+        cos_comp = math.cos(complementary_angle_rad)
 
-        denominator = cosh_at_fairlead - 1.0
+        denominator = 1.0 - cos_comp
         if abs(denominator) < 1e-12:
             raise ValueError(
                 f"Calculation unstable: angle_deg={angle_deg} gives near-zero sag"
             )
 
         # The bend radius at touchdown is the catenary parameter a.
-        bend_radius = vertical_distance / denominator
+        bend_radius = vertical_distance * cos_comp / denominator
 
         # Calculate arc length
-        arc_length = bend_radius * slope
+        arc_length = bend_radius * tanq
 
         # Calculate horizontal distance
-        horizontal_distance = bend_radius * math.asinh(slope)
+        horizontal_distance = bend_radius * math.asinh(tanq)
 
         return SimplifiedCatenaryResults(
             arc_length=arc_length,

--- a/tests/marine_ops/marine_engineering/catenary/test_catenary_integration.py
+++ b/tests/marine_ops/marine_engineering/catenary/test_catenary_integration.py
@@ -63,15 +63,16 @@ class TestUnifiedModuleIntegration:
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             result2 = catenaryEquation({'q': 30, 'd': 100, 'F': None, 'w': None, 'X': None})
 
-        # Modern solver uses angle from horizontal; adapter preserves legacy
-        # angle semantics for deprecated dict callers.
+        # Simplified solver and legacy adapter share the same (complementary)
+        # angle convention, so they must agree.
         assert result1.arc_length > 0
         assert result1.horizontal_distance > 0
         assert result1.bend_radius > 0
         assert result2['S'] > 0
         assert result2['X'] > 0
         assert result2['BendRadius'] > 0
-        assert result1.arc_length != pytest.approx(result2['S'], abs=0.01)
+        assert result1.arc_length == pytest.approx(result2['S'], abs=0.01)
+        assert result1.horizontal_distance == pytest.approx(result2['X'], abs=0.01)
 
     def test_simplified_and_adapter_force_contracts(self):
         """Verify modern simplified and legacy adapter force contracts."""
@@ -180,10 +181,11 @@ class TestWorkflowIntegration:
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             result2 = catenaryEquation({'q': 30, 'd': 100, 'F': None, 'w': None, 'X': None})
 
-        # Modern simplified and legacy adapter intentionally differ for q.
+        # Modern simplified and legacy adapter use the same angle convention
+        # and must agree for the same q/d.
         assert result1.arc_length > 0
         assert result2['S'] > 0
-        assert result1.arc_length != pytest.approx(result2['S'], abs=1e-9)
+        assert result1.arc_length == pytest.approx(result2['S'], abs=1e-6)
 
 
 class TestBackwardCompatibility:

--- a/tests/marine_ops/marine_engineering/catenary/test_simplified.py
+++ b/tests/marine_ops/marine_engineering/catenary/test_simplified.py
@@ -20,12 +20,19 @@ from digitalmodel.marine_ops.marine_analysis.catenary.simplified import (
 
 
 def expected_from_angle(angle_deg, vertical_distance):
-    """Closed-form catenary geometry from fairlead angle and vertical span."""
-    slope = math.tan(math.radians(angle_deg))
-    catenary_parameter = vertical_distance / (math.sqrt(1.0 + slope**2) - 1.0)
+    """Closed-form catenary geometry from fairlead angle and vertical span.
+
+    Complementary-angle convention (q measured from vertical), consistent with
+    the canonical `catenary` workflow (S=173.2050808 for q=30, d=100) and the
+    legacy catenaryEquation adapter.
+    """
+    complementary_rad = math.radians(90.0 - angle_deg)
+    tanqc = math.tan(complementary_rad)
+    cos_comp = math.cos(complementary_rad)
+    catenary_parameter = vertical_distance * cos_comp / (1.0 - cos_comp)
     return {
-        "arc_length": catenary_parameter * slope,
-        "horizontal_distance": catenary_parameter * math.asinh(slope),
+        "arc_length": catenary_parameter * tanqc,
+        "horizontal_distance": catenary_parameter * math.asinh(tanqc),
         "bend_radius": catenary_parameter,
     }
 


### PR DESCRIPTION
## ⚠️ Fixes a suite-wide pytest collection abort introduced by #767

**Symptom:** a single *collection error* in `tests/.../catenary/test_run_quick.py` (a module-level validation script with a top-level `assert`) was **interrupting the entire pytest collection → 0 tests run**.

**Root cause:** #767 changed `SimplifiedCatenarySolver.solve_from_angle` from the **complementary-angle** convention (q from vertical) to a **horizontal-angle** convention, so `solve_from_angle(30,100)` returned **S=373.21** instead of the canonical **S=173.2050808**. That diverged from the rest of digitalmodel:
- the registered `catenary` workflow is durable-tested at `S=173.2050808` for q=30/d=100, and
- the legacy `catenaryEquation` adapter agrees (173.21).

`test_run_quick.py`'s module-level assert (simplified == adapter) then failed at import, aborting collection.

## Fix
- **simplified.py** — restored the complementary-angle math; `solve_from_angle(30,100)` → **S=173.2051, X=131.6958, a=100.0** (exact canonical match).
- **test_simplified.py** — corrected the `expected_from_angle` helper to the same convention.
- **test_catenary_integration.py** — the two contract tests asserted simplified **≠** adapter (the bogus divergence); now assert they **agree**.

## Verification
Collection now clean: **8455 tests collected, 0 errors**. All catenary tests + adapter + durable catenary workflow green (82 passed). Keeps #767's good parts (perf-test robustness, mooring designer type leak) intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)