### PR TITLE
feat(mooring-fatigue): emit top-level screening_status (pass/fail) — follow-up to #778

### DIFF
--- a/src/digitalmodel/mooring_fatigue/workflow.py
+++ b/src/digitalmodel/mooring_fatigue/workflow.py
@@ -48,6 +48,9 @@ def router(cfg: dict) -> dict:
         "governing_damage": governing["total_damage"],
         "governing_fatigue_life_years": governing["fatigue_life_years"],
         "governing_dff_margin": governing["dff_margin"],
+        # Top-level pass/fail (governing line is worst-case): drives the
+        # deckhand report template's mitigation-on-fail section.
+        "screening_status": "pass" if governing["dff_margin"] >= 1.0 else "fail",
         "lines": summaries,
         "results_csv": _display_path(csv_path),
         "summary_csv": _display_path(summary_path),


### PR DESCRIPTION
Small follow-up to [#778](https://github.com/vamseeachanta/digitalmodel/pull/778) flagged during deckhand loop-closure ([deckhand #372](https://github.com/vamseeachanta/deckhand/pull/372)).

The mooring-fatigue summary now emits a top-level `screening_status` (`pass`/`fail` from the governing — worst — line's DFF margin). This is exactly the field the deckhand report template keys on for its mitigation-on-fail section; without it the conditional never fired at render time.

Verified: `uv run python -m digitalmodel examples/workflows/mooring-fatigue/input.yml` → `screening_status: pass`; durable-workflow tests pass (4 mooring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)