### PR TITLE
feat(workflow): onboard jumper-installation durable workflow (#711)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -33,6 +33,16 @@ workflows:
       - examples/workflows/fatigue-analysis/results/input.yml
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[fatigue-analysis]
     runtime: offline
+  - id: jumper-installation
+    basename: jumper_installation
+    title: Deepwater rigid-jumper installation screening over a small Hs sweep
+    input: examples/workflows/jumper-installation/input.yml
+    outputs:
+      - examples/workflows/jumper-installation/results/input.yml
+      - examples/workflows/jumper-installation/results/input_jumper_installation_summary.json
+      - examples/workflows/jumper-installation/results/input_jumper_installation_cases.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[jumper-installation]
+    runtime: offline
   - id: mooring-fatigue
     basename: mooring_fatigue
     title: Metallic mooring-line fatigue damage from tension-range bins

--- a/examples/demos/gtm/demo_05_deepwater_rigid_jumper_installation.py
+++ b/examples/demos/gtm/demo_05_deepwater_rigid_jumper_installation.py
@@ -45,6 +45,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from digitalmodel.installation.jumper_installation import calculations as _shared_jumper_calcs
+
 # ---------------------------------------------------------------------------
 # Imports — graceful handling
 # ---------------------------------------------------------------------------
@@ -744,6 +746,21 @@ def run_parametric_sweep(
     df = pd.DataFrame(rows)
     print(f"\n  Sweep complete: {len(all_results)} results collected")
     return all_results, df
+
+
+_cfg = _shared_jumper_calcs._cfg
+calc_phase_1_liftoff = _shared_jumper_calcs.calc_phase_1_liftoff
+calc_phase_2_inair_bending = _shared_jumper_calcs.calc_phase_2_inair_bending
+calc_phase_3_splash = _shared_jumper_calcs.calc_phase_3_splash
+calc_phase_4_lowering = _shared_jumper_calcs.calc_phase_4_lowering
+calc_phase_5_tiein = _shared_jumper_calcs.calc_phase_5_tiein
+governing_phase = _shared_jumper_calcs.governing_phase
+hs_to_tp = _shared_jumper_calcs.hs_to_tp
+load_vessel_data = _shared_jumper_calcs.load_vessel_data
+load_jumper_data = _shared_jumper_calcs.load_jumper_data
+run_parametric_sweep = _shared_jumper_calcs.run_parametric_sweep
+run_single_case = _shared_jumper_calcs.run_single_case
+status_from_utils = _shared_jumper_calcs.status_from_utils
 
 
 # ---------------------------------------------------------------------------

--- a/examples/workflows/jumper-installation/README.md
+++ b/examples/workflows/jumper-installation/README.md
@@ -1,0 +1,18 @@
+# Jumper Installation
+
+Runs the headless deepwater rigid-jumper installation screening workflow through
+the durable workflow contract. The workflow loads the bundled GTM vessel and
+rigid-jumper catalogs, evaluates the five installation phases, and writes a
+small Hs sweep for downstream reporting.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/jumper-installation/input.yml
+```
+
+Expected outputs are written to `examples/workflows/jumper-installation/results/`:
+
+- `input.yml`
+- `input_jumper_installation_summary.json`
+- `input_jumper_installation_cases.csv`

--- a/examples/workflows/jumper-installation/input.yml
+++ b/examples/workflows/jumper-installation/input.yml
@@ -1,0 +1,49 @@
+basename: jumper_installation
+
+jumper_installation:
+  vessels:
+    catalog: ../../demos/gtm/data/csv_hlv_vessels.json
+    selected: ["Medium CSV"]
+  jumpers:
+    catalog: ../../demos/gtm/data/rigid_jumpers.json
+    lengths_m: [20.0]
+  sweep:
+    depths_m: [1500]
+    hs_m: [1.0, 2.0, 3.0]
+  constants:
+    daf_liftoff: 1.10
+    daf_splash: 1.30
+    rigging_mass_kg: 5000.0
+    cs_slamming: 3.141592653589793
+    cd_cylinder: 1.2
+    ca_cylinder: 1.0
+    v_lowering: 0.5
+    v_current: 0.5
+    splash_submerged_length_m: 10.0
+    wire_allowable_factor: 0.85
+    bending_allowable: 0.6
+    cable_unit_weight_sub_n_per_m: 50.0
+    tie_in_tolerance_mm: 50.0
+    reference_hs: 2.0
+    tp_coefficient: 4.0
+    go_marginal_threshold: 0.85
+    nogo_utilisation: 1.0
+  physical_constants:
+    seawater_density_kg_m3: 1025.0
+    gravity_m_s2: 9.80665
+  lift_span_model:
+    lift_span_fraction: 0.10
+    lift_span_m: null
+    moment_coeff: 8.0
+  tiein_span_model:
+    tiein_unsupported_span_fraction: 0.28
+    tiein_unsupported_span_m: null
+    include_self_weight: false
+    deflection_coeff: 76.8
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/jumper_installation/jumper_installation.yml
+++ b/src/digitalmodel/base_configs/modules/jumper_installation/jumper_installation.yml
@@ -1,0 +1,49 @@
+basename: jumper_installation
+
+jumper_installation:
+  vessels:
+    catalog: examples/demos/gtm/data/csv_hlv_vessels.json
+    selected: []
+  jumpers:
+    catalog: examples/demos/gtm/data/rigid_jumpers.json
+    lengths_m: []
+  sweep:
+    depths_m: []
+    hs_m: []
+  constants:
+    daf_liftoff: 1.10
+    daf_splash: 1.30
+    rigging_mass_kg: 5000.0
+    cs_slamming: 3.141592653589793
+    cd_cylinder: 1.2
+    ca_cylinder: 1.0
+    v_lowering: 0.5
+    v_current: 0.5
+    splash_submerged_length_m: 10.0
+    wire_allowable_factor: 0.85
+    bending_allowable: 0.6
+    cable_unit_weight_sub_n_per_m: 50.0
+    tie_in_tolerance_mm: 50.0
+    reference_hs: 2.0
+    tp_coefficient: 4.0
+    go_marginal_threshold: 0.85
+    nogo_utilisation: 1.0
+  physical_constants:
+    seawater_density_kg_m3: 1025.0
+    gravity_m_s2: 9.80665
+  lift_span_model:
+    lift_span_fraction: 0.5
+    lift_span_m: null
+    moment_coeff: 8.0
+  tiein_span_model:
+    tiein_unsupported_span_fraction: 0.28
+    tiein_unsupported_span_m: null
+    include_self_weight: false
+    deflection_coeff: 76.8
+  output_dir: results
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -185,6 +185,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         orc_install = OrcInstallation()
         if cfg_base["structure"]["flag"]:
             cfg_base = orc_install.create_model_for_water_depth(cfg_base)
+    elif basename == "jumper_installation":
+        from digitalmodel.installation.jumper_installation.workflow import (
+            router as jumper_installation,
+        )
+
+        cfg_base = jumper_installation(cfg_base)
     elif basename == "ship_design":
         ship_design = ShipDesign()
         cfg_base = ship_design.router(cfg_base)

--- a/src/digitalmodel/installation/__init__.py
+++ b/src/digitalmodel/installation/__init__.py
@@ -1,0 +1,1 @@
+"""Installation workflows and screening calculations."""

--- a/src/digitalmodel/installation/jumper_installation/__init__.py
+++ b/src/digitalmodel/installation/jumper_installation/__init__.py
@@ -1,0 +1,29 @@
+"""Deepwater rigid-jumper installation screening workflow."""
+
+from digitalmodel.installation.jumper_installation.calculations import (
+    calc_phase_1_liftoff,
+    calc_phase_2_inair_bending,
+    calc_phase_3_splash,
+    calc_phase_4_lowering,
+    calc_phase_5_tiein,
+    governing_phase,
+    hs_to_tp,
+    run_parametric_sweep,
+    run_single_case,
+    status_from_utils,
+)
+from digitalmodel.installation.jumper_installation.workflow import router
+
+__all__ = [
+    "calc_phase_1_liftoff",
+    "calc_phase_2_inair_bending",
+    "calc_phase_3_splash",
+    "calc_phase_4_lowering",
+    "calc_phase_5_tiein",
+    "governing_phase",
+    "hs_to_tp",
+    "router",
+    "run_parametric_sweep",
+    "run_single_case",
+    "status_from_utils",
+]

--- a/src/digitalmodel/installation/jumper_installation/calculations.py
+++ b/src/digitalmodel/installation/jumper_installation/calculations.py
@@ -1,0 +1,399 @@
+"""Shared rigid-jumper installation calculations used by the demo and workflow."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DATA_DIR = REPO_ROOT / "examples" / "demos" / "gtm" / "data"
+
+SEAWATER_DENSITY = 1025.0
+GRAVITY = 9.80665
+WATER_DEPTHS = [500, 1000, 1500, 2000, 2500, 3000]
+HS_VALUES = [1.0, 1.5, 2.0, 2.5, 3.0]
+REFERENCE_HS = 2.0
+DAF_LIFT = 1.10
+DAF_SPLASH = 1.30
+RIGGING_MASS_KG = 5000.0
+CS_PIPE = math.pi
+CD_CYLINDER = 1.2
+CA_CYLINDER = 1.0
+V_LOWERING = 0.5
+V_CURRENT = 0.5
+SPLASH_SUBMERGED_LENGTH = 10.0
+WIRE_ALLOWABLE_FACTOR = 0.85
+BENDING_ALLOWABLE = 0.6
+TIE_IN_TOLERANCE_MM = 50.0
+CABLE_UNIT_WEIGHT_SUB = 50.0
+LIFT_SPAN_FRACTION = 0.5
+LIFT_SPAN_M = None
+LIFT_MOMENT_COEFF = 8.0
+TIEIN_UNSUPPORTED_SPAN_FRACTION = 0.28
+TIEIN_UNSUPPORTED_SPAN_M = None
+TIEIN_INCLUDE_SELF_WEIGHT = False
+TIEIN_DEFLECTION_COEFF = 76.8
+
+
+def _cfg(config: Optional[Any], attr: str, fallback: Any) -> Any:
+    if config is None:
+        return fallback
+    return getattr(config, attr)
+
+
+def load_vessel_data(path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    path = Path(path) if path is not None else DATA_DIR / "csv_hlv_vessels.json"
+    with path.open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    vessels = data["vessels"]
+    print(f"  Loaded {len(vessels)} vessels from {path.name}")
+    return vessels
+
+
+def load_jumper_data(
+    path: Optional[Path] = None,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    path = Path(path) if path is not None else DATA_DIR / "rigid_jumpers.json"
+    with path.open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    common = data["common_properties"]
+    jumpers = data["jumpers"]
+    print(f"  Loaded {len(jumpers)} jumper lengths from {path.name}")
+    return common, jumpers
+
+
+def hs_to_tp(hs: float, config: Optional[Any] = None) -> float:
+    coeff = _cfg(config, "tp_coefficient", 4.0)
+    return coeff * math.sqrt(hs)
+
+
+def status_from_utils(phase_utils: Dict[str, float], config: Optional[Any] = None) -> str:
+    nogo = _cfg(config, "nogo_utilisation", 1.0)
+    marginal = _cfg(config, "go_marginal_threshold", 0.85)
+    max_util = max(phase_utils.values()) if phase_utils else 0.0
+    if max_util > nogo:
+        return "NO_GO"
+    if max_util >= marginal:
+        return "MARGINAL"
+    return "GO"
+
+
+def governing_phase(phase_utils: Dict[str, float]) -> str:
+    if not phase_utils:
+        return "N/A"
+    return max(phase_utils, key=phase_utils.get)  # type: ignore[arg-type]
+
+
+def calc_phase_1_liftoff(
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    vessel: Dict[str, Any],
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    g = _cfg(config, "gravity_m_s2", GRAVITY)
+    daf_lift = _cfg(config, "daf_liftoff", DAF_LIFT)
+    rigging_kg = _cfg(config, "rigging_mass_kg", RIGGING_MASS_KG)
+
+    mass_per_m = common["mass_per_meter"]["total_air_kg_per_m"]
+    mass_total = mass_per_m * jumper["length_m"] + rigging_kg
+    hook_load_te = mass_total * daf_lift / 1000.0
+    crane_swl_te = vessel["crane_main"]["swl_max_te"]
+    utilisation = hook_load_te / crane_swl_te
+
+    return {
+        "phase": "lift_off",
+        "mass_total_kg": round(mass_total, 1),
+        "hook_load_te": round(hook_load_te, 2),
+        "crane_swl_te": crane_swl_te,
+        "daf": daf_lift,
+        "utilisation": round(utilisation, 4),
+        "status": "PASS" if utilisation <= 1.0 else "FAIL",
+    }
+
+
+def calc_phase_2_inair_bending(
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    w_air = common["weight_per_meter"]["air_n_per_m"]
+    od = common["od_m"]
+    i_steel = common["i_steel_m4"]
+    smys = common["smys_pa"]
+
+    daf_lift = _cfg(config, "daf_liftoff", DAF_LIFT)
+    bending_allow = _cfg(config, "bending_allowable", BENDING_ALLOWABLE)
+    span_fraction = _cfg(config, "lift_span_fraction", LIFT_SPAN_FRACTION)
+    span_override = _cfg(config, "lift_span_m", LIFT_SPAN_M)
+    moment_coeff = _cfg(config, "lift_moment_coeff", LIFT_MOMENT_COEFF)
+
+    horizontal_span = jumper["configuration"]["horizontal_span_m"]
+    lift_span = (
+        float(span_override)
+        if span_override is not None and span_override > 0
+        else span_fraction * horizontal_span
+    )
+    w_eff = w_air * daf_lift
+    m_max = w_eff * lift_span**2 / moment_coeff
+    sigma = m_max * (od / 2.0) / i_steel
+    allowable = bending_allow * smys
+    utilisation = sigma / allowable
+
+    return {
+        "phase": "in_air_bending",
+        "weight_per_m_n": round(w_air, 2),
+        "lift_daf": daf_lift,
+        "lift_span_m": round(lift_span, 3),
+        "w_eff_n_per_m": round(w_eff, 2),
+        "bending_moment_knm": round(m_max / 1000.0, 2),
+        "bending_stress_mpa": round(sigma / 1e6, 2),
+        "allowable_stress_mpa": round(allowable / 1e6, 2),
+        "utilisation": round(utilisation, 4),
+        "status": "PASS" if utilisation <= 1.0 else "FAIL",
+    }
+
+
+def calc_phase_3_splash(
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    vessel: Dict[str, Any],
+    hs: float,
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    g = _cfg(config, "gravity_m_s2", GRAVITY)
+    rho = _cfg(config, "seawater_density_kg_m3", SEAWATER_DENSITY)
+    cs = _cfg(config, "cs_slamming", CS_PIPE)
+    cd = _cfg(config, "cd_cylinder", CD_CYLINDER)
+    v_low = _cfg(config, "v_lowering", V_LOWERING)
+    daf_splash = _cfg(config, "daf_splash", DAF_SPLASH)
+    rigging_kg = _cfg(config, "rigging_mass_kg", RIGGING_MASS_KG)
+    splash_sub = _cfg(config, "splash_submerged_length_m", SPLASH_SUBMERGED_LENGTH)
+
+    od = common["od_m"]
+    length = jumper["length_m"]
+    mass_total = common["mass_per_meter"]["total_air_kg_per_m"] * length + rigging_kg
+    w_air = mass_total * g
+    submerged_len = min(length, splash_sub)
+    projected_area = od * submerged_len
+    tp = hs_to_tp(hs, config=config)
+    v_wave = math.pi * hs / tp
+    v_rel = v_low + v_wave
+    f_slam = 0.5 * rho * cs * projected_area * v_rel**2
+    f_drag = 0.5 * rho * cd * projected_area * v_low**2
+    hook_splash_te = (w_air + f_slam + f_drag) * daf_splash / (g * 1000.0)
+    crane_swl_te = vessel["crane_main"]["swl_max_te"]
+    utilisation = hook_splash_te / crane_swl_te
+
+    return {
+        "phase": "splash_zone",
+        "slamming_force_kn": round(f_slam / 1000.0, 2),
+        "drag_force_kn": round(f_drag / 1000.0, 2),
+        "hook_load_splash_te": round(hook_splash_te, 2),
+        "crane_swl_te": crane_swl_te,
+        "daf": daf_splash,
+        "v_wave_ms": round(v_wave, 3),
+        "v_rel_ms": round(v_rel, 3),
+        "utilisation": round(utilisation, 4),
+        "status": "PASS" if utilisation <= 1.0 else "FAIL",
+    }
+
+
+def calc_phase_4_lowering(
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    vessel: Dict[str, Any],
+    depth: float,
+    hs: float,
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    g = _cfg(config, "gravity_m_s2", GRAVITY)
+    rho = _cfg(config, "seawater_density_kg_m3", SEAWATER_DENSITY)
+    ca = _cfg(config, "ca_cylinder", CA_CYLINDER)
+    cable_w = _cfg(config, "cable_unit_weight_sub_n_per_m", CABLE_UNIT_WEIGHT_SUB)
+    wire_factor = _cfg(config, "wire_allowable_factor", WIRE_ALLOWABLE_FACTOR)
+    rigging_kg = _cfg(config, "rigging_mass_kg", RIGGING_MASS_KG)
+
+    od = common["od_m"]
+    length = jumper["length_m"]
+    static_tension = common["weight_per_meter"]["submerged_n_per_m"] * length
+    static_tension += cable_w * depth
+    mass_total = common["mass_per_meter"]["total_air_kg_per_m"] * length + rigging_kg
+    added_mass = rho * math.pi / 4.0 * od**2 * length * ca
+    omega = 2.0 * math.pi / hs_to_tp(hs, config=config)
+    heave_rao = vessel["motion_characteristics"]["heave_rao"]["peak_amplitude_m_per_m"]
+    dynamic_load = (mass_total + added_mass) * omega**2 * heave_rao * (hs / 2.0)
+    max_tension_te = (static_tension + dynamic_load) / (g * 1000.0)
+    wire_mbl_te = vessel["crane_main"]["main_wire_mbl_te"]
+    allowable_te = wire_factor * wire_mbl_te
+    utilisation = max_tension_te / allowable_te
+
+    return {
+        "phase": "lowering",
+        "static_tension_kn": round(static_tension / 1000.0, 2),
+        "dynamic_load_kn": round(dynamic_load / 1000.0, 2),
+        "max_tension_te": round(max_tension_te, 2),
+        "wire_mbl_te": wire_mbl_te,
+        "allowable_te": round(allowable_te, 2),
+        "utilisation": round(utilisation, 4),
+        "status": "PASS" if utilisation <= 1.0 else "FAIL",
+    }
+
+
+def calc_phase_5_tiein(
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    rho = _cfg(config, "seawater_density_kg_m3", SEAWATER_DENSITY)
+    cd = _cfg(config, "cd_cylinder", CD_CYLINDER)
+    v_cur = _cfg(config, "v_current", V_CURRENT)
+    tolerance_mm = _cfg(config, "tie_in_tolerance_mm", TIE_IN_TOLERANCE_MM)
+    span_fraction = _cfg(
+        config, "tiein_unsupported_span_fraction", TIEIN_UNSUPPORTED_SPAN_FRACTION
+    )
+    span_override = _cfg(config, "tiein_unsupported_span_m", TIEIN_UNSUPPORTED_SPAN_M)
+    include_sw = _cfg(config, "tiein_include_self_weight", TIEIN_INCLUDE_SELF_WEIGHT)
+    defl_coeff = _cfg(config, "tiein_deflection_coeff", TIEIN_DEFLECTION_COEFF)
+
+    od = common["od_m"]
+    i_steel = common["i_steel_m4"]
+    horizontal_span = jumper["configuration"]["horizontal_span_m"]
+    tiein_span = (
+        float(span_override)
+        if span_override is not None and span_override > 0
+        else span_fraction * horizontal_span
+    )
+    w_current = 0.5 * rho * cd * od * v_cur**2
+    w_sub = common["weight_per_meter"]["submerged_n_per_m"] if include_sw else 0.0
+    w_res = math.hypot(w_sub, w_current)
+    delta_mm = (
+        w_res * tiein_span**4 / (defl_coeff * common["youngs_modulus_pa"] * i_steel)
+    ) * 1000.0
+    utilisation = delta_mm / tolerance_mm
+
+    return {
+        "phase": "tie_in",
+        "tiein_span_m": round(tiein_span, 3),
+        "current_load_n_per_m": round(w_current, 4),
+        "self_weight_load_n_per_m": round(w_sub, 2),
+        "resultant_load_n_per_m": round(w_res, 2),
+        "deflection_mm": round(delta_mm, 4),
+        "tolerance_mm": tolerance_mm,
+        "utilisation": round(utilisation, 4),
+        "status": "PASS" if utilisation <= 1.0 else "FAIL",
+    }
+
+
+def run_single_case(
+    vessel: Dict[str, Any],
+    jumper: Dict[str, Any],
+    common: Dict[str, Any],
+    depth: float,
+    hs: float,
+    config: Optional[Any] = None,
+) -> Dict[str, Any]:
+    p1 = calc_phase_1_liftoff(jumper, common, vessel, config=config)
+    p2 = calc_phase_2_inair_bending(jumper, common, config=config)
+    p3 = calc_phase_3_splash(jumper, common, vessel, hs, config=config)
+    p4 = calc_phase_4_lowering(jumper, common, vessel, depth, hs, config=config)
+    p5 = calc_phase_5_tiein(jumper, common, config=config)
+    phase_utils = {
+        "lift_off": p1["utilisation"],
+        "in_air_bending": p2["utilisation"],
+        "splash_zone": p3["utilisation"],
+        "lowering": p4["utilisation"],
+        "tie_in": p5["utilisation"],
+    }
+    max_util = max(phase_utils.values())
+    return {
+        "vessel": vessel["name"],
+        "vessel_id": vessel["id"],
+        "jumper_id": jumper["id"],
+        "jumper_name": jumper["name"],
+        "length_m": jumper["length_m"],
+        "water_depth_m": depth,
+        "hs_m": hs,
+        "tp_s": round(hs_to_tp(hs, config=config), 2),
+        "phases": {
+            "lift_off": p1,
+            "in_air_bending": p2,
+            "splash_zone": p3,
+            "lowering": p4,
+            "tie_in": p5,
+        },
+        "phase_utilisations": phase_utils,
+        "overall_status": status_from_utils(phase_utils, config=config),
+        "governing_phase": governing_phase(phase_utils),
+        "max_utilisation": round(max_util, 4),
+    }
+
+
+def run_parametric_sweep(
+    vessels: List[Dict],
+    common: Dict[str, Any],
+    jumpers: List[Dict],
+    config: Optional[Any] = None,
+) -> Tuple[List[Dict], pd.DataFrame]:
+    if config is not None:
+        by_vessel = {v["name"]: v for v in vessels}
+        swept_vessels = [by_vessel[name] for name in config.vessels]
+        by_length = {j["length_m"]: j for j in jumpers}
+        swept_jumpers = [by_length[float(length)] for length in config.lengths_m]
+        depths = list(config.depths)
+        hs_values = list(config.hs)
+    else:
+        swept_vessels = list(vessels)
+        swept_jumpers = list(jumpers)
+        depths = list(WATER_DEPTHS)
+        hs_values = list(HS_VALUES)
+
+    total = len(swept_vessels) * len(swept_jumpers) * len(depths) * len(hs_values)
+    print(f"PARAMETRIC JUMPER INSTALLATION SWEEP: {total} cases")
+    all_results: List[Dict] = []
+    case_num = 0
+    for vessel in swept_vessels:
+        for jumper in swept_jumpers:
+            for depth in depths:
+                for hs in hs_values:
+                    case_num += 1
+                    try:
+                        result = run_single_case(
+                            vessel, jumper, common, depth, hs, config=config
+                        )
+                        all_results.append(result)
+                    except Exception as exc:
+                        logger.warning("Case %d failed: %s", case_num, exc)
+                        all_results.append(
+                            {
+                                "vessel": vessel["name"],
+                                "jumper_name": jumper["name"],
+                                "length_m": jumper["length_m"],
+                                "water_depth_m": depth,
+                                "hs_m": hs,
+                                "overall_status": "ERROR",
+                                "max_utilisation": None,
+                                "governing_phase": str(exc),
+                            }
+                        )
+
+    rows = [
+        {
+            "Vessel": result.get("vessel", ""),
+            "Jumper": result.get("jumper_name", ""),
+            "Length (m)": result.get("length_m", 0),
+            "Depth (m)": result.get("water_depth_m", 0),
+            "Hs (m)": result.get("hs_m", 0),
+            "Status": result.get("overall_status", "ERROR"),
+            "Max Util": result.get("max_utilisation", None),
+            "Governing Phase": result.get("governing_phase", "N/A"),
+        }
+        for result in all_results
+    ]
+    return all_results, pd.DataFrame(rows)

--- a/src/digitalmodel/installation/jumper_installation/workflow.py
+++ b/src/digitalmodel/installation/jumper_installation/workflow.py
@@ -1,0 +1,256 @@
+"""Headless durable workflow for deepwater rigid-jumper installation screening."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from digitalmodel.installation.jumper_installation.calculations import (
+    governing_phase,
+    load_jumper_data,
+    load_vessel_data,
+    run_parametric_sweep,
+    status_from_utils,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("jumper_installation") or {}
+    config = _workflow_config(settings)
+    vessels = load_vessel_data(_config_path(cfg, settings["vessels"]["catalog"]))
+    common, jumpers = load_jumper_data(_config_path(cfg, settings["jumpers"]["catalog"]))
+    results, _ = run_parametric_sweep(vessels, common, jumpers, config=config)
+
+    output_dir = _output_dir(cfg, settings)
+    cases_csv = output_dir / f"{_input_stem(cfg)}_jumper_installation_cases.csv"
+    summary_json = output_dir / f"{_input_stem(cfg)}_jumper_installation_summary.json"
+    rows = [_case_row(result) for result in results]
+    summary = _summary(results, rows, cases_csv, summary_json, config)
+    _write_cases_csv(cases_csv, rows)
+    _write_summary_json(summary_json, summary, results)
+
+    cfg["jumper_installation"] = {
+        "screening_status": summary["screening_status"],
+        "governing_phase": summary["governing_phase"],
+        "max_utilisation": summary["max_utilisation"],
+        "summary": summary,
+        "cases": rows,
+    }
+    cfg.setdefault("outputs", {})["cases_csv"] = _display_path(cases_csv)
+    cfg["outputs"]["summary_json"] = _display_path(summary_json)
+    _print_self_check(rows, summary)
+    return cfg
+
+
+def _workflow_config(settings: dict[str, Any]) -> SimpleNamespace:
+    constants = settings.get("constants") or {}
+    physical = settings.get("physical_constants") or {}
+    lift = settings.get("lift_span_model") or {}
+    tiein = settings.get("tiein_span_model") or {}
+    jumpers = settings.get("jumpers") or {}
+    sweep = settings.get("sweep") or {}
+    vessels = settings.get("vessels") or {}
+
+    return SimpleNamespace(
+        vessels=list(vessels.get("selected", [])),
+        lengths_m=[float(value) for value in jumpers.get("lengths_m", [])],
+        depths=[int(value) for value in sweep.get("depths_m", [])],
+        hs=[float(value) for value in sweep.get("hs_m", [])],
+        daf_liftoff=_float(constants, "daf_liftoff"),
+        daf_splash=_float(constants, "daf_splash"),
+        rigging_mass_kg=_float(constants, "rigging_mass_kg"),
+        cs_slamming=_float(constants, "cs_slamming"),
+        cd_cylinder=_float(constants, "cd_cylinder"),
+        ca_cylinder=_float(constants, "ca_cylinder"),
+        v_lowering=_float(constants, "v_lowering"),
+        v_current=_float(constants, "v_current"),
+        splash_submerged_length_m=_float(constants, "splash_submerged_length_m"),
+        wire_allowable_factor=_float(constants, "wire_allowable_factor"),
+        bending_allowable=_float(constants, "bending_allowable"),
+        cable_unit_weight_sub_n_per_m=_float(
+            constants, "cable_unit_weight_sub_n_per_m"
+        ),
+        tie_in_tolerance_mm=_float(constants, "tie_in_tolerance_mm"),
+        reference_hs=_float(constants, "reference_hs"),
+        tp_coefficient=_float(constants, "tp_coefficient"),
+        go_marginal_threshold=_float(constants, "go_marginal_threshold"),
+        nogo_utilisation=_float(constants, "nogo_utilisation"),
+        seawater_density_kg_m3=_float(physical, "seawater_density_kg_m3"),
+        gravity_m_s2=_float(physical, "gravity_m_s2"),
+        lift_span_fraction=_float(lift, "lift_span_fraction"),
+        lift_span_m=_optional_float(lift, "lift_span_m"),
+        lift_moment_coeff=_float(lift, "moment_coeff"),
+        tiein_unsupported_span_fraction=_float(
+            tiein, "tiein_unsupported_span_fraction"
+        ),
+        tiein_unsupported_span_m=_optional_float(tiein, "tiein_unsupported_span_m"),
+        tiein_include_self_weight=bool(tiein.get("include_self_weight", False)),
+        tiein_deflection_coeff=_float(tiein, "deflection_coeff"),
+    )
+
+
+def _summary(
+    results: list[dict[str, Any]],
+    rows: list[dict[str, Any]],
+    cases_csv: Path,
+    summary_json: Path,
+    config: SimpleNamespace,
+) -> dict[str, Any]:
+    if not results:
+        raise ValueError("jumper_installation produced no cases")
+    governing = max(results, key=lambda item: float(item["max_utilisation"]))
+    phase_utils = {
+        key: float(value) for key, value in governing["phase_utilisations"].items()
+    }
+    status = status_from_utils(phase_utils, config=config)
+    return {
+        "screening_status": "fail" if status == "NO_GO" else "pass",
+        "overall_status": status,
+        "governing_phase": governing_phase(phase_utils),
+        "max_utilisation": float(governing["max_utilisation"]),
+        "n_cases": len(results),
+        "vessels": sorted({str(row["vessel"]) for row in rows}),
+        "jumper_lengths_m": sorted({float(row["length_m"]) for row in rows}),
+        "water_depths_m": sorted({float(row["water_depth_m"]) for row in rows}),
+        "hs_m": sorted({float(row["hs_m"]) for row in rows}),
+        "cases_csv": _display_path(cases_csv),
+        "summary_json": _display_path(summary_json),
+    }
+
+
+def _case_row(result: dict[str, Any]) -> dict[str, Any]:
+    phase_utils = result["phase_utilisations"]
+    row = {
+        "vessel": result["vessel"],
+        "jumper_name": result["jumper_name"],
+        "length_m": result["length_m"],
+        "water_depth_m": result["water_depth_m"],
+        "hs_m": result["hs_m"],
+        "tp_s": result["tp_s"],
+        "overall_status": result["overall_status"],
+        "screening_status": (
+            "fail" if result["overall_status"] == "NO_GO" else "pass"
+        ),
+        "governing_phase": result["governing_phase"],
+        "max_utilisation": result["max_utilisation"],
+    }
+    for phase, utilisation in phase_utils.items():
+        row[f"{phase}_utilisation"] = utilisation
+    return row
+
+
+def _write_cases_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_summary_json(
+    path: Path,
+    summary: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "screening_status": summary["screening_status"],
+        "governing_phase": summary["governing_phase"],
+        "max_utilisation": summary["max_utilisation"],
+        "summary": summary,
+        "cases": results,
+    }
+    path.write_text(json.dumps(_json_safe(payload), indent=2), encoding="utf-8")
+
+
+def _print_self_check(rows: list[dict[str, Any]], summary: dict[str, Any]) -> None:
+    print("SELF-CHECK jumper-installation")
+    print("  swept Hs cases:")
+    for row in rows:
+        print(
+            "    "
+            f"Hs={row['hs_m']:.1f} m, "
+            f"governing_phase={row['governing_phase']}, "
+            f"max_utilisation={row['max_utilisation']:.4f}, "
+            f"screening_status={row['screening_status']}"
+        )
+    print(
+        "  summary: "
+        f"governing_phase={summary['governing_phase']}, "
+        f"max_utilisation={summary['max_utilisation']:.4f}, "
+        f"screening_status={summary['screening_status']}"
+    )
+
+
+def _output_dir(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(str(settings.get("output_dir", "results")))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir
+
+
+def _config_path(cfg: dict, value: str) -> Path:
+    path = Path(str(value))
+    if not path.is_absolute():
+        path = _config_dir(cfg) / path
+    return path
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "jumper_installation"))
+
+
+def _float(settings: dict[str, Any], name: str) -> float:
+    value = settings.get(name)
+    if value is None:
+        raise ValueError(f"jumper_installation {name} is required")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"jumper_installation {name} must be finite")
+    return value
+
+
+def _optional_float(settings: dict[str, Any], name: str) -> float | None:
+    value = settings.get(name)
+    if value is None:
+        return None
+    value = float(value)
+    if value <= 0.0 or not math.isfinite(value):
+        raise ValueError(f"jumper_installation {name} must be positive when set")
+    return value
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -64,6 +64,28 @@ def test_workflow_registry(workflow):
         damage = cfg["fatigue_analysis"]["damage"]
         assert damage == pytest.approx(7.418780212e-11)
         assert 0 < damage < 1.0e-9
+    elif workflow["id"] == "jumper-installation":
+        summary = cfg["jumper_installation"]["summary"]
+        results_path = Path(summary["cases_csv"])
+        summary_path = Path(summary["summary_json"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+
+        cases = pd.read_csv(results_path)
+        summary_json = yaml.safe_load(summary_path.read_text())
+
+        assert summary["screening_status"] in {"pass", "fail"}
+        assert summary["screening_status"] == "pass"
+        assert summary["governing_phase"] == "splash_zone"
+        assert summary["max_utilisation"] == pytest.approx(cases["max_utilisation"].max())
+        assert len(cases) == 3
+        assert cases["hs_m"].tolist() == [1.0, 2.0, 3.0]
+        assert cases["max_utilisation"].is_monotonic_increasing
+        assert set(cases["governing_phase"]) == {"splash_zone"}
+        assert summary_json["summary"]["screening_status"] == "pass"
+        assert summary_json["summary"]["governing_phase"] == "splash_zone"
     elif workflow["id"] == "mooring-fatigue":
         summary = cfg["mooring_fatigue"]
         results_path = Path(summary["results_csv"])


### PR DESCRIPTION
Onboards the deepwater rigid-jumper installation demo into the registry — the next **T0 near-ready** item from the demand signal (deckhand [#368](https://github.com/vamseeachanta/deckhand/issues/368)).

## Approach — reuse, not reinvent
The demo's 5 phase calcs (liftoff, in-air bending, splash, lowering, tie-in) + parametric sweep moved to `src/digitalmodel/installation/jumper_installation/`; the demo now imports them (DRY — demo still runs). Config-driven `input.yml`, engine route, and the required `base_configs` default. Emits `screening_status` (pass/fail from governing-phase utilisation) + governing_phase + max utilisation.

## Self-check
Hs 1/2/3 m → governing **splash_zone**, max util 0.0039/0.0041/0.0042, **screening_status pass** (util rises with Hs ✓).

⚠️ **Reviewer note:** example utilisations are very low (~0.4%) — reflects the demo's bundled *light* example data, not an onboarding bug (the calc functions are reused verbatim). Consider a more representative example case.

## Provenance & verification
Built via **codex**, **hand-verified**: real `uv` module run works (codex sandbox couldn't run uv) + `base_configs` default present + the modified demo still imports + **71/71 durable-workflow tests pass**.

Part of [#711](https://github.com/vamseeachanta/digitalmodel/issues/711); T0 item from deckhand [#368](https://github.com/vamseeachanta/deckhand/issues/368). Routing follow-up in deckhand after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)