### PR TITLE
fix(#773): repair rigging shackle/sling lookups + onboard catalog-resolution workflow

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -591,3 +591,12 @@ workflows:
       - examples/workflows/ct-hydraulics/results/ct_hydraulics/ct_hydraulics_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[ct-hydraulics]
     runtime: offline
+  - id: rigging
+    basename: rigging
+    title: Resolve rigging-group elements to vendor catalog entries (WLL, geometry, weight)
+    input: examples/workflows/rigging/input.yml
+    outputs:
+      - examples/workflows/rigging/results/input.yml
+      - examples/workflows/rigging/results/rigging/rigging_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rigging]
+    runtime: offline

--- a/examples/workflows/rigging/input.yml
+++ b/examples/workflows/rigging/input.yml
@@ -1,0 +1,33 @@
+basename: rigging
+
+# Rigging catalog-resolution screen: resolve each element of a rigging
+# group to its vendor catalog entry (WLL ratings, geometry, weight) and
+# summarise the group. All part numbers below exist in the loaded
+# vendor workbooks (data/slings/*.xlsx, data/crosby/*.xlsx):
+#   - sling 1500            -> MIS-ProductSheets_twinPathSlings.xlsx
+#   - shackle G2100 2038614 -> 204_subsea_shackles_g2100.xlsx
+#   - shackle G2130 1019533 -> 26_shackles_bolt_type_anchor_g2130.xlsx
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: True
+
+rigging:
+  connections: NULL
+  groups:
+    - label: uta1_clump_weight
+      elements:
+        - category: shackle
+          subcategory: G2100
+          part_number: 2038614
+          wll_mt: 25
+        - category: sling
+          subcategory: polyester_endless_round
+          part_number: 1500
+          length: 4
+          wll_mt: 5
+        - category: shackle
+          subcategory: G2130
+          part_number: 1019533
+          wll_mt: 6.5

--- a/src/digitalmodel/specialized/rigging/rigging.py
+++ b/src/digitalmodel/specialized/rigging/rigging.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from assetutilities.common.data import ReadFromExcel
 
 from digitalmodel.specialized.rigging.rigging_components import Slings
@@ -16,24 +19,64 @@ class Rigging:
     def get_rigging_groups(self, cfg=None):
         self.cfg = cfg
         rigging_groups = self.cfg.rigging["groups"]
+        resolved_groups = []
         for rigging_group in rigging_groups:
-            self.get_rigging_group(rigging_group)
+            resolved_groups.append(self.get_rigging_group(rigging_group))
+        # Store the resolved per-element vendor records back into the config
+        # so the engine emits a meaningful, deterministic output (previously
+        # the lookups ran and their results were discarded).
+        self.cfg["rigging"]["resolved_groups"] = resolved_groups
+        summary_path = self._write_summary(resolved_groups)
+        if summary_path is not None:
+            self.cfg["rigging"]["summary_json"] = summary_path
         # Return the cfg so the engine's `cfg_base = ...router/get_rigging_groups`
         # assignment doesn't null the config (was returning None).
         return self.cfg
 
     def get_rigging_group(self, rigging_group=None):
         rigging_elements = rigging_group["elements"]
+        resolved_elements = []
         for rigging in rigging_elements:
+            resolved = {
+                "category": rigging.get("category"),
+                "subcategory": rigging.get("subcategory"),
+                "part_number": rigging.get("part_number"),
+            }
             if rigging["category"] == "sling":
-                rigging_dict = self.get_sling(rigging)
+                sling, sling_model = self.get_sling(rigging)
+                resolved["catalog_record"] = sling
+                resolved["model"] = sling_model
             elif rigging["category"] == "shackle":
-                rigging_dict = self.get_shackle(rigging)
+                resolved["catalog_record"] = self.get_shackle(rigging)
+                resolved["model"] = {}
+            resolved_elements.append(resolved)
+        return {
+            "label": rigging_group.get("label"),
+            "elements": resolved_elements,
+        }
 
     def get_sling(self, cfg=None):
-        slings.get_sling(cfg)
-        return 1
+        # ``Slings.get_sling`` returns a (sling, sling_model) tuple; surface
+        # both so the resolved group carries the full vendor record plus the
+        # normalised model.
+        sling, sling_model = slings.get_sling(cfg)
+        return sling, sling_model
 
     def get_shackle(self, cfg=None):
-        shackles.get_shackle(cfg)
-        return 1
+        return shackles.get_shackle(cfg)
+
+    def _write_summary(self, resolved_groups):
+        # Mirror the durable-workflow output convention: write a deterministic
+        # JSON summary of the resolved vendor catalog entries to
+        # ``results/rigging/`` resolved relative to the input file's directory.
+        config_dir = self.cfg.get("_config_dir_path")
+        if not config_dir:
+            return None
+        output_dir = Path(config_dir) / "results" / "rigging"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        summary_path = output_dir / "rigging_summary.json"
+        summary = {"groups": resolved_groups}
+        with summary_path.open("w", encoding="utf-8") as stream:
+            json.dump(summary, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        return str(summary_path)

--- a/src/digitalmodel/specialized/rigging/rigging_components.py
+++ b/src/digitalmodel/specialized/rigging/rigging_components.py
@@ -1,3 +1,6 @@
+import io
+import math
+
 import pkgutil
 
 from assetutilities.common.data import ReadFromExcel
@@ -5,6 +8,47 @@ from digitalmodel.solvers.fea_model.LineType_components import LineType
 from digitalmodel.solvers.fea_model.line_components import Line
 
 read_excel = ReadFromExcel()
+
+
+def _as_excel_io(data):
+    """Wrap packaged workbook bytes in a ``BytesIO`` for the excel reader.
+
+    ``pkgutil.get_data`` returns raw bytes; pandas warns (and, under the
+    test suite's ``filterwarnings = error``, raises) when bytes are passed
+    straight to ``read_excel``. Wrapping in a file-like object is the
+    documented way to read an in-memory workbook.
+    """
+    if isinstance(data, (bytes, bytearray)):
+        return io.BytesIO(data)
+    return data
+
+
+# Subcategory labels that identify a (polyester round / twin-path) sling.
+SLING_SUBCATEGORIES = ["twinpathslings", "polyester_endless_round"]
+# Subcategory labels that identify a Crosby shackle grade (= loaded workbooks).
+SHACKLE_SUBCATEGORIES = ["G2100", "G2110", "G2130"]
+
+
+def _to_number(value):
+    """Coerce vendor-sheet cells to plain Python ints/floats when numeric.
+
+    Excel ints arrive as ``numpy.int64`` and floats as ``numpy.float64``;
+    converting them keeps the emitted summary JSON/YAML deterministic and
+    free of numpy-specific tags. Non-numeric / NaN cells pass through.
+    """
+    if value is None:
+        return None
+    try:
+        if isinstance(value, bool):
+            return value
+        number = float(value)
+    except (TypeError, ValueError):
+        return value
+    if math.isnan(number):
+        return None
+    if number.is_integer():
+        return int(number)
+    return number
 
 
 class Slings:
@@ -16,14 +60,15 @@ class Slings:
         self.sling_data = self.get_vendor_data()
 
     def get_vendor_data(self, cfg=None):
-        cfg_data = {"io": self.twinpathslings_datafile}
+        cfg_data = {"io": _as_excel_io(self.twinpathslings_datafile)}
         excel_data = read_excel.from_xlsx(cfg_data)
         twinpathslings_data = excel_data["Sheet1"]
         return {"twinpathslings": twinpathslings_data}
 
     def get_sling(self, cfg=None):
         sling = {}
-        if cfg["subcategory"] in ["twinpathslings", "polyester_endless_round"]:
+        sling_model = {}
+        if cfg["subcategory"] in SLING_SUBCATEGORIES:
             sling = self.get_twinpathslings(cfg)
             sling_model = self.get_twinpathslings_model(sling)
 
@@ -37,9 +82,29 @@ class Slings:
         return sling
 
     def get_twinpathslings_model(self, sling=None):
-        cfg_model = {}
-        cfg_model["OD"] = sling["diameter"]
-        sling_model = self.get_twinpathslings_model({"cfg": cfg_model})
+        # Build a clean, deterministic model dict from the REAL vendor
+        # columns of the twinpathslings Sheet1. There is no ``diameter``
+        # column for these polyester round slings, so we surface the rated
+        # capacities, width range, unit weight, and design factor that the
+        # catalog actually provides. (Previously this read a non-existent
+        # ``diameter`` key and then recursed into itself.)
+        sling = sling or {}
+
+        def _get(key):
+            return _to_number(sling.get(key))
+
+        sling_model = {
+            "part_number": _to_number(sling.get("part_number")),
+            "wll_vertical_lb": _get("vertical_lb"),
+            "wll_choker_lb": _get("choker_lb"),
+            "wll_vertical_basket_90_deg_lb": _get("vertical_basket_90_deg_lb"),
+            "wll_basket_60_deg_lb": _get("basket_hitnges_60_deg_lb"),
+            "wll_basket_45_deg_lb": _get("basket_hitnges_45_deg_lb"),
+            "weight_lb_per_ft": _get("w_lb_per_ft"),
+            "min_width_in": _get("min_width_in"),
+            "max_width_in": _get("max_width_in"),
+            "design_factor": _get("design_factor"),
+        }
 
         return sling_model
 
@@ -73,15 +138,15 @@ class Shackles:
         self.shackle_data = self.get_vendor_data()
 
     def get_vendor_data(self, cfg=None):
-        cfg_G2100_data = {"io": self.G2100_datafile}
+        cfg_G2100_data = {"io": _as_excel_io(self.G2100_datafile)}
         excel_data = read_excel.from_xlsx(cfg_G2100_data)
         G2100_data = excel_data["Sheet1"]
 
-        cfg_G2110_data = {"io": self.G2110_datafile}
+        cfg_G2110_data = {"io": _as_excel_io(self.G2110_datafile)}
         excel_data = read_excel.from_xlsx(cfg_G2110_data)
         G2110_data = excel_data["Sheet1"]
 
-        cfg_G2130_data = {"io": self.G2130_datafile}
+        cfg_G2130_data = {"io": _as_excel_io(self.G2130_datafile)}
         excel_data = read_excel.from_xlsx(cfg_G2130_data)
         G2130_data = excel_data["Sheet1"]
 
@@ -91,15 +156,21 @@ class Shackles:
 
     def get_shackle(self, cfg=None):
         shackle = {}
-        if cfg["subcategory"] in ["twinpathslings", "polyester_endless_round"]:
-            shackle = self.get_twinpathslings(cfg)
+        # Shackles are keyed by Crosby grade (G2100/G2110/G2130), which are
+        # exactly the keys of ``self.shackle_data``. Dispatch to the existing
+        # ``get_shackle_model`` lookup. (Previously this tested for *sling*
+        # subcategories and called a non-existent ``get_twinpathslings``.)
+        if cfg["subcategory"] in SHACKLE_SUBCATEGORIES:
+            shackle = self.get_shackle_model(cfg)
 
         return shackle
 
     def get_shackle_model(self, cfg=None):
-        shackle_model_cfg = {}
         shackle_data = self.shackle_data[cfg["subcategory"]]
         shackle = shackle_data.loc[
             shackle_data["part_number"] == cfg["part_number"]
         ].to_dict("records")[0]
+        # Coerce numpy scalars to plain Python so downstream summaries stay
+        # deterministic and serialise cleanly to JSON/YAML.
+        shackle = {key: _to_number(value) for key, value in shackle.items()}
         return shackle

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -801,6 +801,47 @@ def test_workflow_registry(workflow):
         assert ct["id_in"] == pytest.approx(1.482)
         assert ct["reynolds_number"] == pytest.approx(131177.7)
         assert ct["pressure_loss_psi"] == pytest.approx(1300.1)
+    elif workflow["id"] == "rigging":
+        groups = cfg["rigging"]["resolved_groups"]
+        assert len(groups) == 1
+        group = groups[0]
+        assert group["label"] == "uta1_clump_weight"
+
+        elements = {element["part_number"]: element for element in group["elements"]}
+        assert set(elements) == {2038614, 1500, 1019533}
+
+        # Shackle G2100 part 2038614 resolves to its crosby workbook row.
+        g2100 = elements[2038614]
+        assert g2100["category"] == "shackle"
+        assert g2100["subcategory"] == "G2100"
+        assert g2100["catalog_record"]["wll_te"] == pytest.approx(25.0)
+        assert g2100["catalog_record"]["w_lb"] == pytest.approx(38.6)
+        assert g2100["catalog_record"]["design_factor"] == 6
+
+        # Sling 1500 (polyester endless round) resolves to its rated
+        # capacities, width range, unit weight, and design factor.
+        sling = elements[1500]
+        assert sling["category"] == "sling"
+        model = sling["model"]
+        assert model["wll_vertical_lb"] == pytest.approx(15000.0)
+        assert model["wll_choker_lb"] == pytest.approx(12000.0)
+        assert model["wll_vertical_basket_90_deg_lb"] == pytest.approx(30000.0)
+        assert model["min_width_in"] == pytest.approx(1.5)
+        assert model["max_width_in"] == pytest.approx(3.0)
+        assert model["weight_lb_per_ft"] == pytest.approx(0.45)
+        assert model["design_factor"] == 5
+
+        # Shackle G2130 part 1019533 resolves to its bolt-type anchor row.
+        g2130 = elements[1019533]
+        assert g2130["subcategory"] == "G2130"
+        assert g2130["catalog_record"]["wll_te"] == pytest.approx(6.5)
+        assert g2130["catalog_record"]["size_in"] == pytest.approx(0.875)
+
+        summary_path = Path(cfg["rigging"]["summary_json"])
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+        summary = yaml.safe_load(summary_path.read_text())
+        assert summary["groups"][0]["label"] == "uta1_clump_weight"
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:


### PR DESCRIPTION
Closes #773. Repairs the broken rigging compute logic (the blocker that survived #756/#757) and onboards rigging as a durable workflow.

## Bug fixes (`specialized/rigging/rigging_components.py`)
**A — `Shackles.get_shackle`** guarded on *sling* subcategories and called a non-existent `get_twinpathslings` (silent no-op for real shackles). Now dispatches `G2100`/`G2110`/`G2130` to the existing, correct `get_shackle_model` (part-number lookup against the loaded Crosby workbooks).

**B — `Slings.get_twinpathslings_model`** referenced a non-existent `diameter` column **and** called itself with no base case (infinite recursion). Now builds a deterministic model dict from the REAL Sheet1 columns (rated capacities, width, unit weight, design factor) — no recursion.

**`Rigging.get_rigging_groups`** previously discarded all lookups. Now collects each element's resolved record into `cfg["rigging"]["resolved_groups"]` and writes a deterministic `results/rigging/rigging_summary.json`.

## Workflow (no invented physics)
Onboards rigging as **catalog resolution**: each element in each rigging group → its vendor catalog entry (WLL ratings, geometry, weight, design factor). This is exactly what the restored workbooks support — no OrcaFlex line model is fabricated (the polyester slings have no diameter column; that path would need a separate domain spec and is explicitly deferred).

- engine route + base config already existed (basename `rigging`)
- adds `examples/workflows/rigging/input.yml`, registry row (id `rigging`), test parametrization

## Verification
- `uv run python -m digitalmodel examples/workflows/rigging/input.yml` → exit 0, deterministic JSON. Resolved values match the workbook rows exactly: shackle G2100/2038614 → wll_te 25, w_lb 38.6, DF 6; sling 1500 → vertical 15000 lb, choker 12000 lb, basket90 30000 lb, width 1.5–3 in, DF 5; shackle G2130/1019533 → wll_te 6.5.
- `test_workflow_registry[rigging]` passes; ct-hydraulics + mooring-fatigue neighbors unaffected.

## Unblocks
Rigging is now a registered workflow → it can finally be routed in deckhand (the Open-Deck rigging leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)