### PR TITLE
feat(mooring-fatigue): v2 free-corrosion S-N basis (versioned-routing canary)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -101,6 +101,9 @@ workflows:
       - examples/workflows/mooring-fatigue/results/input_mooring_fatigue_summary.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[mooring-fatigue]
     runtime: offline
+    version: 1
+    status: stable
+    latest: true
     parametric:
       physics: log_log
       response: damage
@@ -118,6 +121,24 @@ workflows:
         - {name: n_cycles, scale: log, grid: [10000, 100000, 1000000]}
         - {name: sn_curve, values: [B1, B2, C, C1, C2, D, E, F]}
       atlas: atlases/mooring_fatigue
+  # Versioned-routing canary (schema v2): a second algorithm version of the same
+  # id. v2 assesses against the DNV-RP-C203 free-corrosion S-N basis (single
+  # slope, no endurance limit, no cathodic-protection credit) — more conservative
+  # than v1's seawater-CP bilinear curve. Shipped `experimental` so unpinned
+  # routing stays on v1 (latest-stable); pin `digitalmodel:mooring-fatigue@2`
+  # to opt in.
+  - id: mooring-fatigue
+    version: 2
+    status: experimental
+    basename: mooring_fatigue
+    title: Metallic mooring-line fatigue — conservative free-corrosion S-N basis
+    input: examples/workflows/mooring-fatigue-v2/input.yml
+    outputs:
+      - examples/workflows/mooring-fatigue-v2/results/input.yml
+      - examples/workflows/mooring-fatigue-v2/results/input_mooring_fatigue.csv
+      - examples/workflows/mooring-fatigue-v2/results/input_mooring_fatigue_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[mooring-fatigue]
+    runtime: offline
   - id: mooring-fatigue-atlas-query
     basename: parametric_query
     title: Instant interpolated mooring fatigue life from the pre-computed atlas

--- a/examples/workflows/mooring-fatigue-v2/input.yml
+++ b/examples/workflows/mooring-fatigue-v2/input.yml
@@ -1,0 +1,42 @@
+# mooring-fatigue v2 (experimental) — conservative free-corrosion S-N basis.
+# Identical lines/loads to v1, but assessed against the DNV-RP-C203 free-corrosion
+# curve (single-slope, NO endurance limit, no cathodic-protection credit) instead
+# of the seawater-CP bilinear curve. Appropriate where effective CP cannot be
+# assured; yields shorter (more conservative) fatigue life than v1. Pin with
+# `digitalmodel:mooring-fatigue@2` to opt in; unpinned routing stays on v1.
+basename: mooring_fatigue
+
+mooring_fatigue:
+  design_life_years: 25.0
+  dff: 3.0
+  sn_curve:
+    curve: D
+    environment: free_corrosion
+  output_dir: results
+  lines:
+    - id: chain-01
+      material: CHAIN
+      area_mm2: 8000.0
+      tension_range_bins:
+        - tension_range_kN: 220.0
+          n_cycles: 150000
+        - tension_range_kN: 300.0
+          n_cycles: 60000
+        - tension_range_kN: 380.0
+          n_cycles: 10000
+    - id: wire-01
+      material: STEEL-WIRE
+      area_mm2: 5200.0
+      tension_range_bins:
+        - tension_range_kN: 180.0
+          n_cycles: 180000
+        - tension_range_kN: 260.0
+          n_cycles: 90000
+        - tension_range_kN: 360.0
+          n_cycles: 20000
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true


### PR DESCRIPTION
Closes #932. The versioned-routing **canary** — a genuine second algorithm version of `mooring-fatigue` that exercises the schema-v2 registry (#923) and the deckhand resolver end-to-end on real data.

## What
- **`mooring-fatigue` v2** = DNV-RP-C203 **free-corrosion S-N basis** (single slope, no endurance limit, no cathodic-protection credit) vs v1's seawater-CP bilinear curve. A real, standard, more-conservative assessment basis — `environment: free_corrosion` is already supported by the engine, so **no engine code change** (new example input + registry row only).
- v1 gains `version: 1 / status: stable / latest: true`; v2 is `version: 2 / status: experimental`. **Unpinned routing stays on v1** (latest-stable) — no client-facing default change; `digitalmodel:mooring-fatigue@2` opts in.

## Verification (to-best-level)
- **Engineering direction correct** — free-corrosion is more conservative: chain life 2587→1974 yr (+31% damage), wire 609→573 yr.
- **Registry invariants** (`test_registry_versioning.py`): 2 passed (distinct versions, exactly one latest-stable).
- **Durable-workflow test**: both `mooring-fatigue` rows run and produce outputs (duplicate-id handled by pytest).
- **Deckhand resolver end-to-end** (merged #484, against this branch's registry):
  - `digitalmodel:mooring-fatigue` → **v1** (latest-stable), firable
  - `digitalmodel:mooring-fatigue@2` → **v2** (experimental, annotated), firable
  - `digitalmodel:mooring-fatigue@1` → **v1**, firable
  - `digitalmodel:mooring-fatigue@9` → rejected: *"version 9 not in registry (have [1, 2])"*

## Notes
- `results/` is gitignored (generated at test time) — only the input + registry row are committed.
- Promoting v2 to `latest` (changing the client default to free-corrosion) is a deliberate domain-owner decision, intentionally **not** part of this canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)