### PR TITLE
feat(parametric): refresh --check CI drift gate (#833)

### DIFF
--- a/.github/workflows/parametric-atlas-drift.yml
+++ b/.github/workflows/parametric-atlas-drift.yml
@@ -1,0 +1,48 @@
+# Parametric atlas drift gate (#833, epic #794)
+#
+# Fails the build when a COMPUTED parametric atlas is stale relative to its
+# build basis — i.e. a workflow's source, a cited standard, the input template,
+# or the parametric spec changed but the committed atlas under atlases/ was not
+# regenerated. This makes the refresh staleness mechanism enforced rather than
+# advisory: a change that should invalidate an atlas can no longer merge silently.
+#
+# Licensed-solver libraries (#801) are reported but do NOT fail the build — CI
+# cannot run a licensed solve; that drift is an operator concern.
+name: Parametric atlas drift
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  atlas-drift:
+    name: Atlas staleness check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Create virtual environment and install
+        run: |
+          uv venv
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+          UV_NO_SOURCES=true uv pip install -e .
+          uv pip install pyyaml
+
+      - name: Atlas drift check (computed atlases must be up to date)
+        run: python -m digitalmodel.parametric.refresh

--- a/src/digitalmodel/parametric/refresh.py
+++ b/src/digitalmodel/parametric/refresh.py
@@ -227,46 +227,46 @@ def _git_sha(repo_root: Path) -> str:
 
 
 def main(argv: list[str]) -> int:
+    """CI drift gate (#833). Exit non-zero when a COMPUTED atlas is stale — a
+    code/standard/template change that wasn't regenerated. Libraries (#801) are
+    reported but do NOT fail the build (CI can't run a licensed solve) unless
+    --strict-libraries is given. --apply regenerates stale computed atlases."""
     apply = "--apply" in argv
-    ids = parametric_workflow_ids()
+    strict_libraries = "--strict-libraries" in argv
+
     stale_ids = []
-    for wid in ids:
+    for wid in parametric_workflow_ids():
         status = refresh_status(wid)
-        flag = "STALE" if status["stale"] else "ok"
-        print(f"[{flag:5}] {wid}  ({status['reason']})")
+        print(f"[{'STALE' if status['stale'] else 'ok':5}] {wid}  ({status['reason']})")
         if status["stale"]:
             stale_ids.append(wid)
 
-    # licensed-solver libraries: report-only (operator runs them; never auto-build)
     stale_libs = []
     for basename in LIBRARY_EXPECTATIONS:
         status = library_status(basename)
-        flag = "STALE" if status["stale"] else "ok"
-        print(f"[{flag:5}] {basename} (library)  ({status['reason']})")
+        print(f"[{'STALE' if status['stale'] else 'ok':5}] {basename} (library)  ({status['reason']})")
         if status["stale"]:
             stale_libs.append(basename)
-
-    if not stale_ids and not stale_libs:
-        print("all atlases current")
-        return 0
 
     if stale_libs:
         print(f"\n{len(stale_libs)} stale library(ies) — need a licensed run "
               f"(operator); not auto-regenerated: {stale_libs}")
-    if not stale_ids:
-        return 1  # only libraries stale: report, nothing to auto-build
-    if not apply:
+
+    if apply and stale_ids:
+        from digitalmodel.parametric.build import build_atlas_from_registry
+        for wid in stale_ids:
+            print(f"refreshing {wid} ...")
+            atlas = build_atlas_from_registry(wid)
+            if not atlas.validation["passes"]:
+                print(f"  WARNING: {wid} regenerated but failed validation gate")
+        stale_ids = []  # regenerated; commit the result
+
+    if not stale_ids and not stale_libs:
+        print("all atlases current")
+    fail = bool(stale_ids) or (strict_libraries and bool(stale_libs))
+    if stale_ids and not apply:
         print(f"\n{len(stale_ids)} stale computed atlas(es); run with --apply to regenerate")
-        return 1
-
-    from digitalmodel.parametric.build import build_atlas_from_registry
-
-    for wid in stale_ids:
-        print(f"refreshing {wid} ...")
-        atlas = build_atlas_from_registry(wid)
-        if not atlas.validation["passes"]:
-            print(f"  WARNING: {wid} regenerated but failed validation gate")
-    return 1 if stale_libs else 0
+    return 1 if fail else 0
 
 
 if __name__ == "__main__":

--- a/tests/parametric/test_refresh.py
+++ b/tests/parametric/test_refresh.py
@@ -51,3 +51,27 @@ def test_tampered_basis_is_stale_and_escalates(tmp_path):
     assert result["in_range"] is False
     assert result["stale"] is True
     assert "stale" in result["reason"]
+
+
+# -- CI drift gate (#833) ----------------------------------------------------
+
+def test_ci_gate_is_green_on_the_committed_state():
+    # the real committed atlases are all current -> exit 0
+    assert refresh.main([]) == 0
+
+
+def test_ci_gate_fails_on_a_stale_computed_atlas(monkeypatch):
+    monkeypatch.setattr(refresh, "parametric_workflow_ids", lambda: ["w"])
+    monkeypatch.setattr(refresh, "refresh_status",
+                        lambda wid: {"stale": True, "reason": "basis changed"})
+    monkeypatch.setattr(refresh, "LIBRARY_EXPECTATIONS", {})
+    assert refresh.main([]) == 1
+
+
+def test_ci_gate_reports_but_does_not_fail_on_a_stale_library(monkeypatch):
+    monkeypatch.setattr(refresh, "parametric_workflow_ids", lambda: [])
+    monkeypatch.setattr(refresh, "LIBRARY_EXPECTATIONS", {"diffraction_library": {}})
+    monkeypatch.setattr(refresh, "library_status",
+                        lambda b: {"stale": True, "reason": "needs licensed run"})
+    assert refresh.main([]) == 0                       # report-only by default
+    assert refresh.main(["--strict-libraries"]) == 1   # enforced under --strict


### PR DESCRIPTION
## Parent
Closes #833 · Epic #794.

## Problem
The refresh staleness mechanism (#799/#831) was advisory — the `refresh --check` CLI existed but nothing ran it. A change that should invalidate an atlas (edit an S-N curve, bump a cited standard, change a workflow's math) could merge without regenerating the committed atlas.

## What this adds
- **`.github/workflows/parametric-atlas-drift.yml`** — a dedicated job that installs the package and runs `python -m digitalmodel.parametric.refresh` on every PR / push to `main`/`develop`. It's its own check, so the signal isn't lost in the separately-red `quality-gates` baseline.
- **`refresh.main()`** now exits non-zero **only on a stale computed atlas**. Libraries (#801) are reported but do **not** fail the build — CI can't run a licensed solve; that's an operator concern — unless `--strict-libraries` is passed. `--apply` still regenerates computed atlases.

## Verification
- **Green on the committed state** (exit 0).
- A stale **computed** atlas → exit 1 (fails CI).
- A stale **library** → reported, exit 0 (exit 1 only under `--strict-libraries`).
- 8 refresh tests pass.

## Effect
Touch `src/digitalmodel/fatigue/sn_curves.py` (or any tracked source / cited standard / input template) without regenerating its atlas → the content fingerprint mismatches → this gate turns red. The staleness protection is now enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)