### PR TITLE
Cathodic-protection demo set across structure types (#403)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -9,6 +9,38 @@ workflows:
       - examples/workflows/cathodic-protection/results/input.yml
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[cathodic-protection]
     runtime: offline
+  - id: cathodic-protection-jacket
+    basename: cathodic_protection
+    title: Sacrificial-anode CP for a fixed steel jacket (DNV-RP-B401)
+    input: examples/workflows/cathodic-protection-jacket/input.yml
+    outputs:
+      - examples/workflows/cathodic-protection-jacket/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[cathodic-protection-jacket]
+    runtime: offline
+  - id: cathodic-protection-manifold
+    basename: cathodic_protection
+    title: Sacrificial-anode CP for a subsea manifold (DNV-RP-B401)
+    input: examples/workflows/cathodic-protection-manifold/input.yml
+    outputs:
+      - examples/workflows/cathodic-protection-manifold/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[cathodic-protection-manifold]
+    runtime: offline
+  - id: cathodic-protection-monopile
+    basename: cathodic_protection
+    title: Sacrificial-anode CP for an offshore-wind monopile (DNV-RP-B401)
+    input: examples/workflows/cathodic-protection-monopile/input.yml
+    outputs:
+      - examples/workflows/cathodic-protection-monopile/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[cathodic-protection-monopile]
+    runtime: offline
+  - id: cathodic-protection-fpso
+    basename: cathodic_protection
+    title: Sacrificial-anode CP for an FPSO hull (ABS Offshore 2018)
+    input: examples/workflows/cathodic-protection-fpso/input.yml
+    outputs:
+      - examples/workflows/cathodic-protection-fpso/results/input.yml
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[cathodic-protection-fpso]
+    runtime: offline
   - id: catenary
     basename: catenary
     title: Angle-based catenary geometry

--- a/examples/workflows/cathodic-protection-fpso/input.yml
+++ b/examples/workflows/cathodic-protection-fpso/input.yml
@@ -1,0 +1,29 @@
+basename: cathodic_protection
+
+# FPSO hull (floating offshore structure) — sacrificial-anode CP per
+# ABS Guidance Notes on Cathodic Protection of Offshore Structures (Dec 2018).
+inputs:
+  calculation_type: ABS_gn_offshore_2018
+
+  design_data:
+    design_life: 25.0 # yr
+    seawater_max_temperature: 25.0 # degC (tropical service)
+
+  structure:
+    surface_area_m2: 8000.0   # external submerged hull area
+    water_depth_m: 20.0       # 0-30 m band (near-surface hull)
+    climatic_region: tropical
+    zone: submerged
+
+  anode:
+    material: aluminium
+    utilisation_factor: 0.80
+    physical_properties:
+      net_weight: 180.0 # kg per stand-off hull anode
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+    cfg_sensitivities: false

--- a/examples/workflows/cathodic-protection-jacket/input.yml
+++ b/examples/workflows/cathodic-protection-jacket/input.yml
@@ -1,0 +1,41 @@
+basename: cathodic_protection
+
+# Fixed steel jacket / offshore platform — sacrificial-anode CP per DNV-RP-B401 (2021).
+# Three exposure zones (submerged / splash / atmospheric) with stand-off anodes.
+inputs:
+  calculation_type: DNV_RP_B401_offshore
+
+  design_data:
+    design_life: 25.0 # yr
+    structure_type: jacket
+
+  structure:
+    zones:
+      - zone: submerged
+        area_m2: 5000.0
+        coating_category: I      # high-quality epoxy >=300 um
+      - zone: splash
+        area_m2: 300.0
+        coating_category: III    # standard paint system
+      - zone: atmospheric
+        area_m2: 200.0
+        coating_category: I
+
+  environment:
+    seawater_temperature_C: 10.0
+    seawater_resistivity_ohm_m: 0.30
+
+  anode:
+    material: aluminium
+    type: stand_off
+    individual_anode_mass_kg: 200.0
+    utilization_factor: 0.85
+    length_m: 1.0
+    radius_m: 0.05
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+    cfg_sensitivities: false

--- a/examples/workflows/cathodic-protection-manifold/input.yml
+++ b/examples/workflows/cathodic-protection-manifold/input.yml
@@ -1,0 +1,35 @@
+basename: cathodic_protection
+
+# Subsea manifold / structure — fully submerged sacrificial-anode CP per DNV-RP-B401 (2021).
+# Single deepwater submerged zone, standard paint, cold bottom water.
+inputs:
+  calculation_type: DNV_RP_B401_offshore
+
+  design_data:
+    design_life: 25.0 # yr
+    structure_type: subsea_manifold
+
+  structure:
+    zones:
+      - zone: submerged
+        area_m2: 850.0
+        coating_category: III    # standard paint system
+
+  environment:
+    seawater_temperature_C: 6.0  # deepwater bottom temperature
+    seawater_resistivity_ohm_m: 0.33
+
+  anode:
+    material: aluminium
+    type: stand_off
+    individual_anode_mass_kg: 80.0
+    utilization_factor: 0.85
+    length_m: 0.6
+    radius_m: 0.045
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+    cfg_sensitivities: false

--- a/examples/workflows/cathodic-protection-monopile/input.yml
+++ b/examples/workflows/cathodic-protection-monopile/input.yml
@@ -1,0 +1,41 @@
+basename: cathodic_protection
+
+# Offshore-wind monopile foundation — sacrificial-anode CP per DNV-RP-B401 (2021).
+# Submerged + splash + atmospheric zones, North Sea water, 30-year design life.
+inputs:
+  calculation_type: DNV_RP_B401_offshore
+
+  design_data:
+    design_life: 30.0 # yr (offshore-wind foundation design life)
+    structure_type: monopile
+
+  structure:
+    zones:
+      - zone: submerged
+        area_m2: 1200.0
+        coating_category: I      # high-quality epoxy on external steel
+      - zone: splash
+        area_m2: 180.0
+        coating_category: I
+      - zone: atmospheric
+        area_m2: 120.0
+        coating_category: I
+
+  environment:
+    seawater_temperature_C: 8.0  # North Sea mean
+    seawater_resistivity_ohm_m: 0.28
+
+  anode:
+    material: aluminium
+    type: stand_off
+    individual_anode_mass_kg: 150.0
+    utilization_factor: 0.85
+    length_m: 0.9
+    radius_m: 0.06
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+    cfg_sensitivities: false

--- a/examples/workflows/cathodic-protection-pipeline/README.md
+++ b/examples/workflows/cathodic-protection-pipeline/README.md
@@ -1,0 +1,39 @@
+# cathodic-protection-pipeline (DEFERRED — not yet registered)
+
+Subsea-pipeline external CP via `calculation_type: DNV_RP_F103_2010`
+(DNV-RP-F103, *Cathodic Protection of Submarine Pipelines by Galvanic Anodes* —
+the pipeline-specific DNV code; the DNV-RP-B401 surface-area method is for
+structures, not pipelines).
+
+`input.yml` here is complete and the engine math runs, **but this example is
+intentionally NOT in `docs/registry/workflows.yaml`** because the F103 code path
+is fail-closed on a citation it cannot resolve offline:
+
+```
+CitationResolutionError: code_id='dnv-rp-f103'
+  wiki_path='wikis/engineering-standards/wiki/standards/dnv-rp-f103.md'
+  reason=page_missing
+```
+
+`DNV_RP_F103_2010` calls `get_dnv_f103_reference()`, which calls
+`validate_citation()`. With no `LLM_WIKI_PATH` set and no `citation_repo_root`,
+the resolver parent-walks to the digitalmodel repo root, which has no `wikis/`
+tree — so resolution fails. The page exists only as a test fixture
+(`tests/citations/fixtures/knowledge/.../dnv-rp-f103.md`); the other four CP
+demo paths (jacket / manifold / monopile / FPSO) emit no citation and run with
+zero external dependencies.
+
+## Prerequisite to register this example
+
+Make the DNV-RP-F103 citation resolvable in the offline / registry environment,
+one of:
+
+1. Author `wikis/engineering-standards/wiki/standards/dnv-rp-f103.md` in the
+   **llm-wiki** repo with frontmatter `code_id: dnv-rp-f103`, `publisher: DNV`,
+   `revision: "2010"`, and wire `LLM_WIKI_PATH` (or the parent-walk knowledge
+   base) into CI and the bot compute clone; **or**
+2. Vendor that page into digitalmodel at a resolver-visible location (mirroring
+   the existing test fixture) so a bare `engine()` call resolves it.
+
+Once resolvable, add the registry row + a `test_workflow_registry` assertion
+block and wire it into the Deckhand subsea-pipelines-integrity channel.

--- a/examples/workflows/cathodic-protection-pipeline/input.yml
+++ b/examples/workflows/cathodic-protection-pipeline/input.yml
@@ -1,0 +1,35 @@
+basename: cathodic_protection
+
+# Subsea export pipeline — external sacrificial-anode CP per DNV-RP-F103 (2010).
+# Coated, on-seabed (non-buried) carbon-steel line with distributed bracelet anodes.
+inputs:
+  calculation_type: DNV_RP_F103_2010
+
+  design_data:
+    design_life: 30 # yr
+
+  environment: {}
+
+  pipeline:
+    outer_diameter_m: 0.3239        # 12.75-inch OD
+    wall_thickness_m: 0.0159        # 15.9 mm WT
+    length_m: 1500.0                # m, flowline section between in-line tees
+    burial_condition: non_buried    # exposed on seabed
+    internal_fluid_temperature_C: 60.0
+    coating_type: FBE               # fusion-bonded epoxy linepipe coating
+    resistivity_ohm_m: 0.2e-6       # CMn steel (DNV-RP-F103 Sec.5.6.10)
+
+  anode:
+    material: aluminium
+    utilization_factor: 0.80
+    individual_anode_mass_kg: 50.0  # half-shell bracelet anode
+    contingency_factor: 1.10
+    min_spacing_m: 5.0
+    max_spacing_m: 300.0
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+    cfg_sensitivities: false

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -45,6 +45,36 @@ def test_workflow_registry(workflow):
         assert cp["current_demand_A"]["totals"]["mean"] == pytest.approx(196.667146)
         assert cp["anode_requirements"]["total_mass_kg"] == pytest.approx(5067.071173)
         assert cp["anode_requirements"]["anode_count"] > 180
+    elif workflow["id"] == "cathodic-protection-jacket":
+        results = cfg["results"]
+        assert results["standard"] == "DNV-RP-B401-2021"
+        assert results["current_demand_A"]["total_mean_A"] == pytest.approx(101.85)
+        assert results["current_demand_A"]["total_final_A"] == pytest.approx(168.6)
+        assert results["anode_requirements"]["total_mass_kg"] == pytest.approx(13120.68)
+        assert results["anode_requirements"]["anode_count"] == 66
+        verification = results["current_output_verification"]
+        assert verification["driving_voltage_V"] == pytest.approx(0.25)
+        assert verification["recommended_anode_count"] == 109
+    elif workflow["id"] == "cathodic-protection-manifold":
+        results = cfg["results"]
+        assert results["standard"] == "DNV-RP-B401-2021"
+        assert results["current_demand_A"]["total_mean_A"] == pytest.approx(29.75)
+        assert results["anode_requirements"]["total_mass_kg"] == pytest.approx(3832.5)
+        assert results["anode_requirements"]["anode_count"] == 48
+        assert results["current_output_verification"]["adequate"] is True
+    elif workflow["id"] == "cathodic-protection-monopile":
+        results = cfg["results"]
+        assert results["standard"] == "DNV-RP-B401-2021"
+        assert results["current_demand_A"]["total_mean_A"] == pytest.approx(27.72)
+        assert results["anode_requirements"]["total_mass_kg"] == pytest.approx(4285.19)
+        assert results["anode_requirements"]["anode_count"] == 29
+        assert results["current_output_verification"]["recommended_anode_count"] == 32
+    elif workflow["id"] == "cathodic-protection-fpso":
+        results = cfg["results"]
+        assert results["current_demand_A"]["mean"] == pytest.approx(96.0)
+        assert results["current_demand_A"]["final"] == pytest.approx(248.0)
+        assert results["anode_current_capacity_Ah_kg"] == pytest.approx(1865.0)
+        assert results["anode_mass_kg"] == pytest.approx(14091.153)
     elif workflow["id"] == "catenary":
         assert cfg["S"] == pytest.approx(173.2050808)
         assert cfg["X"] == pytest.approx(131.6957897)


### PR DESCRIPTION
## Summary
Adds a **cathodic-protection (CP) demo set** spanning the structure types the Subsea/Integrity audience owns, for the Deckhand marketing-workflow set ([deckhand#403](https://github.com/vamseeachanta/deckhand/issues/403), epic [#389](https://github.com/vamseeachanta/deckhand/issues/389)). **No engine changes** — every example drives the existing CP engine through already-implemented `calculation_type` paths.

## Support matrix (engine supports exactly 4 CP paths today)
| Structure | calculation_type | Status |
|---|---|---|
| Fixed jacket | `DNV_RP_B401_offshore` (submerged/splash/atmospheric) | ✅ shipped |
| Subsea manifold | `DNV_RP_B401_offshore` (submerged-only) | ✅ shipped |
| Offshore-wind monopile | `DNV_RP_B401_offshore` (3 zones, 30-yr life) | ✅ shipped |
| FPSO hull | `ABS_gn_offshore_2018` | ✅ shipped |
| Ship hull | `ABS_gn_ships_2018` | already in registry (`cathodic-protection`) |
| **Subsea pipeline** | `DNV_RP_F103_2010` | ⚠️ **deferred** — see below |

## What's in this PR
- 4 new `examples/workflows/cathodic-protection-<structure>/input.yml` (self-contained, realistic, code-cited inline)
- 4 registry rows in `docs/registry/workflows.yaml` (`runtime: offline`)
- 4 guarded `test_workflow_registry` assertion blocks with **hand-verified** numbers

## Verification
- `uv run python -m digitalmodel examples/workflows/cathodic-protection-<s>/input.yml` — all 4 run clean
- `pytest …::test_workflow_registry[cathodic-protection-{jacket,manifold,monopile,fpso}]` — **5 passed** (incl. existing)
- Deckhand `capability-smoke.py --workflow digitalmodel:cathodic-protection-<s> --run` — **all 4 PASS** on the bot's own codepath
- Numbers spot-checked against the existing CP unit-test hand-calcs, e.g. jacket: submerged 5000 m² Cat I → I_mean = 5000·0.050·0.30 = **75.0 A**; total mean **101.85 A**; anode mass = 101.85·25·8760/(2000·0.85) = **13,120.68 kg**; driving voltage −0.80−(−1.05) = **0.25 V**. FPSO: I_cm = 8000·0.075·0.16 = **96.0 A**, capacity 2000−27·5 = **1865 Ah/kg**, mass **14,091.15 kg**.

## Deferred: subsea pipeline (DNV-RP-F103)
The pipeline example (`cathodic-protection-pipeline/`) is complete and the math runs, but is **intentionally unregistered** (README in-dir explains). The `DNV_RP_F103_2010` path is fail-closed on a `dnv-rp-f103` citation wiki page that is absent offline — it exists only as a test fixture, and the resolver's parent-walk finds no `wikis/` tree in this repo. Registering it needs that citation made resolvable in CI/compute (author the page in llm-wiki + wire `LLM_WIKI_PATH`, or vendor it like the fixture). Scoped as a prerequisite — **not faked**.

> Note: digitalmodel main CI baseline is independently red (engine + a native segfault); this PR adds only new files, registry rows, and additive test blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)