### PR TITLE
installation: reusable confidence-weighted vessel suitability API (#881)

### DIFF
--- a/examples/demos/installation/vessel_capability_score.py
+++ b/examples/demos/installation/vessel_capability_score.py
@@ -1,75 +1,79 @@
 #!/usr/bin/env python3
 # ABOUTME: Confidence-weighted vessel capability/suitability score for a lift.
-# ABOUTME: Wires vessel_db crane curves + confidence tiers -> capability_score (#591/#592/#857).
+# ABOUTME: Thin CLI over marine_ops.installation.vessel_suitability (#881/#591/#592).
 """
 Vessel capability score (confidence-weighted) for a crane lift
 ==============================================================
 
 Ranks the installation fleet for a lift by **capability margin weighted by data
-confidence**, and flags whether each ranking is *defensible* (backed by at least
-estimated-grade data on every scored field). Unlike a raw go/no-go, this surfaces
-WHERE the data is weak — the gap #593 identified for client-facing GTM claims.
+confidence**, flagging whether each ranking is *defensible* (>= estimated-grade
+data on every scored field) — the gap #593 identified for client-facing claims.
 
-Crane SWL comes from the merged vessel DB (worldenergydata source of truth +
-curated). Confidence is derived from the data source: worldenergydata records
-(real IMO + published reach) -> cited; curated brochure records -> brochure.
+Thin wrapper over the reusable API
+``marine_ops.installation.vessel_suitability`` (rank_fleet / LiftRequirement),
+which scores over the merged vessel DB fleet (worldenergydata source of truth +
+curated).
 
 Usage:
     cd digitalmodel
     uv run python examples/demos/installation/vessel_capability_score.py --lift-te 3000 --radius-m 35
+    uv run python examples/demos/installation/vessel_capability_score.py --lift-te 4000 --radius-m 40 --min-dp 2
 """
 
 from __future__ import annotations
 
 import argparse
 
-from digitalmodel.marine_ops.vessel_db.confidence import (
-    ConfidenceTier,
-    capability_score,
+from digitalmodel.marine_ops.installation.vessel_suitability import (
+    LiftRequirement,
+    rank_fleet,
 )
-from digitalmodel.marine_ops.vessel_db.loader import installation_vessels
-
-_SOURCE_TIER = {
-    "worldenergydata": ConfidenceTier.CITED,   # real IMO + published reach
-    "curated": ConfidenceTier.BROCHURE,        # operator brochure / web research
-}
 
 
-def score_fleet(lift_te: float, radius_m: float):
-    rows = []
-    for name, info in installation_vessels().items():
-        curve = info["crane_curve"]
-        swl = curve.capacity_at_radius(radius_m)
-        margin = swl / lift_te if lift_te > 0 else 0.0
-        tier = _SOURCE_TIER.get(info.get("source", ""), ConfidenceTier.GENERIC)
-        # headline-only SWL (no published radius curve) is weaker evidence.
-        if len(curve.radii_m) <= 1 or float(curve.radii_m.max()) == 0.0:
-            tier = ConfidenceTier.ESTIMATED if tier.score > ConfidenceTier.ESTIMATED.score else tier
-        cs = capability_score("heavy_lift", {"crane_swl": margin}, {"crane_swl": tier})
-        rows.append((name, swl, margin, cs))
-    rows.sort(key=lambda r: r[3].score, reverse=True)
-    return rows
+def score_fleet(lift_te: float, radius_m: float, min_dp=None, deck_area=None):
+    """Ranked SuitabilityResult list for a lift (kept for demo/test convenience)."""
+    return rank_fleet(
+        LiftRequirement(
+            weight_te=lift_te,
+            radius_m=radius_m,
+            min_dp_class=min_dp,
+            deck_area_m2=deck_area,
+        )
+    )
 
 
 def main() -> None:
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     p.add_argument("--lift-te", type=float, default=3000.0)
     p.add_argument("--radius-m", type=float, default=35.0)
+    p.add_argument("--min-dp", type=int, default=None, help="required DP class (2/3)")
+    p.add_argument(
+        "--deck-area", type=float, default=None, help="required deck area m2"
+    )
     args = p.parse_args()
 
-    rows = score_fleet(args.lift_te, args.radius_m)
+    rows = score_fleet(args.lift_te, args.radius_m, args.min_dp, args.deck_area)
     print("=" * 80)
-    print(f"  VESSEL CAPABILITY SCORE (confidence-weighted) — lift {args.lift_te:.0f} te @ {args.radius_m:.0f} m")
+    print(
+        f"  VESSEL CAPABILITY SCORE (confidence-weighted) — lift {args.lift_te:.0f} te @ {args.radius_m:.0f} m"
+    )
     print("=" * 80)
-    print(f"  {'score':>5} {'defensible':>10} {'confidence':>10}  {'SWL@R':>7} {'margin':>6}  vessel")
+    print(
+        f"  {'score':>5} {'defensible':>10} {'confidence':>10}  {'SWL@R':>7} {'margin':>6}  vessel"
+    )
     print("-" * 80)
-    for name, swl, margin, cs in rows:
-        print(f"  {cs.score:>5.0f} {('yes' if cs.defensible else 'no'):>10} "
-              f"{cs.confidence.value:>10}  {swl:>7.0f} {margin:>6.2f}  {name[:30]}")
+    for r in rows:
+        print(
+            f"  {r.score:>5.0f} {('yes' if r.defensible else 'no'):>10} "
+            f"{r.confidence.value:>10}  {r.swl_at_radius_te:>7.0f} {r.margin:>6.2f}  {r.vessel[:30]}"
+        )
     print("-" * 80)
-    n_def = sum(1 for *_, cs in rows if cs.defensible)
-    print(f"  {n_def}/{len(rows)} vessels meet the lift with defensible (>= estimated) data")
+    n_def = sum(1 for r in rows if r.defensible)
+    print(
+        f"  {n_def}/{len(rows)} vessels meet the lift with defensible (>= estimated) data"
+    )
 
 
 if __name__ == "__main__":

--- a/src/digitalmodel/marine_ops/installation/__init__.py
+++ b/src/digitalmodel/marine_ops/installation/__init__.py
@@ -9,8 +9,14 @@ References:
     DNV-ST-N001 (2021) -- Marine Operations and Marine Warranty
     DNV-RP-C205 (2021) -- Environmental Conditions and Environmental Loads
 """
+
 from __future__ import annotations
 
+from digitalmodel.marine_ops.installation.crane_tip_motion import (
+    crane_tip_raos,
+    crane_tip_significant_motion,
+    crane_tip_significant_velocity,
+)
 from digitalmodel.marine_ops.installation.models import (
     CraneCurve,
     CraneTipConfig,
@@ -23,24 +29,26 @@ from digitalmodel.marine_ops.installation.models import (
     Structure,
     Vessel,
 )
-from digitalmodel.marine_ops.installation.crane_tip_motion import (
-    crane_tip_raos,
-    crane_tip_significant_motion,
-    crane_tip_significant_velocity,
+from digitalmodel.marine_ops.installation.operability import (
+    compute_operability,
+    hs_limit_for_criterion,
+    weather_window_operability,
 )
 from digitalmodel.marine_ops.installation.splash_zone import (
     slamming_force,
     splash_zone_assessment,
     varying_buoyancy_force,
 )
-from digitalmodel.marine_ops.installation.operability import (
-    compute_operability,
-    hs_limit_for_criterion,
-    weather_window_operability,
-)
 from digitalmodel.marine_ops.installation.vessel_screening import (
     VesselScreeningResult,
     screen_vessels,
+)
+from digitalmodel.marine_ops.installation.vessel_suitability import (
+    LiftRequirement,
+    SuitabilityResult,
+    assess_named,
+    assess_vessel,
+    rank_fleet,
 )
 
 __all__ = [
@@ -70,4 +78,10 @@ __all__ = [
     "weather_window_operability",
     # Vessel screening
     "screen_vessels",
+    # Confidence-weighted suitability (over the vessel DB fleet)
+    "LiftRequirement",
+    "SuitabilityResult",
+    "rank_fleet",
+    "assess_vessel",
+    "assess_named",
 ]

--- a/src/digitalmodel/marine_ops/installation/vessel_suitability.py
+++ b/src/digitalmodel/marine_ops/installation/vessel_suitability.py
@@ -1,0 +1,126 @@
+"""
+ABOUTME: Reusable, confidence-weighted vessel suitability ranking for a lift.
+
+Promotes the confidence-weighted capability scoring from the demo into a library
+API the GTM suitability work (#591/#592) and chat workflows can call directly.
+For a lift requirement it ranks the installation fleet (worldenergydata source of
+truth + curated, via `vessel_db.installation_vessels`) by capability margin
+weighted by data confidence, and flags whether each ranking is *defensible*.
+
+References:
+    DNV-RP-H103 (2011) -- Modelling and Analysis of Marine Operations
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from digitalmodel.marine_ops.vessel_db.confidence import (
+    ConfidenceTier,
+    capability_score,
+)
+from digitalmodel.marine_ops.vessel_db.loader import (
+    installation_vessels,
+    normalize_vessel_name,
+)
+
+# Data-source -> base confidence tier for the crane SWL value.
+_SOURCE_TIER = {
+    "worldenergydata": ConfidenceTier.CITED,  # real IMO + published reach
+    "curated": ConfidenceTier.BROCHURE,  # operator brochure / web research
+}
+
+
+@dataclass
+class LiftRequirement:
+    """What a lift needs of a vessel."""
+
+    weight_te: float
+    radius_m: float
+    daf: float = 1.30
+    min_dp_class: Optional[int] = None  # e.g. 2 or 3; None = no requirement
+    deck_area_m2: Optional[float] = None  # required free deck area
+
+
+@dataclass
+class SuitabilityResult:
+    vessel: str
+    score: float  # 0..100, confidence-weighted
+    defensible: bool
+    confidence: ConfidenceTier  # weakest-link tier
+    swl_at_radius_te: float
+    margin: float  # SWL@radius / (weight * daf-free) static
+    limiting_factors: list[str] = field(default_factory=list)
+    source: str = ""
+
+
+def _dp_int(dp_class) -> Optional[int]:
+    """Parse a DP class like 'DP3' / 'Lloyd's ... Class 3' -> 3."""
+    if dp_class is None:
+        return None
+    import re
+
+    m = re.search(r"(?:DP[^0-9]*|class[^0-9]*|\b)([0-3])\b", str(dp_class), re.I)
+    return int(m.group(1)) if m else None
+
+
+def assess_vessel(name: str, info: dict, req: LiftRequirement) -> SuitabilityResult:
+    """Score one installation-vessel entry (from installation_vessels) for a lift."""
+    curve = info["crane_curve"]
+    swl = curve.capacity_at_radius(req.radius_m)
+    static_margin = swl / req.weight_te if req.weight_te > 0 else 0.0
+    dyn_margin = swl / (req.weight_te * req.daf) if req.weight_te > 0 else 0.0
+
+    base_tier = _SOURCE_TIER.get(info.get("source", ""), ConfidenceTier.GENERIC)
+    # Headline-only SWL (no published radius curve) is weaker evidence.
+    headline_only = len(curve.radii_m) <= 1 or float(curve.radii_m.max()) == 0.0
+    crane_tier = (
+        ConfidenceTier.ESTIMATED
+        if headline_only and base_tier.score > ConfidenceTier.ESTIMATED.score
+        else base_tier
+    )
+
+    margins = {"crane_swl": dyn_margin}
+    confidences = {"crane_swl": crane_tier}
+
+    # Optional gated factors.
+    if req.min_dp_class is not None:
+        dp = _dp_int(info.get("dp_class"))
+        margins["dp_class"] = (dp / req.min_dp_class) if dp else 0.0
+        confidences["dp_class"] = ConfidenceTier.CITED if dp else ConfidenceTier.GAP
+    if req.deck_area_m2 is not None:
+        deck = info.get("deck_area_m2")
+        margins["deck_area"] = (deck / req.deck_area_m2) if deck else 0.0
+        confidences["deck_area"] = ConfidenceTier.CITED if deck else ConfidenceTier.GAP
+
+    cs = capability_score("heavy_lift", margins, confidences)
+    return SuitabilityResult(
+        vessel=name,
+        score=cs.score,
+        defensible=cs.defensible,
+        confidence=cs.confidence,
+        swl_at_radius_te=round(swl, 1),
+        margin=round(static_margin, 2),
+        limiting_factors=cs.limiting_factors,
+        source=info.get("source", ""),
+    )
+
+
+def rank_fleet(req: LiftRequirement, base=None) -> list[SuitabilityResult]:
+    """Rank every installation vessel for the lift, best (highest score) first."""
+    fleet = installation_vessels(base)
+    results = [assess_vessel(name, info, req) for name, info in fleet.items()]
+    results.sort(key=lambda r: r.score, reverse=True)
+    return results
+
+
+def assess_named(
+    vessel_name: str, req: LiftRequirement, base=None
+) -> Optional[SuitabilityResult]:
+    """Suitability for a single named vessel (normalised match), or None."""
+    target = normalize_vessel_name(vessel_name)
+    for name, info in installation_vessels(base).items():
+        if normalize_vessel_name(name) == target:
+            return assess_vessel(name, info, req)
+    return None

--- a/tests/marine_ops/installation/test_vessel_suitability.py
+++ b/tests/marine_ops/installation/test_vessel_suitability.py
@@ -1,0 +1,90 @@
+"""Tests for the reusable confidence-weighted vessel suitability API (#881)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from digitalmodel.marine_ops.installation.models import CraneCurve
+from digitalmodel.marine_ops.installation.vessel_suitability import (
+    LiftRequirement,
+    assess_named,
+    assess_vessel,
+    rank_fleet,
+)
+from digitalmodel.marine_ops.vessel_db.confidence import ConfidenceTier
+
+
+def _info(swl, radii=(0.0,), source="worldenergydata", dp="DP3", deck=8000.0):
+    caps = [swl] * len(radii)
+    return {
+        "crane_curve": CraneCurve(
+            radii_m=np.array(radii, dtype=float),
+            capacities_te=np.array(caps, dtype=float),
+            max_hook_load_te=float(swl),
+        ),
+        "dp_class": dp,
+        "deck_area_m2": deck,
+        "source": source,
+    }
+
+
+def test_assess_meets_lift_defensible():
+    info = _info(10000.0, radii=(20.0, 48.0), source="worldenergydata")
+    r = assess_vessel("BIG HLV", info, LiftRequirement(weight_te=2000.0, radius_m=30.0))
+    assert r.swl_at_radius_te > 0
+    assert r.defensible is True
+    assert r.score > 0
+    assert r.confidence == ConfidenceTier.CITED
+
+
+def test_headline_only_downgrades_confidence():
+    # no published radius curve -> crane confidence drops to estimated
+    info = _info(25000.0, radii=(0.0,), source="curated")
+    r = assess_vessel(
+        "HEADLINE HLV", info, LiftRequirement(weight_te=2000.0, radius_m=40.0)
+    )
+    assert r.confidence == ConfidenceTier.ESTIMATED
+
+
+def test_undercapacity_not_defensible():
+    info = _info(1000.0, radii=(20.0, 40.0), source="worldenergydata")
+    r = assess_vessel("SMALL", info, LiftRequirement(weight_te=5000.0, radius_m=30.0))
+    assert r.defensible is False
+    assert any("crane_swl" in lf for lf in r.limiting_factors)
+
+
+def test_dp_gate_fails_when_below_required():
+    info = _info(8000.0, radii=(20.0, 40.0), dp="DP1")
+    r = assess_vessel(
+        "LOWDP", info, LiftRequirement(weight_te=2000.0, radius_m=30.0, min_dp_class=3)
+    )
+    assert r.defensible is False  # DP1 < DP3 -> margin < 1
+
+
+def test_deck_gate_gap_when_unknown():
+    info = _info(8000.0, radii=(20.0, 40.0), deck=None)
+    r = assess_vessel(
+        "NODECK",
+        info,
+        LiftRequirement(weight_te=2000.0, radius_m=30.0, deck_area_m2=5000.0),
+    )
+    assert r.confidence == ConfidenceTier.GAP  # deck data missing -> weakest link gap
+
+
+# ---- integration over the real merged fleet ----
+
+
+def test_rank_fleet_orders_and_runs():
+    rows = rank_fleet(LiftRequirement(weight_te=3000.0, radius_m=35.0))
+    assert rows, "no vessels ranked"
+    scores = [r.score for r in rows]
+    assert scores == sorted(scores, reverse=True)
+    assert all(0.0 <= r.score <= 100.0 for r in rows)
+
+
+def test_assess_named_normalised_match():
+    # 'Sleipnir' should match the WED 'SLEIPNIR' entry regardless of case/prefix.
+    r = assess_named("SSCV Sleipnir", LiftRequirement(weight_te=2000.0, radius_m=40.0))
+    if r is not None:  # present only when the WED fleet is available
+        assert r.swl_at_radius_te > 0

--- a/tests/marine_ops/vessel_db/test_capability_demo.py
+++ b/tests/marine_ops/vessel_db/test_capability_demo.py
@@ -8,8 +8,13 @@ from pathlib import Path
 
 
 def _load_demo():
-    path = (Path(__file__).resolve().parents[3]
-            / "examples" / "demos" / "installation" / "vessel_capability_score.py")
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "demos"
+        / "installation"
+        / "vessel_capability_score.py"
+    )
     spec = importlib.util.spec_from_file_location("vessel_capability_score", path)
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
@@ -22,16 +27,16 @@ def test_score_fleet_ranks_and_flags():
     rows = demo.score_fleet(lift_te=3000.0, radius_m=35.0)
     assert rows, "no vessels scored"
     # sorted by score descending
-    scores = [cs.score for *_, cs in rows]
+    scores = [r.score for r in rows]
     assert scores == sorted(scores, reverse=True)
     # a vessel that comfortably meets the lift with cited data should be defensible
-    assert any(cs.defensible for *_, cs in rows)
+    assert any(r.defensible for r in rows)
     # an under-capacity vessel should be flagged non-defensible
-    assert any((not cs.defensible) for *_, cs in rows)
+    assert any((not r.defensible) for r in rows)
 
 
 def test_undercapacity_is_not_defensible():
     demo = _load_demo()
     # absurd lift -> nobody is defensible
     rows = demo.score_fleet(lift_te=50000.0, radius_m=30.0)
-    assert all(not cs.defensible for *_, cs in rows)
+    assert all(not r.defensible for r in rows)

--- a/tests/marine_ops/vessel_db/test_go_no_go_demo.py
+++ b/tests/marine_ops/vessel_db/test_go_no_go_demo.py
@@ -7,8 +7,13 @@ import sys
 from pathlib import Path
 
 # Load the demo module by path (it lives under examples/, not the package).
-_DEMO = (Path(__file__).resolve().parents[3]
-         / "examples" / "demos" / "installation" / "go_no_go_crane_curves.py")
+_DEMO = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "demos"
+    / "installation"
+    / "go_no_go_crane_curves.py"
+)
 _spec = importlib.util.spec_from_file_location("go_no_go_crane_curves", _DEMO)
 demo = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = demo  # so @dataclass can resolve cls.__module__
@@ -19,10 +24,17 @@ def test_demo_file_exists():
     assert _DEMO.is_file()
 
 
-def test_light_lift_all_go():
-    verdicts = demo.screen_fleet(lift_te=50.0, radius_m=20.0)
+def test_light_lift_go_for_capable_vessels():
+    # The fleet now spans 80+ real vessels incl. small crane barges, so a fixed
+    # light lift is not GO for *every* vessel — but any vessel with ample
+    # capacity (SWL >= 2x lift, well within the 0.70 static + dynamic limits)
+    # must be GO.
+    lift = 50.0
+    verdicts = demo.screen_fleet(lift_te=lift, radius_m=20.0)
     assert verdicts, "no vessels screened"
-    assert all(v.decision == "GO" for v in verdicts)
+    ample = [v for v in verdicts if v.swl_at_radius_te >= 2 * lift]
+    assert ample, "expected some vessels with ample capacity for a light lift"
+    assert all(v.decision == "GO" for v in ample)
 
 
 def test_absurd_lift_all_no_go():
@@ -44,9 +56,9 @@ def test_radius_curve_is_applied_when_published():
     curved = [name for name, v in near.items() if not v.headline_only]
     assert curved, "expected at least one vessel with a published radius curve"
     name = curved[0]
-    assert far[name].swl_at_radius_te <= near[name].swl_at_radius_te, (
-        f"{name}: SWL should not increase with radius"
-    )
+    assert (
+        far[name].swl_at_radius_te <= near[name].swl_at_radius_te
+    ), f"{name}: SWL should not increase with radius"
 
 
 def test_decisions_are_valid_states():


### PR DESCRIPTION
Closes #881. Refs #593, #591, #592, #857, #826.

Promotes the confidence-weighted capability scoring from the demo into a reusable `marine_ops.installation` API the GTM vessel-suitability work (#591/#592) and chat workflows can call directly. Builds on the merged confidence tiers (#857) and the now-165-vessel worldenergydata fleet (#508) → **84 installation crane vessels** via the adapter.

## API — `marine_ops/installation/vessel_suitability.py`
- `LiftRequirement(weight_te, radius_m, daf=1.30, min_dp_class=None, deck_area_m2=None)`
- `SuitabilityResult(vessel, score, defensible, confidence, swl_at_radius_te, margin, limiting_factors, source)`
- `rank_fleet(req)` — ranks the merged fleet by capability margin × data confidence (via `vessel_db.confidence.capability_score`); reports weakest-link confidence + a `defensible` flag. Optional DP-class / deck-area gating.
- `assess_vessel(...)`, `assess_named("Sleipnir", req)` (normalised match). Exported from the package.

## Demo + tests
- `vessel_capability_score.py` refactored to a thin CLI over the API (adds `--min-dp`, `--deck-area`).
- 7 new suitability tests.
- **Fixed a latent break:** `test_go_no_go_demo.test_light_lift` assumed *every* vessel could do a 50 te lift — true for the old 9-vessel fleet, false now that #508 grew it to 80+ (small crane barges). Re-scoped to assert GO only for amply-capable vessels. worldenergydata-side CI couldn't catch this digitalmodel test.
- Full installation + vessel_db suites: **256 passing, 1 skipped.** Pre-linted with the repo-pinned Black 25.9.0 + isort 5.13.2 + flake8 (CI Lint gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)