### PR TITLE
fix(ship): return cfg from ShipDesign.router (#757-class bug)

### DIFF
--- a/src/digitalmodel/infrastructure/base_solvers/marine/ship/ship_design.py
+++ b/src/digitalmodel/infrastructure/base_solvers/marine/ship/ship_design.py
@@ -19,5 +19,11 @@ class ShipDesign:
 
         Args:
             cfg: Configuration dictionary with analysis parameters.
+
+        Returns:
+            The (possibly updated) configuration dictionary. The engine assigns
+            ``cfg_base = ship_design.router(cfg_base)``; without a return the
+            config would be nulled (cf. #757 for the rigging router).
         """
-        sfa.router(cfg)
+        cfg = sfa.router(cfg)
+        return cfg


### PR DESCRIPTION
Surgical fix found while assessing `ship_design` for #711 onboarding.

## Problem
`ShipDesign.router` delegated to `ShipFatigueAnalysis.router(cfg)` but **discarded the result**, so the engine's `cfg_base = ...router(cfg_base)` would null the config — the same bug class #757 fixed for rigging/gis.

## Fix
```python
-        sfa.router(cfg)
+        cfg = sfa.router(cfg)
+        return cfg
```
Mirrors how `naval_architecture/workflow.py` returns `cfg`. One file, +7/-1.

## Scope / honesty
This is a correct standalone fix and safe to merge. It does **not** make `ship_design` runnable — the underlying `ShipFatigueAnalysis` compute is hollow (wrong class imported, required methods missing, no offline fixtures, mock-only test). That's filed separately as **#776**, and `ship_design` workflow onboarding is deferred until #776 is fixed. Onboarding was intentionally NOT done here (would have shipped a hollow workflow).

## Related
- #776 (ShipFatigueAnalysis hollow — blocks onboarding)
- #757 (original return-class fixes), #773 (rigging, same family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)