### PR TITLE
diffraction: bulk fleet deck generator + OrcaWave batch-config emitter (#929)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/fleet_decks.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/fleet_decks.py
@@ -1,0 +1,244 @@
+"""Bulk diffraction-deck generation over the vessel-database fleet.
+
+``vessel_deck_builder.build_deck`` prepares ONE OrcaWave deck from a vessel
+record. This module loops the whole fleet (all ``particulars`` records across
+scopes, deduped) and:
+
+  - builds a deck per vessel (``decks/<vessel_id>/{hull.gdf, <name>.yml,
+    manifest.json}``) with a fleet ``index.json``;
+  - emits an OrcaWave **batch config** (YAML) consumable by
+    ``orcawave_batch_runner`` and dispatch-ready through the licensed-run lane.
+
+License-free: this only *prepares* decks + the batch config. The solves run on a
+licensed OrcaWave/AQWA machine. Parametric forms that a single hull surface can't
+represent (semisub/spar) emit a placeholder deck flagged ``mesh-to-supply`` and
+are excluded from the batch config by default.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from digitalmodel.hydrodynamics.diffraction.vessel_deck_builder import (
+    DeckResult,
+    build_deck,
+)
+from digitalmodel.marine_ops.vessel_db.loader import Record, datasets, iter_records
+
+FLEET_LAYER = "particulars"
+
+
+@dataclass
+class FleetResult:
+    """Outcome of a fleet deck-generation pass."""
+
+    out_dir: Path
+    decks: list[DeckResult] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)  # (vessel, reason)
+    index_path: Optional[Path] = None
+
+    @property
+    def n_built(self) -> int:
+        return len(self.decks)
+
+    @property
+    def n_parametric(self) -> int:
+        return sum(1 for d in self.decks if d.mesh_kind == "parametric")
+
+    @property
+    def n_placeholder(self) -> int:
+        return sum(1 for d in self.decks if d.mesh_kind == "placeholder")
+
+
+def iter_fleet_records(scopes: Optional[list[str]] = None) -> list[Record]:
+    """All ``particulars`` records across scopes, deduped by normalized name.
+
+    ``scopes`` restricts to specific dataset scopes (e.g. ``["install"]`` for the
+    installation fleet); ``None`` means every scope. First occurrence of a name
+    wins (a vessel may appear in more than one scope).
+    """
+    seen: set[str] = set()
+    records: list[Record] = []
+    for scope, layer in datasets():
+        if layer != FLEET_LAYER:
+            continue
+        if scopes and scope not in scopes:
+            continue
+        for record in iter_records(scope, layer):
+            key = _name_key(record.name)
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append(record)
+    return records
+
+
+def generate_fleet_decks(
+    out_dir: str | Path,
+    *,
+    scopes: Optional[list[str]] = None,
+    periods: Optional[list[float]] = None,
+    headings: Optional[list[float]] = None,
+    water_depth: float | str = "infinite",
+    target_panels: int = 1000,
+) -> FleetResult:
+    """Build an OrcaWave diffraction deck for every fleet vessel with usable dims.
+
+    Vessels missing principal dimensions (LOA/beam/draft) are recorded in
+    ``skipped`` rather than failing the run.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    result = FleetResult(out_dir=out)
+
+    for record in iter_fleet_records(scopes):
+        deck = build_deck(
+            record,
+            out,
+            periods=periods,
+            headings=headings,
+            water_depth=water_depth,
+            target_panels=target_panels,
+        )
+        if deck is None:
+            result.skipped.append((record.name, "insufficient principal dimensions"))
+            continue
+        result.decks.append(deck)
+
+    index = [
+        {
+            "vessel": d.vessel,
+            "vessel_dir": d.deck_path.parent.name,
+            "deck": d.deck_path.name,
+            "form": d.form,
+            "mesh_kind": d.mesh_kind,
+            "n_panels": d.n_panels,
+            "mass_basis": d.mass_basis,
+        }
+        for d in result.decks
+    ]
+    index_path = out / "index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "n_built": result.n_built,
+                "n_parametric": result.n_parametric,
+                "n_placeholder": result.n_placeholder,
+                "n_skipped": len(result.skipped),
+                "water_depth": water_depth,
+                "decks": index,
+                "skipped": [{"vessel": v, "reason": r} for v, r in result.skipped],
+                "provenance": (
+                    "parametric prep from vessel_db; run on a licensed OrcaWave/AQWA machine"
+                ),
+            },
+            indent=2,
+        )
+    )
+    result.index_path = index_path
+    return result
+
+
+def emit_orcawave_batch_config(
+    fleet: FleetResult,
+    out_path: str | Path,
+    *,
+    execution_mode: str = "parallel",
+    max_workers: int = 4,
+    include_placeholder: bool = False,
+    validate: bool = True,
+    generate_plots: bool = True,
+    export_formats: Optional[list[str]] = None,
+) -> Path:
+    """Write an OrcaWave batch config (YAML) for the generated fleet decks.
+
+    The config is consumable by ``orcawave_batch_runner.run_orcawave_batch`` (and
+    dispatch-ready through the licensed-run lane). Placeholder decks (no real
+    mesh) are excluded unless ``include_placeholder`` — they would fail a solve.
+    """
+    out_path = Path(out_path)
+    base_output_dir = fleet.out_dir / "batch_output"
+    jobs = []
+    for deck in fleet.decks:
+        if deck.mesh_kind == "placeholder" and not include_placeholder:
+            continue
+        vessel_dir = deck.deck_path.parent
+        jobs.append(
+            {
+                "spec_path": str(deck.deck_path),
+                "job_name": vessel_dir.name,
+                "output_dir": str(base_output_dir / vessel_dir.name),
+                "validate": validate,
+                "generate_plots": generate_plots,
+                "export_formats": export_formats or ["csv"],
+            }
+        )
+
+    config = {
+        "execution_mode": execution_mode,
+        "max_workers": max_workers,
+        "base_output_dir": str(base_output_dir),
+        "generate_summary_report": True,
+        "jobs": jobs,
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    return out_path
+
+
+def _name_key(name: str) -> str:
+    return "".join(ch for ch in name.lower() if ch.isalnum())
+
+
+def _cli(argv=None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="fleet_decks", help="output directory")
+    parser.add_argument(
+        "--scope",
+        action="append",
+        dest="scopes",
+        help="restrict to a dataset scope (repeatable), e.g. --scope install",
+    )
+    parser.add_argument("--target-panels", type=int, default=1000)
+    parser.add_argument(
+        "--batch-config",
+        default=None,
+        help="also write an OrcaWave batch config YAML at this path",
+    )
+    parser.add_argument(
+        "--include-placeholder",
+        action="store_true",
+        help="include semisub/spar placeholder decks in the batch config",
+    )
+    args = parser.parse_args(argv)
+
+    fleet = generate_fleet_decks(
+        args.out, scopes=args.scopes, target_panels=args.target_panels
+    )
+    print(
+        f"built {fleet.n_built} decks "
+        f"({fleet.n_parametric} parametric, {fleet.n_placeholder} placeholder); "
+        f"{len(fleet.skipped)} skipped -> {fleet.out_dir}"
+    )
+    if args.batch_config:
+        path = emit_orcawave_batch_config(
+            fleet, args.batch_config, include_placeholder=args.include_placeholder
+        )
+        n_jobs = sum(
+            1
+            for d in fleet.decks
+            if d.mesh_kind != "placeholder" or args.include_placeholder
+        )
+        print(f"wrote batch config ({n_jobs} jobs) -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/tests/hydrodynamics/diffraction/test_fleet_decks.py
+++ b/tests/hydrodynamics/diffraction/test_fleet_decks.py
@@ -1,0 +1,134 @@
+"""Bulk fleet diffraction-deck generation (digitalmodel #929)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.hydrodynamics.diffraction import fleet_decks
+from digitalmodel.hydrodynamics.diffraction.orcawave_batch_runner import (
+    OrcaWaveBatchConfig,
+)
+from digitalmodel.marine_ops.vessel_db.loader import Record
+
+
+def _record(name: str, vessel_type: str, **dims) -> Record:
+    return Record(
+        name=name,
+        scope="floating",
+        layer="particulars",
+        vessel_type=vessel_type,
+        raw_fields=dims,
+    )
+
+
+@pytest.fixture
+def fleet(monkeypatch):
+    records = [
+        _record(
+            "Test FPSO", "FPSO", loa_m=258, beam_m=46, draft_m=14, displacement_t=160000
+        ),
+        _record(
+            "Test VLCC",
+            "VLCC tanker",
+            loa_m=330,
+            beam_m=60,
+            draft_m=22,
+            displacement_t=320000,
+        ),
+        _record("Test Semi", "semisubmersible", loa_m=120, beam_m=78, draft_m=20),
+        _record(
+            "No Draft Barge", "barge", loa_m=100, beam_m=30
+        ),  # missing draft -> skip
+    ]
+    monkeypatch.setattr(fleet_decks, "iter_fleet_records", lambda scopes=None: records)
+    return records
+
+
+def test_generate_fleet_decks_builds_and_skips(tmp_path: Path, fleet):
+    result = fleet_decks.generate_fleet_decks(tmp_path, target_panels=120)
+
+    assert result.n_built == 3
+    assert result.n_placeholder == 1  # the semisub
+    assert result.n_parametric == 2
+    assert [name for name, _ in result.skipped] == ["No Draft Barge"]
+
+    # Each built deck wrote its dir with a spec .yml + manifest.
+    for deck in result.decks:
+        assert deck.deck_path.is_file()
+        assert (deck.deck_path.parent / "manifest.json").is_file()
+
+    index = json.loads((tmp_path / "index.json").read_text())
+    assert index["n_built"] == 3
+    assert index["n_skipped"] == 1
+    assert len(index["decks"]) == 3
+
+
+def test_emit_batch_config_excludes_placeholder_and_parses(tmp_path: Path, fleet):
+    result = fleet_decks.generate_fleet_decks(tmp_path, target_panels=120)
+    cfg_path = fleet_decks.emit_orcawave_batch_config(result, tmp_path / "batch.yml")
+
+    raw = yaml.safe_load(cfg_path.read_text())
+    # Placeholder (semisub) excluded by default -> 2 jobs from 3 decks.
+    assert len(raw["jobs"]) == 2
+    job_names = {j["job_name"] for j in raw["jobs"]}
+    assert not any("semi" in n.lower() for n in job_names)
+    for job in raw["jobs"]:
+        assert Path(job["spec_path"]).name.endswith(".yml")
+        assert "output_dir" in job
+
+    # The emitted YAML must parse back through the real batch-runner schema
+    # (proves dispatch-readiness, not just a hand-rolled dict).
+    parsed = OrcaWaveBatchConfig.from_yaml(cfg_path)
+    assert len(parsed.jobs) == 2
+    assert str(parsed.execution_mode.value) == "parallel"
+
+
+def test_emit_batch_config_can_include_placeholder(tmp_path: Path, fleet):
+    result = fleet_decks.generate_fleet_decks(tmp_path, target_panels=120)
+    cfg_path = fleet_decks.emit_orcawave_batch_config(
+        result, tmp_path / "batch_all.yml", include_placeholder=True
+    )
+    raw = yaml.safe_load(cfg_path.read_text())
+    assert len(raw["jobs"]) == 3
+
+
+def test_iter_fleet_records_dedups_across_scopes(monkeypatch):
+    rec_floating = _record("Shared Vessel", "FPSO", loa_m=200, beam_m=40, draft_m=12)
+    rec_install = _record("shared vessel", "FPSO", loa_m=200, beam_m=40, draft_m=12)
+    rec_install.scope = "install"
+
+    monkeypatch.setattr(
+        fleet_decks,
+        "datasets",
+        lambda: [("floating", "particulars"), ("install", "particulars")],
+    )
+
+    def fake_iter(scope, layer, base=None):
+        return {"floating": [rec_floating], "install": [rec_install]}[scope]
+
+    monkeypatch.setattr(fleet_decks, "iter_records", fake_iter)
+
+    out = fleet_decks.iter_fleet_records()
+    assert len(out) == 1  # same name across two scopes -> deduped
+
+
+def test_scope_filter_passed_through(monkeypatch):
+    seen_scopes = []
+
+    monkeypatch.setattr(
+        fleet_decks,
+        "datasets",
+        lambda: [("floating", "particulars"), ("install", "particulars")],
+    )
+
+    def fake_iter(scope, layer, base=None):
+        seen_scopes.append(scope)
+        return []
+
+    monkeypatch.setattr(fleet_decks, "iter_records", fake_iter)
+    fleet_decks.iter_fleet_records(scopes=["install"])
+    assert seen_scopes == ["install"]


### PR DESCRIPTION
Closes #929. Makes the diffraction model generator **bulk-ready**.

## What
- **`iter_fleet_records(scopes)`** — all `particulars` records across vessel-db scopes, deduped by normalized name.
- **`generate_fleet_decks(out, ...)`** — builds a deck per vessel with usable principal dims; vessels missing LOA/beam/draft are recorded in `skipped` (not failed). Writes `decks/<id>/{hull.gdf, <name>.yml, manifest.json}` + a fleet `index.json` (built/parametric/placeholder/skipped counts).
- **`emit_orcawave_batch_config(fleet, out)`** — a YAML batch config consumable by `orcawave_batch_runner` and **dispatch-ready through the licensed-run lane**. Placeholder (semisub/spar) decks are excluded by default — they have no real mesh and would fail a solve (`--include-placeholder` to keep them).
- **CLI**: `python -m digitalmodel.hydrodynamics.diffraction.fleet_decks --out fleet_decks --batch-config orcawave_batch.yml`.

License-free (prepare only; solves run on a licensed OrcaWave/AQWA host).

## Verified on the real vessel DB
`23 decks (21 parametric, 2 placeholder), 18 skipped for missing dims, 21-job batch config`. The emitted YAML round-trips through `OrcaWaveBatchConfig.from_yaml` (test-asserted — proves dispatch-readiness, not a hand-rolled dict).

## Scope note (data, not generator)
The buildable count is bounded by how many `particulars` records carry LOA/beam/draft (23 of 41). Reaching the full ~84 installation fleet (`installation_vessels()`) needs principal particulars for the WED-sourced crane vessels — a **vessel-DB data gap**, not a generator limit. The generator scales to whatever has dims; `--scope install` restricts to the installation fleet.

## Tests
6 new (build+skip accounting, index, batch-config placeholder exclude/include, from_yaml round-trip, cross-scope dedup, scope filter). Don't self-merge.

Part of #928 (postproc) + #930 (vessel envelope by operation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)