### PR TITLE
Rig Capability Assessment workflow (stages 1–4) (#821)

### DIFF
--- a/examples/workflows/rig-capability-assessment/README.md
+++ b/examples/workflows/rig-capability-assessment/README.md
@@ -1,0 +1,44 @@
+# Rig Capability Assessment (stages 1–4)
+
+Screen candidate onshore drilling rigs against a well/field program and rank the
+survivors on a weighted capability fit. Rule-based, deterministic, public-data —
+no network, no licensed solver, no downhole physics.
+
+Issue: digitalmodel#821. Full design + public data registry:
+`deckhand/docs/deckhand/workflows/rig-capability-assessment.md`.
+
+## Run
+
+```bash
+uv run python -m digitalmodel examples/workflows/rig-capability-assessment/input.yml
+```
+
+Writes `results/rig_capability_summary.json` with, per rig: qualified (pass/fail),
+the specific unmet hard-gates (fail reasons), the weighted fit score, and the
+per-dimension score breakdown — plus the derived required capability and the
+ranking.
+
+## What it does
+
+1. **Required capability** — derived from the `well_design` envelope (heaviest
+   string → hookload via a 1.25 design factor; mud pressure; pad mode; automation
+   / data interop), floored at the publicly-stated "super-spec" threshold (H&P
+   FY2025 10-K: AC, ≥1,500 HP, ≥750,000 lb hookload, 7,500 psi, walking). Override
+   with an explicit `required_capability:` block.
+2. **Rig ingest** — each candidate references a bundled public rig-CLASS default
+   (`hp_flexrig`, `precision_st1500`, `pten_apex`, `nabors_pace_x800`) and may add
+   per-rig `overrides:`.
+3. **Hard-gate screen** — pass/fail with explicit reasons. (The example's Nabors
+   PACE-X800 fails the default `walking` gate because it uses an X-Y skid — a
+   deliberate demonstration.)
+4. **Weighted fit scoring** — ranks survivors on capability margin, pad mobility,
+   automation/digital, power/emissions, and geothermal HT readiness.
+
+## Caveats
+
+- Rig-class defaults are **marketing-grade, not contractual** — binding capability
+  needs the per-rig IADC daily drilling report / spec sheet.
+- `ht_track_record` is a coarse 0–1 prior (no contractor publishes it) — override
+  with real EGS high-temperature evidence per engagement.
+- KPI baselining (ROP/cost/NPT/uptime) and any paid rig-level feed (Enverus,
+  S&P Petrodata) are **out of scope** here — future issues.

--- a/examples/workflows/rig-capability-assessment/input.yml
+++ b/examples/workflows/rig-capability-assessment/input.yml
@@ -1,0 +1,56 @@
+basename: rig_capability_assessment
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+rig_capability_assessment:
+  meta:
+    project: "Cape-style EGS field development"
+    client_context: geothermal
+    prepared_for: "Category Manager - Drilling Rigs"
+
+  # --- well / field program the rig must satisfy (stage 1 driver) ---
+  program:
+    wells_per_pad: 12
+    total_wells: 40
+    schedule_wells_per_year: 24
+    well_design:
+      target_tvd_ft: 8600          # cf. Utah FORGE 16A ~8,559 ft TVD
+      measured_depth_ft: 11000
+      lateral_length_ft: 5000
+      max_casing_od_in: 13.375
+      heaviest_string_lbf: 600000  # drives derived hookload gate (x1.25)
+      bottomhole_temp_F: 400
+      formation: crystalline_basement
+      mud_max_circulating_psi: 7500
+
+  # required_capability omitted -> auto-derived from well_design + super-spec floor.
+
+  scoring_weights:
+    capability_margin: 0.25
+    pad_mobility: 0.20
+    automation_digital: 0.20
+    power_emissions: 0.15
+    ht_readiness: 0.20
+
+  candidate_rigs:
+    - id: HP_FlexRig_Flex3
+      source: hp_flexrig
+    - id: PD_SuperTriple_ST1500
+      source: precision_st1500
+    - id: PTEN_APEX_XC
+      source: pten_apex
+    - id: NBR_PACE_X800            # X-Y skid -> fails the default 'walking' gate (demonstrative)
+      source: nabors_pace_x800
+    # example of a per-rig override on top of bundled class defaults:
+    - id: HP_FlexRig_Fervo_HTpack
+      source: hp_flexrig
+      overrides:
+        ht_track_record: 0.75      # demonstrated EGS high-temp run history
+
+  outputs:
+    directory: results
+    summary_json: rig_capability_summary.json

--- a/src/digitalmodel/base_configs/modules/rig_capability_assessment/rig_capability_assessment.yml
+++ b/src/digitalmodel/base_configs/modules/rig_capability_assessment/rig_capability_assessment.yml
@@ -1,0 +1,9 @@
+basename: rig_capability_assessment
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+rig_capability_assessment: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -438,6 +438,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         scour = ScourWorkflow()
         cfg_base = scour.router(cfg_base)
+    elif basename == "rig_capability_assessment":
+        from digitalmodel.field_development.rig_capability import (
+            router as rig_capability,
+        )
+
+        cfg_base = rig_capability(cfg_base)
     elif basename in ["capex_estimate", "opex_estimate", "concept_selection"]:
         from digitalmodel.field_development.registry_workflows import (
             FieldDevelopmentRegistryWorkflow,

--- a/src/digitalmodel/field_development/rig_capability.py
+++ b/src/digitalmodel/field_development/rig_capability.py
@@ -1,0 +1,365 @@
+# ABOUTME: Rig Capability Assessment workflow (stages 1-4) — onshore rig screen + scoring.
+# ABOUTME: Issue #821 — rule-based, public-data, no network/solver. See deckhand rig-capability-assessment.md.
+"""Onshore drilling-rig capability assessment for field development.
+
+Pure-python, deterministic, explainable. Given a well/field program and a set of
+candidate rigs (from a bundled public rig-CLASS defaults table or per-rig
+overrides), it:
+
+  1. derives the required rig capability from the well-design envelope,
+  2. ingests candidate rigs (defaults keyed by ``source`` + optional overrides),
+  3. applies hard-gate screening (pass/fail with explicit reasons),
+  4. scores & ranks survivors on a weighted capability fit.
+
+No network access, no licensed solver, no downhole physics. Rig-class defaults are
+**marketing-grade, not contractual** (see ``RIG_CLASS_DEFAULTS`` source notes);
+binding capability needs the per-rig IADC daily drilling report / spec sheet.
+
+The one publicly-stated numeric "super-spec" threshold (Helmerich & Payne FY2025
+10-K) is used as the default hard-gate set: AC drive, >=1,500 HP drawworks,
+>=750,000 lb hookload, 7,500 psi mud system, multi-well-pad (walking) capability.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# --- super-spec defaults (H&P FY2025 10-K numeric definition) ---------------
+SUPERSPEC_MIN_HOOKLOAD_LBF = 750_000.0
+SUPERSPEC_MIN_DRAWWORKS_HP = 1_500.0
+SUPERSPEC_MIN_MUD_PSI = 7_500.0
+
+# Hookload design factor applied to the heaviest planned string when an explicit
+# min hookload is not supplied (covers overpull / margin-of-overpull on stuck pipe).
+DEFAULT_HOOKLOAD_DESIGN_FACTOR = 1.25
+
+# Capability-margin headroom that scores 1.0 (e.g. 50% above the gate is "full marks").
+MARGIN_SATURATION = 0.50
+# Walk speed (ft/hr) that scores 1.0 on the pad-mobility dimension.
+WALK_SPEED_SATURATION_FT_HR = 100.0
+
+DEFAULT_SCORING_WEIGHTS = {
+    "capability_margin": 0.25,
+    "pad_mobility": 0.20,
+    "automation_digital": 0.20,
+    "power_emissions": 0.15,
+    "ht_readiness": 0.20,
+}
+
+
+# Public rig-CLASS defaults. Values are class/marketing-grade and attributed.
+# ht_track_record is a coarse 0-1 geothermal high-temperature readiness prior
+# (no contractor publishes this) — override per engagement with real evidence.
+RIG_CLASS_DEFAULTS: dict[str, dict[str, Any]] = {
+    "hp_flexrig": {
+        "model": "H&P FlexRig (Flex3/Flex5 class)",
+        "contractor": "Helmerich & Payne",
+        "hookload_lbf": 750_000.0,
+        "drawworks_hp": 1_500.0,
+        "mud_psi": 7_500.0,
+        "mud_pump_total_hp": 3_200.0,
+        "top_drive": True,
+        "drive_type": "AC",
+        "pad": "walking",
+        "walk_speed_ft_hr": 100.0,
+        "automation": True,
+        "data_interop": True,
+        "bi_fuel_or_highline": True,
+        "ht_track_record": 0.5,
+        "source": "hpinc.com/drilling-automation/flexrig-solutions; FY2025 10-K (CIK 0000046765). Marketing-grade.",
+    },
+    "precision_st1500": {
+        "model": "Precision Super Triple ST-1500",
+        "contractor": "Precision Drilling",
+        "hookload_lbf": 825_000.0,
+        "drawworks_hp": 1_500.0,
+        "mud_psi": 7_500.0,
+        "mud_pump_total_hp": 3_200.0,
+        "top_drive": True,
+        "drive_type": "AC",
+        "pad": "walking",
+        "walk_speed_ft_hr": 100.0,
+        "automation": True,
+        "data_interop": True,
+        "bi_fuel_or_highline": True,
+        "ht_track_record": 0.3,
+        "source": "iadc.org/.../2020_Super_Triple_1500HP.pdf (ST-1500 spec sheet). Marketing-grade.",
+    },
+    "pten_apex": {
+        "model": "Patterson-UTI APEX XC",
+        "contractor": "Patterson-UTI",
+        "hookload_lbf": 1_000_000.0,
+        "drawworks_hp": 1_500.0,
+        "mud_psi": 7_500.0,
+        "mud_pump_total_hp": 3_200.0,
+        "top_drive": True,
+        "drive_type": "AC",  # APEX XC class; AC/top-drive rating not separately disclosed by PTEN.
+        "pad": "walking",
+        "walk_speed_ft_hr": 100.0,
+        "automation": True,
+        "data_interop": True,
+        "bi_fuel_or_highline": True,
+        "ht_track_record": 0.2,
+        "source": "patenergy.com/services/apex-fleet; 10-K (CIK 0000889900). AC/TD rating not disclosed; assumed AC for XC.",
+    },
+    "nabors_pace_x800": {
+        "model": "Nabors PACE-X800",
+        "contractor": "Nabors",
+        "hookload_lbf": 750_000.0,
+        "drawworks_hp": 1_500.0,
+        "mud_psi": 7_500.0,
+        "mud_pump_total_hp": 3_000.0,
+        "top_drive": True,
+        "drive_type": "AC",
+        "pad": "skidding",  # PACE-X800 uses an X-Y skid system, not omnidirectional walking.
+        "walk_speed_ft_hr": 0.0,
+        "automation": True,
+        "data_interop": True,
+        "bi_fuel_or_highline": True,
+        "ht_track_record": 0.2,
+        "source": "nabors.com/.../pace-x/ (PACE-X800: X-Y skid, 2x1500 HP, 7,500 psi, SmartROS). Marketing-grade.",
+    },
+}
+
+
+# --- data model -------------------------------------------------------------
+@dataclass
+class RequiredCapability:
+    """Hard-gate thresholds a rig must meet to qualify."""
+
+    min_hookload_lbf: float
+    min_drawworks_hp: float
+    min_mud_psi: float
+    top_drive: bool = True
+    drive_type: str = "AC"  # "AC" requires AC; "any" disables the gate
+    pad_capability: str = "walking"  # "walking" | "skidding" | "any"
+    automation: bool = True
+    data_interop: bool = True  # require real-time data sharing (e.g. WITSML)
+
+
+@dataclass
+class RigAssessment:
+    """Per-rig screen + score result."""
+
+    rig_id: str
+    model: str
+    contractor: str
+    qualified: bool
+    fail_reasons: list[str] = field(default_factory=list)
+    fit_score: float = 0.0
+    dimension_scores: dict[str, float] = field(default_factory=dict)
+    source: str = ""
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "required", "y"}
+    return bool(value)
+
+
+def derive_required_capability(cfg: dict[str, Any]) -> RequiredCapability:
+    """Stage 1 — required capability from explicit overrides, else well design."""
+    explicit = cfg.get("required_capability") or {}
+    well = cfg.get("program", {}).get("well_design", {})
+
+    heaviest = float(well.get("heaviest_string_lbf", 0.0) or 0.0)
+    derived_hookload = heaviest * DEFAULT_HOOKLOAD_DESIGN_FACTOR
+    min_hookload = float(
+        explicit.get("min_hookload_lbf")
+        or max(derived_hookload, SUPERSPEC_MIN_HOOKLOAD_LBF)
+    )
+
+    min_mud = float(
+        explicit.get("min_mud_psi")
+        or well.get("mud_max_circulating_psi")
+        or SUPERSPEC_MIN_MUD_PSI
+    )
+    min_hp = float(explicit.get("min_drawworks_hp") or SUPERSPEC_MIN_DRAWWORKS_HP)
+
+    return RequiredCapability(
+        min_hookload_lbf=min_hookload,
+        min_drawworks_hp=min_hp,
+        min_mud_psi=min_mud,
+        top_drive=_as_bool(explicit.get("top_drive", True)),
+        drive_type=str(explicit.get("drive_type", "AC")),
+        pad_capability=str(explicit.get("pad_capability", "walking")),
+        automation=_as_bool(explicit.get("automation", True)),
+        data_interop=_as_bool(explicit.get("data_interop", True)),
+    )
+
+
+def resolve_rig(spec: dict[str, Any]) -> dict[str, Any]:
+    """Stage 2 — merge a candidate's bundled class defaults with per-rig overrides."""
+    source_key = spec.get("source")
+    base: dict[str, Any] = {}
+    if source_key and source_key in RIG_CLASS_DEFAULTS:
+        base = dict(RIG_CLASS_DEFAULTS[source_key])
+    overrides = spec.get("overrides") or {}
+    merged = {**base, **overrides}
+    merged["rig_id"] = spec.get("id", merged.get("model", "rig"))
+    merged.setdefault("contractor", spec.get("contractor", "unknown"))
+    merged.setdefault("model", merged["rig_id"])
+    return merged
+
+
+def screen_rig(rig: dict[str, Any], req: RequiredCapability) -> list[str]:
+    """Stage 3 — hard-gate screen; returns the list of unmet gates (empty = pass)."""
+    fails: list[str] = []
+    if float(rig.get("hookload_lbf", 0)) < req.min_hookload_lbf:
+        fails.append(
+            f"hookload {rig.get('hookload_lbf', 0):,.0f} < required {req.min_hookload_lbf:,.0f} lbf"
+        )
+    if float(rig.get("drawworks_hp", 0)) < req.min_drawworks_hp:
+        fails.append(
+            f"drawworks {rig.get('drawworks_hp', 0):,.0f} < required {req.min_drawworks_hp:,.0f} HP"
+        )
+    if float(rig.get("mud_psi", 0)) < req.min_mud_psi:
+        fails.append(
+            f"mud system {rig.get('mud_psi', 0):,.0f} < required {req.min_mud_psi:,.0f} psi"
+        )
+    if req.top_drive and not _as_bool(rig.get("top_drive", False)):
+        fails.append("no top drive")
+    if req.drive_type.upper() == "AC" and str(rig.get("drive_type", "")).upper() != "AC":
+        fails.append(f"drive type {rig.get('drive_type', '?')} != AC")
+    if req.pad_capability != "any" and rig.get("pad") != req.pad_capability:
+        fails.append(f"pad capability {rig.get('pad', '?')} != {req.pad_capability}")
+    if req.automation and not _as_bool(rig.get("automation", False)):
+        fails.append("no drilling automation")
+    if req.data_interop and not _as_bool(rig.get("data_interop", False)):
+        fails.append("no real-time data interoperability")
+    return fails
+
+
+def _margin_score(value: float, gate: float) -> float:
+    if gate <= 0:
+        return 1.0
+    headroom = (value - gate) / gate
+    return max(0.0, min(1.0, headroom / MARGIN_SATURATION))
+
+
+def score_rig(
+    rig: dict[str, Any], req: RequiredCapability, weights: dict[str, float]
+) -> tuple[float, dict[str, float]]:
+    """Stage 4 — weighted fit score for a qualifying rig."""
+    capability_margin = (
+        _margin_score(float(rig.get("hookload_lbf", 0)), req.min_hookload_lbf)
+        + _margin_score(float(rig.get("drawworks_hp", 0)), req.min_drawworks_hp)
+        + _margin_score(float(rig.get("mud_psi", 0)), req.min_mud_psi)
+    ) / 3.0
+
+    pad_mobility = min(
+        1.0, float(rig.get("walk_speed_ft_hr", 0)) / WALK_SPEED_SATURATION_FT_HR
+    )
+
+    automation_digital = 0.5 * _as_bool(rig.get("automation", False)) + 0.5 * _as_bool(
+        rig.get("data_interop", False)
+    )
+
+    power_emissions = 0.6 * (str(rig.get("drive_type", "")).upper() == "AC") + 0.4 * _as_bool(
+        rig.get("bi_fuel_or_highline", False)
+    )
+
+    ht_readiness = max(0.0, min(1.0, float(rig.get("ht_track_record", 0.0))))
+
+    dims = {
+        "capability_margin": round(capability_margin, 4),
+        "pad_mobility": round(pad_mobility, 4),
+        "automation_digital": round(automation_digital, 4),
+        "power_emissions": round(power_emissions, 4),
+        "ht_readiness": round(ht_readiness, 4),
+    }
+    total_w = sum(weights.values()) or 1.0
+    fit = sum(weights.get(k, 0.0) * v for k, v in dims.items()) / total_w
+    return round(fit, 4), dims
+
+
+def assess(cfg_params: dict[str, Any]) -> dict[str, Any]:
+    """Run stages 1-4 and return a JSON-able summary."""
+    req = derive_required_capability(cfg_params)
+    weights = {**DEFAULT_SCORING_WEIGHTS, **(cfg_params.get("scoring_weights") or {})}
+
+    candidates = cfg_params.get("candidate_rigs") or []
+    results: list[RigAssessment] = []
+    for spec in candidates:
+        rig = resolve_rig(spec)
+        fails = screen_rig(rig, req)
+        qualified = not fails
+        fit, dims = (0.0, {})
+        if qualified:
+            fit, dims = score_rig(rig, req, weights)
+        results.append(
+            RigAssessment(
+                rig_id=rig["rig_id"],
+                model=rig.get("model", rig["rig_id"]),
+                contractor=rig.get("contractor", "unknown"),
+                qualified=qualified,
+                fail_reasons=fails,
+                fit_score=fit,
+                dimension_scores=dims,
+                source=rig.get("source", ""),
+            )
+        )
+
+    # rank qualified by fit (desc), then disqualified
+    ranked = sorted(
+        results, key=lambda r: (r.qualified, r.fit_score), reverse=True
+    )
+    for rank, r in enumerate((x for x in ranked if x.qualified), start=1):
+        r.dimension_scores = {"_rank": rank, **r.dimension_scores}
+
+    return {
+        "calculation": "rig_capability_assessment",
+        "required_capability": {
+            "min_hookload_lbf": req.min_hookload_lbf,
+            "min_drawworks_hp": req.min_drawworks_hp,
+            "min_mud_psi": req.min_mud_psi,
+            "top_drive": req.top_drive,
+            "drive_type": req.drive_type,
+            "pad_capability": req.pad_capability,
+            "automation": req.automation,
+            "data_interop": req.data_interop,
+        },
+        "scoring_weights": weights,
+        "n_candidates": len(results),
+        "n_qualified": sum(1 for r in results if r.qualified),
+        "ranked_rigs": [
+            {
+                "rig_id": r.rig_id,
+                "model": r.model,
+                "contractor": r.contractor,
+                "qualified": r.qualified,
+                "fit_score": r.fit_score,
+                "fail_reasons": r.fail_reasons,
+                "dimension_scores": r.dimension_scores,
+                "source": r.source,
+            }
+            for r in ranked
+        ],
+        "caveat": (
+            "Rig-class defaults are marketing-grade, not contractual. Stages 1-4 only "
+            "(screen + score); KPI baselining and paid rig-level feeds are out of scope."
+        ),
+    }
+
+
+def router(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Engine entry point for basename == 'rig_capability_assessment'."""
+    params = cfg.get("rig_capability_assessment", {})
+    summary = assess(params)
+
+    output_cfg = params.get("outputs", {})
+    directory = Path(output_cfg.get("directory", "results"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get("summary_json", "rig_capability_summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    summary["summary_json"] = str(summary_path)
+    cfg["rig_capability_assessment"] = {**params, **summary}
+    return cfg

--- a/tests/field_development/test_rig_capability.py
+++ b/tests/field_development/test_rig_capability.py
@@ -1,0 +1,147 @@
+# ABOUTME: Tests for rig_capability — onshore rig capability assessment (stages 1-4).
+# ABOUTME: Issue #821 — hard-gate screen, weighted scoring, defaults-vs-override resolution.
+"""Tests for digitalmodel.field_development.rig_capability."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.field_development.rig_capability import (
+    RIG_CLASS_DEFAULTS,
+    SUPERSPEC_MIN_HOOKLOAD_LBF,
+    assess,
+    derive_required_capability,
+    resolve_rig,
+    score_rig,
+    screen_rig,
+)
+
+
+# --- stage 1: required capability -------------------------------------------
+class TestDeriveRequiredCapability:
+    def test_floors_at_superspec_when_well_light(self):
+        cfg = {"program": {"well_design": {"heaviest_string_lbf": 100_000}}}
+        req = derive_required_capability(cfg)
+        assert req.min_hookload_lbf == SUPERSPEC_MIN_HOOKLOAD_LBF
+
+    def test_heavy_string_drives_hookload_above_floor(self):
+        cfg = {"program": {"well_design": {"heaviest_string_lbf": 800_000}}}
+        req = derive_required_capability(cfg)
+        assert req.min_hookload_lbf == pytest.approx(800_000 * 1.25)
+
+    def test_explicit_required_capability_wins(self):
+        cfg = {
+            "program": {"well_design": {"heaviest_string_lbf": 800_000}},
+            "required_capability": {"min_hookload_lbf": 600_000, "pad_capability": "any"},
+        }
+        req = derive_required_capability(cfg)
+        assert req.min_hookload_lbf == 600_000
+        assert req.pad_capability == "any"
+
+
+# --- stage 2: defaults + overrides ------------------------------------------
+class TestResolveRig:
+    def test_pulls_class_defaults(self):
+        rig = resolve_rig({"id": "r1", "source": "hp_flexrig"})
+        assert rig["contractor"] == "Helmerich & Payne"
+        assert rig["pad"] == "walking"
+
+    def test_overrides_merge_over_defaults(self):
+        rig = resolve_rig(
+            {"id": "r1", "source": "hp_flexrig", "overrides": {"ht_track_record": 0.9}}
+        )
+        assert rig["ht_track_record"] == 0.9
+        assert rig["drive_type"] == "AC"  # untouched default
+
+    def test_unknown_source_yields_minimal_rig(self):
+        rig = resolve_rig({"id": "mystery"})
+        assert rig["rig_id"] == "mystery"
+
+
+# --- stage 3: hard-gate screen ----------------------------------------------
+class TestScreenRig:
+    def test_superspec_rig_passes(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        assert screen_rig(RIG_CLASS_DEFAULTS["hp_flexrig"], req) == []
+
+    def test_skid_rig_fails_walking_gate(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        fails = screen_rig(RIG_CLASS_DEFAULTS["nabors_pace_x800"], req)
+        assert any("pad capability" in f for f in fails)
+
+    def test_low_hookload_fails(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        rig = {**RIG_CLASS_DEFAULTS["hp_flexrig"], "hookload_lbf": 500_000}
+        fails = screen_rig(rig, req)
+        assert any("hookload" in f for f in fails)
+
+    def test_dc_drive_fails_ac_gate(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        rig = {**RIG_CLASS_DEFAULTS["hp_flexrig"], "drive_type": "DC"}
+        assert any("drive type" in f for f in screen_rig(rig, req))
+
+
+# --- stage 4: scoring -------------------------------------------------------
+class TestScoreRig:
+    def test_higher_hookload_scores_higher_margin(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        weights = {"capability_margin": 1.0}
+        low, _ = score_rig({**RIG_CLASS_DEFAULTS["hp_flexrig"]}, req, weights)
+        high, _ = score_rig(
+            {**RIG_CLASS_DEFAULTS["hp_flexrig"], "hookload_lbf": 1_125_000}, req, weights
+        )
+        assert high > low
+
+    def test_score_bounded_unit_interval(self):
+        req = derive_required_capability({"program": {"well_design": {}}})
+        fit, dims = score_rig(RIG_CLASS_DEFAULTS["precision_st1500"], req, None or {"capability_margin": 1.0})
+        assert 0.0 <= fit <= 1.0
+        assert all(0.0 <= v <= 1.0 for v in dims.values())
+
+
+# --- end-to-end assess() ----------------------------------------------------
+class TestAssess:
+    def _cfg(self):
+        return {
+            "program": {"well_design": {"heaviest_string_lbf": 600_000, "mud_max_circulating_psi": 7500}},
+            "candidate_rigs": [
+                {"id": "HP", "source": "hp_flexrig"},
+                {"id": "PD", "source": "precision_st1500"},
+                {"id": "NBR", "source": "nabors_pace_x800"},
+            ],
+        }
+
+    def test_counts_and_disqualification(self):
+        out = assess(self._cfg())
+        assert out["n_candidates"] == 3
+        assert out["n_qualified"] == 2  # Nabors skid disqualified
+        nbr = next(r for r in out["ranked_rigs"] if r["rig_id"] == "NBR")
+        assert not nbr["qualified"]
+        assert nbr["fail_reasons"]
+
+    def test_qualified_rigs_ranked_first_and_numbered(self):
+        out = assess(self._cfg())
+        qualified = [r for r in out["ranked_rigs"] if r["qualified"]]
+        # qualified come before disqualified
+        assert out["ranked_rigs"][0]["qualified"]
+        assert out["ranked_rigs"][-1]["rig_id"] == "NBR"
+        # ranks assigned 1..n
+        ranks = [r["dimension_scores"]["_rank"] for r in qualified]
+        assert ranks == list(range(1, len(qualified) + 1))
+
+    def test_precision_outranks_flexrig_on_capability_margin_only(self):
+        # ST-1500 has higher hookload (825k vs 750k) -> higher capability margin,
+        # so it wins when scoring on capability margin alone.
+        cfg = {
+            **self._cfg(),
+            "scoring_weights": {
+                "capability_margin": 1.0,
+                "pad_mobility": 0.0,
+                "automation_digital": 0.0,
+                "power_emissions": 0.0,
+                "ht_readiness": 0.0,
+            },
+        }
+        out = assess(cfg)
+        order = [r["rig_id"] for r in out["ranked_rigs"] if r["qualified"]]
+        assert order.index("PD") < order.index("HP")


### PR DESCRIPTION
Closes #821.

Scaffolds the runnable, rule-based core of the **Rig Capability Assessment** workflow — screen candidate onshore drilling rigs against a well/field program and rank survivors on a weighted capability fit. Driven by a real prospect need (Fervo Energy, "Category Manager – Drilling Rigs").

## Run
```bash
uv run python -m digitalmodel examples/workflows/rig-capability-assessment/input.yml
```
Routes on `basename: rig_capability_assessment` → `field_development.rig_capability.router`. Writes `results/rig_capability_summary.json`.

## What it does (stages 1–4)
1. **Required capability** derived from the `well_design` envelope (heaviest string → hookload ×1.25), floored at the one publicly-stated numeric "super-spec" threshold (H&P FY2025 10-K: AC, ≥1,500 HP, ≥750k lb hookload, 7,500 psi, walking). Overridable.
2. **Rig ingest** from bundled public rig-CLASS defaults (H&P FlexRig, Precision ST-1500, Patterson APEX, Nabors PACE-X800) + per-rig `overrides`.
3. **Hard-gate screen** — pass/fail with explicit unmet-gate reasons.
4. **Weighted fit scoring** — capability margin / pad mobility / automation-digital / power-emissions / HT readiness. Deterministic; every score traces to a parameter + cited source.

## Example output (verified)
5 candidates → 4 qualified. The HT-override FlexRig tops the ranking; **Nabors PACE-X800 is correctly disqualified** (`pad capability skidding != walking`).

## Tests
`tests/field_development/test_rig_capability.py` — 15 tests (gate logic, scoring monotonicity, defaults-vs-override resolution, end-to-end ranking). **Pass:** `uv run python -m pytest tests/field_development/test_rig_capability.py --import-mode=importlib --noconftest` → 15 passed.

> Note: normal `pytest` collection hits the pre-existing red baseline (root `conftest.py` imports matplotlib → NumPy 1.x/2.x ABI error) — the existing `test_capex_estimator.py` fails identically. Not introduced here.

## Honest scope / non-goals
- Rig-class defaults are **marketing-grade, not contractual**.
- KPI baselining (ROP/cost/NPT/uptime) and **paid** rig-level feeds (Enverus/RigData, S&P Petrodata) are out of scope — flagged, not faked.
- No geothermal downhole physics — consumes public benchmarks only.

Design + public data registry: `deckhand/docs/deckhand/workflows/rig-capability-assessment.md` and `rig-public-data-sources.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)