### PR TITLE
feat(seakeeping): vessel-seakeeping — operability from motion RAOs + a sea state (flywheel loop 4)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -186,6 +186,16 @@ workflows:
       - examples/workflows/rao-spectral-fatigue/results/input_spectral_fatigue_summary.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rao-spectral-fatigue]
     runtime: offline
+  - id: vessel-seakeeping
+    basename: vessel_seakeeping
+    title: Vessel seakeeping operability from motion RAOs and a sea state (S_response=|RAO|^2 S_wave)
+    input: examples/workflows/vessel-seakeeping/input.yml
+    outputs:
+      - examples/workflows/vessel-seakeeping/results/input.yml
+      - examples/workflows/vessel-seakeeping/results/input_vessel_seakeeping.csv
+      - examples/workflows/vessel-seakeeping/results/input_vessel_seakeeping_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[vessel-seakeeping]
+    runtime: offline
   - id: time-series
     basename: time_series
     title: FFT spectrum from a deterministic synthetic signal

--- a/examples/workflows/vessel-seakeeping/README.md
+++ b/examples/workflows/vessel-seakeeping/README.md
@@ -1,0 +1,13 @@
+# Vessel Seakeeping Operability
+
+Screens a vessel's seakeeping operability from its **motion RAOs** and a **sea state scatter**, without a time-domain simulation.
+
+For each degree of freedom (heave, roll, pitch, ...), the motion response spectrum is formed from the DOF's motion RAO and a parametric wave spectrum (`jonswap` default, `pm`, `bretschneider`) by the standard linear transfer `S_response(ω) = |RAO(ω)|² · S_wave(ω)`. The significant motion amplitude `s₁/₃ = 2·√m0` is compared against the DOF's operability criterion across the sea-state scatter, weighted by occurrence probability, giving a per-DOF **operability percentage**. The vessel reports a top-level `screening_status` (pass/fail): it passes only if every DOF meets its `required_operability_pct`, with the governing (lowest-operability) DOF named.
+
+This wraps the tested `digitalmodel.hydrodynamics.seakeeping` engine (`operability_analysis`, `compute_response_spectrum`, `spectral_moments`, `significant_amplitude`) rather than reimplementing it.
+
+The motion RAOs and criteria in `input.yml` are **illustrative** — a real project supplies its own RAOs from a diffraction model. The example keeps heave and pitch operable and drives a roll resonance to fail operability.
+
+Run with `uv run python -m digitalmodel examples/workflows/vessel-seakeeping/input.yml`.
+
+Reference: PNA Vol III (Motions in Waves); DNV-RP-C205 (wave spectra).

--- a/examples/workflows/vessel-seakeeping/input.yml
+++ b/examples/workflows/vessel-seakeeping/input.yml
@@ -1,0 +1,35 @@
+basename: vessel_seakeeping
+
+vessel_seakeeping:
+  vessel: FPSO (illustrative)
+  spectrum_type: jonswap
+  gamma: 3.3
+  required_operability_pct: 95.0
+  output_dir: results
+  # Shared RAO frequency grid (rad/s). Motion RAOs and criteria below are
+  # illustrative; a real project supplies its own from a diffraction model.
+  rao_frequency_rad_s: [0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.00, 1.10, 1.20]
+  sea_states:
+    - {hs: 1.5, tp: 8.0,  probability: 0.40}
+    - {hs: 2.5, tp: 10.0, probability: 0.40}
+    - {hs: 4.0, tp: 12.0, probability: 0.20}
+  dofs:
+    - name: heave
+      unit: m
+      rao_amplitude: [1.00, 1.00, 0.95, 0.85, 0.60, 0.35, 0.20, 0.10, 0.05, 0.02]
+      criterion: 2.5            # max significant heave amplitude (m)
+    - name: roll
+      unit: deg
+      # resonant peak near 0.5 rad/s (roll natural period ~ 12.6 s)
+      rao_amplitude: [2.0, 5.0, 9.0, 6.0, 3.0, 1.5, 0.8, 0.4, 0.2, 0.1]
+      criterion: 4.0            # max significant roll amplitude (deg)
+    - name: pitch
+      unit: deg
+      rao_amplitude: [0.5, 1.0, 1.5, 1.75, 1.5, 1.0, 0.5, 0.25, 0.15, 0.05]
+      criterion: 3.0            # max significant pitch amplitude (deg)
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/vessel_seakeeping/vessel_seakeeping.yml
+++ b/src/digitalmodel/base_configs/modules/vessel_seakeeping/vessel_seakeeping.yml
@@ -1,0 +1,19 @@
+basename: vessel_seakeeping
+
+vessel_seakeeping:
+  vessel: vessel
+  spectrum_type: jonswap          # jonswap | pm | bretschneider
+  gamma: 3.3                      # JONSWAP peakedness
+  required_operability_pct: 95.0  # a DOF passes if its operable-weighted % >= this
+  output_dir: results
+  # Shared RAO frequency grid (rad/s); each DOF supplies its motion RAO amplitude
+  # on this grid plus an operability criterion (max allowable significant amplitude).
+  rao_frequency_rad_s: []
+  sea_states: []                  # scatter: list of {hs, tp, probability}
+  dofs: []                        # list of {name, rao_amplitude, criterion, unit}
+
+default:
+  log_level: DEBUG
+  config:
+    overwrite:
+      output: True

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -222,6 +222,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         )
 
         cfg_base = rao_spectral_fatigue(cfg_base)
+    elif basename == "vessel_seakeeping":
+        from digitalmodel.vessel_seakeeping.workflow import (
+            router as vessel_seakeeping,
+        )
+
+        cfg_base = vessel_seakeeping(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/vessel_seakeeping/__init__.py
+++ b/src/digitalmodel/vessel_seakeeping/__init__.py
@@ -1,0 +1,8 @@
+"""Vessel seakeeping operability screening from motion RAOs and a sea state.
+
+Wraps the tested ``digitalmodel.hydrodynamics.seakeeping`` frequency-domain
+engine (RAO x wave spectrum -> response spectrum -> significant motion
+amplitude) into a registry workflow: per degree of freedom, the significant
+motion amplitude is compared against an operability criterion across a sea-state
+scatter, yielding a per-DOF operability percentage and a top-level pass/fail.
+"""

--- a/src/digitalmodel/vessel_seakeeping/workflow.py
+++ b/src/digitalmodel/vessel_seakeeping/workflow.py
@@ -1,0 +1,239 @@
+"""Durable workflow: vessel seakeeping operability from motion RAOs + a sea state.
+
+For each degree of freedom (heave, roll, pitch, ...) the motion response
+spectrum is formed from the DOF's motion RAO and a parametric wave spectrum
+(JONSWAP / Pierson-Moskowitz / Bretschneider) via the standard linear transfer
+``S_response(w) = |RAO(w)|^2 * S_wave(w)``; the significant motion amplitude
+``s_1/3 = 2*sqrt(m0)`` is compared against an operability criterion across the
+sea-state scatter, weighted by occurrence. Each DOF gets an operability
+percentage; the vessel passes when every DOF meets its required operability.
+
+This wires the tested ``digitalmodel.hydrodynamics.seakeeping`` engine
+(``operability_analysis``, ``compute_response_spectrum``, ``spectral_moments``,
+``significant_amplitude``) into a durable workflow rather than reimplementing
+it. Reference: PNA Vol III (Motions in Waves); DNV-RP-C205 (wave spectra).
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SPECTRA = {"jonswap", "pm", "bretschneider"}
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("vessel_seakeeping") or {}
+    vessel = str(settings.get("vessel", "vessel"))
+    spectrum_type = _spectrum_type(settings)
+    gamma = float(settings.get("gamma", 3.3))
+    required_operability = _positive(
+        settings,
+        "required_operability_pct",
+        "vessel_seakeeping.required_operability_pct",
+    )
+    rao_freqs = _rao_frequencies(settings)
+    scatter = _scatter(settings)
+
+    from digitalmodel.hydrodynamics.seakeeping import operability_analysis
+
+    rows: list[dict[str, Any]] = []
+    summaries: list[dict[str, Any]] = []
+    for dof in _dofs(settings, len(rao_freqs)):
+        name = dof["name"]
+        criterion = dof["criterion"]
+        result = operability_analysis(
+            rao_freqs,
+            dof["rao_amplitude"],
+            scatter,
+            {name: criterion},
+            spectrum_type=spectrum_type,
+            gamma=gamma,
+        )
+        operability_pct = result["operability_pct"]
+        for sea_state in result["sea_state_results"]:
+            rows.append(
+                {
+                    "dof": name,
+                    "unit": dof["unit"],
+                    "hs": sea_state["hs"],
+                    "tp": sea_state["tp"],
+                    "probability": sea_state["probability"],
+                    "significant_amplitude": sea_state["significant_amplitude"],
+                    "criterion": criterion,
+                    "operable": sea_state["operable"],
+                }
+            )
+        summaries.append(
+            {
+                "dof": name,
+                "unit": dof["unit"],
+                "criterion": criterion,
+                "operability_pct": operability_pct,
+                "required_operability_pct": required_operability,
+                "passes": operability_pct >= required_operability,
+            }
+        )
+
+    governing = min(summaries, key=lambda item: item["operability_pct"])
+    csv_path = _results_csv_path(cfg, settings)
+    summary_path = _summary_csv_path(cfg, settings)
+    _write_csv(csv_path, rows)
+    _write_csv(summary_path, summaries)
+
+    cfg["vessel_seakeeping"] = {
+        "vessel": vessel,
+        "spectrum_type": spectrum_type,
+        "required_operability_pct": required_operability,
+        "governing_dof": governing["dof"],
+        "governing_operability_pct": governing["operability_pct"],
+        "response_transfer": "S_response(w) = |RAO(w)|^2 * S_wave(w)",
+        # Top-level pass/fail: the vessel is operable only if every DOF meets
+        # its required operability. Drives the deckhand report mitigation section.
+        "screening_status": "pass" if all(s["passes"] for s in summaries) else "fail",
+        "dofs": summaries,
+        "results_csv": _display_path(csv_path),
+        "summary_csv": _display_path(summary_path),
+    }
+    cfg["screening_status"] = cfg["vessel_seakeeping"]["screening_status"]
+    return cfg
+
+
+def _spectrum_type(settings: dict[str, Any]) -> str:
+    kind = str(settings.get("spectrum_type", "jonswap")).strip().lower()
+    if kind not in _SPECTRA:
+        raise ValueError(
+            f"vessel_seakeeping spectrum_type must be one of {sorted(_SPECTRA)}; got {kind!r}"
+        )
+    return kind
+
+
+def _rao_frequencies(settings: dict[str, Any]) -> Any:
+    import numpy as np
+
+    freqs = settings.get("rao_frequency_rad_s")
+    if not isinstance(freqs, list) or len(freqs) < 2:
+        raise ValueError(
+            "vessel_seakeeping rao_frequency_rad_s must be a list of >=2 values"
+        )
+    values = [float(v) for v in freqs]
+    if any(b <= a for a, b in zip(values, values[1:])):
+        raise ValueError(
+            "vessel_seakeeping rao_frequency_rad_s must be strictly increasing"
+        )
+    if values[0] <= 0.0:
+        raise ValueError("vessel_seakeeping rao_frequency_rad_s must be positive")
+    return np.asarray(values, dtype=float)
+
+
+def _scatter(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    sea_states = settings.get("sea_states")
+    if not isinstance(sea_states, list) or not sea_states:
+        raise ValueError("vessel_seakeeping sea_states must be a non-empty list")
+    scatter = []
+    for entry in sea_states:
+        hs = _positive(entry, "hs", "sea_state.hs")
+        tp = _positive(entry, "tp", "sea_state.tp")
+        prob = float(entry.get("probability", 1.0))
+        if prob < 0.0:
+            raise ValueError("sea_state.probability must be non-negative")
+        scatter.append({"hs": hs, "tp": tp, "probability": prob})
+    if sum(e["probability"] for e in scatter) <= 0.0:
+        raise ValueError(
+            "vessel_seakeeping sea_state probabilities must sum to a positive value"
+        )
+    return scatter
+
+
+def _dofs(settings: dict[str, Any], n_freqs: int) -> list[dict[str, Any]]:
+    import numpy as np
+
+    dofs = settings.get("dofs")
+    if not isinstance(dofs, list) or not dofs:
+        raise ValueError("vessel_seakeeping dofs must be a non-empty list")
+    parsed = []
+    for dof in dofs:
+        name = str(dof.get("name", "")).strip()
+        if not name:
+            raise ValueError("each vessel_seakeeping dof needs a name")
+        amplitude = dof.get("rao_amplitude")
+        if not isinstance(amplitude, list) or len(amplitude) != n_freqs:
+            raise ValueError(
+                f"dof {name!r} rao_amplitude must be a list matching rao_frequency_rad_s "
+                f"(length {n_freqs})"
+            )
+        if any(float(v) < 0.0 for v in amplitude):
+            raise ValueError(f"dof {name!r} rao_amplitude must be non-negative")
+        criterion = _positive(dof, "criterion", f"dof {name!r} criterion")
+        parsed.append(
+            {
+                "name": name,
+                "rao_amplitude": np.asarray([float(v) for v in amplitude], dtype=float),
+                "criterion": criterion,
+                "unit": str(dof.get("unit", "")),
+            }
+        )
+    return parsed
+
+
+def _positive(source: dict[str, Any], name: str, label: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"{label} is required")
+    value = float(value)
+    if value <= 0.0 or math.isnan(value):
+        raise ValueError(f"{label} must be positive")
+    return value
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return _output_dir(cfg, settings) / f"{_input_stem(cfg)}_vessel_seakeeping.csv"
+
+
+def _summary_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return (
+        _output_dir(cfg, settings) / f"{_input_stem(cfg)}_vessel_seakeeping_summary.csv"
+    )
+
+
+def _output_dir(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "vessel_seakeeping"))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("vessel_seakeeping cannot write empty results")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -371,6 +371,29 @@ def test_workflow_registry(workflow, monkeypatch):
         assert summary["governing_margin"] == pytest.approx(
             location_summary["margin"].min()
         )
+    elif workflow["id"] == "vessel-seakeeping":
+        summary = cfg["vessel_seakeeping"]
+        assert summary["response_transfer"] == "S_response(w) = |RAO(w)|^2 * S_wave(w)"
+        summary_path = Path(summary["summary_csv"])
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+        dof_summary = pd.read_csv(summary_path)
+
+        assert cfg["screening_status"] == summary["screening_status"]
+        assert summary["screening_status"] == "fail"  # roll resonance fails operability
+        assert summary["governing_dof"] == "roll"
+        assert set(dof_summary["dof"]) == {"heave", "roll", "pitch"}
+        by_dof = {row["dof"]: row for _, row in dof_summary.iterrows()}
+        assert bool(by_dof["heave"]["passes"]) is True
+        assert bool(by_dof["pitch"]["passes"]) is True
+        assert bool(by_dof["roll"]["passes"]) is False
+        # governing DOF carries the lowest operability percentage
+        assert summary["governing_operability_pct"] == pytest.approx(
+            dof_summary["operability_pct"].min()
+        )
+        # operability percentage is bounded [0, 100]
+        for _, row in dof_summary.iterrows():
+            assert 0.0 <= row["operability_pct"] <= 100.0
     elif workflow["id"] == "time-series":
         fft_path = Path(cfg["time_series"]["csv"]["signal_fft"])
         fft = pd.read_csv(fft_path)
@@ -1444,4 +1467,81 @@ def test_rao_spectral_fatigue_constant_rao_matches_fixed_gain_screening(tmp_path
     assert location["fatigue_life_years"] == pytest.approx(1.0 / expected, rel=1e-9)
     assert cfg["rao_spectral_fatigue"]["wave_to_stress_transfer"] == (
         "S_stress(f) = |H(f)|**2 * S_wave(f)"
+    )
+
+
+def test_vessel_seakeeping_significant_amplitude_matches_library(tmp_path):
+    """AC6 validation gate for vessel-seakeeping: the workflow's per-sea-state
+    significant motion amplitude must equal an independent computation through
+    the validated digitalmodel.hydrodynamics.seakeeping primitives
+    (compute_response_spectrum -> spectral_moments -> significant_amplitude) on
+    the same RAO and JONSWAP spectrum -- i.e. the workflow faithfully wires the
+    tested library, not a re-implementation."""
+    import numpy as np
+
+    from digitalmodel.hydrodynamics.seakeeping import (
+        compute_response_spectrum,
+        significant_amplitude,
+        spectral_moments,
+    )
+    from digitalmodel.hydrodynamics.wave_spectra import WaveSpectra
+
+    freqs = [0.3, 0.5, 0.7, 0.9, 1.1]
+    rao = [1.0, 0.8, 0.5, 0.25, 0.1]
+    hs, tp, gamma = 3.0, 11.0, 3.3
+
+    input_path = tmp_path / "vessel_seakeeping.yml"
+    input_path.write_text(
+        yaml.safe_dump(
+            {
+                "basename": "vessel_seakeeping",
+                "vessel_seakeeping": {
+                    "vessel": "unit-test",
+                    "spectrum_type": "jonswap",
+                    "gamma": gamma,
+                    "required_operability_pct": 95.0,
+                    "output_dir": "results",
+                    "rao_frequency_rad_s": freqs,
+                    "sea_states": [{"hs": hs, "tp": tp, "probability": 1.0}],
+                    "dofs": [
+                        {
+                            "name": "heave",
+                            "unit": "m",
+                            "rao_amplitude": rao,
+                            "criterion": 2.0,
+                        }
+                    ],
+                },
+                "default": {
+                    "log_level": "INFO",
+                    "config": {"overwrite": {"output": True}},
+                },
+            }
+        )
+    )
+
+    cfg = engine(inputfile=str(input_path))
+
+    # independent recomputation through the library primitives
+    rao_freqs = np.asarray(freqs, dtype=float)
+    omega, s_wave = WaveSpectra().jonswap(
+        hs=hs,
+        tp=tp,
+        gamma=gamma,
+        freq_min=float(rao_freqs[0]),
+        freq_max=float(rao_freqs[-1]),
+        n_points=len(rao_freqs),
+    )
+    s_resp = compute_response_spectrum(np.asarray(rao, dtype=float), s_wave)
+    m0 = spectral_moments(omega, s_resp, orders=[0])[0]
+    expected_sig = significant_amplitude(m0)
+
+    results_path = Path(cfg["vessel_seakeeping"]["results_csv"])
+    if not results_path.is_absolute():
+        results_path = REPO_ROOT / results_path
+    results = pd.read_csv(results_path)
+    heave_row = results[results["dof"] == "heave"].iloc[0]
+    assert heave_row["significant_amplitude"] == pytest.approx(expected_sig, rel=1e-9)
+    assert cfg["vessel_seakeeping"]["response_transfer"] == (
+        "S_response(w) = |RAO(w)|^2 * S_wave(w)"
     )


### PR DESCRIPTION
Closes #906. Flywheel loop 4.

New registry workflow `vessel-seakeeping`: per DOF, form `S_response(w)=|RAO(w)|^2*S_wave(w)`, take `2*sqrt(m0)`, and compute per-DOF operability % across a sea-state scatter; vessel passes only if every DOF meets required operability.

- wraps the tested `hydrodynamics.seakeeping` engine (operability_analysis, compute_response_spectrum, spectral_moments, significant_amplitude) — no reimplementation
- AC6 validation `test_vessel_seakeeping_significant_amplitude_matches_library`: workflow significant amplitude matches an independent library recomputation
- example: heave/pitch operable, roll resonance fails -> screening_status fail (governing roll)

Verified: `uv run python -m digitalmodel examples/workflows/vessel-seakeeping/input.yml` EXIT0; durable suite 97 passed/2 skipped; ruff/black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)