### PR TITLE
feat(parametric): atlas catalog / coverage report (#835)

### DIFF
--- a/src/digitalmodel/parametric/catalog.py
+++ b/src/digitalmodel/parametric/catalog.py
@@ -1,0 +1,80 @@
+"""Atlas catalog (#835, epic #794).
+
+Summarize every committed atlas from its manifest: response, physics class,
+axes + ranges, grid size, held-out error, provenance, and (for libraries)
+coverage + stub/real. Gives an operator a single view of what's answerable
+instantly, how accurate, against which standard, and what's still a stub.
+
+    uv run python -m digitalmodel.parametric.catalog
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.parametric.atlas import Atlas
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_ATLAS_ROOT = REPO_ROOT / "atlases"
+
+
+def _axis_summary(ax: Any) -> str:
+    if ax.is_categorical:
+        return f"{ax.name}{{{len(ax.values)}}}"
+    tag = "*" if getattr(ax, "derived", None) else ""  # derived axis marker
+    return f"{ax.name}{tag}[{min(ax.grid):g}–{max(ax.grid):g}]"
+
+
+def _summarize(atlas: Atlas) -> dict[str, Any]:
+    prov = atlas.provenance
+    kind = prov.get("kind", "computed")
+    if kind == "library":
+        solver = prov.get("solver", {})
+        err = "library"
+        provenance = f"{solver.get('name', '?')} {solver.get('version', '?')}"
+        if solver.get("licensed") is False:
+            provenance += " (STUB)"
+    else:
+        max_err = atlas.validation.get("max_rel_error")
+        err = f"{max_err:.3f}" if max_err is not None else "n/a"
+        standards = ",".join(s.get("id", "") for s in prov.get("standards", [])) or "—"
+        provenance = f"{prov.get('code_version', '?')} · {standards}"
+    return {
+        "atlas": atlas.basename,
+        "kind": kind,
+        "response": atlas.response,
+        "physics": atlas.physics,
+        "axes": ", ".join(_axis_summary(a) for a in atlas.axes),
+        "cells": len(atlas.grid),
+        "max_err": err,
+        "provenance": provenance,
+    }
+
+
+def build_catalog(atlas_root: Path = DEFAULT_ATLAS_ROOT) -> list[dict[str, Any]]:
+    rows = []
+    for default in sorted(Path(atlas_root).glob("*/default.txt")):
+        basename = default.parent.name
+        rows.append(_summarize(Atlas.load(atlas_root, basename)))
+    return rows
+
+
+def render_markdown(rows: list[dict[str, Any]]) -> str:
+    head = ("| Atlas | Kind | Response | Physics | Axes (ranges; * = derived) | "
+            "Cells | Held-out err | Provenance |\n"
+            "|---|---|---|---|---|---|---|---|\n")
+    body = "".join(
+        f"| {r['atlas']} | {r['kind']} | {r['response']} | {r['physics']} | "
+        f"{r['axes']} | {r['cells']} | {r['max_err']} | {r['provenance']} |\n"
+        for r in rows
+    )
+    return (f"# Parametric atlas catalog\n\n{len(rows)} atlases.\n\n{head}{body}")
+
+
+def main() -> None:
+    print(render_markdown(build_catalog()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parametric/test_catalog.py
+++ b/tests/parametric/test_catalog.py
@@ -1,0 +1,40 @@
+"""Atlas catalog (#835)."""
+
+from __future__ import annotations
+
+from digitalmodel.parametric.catalog import build_catalog, render_markdown
+
+
+def test_catalog_lists_every_committed_atlas():
+    rows = build_catalog()
+    names = {r["atlas"] for r in rows}
+    # the computed fan-out + the licensed library
+    assert {"mooring_fatigue", "code_check", "rao_tabulation",
+            "diffraction_library"} <= names
+    assert len(rows) >= 11
+    for r in rows:
+        assert r["cells"] > 0
+        assert r["response"]
+
+
+def test_library_is_flagged_distinctly():
+    by_name = {r["atlas"]: r for r in build_catalog()}
+    lib = by_name["diffraction_library"]
+    assert lib["kind"] == "library"
+    assert lib["max_err"] == "library"
+    assert "STUB" in lib["provenance"]
+
+
+def test_computed_atlas_shows_error_and_standard():
+    by_name = {r["atlas"]: r for r in build_catalog()}
+    mooring = by_name["mooring_fatigue"]
+    assert mooring["kind"] == "computed"
+    float(mooring["max_err"])  # parses as a number
+    assert "DNV-RP-C203" in mooring["provenance"]
+
+
+def test_render_markdown_table():
+    md = render_markdown(build_catalog())
+    assert md.startswith("# Parametric atlas catalog")
+    assert "| Atlas |" in md
+    assert "mooring_fatigue" in md


### PR DESCRIPTION
## Parent
Closes #835 · Epic #794.

## What this adds
`parametric/catalog.py` — a one-command summary of every committed atlas, read from its manifest:

`python -m digitalmodel.parametric.catalog` →

| Atlas | Kind | Response | Physics | Axes (ranges; * = derived) | Cells | Held-out err | Provenance |
|---|---|---|---|---|---|---|---|
| code_check | computed | utilisation | utilization_threshold | …, smys{3} | 2700 | 0.061 | bb8ce47f · API-RP-2RD |
| diffraction_library | library | heave_rao_m_per_m | linear | case{3}, frequency_rad_s[0.2–1.2], … | 120 | library | OrcaWave/AQWA STUB (STUB) |
| mooring_fatigue | computed | damage | log_log | … | 4680 | 0.045 | bb8ce47f · DNV-RP-C203 |
| … | | | | | | | |

Gives an operator a single view of **what's answerable instantly, how accurate, against which standard, and what's still a STUB** vs a real licensed run. Derived axes (#830) are marked with `*`; libraries show solver + STUB flag and `held-out err = library`.

## Verification
4 tests: lists all 11 committed atlases, flags the library distinctly, parses computed-atlas error + standard, renders the markdown table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)