### PR TITLE
diffraction: add run_aqwa as a deployable licensed-run program (#939)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/workflow.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/workflow.py
@@ -5,16 +5,25 @@ from typing import Any
 
 from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
 
-_SUPPORTED_OPERATIONS = ("convert_spec", "run_orcawave")
+_SUPPORTED_OPERATIONS = ("convert_spec", "run_orcawave", "run_aqwa")
+
+# Solve operation -> (runner module, convenience fn, human label). Both runners
+# share the same signature and fail-closed contract, so the lane's fixed
+# ``python -m digitalmodel <input>`` command drives either solver (#900/#939).
+_SOLVERS = {
+    "run_orcawave": ("orcawave_runner", "run_orcawave", "OrcaWave"),
+    "run_aqwa": ("aqwa_runner", "run_aqwa", "AQWA"),
+}
 
 
 class DiffractionWorkflow:
     """Engine router for diffraction-domain workflows.
 
     ``convert_spec`` (default, offline) converts a canonical spec into solver
-    input decks. ``run_orcawave`` (requires an OrcaWave license) converts and
-    solves end-to-end from a single input file, so the licensed-run lane's fixed
-    ``python -m digitalmodel <input>`` command can drive a solve (issue #900).
+    input decks. ``run_orcawave`` / ``run_aqwa`` (require an OrcaWave / AQWA
+    license) convert and solve end-to-end from a single input file, so the
+    licensed-run lane's fixed ``python -m digitalmodel <input>`` command can
+    drive a solve (issues #900 / #939).
     """
 
     def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
@@ -22,14 +31,16 @@ class DiffractionWorkflow:
         operation = settings.get("operation", "convert_spec")
         if operation == "convert_spec":
             return self._convert_spec(cfg, settings)
-        if operation == "run_orcawave":
-            return self._run_orcawave(cfg, settings)
+        if operation in _SOLVERS:
+            return self._run_solver(cfg, settings, operation)
         raise ValueError(
             f"Unsupported diffraction operation: {operation!r}. "
             f"Supported operations: {', '.join(_SUPPORTED_OPERATIONS)}"
         )
 
-    def _convert_spec(self, cfg: dict[str, Any], settings: dict[str, Any]) -> dict[str, Any]:
+    def _convert_spec(
+        self, cfg: dict[str, Any], settings: dict[str, Any]
+    ) -> dict[str, Any]:
         spec_path = self._resolve_spec_path(cfg, settings)
         output_dir = self._resolve_output_dir(cfg, settings)
         solver = settings.get("solver", "all").lower()
@@ -50,17 +61,26 @@ class DiffractionWorkflow:
         settings["validation_issues"] = issues
         return cfg
 
-    def _run_orcawave(self, cfg: dict[str, Any], settings: dict[str, Any]) -> dict[str, Any]:
-        # Lazy import: only pull the OrcFxAPI-adjacent runner when a solve is asked for.
+    def _run_solver(
+        self, cfg: dict[str, Any], settings: dict[str, Any], operation: str
+    ) -> dict[str, Any]:
+        import importlib
+
+        # Lazy import: only pull the OrcFxAPI/AQWA-adjacent runner on a solve request.
         from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
-        from digitalmodel.hydrodynamics.diffraction.orcawave_runner import run_orcawave
+
+        module_name, func_name, label = _SOLVERS[operation]
+        runner_module = importlib.import_module(
+            f"digitalmodel.hydrodynamics.diffraction.{module_name}"
+        )
+        run_solve = getattr(runner_module, func_name)  # patch-friendly at call time
 
         spec_path = self._resolve_spec_path(cfg, settings)
         output_dir = self._resolve_output_dir(cfg, settings)
         requested_dry_run = bool(settings.get("dry_run", False))
 
         spec = DiffractionSpec.from_yaml(spec_path)
-        result = run_orcawave(
+        result = run_solve(
             spec,
             output_dir=output_dir,
             dry_run=requested_dry_run,
@@ -74,19 +94,22 @@ class DiffractionWorkflow:
         settings["run_status"] = status
         settings["outputs"] = {
             "input_file": str(getattr(result, "input_file", "") or ""),
-            "modular_files": [str(p) for p in getattr(result, "modular_files", []) or []],
+            "modular_files": [
+                str(p) for p in getattr(result, "modular_files", []) or []
+            ],
             "mesh_files": [str(p) for p in getattr(result, "mesh_files", []) or []],
         }
         if status == "failed":
             raise RuntimeError(
-                f"OrcaWave solve failed: {getattr(result, 'error_message', None) or 'unknown error'}"
+                f"{label} solve failed: "
+                f"{getattr(result, 'error_message', None) or 'unknown error'}"
             )
         # A silent dry-run fallback (no executable/license) must NOT read as success
         # for a real solve request — the licensed-run lane would record a false finish.
         if status == "dry_run" and not requested_dry_run:
             raise RuntimeError(
-                "OrcaWave solver unavailable: run fell back to dry-run "
-                "(no OrcaWave executable/license found). Run on a licensed host."
+                f"{label} solver unavailable: run fell back to dry-run "
+                f"(no {label} executable/license found). Run on a licensed host."
             )
         return cfg
 

--- a/tests/hydrodynamics/diffraction/test_workflow_router.py
+++ b/tests/hydrodynamics/diffraction/test_workflow_router.py
@@ -67,7 +67,10 @@ def test_diffraction_workflow_generates_aqwa_deck(tmp_path: Path) -> None:
 
 # --- operation: run_orcawave (issue #900) -----------------------------------
 
-def _solve_cfg(tmp_path: Path, dry_run: bool = True, operation: str = "run_orcawave") -> dict:
+
+def _solve_cfg(
+    tmp_path: Path, dry_run: bool = True, operation: str = "run_orcawave"
+) -> dict:
     return {
         "basename": "diffraction",
         "_config_dir_path": str(UNIT_BOX),
@@ -83,9 +86,15 @@ def _solve_cfg(tmp_path: Path, dry_run: bool = True, operation: str = "run_orcaw
 
 def _fake_result(status_value: str):
     from digitalmodel.hydrodynamics.diffraction.orcawave_runner import RunStatus
-    return SimpleNamespace(status=RunStatus(status_value), output_dir="out",
-                           input_file="UnitBoxRAO.yml", modular_files=[],
-                           mesh_files=[], error_message="boom")
+
+    return SimpleNamespace(
+        status=RunStatus(status_value),
+        output_dir="out",
+        input_file="UnitBoxRAO.yml",
+        modular_files=[],
+        mesh_files=[],
+        error_message="boom",
+    )
 
 
 def test_run_orcawave_dry_run_offline(tmp_path: Path) -> None:
@@ -108,8 +117,10 @@ def test_unsupported_operation_lists_supported(tmp_path: Path) -> None:
 def test_run_orcawave_failed_status_raises(tmp_path: Path) -> None:
     from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
 
-    with patch("digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
-               return_value=_fake_result("failed")):
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=_fake_result("failed"),
+    ):
         with pytest.raises(RuntimeError, match="OrcaWave solve failed"):
             DiffractionWorkflow().router(_solve_cfg(tmp_path, dry_run=False))
 
@@ -119,7 +130,64 @@ def test_run_orcawave_silent_dry_run_fallback_raises(tmp_path: Path) -> None:
     # The lane must NOT read that as success.
     from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
 
-    with patch("digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
-               return_value=_fake_result("dry_run")):
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=_fake_result("dry_run"),
+    ):
         with pytest.raises(RuntimeError, match="fell back to dry-run"):
             DiffractionWorkflow().router(_solve_cfg(tmp_path, dry_run=False))
+
+
+# --- operation: run_aqwa (issue #939) ---------------------------------------
+
+
+def _fake_aqwa_result(status):
+    from digitalmodel.hydrodynamics.diffraction.aqwa_runner import AQWARunStatus
+
+    return SimpleNamespace(
+        status=getattr(AQWARunStatus, status),
+        output_dir="out",
+        input_file="UnitBox.dat",
+        modular_files=[],
+        mesh_files=[],
+        error_message="boom",
+    )
+
+
+def test_run_aqwa_dry_run_offline(tmp_path: Path) -> None:
+    # Real runner, no license: prepares + skips the solver -> DRY_RUN, records outputs.
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    cfg = DiffractionWorkflow().router(
+        _solve_cfg(tmp_path, dry_run=True, operation="run_aqwa")
+    )
+    settings = cfg["diffraction"]
+    assert settings["run_status"] == "dry_run"
+    assert "input_file" in settings["outputs"]
+
+
+def test_run_aqwa_failed_status_raises(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.aqwa_runner.run_aqwa",
+        return_value=_fake_aqwa_result("FAILED"),
+    ):
+        with pytest.raises(RuntimeError, match="AQWA solve failed"):
+            DiffractionWorkflow().router(
+                _solve_cfg(tmp_path, dry_run=False, operation="run_aqwa")
+            )
+
+
+def test_run_aqwa_silent_dry_run_fallback_raises(tmp_path: Path) -> None:
+    # AQWA solver unavailable: runner returns DRY_RUN despite a real solve request.
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.aqwa_runner.run_aqwa",
+        return_value=_fake_aqwa_result("DRY_RUN"),
+    ):
+        with pytest.raises(RuntimeError, match="fell back to dry-run"):
+            DiffractionWorkflow().router(
+                _solve_cfg(tmp_path, dry_run=False, operation="run_aqwa")
+            )


### PR DESCRIPTION
Closes #939. Part of the solver-preparedness epic #938 (a). Makes **AQWA** dispatchable through the licensed-run lane alongside OrcaWave.

## Context
AQWA's `AQWARunner` (fail-closed), `aqwa_backend`, `aqwa_batch_runner`, `aqwa_result_extractor`, and `run_aqwa()` convenience fn already existed — the only gap was the engine operation that the lane's fixed `python -m digitalmodel <input>` drives.

## Change
- `DiffractionWorkflow`: refactored `_run_orcawave` into a shared **`_run_solver(operation)`** driven by a `_SOLVERS` map (`run_orcawave` | `run_aqwa`). Both share the same signature and fail-closed contract — a **silent dry-run fallback** (no exe/license) on a *real* solve request **raises**, so the lane can't record a false finish. OrcaWave behavior is byte-for-byte unchanged (its 6 router tests pass untouched).
- Dispatch: `basename: diffraction`, `diffraction.operation: run_aqwa`.

## Out of scope (tracked)
- Lane allowlist `aqwa-diffraction-solve` + a scope case → deckhand #490 (parallel session owns the lane + the host AQWA/ANSYS license).
- ANSYS solver runner → #940 (greenfield).

## Tests
3 new router tests (dry-run offline, failed→raise, silent-dry-run-fallback→raise) mirroring OrcaWave. **Full diffraction suite: 1593 passed, 27 skipped, 0 failures.** Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)