### PR TITLE
fix(#776): ShipFatigueAnalysis imports the correct FatigueAnalysis class + real test

### DIFF
--- a/src/digitalmodel/infrastructure/base_solvers/marine/ship/ship_fatigue_analysis.py
+++ b/src/digitalmodel/infrastructure/base_solvers/marine/ship/ship_fatigue_analysis.py
@@ -7,10 +7,12 @@ import numpy as np
 
 from assetutilities.common.utilities import add_cwd_to_filename
 from assetutilities.common.data import ReadData
-from digitalmodel.signal_processing.signal_analysis.fatigue import FatigueDamageCalculator
+from digitalmodel.infrastructure.base_solvers.fatigue.fatigue_analysis import (
+    FatigueAnalysis,
+)
 
 read_data = ReadData()
-fatigue_analysis = FatigueDamageCalculator()
+fatigue_analysis = FatigueAnalysis()
 
 
 class ShipFatigueAnalysis:

--- a/tests/specialized/ship_design/test_ship_fatigue_analysis_import.py
+++ b/tests/specialized/ship_design/test_ship_fatigue_analysis_import.py
@@ -1,0 +1,102 @@
+"""Real (non-mock) tests for the fatigue engine used by ShipFatigueAnalysis.
+
+Issue #776: ``ShipFatigueAnalysis`` imported ``FatigueDamageCalculator`` from
+``digitalmodel.signal_processing.signal_analysis.fatigue`` but the code calls
+``router``, ``get_default_timetrace_cfg`` and ``get_default_sn_cfg`` -- methods
+that live only on the *different* class ``FatigueAnalysis`` in
+``digitalmodel.infrastructure.base_solvers.fatigue.fatigue_analysis``. Any real
+run therefore raised ``AttributeError``. The import was corrected to point at
+``FatigueAnalysis``.
+
+These tests are deliberately NOT mocks. They:
+  1. Assert the import wiring is correct (the module-level instance is a
+     ``FatigueAnalysis`` exposing the methods the ship code actually calls).
+  2. Exercise the real fatigue-damage arithmetic on the ``FatigueAnalysis``
+     methods that are computable offline -- i.e. those that take an explicit
+     S-N (fatigue) curve and do not depend on the missing
+     ``fatigue_data.csv`` lookup -- and assert exact numeric results.
+
+NOTE on scope: the full ``ShipFatigueAnalysis.router`` cannot run offline in
+this repo. It requires SEASAM ``seasam_xtract`` ASCII extract files (read via
+``read_seasam_xtract``); no such fixture exists anywhere in the tree. The S-N
+curve CSV referenced by the default cfgs
+(``tests/test_data/fatigue_analysis/fatigue_data.csv``) is also absent. So the
+exercisable real compute is the curve-direct damage math below.
+"""
+
+import pandas as pd
+import pytest
+
+from digitalmodel.infrastructure.base_solvers.fatigue.fatigue_analysis import (
+    FatigueAnalysis,
+)
+import digitalmodel.infrastructure.base_solvers.marine.ship.ship_fatigue_analysis as ship_mod
+
+
+# A simple power-law S-N curve in the form FatigueAnalysis expects:
+#   N = a1 * s ** m1   (m1 negative -> higher stress, fewer cycles)
+SN_CURVE = {"a1": 1.0e15, "m1": -3.0}
+
+
+def test_ship_module_wires_the_correct_fatigue_class():
+    """Regression for the #776 wrong-import: the module-level instance the
+    ship code calls must be a FatigueAnalysis exposing router /
+    get_default_sn_cfg / get_default_timetrace_cfg (NOT FatigueDamageCalculator,
+    which has none of these)."""
+    assert isinstance(ship_mod.fatigue_analysis, FatigueAnalysis)
+    for method in ("router", "get_default_sn_cfg", "get_default_timetrace_cfg"):
+        assert hasattr(ship_mod.fatigue_analysis, method), (
+            f"ship fatigue engine is missing {method!r}; wrong class imported"
+        )
+
+
+def test_get_cycles_to_failure_matches_power_law():
+    fa = FatigueAnalysis()
+    # N(100) = 1e15 * 100**-3 = 1e15 / 1e6 = 1e9
+    assert fa.get_cycles_to_failure(SN_CURVE, 100.0) == pytest.approx(1.0e9)
+    # N(200) = 1e15 * 200**-3 = 1e15 / 8e6 = 1.25e8
+    assert fa.get_cycles_to_failure(SN_CURVE, 200.0) == pytest.approx(1.25e8)
+
+
+def test_damage_from_rainflow_cycles_is_real_miners_sum():
+    """Real Miner's-rule accumulation over rainflow-counted cycles -- the same
+    routine ShipFatigueAnalysis ultimately drives through router()."""
+    fa = FatigueAnalysis()
+    rainflow_df = pd.DataFrame(
+        {
+            "range": [100.0, 50.0],
+            "count": [1_000.0, 2_000.0],
+        }
+    )
+    # N(100) = 1e9 ; N(50) = 1e15 * 50**-3 = 1e15 / 1.25e5 = 8e9
+    # damage = 1000/1e9 + 2000/8e9 = 1e-6 + 2.5e-7 = 1.25e-6
+    damage = fa.damage_from_rainflow_cycles(rainflow_df, SN_CURVE)
+    assert damage == pytest.approx(1.25e-6, rel=1e-12)
+
+
+def test_damage_accumulates_monotonically():
+    """Adding cycles can only increase (never decrease) accumulated damage."""
+    fa = FatigueAnalysis()
+    one = pd.DataFrame({"range": [120.0], "count": [500.0]})
+    two = pd.DataFrame({"range": [120.0, 80.0], "count": [500.0, 300.0]})
+    assert fa.damage_from_rainflow_cycles(two, SN_CURVE) > fa.damage_from_rainflow_cycles(
+        one, SN_CURVE
+    )
+
+
+def test_default_sn_cfg_shape():
+    """The default S-N cfg the ship code requests must have the contract the
+    router() dispatch keys on (calculation_type=damage, stress_input=sn)."""
+    fa = FatigueAnalysis()
+    cfg = fa.get_default_sn_cfg()
+    assert cfg["inputs"]["calculation_type"] == "damage"
+    assert cfg["inputs"]["stress_input"] == "sn"
+    assert "SN" in cfg["inputs"]
+
+
+def test_default_timetrace_cfg_shape():
+    fa = FatigueAnalysis()
+    cfg = fa.get_default_timetrace_cfg()
+    assert cfg["inputs"]["calculation_type"] == "damage"
+    assert cfg["inputs"]["stress_input"] == "timetrace"
+    assert "timetraces" in cfg["inputs"]


### PR DESCRIPTION
Addresses #776 (the import half — see "Still blocked" below).

## Fix
`ShipFatigueAnalysis` imported `FatigueDamageCalculator` (API: `calculate_damage`/`_miners_rule`) but calls `router` / `get_default_timetrace_cfg` / `get_default_sn_cfg` — methods that exist only on `FatigueAnalysis`. Any real run raised `AttributeError`.

```python
-from digitalmodel.signal_processing.signal_analysis.fatigue import FatigueDamageCalculator
-fatigue_analysis = FatigueDamageCalculator()
+from digitalmodel.infrastructure.base_solvers.fatigue.fatigue_analysis import FatigueAnalysis
+fatigue_analysis = FatigueAnalysis()
```
The name is referenced only at instantiation; all other uses are `fatigue_analysis.<method>` and now resolve.

## Real (non-mock) test
Adds `tests/specialized/ship_design/test_ship_fatigue_analysis_import.py` (6 tests, all pass) — replaces the do-nothing `MagicMock` pattern with: a regression assert that the ship module's `fatigue_analysis` is a `FatigueAnalysis` with the 3 required methods, plus real arithmetic on the offline-computable curve-direct methods (`get_cycles_to_failure` power-law, Miner's-rule sum = 1.25e-6, monotonic accumulation, default-cfg shape).

## Still blocked (honest scope) — #776 stays open
This does NOT make `ship_design` an onboardable durable workflow. Full `ShipFatigueAnalysis.router` needs two data artifacts absent from the repo: (1) SEASAM `seasam_xtract` ASCII extract fixture(s); (2) the `tests/test_data/fatigue_analysis/fatigue_data.csv` S-N table the default cfgs reference. Onboarding stays deferred in #776 until those are supplied. The import fix + real test are correct and safe to merge now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)