### PR TITLE
feat(wells): esp-pump-hydraulics — TDH + stage/motor sizing (flywheel loop 9)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -931,6 +931,15 @@ workflows:
       - examples/workflows/ct-hydraulics/results/ct_hydraulics/ct_hydraulics_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[ct-hydraulics]
     runtime: offline
+  - id: esp-pump-hydraulics
+    basename: esp_pump_hydraulics
+    title: ESP hydraulics — total dynamic head, stage count and motor sizing
+    input: examples/workflows/esp-pump-hydraulics/input.yml
+    outputs:
+      - examples/workflows/esp-pump-hydraulics/results/input.yml
+      - examples/workflows/esp-pump-hydraulics/results/esp_pump_hydraulics/esp_pump_hydraulics_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[esp-pump-hydraulics]
+    runtime: offline
   - id: rigging
     basename: rigging
     title: Resolve rigging-group elements to vendor catalog entries (WLL, geometry, weight)

--- a/examples/workflows/esp-pump-hydraulics/README.md
+++ b/examples/workflows/esp-pump-hydraulics/README.md
@@ -1,0 +1,21 @@
+# ESP Pump Hydraulics
+
+Sizes an **electric submersible pump (ESP)** for a producing well from the total dynamic head (TDH) and the selected pump's per-stage curve values.
+
+```
+TDH = net_lift + friction_head + discharge_head            [m]
+  net_lift       = dynamic fluid level (depth the pump lifts from)
+  friction_head  = Hazen-Williams tubing loss over the pump setting depth
+  discharge_head = wellhead pressure expressed as head
+
+stages_required = ceil(TDH / head_per_stage)
+brake_power     = stages × bhp_per_stage × specific_gravity   [hp]
+```
+
+Tubing friction uses the Hazen-Williams correlation `hf = 10.67·L·Q^1.852 / (C^1.852·d^4.87)` (SI). The screen **passes** when the required stages fit the pump housing (`max_stages`), the brake power is within the motor rating, and the design rate is inside the pump's recommended operating range; otherwise it reports the governing check and `screening_status: fail`.
+
+The example sizes a 1200 m³/d deep producer: TDH ≈ 2425 m needs 405 stages against a 400-stage housing → `fail` on stage count (select a higher-head pump or larger tubing).
+
+Run with `uv run python -m digitalmodel examples/workflows/esp-pump-hydraulics/input.yml`.
+
+Reference: standard ESP sizing procedure (Centrilift / Schlumberger ESP handbooks); Hazen-Williams pipe-friction correlation.

--- a/examples/workflows/esp-pump-hydraulics/input.yml
+++ b/examples/workflows/esp-pump-hydraulics/input.yml
@@ -1,0 +1,34 @@
+basename: esp_pump_hydraulics
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+esp_pump_hydraulics:
+  case:
+    id: registry_esp_pump_hydraulics
+    description: ESP sizing — total dynamic head, stage count and motor power for a deep producer
+  well:
+    pump_setting_depth_m: 2500.0      # tubing length (friction)
+    dynamic_fluid_level_m: 1800.0     # producing fluid level (net lift)
+    wellhead_pressure_kpa: 2000.0
+  fluid:
+    specific_gravity: 0.85
+    flow_rate_m3_per_day: 1200.0
+    hazen_williams_C: 120
+  tubing:
+    inner_diameter_m: 0.076           # ~3 in tubing
+  pump:
+    head_per_stage_m: 6.0             # at design rate (manufacturer curve)
+    bhp_per_stage_hp: 0.5             # brake hp per stage at design rate (water)
+    max_stages: 400                   # pump housing limit
+    min_rate_m3_per_day: 600.0        # recommended operating range
+    max_rate_m3_per_day: 2000.0
+  motor:
+    rating_hp: 250.0
+  outputs:
+    directory: results/esp_pump_hydraulics
+    summary_json: esp_pump_hydraulics_summary.json

--- a/src/digitalmodel/base_configs/modules/esp_pump_hydraulics/esp_pump_hydraulics.yml
+++ b/src/digitalmodel/base_configs/modules/esp_pump_hydraulics/esp_pump_hydraulics.yml
@@ -1,0 +1,10 @@
+basename: esp_pump_hydraulics
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+esp_pump_hydraulics: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -232,6 +232,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.lifting_lug.workflow import router as lifting_lug
 
         cfg_base = lifting_lug(cfg_base)
+    elif basename == "esp_pump_hydraulics":
+        from digitalmodel.production_engineering.esp_pump_hydraulics import (
+            router as esp_pump_hydraulics,
+        )
+
+        cfg_base = esp_pump_hydraulics(cfg_base)
     elif basename == "span_rectification":
         from digitalmodel.subsea.pipeline.span_rectification import (
             router as span_rectification,

--- a/src/digitalmodel/production_engineering/esp_pump_hydraulics.py
+++ b/src/digitalmodel/production_engineering/esp_pump_hydraulics.py
@@ -1,0 +1,216 @@
+# ABOUTME: Electric submersible pump (ESP) hydraulics — TDH, stage count, motor sizing.
+# ABOUTME: Total dynamic head + Hazen-Williams tubing friction + pump-curve stage sizing.
+"""Electric submersible pump (ESP) hydraulics screening.
+
+Sizes an ESP for a producing well from the total dynamic head (TDH) and the
+selected pump's per-stage curve values:
+
+    TDH = net_lift + friction_head + discharge_head            [m]
+        net_lift      = dynamic fluid level (depth from surface to the
+                        producing fluid level the pump must lift from)
+        friction_head = Hazen-Williams tubing loss over the pump setting depth
+        discharge_head = wellhead pressure expressed as head
+
+    stages       = ceil(TDH / head_per_stage)
+    brake_power  = stages * bhp_per_stage * specific_gravity   [hp]
+
+The screen passes when the required stages fit the pump housing, the brake
+power is within the motor rating, and the design rate is inside the pump's
+recommended operating range.
+
+Hazen-Williams (SI): hf = 10.67 * L * Q^1.852 / (C^1.852 * d^4.87), with Q in
+m^3/s, d and L in m, hf in m.
+
+References: standard ESP sizing procedure (e.g. Centrilift / Schlumberger ESP
+handbooks); Hazen-Williams pipe-friction correlation.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_G = 9.81  # m/s^2
+_SECONDS_PER_DAY = 86400.0
+
+
+@dataclass
+class ESPResult:
+    standard: str
+    flow_rate_m3_per_day: float
+    net_lift_m: float
+    friction_head_m: float
+    discharge_head_m: float
+    total_dynamic_head_m: float
+    stages_required: int
+    brake_power_hp: float
+    checks: list[dict[str, Any]]
+    governing_check: str
+    screening_status: str
+
+
+def hazen_williams_head_m(
+    flow_rate_m3_per_day: float,
+    length_m: float,
+    inner_diameter_m: float,
+    c_factor: float,
+) -> float:
+    """Hazen-Williams friction head (m) for liquid flow in a circular conduit."""
+    if inner_diameter_m <= 0.0:
+        raise ValueError("inner_diameter_m must be positive")
+    if c_factor <= 0.0:
+        raise ValueError("hazen_williams_C must be positive")
+    if length_m < 0.0:
+        raise ValueError("length_m must be non-negative")
+    q = flow_rate_m3_per_day / _SECONDS_PER_DAY  # m^3/s
+    return 10.67 * length_m * q**1.852 / (c_factor**1.852 * inner_diameter_m**4.87)
+
+
+def size_esp(
+    flow_rate_m3_per_day: float,
+    dynamic_fluid_level_m: float,
+    pump_setting_depth_m: float,
+    wellhead_pressure_kpa: float,
+    specific_gravity: float,
+    tubing_inner_diameter_m: float,
+    head_per_stage_m: float,
+    bhp_per_stage_hp: float,
+    max_stages: int,
+    motor_rating_hp: float,
+    min_rate_m3_per_day: float,
+    max_rate_m3_per_day: float,
+    hazen_williams_c: float = 120.0,
+) -> ESPResult:
+    """Total dynamic head, stage count, motor brake power and pass/fail checks."""
+    if specific_gravity <= 0.0:
+        raise ValueError("specific_gravity must be positive")
+    if head_per_stage_m <= 0.0:
+        raise ValueError("head_per_stage_m must be positive")
+    if bhp_per_stage_hp <= 0.0:
+        raise ValueError("bhp_per_stage_hp must be positive")
+    if max_stages <= 0:
+        raise ValueError("max_stages must be positive")
+
+    net_lift = dynamic_fluid_level_m
+    friction_head = hazen_williams_head_m(
+        flow_rate_m3_per_day,
+        pump_setting_depth_m,
+        tubing_inner_diameter_m,
+        hazen_williams_c,
+    )
+    discharge_head = wellhead_pressure_kpa * 1.0e3 / (specific_gravity * 1000.0 * _G)
+    tdh = net_lift + friction_head + discharge_head
+
+    stages = math.ceil(tdh / head_per_stage_m)
+    brake_power = stages * bhp_per_stage_hp * specific_gravity
+
+    checks = [
+        _check(
+            "pump_stages",
+            stages,
+            max_stages,
+            f"stages {stages} vs housing max {max_stages}",
+        ),
+        _check(
+            "motor_power",
+            brake_power,
+            motor_rating_hp,
+            f"brake power {brake_power:.1f} hp vs motor rating {motor_rating_hp:.1f} hp",
+        ),
+        _check(
+            "rate_within_range",
+            flow_rate_m3_per_day,
+            max_rate_m3_per_day,
+            f"design rate {flow_rate_m3_per_day:.0f} vs pump max {max_rate_m3_per_day:.0f} m3/d",
+            lower=min_rate_m3_per_day,
+        ),
+    ]
+    governing = max(checks, key=lambda c: c["utilization"])
+    passes = all(c["passes"] for c in checks)
+
+    return ESPResult(
+        standard="ESP sizing (TDH) + Hazen-Williams",
+        flow_rate_m3_per_day=flow_rate_m3_per_day,
+        net_lift_m=net_lift,
+        friction_head_m=friction_head,
+        discharge_head_m=discharge_head,
+        total_dynamic_head_m=tdh,
+        stages_required=stages,
+        brake_power_hp=brake_power,
+        checks=checks,
+        governing_check=governing["name"],
+        screening_status="pass" if passes else "fail",
+    )
+
+
+def _check(
+    name: str,
+    demand: float,
+    allowable: float,
+    description: str,
+    lower: float | None = None,
+) -> dict[str, Any]:
+    utilization = demand / allowable if allowable > 0 else float("inf")
+    passes = demand <= allowable
+    if lower is not None and demand < lower:
+        passes = False
+    return {
+        "name": name,
+        "demand": demand,
+        "allowable": allowable,
+        "utilization": utilization,
+        "passes": passes,
+        "description": description,
+    }
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("esp_pump_hydraulics") or {}
+    well = settings["well"]
+    fluid = settings["fluid"]
+    tubing = settings["tubing"]
+    pump = settings["pump"]
+    motor = settings["motor"]
+
+    result = size_esp(
+        flow_rate_m3_per_day=float(fluid["flow_rate_m3_per_day"]),
+        dynamic_fluid_level_m=float(well["dynamic_fluid_level_m"]),
+        pump_setting_depth_m=float(well["pump_setting_depth_m"]),
+        wellhead_pressure_kpa=float(well["wellhead_pressure_kpa"]),
+        specific_gravity=float(fluid["specific_gravity"]),
+        tubing_inner_diameter_m=float(tubing["inner_diameter_m"]),
+        head_per_stage_m=float(pump["head_per_stage_m"]),
+        bhp_per_stage_hp=float(pump["bhp_per_stage_hp"]),
+        max_stages=int(pump["max_stages"]),
+        motor_rating_hp=float(motor["rating_hp"]),
+        min_rate_m3_per_day=float(pump["min_rate_m3_per_day"]),
+        max_rate_m3_per_day=float(pump["max_rate_m3_per_day"]),
+        hazen_williams_c=float(fluid.get("hazen_williams_C", 120.0)),
+    )
+
+    payload = {
+        **settings,
+        "result": asdict(result),
+        "screening_status": result.screening_status,
+    }
+    payload["summary_json"] = str(
+        _write_summary(cfg, settings.get("outputs", {}), payload)
+    )
+    cfg["esp_pump_hydraulics"] = payload
+    cfg["screening_status"] = result.screening_status
+    return cfg
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/esp_pump_hydraulics"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get(
+        "summary_json", "esp_pump_hydraulics_summary.json"
+    )
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1227,6 +1227,31 @@ def test_workflow_registry(workflow, monkeypatch):
         assert result["n_supports"] == expected_subspans - 1
         assert result["resulting_sub_span_m"] == pytest.approx(60.0 / expected_subspans)
         assert result["resulting_sub_span_m"] <= allowable + 1e-9
+    elif workflow["id"] == "esp-pump-hydraulics":
+        result = cfg["esp_pump_hydraulics"]["result"]
+        # TDH = net lift + friction + discharge head
+        assert result["net_lift_m"] == pytest.approx(1800.0)
+        assert result["total_dynamic_head_m"] == pytest.approx(
+            result["net_lift_m"]
+            + result["friction_head_m"]
+            + result["discharge_head_m"],
+            rel=1e-12,
+        )
+        # stages = ceil(TDH / head_per_stage) = ceil(2425.4 / 6.0) = 405
+        assert result["stages_required"] == math.ceil(
+            result["total_dynamic_head_m"] / 6.0
+        )
+        assert result["stages_required"] == 405
+        # brake power = stages * bhp_per_stage * SG
+        assert result["brake_power_hp"] == pytest.approx(405 * 0.5 * 0.85)
+        # stages exceed the 400 housing -> governing fail; motor + rate pass
+        checks = {c["name"]: c for c in result["checks"]}
+        assert checks["pump_stages"]["passes"] is False
+        assert checks["motor_power"]["passes"] is True
+        assert checks["rate_within_range"]["passes"] is True
+        assert result["governing_check"] == "pump_stages"
+        assert result["screening_status"] == "fail"
+        assert cfg["screening_status"] == "fail"
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:
@@ -1641,3 +1666,44 @@ def test_span_rectification_support_count_closed_form():
     assert r3["rectification_required"] is False
     assert r3["n_supports"] == 0
     assert r3["resulting_sub_span_m"] == pytest.approx(10.0)
+
+
+def test_esp_pump_hydraulics_tdh_and_sizing_closed_form():
+    """AC6 validation gate for esp-pump-hydraulics: the Hazen-Williams friction
+    head, the total dynamic head decomposition, the stage count (ceil rule) and
+    the brake power reproduce their closed-form expressions."""
+    from digitalmodel.production_engineering.esp_pump_hydraulics import (
+        hazen_williams_head_m,
+        size_esp,
+    )
+
+    # Hazen-Williams closed form: hf = 10.67 L Q^1.852 / (C^1.852 d^4.87)
+    q = 1200.0 / 86400.0
+    expected_hf = 10.67 * 2500.0 * q**1.852 / (120.0**1.852 * 0.076**4.87)
+    assert hazen_williams_head_m(1200.0, 2500.0, 0.076, 120.0) == pytest.approx(
+        expected_hf, rel=1e-12
+    )
+
+    r = size_esp(
+        flow_rate_m3_per_day=1200.0,
+        dynamic_fluid_level_m=1800.0,
+        pump_setting_depth_m=2500.0,
+        wellhead_pressure_kpa=2000.0,
+        specific_gravity=0.85,
+        tubing_inner_diameter_m=0.076,
+        head_per_stage_m=6.0,
+        bhp_per_stage_hp=0.5,
+        max_stages=400,
+        motor_rating_hp=250.0,
+        min_rate_m3_per_day=600.0,
+        max_rate_m3_per_day=2000.0,
+        hazen_williams_c=120.0,
+    )
+    expected_discharge = 2000.0 * 1.0e3 / (0.85 * 1000.0 * 9.81)
+    expected_tdh = 1800.0 + expected_hf + expected_discharge
+    assert r.friction_head_m == pytest.approx(expected_hf, rel=1e-12)
+    assert r.discharge_head_m == pytest.approx(expected_discharge, rel=1e-12)
+    assert r.total_dynamic_head_m == pytest.approx(expected_tdh, rel=1e-12)
+    assert r.stages_required == math.ceil(expected_tdh / 6.0)
+    assert r.brake_power_hp == pytest.approx(r.stages_required * 0.5 * 0.85, rel=1e-12)
+    assert r.screening_status == "fail"  # 405 stages > 400 housing


### PR DESCRIPTION
Closes #920. Flywheel loop 9.

New registry workflow `esp-pump-hydraulics`: TDH = net_lift + Hazen-Williams tubing friction + discharge head; stages = ceil(TDH/head_per_stage); brake_power = stages*bhp_per_stage*SG. Checks stage count vs housing, brake power vs motor rating, rate within the pump operating window; governing check + top-level `screening_status`.

- new `src/digitalmodel/production_engineering/esp_pump_hydraulics.py` + router
- AC6 `test_esp_pump_hydraulics_tdh_and_sizing_closed_form`: Hazen-Williams head, TDH decomposition, ceil stage rule, brake power reproduce the closed-form expressions
- example: deep 1200 m3/d producer needs 405 stages vs a 400-stage housing -> fail

Verified: `uv run python -m digitalmodel examples/workflows/esp-pump-hydraulics/input.yml` EXIT0; durable suite 103 passed/2 skipped; ruff/black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)