### PR TITLE
feat(fatigue): spectral (frequency-domain) fatigue durable workflow

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -63,6 +63,16 @@ workflows:
       - examples/workflows/synthetic-rope-mooring-fatigue/results/input_synthetic_rope_mooring_fatigue_summary.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[synthetic-rope-mooring-fatigue]
     runtime: offline
+  - id: spectral-fatigue
+    basename: spectral_fatigue
+    title: Frequency-domain (spectral) fatigue from a stress PSD (Dirlik / DNV-RP-C203)
+    input: examples/workflows/spectral-fatigue/input.yml
+    outputs:
+      - examples/workflows/spectral-fatigue/results/input.yml
+      - examples/workflows/spectral-fatigue/results/input_spectral_fatigue.csv
+      - examples/workflows/spectral-fatigue/results/input_spectral_fatigue_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[spectral-fatigue]
+    runtime: offline
   - id: time-series
     basename: time_series
     title: FFT spectrum from a deterministic synthetic signal

--- a/examples/workflows/spectral-fatigue/README.md
+++ b/examples/workflows/spectral-fatigue/README.md
@@ -1,0 +1,6 @@
+# Spectral (Frequency-Domain) Fatigue
+Estimates fatigue damage and life of an offshore detail (riser, hull, joint) directly from a stress response power spectral density (PSD) — no time-domain simulation or rainflow count.
+Damage estimator: `dirlik` (default), `narrow_band`, `wirsching_light`, or `benasciutti_tovo`, against a DNV-RP-C203 S-N curve (`slope` m, `log_intercept` log10 a). Wraps the tested `digitalmodel.fatigue.spectral_fatigue` library.
+Each location accumulates damage across its sea states weighted by `occurrence_fraction`; the workflow reports per-location fatigue life and a top-level `screening_status` (pass/fail vs design life × DFF) with the governing location.
+The example keeps a riser keel joint healthy and drives the splash-zone hot spot to a fatigue-governed failure.
+Run with `uv run python -m digitalmodel examples/workflows/spectral-fatigue/input.yml`.

--- a/examples/workflows/spectral-fatigue/input.yml
+++ b/examples/workflows/spectral-fatigue/input.yml
@@ -1,0 +1,32 @@
+basename: spectral_fatigue
+
+spectral_fatigue:
+  design_life_years: 25.0
+  dff: 3.0
+  method: dirlik                 # dirlik | narrow_band | wirsching_light | benasciutti_tovo
+  sn_curve:                      # DNV-RP-C203 D-curve in air
+    slope: 3.0
+    log_intercept: 12.164
+  output_dir: results
+  locations:
+    - id: riser-splash-zone
+      # wave-frequency stress PSD (MPa^2/Hz) at the splash-zone hot spot,
+      # split into a mild operating state and a severe storm state by occurrence.
+      sea_states:
+        - occurrence_fraction: 0.85
+          frequency_Hz:        [0.04, 0.06, 0.08, 0.10, 0.12, 0.16, 0.24, 0.40]
+          stress_psd_MPa2_Hz:  [50.0, 300.0, 1200.0, 2500.0, 1500.0, 400.0, 80.0, 10.0]
+        - occurrence_fraction: 0.15
+          frequency_Hz:        [0.04, 0.06, 0.08, 0.10, 0.12, 0.16, 0.24, 0.40]
+          stress_psd_MPa2_Hz:  [120.0, 800.0, 3500.0, 7000.0, 4200.0, 1100.0, 220.0, 30.0]
+    - id: riser-keel-joint
+      sea_states:
+        - occurrence_fraction: 1.0
+          frequency_Hz:        [0.04, 0.06, 0.08, 0.10, 0.12, 0.16, 0.24, 0.40]
+          stress_psd_MPa2_Hz:  [10.0, 60.0, 240.0, 500.0, 300.0, 80.0, 16.0, 2.0]
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/spectral_fatigue/spectral_fatigue.yml
+++ b/src/digitalmodel/base_configs/modules/spectral_fatigue/spectral_fatigue.yml
@@ -1,0 +1,21 @@
+basename: spectral_fatigue
+
+spectral_fatigue:
+  design_life_years: 25.0
+  dff: 3.0
+  # Damage estimator: dirlik (default, accurate wide-band) | narrow_band |
+  # wirsching_light | benasciutti_tovo. Reuses digitalmodel.fatigue.spectral_fatigue.
+  method: dirlik
+  # S-N curve: slope m and log10 intercept a (N = a * S^-m). Default is the
+  # DNV-RP-C203 D-curve in air (m = 3.0, log10 a = 12.164).
+  sn_curve:
+    slope: 3.0
+    log_intercept: 12.164
+  output_dir: results
+  locations: []
+
+default:
+  log_level: DEBUG
+  config:
+    overwrite:
+      output: True

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -210,6 +210,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         )
 
         cfg_base = synthetic_rope_mooring_fatigue(cfg_base)
+    elif basename == "spectral_fatigue":
+        from digitalmodel.spectral_fatigue.workflow import (
+            router as spectral_fatigue,
+        )
+
+        cfg_base = spectral_fatigue(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/spectral_fatigue/workflow.py
+++ b/src/digitalmodel/spectral_fatigue/workflow.py
@@ -1,0 +1,237 @@
+"""Durable workflow for frequency-domain (spectral) fatigue screening.
+
+Wires the tested spectral-fatigue library (digitalmodel.fatigue.spectral_fatigue)
+into a registry workflow: stress response PSD -> spectral moments -> damage
+estimator (Dirlik default; narrow-band / Wirsching-Light / Benasciutti-Tovo) ->
+DNV-RP-C203 S-N -> damage accumulated over sea states by occurrence.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.fatigue.spectral_fatigue import (
+    benasciutti_tovo_damage,
+    compute_spectral_moments,
+    dirlik_damage,
+    narrow_band_damage,
+    wirsching_light_damage,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Damage estimators, keyed by config name. All share the signature
+# (moments, sn_slope, sn_intercept, duration) -> SpectralFatigueResult.
+METHODS = {
+    "dirlik": dirlik_damage,
+    "narrow_band": narrow_band_damage,
+    "wirsching_light": wirsching_light_damage,
+    "benasciutti_tovo": benasciutti_tovo_damage,
+}
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("spectral_fatigue") or {}
+    design_life_years = _positive_float(settings, "design_life_years")
+    dff = _positive_float(settings, "dff")
+    damage_fn, method_name = _method(settings)
+    sn_slope, sn_intercept = _sn_curve(settings)
+
+    rows: list[dict[str, Any]] = []
+    summaries: list[dict[str, Any]] = []
+    for location in _locations(settings):
+        location_rows, summary = _evaluate_location(
+            location, damage_fn, method_name, sn_slope, sn_intercept,
+            design_life_years, dff,
+        )
+        rows.extend(location_rows)
+        summaries.append(summary)
+
+    governing = min(summaries, key=lambda item: item["margin"])
+    csv_path = _results_csv_path(cfg, settings)
+    summary_path = _summary_csv_path(cfg, settings)
+    _write_csv(csv_path, rows)
+    _write_csv(summary_path, summaries)
+
+    cfg["spectral_fatigue"] = {
+        "design_life_years": design_life_years,
+        "dff": dff,
+        "method": method_name,
+        "sn_curve": {"slope": sn_slope, "log_intercept": sn_intercept},
+        "governing_location": governing["location_id"],
+        "governing_margin": governing["margin"],
+        "governing_fatigue_life_years": governing["fatigue_life_years"],
+        # Top-level pass/fail (governing location is worst-case): drives the
+        # deckhand report template's mitigation-on-fail section.
+        "screening_status": "pass" if all(s["passes"] for s in summaries) else "fail",
+        "locations": summaries,
+        "results_csv": _display_path(csv_path),
+        "summary_csv": _display_path(summary_path),
+    }
+    cfg["screening_status"] = cfg["spectral_fatigue"]["screening_status"]
+    return cfg
+
+
+def _evaluate_location(
+    location: dict[str, Any],
+    damage_fn: Any,
+    method_name: str,
+    sn_slope: float,
+    sn_intercept: float,
+    design_life_years: float,
+    dff: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    location_id = str(location.get("id", location.get("name", "location")))
+    sea_states = _sea_states(location, location_id)
+    rows: list[dict[str, Any]] = []
+    annual_damage = 0.0
+    for index, sea_state in enumerate(sea_states):
+        frequency, psd = _psd(sea_state, location_id)
+        occurrence = _occurrence(sea_state, location_id)
+        moments = compute_spectral_moments(frequency, psd)
+        result = damage_fn(moments, sn_slope, sn_intercept, duration=1.0)
+        contribution = result.damage_per_year * occurrence
+        annual_damage += contribution
+        rows.append(
+            {
+                "location_id": location_id,
+                "sea_state_index": index,
+                "occurrence_fraction": occurrence,
+                "method": method_name,
+                "rms_stress_MPa": moments.rms,
+                "bandwidth_parameter": moments.bandwidth_parameter,
+                "peak_rate_Hz": moments.nu_p,
+                "damage_per_year_full": result.damage_per_year,
+                "damage_per_year_weighted": contribution,
+            }
+        )
+
+    if annual_damage <= 0.0:
+        raise ValueError(f"{location_id} accumulated zero damage; check the PSD inputs")
+    fatigue_life_years = 1.0 / annual_damage
+    required_years = design_life_years * dff
+    margin = fatigue_life_years / required_years
+    summary = {
+        "location_id": location_id,
+        "method": method_name,
+        "annual_damage": annual_damage,
+        "fatigue_life_years": fatigue_life_years,
+        "required_life_years": required_years,
+        "margin": margin,
+        "passes": margin >= 1.0,
+    }
+    return rows, summary
+
+
+def _method(settings: dict[str, Any]) -> tuple[Any, str]:
+    name = str(settings.get("method", "dirlik")).strip().lower()
+    if name not in METHODS:
+        raise ValueError(
+            f"spectral_fatigue method must be one of {sorted(METHODS)}; got {name!r}"
+        )
+    return METHODS[name], name
+
+
+def _sn_curve(settings: dict[str, Any]) -> tuple[float, float]:
+    sn = settings.get("sn_curve") or {}
+    slope = _positive_float(sn, "slope", "sn_curve.slope")
+    intercept = _positive_float(sn, "log_intercept", "sn_curve.log_intercept")
+    return slope, intercept
+
+
+def _locations(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    locations = settings.get("locations")
+    if not isinstance(locations, list) or not locations:
+        raise ValueError("spectral_fatigue locations must be a non-empty list")
+    return locations
+
+
+def _sea_states(location: dict[str, Any], location_id: str) -> list[dict[str, Any]]:
+    sea_states = location.get("sea_states")
+    if not isinstance(sea_states, list) or not sea_states:
+        raise ValueError(f"{location_id} sea_states must be a non-empty list")
+    return sea_states
+
+
+def _psd(sea_state: dict[str, Any], location_id: str) -> tuple[list[float], list[float]]:
+    frequency = sea_state.get("frequency_Hz")
+    psd = sea_state.get("stress_psd_MPa2_Hz")
+    if not isinstance(frequency, list) or not isinstance(psd, list):
+        raise ValueError(
+            f"{location_id} sea_state needs list frequency_Hz and stress_psd_MPa2_Hz"
+        )
+    if len(frequency) != len(psd) or len(frequency) < 2:
+        raise ValueError(
+            f"{location_id} frequency_Hz and stress_psd_MPa2_Hz must be equal-length (>=2)"
+        )
+    return [float(v) for v in frequency], [float(v) for v in psd]
+
+
+def _occurrence(sea_state: dict[str, Any], location_id: str) -> float:
+    value = sea_state.get("occurrence_fraction", 1.0)
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"{location_id} occurrence_fraction must be positive")
+    return value
+
+
+def _positive_float(source: dict[str, Any], name: str, label: str | None = None) -> float:
+    label = label or name
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"spectral_fatigue {label} is required")
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"spectral_fatigue {label} must be positive")
+    return value
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return _output_dir(cfg, settings) / f"{_input_stem(cfg)}_spectral_fatigue.csv"
+
+
+def _summary_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return _output_dir(cfg, settings) / f"{_input_stem(cfg)}_spectral_fatigue_summary.csv"
+
+
+def _output_dir(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "spectral_fatigue"))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("spectral_fatigue cannot write empty results")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -147,6 +147,42 @@ def test_workflow_registry(workflow):
                 group.sort_values("normalised_range")["allowable_cycles"]
                 .is_monotonic_decreasing
             )
+    elif workflow["id"] == "spectral-fatigue":
+        summary = cfg["spectral_fatigue"]
+        results_path = Path(summary["results_csv"])
+        summary_path = Path(summary["summary_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+        results = pd.read_csv(results_path)
+        location_summary = pd.read_csv(summary_path)
+
+        assert cfg["screening_status"] == summary["screening_status"]
+        assert summary["screening_status"] == "fail"            # splash zone fails
+        assert summary["method"] == "dirlik"
+        assert summary["governing_location"] == "riser-splash-zone"
+        assert set(location_summary["location_id"]) == {
+            "riser-splash-zone",
+            "riser-keel-joint",
+        }
+        by_loc = {row["location_id"]: row for _, row in location_summary.iterrows()}
+        assert bool(by_loc["riser-splash-zone"]["passes"]) is False
+        assert bool(by_loc["riser-keel-joint"]["passes"]) is True
+        # life = 1 / accumulated annual damage; governing = smallest margin
+        for _, row in location_summary.iterrows():
+            assert row["fatigue_life_years"] == pytest.approx(1.0 / row["annual_damage"])
+        assert summary["governing_margin"] == pytest.approx(
+            location_summary["margin"].min()
+        )
+        # multi-sea-state weighting: splash zone has 2 states, keel 1; each
+        # weighted contribution = full damage * occurrence fraction.
+        assert (results["damage_per_year_full"] > 0.0).all()
+        assert len(results[results["location_id"] == "riser-splash-zone"]) == 2
+        for _, row in results.iterrows():
+            assert row["damage_per_year_weighted"] == pytest.approx(
+                row["damage_per_year_full"] * row["occurrence_fraction"]
+            )
     elif workflow["id"] == "time-series":
         fft_path = Path(cfg["time_series"]["csv"]["signal_fft"])
         fft = pd.read_csv(fft_path)
@@ -1092,3 +1128,62 @@ def test_synthetic_rope_tn_curve_matches_dnv_os_e301_table_f3(tmp_path):
     # Published anchor: R = 0.10 -> N = 0.259 * 10^13.46
     anchor = results.loc[results["normalised_range"].round(6) == 0.10].iloc[0]
     assert anchor["allowable_cycles"] == pytest.approx(a_d * 10 ** 13.46, rel=1e-9)
+
+
+def test_spectral_fatigue_workflow_matches_narrow_band_closed_form(tmp_path):
+    """AC6 validation gate: the spectral-fatigue workflow faithfully wires the
+    validated digitalmodel.fatigue.spectral_fatigue library — the per-location
+    annual damage equals a direct narrow-band (Rayleigh, Bendat 1964) library
+    call on the same PSD and S-N curve."""
+    from digitalmodel.fatigue.spectral_fatigue import (
+        compute_spectral_moments,
+        narrow_band_damage,
+    )
+
+    frequency = [0.04, 0.08, 0.10, 0.12, 0.20, 0.40]
+    psd = [40.0, 900.0, 1800.0, 1100.0, 120.0, 8.0]
+    sn_slope, sn_log_intercept = 3.0, 12.164
+
+    input_path = tmp_path / "spectral.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "spectral_fatigue",
+                "spectral_fatigue": {
+                    "design_life_years": 20.0,
+                    "dff": 3.0,
+                    "method": "narrow_band",
+                    "sn_curve": {
+                        "slope": sn_slope,
+                        "log_intercept": sn_log_intercept,
+                    },
+                    "output_dir": "results",
+                    "locations": [
+                        {
+                            "id": "detail-a",
+                            "sea_states": [
+                                {
+                                    "occurrence_fraction": 1.0,
+                                    "frequency_Hz": frequency,
+                                    "stress_psd_MPa2_Hz": psd,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    cfg = engine(inputfile=str(input_path))
+
+    moments = compute_spectral_moments(frequency, psd)
+    expected = narrow_band_damage(moments, sn_slope, sn_log_intercept).damage_per_year
+
+    location = cfg["spectral_fatigue"]["locations"][0]
+    assert location["annual_damage"] == pytest.approx(expected, rel=1e-9)
+    assert location["fatigue_life_years"] == pytest.approx(1.0 / expected, rel=1e-9)


### PR DESCRIPTION
Builds `digitalmodel:spectral-fatigue` from the llm-wiki spine node `spectral-fatigue-frequency-domain` (#713), serving the demand-signal `riser ← wave fatigue` gap. Loop 2 of the bot↔wiki flywheel.

## What — a wiring job over tested machinery
The numerical core already exists and is tested (`src/digitalmodel/fatigue/spectral_fatigue.py`). This PR wires it into a durable workflow:
- Per **location**: stress response **PSD** per sea state → spectral moments → chosen estimator (**Dirlik** default; `narrow_band` / `wirsching_light` / `benasciutti_tovo`) → **DNV-RP-C203** S-N (slope m, log10 intercept a) → `damage_per_year` accumulated across sea states weighted by `occurrence_fraction`.
- Per-location fatigue life + margin vs design life × DFF; governing location = smallest margin; top-level `screening_status` (drives the deckhand report mitigation section).
- engine dispatch + registry entry + base-config default + example + durable-workflow assertion block.

## Acceptance criteria (from the spine node)
AC1 estimator (Dirlik default, others selectable) ✓ · AC2 DNV-RP-C203 S-N ✓ · AC3 PSD input contract (RAO transfer deferred) ✓ · AC4 multi-sea-state accumulation + `screening_status` ✓ · AC5 units (MPa, MPa²/Hz, Hz, years) ✓ · **AC6 validation** — `test_spectral_fatigue_workflow_matches_narrow_band_closed_form` reproduces the narrow-band Rayleigh closed form via a direct library call ✓ · AC7 delivery (summary + report) ✓

## Verification
- `uv run python -m digitalmodel examples/workflows/spectral-fatigue/input.yml` → EXIT 0. Example: riser splash-zone **fails** (life 25.5 yr vs 75 yr required, governing), keel joint **passes** (443 yr); multi-sea-state occurrence weighting confirmed.
- Full durable suite → **76 passed, 1 skipped** (+2 spectral tests).

## After merge
Route `digitalmodel:spectral-fatigue` under the deckhand riser subdomain (+ report template + CTA), then flip the spine `escalates → covered`. RAO × wave-spectrum → stress-PSD transfer is a documented follow-up (AC3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)