### PR TITLE
vessel_db: unified confidence tiers + capability scoring (#857)

### DIFF
--- a/examples/demos/installation/vessel_capability_score.py
+++ b/examples/demos/installation/vessel_capability_score.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# ABOUTME: Confidence-weighted vessel capability/suitability score for a lift.
+# ABOUTME: Wires vessel_db crane curves + confidence tiers -> capability_score (#591/#592/#857).
+"""
+Vessel capability score (confidence-weighted) for a crane lift
+==============================================================
+
+Ranks the installation fleet for a lift by **capability margin weighted by data
+confidence**, and flags whether each ranking is *defensible* (backed by at least
+estimated-grade data on every scored field). Unlike a raw go/no-go, this surfaces
+WHERE the data is weak — the gap #593 identified for client-facing GTM claims.
+
+Crane SWL comes from the merged vessel DB (worldenergydata source of truth +
+curated). Confidence is derived from the data source: worldenergydata records
+(real IMO + published reach) -> cited; curated brochure records -> brochure.
+
+Usage:
+    cd digitalmodel
+    uv run python examples/demos/installation/vessel_capability_score.py --lift-te 3000 --radius-m 35
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from digitalmodel.marine_ops.vessel_db.confidence import (
+    ConfidenceTier,
+    capability_score,
+)
+from digitalmodel.marine_ops.vessel_db.loader import installation_vessels
+
+_SOURCE_TIER = {
+    "worldenergydata": ConfidenceTier.CITED,   # real IMO + published reach
+    "curated": ConfidenceTier.BROCHURE,        # operator brochure / web research
+}
+
+
+def score_fleet(lift_te: float, radius_m: float):
+    rows = []
+    for name, info in installation_vessels().items():
+        curve = info["crane_curve"]
+        swl = curve.capacity_at_radius(radius_m)
+        margin = swl / lift_te if lift_te > 0 else 0.0
+        tier = _SOURCE_TIER.get(info.get("source", ""), ConfidenceTier.GENERIC)
+        # headline-only SWL (no published radius curve) is weaker evidence.
+        if len(curve.radii_m) <= 1 or float(curve.radii_m.max()) == 0.0:
+            tier = ConfidenceTier.ESTIMATED if tier.score > ConfidenceTier.ESTIMATED.score else tier
+        cs = capability_score("heavy_lift", {"crane_swl": margin}, {"crane_swl": tier})
+        rows.append((name, swl, margin, cs))
+    rows.sort(key=lambda r: r[3].score, reverse=True)
+    return rows
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--lift-te", type=float, default=3000.0)
+    p.add_argument("--radius-m", type=float, default=35.0)
+    args = p.parse_args()
+
+    rows = score_fleet(args.lift_te, args.radius_m)
+    print("=" * 80)
+    print(f"  VESSEL CAPABILITY SCORE (confidence-weighted) — lift {args.lift_te:.0f} te @ {args.radius_m:.0f} m")
+    print("=" * 80)
+    print(f"  {'score':>5} {'defensible':>10} {'confidence':>10}  {'SWL@R':>7} {'margin':>6}  vessel")
+    print("-" * 80)
+    for name, swl, margin, cs in rows:
+        print(f"  {cs.score:>5.0f} {('yes' if cs.defensible else 'no'):>10} "
+              f"{cs.confidence.value:>10}  {swl:>7.0f} {margin:>6.2f}  {name[:30]}")
+    print("-" * 80)
+    n_def = sum(1 for *_, cs in rows if cs.defensible)
+    print(f"  {n_def}/{len(rows)} vessels meet the lift with defensible (>= estimated) data")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/marine_ops/vessel_db/__init__.py
+++ b/src/digitalmodel/marine_ops/vessel_db/__init__.py
@@ -12,6 +12,14 @@ from digitalmodel.marine_ops.vessel_db.gyradii import (
     GyradiiEstimate,
     estimate_gyradii,
 )
+from digitalmodel.marine_ops.vessel_db.confidence import (
+    CapabilityScore,
+    ConfidenceTier,
+    RecordConfidence,
+    capability_score,
+    field_confidence,
+    record_confidence,
+)
 from digitalmodel.marine_ops.vessel_db.loader import (
     ProvenanceViolation,
     Record,
@@ -47,6 +55,13 @@ from digitalmodel.marine_ops.vessel_db.mass_properties import (
 __all__ = [
     "GyradiiEstimate",
     "estimate_gyradii",
+    # unified confidence tiers + capability scoring
+    "ConfidenceTier",
+    "RecordConfidence",
+    "CapabilityScore",
+    "field_confidence",
+    "record_confidence",
+    "capability_score",
     "Record",
     "ProvenanceViolation",
     "datasets",

--- a/src/digitalmodel/marine_ops/vessel_db/confidence.py
+++ b/src/digitalmodel/marine_ops/vessel_db/confidence.py
@@ -1,0 +1,181 @@
+"""
+ABOUTME: Unified per-field confidence tiers + capability scoring for vessel data.
+
+Provenance is captured three ways across the ecosystem (in-repo per-field
+citations / `estimated:` / `gap`; worldenergydata per-record DATA_SOURCE +
+DIMENSION_CONFIDENCE; synthetic fixtures with none). This module collapses all of
+that into ONE comparable signal so capability/suitability scores can weight
+themselves by how trustworthy the underlying data is.
+
+Tiers (high -> low), each mapped to a 0..1 score:
+
+    measured  1.00  instrument/cert/class-society/IMO-register direct
+    cited     0.85  high-confidence public source with URL
+    brochure  0.75  operator/builder spec sheet / brochure PDF
+    estimated 0.55  documented empirical relation (e.g. kxx=0.35*beam)
+    generic   0.40  class-typical / representative, no named source
+    gap       0.00  not found
+
+The tier is DERIVED from the markers already in the data — never asserted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from digitalmodel.marine_ops.vessel_db.loader import (
+    Record,
+    _is_covered,
+    parse_value,
+)
+
+
+class ConfidenceTier(str, Enum):
+    MEASURED = "measured"
+    CITED = "cited"
+    BROCHURE = "brochure"
+    ESTIMATED = "estimated"
+    GENERIC = "generic"
+    GAP = "gap"
+
+    @property
+    def score(self) -> float:
+        return _TIER_SCORE[self]
+
+
+_TIER_SCORE = {
+    ConfidenceTier.MEASURED: 1.00,
+    ConfidenceTier.CITED: 0.85,
+    ConfidenceTier.BROCHURE: 0.75,
+    ConfidenceTier.ESTIMATED: 0.55,
+    ConfidenceTier.GENERIC: 0.40,
+    ConfidenceTier.GAP: 0.00,
+}
+
+# Source-name hints that imply a measured/authoritative origin.
+_MEASURED_HINTS = ("lloyd", "equasis", "class society", "dnv register", "abs ",
+                   "imo register", "classification", "certificate")
+# Citation access type -> tier.
+_ACCESS_TIER = {
+    "brochure-pdf": ConfidenceTier.BROCHURE,
+    "estimated": ConfidenceTier.ESTIMATED,
+    "public": ConfidenceTier.CITED,
+    "paywalled": ConfidenceTier.CITED,
+}
+
+# Default engineering fields rolled up by record_confidence.
+DEFAULT_FIELDS = ("loa", "beam", "draft", "displacement", "kxx", "kyy", "kzz")
+
+
+def field_confidence(rec: Record, field_name: str) -> ConfidenceTier:
+    """Confidence tier for one canonical field of a vessel record."""
+    val, marker, raw_name = rec.dimension(field_name)
+    if marker in ("gap", "missing"):
+        return ConfidenceTier.GAP
+    if marker == "estimated":
+        return ConfidenceTier.ESTIMATED
+    # marker == "number": trust depends on the citation backing it.
+    dc = str(rec.raw_fields.get("dimension_confidence", "")).lower()
+    if dc in ("generic", "default", "unknown"):
+        return ConfidenceTier.GENERIC
+    if dc in ("measured", "high", "certified"):
+        return ConfidenceTier.MEASURED
+
+    cited = rec.cited_fields()
+    blanket = bool(cited & {"all", "geometry"})
+    if not _is_covered(raw_name or field_name, cited, blanket):
+        return ConfidenceTier.GENERIC  # an un-cited bare number is weak
+
+    # Pick the covering citation and read its access type / source hints.
+    for c in rec.citations:
+        cfields = set(c.get("fields", []))
+        if (cfields & {"all", "geometry"}) or _is_covered(raw_name or field_name, cfields, False):
+            src = str(c.get("source", "")).lower()
+            if any(h in src for h in _MEASURED_HINTS):
+                return ConfidenceTier.MEASURED
+            return _ACCESS_TIER.get(str(c.get("access", "public")).lower(),
+                                    ConfidenceTier.CITED)
+    return ConfidenceTier.CITED
+
+
+@dataclass
+class RecordConfidence:
+    vessel_name: str
+    score: float                         # 0..1 weighted over scored fields
+    dominant_tier: ConfidenceTier
+    per_field: dict[str, ConfidenceTier] = field(default_factory=dict)
+    n_scored: int = 0
+
+
+def record_confidence(rec: Record, fields: Optional[tuple[str, ...]] = None) -> RecordConfidence:
+    """Roll up field tiers into a record-level confidence (mean tier score)."""
+    fields = fields or DEFAULT_FIELDS
+    per: dict[str, ConfidenceTier] = {}
+    for f in fields:
+        _, marker, _ = rec.dimension(f)
+        if marker == "missing":
+            continue  # field not present at all -> not scored (see completeness)
+        per[f] = field_confidence(rec, f)
+    if not per:
+        return RecordConfidence(rec.name, 0.0, ConfidenceTier.GAP, {}, 0)
+    score = sum(t.score for t in per.values()) / len(per)
+    dominant = max(set(per.values()), key=lambda t: sum(1 for x in per.values() if x == t))
+    return RecordConfidence(rec.name, round(score, 3), dominant, per, len(per))
+
+
+# ---------------------------------------------------------------------------
+# Capability scoring
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CapabilityScore:
+    operation: str
+    score: float                         # 0..100 (capability margin x confidence)
+    confidence: ConfidenceTier           # weakest-link tier across scored fields
+    limiting_factors: list[str] = field(default_factory=list)
+    defensible: bool = False             # backed by >= estimated data on all key fields
+
+
+def capability_score(
+    operation: str,
+    margins: dict[str, float],
+    confidences: dict[str, ConfidenceTier],
+    weights: Optional[dict[str, float]] = None,
+    *,
+    min_defensible: ConfidenceTier = ConfidenceTier.ESTIMATED,
+) -> CapabilityScore:
+    """Score a vessel for an operation from per-field margins + confidences.
+
+    ``margins[field]`` is capability/requirement (>=1 means the vessel meets it,
+    capped at 1 for scoring). The field score is ``min(margin,1) * tier_score``;
+    the overall is the weighted mean x100. ``confidence`` is the weakest tier
+    among the fields. ``defensible`` is True only if every field is at least
+    ``min_defensible`` and all margins >= 1.
+    """
+    if not margins:
+        return CapabilityScore(operation, 0.0, ConfidenceTier.GAP, ["no capability fields"], False)
+    weights = weights or {k: 1.0 for k in margins}
+    total_w = sum(weights.get(k, 1.0) for k in margins) or 1.0
+
+    acc = 0.0
+    limiting: list[str] = []
+    weakest = ConfidenceTier.MEASURED
+    order = list(_TIER_SCORE)  # measured..gap, descending
+    for fname, margin in margins.items():
+        tier = confidences.get(fname, ConfidenceTier.GAP)
+        if order.index(tier) > order.index(weakest):
+            weakest = tier
+        capped = min(margin, 1.0)
+        acc += weights.get(fname, 1.0) * capped * tier.score
+        if margin < 1.0:
+            limiting.append(f"{fname} margin {margin:.2f}<1")
+        if tier in (ConfidenceTier.GENERIC, ConfidenceTier.GAP):
+            limiting.append(f"{fname} data is {tier.value}")
+
+    score = round(100.0 * acc / total_w, 1)
+    defensible = (all(margins[k] >= 1.0 for k in margins)
+                  and all(order.index(confidences.get(k, ConfidenceTier.GAP))
+                          <= order.index(min_defensible) for k in margins))
+    return CapabilityScore(operation, score, weakest, limiting, defensible)

--- a/tests/marine_ops/vessel_db/test_capability_demo.py
+++ b/tests/marine_ops/vessel_db/test_capability_demo.py
@@ -1,0 +1,37 @@
+"""Smoke test for the confidence-weighted capability-score demo."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_demo():
+    path = (Path(__file__).resolve().parents[3]
+            / "examples" / "demos" / "installation" / "vessel_capability_score.py")
+    spec = importlib.util.spec_from_file_location("vessel_capability_score", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_score_fleet_ranks_and_flags():
+    demo = _load_demo()
+    rows = demo.score_fleet(lift_te=3000.0, radius_m=35.0)
+    assert rows, "no vessels scored"
+    # sorted by score descending
+    scores = [cs.score for *_, cs in rows]
+    assert scores == sorted(scores, reverse=True)
+    # a vessel that comfortably meets the lift with cited data should be defensible
+    assert any(cs.defensible for *_, cs in rows)
+    # an under-capacity vessel should be flagged non-defensible
+    assert any((not cs.defensible) for *_, cs in rows)
+
+
+def test_undercapacity_is_not_defensible():
+    demo = _load_demo()
+    # absurd lift -> nobody is defensible
+    rows = demo.score_fleet(lift_te=50000.0, radius_m=30.0)
+    assert all(not cs.defensible for *_, cs in rows)

--- a/tests/marine_ops/vessel_db/test_confidence.py
+++ b/tests/marine_ops/vessel_db/test_confidence.py
@@ -1,0 +1,126 @@
+"""Tests for unified confidence tiers + capability scoring (#857)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.marine_ops.vessel_db.confidence import (
+    ConfidenceTier,
+    capability_score,
+    field_confidence,
+    record_confidence,
+)
+from digitalmodel.marine_ops.vessel_db.loader import Record
+
+
+def _rec(fields, citations=None, vtype="fpso"):
+    return Record(name="X", scope="floating", layer="particulars",
+                  vessel_type=vtype, raw_fields=fields, citations=citations or [])
+
+
+def test_tier_score_order():
+    assert ConfidenceTier.MEASURED.score > ConfidenceTier.CITED.score
+    assert ConfidenceTier.CITED.score > ConfidenceTier.BROCHURE.score
+    assert ConfidenceTier.BROCHURE.score > ConfidenceTier.ESTIMATED.score
+    assert ConfidenceTier.ESTIMATED.score > ConfidenceTier.GENERIC.score
+    assert ConfidenceTier.GAP.score == 0.0
+
+
+def test_estimated_marker_maps_to_estimated():
+    rec = _rec({"beam_m": "estimated:kxx=0.35*beam"})
+    assert field_confidence(rec, "beam") == ConfidenceTier.ESTIMATED
+
+
+def test_gap_marker_maps_to_gap():
+    rec = _rec({"beam_m": "gap"})
+    assert field_confidence(rec, "beam") == ConfidenceTier.GAP
+
+
+def test_missing_field_is_gap():
+    assert field_confidence(_rec({}), "beam") == ConfidenceTier.GAP
+
+
+def test_public_citation_is_cited():
+    rec = _rec({"loa_m": 250.0},
+               citations=[{"fields": ["loa_m"], "source": "Ship-Technology", "access": "public"}])
+    assert field_confidence(rec, "loa") == ConfidenceTier.CITED
+
+
+def test_brochure_access_is_brochure():
+    rec = _rec({"loa_m": 250.0},
+               citations=[{"fields": ["loa_m"], "source": "Heerema folder", "access": "brochure-pdf"}])
+    assert field_confidence(rec, "loa") == ConfidenceTier.BROCHURE
+
+
+def test_class_society_source_is_measured():
+    rec = _rec({"loa_m": 250.0},
+               citations=[{"fields": ["loa_m"], "source": "Equasis register", "access": "public"}])
+    assert field_confidence(rec, "loa") == ConfidenceTier.MEASURED
+
+
+def test_wed_generic_dimension_confidence():
+    # worldenergydata blanket-cited row tagged generic.
+    rec = _rec({"loa_m": 164.0, "dimension_confidence": "generic"},
+               citations=[{"fields": ["all"], "source": "worldenergydata vessel_fleet (bsee_war)", "access": "public"}])
+    assert field_confidence(rec, "loa") == ConfidenceTier.GENERIC
+
+
+def test_uncited_number_is_generic():
+    rec = _rec({"loa_m": 250.0})  # number with no citation
+    assert field_confidence(rec, "loa") == ConfidenceTier.GENERIC
+
+
+def test_record_confidence_rollup():
+    rec = _rec(
+        {"loa_m": 250.0, "beam_m": 40.0, "draft_m": 12.0, "displacement_t": 90000.0,
+         "kxx_roll_m": "estimated:kxx=0.35*beam"},
+        citations=[{"fields": ["loa_m", "beam_m", "draft_m", "displacement_t"],
+                    "source": "Ship-Technology", "access": "public"}],
+    )
+    rc = record_confidence(rec)
+    assert 0.0 < rc.score <= 1.0
+    assert rc.per_field["loa"] == ConfidenceTier.CITED
+    assert rc.per_field["kxx"] == ConfidenceTier.ESTIMATED
+    assert rc.n_scored >= 5
+
+
+def test_capability_score_defensible_when_strong():
+    cs = capability_score(
+        "heavy_lift",
+        margins={"crane_swl": 2.0, "deck": 1.5},
+        confidences={"crane_swl": ConfidenceTier.BROCHURE, "deck": ConfidenceTier.CITED},
+    )
+    assert cs.score > 0
+    assert cs.defensible is True
+    assert cs.confidence == ConfidenceTier.BROCHURE  # weakest link
+
+
+def test_capability_score_not_defensible_on_gap_or_shortfall():
+    cs = capability_score(
+        "heavy_lift",
+        margins={"crane_swl": 0.8, "deck": 1.2},                       # crane short
+        confidences={"crane_swl": ConfidenceTier.GENERIC, "deck": ConfidenceTier.GAP},
+    )
+    assert cs.defensible is False
+    assert any("crane_swl" in lf for lf in cs.limiting_factors)
+    assert cs.confidence == ConfidenceTier.GAP
+
+
+def test_capability_score_weakest_link_reported():
+    cs = capability_score(
+        "lift",
+        margins={"a": 1.5, "b": 1.5},
+        confidences={"a": ConfidenceTier.MEASURED, "b": ConfidenceTier.ESTIMATED},
+    )
+    assert cs.confidence == ConfidenceTier.ESTIMATED
+
+
+# ---- integration with the real curated DB ----
+
+def test_confidence_runs_on_real_records():
+    from digitalmodel.marine_ops.vessel_db.loader import iter_records
+    recs = iter_records("floating", "particulars")
+    assert recs
+    for rec in recs[:5]:
+        rc = record_confidence(rec)
+        assert 0.0 <= rc.score <= 1.0


### PR DESCRIPTION
Closes #857. Refs #593, #591, #592, #826.

The keystone from the #593 provenance assessment: one comparable **confidence tier** across all vessel data stores, plus a **capability score** weighted by it.

## `marine_ops.vessel_db.confidence`
- `ConfidenceTier`: `measured > cited > brochure > estimated > generic > gap` (0–1 scores).
- `field_confidence(rec, field)` — *derived*, never asserted: citation access type → brochure/cited; class-society/Equasis source → measured; `estimated:`/`gap` markers; worldenergydata `DIMENSION_CONFIDENCE` → generic/measured; un-cited bare number → generic.
- `record_confidence(rec)` — weighted roll-up + dominant tier + per-field breakdown.
- `capability_score(op, margins, confidences)` — suitability 0–100 = capability margin × data confidence; reports the **weakest-link** confidence, limiting factors, and a **`defensible`** flag (≥ estimated data on every field AND all margins met).

## Demo — `examples/demos/installation/vessel_capability_score.py`
Confidence-weighted fleet ranking for a lift, surfacing *where the data is weak* — the exact gap #593 flagged for client-facing GTM claims:

```
score defensible confidence    SWL@R margin  vessel
   85        yes      cited    14000   4.67  SAIPEM 7000
   75        yes   brochure     3644   1.21  BokaLift 2
   55        yes  estimated    25000   8.33  Pioneering Spirit   <- huge margin, weak data
   46         no  estimated     2500   0.83  DLV 2000            <- under capacity
```

## Tests
16 new (tier order, marker→tier derivation, WED generic, roll-up, capability defensibility/weakest-link, demo). Full `vessel_db` suite: **71 passing, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)