### PR TITLE
feat(workflow): onboard fpso-mooring-full durable workflow (#711)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -288,6 +288,16 @@ workflows:
       - examples/workflows/fpso-spread-mooring/results/fpso_spread_mooring_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[fpso-spread-mooring]
     runtime: offline
+  - id: fpso-mooring-full
+    basename: fpso_mooring_full
+    title: FPSO spread-mooring environmental load and static equilibrium workflow
+    input: examples/workflows/fpso-mooring-full/input.yml
+    outputs:
+      - examples/workflows/fpso-mooring-full/results/input.yml
+      - examples/workflows/fpso-mooring-full/results/fpso_mooring_full_summary.json
+      - examples/workflows/fpso-mooring-full/results/fpso_mooring_full_line_tensions.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[fpso-mooring-full]
+    runtime: offline
   - id: wall-thickness-quickcheck
     basename: wall_thickness
     title: DNV/API wall-thickness quickcheck cached deckhand report

--- a/examples/workflows/fpso-mooring-full/README.md
+++ b/examples/workflows/fpso-mooring-full/README.md
@@ -1,0 +1,18 @@
+# FPSO Mooring Full
+
+Runs the headless FPSO spread-mooring demo through the durable workflow contract.
+The workflow reads the demo defaults from `input.yml`, calculates OCIMF
+wind/current loading, adds a JONSWAP spectrum-derived wave drift term, solves
+static offset, and writes per-line catenary tensions.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/fpso-mooring-full/input.yml
+```
+
+Expected outputs are written to `examples/workflows/fpso-mooring-full/results/`:
+
+- `input.yml`
+- `fpso_mooring_full_summary.json`
+- `fpso_mooring_full_line_tensions.csv`

--- a/examples/workflows/fpso-mooring-full/input.yml
+++ b/examples/workflows/fpso-mooring-full/input.yml
@@ -1,0 +1,38 @@
+basename: fpso_mooring_full
+
+vessel:
+  loa: 330.0
+  beam: 60.0
+  draft: 22.0
+  freeboard: 25.0
+  displacement: 320000.0
+
+environment:
+  Hs: 3.0
+  Tp: 10.0
+  gamma: 3.3
+  wave_heading: 45.0
+  wind_speed: 20.0
+  wind_heading: 45.0
+  current_speed: 1.5
+  current_heading: 30.0
+
+mooring:
+  n_lines: 8
+  chain_diameter: 120.0
+  chain_grade: R4
+  chain_link_type: Studless
+  water_depth: 1500.0
+  line_length: 2000.0
+  pretension: 1500000.0
+
+output:
+  summary_json: examples/workflows/fpso-mooring-full/results/fpso_mooring_full_summary.json
+  line_tensions_csv: examples/workflows/fpso-mooring-full/results/fpso_mooring_full_line_tensions.csv
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/fpso_mooring_full/fpso_mooring_full.yml
+++ b/src/digitalmodel/base_configs/modules/fpso_mooring_full/fpso_mooring_full.yml
@@ -1,0 +1,8 @@
+basename: fpso_mooring_full
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -355,6 +355,13 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         fmw = FPSOMooringWorkflow()
         cfg_base = fmw.router(cfg_base)
+    elif basename == "fpso_mooring_full":
+        from digitalmodel.marine_ops.marine_engineering.mooring_analysis.fpso_full_workflow import (
+            FPSOMooringFullWorkflow,
+        )
+
+        fmw = FPSOMooringFullWorkflow()
+        cfg_base = fmw.router(cfg_base)
     elif basename == "jacket_checks":
         from digitalmodel.structural.jacket_topside.workflow import JacketChecksWorkflow
 

--- a/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_catenary.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_catenary.py
@@ -1,0 +1,37 @@
+"""Catenary setup helpers for the FPSO full mooring workflow."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+from .component_database import ChainProperties
+
+
+def baseline_bounds(
+    solver: object,
+    solve_line: Callable,
+    chain: ChainProperties,
+    water_depth: float,
+    line_length: float,
+    pretension: float,
+    max_span: float,
+) -> tuple[float, float]:
+    low = max_span * 0.1
+    high = max_span * 0.8
+    weight = chain.weight_water * 9.81
+    for fraction in np.linspace(0.2, 0.9, 15):
+        span = max_span * float(fraction)
+        try:
+            tension = solve_line(
+                solver, line_length, span, water_depth, weight, chain
+            )
+        except ValueError:
+            break
+        if tension["horizontal_tension_N"] < pretension:
+            low = span
+        else:
+            high = span
+            break
+    return low, high

--- a/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_output.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_output.py
@@ -1,0 +1,125 @@
+"""Output helpers for the FPSO full mooring durable workflow."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def result_folder(cfg: dict) -> Path:
+    analysis = cfg.get("Analysis", {})
+    if analysis.get("result_folder"):
+        return Path(analysis["result_folder"])
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"]) / "results"
+    return Path("results")
+
+
+def write_outputs(cfg: dict, result: dict, result_folder: Path) -> None:
+    summary_path = _output_path(
+        cfg,
+        result_folder,
+        "summary_json",
+        "fpso_mooring_full_summary.json",
+    )
+    tensions_path = _output_path(
+        cfg,
+        result_folder,
+        "line_tensions_csv",
+        "fpso_mooring_full_line_tensions.csv",
+    )
+    summary_path.write_text(json.dumps(result, indent=2))
+    _write_tensions_csv(tensions_path, result["line_tensions"])
+    cfg.setdefault("outputs", {})["summary_json"] = _display_path(summary_path)
+    cfg["outputs"]["line_tensions_csv"] = _display_path(tensions_path)
+
+
+def print_self_check(cfg: dict, result: dict) -> None:
+    vessel = cfg["vessel"]
+    environment = cfg["environment"]
+    equilibrium = result["static_equilibrium"]
+    summary = result["summary"]
+    print("SELF-CHECK fpso-mooring-full")
+    print(
+        "  vessel: "
+        f"LOA={vessel['loa']} m, beam={vessel['beam']} m, "
+        f"draft={vessel['draft']} m, displacement={vessel['displacement']} t"
+    )
+    print(
+        "  environment: "
+        f"Hs={environment['Hs']} m, Tp={environment['Tp']} s, "
+        f"wind={environment['wind_speed']} m/s @ "
+        f"{environment['wind_heading']} deg, "
+        f"current={environment['current_speed']} m/s @ "
+        f"{environment['current_heading']} deg"
+    )
+    print(
+        "  computed offset: "
+        f"{equilibrium['offset_m']:.3f} m "
+        f"(x={equilibrium['offset_x_m']:.3f}, "
+        f"y={equilibrium['offset_y_m']:.3f})"
+    )
+    print(
+        "  max line tension: "
+        f"{summary['max_line_tension_MN']:.3f} MN "
+        f"({summary['max_tension_line']})"
+    )
+
+
+def json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [json_safe(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return [json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _write_tensions_csv(path: Path, rows: list[dict]) -> None:
+    fieldnames = [
+        "line_id",
+        "heading_deg",
+        "horizontal_span_m",
+        "top_tension_N",
+        "horizontal_tension_N",
+        "anchor_tension_N",
+        "safety_factor",
+    ]
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _output_path(
+    cfg: dict,
+    result_folder: Path,
+    key: str,
+    filename: str,
+) -> Path:
+    configured = cfg.get("output", {}).get(key)
+    path = Path(configured) if configured else result_folder / filename
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_workflow.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/fpso_full_workflow.py
@@ -1,0 +1,400 @@
+"""Headless FPSO spread-mooring workflow for the durable workflow registry."""
+from __future__ import annotations
+
+import math
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+import numpy as np
+
+from digitalmodel.hydrodynamics.wave_spectra import WaveSpectra
+from digitalmodel.marine_ops.marine_engineering.environmental_loading import (
+    EnvironmentalConditions,
+    EnvironmentalForces,
+    OCIMFDatabase,
+    VesselGeometry,
+    create_sample_database,
+)
+from digitalmodel.marine_ops.marine_engineering.mooring_analysis import (
+    CatenaryInput,
+    CatenarySolver,
+)
+from .component_database import ChainGrade, ChainProperties, ComponentDatabase, LinkType
+from .fpso_full_catenary import baseline_bounds
+from .fpso_full_output import (
+    json_safe,
+    print_self_check,
+    result_folder,
+    write_outputs,
+)
+
+
+class FPSOMooringFullWorkflow:
+    """Run the demo FPSO mooring analysis from durable workflow YAML."""
+
+    def router(self, cfg: dict) -> dict:
+        vessel = cfg["vessel"]
+        environment = cfg["environment"]
+        mooring = cfg["mooring"]
+
+        spectrum = self._wave_spectrum(environment)
+        forces = self._environmental_forces(cfg, vessel, environment, spectrum)
+        chain = self._chain_properties(mooring)
+        line_model = self._line_model(vessel, mooring, chain)
+        equilibrium, line_tensions = self._static_equilibrium(forces, line_model)
+
+        result = self._result(
+            cfg, forces, spectrum, chain, equilibrium, line_tensions
+        )
+        cfg["fpso_mooring_full"] = result
+        write_outputs(cfg, result, result_folder(cfg))
+        print_self_check(cfg, result)
+        return cfg
+
+    def _wave_spectrum(self, environment: dict) -> dict:
+        generator = WaveSpectra()
+        frequencies, density = generator.jonswap(
+            hs=float(environment["Hs"]),
+            tp=float(environment["Tp"]),
+            gamma=float(environment.get("gamma", 3.3)),
+            freq_min=0.1,
+            freq_max=2.0,
+            n_points=100,
+        )
+        m0 = generator.spectral_moment(frequencies, density, n=0)
+        m2 = generator.spectral_moment(frequencies, density, n=2)
+        return {
+            "frequencies": frequencies,
+            "density": density,
+            "m0": m0,
+            "Hs_check": 4.0 * math.sqrt(m0),
+            "Tz": 2.0 * math.pi * math.sqrt(m0 / m2),
+            "peak_frequency": generator.peak_frequency_from_spectrum(
+                frequencies, density
+            ),
+        }
+
+    def _environmental_forces(
+        self,
+        cfg: dict,
+        vessel: dict,
+        environment: dict,
+        spectrum: dict,
+    ) -> dict:
+        database = OCIMFDatabase(str(self._ocimf_database_path(cfg)))
+        calculator = EnvironmentalForces(database)
+        conditions = EnvironmentalConditions(
+            wind_speed=float(environment["wind_speed"]),
+            wind_direction=float(environment["wind_heading"]),
+            current_speed=float(environment["current_speed"]),
+            current_direction=float(environment["current_heading"]),
+        )
+        geometry = self._vessel_geometry(vessel)
+        steady = calculator.calculate_total_forces(
+            conditions,
+            geometry,
+            float(vessel["displacement"]),
+        )
+        wave = self._wave_drift_force(environment, spectrum)
+        total_fx = steady.total_fx + wave["force_N"] * wave["unit_x"]
+        total_fy = steady.total_fy + wave["force_N"] * wave["unit_y"]
+        return self._force_output(steady, wave, total_fx, total_fy)
+
+    def _ocimf_database_path(self, cfg: dict) -> Path:
+        path = result_folder(cfg) / "ocimf_coefficients_sample.csv"
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            create_sample_database(
+                str(path),
+                num_vessels=5,
+                num_headings=13,
+                num_displacements=3,
+            )
+        return path
+
+    def _vessel_geometry(self, vessel: dict) -> VesselGeometry:
+        loa = float(vessel["loa"])
+        beam = float(vessel["beam"])
+        draft = float(vessel["draft"])
+        freeboard = float(vessel.get("freeboard", 10.0))
+        return VesselGeometry(
+            loa=loa,
+            beam=beam,
+            draft=draft,
+            frontal_area_wind=beam * freeboard,
+            lateral_area_wind=loa * freeboard,
+            frontal_area_current=beam * draft,
+            lateral_area_current=loa * draft,
+        )
+
+    def _wave_drift_force(self, environment: dict, spectrum: dict) -> dict:
+        direction = float(environment.get("wave_heading", environment["wind_heading"]))
+        coefficient = float(environment.get("wave_drift_coefficient_N_per_m2", 5e5))
+        force = coefficient * float(spectrum["m0"])
+        radians = math.radians(direction)
+        return {
+            "force_N": force,
+            "heading_deg": direction,
+            "coefficient_N_per_m2": coefficient,
+            "unit_x": math.cos(radians),
+            "unit_y": math.sin(radians),
+        }
+
+    def _force_output(
+        self, steady, wave: dict, total_fx: float, total_fy: float
+    ) -> dict:
+        total_force = math.hypot(total_fx, total_fy)
+        return {
+            "wind_fx_N": steady.wind_fx,
+            "wind_fy_N": steady.wind_fy,
+            "current_fx_N": steady.current_fx,
+            "current_fy_N": steady.current_fy,
+            "wave_drift_force_N": wave["force_N"],
+            "wave_heading_deg": wave["heading_deg"],
+            "total_fx_N": total_fx,
+            "total_fy_N": total_fy,
+            "total_force_N": total_force,
+            "total_heading_deg": math.degrees(math.atan2(total_fy, total_fx)),
+            "coefficients": asdict(steady.coefficients),
+        }
+
+    def _chain_properties(self, mooring: dict) -> ChainProperties:
+        diameter = float(mooring["chain_diameter"])
+        grade = str(mooring.get("chain_grade", "R4"))
+        link_type = str(mooring.get("chain_link_type", "Studless"))
+        try:
+            return ComponentDatabase().get_chain(diameter, grade, link_type)
+        except (FileNotFoundError, ValueError):
+            chain_link = (
+                LinkType.STUDLESS
+                if link_type.lower() == "studless"
+                else LinkType.STUD_LINK
+            )
+            return ChainProperties.from_excel_formula(
+                diameter,
+                ChainGrade[grade.upper()],
+                chain_link,
+            )
+
+    def _line_model(self, vessel: dict, mooring: dict, chain: ChainProperties) -> dict:
+        water_depth = float(mooring["water_depth"])
+        line_length = float(mooring["line_length"])
+        pretension = float(mooring["pretension"])
+        fairlead_radius = float(mooring.get("fairlead_radius", vessel["loa"] / 2.0))
+        return {
+            "n_lines": int(mooring["n_lines"]),
+            "line_length": line_length,
+            "water_depth": water_depth,
+            "pretension": pretension,
+            "fairlead_radius": fairlead_radius,
+            "baseline_span": self._baseline_span(
+                chain, water_depth, line_length, pretension
+            ),
+            "weight_per_length": chain.weight_water * 9.81,
+            "ea_stiffness": float(chain.stiffness) * 1000.0,
+            "mbl_N": float(chain.mbl) * 1000.0,
+        }
+
+    def _baseline_span(
+        self,
+        chain: ChainProperties,
+        water_depth: float,
+        line_length: float,
+        pretension: float,
+    ) -> float:
+        solver = CatenarySolver()
+        weight = chain.weight_water * 9.81
+        max_span = math.sqrt(max(line_length**2 - water_depth**2, 1.0)) * 0.98
+        low, high = baseline_bounds(
+            solver,
+            self._solve_line,
+            chain,
+            water_depth,
+            line_length,
+            pretension,
+            max_span,
+        )
+        for _ in range(50):
+            mid = 0.5 * (low + high)
+            tension = self._solve_line(
+                solver, line_length, mid, water_depth, weight, chain
+            )
+            if tension["horizontal_tension_N"] < pretension:
+                low = mid
+            else:
+                high = mid
+        return 0.5 * (low + high)
+
+    def _static_equilibrium(
+        self, forces: dict, line_model: dict
+    ) -> tuple[dict, list[dict]]:
+        force_mag = float(forces["total_force_N"])
+        direction = math.radians(float(forces["total_heading_deg"]))
+        unit = np.array([math.cos(direction), math.sin(direction)])
+        high = self._equilibrium_bracket(force_mag, unit, line_model)
+        low = 0.0
+        for _ in range(50):
+            mid = 0.5 * (low + high)
+            balance = self._restoring_projection(mid, unit, line_model) + force_mag
+            if balance > 0.0:
+                low = mid
+            else:
+                high = mid
+        offset = 0.5 * (low + high)
+        lines = self._line_tensions(offset * unit, line_model)
+        restoring = self._restoring_force(offset * unit, line_model, lines)
+        equilibrium = {
+            "offset_m": offset,
+            "offset_x_m": offset * float(unit[0]),
+            "offset_y_m": offset * float(unit[1]),
+            "restoring_fx_N": float(restoring[0]),
+            "restoring_fy_N": float(restoring[1]),
+        }
+        return equilibrium, lines
+
+    def _equilibrium_bracket(
+        self,
+        force_mag: float,
+        unit: np.ndarray,
+        line_model: dict,
+    ) -> float:
+        high = 1.0
+        for _ in range(12):
+            balance = self._restoring_projection(high, unit, line_model) + force_mag
+            if balance <= 0.0:
+                return high
+            high *= 2.0
+        return high
+
+    def _restoring_projection(
+        self,
+        offset: float,
+        unit: np.ndarray,
+        line_model: dict,
+    ) -> float:
+        try:
+            lines = self._line_tensions(offset * unit, line_model)
+        except ValueError:
+            return float("-inf")
+        restoring = self._restoring_force(offset * unit, line_model, lines)
+        return float(np.dot(restoring, unit))
+
+    def _line_tensions(self, offset: np.ndarray, line_model: dict) -> list[dict]:
+        solver = CatenarySolver()
+        tensions = []
+        for index in range(line_model["n_lines"]):
+            angle_deg = index * 360.0 / line_model["n_lines"]
+            state = self._line_state(solver, index + 1, angle_deg, offset, line_model)
+            tensions.append(state)
+        return tensions
+
+    def _line_state(
+        self,
+        solver: CatenarySolver,
+        line_number: int,
+        angle_deg: float,
+        offset: np.ndarray,
+        line_model: dict,
+    ) -> dict:
+        angle = math.radians(angle_deg)
+        radial = np.array([math.cos(angle), math.sin(angle)])
+        fairlead = offset + line_model["fairlead_radius"] * radial
+        anchor_radius = line_model["fairlead_radius"] + line_model["baseline_span"]
+        anchor = anchor_radius * radial
+        span = float(np.linalg.norm(anchor - fairlead))
+        result = self._solve_line(
+            solver,
+            line_model["line_length"],
+            span,
+            line_model["water_depth"],
+            line_model["weight_per_length"],
+            line_model,
+        )
+        return {
+            "line_id": f"Line_{line_number}",
+            "heading_deg": angle_deg,
+            "horizontal_span_m": span,
+            "top_tension_N": result["top_tension_N"],
+            "horizontal_tension_N": result["horizontal_tension_N"],
+            "anchor_tension_N": result["anchor_tension_N"],
+            "safety_factor": line_model["mbl_N"] / result["top_tension_N"],
+        }
+
+    def _solve_line(
+        self,
+        solver: CatenarySolver,
+        line_length: float,
+        span: float,
+        water_depth: float,
+        weight: float,
+        source: Any,
+    ) -> dict:
+        stiffness = source["ea_stiffness"] if isinstance(source, dict) else (
+            source.stiffness * 1000.0
+        )
+        solved = solver.solve(
+            CatenaryInput(
+                length=line_length,
+                horizontal_span=span,
+                vertical_span=water_depth,
+                weight_per_length=weight,
+                ea_stiffness=float(stiffness),
+                water_depth=water_depth,
+            )
+        )
+        return {
+            "top_tension_N": solved.total_tension_fairlead,
+            "horizontal_tension_N": solved.horizontal_tension,
+            "anchor_tension_N": solved.total_tension_anchor,
+        }
+
+    def _restoring_force(
+        self,
+        offset: np.ndarray,
+        line_model: dict,
+        lines: list[dict],
+    ) -> np.ndarray:
+        restoring = np.array([0.0, 0.0])
+        for line in lines:
+            angle = math.radians(line["heading_deg"])
+            radial = np.array([math.cos(angle), math.sin(angle)])
+            fairlead = offset + line_model["fairlead_radius"] * radial
+            anchor_radius = line_model["fairlead_radius"] + line_model["baseline_span"]
+            direction = anchor_radius * radial - fairlead
+            restoring += (
+                line["horizontal_tension_N"] * direction / np.linalg.norm(direction)
+            )
+        return restoring
+
+    def _result(
+        self,
+        cfg: dict,
+        forces: dict,
+        spectrum: dict,
+        chain: ChainProperties,
+        equilibrium: dict,
+        line_tensions: list[dict],
+    ) -> dict:
+        max_tension = max(line["top_tension_N"] for line in line_tensions)
+        max_line = max(line_tensions, key=lambda item: item["top_tension_N"])
+        return json_safe({
+            "inputs": {key: dict(cfg[key]) for key in (
+                "vessel", "environment", "mooring"
+            )},
+            "wave_spectrum": {key: spectrum[key] for key in (
+                "m0", "Hs_check", "Tz", "peak_frequency"
+            )},
+            "environmental_forces": forces,
+            "static_equilibrium": equilibrium,
+            "line_tensions": line_tensions,
+            "chain": asdict(chain),
+            "summary": {
+                "n_lines": len(line_tensions),
+                "pretension_N": float(cfg["mooring"]["pretension"]),
+                "max_line_tension_N": max_tension,
+                "max_line_tension_MN": max_tension / 1.0e6,
+                "max_tension_line": max_line["line_id"],
+                "min_safety_factor": min(
+                    line["safety_factor"] for line in line_tensions),
+            },
+        })

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -477,6 +477,31 @@ def test_workflow_registry(workflow):
             summary_path = REPO_ROOT / summary_path
         summary_json = yaml.safe_load(summary_path.read_text())
         assert summary_json["summary"]["critical_line"]["line_id"] == "ML1"
+    elif workflow["id"] == "fpso-mooring-full":
+        result = cfg["fpso_mooring_full"]
+        summary = result["summary"]
+        lines = result["line_tensions"]
+
+        assert summary["n_lines"] == 8
+        assert result["environmental_forces"]["total_force_N"] > 0.0
+        assert result["environmental_forces"]["wave_drift_force_N"] > 0.0
+        assert result["static_equilibrium"]["offset_m"] > 0.0
+        assert len(lines) == 8
+        assert summary["max_line_tension_N"] == pytest.approx(
+            max(line["top_tension_N"] for line in lines)
+        )
+        assert summary["max_line_tension_N"] > summary["pretension_N"]
+
+        summary_path = Path(cfg["outputs"]["summary_json"])
+        tensions_path = Path(cfg["outputs"]["line_tensions_csv"])
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+        if not tensions_path.is_absolute():
+            tensions_path = REPO_ROOT / tensions_path
+        summary_json = yaml.safe_load(summary_path.read_text())
+        tensions = pd.read_csv(tensions_path)
+        assert summary_json["summary"]["n_lines"] == 8
+        assert len(tensions) == 8
     elif workflow["id"] == "wall-thickness-quickcheck":
         result = cfg["wall_thickness"]["quickcheck"]
         selection = result["selection"]["with_arrestors"]


### PR DESCRIPTION
Onboards the standalone FPSO demo (`examples/domains/fpso/fpso_mooring_analysis.py`) into the durable-workflow registry under the uv-module contract — the **T0 near-ready** item from the demand signal (deckhand [#368](https://github.com/vamseeachanta/deckhand/issues/368)).

## Approach — reuse, not reinvent
Reuses existing package modules (`hydrodynamics.wave_spectra`, `marine_ops.marine_engineering.{environmental_loading, mooring_analysis}`). The new `fpso_full_*` modules are config-driven orchestration, not new physics (`fpso_full_catenary` is a 37-line bound-finder over the existing solver). Full end-to-end variant — distinct id from the existing `fpso-spread-mooring` screening leg.

Runs via: `uv run python -m digitalmodel examples/workflows/fpso-mooring-full/input.yml`.

## Self-check
LOA 330 / displ 320 kt, Hs 3 / wind 20@45 / current 1.5@30, WD 1500 m, pretension 1.5 MN/line → **offset 192.4 m, max tension 8.62 MN (Line_7)**, force-balance residual ~0.04%.

⚠️ **Reviewer note:** the example offset (~13% of WD) is high — driven by the low 1.5 MN pretension; reads as a soft-system illustration. Consider raising pretension or documenting it as such. (Physics direction + convergence are sound; this is an example-tuning note, not a solver bug.)

## Provenance & verification
Built via **codex** (heavy lane), **hand-verified**: ran the real uv-module contract (codex sandbox couldn't run uv) — no missing base_config this time — and **67/67 durable-workflow tests pass**.

Part of [#711](https://github.com/vamseeachanta/digitalmodel/issues/711) onboarding; T0 item from deckhand [#368](https://github.com/vamseeachanta/deckhand/issues/368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)