### PR TITLE
ci: Deploy mkdocs API reference to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build docs
+        env:
+          UV_NO_SOURCES: "true"
+        run: uv run --group docs mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pages.yml` to publish the auto-generated API reference to GitHub Pages, mirroring the proven docs CI pattern already in this repo (`docs.yml`) and in worldenergydata.

- **build** job: `actions/checkout@v6`, `actions/setup-python@v6` (3.11), `astral-sh/setup-uv@v7`, then the **same** build command as `docs.yml` — `uv run --group docs mkdocs build --strict` with `UV_NO_SOURCES: "true"` — and uploads `site/` via `actions/upload-pages-artifact@v3`.
- **deploy** job: `needs: build`, `environment: github-pages`, publishes via `actions/deploy-pages@v4`.
- Triggers: push to `main` (paths `src/**`, `docs/**`, `mkdocs.yml`, `.github/workflows/pages.yml`) + `workflow_dispatch`.
- Permissions `contents:read, pages:write, id-token:write`; concurrency group `pages`.

## Scope / confidentiality

Deploys **only** the existing mkdocs site (`docs_dir: docs/api`, `site_dir: site`). This PR does **not**:
- change `docs_dir`,
- add the ~300 report HTML/PNG gallery,
- include `docs/domains/ansys/thin-wall-pipeline/` (DT67, client-derived) or `apirp2rd` legacy dirs.

`site/` is already gitignored (`.gitignore` line `/site`).

## Build verification

Local `mkdocs build --strict` was attempted with the identical command; the uv environment resolution was network-throttled in this sandbox and did not complete within the time budget (no docs error was emitted — it never got past env resolution). The workflow reuses the exact build command + env from the repo's already-passing `docs.yml` CI, so the build is exercised in CI.

Refs digitalmodel#913
Ecosystem workspace-hub#3223