### PR TITLE
fix(cli): python -m digitalmodel --help exits 0 (#884)

### DIFF
--- a/src/digitalmodel/__main__.py
+++ b/src/digitalmodel/__main__.py
@@ -59,6 +59,16 @@ def _resolve_cli(name: str):
 
 
 def main():
+    # -h/--help prints usage and exits 0. Without this, engine() treats
+    # "--help" as an input filename and raises, which also fails the ace-win-2
+    # licensed-run verify probe (`python -m digitalmodel --help` must exit 0 to
+    # write the go-live marker). Bare invocation still goes to engine() (#713
+    # contract); the engine contract `python -m digitalmodel <input.yml>` is
+    # unaffected: a real file still takes the path below.
+    argv = sys.argv[1:]
+    if argv and argv[0] in ("-h", "--help"):
+        print(__doc__)
+        return 0
     # An existing file always wins: `python -m digitalmodel <input.yml>` is
     # the engine contract and must stay unchanged (durable-workflow callers).
     if len(sys.argv) > 1 and not Path(sys.argv[1]).exists():

--- a/tests/test_main_module_routing.py
+++ b/tests/test_main_module_routing.py
@@ -58,3 +58,13 @@ class TestMainRouting:
             with patch("digitalmodel.__main__.engine") as mock_engine:
                 main()
         mock_engine.assert_called_once()
+
+    @pytest.mark.parametrize("flag", ["--help", "-h"])
+    def test_help_prints_usage_and_exits_zero_without_engine(self, flag, capsys):
+        # `python -m digitalmodel --help` must exit 0 (the ace-win-2 licensed-run
+        # verify probe requires it) and never reach engine().
+        with patch.object(sys, "argv", ["digitalmodel", flag]):
+            with patch("digitalmodel.__main__.engine") as mock_engine:
+                assert main() == 0
+        mock_engine.assert_not_called()
+        assert "digitalmodel" in capsys.readouterr().out.lower()


### PR DESCRIPTION
Closes #884. Unblocks the ace-win-2 licensed-run verify marker.

`python -m digitalmodel --help` / `-h` fell through `main()` to `engine()`, which treats `--help` as an input filename and raises (exit 1). The ace-win-2 verify probe requires `uv run python -m digitalmodel --help` to exit 0 to write the go-live marker, so this kept the licensed-run agent gated off.

**Fix:** intercept `-h`/`--help` in `__main__.py:main()` → print usage, `return 0`, before `engine()`. Bare invocation still goes to `engine()` (#713 contract); the `<input.yml>` engine contract is untouched.

**Verification**
- `tests/test_main_module_routing.py` 9/9 (incl. existing bare→engine + 2 new parametrized `--help`/`-h` cases).
- Real `uv run python -m digitalmodel --help` now exits 0 and prints usage. (AC#1)

Part of bringing the acma `orcaflex-strength-post` licensed-run lane live; the post-process drift is tracked separately in #885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)