### PR TITLE
feat(spectral): rao-spectral-fatigue — fatigue from a stress RAO + wave spectrum (flywheel loop 3)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -176,6 +176,16 @@ workflows:
       - examples/workflows/spectral-fatigue-atlas-query/results/input_result.yml
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[spectral-fatigue-atlas-query]
     runtime: offline
+  - id: rao-spectral-fatigue
+    basename: rao_spectral_fatigue
+    title: Spectral fatigue from a stress RAO and a wave spectrum (S_stress=|H|^2 S_wave, DNV-RP-C203)
+    input: examples/workflows/rao-spectral-fatigue/input.yml
+    outputs:
+      - examples/workflows/rao-spectral-fatigue/results/input.yml
+      - examples/workflows/rao-spectral-fatigue/results/input_spectral_fatigue.csv
+      - examples/workflows/rao-spectral-fatigue/results/input_spectral_fatigue_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rao-spectral-fatigue]
+    runtime: offline
   - id: time-series
     basename: time_series
     title: FFT spectrum from a deterministic synthetic signal

--- a/examples/workflows/rao-spectral-fatigue/README.md
+++ b/examples/workflows/rao-spectral-fatigue/README.md
@@ -1,0 +1,15 @@
+# Spectral Fatigue from a Stress RAO
+
+Estimates frequency-domain fatigue damage and life of an offshore detail (riser, hull, joint) from a **stress transfer function (RAO)** `H(f)` and a **parametric wave spectrum**, rather than a precomputed stress PSD.
+
+The stress response PSD is formed by the standard linear transfer relation `S_stress(f) = |H(f)|² · S_wave(f)` (MPa²/Hz), where `S_wave(f)` is generated from `(Hs, Tp)` by the in-repo DNV-RP-C205 wave spectra (`jonswap` default, `pierson_moskowitz`, `bretschneider`) and `H(f)` is interpolated onto the spectral grid. The resulting stress PSD is handed to the tested `spectral_fatigue` damage chain (spectral moments → `dirlik` / `narrow_band` / `wirsching_light` / `benasciutti_tovo` → DNV-RP-C203 S-N → damage accumulated over sea states by `occurrence_fraction`).
+
+This generalises the fixed-gain screening already baked into the spectral-fatigue atlas (`parametric.generate` maps the wave spectrum to stress with a constant `stress_gain_MPa_per_m`); here the gain is the frequency-dependent RAO.
+
+Each location reports per-location fatigue life and the workflow reports a top-level `screening_status` (pass/fail vs design life × DFF) with the governing location. The example keeps a riser keel joint healthy and drives the splash-zone hot spot to a fatigue-governed failure.
+
+The stress RAOs in `input.yml` are **illustrative** — a real project supplies its own `H(f)` from a coupled hydrodynamic + structural model.
+
+Run with `uv run python -m digitalmodel examples/workflows/rao-spectral-fatigue/input.yml`.
+
+Reference: DNV-RP-C205 (wave spectra); DNV-RP-F204 / DNV-RP-C203 Sec. 4 (frequency-domain fatigue from a stress transfer function).

--- a/examples/workflows/rao-spectral-fatigue/input.yml
+++ b/examples/workflows/rao-spectral-fatigue/input.yml
@@ -1,0 +1,35 @@
+basename: rao_spectral_fatigue
+
+rao_spectral_fatigue:
+  design_life_years: 25.0
+  dff: 3.0
+  method: dirlik                 # dirlik | narrow_band | wirsching_light | benasciutti_tovo
+  sn_curve:                      # DNV-RP-C203 D-curve in air
+    slope: 3.0
+    log_intercept: 12.164
+  output_dir: results
+  locations:
+    # Illustrative stress transfer functions (RAOs). H(f) is the hot-spot stress
+    # range per metre of wave amplitude (MPa/m); a real project supplies its own
+    # from a hydrodynamic + structural model. Sea states are JONSWAP spectra
+    # weighted by long-term occurrence.
+    - id: riser-splash-zone
+      rao_frequency_Hz:      [0.04, 0.06, 0.08, 0.10, 0.12, 0.16, 0.24, 0.40]
+      rao_stress_MPa_per_m:  [1.2,  3.3,  7.4,  9.0,  6.7,  2.9,  0.8,  0.2]
+      sea_states:
+        - occurrence_fraction: 0.85
+          wave_spectrum: {type: jonswap, Hs: 2.5, Tp: 9.0, gamma: 3.3}
+        - occurrence_fraction: 0.15
+          wave_spectrum: {type: jonswap, Hs: 6.0, Tp: 12.0, gamma: 2.0}
+    - id: riser-keel-joint
+      rao_frequency_Hz:      [0.04, 0.06, 0.08, 0.10, 0.12, 0.16, 0.24, 0.40]
+      rao_stress_MPa_per_m:  [0.9,  2.2,  4.0,  4.9,  3.6,  1.6,  0.4,  0.1]
+      sea_states:
+        - occurrence_fraction: 1.0
+          wave_spectrum: {type: jonswap, Hs: 3.0, Tp: 10.0, gamma: 3.3}
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/rao_spectral_fatigue/rao_spectral_fatigue.yml
+++ b/src/digitalmodel/base_configs/modules/rao_spectral_fatigue/rao_spectral_fatigue.yml
@@ -1,0 +1,23 @@
+basename: rao_spectral_fatigue
+
+rao_spectral_fatigue:
+  design_life_years: 25.0
+  dff: 3.0
+  # Damage estimator: dirlik (default, wide-band) | narrow_band |
+  # wirsching_light | benasciutti_tovo. Reuses the spectral_fatigue damage chain.
+  method: dirlik
+  # S-N curve: slope m and log10 intercept a (N = a * S^-m). Default is the
+  # DNV-RP-C203 D-curve in air (m = 3.0, log10 a = 12.164).
+  sn_curve:
+    slope: 3.0
+    log_intercept: 12.164
+  output_dir: results
+  # Each location carries a stress RAO H(f) (MPa per m of wave amplitude) and a
+  # set of sea states, each a parametric wave spectrum weighted by occurrence.
+  locations: []
+
+default:
+  log_level: DEBUG
+  config:
+    overwrite:
+      output: True

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -216,6 +216,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         )
 
         cfg_base = spectral_fatigue(cfg_base)
+    elif basename == "rao_spectral_fatigue":
+        from digitalmodel.rao_spectral_fatigue.workflow import (
+            router as rao_spectral_fatigue,
+        )
+
+        cfg_base = rao_spectral_fatigue(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/rao_spectral_fatigue/__init__.py
+++ b/src/digitalmodel/rao_spectral_fatigue/__init__.py
@@ -1,0 +1,8 @@
+"""Frequency-domain fatigue from a stress RAO and a wave spectrum.
+
+Generalises the ``spectral_fatigue`` workflow's PSD input: instead of supplying
+a precomputed stress PSD, supply a stress transfer function (RAO) ``H(f)`` and a
+parametric wave spectrum (Hs, Tp). The stress response PSD is formed by the
+standard linear transfer relation ``S_stress(f) = |H(f)|**2 * S_wave(f)`` and
+handed to the tested ``digitalmodel.fatigue.spectral_fatigue`` damage chain.
+"""

--- a/src/digitalmodel/rao_spectral_fatigue/workflow.py
+++ b/src/digitalmodel/rao_spectral_fatigue/workflow.py
@@ -1,0 +1,181 @@
+"""Durable workflow: spectral fatigue from a stress RAO and a wave spectrum.
+
+The ``spectral_fatigue`` workflow takes a stress response PSD directly. In
+practice a project has a stress transfer function (RAO) ``H(f)`` -- stress per
+unit wave amplitude at a structural hot spot -- and a sea state described by a
+parametric wave spectrum, not the stress PSD itself. This workflow closes that
+gap with the standard linear (quasi-static / frequency-domain) transfer:
+
+    S_stress(f) = |H(f)|**2 * S_wave(f)          [MPa**2 / Hz]
+
+S_wave(f) is generated from (Hs, Tp) by the in-repo DNV-RP-C205 wave spectra
+(JONSWAP default; Pierson-Moskowitz / Bretschneider), H(f) is interpolated onto
+the spectral grid, and the resulting stress PSD is handed to the tested
+``spectral_fatigue`` damage chain (spectral moments -> Dirlik / narrow-band /
+Wirsching-Light / Benasciutti-Tovo -> DNV-RP-C203 S-N -> damage accumulated over
+sea states by occurrence). This generalises the fixed-gain screening already
+baked into the spectral-fatigue atlas (``parametric.generate`` uses a constant
+``stress_gain_MPa_per_m``; here the gain is the frequency-dependent RAO).
+
+Reference: DNV-RP-C205 (wave spectra), DNV-RP-F204 / DNV-RP-C203 Sec. 4
+(frequency-domain fatigue from a stress transfer function).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from digitalmodel.spectral_fatigue.workflow import router as spectral_fatigue_router
+
+_SPECTRA = {"jonswap", "pierson_moskowitz", "bretschneider"}
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("rao_spectral_fatigue") or {}
+    locations = _locations(settings)
+
+    # Build a spectral_fatigue-schema config: convert each (RAO, wave spectrum)
+    # into a stress PSD, then delegate to the tested damage chain.
+    sf_locations: list[dict[str, Any]] = []
+    for location in locations:
+        location_id = str(location.get("id", location.get("name", "location")))
+        rao_freq, rao_stress = _stress_rao(location, location_id)
+        sea_states_out: list[dict[str, Any]] = []
+        for sea_state in _sea_states(location, location_id):
+            occurrence = _occurrence(sea_state, location_id)
+            frequency_hz, stress_psd = _stress_psd_from_rao(
+                rao_freq,
+                rao_stress,
+                _wave_spectrum(sea_state, location_id),
+                location_id,
+            )
+            sea_states_out.append(
+                {
+                    "occurrence_fraction": occurrence,
+                    "frequency_Hz": frequency_hz,
+                    "stress_psd_MPa2_Hz": stress_psd,
+                }
+            )
+        sf_locations.append({"id": location_id, "sea_states": sea_states_out})
+
+    sf_settings = {
+        "design_life_years": settings.get("design_life_years"),
+        "dff": settings.get("dff"),
+        "method": settings.get("method", "dirlik"),
+        "sn_curve": settings.get("sn_curve"),
+        "output_dir": settings.get("output_dir", "results"),
+        "locations": sf_locations,
+    }
+
+    inner = dict(cfg)
+    inner["basename"] = "spectral_fatigue"
+    inner["spectral_fatigue"] = sf_settings
+    inner.pop("rao_spectral_fatigue", None)
+    inner = spectral_fatigue_router(inner)
+
+    result = dict(inner["spectral_fatigue"])
+    result["wave_to_stress_transfer"] = "S_stress(f) = |H(f)|**2 * S_wave(f)"
+    cfg["rao_spectral_fatigue"] = result
+    cfg["screening_status"] = inner["screening_status"]
+    return cfg
+
+
+def _stress_psd_from_rao(
+    rao_freq: list[float],
+    rao_stress: list[float],
+    wave_spectrum: dict[str, Any],
+    location_id: str,
+) -> tuple[list[float], list[float]]:
+    """S_stress(f) = |H(f)|**2 * S_wave(f), on the wave spectrum's frequency grid.
+
+    Mirrors ``parametric.generate._spectral_fatigue_annual_damage`` exactly, with
+    the constant ``stress_gain_MPa_per_m`` replaced by the interpolated RAO H(f).
+    """
+    import numpy as np
+
+    from digitalmodel.hydrodynamics.wave_spectra import WaveSpectra
+
+    kind = str(wave_spectrum.get("type", "jonswap")).strip().lower()
+    if kind not in _SPECTRA:
+        raise ValueError(
+            f"{location_id} wave_spectrum.type must be one of {sorted(_SPECTRA)}; got {kind!r}"
+        )
+    hs = _positive(wave_spectrum, "Hs", f"{location_id} wave_spectrum.Hs")
+    tp = _positive(wave_spectrum, "Tp", f"{location_id} wave_spectrum.Tp")
+
+    spectra = WaveSpectra()
+    if kind == "jonswap":
+        gamma = float(wave_spectrum.get("gamma", 3.3))
+        omega, s_omega = spectra.jonswap(hs=hs, tp=tp, gamma=gamma)
+    elif kind == "pierson_moskowitz":
+        omega, s_omega = spectra.pierson_moskowitz(hs=hs, tp=tp)
+    else:
+        omega, s_omega = spectra.bretschneider(hs=hs, tp=tp)
+
+    f_hz = omega / (2.0 * np.pi)  # rad/s -> Hz
+    s_wave_hz = s_omega * 2.0 * np.pi  # m^2*s (per rad/s) -> m^2/Hz
+
+    rao_interp = np.interp(f_hz, rao_freq, rao_stress)  # MPa/m, clamped to RAO ends
+    stress_psd = (rao_interp**2) * s_wave_hz  # MPa^2/Hz
+    return f_hz.tolist(), stress_psd.tolist()
+
+
+def _stress_rao(
+    location: dict[str, Any], location_id: str
+) -> tuple[list[float], list[float]]:
+    freq = location.get("rao_frequency_Hz")
+    stress = location.get("rao_stress_MPa_per_m")
+    if not isinstance(freq, list) or not isinstance(stress, list):
+        raise ValueError(
+            f"{location_id} needs list rao_frequency_Hz and rao_stress_MPa_per_m"
+        )
+    if len(freq) != len(stress) or len(freq) < 2:
+        raise ValueError(
+            f"{location_id} rao_frequency_Hz and rao_stress_MPa_per_m must be equal-length (>=2)"
+        )
+    freq = [float(v) for v in freq]
+    stress = [float(v) for v in stress]
+    if any(b <= a for a, b in zip(freq, freq[1:])):
+        raise ValueError(f"{location_id} rao_frequency_Hz must be strictly increasing")
+    if any(v < 0.0 for v in stress):
+        raise ValueError(f"{location_id} rao_stress_MPa_per_m must be non-negative")
+    return freq, stress
+
+
+def _locations(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    locations = settings.get("locations")
+    if not isinstance(locations, list) or not locations:
+        raise ValueError("rao_spectral_fatigue locations must be a non-empty list")
+    return locations
+
+
+def _sea_states(location: dict[str, Any], location_id: str) -> list[dict[str, Any]]:
+    sea_states = location.get("sea_states")
+    if not isinstance(sea_states, list) or not sea_states:
+        raise ValueError(f"{location_id} sea_states must be a non-empty list")
+    return sea_states
+
+
+def _wave_spectrum(sea_state: dict[str, Any], location_id: str) -> dict[str, Any]:
+    wave_spectrum = sea_state.get("wave_spectrum")
+    if not isinstance(wave_spectrum, dict):
+        raise ValueError(f"{location_id} sea_state needs a wave_spectrum mapping")
+    return wave_spectrum
+
+
+def _occurrence(sea_state: dict[str, Any], location_id: str) -> float:
+    value = float(sea_state.get("occurrence_fraction", 1.0))
+    if value <= 0.0:
+        raise ValueError(f"{location_id} occurrence_fraction must be positive")
+    return value
+
+
+def _positive(source: dict[str, Any], name: str, label: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"{label} is required")
+    value = float(value)
+    if value <= 0.0 or math.isnan(value):
+        raise ValueError(f"{label} must be positive")
+    return value

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -11,7 +11,6 @@ from tests.workflows.field_dev_production_assertions import (
     assert_field_dev_production_workflow,
 )
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_PATH = REPO_ROOT / "docs" / "registry" / "workflows.yaml"
 
@@ -84,9 +83,7 @@ def test_workflow_registry(workflow, monkeypatch):
         expected_mass = demand["total_charge_Ah"] / (
             anodes["anode_capacity_Ah_kg"] * anodes["utilization_factor"]
         )
-        assert anodes["total_anode_mass_kg"] == pytest.approx(
-            expected_mass, abs=1.0e-3
-        )
+        assert anodes["total_anode_mass_kg"] == pytest.approx(expected_mass, abs=1.0e-3)
         assert anodes["anode_count"] == math.ceil(
             anodes["total_anode_mass_kg"]
             * anodes["contingency_factor"]
@@ -156,7 +153,9 @@ def test_workflow_registry(workflow, monkeypatch):
         assert summary["screening_status"] in {"pass", "fail"}
         assert summary["screening_status"] == "pass"
         assert summary["governing_phase"] == "splash_zone"
-        assert summary["max_utilisation"] == pytest.approx(cases["max_utilisation"].max())
+        assert summary["max_utilisation"] == pytest.approx(
+            cases["max_utilisation"].max()
+        )
         assert len(cases) == 3
         assert cases["hs_m"].tolist() == [1.0, 2.0, 3.0]
         assert cases["max_utilisation"].is_monotonic_increasing
@@ -188,12 +187,14 @@ def test_workflow_registry(workflow, monkeypatch):
         assert set(line_summary["line_id"]) == {"chain-01", "wire-01"}
         assert (results["stress_range_MPa"] > 0.0).all()
         assert (results["damage"] > 0.0).all()
-        assert (
-            results.sort_values("stress_range_MPa")["allowable_cycles"]
-            .is_monotonic_decreasing
-        )
-    elif workflow["id"] in {"mooring-fatigue-atlas-query", "synthetic-rope-atlas-query",
-                            "spectral-fatigue-atlas-query"}:
+        assert results.sort_values("stress_range_MPa")[
+            "allowable_cycles"
+        ].is_monotonic_decreasing
+    elif workflow["id"] in {
+        "mooring-fatigue-atlas-query",
+        "synthetic-rope-atlas-query",
+        "spectral-fatigue-atlas-query",
+    }:
         result = cfg["parametric_query"]["result"]
         # in-range query returns an interpolated screening estimate, not a verdict
         assert result["in_range"] is True
@@ -300,10 +301,9 @@ def test_workflow_registry(workflow, monkeypatch):
         # per-line: the mean-load knockdown makes a_eff line-specific, so the
         # T-N curve is only monotonic within a single line, not across lines.
         for _, group in results.groupby("line_id"):
-            assert (
-                group.sort_values("normalised_range")["allowable_cycles"]
-                .is_monotonic_decreasing
-            )
+            assert group.sort_values("normalised_range")[
+                "allowable_cycles"
+            ].is_monotonic_decreasing
     elif workflow["id"] == "spectral-fatigue":
         summary = cfg["spectral_fatigue"]
         results_path = Path(summary["results_csv"])
@@ -316,7 +316,7 @@ def test_workflow_registry(workflow, monkeypatch):
         location_summary = pd.read_csv(summary_path)
 
         assert cfg["screening_status"] == summary["screening_status"]
-        assert summary["screening_status"] == "fail"            # splash zone fails
+        assert summary["screening_status"] == "fail"  # splash zone fails
         assert summary["method"] == "dirlik"
         assert summary["governing_location"] == "riser-splash-zone"
         assert set(location_summary["location_id"]) == {
@@ -328,7 +328,9 @@ def test_workflow_registry(workflow, monkeypatch):
         assert bool(by_loc["riser-keel-joint"]["passes"]) is True
         # life = 1 / accumulated annual damage; governing = smallest margin
         for _, row in location_summary.iterrows():
-            assert row["fatigue_life_years"] == pytest.approx(1.0 / row["annual_damage"])
+            assert row["fatigue_life_years"] == pytest.approx(
+                1.0 / row["annual_damage"]
+            )
         assert summary["governing_margin"] == pytest.approx(
             location_summary["margin"].min()
         )
@@ -340,6 +342,35 @@ def test_workflow_registry(workflow, monkeypatch):
             assert row["damage_per_year_weighted"] == pytest.approx(
                 row["damage_per_year_full"] * row["occurrence_fraction"]
             )
+    elif workflow["id"] == "rao-spectral-fatigue":
+        summary = cfg["rao_spectral_fatigue"]
+        # the RAO -> stress-PSD transfer is recorded on the result
+        assert (
+            summary["wave_to_stress_transfer"] == "S_stress(f) = |H(f)|**2 * S_wave(f)"
+        )
+        summary_path = Path(summary["summary_csv"])
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+        location_summary = pd.read_csv(summary_path)
+
+        assert cfg["screening_status"] == summary["screening_status"]
+        assert summary["screening_status"] == "fail"  # splash zone fails
+        assert summary["method"] == "dirlik"
+        assert summary["governing_location"] == "riser-splash-zone"
+        assert set(location_summary["location_id"]) == {
+            "riser-splash-zone",
+            "riser-keel-joint",
+        }
+        by_loc = {row["location_id"]: row for _, row in location_summary.iterrows()}
+        assert bool(by_loc["riser-splash-zone"]["passes"]) is False
+        assert bool(by_loc["riser-keel-joint"]["passes"]) is True
+        for _, row in location_summary.iterrows():
+            assert row["fatigue_life_years"] == pytest.approx(
+                1.0 / row["annual_damage"]
+            )
+        assert summary["governing_margin"] == pytest.approx(
+            location_summary["margin"].min()
+        )
     elif workflow["id"] == "time-series":
         fft_path = Path(cfg["time_series"]["csv"]["signal_fft"])
         fft = pd.read_csv(fft_path)
@@ -1284,7 +1315,7 @@ def test_synthetic_rope_tn_curve_matches_dnv_os_e301_table_f3(tmp_path):
         assert row["allowable_cycles"] == pytest.approx(expected_n, rel=1e-9)
     # Published anchor: R = 0.10 -> N = 0.259 * 10^13.46
     anchor = results.loc[results["normalised_range"].round(6) == 0.10].iloc[0]
-    assert anchor["allowable_cycles"] == pytest.approx(a_d * 10 ** 13.46, rel=1e-9)
+    assert anchor["allowable_cycles"] == pytest.approx(a_d * 10**13.46, rel=1e-9)
 
 
 def test_spectral_fatigue_workflow_matches_narrow_band_closed_form(tmp_path):
@@ -1344,3 +1375,73 @@ def test_spectral_fatigue_workflow_matches_narrow_band_closed_form(tmp_path):
     location = cfg["spectral_fatigue"]["locations"][0]
     assert location["annual_damage"] == pytest.approx(expected, rel=1e-9)
     assert location["fatigue_life_years"] == pytest.approx(1.0 / expected, rel=1e-9)
+
+
+def test_rao_spectral_fatigue_constant_rao_matches_fixed_gain_screening(tmp_path):
+    """AC6 validation gate for rao-spectral-fatigue: a *constant* stress RAO
+    H(f) = g must reduce the RAO transfer S_stress(f) = |H(f)|^2 * S_wave(f) to
+    the validated fixed-gain atlas screening model
+    parametric.generate._spectral_fatigue_annual_damage (constant
+    stress_gain_MPa_per_m). The generalisation must agree exactly with the
+    special case it generalises."""
+    from digitalmodel.parametric.generate import _spectral_fatigue_annual_damage
+
+    gain = 18.0  # MPa per m of wave amplitude (constant RAO)
+    hs, tp, gamma = 3.5, 10.0, 3.3
+    sn_slope, sn_log_intercept = 3.0, 12.164
+
+    input_path = tmp_path / "rao_spectral.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "rao_spectral_fatigue",
+                "rao_spectral_fatigue": {
+                    "design_life_years": 25.0,
+                    "dff": 3.0,
+                    "method": "dirlik",
+                    "sn_curve": {"slope": sn_slope, "log_intercept": sn_log_intercept},
+                    "output_dir": "results",
+                    "locations": [
+                        {
+                            "id": "detail-a",
+                            # constant RAO -> H(f) = gain everywhere
+                            "rao_frequency_Hz": [0.0, 0.1, 0.2, 0.4],
+                            "rao_stress_MPa_per_m": [gain, gain, gain, gain],
+                            "sea_states": [
+                                {
+                                    "occurrence_fraction": 1.0,
+                                    "wave_spectrum": {
+                                        "type": "jonswap",
+                                        "Hs": hs,
+                                        "Tp": tp,
+                                        "gamma": gamma,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    cfg = engine(inputfile=str(input_path))
+
+    expected = _spectral_fatigue_annual_damage(
+        {"Hs": hs, "Tp": tp},
+        gamma=gamma,
+        stress_gain_MPa_per_m=gain,
+        sn_slope=sn_slope,
+        sn_intercept=sn_log_intercept,
+    )
+
+    location = cfg["rao_spectral_fatigue"]["locations"][0]
+    assert location["annual_damage"] == pytest.approx(expected, rel=1e-9)
+    assert location["fatigue_life_years"] == pytest.approx(1.0 / expected, rel=1e-9)
+    assert cfg["rao_spectral_fatigue"]["wave_to_stress_transfer"] == (
+        "S_stress(f) = |H(f)|**2 * S_wave(f)"
+    )


### PR DESCRIPTION
Closes #904. Flywheel loop 3.

Generalises `spectral_fatigue`: accept a stress RAO H(f) + parametric wave spectrum and form the stress response PSD via `S_stress(f)=|H(f)|^2*S_wave(f)`, then delegate to the tested spectral_fatigue damage chain.

- new registry workflow `rao-spectral-fatigue` (basename `rao_spectral_fatigue`)
- reuses `hydrodynamics.wave_spectra.WaveSpectra` (DNV-RP-C205) + `fatigue.spectral_fatigue` (DNV-RP-C203)
- AC6 validation `test_rao_spectral_fatigue_constant_rao_matches_fixed_gain_screening`: constant RAO reduces exactly to the validated fixed-gain atlas model
- example: splash-zone fails (30.8 yr) / keel passes (193.8 yr)

Verified: `uv run python -m digitalmodel examples/workflows/rao-spectral-fatigue/input.yml` EXIT0; durable suite 95 passed/1 skipped; ruff/black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)