### PR TITLE
installation: vessel suitability report generator (confidence-badged HTML + markdown) (#883)

### DIFF
--- a/examples/demos/installation/suitability_report.py
+++ b/examples/demos/installation/suitability_report.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# ABOUTME: Generate a confidence-badged vessel suitability report (HTML + markdown).
+# ABOUTME: Thin CLI over marine_ops.installation.suitability_report (#883/#591/#592).
+"""
+Vessel suitability report
+=========================
+
+Renders a ranked, confidence-badged fleet-suitability report for a lift scenario
+(HTML + markdown) over the merged vessel DB fleet — the GTM-consumable artifact
+on top of the suitability API.
+
+Usage:
+    cd digitalmodel
+    uv run python examples/demos/installation/suitability_report.py --lift-te 4000 --radius-m 40
+    uv run python examples/demos/installation/suitability_report.py --lift-te 3000 --radius-m 35 --min-dp 2
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from digitalmodel.marine_ops.installation.suitability_report import (
+    build_report,
+    to_html,
+    to_markdown,
+)
+from digitalmodel.marine_ops.installation.vessel_suitability import LiftRequirement
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--lift-te", type=float, default=4000.0)
+    p.add_argument("--radius-m", type=float, default=40.0)
+    p.add_argument("--min-dp", type=int, default=None)
+    p.add_argument("--deck-area", type=float, default=None)
+    p.add_argument("--top", type=int, default=20, help="rows to render (0 = all)")
+    args = p.parse_args()
+
+    req = LiftRequirement(
+        weight_te=args.lift_te,
+        radius_m=args.radius_m,
+        min_dp_class=args.min_dp,
+        deck_area_m2=args.deck_area,
+    )
+    title = f"Vessel suitability — {args.lift_te:.0f} te @ {args.radius_m:.0f} m"
+    report = build_report(req, title=title)
+    limit = args.top or None
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    md = OUTPUT_DIR / "suitability_report.md"
+    html = OUTPUT_DIR / "suitability_report.html"
+    md.write_text(to_markdown(report, limit=limit))
+    html.write_text(to_html(report, limit=limit))
+
+    print(to_markdown(report, limit=min(limit or 10, 10)))
+    print(f"\nWrote {md}\n      {html}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/marine_ops/installation/__init__.py
+++ b/src/digitalmodel/marine_ops/installation/__init__.py
@@ -39,6 +39,12 @@ from digitalmodel.marine_ops.installation.splash_zone import (
     splash_zone_assessment,
     varying_buoyancy_force,
 )
+from digitalmodel.marine_ops.installation.suitability_report import (
+    SuitabilityReport,
+    build_report,
+    to_html,
+    to_markdown,
+)
 from digitalmodel.marine_ops.installation.vessel_screening import (
     VesselScreeningResult,
     screen_vessels,
@@ -84,4 +90,9 @@ __all__ = [
     "rank_fleet",
     "assess_vessel",
     "assess_named",
+    # Suitability report
+    "SuitabilityReport",
+    "build_report",
+    "to_markdown",
+    "to_html",
 ]

--- a/src/digitalmodel/marine_ops/installation/suitability_report.py
+++ b/src/digitalmodel/marine_ops/installation/suitability_report.py
@@ -1,0 +1,166 @@
+"""
+ABOUTME: Render a confidence-badged vessel suitability report (markdown + HTML).
+
+Turns the suitability API (vessel_suitability.rank_fleet) into a consumable
+artifact for GTM review (#591/#592): a ranked fleet table with a confidence
+badge and a `defensible` flag per vessel, plus a summary (how many are
+defensible, the confidence-tier mix, and the data-source mix). The report header
+states the provenance honestly — public-sourced fleet, estimated/headline-only
+values flagged — so it is never read as vessel-specific certified engineering.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Optional
+
+from digitalmodel.marine_ops.installation.vessel_suitability import (
+    LiftRequirement,
+    SuitabilityResult,
+    rank_fleet,
+)
+from digitalmodel.marine_ops.vessel_db.confidence import ConfidenceTier
+
+# Confidence tier -> (label, hex colour) for the HTML badge.
+_TIER_STYLE = {
+    ConfidenceTier.MEASURED: ("measured", "#1a7f37"),
+    ConfidenceTier.CITED: ("cited", "#2da44e"),
+    ConfidenceTier.BROCHURE: ("brochure", "#9a6700"),
+    ConfidenceTier.ESTIMATED: ("estimated", "#bf8700"),
+    ConfidenceTier.GENERIC: ("generic", "#cf222e"),
+    ConfidenceTier.GAP: ("gap", "#82071e"),
+}
+
+_PROVENANCE_NOTE = (
+    "Fleet data is public-sourced (worldenergydata vessel_fleet + curated brochure "
+    "records). Crane SWL marked 'estimated' is headline-only (no published radius "
+    "curve); 'generic' is class-typical. This screening ranks data-backed suitability "
+    "and is NOT a substitute for vessel-specific lift engineering."
+)
+
+
+@dataclass
+class SuitabilityReport:
+    title: str
+    requirement: LiftRequirement
+    rows: list[SuitabilityResult]
+    n_defensible: int
+    confidence_mix: dict[str, int] = field(default_factory=dict)
+    source_mix: dict[str, int] = field(default_factory=dict)
+
+
+def build_report(
+    req: LiftRequirement,
+    title: str = "Vessel suitability screening",
+    base=None,
+) -> SuitabilityReport:
+    rows = rank_fleet(req, base=base)
+    return SuitabilityReport(
+        title=title,
+        requirement=req,
+        rows=rows,
+        n_defensible=sum(1 for r in rows if r.defensible),
+        confidence_mix=dict(Counter(r.confidence.value for r in rows)),
+        source_mix=dict(Counter((r.source or "unknown") for r in rows)),
+    )
+
+
+def _req_line(req: LiftRequirement) -> str:
+    parts = [
+        f"{req.weight_te:.0f} te @ {req.radius_m:.0f} m radius",
+        f"DAF {req.daf:.2f}",
+    ]
+    if req.min_dp_class is not None:
+        parts.append(f"min DP{req.min_dp_class}")
+    if req.deck_area_m2 is not None:
+        parts.append(f"deck ≥ {req.deck_area_m2:.0f} m²")
+    return ", ".join(parts)
+
+
+def to_markdown(report: SuitabilityReport, limit: Optional[int] = None) -> str:
+    rows = report.rows[:limit] if limit else report.rows
+    out = [f"# {report.title}", ""]
+    out.append(f"**Lift requirement:** {_req_line(report.requirement)}")
+    out.append("")
+    out.append(
+        f"**{report.n_defensible} of {len(report.rows)}** vessels meet the lift "
+        "with defensible (≥ estimated) data."
+    )
+    out.append("")
+    out.append(
+        "_Confidence mix:_ "
+        + ", ".join(f"{k} {v}" for k, v in report.confidence_mix.items())
+    )
+    out.append("")
+    out.append(
+        "| # | Vessel | Score | Defensible | Confidence | SWL@R (te) | Margin | Source |"
+    )
+    out.append(
+        "|--:|--------|------:|:----------:|:----------:|----------:|------:|--------|"
+    )
+    for i, r in enumerate(rows, 1):
+        out.append(
+            f"| {i} | {r.vessel} | {r.score:.0f} | "
+            f"{'✓' if r.defensible else '—'} | {r.confidence.value} | "
+            f"{r.swl_at_radius_te:.0f} | {r.margin:.2f} | {r.source} |"
+        )
+    out.append("")
+    out.append(f"> {_PROVENANCE_NOTE}")
+    return "\n".join(out) + "\n"
+
+
+def _badge(tier: ConfidenceTier) -> str:
+    label, colour = _TIER_STYLE.get(tier, (tier.value, "#57606a"))
+    return (
+        f'<span style="background:{colour};color:#fff;padding:1px 6px;'
+        f'border-radius:6px;font-size:0.85em">{label}</span>'
+    )
+
+
+def to_html(report: SuitabilityReport, limit: Optional[int] = None) -> str:
+    rows = report.rows[:limit] if limit else report.rows
+    trs = []
+    for i, r in enumerate(rows, 1):
+        flag = "✓" if r.defensible else "—"
+        flag_col = "#1a7f37" if r.defensible else "#cf222e"
+        lf = "; ".join(r.limiting_factors[:3])
+        trs.append(
+            f"<tr><td>{i}</td><td>{r.vessel}</td><td style='text-align:right'>{r.score:.0f}</td>"
+            f"<td style='text-align:center;color:{flag_col};font-weight:600'>{flag}</td>"
+            f"<td style='text-align:center'>{_badge(r.confidence)}</td>"
+            f"<td style='text-align:right'>{r.swl_at_radius_te:.0f}</td>"
+            f"<td style='text-align:right'>{r.margin:.2f}</td>"
+            f"<td>{r.source}</td><td style='font-size:0.85em;color:#57606a'>{lf}</td></tr>"
+        )
+    mix = ", ".join(f"{k}&nbsp;{v}" for k, v in report.confidence_mix.items())
+    css = (
+        "body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;margin:2rem;color:#1f2328}"
+        "table{border-collapse:collapse;width:100%;font-size:0.92em}"
+        "th,td{border-bottom:1px solid #d0d7de;padding:6px 10px}"
+        "th{text-align:left;background:#f6f8fa}"
+        ".summary{background:#f6f8fa;border:1px solid #d0d7de;border-radius:8px;"
+        "padding:10px 14px;margin:1rem 0}"
+        ".note{color:#57606a;font-size:0.85em;margin-top:1rem;"
+        "border-top:1px solid #d0d7de;padding-top:0.6rem}"
+    )
+    headers = (
+        "<th>#</th><th>Vessel</th><th>Score</th><th>Defensible</th>"
+        "<th>Confidence</th><th>SWL@R (te)</th><th>Margin</th>"
+        "<th>Source</th><th>Limiting factors</th>"
+    )
+    summary = (
+        f"<b>Lift requirement:</b> {_req_line(report.requirement)}<br>"
+        f"<b>{report.n_defensible} of {len(report.rows)}</b> vessels meet the lift "
+        f"with defensible (&ge; estimated) data.<br>"
+        f"<b>Confidence mix:</b> {mix}"
+    )
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        f"<title>{report.title}</title><style>{css}</style></head><body>"
+        f"<h1>{report.title}</h1>"
+        f'<div class="summary">{summary}</div>'
+        f"<table><thead><tr>{headers}</tr></thead>"
+        f"<tbody>{''.join(trs)}</tbody></table>"
+        f'<p class="note">{_PROVENANCE_NOTE}</p></body></html>'
+    )

--- a/tests/marine_ops/installation/test_suitability_report.py
+++ b/tests/marine_ops/installation/test_suitability_report.py
@@ -1,0 +1,65 @@
+"""Tests for the vessel suitability report generator (#883)."""
+
+from __future__ import annotations
+
+from digitalmodel.marine_ops.installation.suitability_report import (
+    build_report,
+    to_html,
+    to_markdown,
+)
+from digitalmodel.marine_ops.installation.vessel_suitability import LiftRequirement
+
+
+def _report(weight=4000.0, radius=40.0, **kw):
+    return build_report(
+        LiftRequirement(weight_te=weight, radius_m=radius, **kw), title="Test screening"
+    )
+
+
+def test_report_structure_and_summary():
+    rep = _report()
+    assert rep.rows, "no vessels in report"
+    assert rep.title == "Test screening"
+    # summary counts are consistent
+    assert rep.n_defensible == sum(1 for r in rep.rows if r.defensible)
+    assert sum(rep.confidence_mix.values()) == len(rep.rows)
+    assert sum(rep.source_mix.values()) == len(rep.rows)
+
+
+def test_rows_ranked_descending():
+    rep = _report()
+    scores = [r.score for r in rep.rows]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_markdown_contains_table_and_provenance():
+    rep = _report()
+    md = to_markdown(rep, limit=5)
+    assert "| # | Vessel | Score |" in md
+    assert "defensible" in md.lower()
+    assert "public-sourced" in md  # provenance note present
+    # top-ranked vessel name appears
+    assert rep.rows[0].vessel.split()[0] in md
+
+
+def test_html_renders_badges_and_rows():
+    rep = _report()
+    html = to_html(rep, limit=5)
+    assert html.startswith("<!doctype html>")
+    assert "<table>" in html and "</table>" in html
+    assert "border-radius" in html  # confidence badge styling
+    assert "NOT a substitute" in html  # provenance disclaimer
+    # confidence tier label of the top row shows up as a badge
+    assert rep.rows[0].confidence.value in html
+
+
+def test_limit_caps_rows():
+    rep = _report()
+    md_full = to_markdown(rep)
+    md_small = to_markdown(rep, limit=3)
+    assert md_full.count("\n|") > md_small.count("\n|")
+
+
+def test_dp_requirement_in_header():
+    rep = _report(min_dp_class=3)
+    assert "min DP3" in to_markdown(rep)


### PR DESCRIPTION
Closes #883. Refs #881, #591, #592, #593, #826.

Turns the suitability API (#881) into the **consumable artifact** the GTM work (#591/#592) needs — a ranked, confidence-badged fleet-suitability report over the merged 84-vessel fleet.

## `marine_ops/installation/suitability_report.py`
- `build_report(req, title)` → `SuitabilityReport` (ranked rows + summary: `n_defensible`, confidence-tier mix, data-source mix).
- `to_markdown(report)` / `to_html(report)` — self-contained, dependency-light. Confidence rendered as a coloured **badge**, plus the `defensible` flag, limiting factors, and source per vessel.
- Honest provenance note in the header: public-sourced fleet; `estimated` = headline-only SWL; **not a substitute for vessel-specific lift engineering**.
- Demo CLI `examples/demos/installation/suitability_report.py` writes md + html.

## Example (`--lift-te 4000 --radius-m 40`)
**7 of 84** vessels defensible. Confidence mix: cited 30, estimated 53, brochure 1.

| # | Vessel | Score | Defensible | Confidence | SWL@R | Margin |
|--:|--------|------:|:--:|:--:|--:|--:|
| 1 | SAIPEM 7000 | 85 | ✓ | cited | 14000 | 3.50 |
| 4 | SLEIPNIR | 55 | ✓ | estimated | 10000 | 2.50 |

## Tests
6 new; full installation suite **191 passing**. Pre-linted with repo-pinned Black 25.9.0 / isort 5.13.2 / flake8 (Lint gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)