### PR TITLE
docs(vessel-db): OSV vessel_type vocabulary + mooring-line-types reference

### DIFF
--- a/data/vessels/README.md
+++ b/data/vessels/README.md
@@ -55,6 +55,30 @@ data/vessels/
 | `support` | AHTS / PSV / CTV / SOV·W2W + metocean criteria | Operability limits |
 | `tanker` | VLCC / Suezmax / Aframax / LNGC / LPGC | Extends OCIMF coefficient corpus |
 
+## Vessel type taxonomy (OSV classes)
+
+`scope` is the coarse analysis bucket; `vessel_type` is the finer class within it.
+For offshore-support vessels prefer one of the controlled-vocabulary slugs below
+(also in `SCHEMA.yaml → vessel_type_vocabulary`) so the free-text field stays
+groupable. Non-OSV hulls use a descriptive slug (e.g. `semisub-crane-vessel`,
+`fpso-turret`, `drillship`).
+
+| Slug | Class | Role | Typical scope |
+|---|---|---|---|
+| `ahts` | Anchor Handling Tug Supply | Tow MODUs, position floating facilities, set/recover heavy mooring anchors in deep water | `support` |
+| `psv` | Platform Supply Vessel | Open-deck workhorse: deck cargo, drilling muds/fluids, equipment and personnel to platforms | `support` |
+| `mpsv` | Multipurpose Support Vessel | Flexible logistics + modular equipment spaces, cranes, helideck for varied subsea ops | `support` / `install` |
+| `dsv` | Diving Support Vessel | Saturation diving systems for deep subsea maintenance, repair, pipeline tie-ins | `support` / `install` |
+| `csv` | Construction Support Vessel | High-capacity cranes, A-frames, moonpools for subsea construction, well intervention, deepwater deployment | `install` |
+| `sov` | Service Operation Vessel | Offshore-wind floating accommodation + storage for turbine technicians (walk-to-work) | `support` |
+
+The boundary between MPSV / DSV / CSV is functional, not sharp — a hull carrying a
+heavy crane *and* a sat-diving spread is classed by its dominant mission. The
+naval-architecture **particulars** (LOA, beam, draft, displacement, block
+coefficient) and **mass properties** (LCG/VCG/TCG, kxx/kyy/kzz) that distinguish
+these hulls are captured per record under the layers below — the slug is only the
+mission label.
+
 ## Data layers (per vessel record)
 
 1. **Particulars** — LOA, LBP, beam, depth, draft(s), displacement, block coeff.

--- a/data/vessels/SCHEMA.yaml
+++ b/data/vessels/SCHEMA.yaml
@@ -7,7 +7,8 @@ vessel_record:
   vessel_id: str            # stable slug, e.g. hlv_sleipnir
   name: str                 # as published
   scope: enum[install, floating, support, tanker]
-  vessel_type: str          # e.g. semisub-crane-vessel, fpso-turret, ahts
+  vessel_type: str          # controlled vocab — see vessel_type_vocabulary below;
+                            # e.g. ahts, psv, mpsv, dsv, csv, sov, semisub-crane-vessel, fpso-turret
   owner_operator: str|gap
   builder: str|gap
   year_built: int|gap
@@ -73,3 +74,17 @@ vessel_record:
       access_date: str        # YYYY-MM-DD
       access: enum[public, paywalled, brochure-pdf, estimated]
   gaps: list                  # field paths with no public source
+
+# --- vessel_type controlled vocabulary ---
+# Recognised offshore-support-vessel (OSV) classes. Prefer one of these slugs for
+# vessel_type so the free-text field stays groupable; fall back to a descriptive
+# slug (e.g. semisub-crane-vessel, fpso-turret, drillship) for non-OSV hulls.
+# `scope` is the analysis bucket (install/floating/support/tanker); `vessel_type`
+# is the finer class within it. See README.md "Vessel type taxonomy (OSV classes)".
+vessel_type_vocabulary:
+  ahts:  { name: "Anchor Handling Tug Supply",   scope: support,          role: "tow MODUs, position floating facilities, set/recover heavy mooring anchors in deep water" }
+  psv:   { name: "Platform Supply Vessel",        scope: support,          role: "open-deck cargo, drilling muds/fluids, equipment and personnel to platforms" }
+  mpsv:  { name: "Multipurpose Support Vessel",    scope: [support, install], role: "flexible logistics + modular equipment spaces, cranes, helideck for varied subsea ops" }
+  dsv:   { name: "Diving Support Vessel",          scope: [support, install], role: "saturation diving systems for deep subsea maintenance, repair, pipeline tie-ins" }
+  csv:   { name: "Construction Support Vessel",    scope: install,          role: "high-capacity cranes, A-frames, moonpools for subsea construction, well intervention, deepwater deployment" }
+  sov:   { name: "Service Operation Vessel",       scope: support,          role: "offshore-wind floating accommodation + storage for turbine technicians (walk-to-work)" }

--- a/docs/domains/mooring/MOORING_LINE_TYPES.md
+++ b/docs/domains/mooring/MOORING_LINE_TYPES.md
@@ -1,0 +1,52 @@
+category: asset
+
+# Mooring Line Types (vessel at a berth)
+
+Reference for the standard mooring-line arrangement that holds a vessel alongside
+a berth or jetty during cargo operations, loading/unloading, and adverse weather.
+Proper mooring restrains the surge, sway, and yaw a vessel would otherwise take up
+under wind, waves, tide, and current.
+
+This is the *station-keeping-at-berth* view. For the engineering analysis of
+mooring **systems** (line geometry, material, pretension, restoring curves,
+fatigue) see [`mooring.md`](mooring.md) and the
+[`mooring_analysis`](../../../src/digitalmodel/marine_ops/marine_engineering/mooring_analysis/)
+module; for permanent-floater spreads see the CALM-buoy notes in this directory.
+
+## Line types by function
+
+| Line | Led from | Restrains | Purpose |
+|---|---|---|---|
+| **Head line** | Forward end, leading ahead | Astern motion | Stops the vessel from moving back (aft) along the berth |
+| **Stern line** | Aft end, leading astern | Ahead motion | Stops the vessel from moving forward along the berth |
+| **Breast line** | Roughly perpendicular to the hull (fore and aft breasts) | Off-berth (sway) motion | Holds the vessel close in to the berth face |
+| **Spring line** | Diagonally (fore spring leads aft, aft spring leads forward) | Surge (fore–aft) motion | Controls forward/backward drift; gives extra longitudinal stability during operations |
+
+Head/stern lines and breast lines together resist the off-berth and along-berth
+drift; springs take up the longitudinal surge that head/stern lines alone control
+poorly. A symmetric arrangement (forward and aft breasts, fore and aft springs)
+balances the restraint about the vessel's midship.
+
+## Good practice
+
+- **Right line, right place, right tension.** Balanced tension shares the load
+  across the pattern; a slack or over-tight line concentrates load and can part.
+- Lines of similar **elasticity and length** should share a load group — mixing
+  stiff and soft lines in one group lets the stiff line take the whole load.
+- Watch the **vertical and horizontal lead angles**: shallow leads work the
+  winches and fairleads efficiently; steep leads waste restraint and chafe.
+
+## Safety and inspection
+
+Correct arrangement and tension matter because poor mooring can damage the
+vessel, the berth, cargo equipment, or cause injury. Routinely inspect the load
+path end to end — **ropes/wires, winches and brakes, bollards/bitts, and
+fairleads/rollers** — for wear, chafe, and corrosion. A well-secured vessel
+protects the crew, the cargo, and keeps port operations running smoothly.
+
+## See also
+
+- [`mooring.md`](mooring.md) — mooring module overview and OrcaFlex line setup
+- [`../ship-design/berthing/lngc.md`](../ship-design/berthing/lngc.md) — LNGC berthing/mooring context
+- OCIMF MEG4 — *Mooring Equipment Guidelines* (industry standard for line
+  selection, arrangement, and tending); see [`ocimf_module_readme.md`](ocimf_module_readme.md)


### PR DESCRIPTION
Closes #937.

Docs-only ingestion of two offshore industry primers.

### Vessel DB — OSV `vessel_type` controlled vocabulary
`vessel_type` was free text with no controlled vocabulary; **MPSV / DSV / CSV** were undocumented. Adds the recognised 6-class OSV taxonomy with role + scope mapping:

| Slug | Class | Scope |
|---|---|---|
| ahts | Anchor Handling Tug Supply | support |
| psv | Platform Supply Vessel | support |
| mpsv | Multipurpose Support Vessel | support/install |
| dsv | Diving Support Vessel | support/install |
| csv | Construction Support Vessel | install |
| sov | Service Operation Vessel | support |

- `data/vessels/SCHEMA.yaml` — new `vessel_type_vocabulary` block; `vessel_type` comment points at it.
- `data/vessels/README.md` — taxonomy table after the Scopes table; notes that the naval-architecture particulars/mass-properties that distinguish these hulls are already captured per record (the slug is just the mission label).

### Mooring — line-types reference
- `docs/domains/mooring/MOORING_LINE_TYPES.md` — head/stern/breast/spring line functions, at-berth arrangement, inspection points; cross-linked to the mooring module, LNGC berthing notes, and OCIMF MEG4.

### Notes
- No code paths touched; SCHEMA.yaml validated as YAML.
- No fabricated vessel data — this is taxonomy/reference only and respects the `data/vessels` "flag, don't fake" contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)