### PR TITLE
feat(#711): registry wave 5 naval architecture — damage/platform stability, hull resistance + seakeeping

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -499,3 +499,39 @@ workflows:
       - examples/workflows/vlp-correlations/results/vlp_correlations/vlp_correlations_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[vlp-correlations]
     runtime: offline
+  - id: damage-stability
+    basename: naval_arch
+    title: IMO intact and damage-stability screen from a tabulated GZ curve
+    input: examples/workflows/damage-stability/input.yml
+    outputs:
+      - examples/workflows/damage-stability/results/input.yml
+      - examples/workflows/damage-stability/results/damage_stability/damage_stability_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[damage-stability]
+    runtime: offline
+  - id: platform-stability
+    basename: naval_arch
+    title: FPSO intact stability and wind-heel screen
+    input: examples/workflows/platform-stability/input.yml
+    outputs:
+      - examples/workflows/platform-stability/results/input.yml
+      - examples/workflows/platform-stability/results/platform_stability/platform_stability_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[platform-stability]
+    runtime: offline
+  - id: hull-resistance
+    basename: naval_arch
+    title: Series 60 hull-form coefficients and Holtrop-Mennen resistance screen
+    input: examples/workflows/hull-resistance/input.yml
+    outputs:
+      - examples/workflows/hull-resistance/results/input.yml
+      - examples/workflows/hull-resistance/results/hull_resistance/hull_resistance_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[hull-resistance]
+    runtime: offline
+  - id: hull-seakeeping
+    basename: naval_arch
+    title: Hull natural-period and simple seakeeping response screen
+    input: examples/workflows/hull-seakeeping/input.yml
+    outputs:
+      - examples/workflows/hull-seakeeping/results/input.yml
+      - examples/workflows/hull-seakeeping/results/hull_seakeeping/hull_seakeeping_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[hull-seakeeping]
+    runtime: offline

--- a/examples/workflows/damage-stability/input.yml
+++ b/examples/workflows/damage-stability/input.yml
@@ -1,0 +1,28 @@
+basename: naval_arch
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+naval_arch:
+  calculation: damage_stability
+  damage_stability:
+    case:
+      id: registry_damage_stability
+      description: Registry IMO intact and damage-stability screen
+    intact_stability:
+      angles_deg: [0, 10, 20, 30, 40, 50, 60, 70]
+      gz_m: [0.0, 0.286, 0.594, 0.945, 1.326, 1.402, 1.219, 0.823]
+      gm_m: 1.10
+    flooding:
+      compartment_volume_m3: 500.0
+      permeability: 0.85
+      waterplane_area_m2: 2000.0
+      intact_gm_m: 1.5
+      lost_waterplane_inertia_m4: 5000.0
+      displacement_tonnes: 10000.0
+    outputs:
+      directory: results/damage_stability

--- a/examples/workflows/hull-resistance/input.yml
+++ b/examples/workflows/hull-resistance/input.yml
@@ -1,0 +1,32 @@
+basename: naval_arch
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+naval_arch:
+  calculation: hull_resistance
+  hull_resistance:
+    case:
+      id: registry_hull_resistance
+      description: Registry Series 60 hull-form and Holtrop-Mennen resistance screen
+    hull:
+      lwl_m: 121.92
+      beam_m: 16.26
+      draft_m: 6.50
+      displacement_m3: 7731.43488
+      midship_area_m2: 103.25913
+      waterplane_area_m2: 1387.69344
+      cm: 0.977
+      cp: 0.614
+      lcb_pct: -2.02
+      cstern: 0
+      bulbous_bow_area_m2: 0.0
+      transom_area_m2: 0.0
+    operating:
+      speed_ms: 7.72
+    outputs:
+      directory: results/hull_resistance

--- a/examples/workflows/hull-seakeeping/input.yml
+++ b/examples/workflows/hull-seakeeping/input.yml
@@ -1,0 +1,34 @@
+basename: naval_arch
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+naval_arch:
+  calculation: hull_seakeeping
+  hull_seakeeping:
+    case:
+      id: registry_hull_seakeeping
+      description: Registry natural-period and simple wave-response screen
+    vessel:
+      beam_m: 30.0
+      gm_m: 1.0
+      displacement_tonnes: 10000.0
+      waterplane_area_m2: 3000.0
+      lwl_m: 150.0
+      gml_m: 150.0
+      speed_ms: 8.0
+    wave:
+      frequency_rad_s: 0.8
+      heading_deg: 180.0
+      damping_ratio: 0.05
+      vertical_accel_rms_g: 0.05
+      exposure_hours: 2.0
+      rao_values: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      spectrum_values: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      frequency_step_rad_s: 0.1
+    outputs:
+      directory: results/hull_seakeeping

--- a/examples/workflows/platform-stability/input.yml
+++ b/examples/workflows/platform-stability/input.yml
@@ -1,0 +1,29 @@
+basename: naval_arch
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+naval_arch:
+  calculation: platform_stability
+  platform_stability:
+    case:
+      id: registry_platform_stability
+      description: Registry FPSO intact stability and wind-heel screen
+    platform_type: fpso
+    vessel:
+      displacement_t: 200000.0
+      kg_m: 8.0
+      kb_m: 10.0
+      waterplane_area_m2: 15000.0
+    gz_curve:
+      heel_angles_deg: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90]
+    wind:
+      wind_pressure_kpa: 0.5
+      projected_area_m2: 5000.0
+      heeling_arm_m: 25.0
+    outputs:
+      directory: results/platform_stability

--- a/src/digitalmodel/naval_architecture/workflow.py
+++ b/src/digitalmodel/naval_architecture/workflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -34,16 +36,45 @@ def _stringify_paths(value: Any) -> Any:
     return value
 
 
+def _json_ready(value: Any) -> Any:
+    if is_dataclass(value):
+        return _json_ready(asdict(value))
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _write_summary(
+    output_dir: Path, stem: str, result: dict[str, Any]
+) -> dict[str, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_json = output_dir / f"{stem}_summary.json"
+    with summary_json.open("w", encoding="utf-8") as stream:
+        json.dump(_json_ready(result), stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    return {"summary_json": summary_json}
+
+
 class NavalArchitectureWorkflow:
     """Route selected naval architecture calculations through existing helpers."""
 
     def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
         workflow_cfg = cfg.get("naval_arch", {})
         calculation = workflow_cfg.get("calculation")
-        if calculation == "yaw_moment":
-            return self._run_yaw_moment(cfg, workflow_cfg)
-        if calculation == "rudder_stock_torque":
-            return self._run_rudder_stock_torque(cfg, workflow_cfg)
+        handlers = {
+            "yaw_moment": self._run_yaw_moment,
+            "rudder_stock_torque": self._run_rudder_stock_torque,
+            "damage_stability": self._run_damage_stability,
+            "platform_stability": self._run_platform_stability,
+            "hull_resistance": self._run_hull_resistance,
+            "hull_seakeeping": self._run_hull_seakeeping,
+        }
+        if calculation in handlers:
+            return handlers[calculation](cfg, workflow_cfg)
         raise ValueError(f"Unsupported naval_arch calculation: {calculation}")
 
     def _run_yaw_moment(
@@ -67,6 +98,99 @@ class NavalArchitectureWorkflow:
             "yaw_moment": {
                 **input_payload,
                 "result": result,
+                "artifacts": _stringify_paths(manifest),
+            },
+        }
+        cfg.setdefault("outputs", {})["directory"] = str(output_dir)
+        return cfg
+
+    def _run_damage_stability(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+    ) -> dict[str, Any]:
+        from digitalmodel.naval_architecture.workflow_calculations import (
+            run_damage_stability,
+        )
+
+        return self._run_calculation(
+            cfg, workflow_cfg, "damage_stability", run_damage_stability
+        )
+
+    def _run_platform_stability(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+    ) -> dict[str, Any]:
+        from digitalmodel.naval_architecture.workflow_calculations import (
+            run_platform_stability,
+        )
+
+        return self._run_calculation(
+            cfg, workflow_cfg, "platform_stability", run_platform_stability
+        )
+
+    def _run_hull_resistance(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+    ) -> dict[str, Any]:
+        from digitalmodel.naval_architecture.workflow_calculations import (
+            run_hull_resistance,
+        )
+
+        return self._run_calculation(
+            cfg, workflow_cfg, "hull_resistance", run_hull_resistance
+        )
+
+    def _run_hull_seakeeping(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+    ) -> dict[str, Any]:
+        from digitalmodel.naval_architecture.workflow_calculations import (
+            run_hull_seakeeping,
+        )
+
+        return self._run_calculation(
+            cfg, workflow_cfg, "hull_seakeeping", run_hull_seakeeping
+        )
+
+    def _run_calculation(
+        self,
+        cfg: dict[str, Any],
+        workflow_cfg: dict[str, Any],
+        calculation: str,
+        runner: Any,
+    ) -> dict[str, Any]:
+        input_payload = workflow_cfg[calculation]
+        result = runner(input_payload)
+        return self._store_result(
+            cfg,
+            calculation,
+            input_payload,
+            result,
+            calculation,
+        )
+
+    def _store_result(
+        self,
+        cfg: dict[str, Any],
+        calculation: str,
+        input_payload: dict[str, Any],
+        result: dict[str, Any],
+        output_stem: str,
+    ) -> dict[str, Any]:
+        output_dir = _resolve_dir(
+            cfg,
+            input_payload.get("outputs", {}).get("directory", f"results/{calculation}"),
+        )
+        manifest = _write_summary(output_dir, output_stem, result)
+        cfg["naval_arch"] = {
+            "calculation": calculation,
+            calculation: {
+                **input_payload,
+                "result": _json_ready(result),
                 "artifacts": _stringify_paths(manifest),
             },
         }

--- a/src/digitalmodel/naval_architecture/workflow_calculations.py
+++ b/src/digitalmodel/naval_architecture/workflow_calculations.py
@@ -1,0 +1,207 @@
+"""Calculation adapters for engine-routed naval architecture workflows."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict
+from typing import Any
+
+
+def run_damage_stability(input_payload: dict[str, Any]) -> dict[str, Any]:
+    from digitalmodel.naval_architecture.damage_stability import (
+        angle_of_max_gz,
+        check_imo_intact_stability,
+        flooded_gm,
+        gz_area_under_curve,
+        interpolate_gz,
+        lost_buoyancy_sinkage,
+    )
+
+    intact = input_payload["intact_stability"]
+    flooding = input_payload["flooding"]
+    angles = intact["angles_deg"]
+    gz_values = intact["gz_m"]
+    return {
+        "area_to_30_m_rad": gz_area_under_curve(angles, gz_values, 30.0),
+        "area_to_40_m_rad": gz_area_under_curve(angles, gz_values, 40.0),
+        "gz_at_30_m": interpolate_gz(angles, gz_values, 30.0),
+        "angle_of_max_gz_deg": angle_of_max_gz(angles, gz_values),
+        "imo_intact_stability": check_imo_intact_stability(
+            angles,
+            gz_values,
+            intact["gm_m"],
+        ),
+        "sinkage_m": lost_buoyancy_sinkage(
+            flooding["compartment_volume_m3"],
+            flooding["permeability"],
+            flooding["waterplane_area_m2"],
+        ),
+        "flooded_gm_m": flooded_gm(
+            flooding["intact_gm_m"],
+            flooding["lost_waterplane_inertia_m4"],
+            flooding["displacement_tonnes"],
+        ),
+    }
+
+
+def run_platform_stability(input_payload: dict[str, Any]) -> dict[str, Any]:
+    from digitalmodel.naval_architecture.floating_platform_stability import (
+        check_intact_stability,
+        compute_gm,
+        compute_gz_curve,
+        compute_wind_heel,
+    )
+
+    vessel = input_payload["vessel"]
+    wind_input = input_payload["wind"]
+    platform_type = input_payload["platform_type"]
+    gm_m = compute_gm(
+        vessel["displacement_t"],
+        vessel["kg_m"],
+        vessel["kb_m"],
+        vessel["waterplane_area_m2"],
+    )
+    gz_curve = compute_gz_curve(gm_m, input_payload["gz_curve"]["heel_angles_deg"])
+    wind = compute_wind_heel(
+        wind_input["wind_pressure_kpa"],
+        wind_input["projected_area_m2"],
+        wind_input["heeling_arm_m"],
+        vessel["displacement_t"],
+        gm_m,
+    )
+    stability = asdict(check_intact_stability(platform_type, gm_m, gz_curve, wind))
+    return {
+        **stability,
+        "platform_type": platform_type,
+        "wind_heel_angle_deg": wind.heel_angle_deg,
+        "wind_pressure_kpa": wind.wind_pressure_kpa,
+        "heeling_arm_m": wind.heeling_arm_m,
+        "gz_curve": [{"heel_deg": heel, "gz_m": gz} for heel, gz in gz_curve],
+    }
+
+
+def run_hull_resistance(input_payload: dict[str, Any]) -> dict[str, Any]:
+    hull = input_payload["hull"]
+    speed_ms = input_payload["operating"]["speed_ms"]
+    coefficients = _hull_form_coefficients(hull)
+    wetted_surface, resistance_n = _holtrop_resistance(hull, speed_ms, coefficients)
+
+    from digitalmodel.naval_architecture.holtrop_mennen import effective_power
+    from digitalmodel.naval_architecture.hull_form import (
+        displacement_from_cb,
+        froude_number,
+    )
+
+    return {
+        "coefficients": coefficients,
+        "displacement_tonnes": displacement_from_cb(
+            coefficients["cb"], hull["lwl_m"], hull["beam_m"], hull["draft_m"]
+        ),
+        "froude_number": froude_number(speed_ms, hull["lwl_m"]),
+        "wetted_surface_m2": wetted_surface,
+        "total_resistance_N": resistance_n,
+        "effective_power_W": effective_power(resistance_n, speed_ms),
+    }
+
+
+def _hull_form_coefficients(hull: dict[str, Any]) -> dict[str, float]:
+    from digitalmodel.naval_architecture.hull_form import (
+        block_coefficient,
+        midship_coefficient,
+        prismatic_coefficient,
+        waterplane_coefficient,
+    )
+
+    cb = block_coefficient(
+        hull["displacement_m3"], hull["lwl_m"], hull["beam_m"], hull["draft_m"]
+    )
+    cm = midship_coefficient(hull["midship_area_m2"], hull["beam_m"], hull["draft_m"])
+    cwp = waterplane_coefficient(
+        hull["waterplane_area_m2"], hull["lwl_m"], hull["beam_m"]
+    )
+    cp_from_cb_cm = prismatic_coefficient(cb, cm)
+    return {
+        "cb": cb,
+        "cm": cm,
+        "cwp": cwp,
+        "cp": hull.get("cp", cp_from_cb_cm),
+        "cp_from_cb_cm": cp_from_cb_cm,
+    }
+
+
+def _holtrop_resistance(
+    hull: dict[str, Any],
+    speed_ms: float,
+    coefficients: dict[str, float],
+) -> tuple[float, float]:
+    from digitalmodel.naval_architecture.holtrop_mennen import (
+        total_resistance,
+        wetted_surface_holtrop,
+    )
+
+    abt = hull.get("bulbous_bow_area_m2", 0.0)
+    at = hull.get("transom_area_m2", 0.0)
+    wetted_surface = wetted_surface_holtrop(
+        hull["lwl_m"],
+        hull["beam_m"],
+        hull["draft_m"],
+        coefficients["cb"],
+        coefficients["cm"],
+        coefficients["cwp"],
+        abt,
+    )
+    resistance_n = total_resistance(
+        hull["lwl_m"],
+        hull["beam_m"],
+        hull["draft_m"],
+        coefficients["cb"],
+        coefficients["cm"],
+        coefficients["cwp"],
+        coefficients["cp"],
+        hull["lcb_pct"],
+        hull["cstern"],
+        speed_ms,
+        abt,
+        hull["draft_m"],
+        0.0,
+        at,
+    )
+    return wetted_surface, resistance_n
+
+
+def run_hull_seakeeping(input_payload: dict[str, Any]) -> dict[str, Any]:
+    from digitalmodel.naval_architecture.seakeeping import (
+        encounter_frequency,
+        motion_sickness_incidence,
+        natural_heave_period,
+        natural_pitch_period,
+        natural_roll_period,
+        significant_motion,
+        simple_heave_rao,
+    )
+
+    vessel = input_payload["vessel"]
+    wave = input_payload["wave"]
+    heave_period_s = natural_heave_period(
+        vessel["displacement_tonnes"], vessel["waterplane_area_m2"]
+    )
+    natural_heave_frequency = 2.0 * math.pi / heave_period_s
+    return {
+        "natural_roll_period_s": natural_roll_period(vessel["beam_m"], vessel["gm_m"]),
+        "natural_heave_period_s": heave_period_s,
+        "natural_pitch_period_s": natural_pitch_period(
+            vessel["lwl_m"], vessel["gml_m"], vessel["displacement_tonnes"]
+        ),
+        "encounter_frequency_rad_s": encounter_frequency(
+            wave["frequency_rad_s"], vessel["speed_ms"], wave["heading_deg"]
+        ),
+        "simple_heave_rao": simple_heave_rao(
+            wave["frequency_rad_s"], natural_heave_frequency, wave["damping_ratio"]
+        ),
+        "motion_sickness_incidence_pct": motion_sickness_incidence(
+            wave["vertical_accel_rms_g"], wave["exposure_hours"]
+        ),
+        "significant_motion_m": significant_motion(
+            wave["rao_values"], wave["spectrum_values"], wave["frequency_step_rad_s"]
+        ),
+    }

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -675,6 +675,49 @@ def test_workflow_registry(workflow):
         envelope = pd.read_csv(envelope_csv)
         assert len(envelope) == 160
         assert set(envelope["envelope"]) == {"vme_isotropic", "api_ellipse"}
+    elif workflow["id"] == "damage-stability":
+        result = cfg["naval_arch"]["damage_stability"]["result"]
+        assert cfg["naval_arch"]["calculation"] == "damage_stability"
+        assert result["imo_intact_stability"]["overall_pass"] is True
+        assert result["area_to_30_m_rad"] == pytest.approx(0.236055781)
+        assert result["area_to_40_m_rad"] == pytest.approx(0.434237918)
+        assert result["gz_at_30_m"] == pytest.approx(0.945)
+        assert result["angle_of_max_gz_deg"] == pytest.approx(50.0)
+        assert result["sinkage_m"] == pytest.approx(0.2125)
+        assert result["flooded_gm_m"] == pytest.approx(1.0)
+    elif workflow["id"] == "platform-stability":
+        result = cfg["naval_arch"]["platform_stability"]["result"]
+        assert cfg["naval_arch"]["calculation"] == "platform_stability"
+        assert result["platform_type"] == "fpso"
+        assert result["intact"] is True
+        assert result["gm_m"] == pytest.approx(2.784602183)
+        assert result["gz_at_30deg"] == pytest.approx(1.392301092)
+        assert result["area_0_to_30"] == pytest.approx(0.372829168)
+        assert result["area_0_to_40"] == pytest.approx(0.651059664)
+        assert result["wind_heel_angle_deg"] == pytest.approx(0.655465685)
+        assert result["wind_criterion_ok"] is True
+    elif workflow["id"] == "hull-resistance":
+        result = cfg["naval_arch"]["hull_resistance"]["result"]
+        coefficients = result["coefficients"]
+        assert cfg["naval_arch"]["calculation"] == "hull_resistance"
+        assert coefficients["cb"] == pytest.approx(0.60)
+        assert coefficients["cm"] == pytest.approx(0.977)
+        assert coefficients["cwp"] == pytest.approx(0.70)
+        assert coefficients["cp_from_cb_cm"] == pytest.approx(0.614124872)
+        assert result["froude_number"] == pytest.approx(0.223226279)
+        assert result["wetted_surface_m2"] == pytest.approx(2429.246060393)
+        assert result["total_resistance_N"] == pytest.approx(195598.466626663)
+        assert result["effective_power_W"] == pytest.approx(1510020.162357836)
+    elif workflow["id"] == "hull-seakeeping":
+        result = cfg["naval_arch"]["hull_seakeeping"]["result"]
+        assert cfg["naval_arch"]["calculation"] == "hull_seakeeping"
+        assert result["natural_roll_period_s"] == pytest.approx(24.072800169)
+        assert result["natural_heave_period_s"] == pytest.approx(3.617618822)
+        assert result["natural_pitch_period_s"] == pytest.approx(6.142299697)
+        assert result["encounter_frequency_rad_s"] == pytest.approx(1.321916412)
+        assert result["simple_heave_rao"] == pytest.approx(1.267131324)
+        assert result["motion_sickness_incidence_pct"] == pytest.approx(8.485281374)
+        assert result["significant_motion_m"] == pytest.approx(2.0)
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:


### PR DESCRIPTION
Part of #711, wave 5 (naval architecture remainder, per the operator decision). Extends the existing `naval_arch` selector with thin adapters over `naval_architecture/` module logic — no new engineering. Registry +4 rows.

| Workflow | Verified |
|---|---|
| damage-stability | IMO criteria PASS; area 0-30° 0.2361, area 0-40° 0.4342; sinkage 0.2125 m; flooded GM 1.0 m |
| platform-stability | FPSO intact PASS; GM 2.785 m, GZ@30° 1.392 m, wind heel 0.655° |
| hull-resistance | Holtrop-Mennen resistance 195,598 N, PE 1.51 MW (Cb 0.60, Cwp 0.70, Fn 0.223) |
| hull-seakeeping | roll 24.07 s, heave 3.62 s, pitch 6.14 s, RAO 1.267, motion-sickness incidence 8.49% |

## Verified (real uv)
- all 4 exit 0 via `uv run python -m digitalmodel <input.yml>`
- `tests/workflows/test_durable_workflows.py + tests/contracts/` → 79 passed, 1 skipped

## Pre-existing, untouched
`tests/naval_architecture/` has 19 failures on main unrelated to this lane (missing `turning_circle` module, snap-uv DBus subprocess tests, a vessel-fleet adapter count mismatch). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)