### PR TITLE
feat(installation): lifting-lug-design — padeye strength screening (flywheel loop 6)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -931,3 +931,12 @@ workflows:
       - examples/workflows/rigging/results/rigging/rigging_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[rigging]
     runtime: offline
+  - id: lifting-lug-design
+    basename: lifting_lug
+    title: Lifting lug / padeye strength screening (bearing, net tension, shear tear-out; AISC / DNV-ST-0378)
+    input: examples/workflows/lifting-lug-design/input.yml
+    outputs:
+      - examples/workflows/lifting-lug-design/results/input.yml
+      - examples/workflows/lifting-lug-design/results/lifting_lug/lifting_lug_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[lifting-lug-design]
+    runtime: offline

--- a/examples/workflows/lifting-lug-design/README.md
+++ b/examples/workflows/lifting-lug-design/README.md
@@ -1,0 +1,15 @@
+# Lifting Lug / Padeye Strength Screening
+
+Screens a circular **padeye (lifting lug)** under a sling load against three governing failure modes, using AISC allowable-stress design:
+
+- **Pin-hole bearing**: `σ_b = P / (d_pin · t)` ≤ `0.90·Fy`
+- **Net-section tension** (two ligaments beside the hole): `σ_t = P / (2·t·(R − r))` ≤ `0.60·Fy`
+- **Shear tear-out** to the loaded edge: `τ = P / (2·t·(R − r))` ≤ `0.40·Fy`
+
+where `t` = main-plate thickness + 2·cheek-plate thickness (total thickness at the hole), `R` = padeye outer radius (hole centre to loaded edge), `r` = hole radius, and `P = static_load · DAF · skew_factor` is the factored sling load.
+
+The workflow reports each check's demand, allowable, and utilisation, names the governing check, and emits a top-level `screening_status` (pass/fail). The example drives an S355 padeye to a shear-tear-out-governed failure (utilisation ≈ 1.16) with the bearing check near its limit.
+
+Run with `uv run python -m digitalmodel examples/workflows/lifting-lug-design/input.yml`.
+
+Reference: AISC ASD allowable stresses (0.60/0.40/0.90·Fy); DNV-ST-0378 / DNV 2.7-3 (offshore lifting appliances — padeye design).

--- a/examples/workflows/lifting-lug-design/input.yml
+++ b/examples/workflows/lifting-lug-design/input.yml
@@ -1,0 +1,29 @@
+basename: lifting_lug
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+lifting_lug:
+  case:
+    id: registry_lifting_lug
+    description: AISC / DNV-ST-0378 padeye strength screening for an offshore lift
+  lug:
+    plate_thickness_mm: 40.0
+    cheek_plate_thickness_mm: 0.0      # per side; 0 = no cheek plates
+    pin_diameter_mm: 75.0
+    hole_diameter_mm: 80.0
+    outer_radius_mm: 110.0             # hole centre to loaded edge
+    yield_strength_mpa: 355.0          # S355
+  load:
+    static_load_kN: 420.0              # sling load (SWL share)
+    dynamic_amplification_factor: 2.0  # DAF
+    skew_load_factor: 1.1
+  design:
+    standard: AISC ASD
+  outputs:
+    directory: results/lifting_lug
+    summary_json: lifting_lug_summary.json

--- a/src/digitalmodel/base_configs/modules/lifting_lug/lifting_lug.yml
+++ b/src/digitalmodel/base_configs/modules/lifting_lug/lifting_lug.yml
@@ -1,0 +1,10 @@
+basename: lifting_lug
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+lifting_lug: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -228,6 +228,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         )
 
         cfg_base = vessel_seakeeping(cfg_base)
+    elif basename == "lifting_lug":
+        from digitalmodel.lifting_lug.workflow import router as lifting_lug
+
+        cfg_base = lifting_lug(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/lifting_lug/__init__.py
+++ b/src/digitalmodel/lifting_lug/__init__.py
@@ -1,0 +1,6 @@
+"""Lifting lug / padeye strength screening.
+
+Closed-form ultimate-load checks for a circular padeye (lifting lug) under a
+sling load: pin-hole bearing, net-section tension beside the hole, and
+shear tear-out to the plate edge, against AISC allowable stresses.
+"""

--- a/src/digitalmodel/lifting_lug/workflow.py
+++ b/src/digitalmodel/lifting_lug/workflow.py
@@ -1,0 +1,154 @@
+"""Durable workflow: lifting lug / padeye strength screening.
+
+Checks a circular padeye (lifting lug) under a sling load against three
+governing failure modes, using AISC allowable-stress design:
+
+- Pin-hole bearing:        sigma_b = P / (d_pin * t)       <= 0.90 * Fy
+- Net-section tension:     sigma_t = P / (2 * t * (R - r)) <= 0.60 * Fy
+- Shear tear-out to edge:  tau     = P / (2 * t * (R - r)) <= 0.40 * Fy
+
+where t = main-plate thickness + 2 * cheek-plate thickness (total thickness at
+the hole), R = padeye outer radius (hole centre to loaded edge), r = hole
+radius, and P = static sling load x dynamic amplification x skew factor.
+
+References: AISC ASD allowable stresses (0.60/0.40/0.90 Fy);
+DNV-ST-0378 / DNV 2.7-3 (offshore lifting appliances — padeye design).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+# AISC allowable-stress factors on yield.
+BEARING_FACTOR = 0.90
+TENSION_FACTOR = 0.60
+SHEAR_FACTOR = 0.40
+
+
+@dataclass
+class LugCheck:
+    name: str
+    demand_mpa: float
+    allowable_mpa: float
+    utilization: float
+    passes: bool
+
+
+def design_load_kn(
+    static_load_kn: float, dynamic_amplification: float, skew_factor: float
+) -> float:
+    """Factored sling load P = static * DAF * skew."""
+    if static_load_kn <= 0.0:
+        raise ValueError("static_load_kN must be positive")
+    if dynamic_amplification <= 0.0:
+        raise ValueError("dynamic_amplification_factor must be positive")
+    if skew_factor <= 0.0:
+        raise ValueError("skew_load_factor must be positive")
+    return static_load_kn * dynamic_amplification * skew_factor
+
+
+def lug_checks(
+    design_load_kn: float,
+    total_thickness_mm: float,
+    pin_diameter_mm: float,
+    hole_diameter_mm: float,
+    outer_radius_mm: float,
+    yield_strength_mpa: float,
+) -> list[LugCheck]:
+    """Bearing, net-tension and shear-tear-out checks for a circular padeye."""
+    if total_thickness_mm <= 0.0:
+        raise ValueError("total thickness must be positive")
+    if hole_diameter_mm < pin_diameter_mm:
+        raise ValueError("hole_diameter_mm must be >= pin_diameter_mm")
+    ligament_mm = outer_radius_mm - hole_diameter_mm / 2.0
+    if ligament_mm <= 0.0:
+        raise ValueError(
+            "outer_radius_mm must exceed the hole radius (positive ligament)"
+        )
+    if yield_strength_mpa <= 0.0:
+        raise ValueError("yield_strength_mpa must be positive")
+
+    p_n = design_load_kn * 1.0e3  # kN -> N
+    t = total_thickness_mm
+
+    bearing_area = pin_diameter_mm * t  # mm^2
+    net_tension_area = 2.0 * t * ligament_mm  # mm^2, two ligaments
+    shear_area = 2.0 * t * ligament_mm  # mm^2, two tear-out planes
+
+    sigma_bearing = p_n / bearing_area  # N/mm^2 = MPa
+    sigma_tension = p_n / net_tension_area
+    tau_shear = p_n / shear_area
+
+    checks = [
+        _check("pin_bearing", sigma_bearing, BEARING_FACTOR * yield_strength_mpa),
+        _check("net_tension", sigma_tension, TENSION_FACTOR * yield_strength_mpa),
+        _check("shear_tearout", tau_shear, SHEAR_FACTOR * yield_strength_mpa),
+    ]
+    return checks
+
+
+def _check(name: str, demand: float, allowable: float) -> LugCheck:
+    utilization = demand / allowable
+    return LugCheck(
+        name=name,
+        demand_mpa=demand,
+        allowable_mpa=allowable,
+        utilization=utilization,
+        passes=utilization <= 1.0,
+    )
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("lifting_lug") or {}
+    lug = settings["lug"]
+    load = settings["load"]
+
+    p_design = design_load_kn(
+        static_load_kn=float(load["static_load_kN"]),
+        dynamic_amplification=float(load.get("dynamic_amplification_factor", 1.0)),
+        skew_factor=float(load.get("skew_load_factor", 1.0)),
+    )
+    total_thickness = float(lug["plate_thickness_mm"]) + 2.0 * float(
+        lug.get("cheek_plate_thickness_mm", 0.0)
+    )
+    checks = lug_checks(
+        design_load_kn=p_design,
+        total_thickness_mm=total_thickness,
+        pin_diameter_mm=float(lug["pin_diameter_mm"]),
+        hole_diameter_mm=float(lug["hole_diameter_mm"]),
+        outer_radius_mm=float(lug["outer_radius_mm"]),
+        yield_strength_mpa=float(lug["yield_strength_mpa"]),
+    )
+
+    governing = max(checks, key=lambda c: c.utilization)
+    payload = {
+        **settings,
+        "standard": "AISC ASD / DNV-ST-0378",
+        "design_load_kN": p_design,
+        "total_thickness_mm": total_thickness,
+        "checks": [asdict(c) for c in checks],
+        "governing_check": governing.name,
+        "governing_utilization": governing.utilization,
+        "screening_status": "pass" if all(c.passes for c in checks) else "fail",
+    }
+    payload["summary_json"] = str(
+        _write_summary(cfg, settings.get("outputs", {}), payload)
+    )
+    cfg["lifting_lug"] = payload
+    cfg["screening_status"] = payload["screening_status"]
+    return cfg
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/lifting_lug"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get(
+        "summary_json", "lifting_lug_summary.json"
+    )
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1193,6 +1193,26 @@ def test_workflow_registry(workflow, monkeypatch):
             summary_path = REPO_ROOT / summary_path
         summary = yaml.safe_load(summary_path.read_text())
         assert summary["groups"][0]["label"] == "uta1_clump_weight"
+    elif workflow["id"] == "lifting-lug-design":
+        block = cfg["lifting_lug"]
+        # P = static * DAF * skew = 420 * 2.0 * 1.1
+        assert block["design_load_kN"] == pytest.approx(924.0)
+        checks = {c["name"]: c for c in block["checks"]}
+        assert set(checks) == {"pin_bearing", "net_tension", "shear_tearout"}
+        # shear tear-out governs (0.40 Fy allowable) and fails
+        assert block["governing_check"] == "shear_tearout"
+        assert checks["shear_tearout"]["utilization"] == pytest.approx(
+            1.16197183, rel=1e-6
+        )
+        assert checks["shear_tearout"]["passes"] is False
+        assert bool(checks["pin_bearing"]["passes"]) is True
+        assert bool(checks["net_tension"]["passes"]) is True
+        # shear demand equals tension demand (same area), lower allowable
+        assert checks["shear_tearout"]["demand_mpa"] == pytest.approx(
+            checks["net_tension"]["demand_mpa"]
+        )
+        assert block["screening_status"] == "fail"
+        assert cfg["screening_status"] == "fail"
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:
@@ -1545,3 +1565,36 @@ def test_vessel_seakeeping_significant_amplitude_matches_library(tmp_path):
     assert cfg["vessel_seakeeping"]["response_transfer"] == (
         "S_response(w) = |RAO(w)|^2 * S_wave(w)"
     )
+
+
+def test_lifting_lug_checks_match_closed_form():
+    """AC6 validation gate for lifting-lug-design: the bearing, net-tension and
+    shear tear-out demands equal the closed-form AISC padeye expressions, and
+    the allowables are the AISC factors on yield (0.90 / 0.60 / 0.40 Fy)."""
+    from digitalmodel.lifting_lug.workflow import design_load_kn, lug_checks
+
+    fy = 355.0
+    t = 40.0
+    d_pin, d_hole, r_outer = 75.0, 80.0, 110.0
+    p = design_load_kn(420.0, 2.0, 1.1)
+    assert p == pytest.approx(924.0)
+
+    checks = {c.name: c for c in lug_checks(p, t, d_pin, d_hole, r_outer, fy)}
+    p_n = p * 1.0e3
+    ligament = r_outer - d_hole / 2.0
+
+    assert checks["pin_bearing"].demand_mpa == pytest.approx(
+        p_n / (d_pin * t), rel=1e-12
+    )
+    assert checks["pin_bearing"].allowable_mpa == pytest.approx(0.90 * fy, rel=1e-12)
+    assert checks["net_tension"].demand_mpa == pytest.approx(
+        p_n / (2.0 * t * ligament), rel=1e-12
+    )
+    assert checks["net_tension"].allowable_mpa == pytest.approx(0.60 * fy, rel=1e-12)
+    assert checks["shear_tearout"].demand_mpa == pytest.approx(
+        p_n / (2.0 * t * ligament), rel=1e-12
+    )
+    assert checks["shear_tearout"].allowable_mpa == pytest.approx(0.40 * fy, rel=1e-12)
+    # utilisation = demand / allowable
+    for c in checks.values():
+        assert c.utilization == pytest.approx(c.demand_mpa / c.allowable_mpa, rel=1e-12)


### PR DESCRIPTION
Closes #911. Flywheel loop 6.

New registry workflow `lifting-lug-design`: closed-form padeye strength screening under a sling load — pin-hole bearing (σ_b=P/(d_pin·t)≤0.90Fy), net-section tension (σ_t=P/(2·t·(R−r))≤0.60Fy), shear tear-out (τ=P/(2·t·(R−r))≤0.40Fy). P=static·DAF·skew; t=main+2·cheek; governing check + top-level `screening_status`.

- new package `src/digitalmodel/lifting_lug/` (pure checks + router)
- AC6 `test_lifting_lug_checks_match_closed_form`: demands/allowables reproduce the closed-form AISC expressions
- example: S355 padeye fails on shear tear-out (utilisation ~1.16), bearing near limit

Verified: `uv run python -m digitalmodel examples/workflows/lifting-lug-design/input.yml` EXIT0; durable suite 99 passed/2 skipped; ruff/black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)