### PR TITLE
feat(#711): onboard coiled-tubing hydraulics as durable workflow

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -572,3 +572,12 @@ workflows:
       - examples/workflows/propeller-rudder-interaction/results/propeller_rudder/propeller_rudder_sweep.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[propeller-rudder-interaction]
     runtime: offline
+  - id: ct-hydraulics
+    basename: ct_hydraulics
+    title: Steady-state coiled-tubing pressure-loss, pump pressure, and ECD screen
+    input: examples/workflows/ct-hydraulics/input.yml
+    outputs:
+      - examples/workflows/ct-hydraulics/results/input.yml
+      - examples/workflows/ct-hydraulics/results/ct_hydraulics/ct_hydraulics_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[ct-hydraulics]
+    runtime: offline

--- a/examples/workflows/ct-hydraulics/input.yml
+++ b/examples/workflows/ct-hydraulics/input.yml
@@ -1,0 +1,31 @@
+basename: ct_hydraulics
+
+# Steady-state coiled-tubing hydraulics screen: 1.75 in CT run into a
+# 4.892 in (5-1/2 in 17 ppf casing) wellbore at 3000 m, circulating a
+# 8.55 ppg (light brine) fluid at 60 gpm.
+ct_hydraulics:
+  well:
+    name: example-ct-cleanout
+    measured_depth_m: 3000.0
+    tvd_m: 3000.0
+    hole_id_in: 4.892
+    wellhead_pressure_psi: 500.0
+  ct:
+    od_in: 1.75
+    wall_thickness_in: 0.134
+    length_m: 3000.0
+    roughness_in: 0.0006
+    reel_pressure_drop_psi: 150.0
+  annulus:
+    hole_id_in: 4.892
+    inner_od_in: 1.75
+  bha:
+    pressure_drop_psi: 300.0
+  fluid:
+    density_ppg: 8.55
+    ct_viscosity_cp: 1.0
+  flow:
+    rate_gpm: 60.0
+  options:
+    flow_regime_transition_re: 2100.0
+    include_annulus_friction_in_pump_pressure: true

--- a/src/digitalmodel/marine_ops/ct_hydraulics/ct_hydraulics.py
+++ b/src/digitalmodel/marine_ops/ct_hydraulics/ct_hydraulics.py
@@ -1,4 +1,6 @@
+import json
 import math
+from pathlib import Path
 
 from digitalmodel.units import Q_
 
@@ -20,12 +22,39 @@ class CTHydraulics:
 
         Returns:
             The configuration dictionary with computed ``results``
-            added under ``cfg["ct_hydraulics"]["results"]``.
+            added under ``cfg["ct_hydraulics"]["results"]``. A
+            deterministic JSON summary is also written under
+            ``results/ct_hydraulics/`` next to the input file.
         """
         ct_cfg = cfg.get("ct_hydraulics", {})
-        ct_cfg["results"] = self.calculate(ct_cfg)
+        results = self.calculate(ct_cfg)
+        ct_cfg["results"] = results
+        summary_path = self._write_summary(cfg, ct_cfg, results)
+        if summary_path is not None:
+            ct_cfg["summary_json"] = summary_path
         cfg["ct_hydraulics"] = ct_cfg
         return cfg
+
+    def _write_summary(self, cfg: dict, ct_cfg: dict, results: dict):
+        """Write a deterministic JSON summary of the hydraulics results.
+
+        Mirrors the naval_arch workflow output convention: the file is
+        written to ``<output_dir>/<stem>_summary.json`` resolved relative
+        to the input file's directory. Returns the repo-relative path, or
+        ``None`` when no config directory is known.
+        """
+        config_dir = cfg.get("_config_dir_path")
+        if not config_dir:
+            return None
+        output_dir = Path(ct_cfg.get("output_dir", "results")) / "ct_hydraulics"
+        if not output_dir.is_absolute():
+            output_dir = Path(config_dir) / output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        summary_path = output_dir / "ct_hydraulics_summary.json"
+        with summary_path.open("w", encoding="utf-8") as stream:
+            json.dump(results, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        return str(summary_path)
 
     def calculate(self, ct_cfg: dict) -> dict:
         """Perform steady-state coiled tubing hydraulics calculations.
@@ -65,14 +94,21 @@ class CTHydraulics:
         ct_rough_in = float(ct.get("roughness_in", 0.0))
         reel_pressure_drop_psi = float(ct.get("reel_pressure_drop_psi", 0.0))
 
+        # Use ``or``-style coalescing so an explicit ``None`` from a
+        # deep-merged base config falls back to the same defaults as a
+        # missing key (dict.get only substitutes when the key is absent).
         hole_id_in = float(
-            annulus.get("hole_id_in", well.get("hole_id_in", 0.0))
+            self._coalesce(annulus.get("hole_id_in"), well.get("hole_id_in"), 0.0)
         )
         ann_length_m = float(
-            annulus.get("length_m", well.get("measured_depth_m", ct_length_m))
+            self._coalesce(
+                annulus.get("length_m"),
+                well.get("measured_depth_m"),
+                ct_length_m,
+            )
         )
-        ann_rough_in = float(annulus.get("roughness_in", ct_rough_in))
-        ann_inner_od_in = float(annulus.get("inner_od_in", ct_od_in))
+        ann_rough_in = float(self._coalesce(annulus.get("roughness_in"), ct_rough_in))
+        ann_inner_od_in = float(self._coalesce(annulus.get("inner_od_in"), ct_od_in))
         ann_dh_override_in = annulus.get("hydraulic_diameter_override_in")
 
         ct_section = self._compute_pipe_section(
@@ -276,6 +312,14 @@ class CTHydraulics:
             return 0.0
         delta_p_pa = friction_factor * (length_m / diameter_m) * 0.5 * density * velocity_m_s**2
         return Q_(delta_p_pa, 'Pa').to('psi').magnitude
+
+    @staticmethod
+    def _coalesce(*values):
+        """Return the first non-``None`` value (last value is the default)."""
+        for value in values:
+            if value is not None:
+                return value
+        return values[-1] if values else None
 
     @staticmethod
     def _ppg_to_kgm3(ppg: float) -> float:

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -761,6 +761,17 @@ def test_workflow_registry(workflow):
         )
 
         assert_hydrodynamics_workflow(workflow["id"], cfg)
+    elif workflow["id"] == "ct-hydraulics":
+        results = cfg["ct_hydraulics"]["results"]
+        summary = results["summary"]
+        assert summary["hydrostatic_pressure_psi"] == pytest.approx(4376.0)
+        assert summary["pump_pressure_psi"] == pytest.approx(2258.6)
+        assert summary["downhole_pressure_psi"] == pytest.approx(6476.1)
+        assert summary["equivalent_circulating_density_ppg"] == pytest.approx(8.567)
+        ct = results["coiled_tubing"]
+        assert ct["id_in"] == pytest.approx(1.482)
+        assert ct["reynolds_number"] == pytest.approx(131177.7)
+        assert ct["pressure_loss_psi"] == pytest.approx(1300.1)
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:


### PR DESCRIPTION
Part of #711 (durable workflows v2). Onboards **coiled-tubing hydraulics** (steady-state pressure-loss / pump pressure / ECD) as a registry workflow.

## Why this one
`marine_ops/ct_hydraulics/ct_hydraulics.py` was the cleanest READY candidate in a gap analysis of the remaining #711 backlog — genuine Darcy-Weisbach physics (Haaland friction factor, Reynolds, hydrostatic, ECD) with `Q_` units, already engine-routed, offline/deterministic.

## Changes
- `src/digitalmodel/marine_ops/ct_hydraulics/ct_hydraulics.py` — router now writes a deterministic JSON summary under `results/ct_hydraulics/` (mirrors the naval-arch `_write_summary` convention). **Also fixes a genuine pre-existing bug**: `calculate()` read annulus fields with `dict.get(key, fallback)`, but the base config sets those keys to `null`, so after the engine's deep-merge they existed as `None` and `float(None)` crashed. Added a small `_coalesce()` helper (first non-None wins, mirroring the module's existing `ann_visc_value` handling). Physics untouched.
- `examples/workflows/ct-hydraulics/input.yml` — realistic case: 1.75 in CT (0.134 wall), 3000 m, 4.892 in hole, 8.55 ppg fluid, 60 gpm.
- `docs/registry/workflows.yaml` — registry row (id `ct-hydraulics`, basename `ct_hydraulics`, runtime offline).
- `tests/workflows/test_durable_workflows.py` — registry test parametrization.

(Engine route + base config already existed — no engine change needed.)

## Verification
- `uv run python -m digitalmodel examples/workflows/ct-hydraulics/input.yml` → exit 0, deterministic JSON (re-run byte-identical).
- Numbers hand-checked: hydrostatic 4376.0 psi (0.052 × 8.55 × 9842 ft ✓); CT ID 1.482 in (1.75 − 2×0.134 ✓); pump 2258.6 = 500 WH + 1300.1 CT + 300 BHA + 150 reel + 8.5 annulus ✓; ECD 8.567 ppg just above mud weight ✓.
- `test_workflow_registry[ct-hydraulics]` passes; existing ct_hydraulics compat test still passes; neighbor registry tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)