### PR TITLE
feat(geotechnical): liquefaction-triggering — Seed-Idriss screening (flywheel loop 11)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -767,6 +767,15 @@ workflows:
       - examples/workflows/scour-assessment/results/scour/scour_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[scour-assessment]
     runtime: offline
+  - id: liquefaction-triggering
+    basename: liquefaction
+    title: Seed-Idriss simplified liquefaction-triggering screening (CSR vs CRR, Youd 2001)
+    input: examples/workflows/liquefaction/input.yml
+    outputs:
+      - examples/workflows/liquefaction/results/input.yml
+      - examples/workflows/liquefaction/results/liquefaction/liquefaction_summary.json
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[liquefaction-triggering]
+    runtime: offline
   - id: well-bore-design
     basename: well_bore_design
     title: Standard offshore wellbore casing/cost/risk screen

--- a/examples/workflows/liquefaction/README.md
+++ b/examples/workflows/liquefaction/README.md
@@ -1,0 +1,19 @@
+# Liquefaction Triggering Screening
+
+Screens a saturated soil profile for **earthquake-induced liquefaction triggering** using the Seed-Idriss simplified procedure (NCEER / Youd et al. 2001).
+
+Per layer it compares the earthquake-induced cyclic stress ratio (CSR) to the soil's cyclic resistance ratio (CRR):
+
+```
+CSR    = 0.65 · (a_max/g) · (σv / σv') · rd
+CRR7.5 = 1/(34 − N) + N/135 + 50/(10N + 45)² − 1/200     [N = (N1)60cs]
+FS     = (CRR7.5 / CSR) · MSF · K_σ
+```
+
+with the depth stress-reduction factor `rd` (Liao & Whitman 1986), the magnitude scaling factor `MSF = 174/Mw^2.56` (Idriss, ≈1.0 at Mw 7.5), and the overburden factor `K_σ` (1.0 for screening). Clean sand with `(N1)60cs ≥ 30` is treated as non-liquefiable. A layer liquefies when `FS` is below the required factor of safety; the workflow reports the per-layer factor of safety, the governing (lowest-FS) layer, and a top-level `screening_status`.
+
+The example screens a saturated sand profile under PGA 0.25 g / Mw 7.0: the shallow loose sand (N = 8, FS ≈ 0.45) and the medium layer liquefy, while the deeper dense sand (N = 28, FS ≈ 1.50) is acceptable → `fail`, governed by the 3 m layer.
+
+Run with `uv run python -m digitalmodel examples/workflows/liquefaction/input.yml`.
+
+Reference: Youd et al. (2001) "Liquefaction Resistance of Soils," *J. Geotech. Geoenviron. Eng.* (NCEER/NSF workshops); Seed & Idriss (1971).

--- a/examples/workflows/liquefaction/input.yml
+++ b/examples/workflows/liquefaction/input.yml
@@ -1,0 +1,26 @@
+basename: liquefaction
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+liquefaction:
+  case:
+    id: registry_liquefaction
+    description: Seed-Idriss simplified liquefaction-triggering screen of a saturated sand profile
+  seismic:
+    pga_g: 0.25            # design peak ground acceleration / g
+    magnitude: 7.0         # moment magnitude Mw
+  design:
+    required_factor_of_safety: 1.2
+  layers:
+    # saturated sands below the water table; sigma_v total, sigma_v' effective
+    - {depth_m: 3.0, sigma_v_kpa: 54.0,  sigma_v_eff_kpa: 34.0, N1_60cs: 8.0}
+    - {depth_m: 6.0, sigma_v_kpa: 108.0, sigma_v_eff_kpa: 59.0, N1_60cs: 14.0}
+    - {depth_m: 9.0, sigma_v_kpa: 162.0, sigma_v_eff_kpa: 83.5, N1_60cs: 28.0}
+  outputs:
+    directory: results/liquefaction
+    summary_json: liquefaction_summary.json

--- a/src/digitalmodel/base_configs/modules/liquefaction/liquefaction.yml
+++ b/src/digitalmodel/base_configs/modules/liquefaction/liquefaction.yml
@@ -1,0 +1,10 @@
+basename: liquefaction
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+liquefaction: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -458,6 +458,11 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         scour = ScourWorkflow()
         cfg_base = scour.router(cfg_base)
+    elif basename == "liquefaction":
+        from digitalmodel.geotechnical.cfg_workflows import LiquefactionWorkflow
+
+        liquefaction = LiquefactionWorkflow()
+        cfg_base = liquefaction.router(cfg_base)
     elif basename == "rig_capability_assessment":
         from digitalmodel.field_development.rig_capability import (
             router as rig_capability,

--- a/src/digitalmodel/geotechnical/cfg_workflows.py
+++ b/src/digitalmodel/geotechnical/cfg_workflows.py
@@ -207,3 +207,43 @@ class ScourWorkflow:
         )
         cfg["scour"] = payload
         return cfg
+
+
+class LiquefactionWorkflow:
+    """Run Seed-Idriss simplified liquefaction-triggering screening from cfg."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        from digitalmodel.geotechnical.liquefaction import assess_liquefaction
+
+        workflow_cfg = cfg.get("liquefaction", {})
+        seismic = workflow_cfg["seismic"]
+        design = workflow_cfg.get("design", {})
+
+        result = assess_liquefaction(
+            pga_g=float(seismic["pga_g"]),
+            magnitude=float(seismic["magnitude"]),
+            layers=workflow_cfg["layers"],
+            required_factor_of_safety=float(
+                design.get("required_factor_of_safety", 1.2)
+            ),
+            k_sigma=float(design.get("k_sigma", 1.0)),
+        )
+
+        payload = {
+            **workflow_cfg,
+            "standard": result.standard,
+            "result": asdict(result),
+            "screening_status": result.screening_status,
+        }
+        payload["summary_json"] = str(
+            _write_summary(
+                cfg,
+                workflow_cfg.get("outputs", {}),
+                "results/liquefaction",
+                "liquefaction_summary.json",
+                payload,
+            )
+        )
+        cfg["liquefaction"] = payload
+        cfg["screening_status"] = result.screening_status
+        return cfg

--- a/src/digitalmodel/geotechnical/liquefaction.py
+++ b/src/digitalmodel/geotechnical/liquefaction.py
@@ -1,0 +1,156 @@
+# ABOUTME: Seed-Idriss simplified liquefaction-triggering screening.
+# ABOUTME: CSR vs CRR (SPT (N1)60cs) with rd, MSF; per-layer factor of safety.
+"""Liquefaction triggering — Seed-Idriss simplified procedure (NCEER / Youd 2001).
+
+Per soil layer, compares the earthquake-induced cyclic stress ratio (CSR) to the
+soil's cyclic resistance ratio (CRR) to get a factor of safety against
+liquefaction triggering:
+
+    CSR    = 0.65 * (a_max/g) * (sigma_v / sigma_v') * rd
+    CRR7.5 = 1/(34 - N) + N/135 + 50/(10 N + 45)^2 - 1/200      [N = (N1)60cs]
+    FS     = (CRR7.5 / CSR) * MSF * K_sigma
+
+with the depth stress-reduction factor rd (Liao & Whitman 1986), the magnitude
+scaling factor MSF (Idriss) = 174 / Mw^2.56, and the overburden factor K_sigma
+(taken 1.0 for screening). Clean sand with (N1)60cs >= 30 is treated as
+non-liquefiable. The layer liquefies when FS < the required factor of safety.
+
+References: Youd et al. (2001) "Liquefaction Resistance of Soils" (NCEER/NSF
+workshops), J. Geotech. Geoenviron. Eng.; Seed & Idriss (1971).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+# (N1)60cs at/above which clean sand is treated as non-liquefiable.
+_N_NON_LIQUEFIABLE = 30.0
+# CRR assigned to non-liquefiable layers (high, dimensionless cap).
+_CRR_CAP = 2.0
+
+
+@dataclass
+class LayerResult:
+    depth_m: float
+    rd: float
+    csr: float
+    crr75: float
+    crr: float
+    msf: float
+    factor_of_safety: float
+    liquefies: bool
+
+
+@dataclass
+class LiquefactionResult:
+    standard: str
+    pga_g: float
+    magnitude: float
+    msf: float
+    required_factor_of_safety: float
+    governing_depth_m: float
+    governing_factor_of_safety: float
+    screening_status: str
+    layers: list[LayerResult] = field(default_factory=list)
+
+
+def stress_reduction_factor(depth_m: float) -> float:
+    """Depth stress-reduction factor rd (Liao & Whitman 1986)."""
+    if depth_m < 0.0:
+        raise ValueError("depth_m must be non-negative")
+    if depth_m <= 9.15:
+        return 1.0 - 0.00765 * depth_m
+    if depth_m <= 23.0:
+        return 1.174 - 0.0267 * depth_m
+    if depth_m <= 30.0:
+        return 0.744 - 0.008 * depth_m
+    return 0.5
+
+
+def magnitude_scaling_factor(magnitude: float) -> float:
+    """Magnitude scaling factor MSF = 174 / Mw^2.56 (Idriss; ~1.0 at Mw 7.5)."""
+    if magnitude <= 0.0:
+        raise ValueError("magnitude must be positive")
+    return 174.0 / magnitude**2.56
+
+
+def cyclic_stress_ratio(
+    pga_g: float, sigma_v_kpa: float, sigma_v_eff_kpa: float, rd: float
+) -> float:
+    """Seed-Idriss cyclic stress ratio CSR = 0.65 (a_max/g)(sv/sv') rd."""
+    if sigma_v_eff_kpa <= 0.0:
+        raise ValueError("sigma_v_eff_kpa must be positive")
+    return 0.65 * pga_g * (sigma_v_kpa / sigma_v_eff_kpa) * rd
+
+
+def cyclic_resistance_ratio_75(n1_60cs: float) -> float:
+    """Clean-sand CRR at Mw 7.5 from (N1)60cs (Youd et al. 2001)."""
+    if n1_60cs < 0.0:
+        raise ValueError("n1_60cs must be non-negative")
+    if n1_60cs >= _N_NON_LIQUEFIABLE:
+        return _CRR_CAP
+    return (
+        1.0 / (34.0 - n1_60cs)
+        + n1_60cs / 135.0
+        + 50.0 / (10.0 * n1_60cs + 45.0) ** 2
+        - 1.0 / 200.0
+    )
+
+
+def assess_liquefaction(
+    pga_g: float,
+    magnitude: float,
+    layers: list[dict],
+    required_factor_of_safety: float = 1.2,
+    k_sigma: float = 1.0,
+) -> LiquefactionResult:
+    """Per-layer factor of safety against liquefaction triggering."""
+    if pga_g <= 0.0:
+        raise ValueError("pga_g must be positive")
+    if not layers:
+        raise ValueError("layers must be a non-empty list")
+    if required_factor_of_safety <= 0.0:
+        raise ValueError("required_factor_of_safety must be positive")
+
+    msf = magnitude_scaling_factor(magnitude)
+    results: list[LayerResult] = []
+    for layer in layers:
+        depth = float(layer["depth_m"])
+        sigma_v = float(layer["sigma_v_kpa"])
+        sigma_v_eff = float(layer["sigma_v_eff_kpa"])
+        n1_60cs = float(layer["N1_60cs"])
+
+        rd = stress_reduction_factor(depth)
+        csr = cyclic_stress_ratio(pga_g, sigma_v, sigma_v_eff, rd)
+        crr75 = cyclic_resistance_ratio_75(n1_60cs)
+        crr = crr75  # CRR at the design magnitude is handled via MSF below
+        if csr <= 0.0:
+            raise ValueError(f"layer at {depth} m produced non-positive CSR")
+        fos = (crr / csr) * msf * k_sigma
+        results.append(
+            LayerResult(
+                depth_m=depth,
+                rd=rd,
+                csr=csr,
+                crr75=crr75,
+                crr=crr,
+                msf=msf,
+                factor_of_safety=fos,
+                liquefies=fos < required_factor_of_safety,
+            )
+        )
+
+    governing = min(results, key=lambda r: r.factor_of_safety)
+    passes = not any(r.liquefies for r in results)
+    return LiquefactionResult(
+        standard="Seed-Idriss simplified (Youd et al. 2001 / NCEER)",
+        pga_g=pga_g,
+        magnitude=magnitude,
+        msf=msf,
+        required_factor_of_safety=required_factor_of_safety,
+        governing_depth_m=governing.depth_m,
+        governing_factor_of_safety=governing.factor_of_safety,
+        screening_status="pass" if passes else "fail",
+        layers=results,
+    )

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -997,6 +997,21 @@ def test_workflow_registry(workflow, monkeypatch):
         assert result["pipeline"]["scour_depth_m"] == pytest.approx(0.225)
         assert result["monopile"]["scour_depth_m"] == pytest.approx(7.8)
         assert result["rock_armour"]["thickness_m"] == pytest.approx(0.6)
+    elif workflow["id"] == "liquefaction-triggering":
+        result = cfg["liquefaction"]["result"]
+        layers = {round(L["depth_m"]): L for L in result["layers"]}
+        # shallow loose sand (N=8) liquefies; deep dense sand (N=28) does not
+        assert layers[3]["liquefies"] is True
+        assert layers[9]["liquefies"] is False
+        assert layers[3]["factor_of_safety"] == pytest.approx(0.454, abs=0.01)
+        assert layers[9]["factor_of_safety"] == pytest.approx(1.503, abs=0.01)
+        # governing = the lowest-FS (shallow) layer; overall fails
+        assert result["governing_depth_m"] == pytest.approx(3.0)
+        assert result["governing_factor_of_safety"] == pytest.approx(
+            min(L["factor_of_safety"] for L in result["layers"])
+        )
+        assert result["screening_status"] == "fail"
+        assert cfg["screening_status"] == "fail"
     elif workflow["id"] == "well-bore-design":
         block = cfg["well_bore_design"]
         summary = block["summary"]
@@ -1641,3 +1656,55 @@ def test_span_rectification_support_count_closed_form():
     assert r3["rectification_required"] is False
     assert r3["n_supports"] == 0
     assert r3["resulting_sub_span_m"] == pytest.approx(10.0)
+
+
+def test_liquefaction_seed_idriss_closed_form():
+    """AC6 validation gate for liquefaction-triggering: rd, MSF, CSR, CRR7.5 and
+    the factor of safety reproduce the closed-form Seed-Idriss / Youd 2001
+    expressions, and (N1)60cs >= 30 is treated as non-liquefiable."""
+    from digitalmodel.geotechnical.liquefaction import (
+        assess_liquefaction,
+        cyclic_resistance_ratio_75,
+        cyclic_stress_ratio,
+        magnitude_scaling_factor,
+        stress_reduction_factor,
+    )
+
+    # rd piecewise (Liao & Whitman 1986)
+    assert stress_reduction_factor(3.0) == pytest.approx(1.0 - 0.00765 * 3.0)
+    assert stress_reduction_factor(15.0) == pytest.approx(1.174 - 0.0267 * 15.0)
+    # MSF = 174 / Mw^2.56
+    assert magnitude_scaling_factor(7.0) == pytest.approx(174.0 / 7.0**2.56)
+    # CSR closed form
+    rd = stress_reduction_factor(3.0)
+    assert cyclic_stress_ratio(0.25, 54.0, 34.0, rd) == pytest.approx(
+        0.65 * 0.25 * (54.0 / 34.0) * rd
+    )
+    # CRR7.5 closed form for N=8
+    n = 8.0
+    expected_crr = (
+        1.0 / (34.0 - n) + n / 135.0 + 50.0 / (10.0 * n + 45.0) ** 2 - 1.0 / 200.0
+    )
+    assert cyclic_resistance_ratio_75(n) == pytest.approx(expected_crr)
+    # (N1)60cs >= 30 -> non-liquefiable cap
+    assert cyclic_resistance_ratio_75(35.0) == pytest.approx(2.0)
+
+    # full layer FS = (CRR/CSR) * MSF
+    res = assess_liquefaction(
+        pga_g=0.25,
+        magnitude=7.0,
+        layers=[
+            {
+                "depth_m": 3.0,
+                "sigma_v_kpa": 54.0,
+                "sigma_v_eff_kpa": 34.0,
+                "N1_60cs": 8.0,
+            }
+        ],
+        required_factor_of_safety=1.2,
+    )
+    layer = res.layers[0]
+    expected_fs = (expected_crr / layer.csr) * magnitude_scaling_factor(7.0)
+    assert layer.factor_of_safety == pytest.approx(expected_fs, rel=1e-12)
+    assert layer.liquefies is True
+    assert res.screening_status == "fail"


### PR DESCRIPTION
Closes #926. Flywheel loop 11.

New registry workflow `liquefaction-triggering`: per soil layer, Seed-Idriss simplified screen (NCEER / Youd et al. 2001) — CSR=0.65(a_max/g)(sv/sv')rd, CRR7.5 from (N1)60cs, FS=(CRR/CSR)·MSF·Ksigma. Per-layer factor of safety, governing layer + top-level `screening_status`.

- new `src/digitalmodel/geotechnical/liquefaction.py` + cfg workflow
- AC6 `test_liquefaction_seed_idriss_closed_form`: rd, MSF, CSR, CRR7.5, FS reproduce the closed-form expressions
- example: saturated sand under PGA 0.25g/Mw 7.0 — shallow loose sand (N=8, FS 0.45) liquefies, deep dense sand (N=28, FS 1.50) OK -> fail

Verified: `uv run python -m digitalmodel examples/workflows/liquefaction/input.yml` EXIT0; durable suite 103 passed/2 skipped; ruff/black/isort/flake8 clean.

NOTE: small merge conflict expected with the still-open loop-5 mudmat PR #910 (same geotechnical section); resolvable by keeping both inserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)