### PR TITLE
diffraction: Linux-side postprocessing orchestrator + DiffractionResults loader (#928)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/output_schemas.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/output_schemas.py
@@ -154,6 +154,21 @@ class RAOSet:
             }
         }
 
+    @classmethod
+    def from_dict(cls, d: Dict) -> "RAOSet":
+        comps = d['raos']
+        components = {name: _rao_component_from_dict(comps[name]) for name in
+                     ('surge', 'sway', 'heave', 'roll', 'pitch', 'yaw')}
+        return cls(
+            vessel_name=d['vessel_name'],
+            analysis_tool=d['analysis_tool'],
+            water_depth=float(d['water_depth']),
+            created_date=d.get('created_date', ''),
+            source_file=d.get('source_file'),
+            notes=d.get('notes'),
+            **components,
+        )
+
     @staticmethod
     def _component_to_dict(component: RAOComponent) -> Dict:
         """Convert RAO component to dictionary"""
@@ -216,6 +231,10 @@ class AddedMassSet:
     source_file: Optional[str] = None
     notes: Optional[str] = None
 
+    @classmethod
+    def from_dict(cls, d: Dict) -> "AddedMassSet":
+        return _matrix_set_from_dict(cls, d)
+
     def get_matrix_at_frequency(self, freq: float) -> Optional[HydrodynamicMatrix]:
         """Get added mass matrix at specific frequency"""
         for matrix in self.matrices:
@@ -254,6 +273,10 @@ class DampingSet:
     created_date: str
     source_file: Optional[str] = None
     notes: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "DampingSet":
+        return _matrix_set_from_dict(cls, d)
 
     def get_matrix_at_frequency(self, freq: float) -> Optional[HydrodynamicMatrix]:
         """Get damping matrix at specific frequency"""
@@ -303,6 +326,18 @@ class HydrostaticResults:
             'stiffness_matrix': self.stiffness_matrix.tolist()
         }
 
+    @classmethod
+    def from_dict(cls, d: Dict) -> "HydrostaticResults":
+        return cls(
+            vessel_name=d['vessel_name'],
+            displacement_volume=float(d['displacement_volume']),
+            mass=float(d['mass']),
+            centre_of_gravity=list(d['centre_of_gravity']),
+            centre_of_buoyancy=list(d['centre_of_buoyancy']),
+            waterplane_area=float(d['waterplane_area']),
+            stiffness_matrix=np.asarray(d['stiffness_matrix'], dtype=float),
+        )
+
 
 @dataclass
 class DiffractionResults:
@@ -344,6 +379,83 @@ class DiffractionResults:
         if self.hydrostatics:
             res['hydrostatics'] = self.hydrostatics.to_dict()
         return res
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "DiffractionResults":
+        """Reconstruct results from ``to_dict()`` output.
+
+        License-free loader for Linux-side postprocessing: a licensed run on the
+        host exports ``DiffractionResults.to_dict()`` as JSON, which this rebuilds
+        into the full object (no OrcFxAPI, no heavy binaries). Round-trips
+        ``to_dict()`` losslessly.
+        """
+        hydro = d.get('hydrostatics')
+        return cls(
+            vessel_name=d['vessel_name'],
+            analysis_tool=d['analysis_tool'],
+            water_depth=float(d['water_depth']),
+            raos=RAOSet.from_dict(d['raos']),
+            added_mass=AddedMassSet.from_dict(d['added_mass']),
+            damping=DampingSet.from_dict(d['damping']),
+            hydrostatics=HydrostaticResults.from_dict(hydro) if hydro else None,
+            created_date=d.get('created_date', ''),
+            analysis_date=d.get('analysis_date'),
+            source_files=d.get('source_files'),
+            notes=d.get('notes'),
+            phase_convention=d.get('phase_convention', 'unknown'),
+            unit_system=d.get('unit_system', 'SI'),
+        )
+
+
+# from_dict reconstruction helpers (reverse of the to_dict() serializers above) --
+
+def _frequency_from_dict(d: Dict) -> "FrequencyData":
+    values = np.asarray(d['values'], dtype=float)
+    # __post_init__ recomputes count/min/max/periods from values.
+    return FrequencyData(values=values, periods=None, count=0,
+                         min_freq=0.0, max_freq=0.0,
+                         unit=d.get('unit', Unit.FREQUENCY.value))
+
+
+def _heading_from_dict(d: Dict) -> "HeadingData":
+    values = np.asarray(d['values'], dtype=float)
+    return HeadingData(values=values, count=0, min_heading=0.0, max_heading=0.0,
+                       unit=d.get('unit', Unit.HEADING.value))
+
+
+def _rao_component_from_dict(d: Dict) -> "RAOComponent":
+    return RAOComponent(
+        dof=DOF[d['dof']],
+        magnitude=np.asarray(d['magnitude'], dtype=float),
+        phase=np.asarray(d['phase'], dtype=float),
+        frequencies=_frequency_from_dict(d['frequencies']),
+        headings=_heading_from_dict(d['headings']),
+        unit=d.get('unit', ''),  # __post_init__ resets from dof
+    )
+
+
+def _matrix_from_dict(d: Dict) -> "HydrodynamicMatrix":
+    return HydrodynamicMatrix(
+        matrix=np.asarray(d['matrix'], dtype=float),
+        frequency=float(d['frequency']),
+        matrix_type=d['matrix_type'],
+        units=d.get('units', {}),
+    )
+
+
+def _matrix_set_from_dict(cls, d: Dict):
+    """Shared from_dict for AddedMassSet / DampingSet (identical layout)."""
+    return cls(
+        vessel_name=d['vessel_name'],
+        analysis_tool=d['analysis_tool'],
+        water_depth=float(d['water_depth']),
+        matrices=[_matrix_from_dict(m) for m in d['matrices']],
+        frequencies=_frequency_from_dict(
+            {'values': d['frequencies']['values'], 'unit': Unit.FREQUENCY.value}),
+        created_date=d.get('created_date', ''),
+        source_file=d.get('source_file'),
+        notes=d.get('notes'),
+    )
 
 
 # Schema validation utilities

--- a/src/digitalmodel/hydrodynamics/diffraction/postprocess.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/postprocess.py
@@ -1,0 +1,191 @@
+"""License-free, Linux-side postprocessing for diffraction (OrcaWave/AQWA) runs.
+
+The licensed solver runs on the OrcaFlex/OrcaWave host; only a small *numeric*
+results bundle comes back through the licensed-run lane:
+
+    diffraction_results.json   # DiffractionResults.to_dict() (the authority)
+    *_validation.json          # optional host-side validation report
+    *.csv                      # optional RAO/added-mass/damping tables
+
+This module reconstructs ``DiffractionResults`` from that bundle (no OrcFxAPI, no
+heavy .owr/.owd/.sim/.gdf) and produces, on Linux:
+
+    - validation_report.json   # re-run output validation
+    - <vessel>_vessel_type.yml + RAO/AddedMass/Damping CSV + Excel + summary
+    - rao_<dof>.png            # RAO magnitude vs period per heading
+    - index.json               # manifest of everything written
+
+Entry point: ``postprocess_diffraction_run(bundle_dir, out_dir)``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+
+from digitalmodel.hydrodynamics.diffraction.orcaflex_exporter import OrcaFlexExporter
+from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
+from digitalmodel.hydrodynamics.diffraction.output_validator import OutputValidator
+
+RESULTS_JSON_NAMES = ("diffraction_results.json", "results.json")
+_RESULT_KEYS = {"raos", "added_mass", "damping"}
+_PLOT_DOFS = ("heave", "roll", "pitch")
+
+
+@dataclass
+class PostprocResult:
+    """What a Linux postprocess pass produced."""
+
+    vessel: str
+    out_dir: Path
+    validation_status: str
+    exports: Dict[str, Path] = field(default_factory=dict)
+    plots: List[Path] = field(default_factory=list)
+    validation_report: Path | None = None
+    index: Path | None = None
+
+
+def load_results_bundle(bundle_dir: str | Path) -> DiffractionResults:
+    """Reconstruct DiffractionResults from a returned bundle directory.
+
+    Prefers a well-known ``diffraction_results.json``; otherwise picks the first
+    JSON that looks like a serialized DiffractionResults. Raises if none found.
+    """
+    bundle = Path(bundle_dir)
+    if not bundle.is_dir():
+        raise NotADirectoryError(f"bundle dir not found: {bundle}")
+    for name in RESULTS_JSON_NAMES:
+        candidate = bundle / name
+        if candidate.is_file():
+            return DiffractionResults.from_dict(json.loads(candidate.read_text()))
+    for candidate in sorted(bundle.rglob("*.json")):
+        try:
+            obj = json.loads(candidate.read_text())
+        except (ValueError, OSError):
+            continue
+        if isinstance(obj, dict) and _RESULT_KEYS <= set(obj):
+            return DiffractionResults.from_dict(obj)
+    raise FileNotFoundError(f"no diffraction results JSON found under {bundle}")
+
+
+def postprocess_diffraction_run(
+    bundle_dir: str | Path,
+    out_dir: str | Path,
+    *,
+    make_plots: bool = True,
+) -> PostprocResult:
+    """Postprocess one diffraction run bundle on Linux (no license).
+
+    Loads the bundle, re-runs output validation, exports OrcaFlex-ready vessel
+    type + coefficient CSVs, renders RAO plots, and writes an index manifest.
+    """
+    results = load_results_bundle(bundle_dir)
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # 1) Validation rollup (re-run on Linux against the reconstructed object).
+    report = OutputValidator(results).run_all_validations()
+    validation_path = out / "validation_report.json"
+    validation_path.write_text(json.dumps(report, indent=2, default=str))
+    status = str(report.get("overall_status") or report.get("status") or "UNKNOWN")
+
+    # 2) OrcaFlex export: vessel_type.yml + RAO/AddedMass/Damping CSV + Excel + summary.
+    exports = OrcaFlexExporter(results, out).export_all()
+
+    # 3) RAO plots (optional dep; skipped cleanly if matplotlib is absent).
+    plots = _plot_raos(results, out) if make_plots else []
+
+    # 4) Index manifest.
+    index = {
+        "vessel": results.vessel_name,
+        "analysis_tool": results.analysis_tool,
+        "water_depth": results.water_depth,
+        "validation_status": status,
+        "validation_report": validation_path.name,
+        "exports": {k: Path(v).name for k, v in exports.items()},
+        "plots": [p.name for p in plots],
+    }
+    index_path = out / "index.json"
+    index_path.write_text(json.dumps(index, indent=2, default=str))
+
+    return PostprocResult(
+        vessel=results.vessel_name,
+        out_dir=out,
+        validation_status=status,
+        exports={k: Path(v) for k, v in exports.items()},
+        plots=plots,
+        validation_report=validation_path,
+        index=index_path,
+    )
+
+
+def _plot_raos(results: DiffractionResults, out: Path) -> List[Path]:
+    """RAO magnitude vs wave period, one curve per heading, per DOF.
+
+    Uses a headless matplotlib backend. Returns [] (no error) if matplotlib is
+    not installed — plots are a convenience, not a contract.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:  # noqa: BLE001 - plotting is optional
+        return []
+
+    plots: List[Path] = []
+    rao = results.raos
+    for dof_name in _PLOT_DOFS:
+        comp = getattr(rao, dof_name)
+        periods = np.asarray(comp.frequencies.periods, dtype=float)
+        order = np.argsort(periods)
+        headings = np.asarray(comp.headings.values, dtype=float)
+
+        fig, ax = plt.subplots(figsize=(7.0, 4.5))
+        for j, heading in enumerate(headings):
+            ax.plot(
+                periods[order],
+                np.asarray(comp.magnitude)[order, j],
+                marker="o",
+                markersize=3,
+                label=f"{heading:.0f}°",
+            )
+        ax.set_xlabel("Wave period T (s)")
+        ax.set_ylabel(f"{dof_name.title()} RAO ({comp.unit})")
+        ax.set_title(f"{rao.vessel_name} — {dof_name.title()} RAO")
+        ax.grid(True, alpha=0.3)
+        ax.legend(title="Heading", fontsize="small", ncol=2)
+        path = out / f"rao_{dof_name}.png"
+        fig.savefig(path, dpi=110, bbox_inches="tight")
+        plt.close(fig)
+        plots.append(path)
+    return plots
+
+
+def _cli(argv: Any = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "bundle_dir", help="directory holding the returned results bundle"
+    )
+    parser.add_argument("--out", default="postproc", help="output directory")
+    parser.add_argument("--no-plots", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = postprocess_diffraction_run(
+        args.bundle_dir, args.out, make_plots=not args.no_plots
+    )
+    print(f"postprocessed {result.vessel}: validation={result.validation_status}")
+    print(
+        f"  -> {result.out_dir}  ({len(result.exports)} exports, {len(result.plots)} plots)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/tests/hydrodynamics/diffraction/test_postprocess.py
+++ b/tests/hydrodynamics/diffraction/test_postprocess.py
@@ -1,0 +1,116 @@
+"""Linux-side diffraction postprocessing (digitalmodel #928).
+
+Covers the license-free path: DiffractionResults.to_dict() round-trip through
+from_dict(), bundle loading, and the postprocess orchestrator producing exports
++ validation + index from a returned numeric bundle (no OrcFxAPI, no heavy files).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.output_schemas import DiffractionResults
+from digitalmodel.hydrodynamics.diffraction.postprocess import (
+    PostprocResult,
+    load_results_bundle,
+    postprocess_diffraction_run,
+)
+
+
+def _assert_results_equal(a: DiffractionResults, b: DiffractionResults) -> None:
+    assert a.vessel_name == b.vessel_name
+    assert a.analysis_tool == b.analysis_tool
+    assert a.water_depth == b.water_depth
+    for dof in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
+        ca, cb = getattr(a.raos, dof), getattr(b.raos, dof)
+        assert np.allclose(ca.magnitude, cb.magnitude)
+        assert np.allclose(ca.phase, cb.phase)
+        assert np.allclose(ca.frequencies.values, cb.frequencies.values)
+        assert np.allclose(ca.headings.values, cb.headings.values)
+        assert ca.unit == cb.unit
+    for set_name in ("added_mass", "damping"):
+        sa, sb = getattr(a, set_name), getattr(b, set_name)
+        assert len(sa.matrices) == len(sb.matrices)
+        for ma, mb in zip(sa.matrices, sb.matrices):
+            assert np.allclose(ma.matrix, mb.matrix)
+            assert ma.frequency == pytest.approx(mb.frequency)
+
+
+def test_diffraction_results_to_dict_from_dict_roundtrip(mock_diffraction_results):
+    rebuilt = DiffractionResults.from_dict(mock_diffraction_results.to_dict())
+    _assert_results_equal(rebuilt, mock_diffraction_results)
+
+
+def test_roundtrip_survives_json_serialization(dense_diffraction_results):
+    blob = json.dumps(dense_diffraction_results.to_dict())
+    rebuilt = DiffractionResults.from_dict(json.loads(blob))
+    _assert_results_equal(rebuilt, dense_diffraction_results)
+
+
+def test_load_results_bundle_reads_named_json(tmp_path: Path, mock_diffraction_results):
+    (tmp_path / "diffraction_results.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    loaded = load_results_bundle(tmp_path)
+    _assert_results_equal(loaded, mock_diffraction_results)
+
+
+def test_load_results_bundle_discovers_unnamed_json(
+    tmp_path: Path, mock_diffraction_results
+):
+    # A bundle whose results file is not the canonical name still loads.
+    (tmp_path / "fpso_run_42.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    loaded = load_results_bundle(tmp_path)
+    assert loaded.vessel_name == mock_diffraction_results.vessel_name
+
+
+def test_load_results_bundle_raises_when_absent(tmp_path: Path):
+    (tmp_path / "notes.json").write_text(json.dumps({"hello": "world"}))
+    with pytest.raises(FileNotFoundError):
+        load_results_bundle(tmp_path)
+
+
+def test_postprocess_run_produces_exports_validation_and_index(
+    tmp_path: Path, mock_diffraction_results
+):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "diffraction_results.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    out = tmp_path / "postproc"
+
+    result = postprocess_diffraction_run(bundle, out, make_plots=False)
+
+    assert isinstance(result, PostprocResult)
+    assert result.vessel == mock_diffraction_results.vessel_name
+    assert result.validation_status  # non-empty status string
+    # OrcaFlex export wrote a vessel type + coefficient CSVs.
+    assert "vessel_type" in result.exports
+    assert result.exports["vessel_type"].is_file()
+    assert (out / "validation_report.json").is_file()
+    index = json.loads((out / "index.json").read_text())
+    assert index["vessel"] == mock_diffraction_results.vessel_name
+    assert "exports" in index
+
+
+def test_postprocess_run_no_heavy_files_emitted(
+    tmp_path: Path, mock_diffraction_results
+):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "diffraction_results.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    out = tmp_path / "postproc"
+    postprocess_diffraction_run(bundle, out, make_plots=False)
+
+    heavy = {".owr", ".owd", ".sim", ".gdf", ".dat", ".h5", ".bin"}
+    offenders = [p for p in out.rglob("*") if p.suffix.lower() in heavy]
+    assert offenders == [], f"postproc emitted heavy files: {offenders}"


### PR DESCRIPTION
Closes #928. First slice of the postprocessing + vessel-envelope initiative.

## What
Postprocess licensed OrcaWave/AQWA runs **on Linux** from a small numeric results bundle — no OrcFxAPI, heavy binaries (`.owr/.owd/.sim/.gdf`) stay on the host (keep-Windows-thin).

- **`DiffractionResults.from_dict()`** (+ `RAOSet/AddedMassSet/DampingSet/HydrostaticResults.from_dict` + reconstruction helpers) — the reverse of the existing `to_dict()`. This was the missing loader: nothing could reconstruct results off-host. Round-trips losslessly through JSON.
- **`postprocess.py`**: `load_results_bundle()` + `postprocess_diffraction_run()` → re-runs `OutputValidator`, exports OrcaFlex `vessel_type.yml` + RAO/AddedMass/Damping CSV + Excel + summary (`OrcaFlexExporter`), renders RAO plots (matplotlib, optional dep — skipped cleanly if absent), writes an `index.json` manifest. CLI entry included.

## Bundle contract (informs deckhand #489)
The lane returns: `diffraction_results.json` (= `DiffractionResults.to_dict()`) + RAO/AddedMass/Damping `.csv` + `*_validation.json`. No `.gdf/.owr`. This PR is the **consumer**; deckhand #489 is the **producer** (lane returning the bundle).

## Tests
7 new (to_dict↔from_dict round-trip incl. JSON, bundle load/discover/absent, orchestrator outputs, no-heavy-files guard). Full diffraction suite: **1597 passed, 27 skipped** (license-gated), 0 failures. Smoke-verified end-to-end (FPSO-shaped synthetic → 6 exports + 3 RAO PNGs + validation + index).

## Notes
- Reuses existing license-free modules (`OutputValidator`, `OrcaFlexExporter`); no rebuild.
- New code is black/ruff clean. (Pre-existing `field` F401 in output_schemas left untouched to avoid unrelated churn.)
- Don't self-merge.

Part of #929 (bulk fleet generator) + #930 (vessel envelope by operation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)