### PR TITLE
feat(parametric): staleness fingerprinting for licensed libraries (#831)

### DIFF
--- a/docs/plans/parametric-refresh/licensed-libraries.md
+++ b/docs/plans/parametric-refresh/licensed-libraries.md
@@ -60,9 +60,20 @@ Extending the map = adding a case (one licensed run) here. OrcaFlex follows the
 same model (canonical sea-state × heading cases for a reference model) once the
 diffraction library is proven.
 
-## Not wired into `refresh`
+## Staleness (#831)
 
-Library atlases are not in the `refresh` content-fingerprint iteration: they are
-not code-computable, so `refresh --apply` cannot regenerate them. They refresh
-when the operator re-runs the solver. (A follow-up could fingerprint a library
-against its solver version + case set so a stale library is detectable.)
+Library atlases are not code-computable, so `refresh --apply` never regenerates
+them. Instead their staleness is judged against an operator-declared
+expectation in `refresh.LIBRARY_EXPECTATIONS` (solver name + version + covered
+case set):
+
+- `refresh --check` **reports** each library (`[ok]` / `[STALE]`) and exits 1 if
+  any library is stale, but never auto-builds it ("licensed run required").
+- A query against a stale library **escalates** (the staleness gate in
+  `query._staleness`), exactly like a stale computed atlas.
+
+The shipped library is a STUB; its expectation also says `version: STUB`, so it
+reads current. When the operator runs real diffraction and bumps the expected
+`solver_version`, the stub library immediately reads **stale** → queries
+escalate → which prompts populating the real library. Extending coverage = add
+the case to both the builder and the expectation.

--- a/src/digitalmodel/parametric/query.py
+++ b/src/digitalmodel/parametric/query.py
@@ -67,11 +67,23 @@ def _staleness(atlas: Atlas) -> str | None:
     """Return a reason string if the atlas is stale (its build basis has moved
     since it was generated), else None. Detectable per the refresh contract
     (#799): a stale atlas must escalate, not serve a superseded answer."""
+    from digitalmodel.parametric import refresh
+
+    # licensed-solver libraries (#831): staleness judged vs the declared
+    # operator expectation, not a recompute.
+    if atlas.provenance.get("kind") == "library":
+        try:
+            reasons = refresh.library_drift(atlas)  # checks THIS atlas, no re-load
+        except Exception:
+            return None
+        if reasons:
+            return f"library stale: {'; '.join(reasons)} — licensed run required"
+        return None
+
     workflow_id = atlas.provenance.get("workflow_id")
     stored = atlas.provenance.get("content_fingerprint")
     if not workflow_id or not stored:
         return None  # atlas predates fingerprinting; nothing to check against
-    from digitalmodel.parametric import refresh
 
     try:
         current = refresh.content_fingerprint(workflow_id)

--- a/src/digitalmodel/parametric/refresh.py
+++ b/src/digitalmodel/parametric/refresh.py
@@ -86,6 +86,20 @@ SOURCE_FILES: dict[str, list[str]] = {
     ],
 }
 
+# Expected state of each licensed-solver library (#801/#831). A library is NOT
+# code-computable, so its staleness is judged against what the operator declares
+# as current here — not a re-run. Stale = the committed library's recorded
+# solver name/version or covered case set no longer matches this expectation
+# (e.g. bump `version` once real OrcaWave runs replace the stub, and the stub
+# library immediately reads stale -> escalate -> prompts a real run).
+LIBRARY_EXPECTATIONS: dict[str, dict[str, Any]] = {
+    "diffraction_library": {
+        "solver_name": "OrcaWave/AQWA",
+        "solver_version": "STUB",
+        "cases": ["fpso-design-draft", "fpso-ballast-draft", "semisub-operating"],
+    },
+}
+
 
 def _registry_rows() -> list[dict[str, Any]]:
     return yaml.safe_load(REGISTRY.read_text())["workflows"]
@@ -160,6 +174,49 @@ def refresh_status(
     }
 
 
+def library_drift(atlas: Any) -> list[str]:
+    """Reasons the given library atlas no longer matches its declared
+    expectation (solver name/version, covered case set), or [] if current."""
+    expected = LIBRARY_EXPECTATIONS.get(atlas.basename)
+    if expected is None:
+        return []
+    solver = atlas.provenance.get("solver", {})
+    cases = (atlas.provenance.get("coverage", {}) or {}).get("covered_cases", [])
+    reasons = []
+    if solver.get("name") != expected["solver_name"]:
+        reasons.append(f"solver name {solver.get('name')!r} != {expected['solver_name']!r}")
+    if solver.get("version") != expected["solver_version"]:
+        reasons.append(
+            f"solver version {solver.get('version')!r} != {expected['solver_version']!r}")
+    if set(cases) != set(expected["cases"]):
+        reasons.append(f"covered cases {sorted(cases)} != {sorted(expected['cases'])}")
+    return reasons
+
+
+def library_status(
+    basename: str, atlas_root: Path = DEFAULT_ATLAS_ROOT
+) -> dict[str, Any]:
+    """Staleness of a licensed-solver library vs LIBRARY_EXPECTATIONS. Not
+    code-recomputable, so a stale library is reported for an operator run, never
+    auto-regenerated."""
+    from digitalmodel.parametric.atlas import Atlas
+
+    try:
+        atlas = Atlas.load(atlas_root, basename)
+    except FileNotFoundError:
+        return {"basename": basename, "kind": "library", "stale": True,
+                "reason": "no library built"}
+    reasons = library_drift(atlas)
+    stub = atlas.provenance.get("solver", {}).get("licensed") is False
+    return {
+        "basename": basename,
+        "kind": "library",
+        "stale": bool(reasons),
+        "reason": "; ".join(reasons) if reasons else ("current (STUB)" if stub else "current"),
+        "atlas_id": atlas.atlas_id,
+    }
+
+
 def _git_sha(repo_root: Path) -> str:
     try:
         return subprocess.check_output(
@@ -180,11 +237,26 @@ def main(argv: list[str]) -> int:
         if status["stale"]:
             stale_ids.append(wid)
 
-    if not stale_ids:
+    # licensed-solver libraries: report-only (operator runs them; never auto-build)
+    stale_libs = []
+    for basename in LIBRARY_EXPECTATIONS:
+        status = library_status(basename)
+        flag = "STALE" if status["stale"] else "ok"
+        print(f"[{flag:5}] {basename} (library)  ({status['reason']})")
+        if status["stale"]:
+            stale_libs.append(basename)
+
+    if not stale_ids and not stale_libs:
         print("all atlases current")
         return 0
+
+    if stale_libs:
+        print(f"\n{len(stale_libs)} stale library(ies) — need a licensed run "
+              f"(operator); not auto-regenerated: {stale_libs}")
+    if not stale_ids:
+        return 1  # only libraries stale: report, nothing to auto-build
     if not apply:
-        print(f"\n{len(stale_ids)} stale atlas(es); run with --apply to regenerate")
+        print(f"\n{len(stale_ids)} stale computed atlas(es); run with --apply to regenerate")
         return 1
 
     from digitalmodel.parametric.build import build_atlas_from_registry
@@ -194,7 +266,7 @@ def main(argv: list[str]) -> int:
         atlas = build_atlas_from_registry(wid)
         if not atlas.validation["passes"]:
             print(f"  WARNING: {wid} regenerated but failed validation gate")
-    return 0
+    return 1 if stale_libs else 0
 
 
 if __name__ == "__main__":

--- a/tests/parametric/test_library.py
+++ b/tests/parametric/test_library.py
@@ -81,3 +81,39 @@ def test_out_of_solved_range_escalates():
                           "frequency_rad_s": 3.0, "heading_deg": 90.0})
     assert pred.in_range is False
     assert "outside" in pred.reason
+
+
+# -- staleness (#831) --------------------------------------------------------
+
+def test_committed_library_matches_its_expectation():
+    from digitalmodel.parametric import refresh
+
+    status = refresh.library_status("diffraction_library")
+    assert status["stale"] is False
+
+
+def test_advancing_the_expectation_makes_a_query_escalate(monkeypatch):
+    from digitalmodel.parametric import refresh
+    from digitalmodel.parametric.atlas import Atlas
+    from digitalmodel.parametric.query import _staleness
+
+    atlas = Atlas.load(refresh.DEFAULT_ATLAS_ROOT, "diffraction_library")
+    assert _staleness(atlas) is None  # stub matches the (stub) expectation
+
+    # operator now requires a real OrcaWave run instead of the stub
+    monkeypatch.setitem(
+        refresh.LIBRARY_EXPECTATIONS, "diffraction_library",
+        {**refresh.LIBRARY_EXPECTATIONS["diffraction_library"], "solver_version": "11.0"})
+
+    reason = _staleness(atlas)
+    assert reason is not None and "library stale" in reason
+
+
+def test_missing_case_is_drift():
+    from digitalmodel.parametric import refresh
+    from digitalmodel.parametric.atlas import Atlas
+
+    atlas = Atlas.load(refresh.DEFAULT_ATLAS_ROOT, "diffraction_library")
+    atlas.provenance["coverage"]["covered_cases"] = ["fpso-design-draft"]  # dropped 2
+    reasons = refresh.library_drift(atlas)
+    assert any("covered cases" in r for r in reasons)


### PR DESCRIPTION
## Parent

Closes #831 · Epic #794 · follow-up to #801.

## Problem

Computed atlases are staleness-gated (a basis change → escalate). Library atlases (#801) were intentionally outside that mechanism because they aren't code-computable — but that left a real gap: a library built against a superseded solver version or an old case set was **undetectable**, so a stale licensed result could be served silently.

## What this adds

Staleness for libraries judged against an **operator-declared expectation** (not a recompute):

- **`refresh.LIBRARY_EXPECTATIONS`** — expected solver name + version + covered case set per library.
- **`library_drift(atlas)` / `library_status()`** — compare a library's recorded solver/coverage against its expectation.
- **`refresh --check`** now reports libraries (`[ok]`/`[STALE]`), **exits 1 on drift**, and never auto-regenerates them (a licensed run is the operator step).
- **`query._staleness`** escalates a stale library — checking the queried atlas directly (no re-load, so it's correct under a custom `atlas_root`), same contract as a stale computed atlas.

## The intended lifecycle

The shipped STUB reads **current** (its expectation also says `version: STUB`). When the operator runs real diffraction and bumps the expected `solver_version`, the stub library immediately reads **stale → queries escalate**, which is exactly what should prompt populating the real library. Extending coverage = add the case to both the builder and the expectation.

## Verification

- **14 library/refresh tests pass**, incl. "advancing the expectation makes a query escalate" and "missing case is drift".
- `refresh --check` green: 10 computed atlases + 1 library (`current (STUB)`), exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)