### PR TITLE
feat(pipeline): span-rectification — intermediate-support design (flywheel loop 8)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -479,6 +479,15 @@ workflows:
       - examples/workflows/pipeline-upheaval-buckling/results/input_upheaval_buckling.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[pipeline-upheaval-buckling]
     runtime: offline
+  - id: span-rectification
+    basename: span_rectification
+    title: Free-span rectification — intermediate supports for an over-long span (DNV-RP-F105)
+    input: examples/workflows/span-rectification/input.yml
+    outputs:
+      - examples/workflows/span-rectification/results/input.yml
+      - examples/workflows/span-rectification/results/span_rectification/span_rectification_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[span-rectification]
+    runtime: offline
   - id: orcawave-input-prep
     basename: diffraction
     title: OrcaWave diffraction input YAML preparation from a canonical spec

--- a/examples/workflows/span-rectification/README.md
+++ b/examples/workflows/span-rectification/README.md
@@ -1,0 +1,19 @@
+# Free-Span Rectification Design
+
+Designs the **intermediate-support layout** to rectify an over-long subsea pipeline free span, building on the DNV-RP-F105 Level-1 allowable free-span length.
+
+When an as-surveyed span `L_a` exceeds the allowable span `L_allow`, it is split into shorter sub-spans by intermediate supports (grout bags, mattresses, rock berms). The minimum number of equally spaced supports is:
+
+```
+n_supports = ceil(L_a / L_allow) − 1
+```
+
+giving `n_supports + 1` equal sub-spans of length `L_a / (n_supports + 1)`, each within the allowable limit. No rectification is needed when `L_a ≤ L_allow`.
+
+The allowable span is computed by the same tested `SpanAllowableLength` calculator used by `digitalmodel:free-span-f105` (the governing of the F105 static-deflection and VIV-onset Level-1 limits). The workflow reports the allowable span, the required support count and spacing, the resulting sub-span utilisation, and a top-level `screening_status` — `fail` when the as-built span exceeds the allowable (rectification required), `pass` otherwise.
+
+The example takes a 60 m surveyed span against a ~12.4 m allowable → 4 supports, 12.0 m sub-spans.
+
+Run with `uv run python -m digitalmodel examples/workflows/span-rectification/input.yml`.
+
+Reference: DNV-RP-F105 (free spanning pipelines), Sec. 4.2 (allowable span length).

--- a/examples/workflows/span-rectification/input.yml
+++ b/examples/workflows/span-rectification/input.yml
@@ -1,0 +1,37 @@
+basename: span_rectification
+
+span_rectification:
+  case:
+    id: registry_span_rectification
+    description: DNV-RP-F105 free-span rectification — intermediate supports for an over-long surveyed span
+  pipe_span:
+    od_m: 0.2731
+    wt_m: 0.0127
+    span_length_m: 34.0          # design/allowable-screen span
+    e_modulus_pa: 207000000000.0
+    steel_density_kgm3: 7850.0
+    content_density_kgm3: 900.0
+    water_density_kgm3: 1025.0
+    current_velocity_ms: 0.8
+    wave_velocity_ms: 0.0
+    seabed_gap_m: 0.5
+    bc: pinned-pinned
+    sag_m: 0.0
+    structural_damping: 0.005
+    hydrodynamic_damping: 0.010
+    sn_curve_class: F
+    environment: seawater_cp
+    gamma_on_IL: 1.1
+    gamma_on_CF: 1.3
+    gamma_k: 1.15
+  submerged_weight_N_m: 850.0
+  actual_span_length_m: 60.0      # as-surveyed span (exceeds the allowable -> rectify)
+  outputs:
+    directory: results/span_rectification
+    summary_json: span_rectification_summary.json
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/span_rectification/span_rectification.yml
+++ b/src/digitalmodel/base_configs/modules/span_rectification/span_rectification.yml
@@ -1,0 +1,9 @@
+basename: span_rectification
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+span_rectification: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -232,6 +232,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.lifting_lug.workflow import router as lifting_lug
 
         cfg_base = lifting_lug(cfg_base)
+    elif basename == "span_rectification":
+        from digitalmodel.subsea.pipeline.span_rectification import (
+            router as span_rectification,
+        )
+
+        cfg_base = span_rectification(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/subsea/pipeline/span_rectification.py
+++ b/src/digitalmodel/subsea/pipeline/span_rectification.py
@@ -1,0 +1,114 @@
+# ABOUTME: Free-span rectification design — intermediate supports for an over-long span.
+# ABOUTME: Wraps the DNV-RP-F105 allowable-span calc and sizes the support layout.
+"""Pipeline free-span rectification design (DNV-RP-F105).
+
+Builds on the Level-1 allowable free-span length (`SpanAllowableLength`): when an
+as-surveyed span exceeds the allowable length, it must be *rectified* — split
+into shorter sub-spans by intermediate supports (grout bags, mattresses, rock
+berms) so each sub-span is within the allowable limit.
+
+For an actual span L_a and an allowable span L_allow, the minimum number of
+equally spaced intermediate supports is
+
+    n_supports = ceil(L_a / L_allow) - 1
+
+which yields n_supports + 1 equal sub-spans of length L_a / (n_supports + 1),
+each <= L_allow. No rectification is needed when L_a <= L_allow.
+
+References: DNV-RP-F105 (free spanning pipelines) Sec. 4.2 (allowable span);
+the support layout follows the standard equal-sub-span rectification rule.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def design_rectification(
+    actual_span_m: float, allowable_span_m: float
+) -> dict[str, Any]:
+    """Minimum equal-spaced intermediate supports to bring sub-spans within allowable."""
+    if actual_span_m <= 0.0:
+        raise ValueError("actual_span_m must be positive")
+    if allowable_span_m <= 0.0:
+        raise ValueError("allowable_span_m must be positive")
+
+    if actual_span_m <= allowable_span_m:
+        return {
+            "rectification_required": False,
+            "n_supports": 0,
+            "sub_span_count": 1,
+            "resulting_sub_span_m": actual_span_m,
+            "support_spacing_m": actual_span_m,
+            "span_utilization": actual_span_m / allowable_span_m,
+        }
+
+    sub_span_count = math.ceil(actual_span_m / allowable_span_m)
+    n_supports = sub_span_count - 1
+    resulting_sub_span = actual_span_m / sub_span_count
+    return {
+        "rectification_required": True,
+        "n_supports": n_supports,
+        "sub_span_count": sub_span_count,
+        "resulting_sub_span_m": resulting_sub_span,
+        "support_spacing_m": resulting_sub_span,
+        "span_utilization": resulting_sub_span / allowable_span_m,
+    }
+
+
+def router(cfg: dict) -> dict:
+    from digitalmodel.subsea.pipeline.free_span.models import (
+        BoundaryConditionF105,
+        EnvironmentType,
+        PipeSpanInput,
+    )
+    from digitalmodel.subsea.pipeline.free_span.span_allowable_length import (
+        SpanAllowableLength,
+    )
+
+    settings = cfg.get("span_rectification") or {}
+    pipe_span = dict(settings["pipe_span"])
+    pipe_span["bc"] = BoundaryConditionF105(pipe_span["bc"])
+    pipe_span["environment"] = EnvironmentType(pipe_span["environment"])
+    inp = PipeSpanInput(**pipe_span)
+    submerged_weight = float(settings.get("submerged_weight_N_m", 850.0))
+
+    allowable_span = SpanAllowableLength(
+        inp, submerged_weight_N_m=submerged_weight
+    ).max_span_m()
+    actual_span = float(settings.get("actual_span_length_m", inp.span_length_m))
+
+    rectification = design_rectification(actual_span, allowable_span)
+    # An as-built span exceeding the allowable FAILS the screen; the rectification
+    # (intermediate supports) is the mitigation that brings it back into limit.
+    status = "fail" if rectification["rectification_required"] else "pass"
+
+    result = {
+        "standard": "DNV-RP-F105 Sec 4.2 (allowable span) + equal-sub-span rectification",
+        "allowable_span_m": allowable_span,
+        "actual_span_m": actual_span,
+        **rectification,
+        "screening_status": status,
+    }
+    payload = {**settings, "result": result, "screening_status": status}
+    payload["summary_json"] = str(
+        _write_summary(cfg, settings.get("outputs", {}), payload)
+    )
+    cfg["span_rectification"] = payload
+    cfg["screening_status"] = status
+    return cfg
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/span_rectification"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get(
+        "summary_json", "span_rectification_summary.json"
+    )
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1213,6 +1213,20 @@ def test_workflow_registry(workflow, monkeypatch):
         )
         assert block["screening_status"] == "fail"
         assert cfg["screening_status"] == "fail"
+    elif workflow["id"] == "span-rectification":
+        result = cfg["span_rectification"]["result"]
+        allowable = result["allowable_span_m"]
+        # as-built 60 m span exceeds the ~12.4 m allowable -> rectification required
+        assert result["actual_span_m"] == pytest.approx(60.0)
+        assert result["rectification_required"] is True
+        assert result["screening_status"] == "fail"
+        assert cfg["screening_status"] == "fail"
+        # n_supports = ceil(L_a / L_allow) - 1; equal sub-spans within allowable
+        expected_subspans = math.ceil(60.0 / allowable)
+        assert result["sub_span_count"] == expected_subspans
+        assert result["n_supports"] == expected_subspans - 1
+        assert result["resulting_sub_span_m"] == pytest.approx(60.0 / expected_subspans)
+        assert result["resulting_sub_span_m"] <= allowable + 1e-9
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:
@@ -1598,3 +1612,32 @@ def test_lifting_lug_checks_match_closed_form():
     # utilisation = demand / allowable
     for c in checks.values():
         assert c.utilization == pytest.approx(c.demand_mpa / c.allowable_mpa, rel=1e-12)
+
+
+def test_span_rectification_support_count_closed_form():
+    """AC6 validation gate for span-rectification: the equal-sub-span support
+    count reproduces the closed-form rule n_supports = ceil(L_a/L_allow) - 1,
+    every resulting sub-span is within the allowable, and L_a <= L_allow needs
+    no rectification."""
+    from digitalmodel.subsea.pipeline.span_rectification import design_rectification
+
+    # over-long span: 60 m vs 12.378 m allowable -> 5 sub-spans, 4 supports
+    allowable = 12.378282602855869
+    r = design_rectification(60.0, allowable)
+    assert r["rectification_required"] is True
+    assert r["sub_span_count"] == math.ceil(60.0 / allowable)  # = 5
+    assert r["n_supports"] == r["sub_span_count"] - 1  # = 4
+    assert r["resulting_sub_span_m"] == pytest.approx(60.0 / r["sub_span_count"])
+    assert r["resulting_sub_span_m"] <= allowable + 1e-9
+
+    # exact multiple: 24 m vs 12 m -> 2 sub-spans, 1 support, sub-span == allowable
+    r2 = design_rectification(24.0, 12.0)
+    assert r2["sub_span_count"] == 2
+    assert r2["n_supports"] == 1
+    assert r2["resulting_sub_span_m"] == pytest.approx(12.0)
+
+    # within allowable: no rectification
+    r3 = design_rectification(10.0, 12.0)
+    assert r3["rectification_required"] is False
+    assert r3["n_supports"] == 0
+    assert r3["resulting_sub_span_m"] == pytest.approx(10.0)


### PR DESCRIPTION
Closes #918. Flywheel loop 8.

New registry workflow `span-rectification`: an as-surveyed free span exceeding the DNV-RP-F105 Level-1 allowable is split into equal sub-spans by intermediate supports — n_supports = ceil(L_actual/L_allow) − 1, each sub-span within allowable. Reuses the tested `SpanAllowableLength` calculator (same core as `free-span-f105`).

- new `src/digitalmodel/subsea/pipeline/span_rectification.py`
- AC6 `test_span_rectification_support_count_closed_form`: support count reproduces the closed-form ceil rule; sub-spans within allowable; L_a<=L_allow needs none
- example: 60 m surveyed span vs ~12.4 m allowable -> 4 supports, 12.0 m sub-spans (fail = rectification required)

Verified: `uv run python -m digitalmodel examples/workflows/span-rectification/input.yml` EXIT0; durable suite 101 passed/2 skipped; ruff/black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)