### PR TITLE
feat(registry): add algorithm-version dimension to workflows.yaml (schema_version 2)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -1,4 +1,12 @@
-schema_version: 1
+# schema_version 2 (deckhand versioned routing): a workflow row MAY carry an
+# algorithm-version triple — all optional; absence means v1 / stable / latest:
+#   version: <int >= 1>   algorithm revision; bump when the method or curve changes
+#   status:  stable | deprecated | experimental | retired   (default: stable)
+#   latest:  true         the latest-stable resolution target for this id
+# Multiple rows may share one `id`, differing by `version` (each with its own
+# input/outputs/test). Deckhand resolves an unpinned `<repo>:<id>` to the latest
+# stable version; a pinned `<repo>:<id>@N` resolves that exact version.
+schema_version: 2
 invocation: "uv run python -m digitalmodel {input}"
 workflows:
   - id: cathodic-protection

--- a/tests/workflows/test_registry_versioning.py
+++ b/tests/workflows/test_registry_versioning.py
@@ -1,0 +1,46 @@
+"""Versioned-routing schema for docs/registry/workflows.yaml (schema_version 2).
+
+Each workflow row MAY carry an optional algorithm-version triple
+(``version`` / ``status`` / ``latest``); absence means v1 / stable / latest.
+These invariants guard the multi-version case so Deckhand can resolve a pinned
+``<repo>:<id>@N`` or the latest-stable default unambiguously.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REGISTRY_PATH = Path(__file__).resolve().parents[2] / "docs" / "registry" / "workflows.yaml"
+_VERSION_STATUSES = {"stable", "deprecated", "experimental", "retired"}
+
+
+def _load() -> dict:
+    return yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def test_registry_is_schema_version_2() -> None:
+    assert _load()["schema_version"] == 2
+
+
+def test_workflow_registry_version_invariants() -> None:
+    workflows = _load()["workflows"]
+    groups: dict[str, list[dict]] = {}
+    for row in workflows:
+        groups.setdefault(str(row["id"]), []).append(row)
+
+    for wid, rows in groups.items():
+        # Any version field present must be a positive int with a valid status.
+        for row in rows:
+            if "version" in row:
+                assert isinstance(row["version"], int) and row["version"] >= 1, wid
+            assert row.get("status", "stable") in _VERSION_STATUSES, wid
+        if len(rows) == 1:
+            continue
+        # A workflow id with multiple rows is a genuine multi-version workflow:
+        # every row must pin a distinct version and exactly one latest-stable.
+        versions = [row.get("version") for row in rows]
+        assert all(isinstance(v, int) for v in versions), f"{wid}: versions required"
+        assert len(set(versions)) == len(versions), f"{wid}: duplicate versions"
+        latest = [row for row in rows if row.get("latest")]
+        assert len(latest) == 1, f"{wid}: need exactly one latest:true row"
+        assert latest[0].get("status", "stable") == "stable", f"{wid}: latest not stable"


### PR DESCRIPTION
Closes #922. WS1 of Deckhand versioned workflow routing.

## What
- `docs/registry/workflows.yaml`: bump `schema_version: 1 -> 2`; document the optional per-row algorithm-version triple `version` / `status` / `latest`.
- `tests/workflows/test_registry_versioning.py`: assert schema_version 2 + multi-version invariants (an id with >1 row pins distinct versions and exactly one latest-stable).

## Why
Deckhand resolves an unpinned `<repo>:<id>` to the **latest-stable** version and a pinned `<repo>:<id>@N` to that exact version, stamping repo/domain/subdomain/version on every run for auditability. This gives the registry the version dimension so a workflow can ship a second algorithm version (new method/curve) without breaking existing pins.

## Backward compatibility
**Purely additive — no existing row changes.** All three fields are optional; absence means `v1 / stable / latest`, so every current workflow resolves exactly as before. The permissive registry validator already ignores unknown keys, and no test asserted `schema_version` on the workflow registry. A second version is added only when an algorithm actually changes.

## Test
`tests/workflows/test_registry_versioning.py` — 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)