### PR TITLE
feat(mooring): calibrate synthetic-rope fatigue to DNV-OS-E301 (AC6 gate)

### DIFF
--- a/examples/workflows/synthetic-rope-mooring-fatigue/README.md
+++ b/examples/workflows/synthetic-rope-mooring-fatigue/README.md
@@ -1,5 +1,6 @@
 # Synthetic Rope Mooring Fatigue
-Screens synthetic fibre-rope mooring service life across tension-tension fatigue, creep-rupture, and minimum-tension axial-compression limits.
+Screens synthetic fibre-rope mooring service life across tension-tension fatigue, creep-rupture, and minimum-tension axial-compression limits. A line passes only if all three pass.
 This workflow is synthetic-only; metallic chain or wire lines should use `mooring-fatigue`.
+The polyester tension-tension T-N curve is **DNV-OS-E301 (Oct 2010) Table F3**: `N = aD * R^(-m)` with `aD = 0.259`, `m = 13.46`, `R = tension range / characteristic strength (MBL)`; the fatigue safety factor `dff = 60` follows DNV-OS-E301 F702 for polyester. Creep carries a separate `creep_safety_factor`. Nylon/HMPE must supply their own validated `tn_curve` (and creep for HMPE) or the run escalates.
 The example keeps one polyester line healthy and drives another to creep-governed failure.
 Run with `uv run python -m digitalmodel examples/workflows/synthetic-rope-mooring-fatigue/input.yml`.

--- a/examples/workflows/synthetic-rope-mooring-fatigue/input.yml
+++ b/examples/workflows/synthetic-rope-mooring-fatigue/input.yml
@@ -2,11 +2,12 @@ basename: synthetic_rope_mooring_fatigue
 
 synthetic_rope_mooring_fatigue:
   design_life_years: 25.0
-  dff: 3.0
-  tn_curve:
-    intercept: 1.0e6
-    slope: 10.0
-    mean_load_knockdown: 1.5
+  dff: 60.0                  # fatigue SF — DNV-OS-E301 F702, polyester
+  creep_safety_factor: 3.0
+  tn_curve:                  # polyester T-N, DNV-OS-E301 Table F3 (N = aD * R^-m)
+    intercept: 0.259        # aD
+    slope: 13.46            # m
+    mean_load_knockdown: 0.0
   creep:
     reference_life_years: 100.0
     load_ratio_ref: 0.30

--- a/src/digitalmodel/base_configs/modules/synthetic_rope_mooring_fatigue/synthetic_rope_mooring_fatigue.yml
+++ b/src/digitalmodel/base_configs/modules/synthetic_rope_mooring_fatigue/synthetic_rope_mooring_fatigue.yml
@@ -2,11 +2,20 @@ basename: synthetic_rope_mooring_fatigue
 
 synthetic_rope_mooring_fatigue:
   design_life_years: 25.0
-  dff: 3.0
+  # dff = fatigue (T-N) safety factor. DNV-OS-E301 (Oct 2010) F702 specifies 60
+  # for polyester ropes; deliberately large vs steel (1-10) per its guidance note.
+  dff: 60.0
+  # creep-rupture carries its own factor — the fatigue SF must NOT apply here.
+  creep_safety_factor: 3.0
+  # Polyester tension-tension T-N design curve, DNV-OS-E301 Table F3:
+  #   N = aD * R^(-m),  R = tension range / characteristic strength (~MBL).
+  # The curve is range-only (no mean-load term), so mean_load_knockdown = 0;
+  # mean load enters the creep leg. nylon/HMPE must supply their own validated
+  # tn_curve (see workflow material guard).
   tn_curve:
-    intercept: 1.0e6
-    slope: 10.0
-    mean_load_knockdown: 1.5
+    intercept: 0.259      # aD (DNV-OS-E301 Table F3, polyester)
+    slope: 13.46          # m  (DNV-OS-E301 Table F3, polyester)
+    mean_load_knockdown: 0.0
   creep:
     reference_life_years: 100.0
     load_ratio_ref: 0.30

--- a/src/digitalmodel/synthetic_rope_mooring_fatigue/workflow.py
+++ b/src/digitalmodel/synthetic_rope_mooring_fatigue/workflow.py
@@ -21,7 +21,15 @@ def router(cfg: dict) -> dict:
         "design_life_years",
         "synthetic_rope_mooring_fatigue design_life_years",
     )
+    # dff is the FATIGUE (T-N) safety factor — DNV-OS-E301 F702 specifies 60 for
+    # polyester. Creep-rupture carries its own factor (the fatigue factor is
+    # unusually large and must not be applied to the creep limit state).
     dff = _positive_float(settings, "dff", "synthetic_rope_mooring_fatigue dff")
+    creep_safety_factor = _positive_float(
+        settings,
+        "creep_safety_factor",
+        "synthetic_rope_mooring_fatigue creep_safety_factor",
+    )
     config_tn = _tn_curve(settings.get("tn_curve") or {}, "tn_curve")
     config_creep = _creep(settings.get("creep") or {}, "creep")
     min_tension = _min_tension(settings.get("min_tension") or {})
@@ -36,6 +44,7 @@ def router(cfg: dict) -> dict:
             min_tension,
             design_life_years,
             dff,
+            creep_safety_factor,
         )
         rows.extend(line_rows)
         summaries.append(summary)
@@ -93,6 +102,7 @@ def _evaluate_line(
     min_tension: dict[str, float],
     design_life_years: float,
     dff: float,
+    creep_safety_factor: float,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     line_id, material, mbl, lm, min_tension_kn, temperature = _line_inputs(line)
     tn = _tn_curve(line.get("tn_curve") or config_tn, f"{line_id} tn_curve")
@@ -118,6 +128,7 @@ def _evaluate_line(
         min_tension,
         design_life_years,
         dff,
+        creep_safety_factor,
     )
     return rows, summary
 
@@ -192,14 +203,16 @@ def _line_summary(
     min_tension: dict[str, float],
     design_life_years: float,
     dff: float,
+    creep_safety_factor: float,
 ) -> dict[str, Any]:
     fatigue_life_years = design_life_years / total_damage
-    required_years = design_life_years * dff
-    fatigue_margin = fatigue_life_years / required_years
+    fatigue_required_years = design_life_years * dff
+    fatigue_margin = fatigue_life_years / fatigue_required_years
     creep_life_years = creep["reference_life_years"] * 10 ** (
         (creep["load_ratio_ref"] - lm) * creep["decades_per_load_ratio"]
     )
-    creep_margin = creep_life_years / required_years
+    creep_required_years = design_life_years * creep_safety_factor
+    creep_margin = creep_life_years / creep_required_years
     compression_margin = min_ratio / min_tension["min_ratio_allow"]
     margins = {
         "fatigue": fatigue_margin,

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1027,3 +1027,68 @@ def test_wave_spectrum_pierson_moskowitz_engine_textbook_check(tmp_path):
     assert spectrum.loc[spectrum["S"].idxmax(), "frequency"] == pytest.approx(
         cfg["wave_spectrum"]["peak_frequency"]
     )
+
+
+def test_synthetic_rope_tn_curve_matches_dnv_os_e301_table_f3(tmp_path):
+    """AC6 validation gate: the polyester tension-tension T-N leg reproduces the
+    DNV-OS-E301 (Oct 2010) Table F3 design curve  N = aD * R^(-m), with
+    aD = 0.259, m = 13.46 and R = tension range / characteristic strength (MBL).
+    The curve is range-only (mean_load_knockdown = 0), so allowable_cycles must
+    equal aD * R^(-m) exactly for each bin."""
+    a_d, m = 0.259, 13.46
+    mbl = 10000.0
+    ranges = [500.0, 1000.0, 2000.0]  # R = 0.05, 0.10, 0.20
+    input_path = tmp_path / "synthetic_rope.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "synthetic_rope_mooring_fatigue",
+                "synthetic_rope_mooring_fatigue": {
+                    "design_life_years": 20.0,
+                    "dff": 60.0,
+                    "creep_safety_factor": 3.0,
+                    "tn_curve": {
+                        "intercept": a_d,
+                        "slope": m,
+                        "mean_load_knockdown": 0.0,
+                    },
+                    "creep": {
+                        "reference_life_years": 100.0,
+                        "load_ratio_ref": 0.30,
+                        "decades_per_load_ratio": 6.0,
+                    },
+                    "min_tension": {"min_ratio_allow": 0.05},
+                    "output_dir": "results",
+                    "lines": [
+                        {
+                            "id": "polyester-val",
+                            "material": "POLYESTER",
+                            "MBL_kN": mbl,
+                            "mean_tension_kN": 2000.0,
+                            "min_tension_kN": 1000.0,
+                            "tension_range_bins": [
+                                {"tension_range_kN": r, "n_cycles": 1000.0}
+                                for r in ranges
+                            ],
+                        }
+                    ],
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    engine(inputfile=str(input_path))
+    results = pd.read_csv(
+        tmp_path / "results" / "synthetic_rope_synthetic_rope_mooring_fatigue.csv"
+    )
+
+    for _, row in results.iterrows():
+        expected_n = a_d * row["normalised_range"] ** (-m)
+        assert row["allowable_cycles"] == pytest.approx(expected_n, rel=1e-9)
+    # Published anchor: R = 0.10 -> N = 0.259 * 10^13.46
+    anchor = results.loc[results["normalised_range"].round(6) == 0.10].iloc[0]
+    assert anchor["allowable_cycles"] == pytest.approx(a_d * 10 ** 13.46, rel=1e-9)


### PR DESCRIPTION
Satisfies the AC6 validation gate from the llm-wiki spine node `synthetic-fibre-rope-mooring-fatigue` — the prerequisite to flip that node `escalates → covered`. Follow-up to #786.

## What
- **Polyester T-N curve = DNV-OS-E301 (Oct 2010) Table F3**: `N = aD · R^(−m)` with `aD = 0.259`, `m = 13.46`, `R = tension range / characteristic strength (MBL)`. The curve is range-only, so `mean_load_knockdown = 0` (mean load enters the creep leg). Source is in the wiki (`papers/dnv-os-e301-2010-position-mooring`, F604/Table F3/Fig.10).
- **Split the safety factor.** DNV-OS-E301 F702 specifies a fatigue factor of **60** for polyester — deliberately large vs steel (1–10) per its guidance note, and **fatigue-specific**. The original single `dff` applied that to creep too, which is wrong. Now: `dff` (fatigue, default 60) + a separate `creep_safety_factor` (default 3.0).
- **Validation test** `test_synthetic_rope_tn_curve_matches_dnv_os_e301_table_f3` reproduces the Table F3 curve exactly (`allowable_cycles == aD · R^(−m)`, incl. the `R=0.10 → 0.259·10^13.46` anchor).

## Verification
- `uv run python -m digitalmodel examples/workflows/synthetic-rope-mooring-fatigue/input.yml` → EXIT 0; T-N output matches DNV exactly (R=0.10 → 7.4696e12 = 0.259·10^13.46).
- Full durable suite → **74 passed, 1 skipped** (+1 new validation test). Demo narrative unchanged: polyester-01 passes all three legs; polyester-02 fails on creep.

## After merge
Flips the llm-wiki spine `synthetic-fibre-rope-mooring-fatigue` Method from `escalates` → `covered` (separate llm-wiki PR), closing the flywheel loop. Nylon/HMPE still require their own validated `tn_curve` or escalate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)