### PR TITLE
ansys: deployable licensed-run ANSYS/MAPDL program (subprocess runner) (#940)

### DIFF
--- a/src/digitalmodel/ansys/runner.py
+++ b/src/digitalmodel/ansys/runner.py
@@ -1,0 +1,230 @@
+"""Fail-closed ANSYS Mechanical APDL solver runner (subprocess `mapdl`).
+
+The ANSYS module otherwise only *generates* APDL scripts; this runs them. It
+mirrors the OrcaWave/AQWA runner contract so the licensed-run lane's fixed
+``uv run python -m digitalmodel <input>`` command can drive an ANSYS solve on a
+licensed host (digitalmodel #940):
+
+  - executes a prepared APDL ``.inp``/``.ans`` script via ``mapdl -b -i .. -o ..``;
+  - **fail-closed**: if no executable/license is found and a real solve was
+    requested, the run falls back to DRY_RUN (the workflow then raises, so the
+    lane can never record a false finish);
+  - metadata-only result (status, paths, return code) — heavy ``.rst``/``.out``
+    files stay on the host.
+
+Invocation is subprocess-based (no PyANSYS hard dependency).
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+# APDL solver error markers (MAPDL may return rc=0 yet write errors to the log).
+_ERROR_MARKERS = ("*** ERROR ***", "SOLUTION NOT CONVERGED", "*** FATAL ***")
+_RESULT_SUFFIXES = (".rst", ".rth", ".out", ".mntr", ".db")
+
+
+class ANSYSRunStatus(str, Enum):
+    PENDING = "pending"
+    PREPARING = "preparing"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    DRY_RUN = "dry_run"
+
+
+@dataclass
+class ANSYSRunConfig:
+    output_dir: Path = Path("output")
+    executable_path: Optional[Path] = None
+    timeout_seconds: int = 7200
+    dry_run: bool = False
+    extra_args: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ANSYSRunResult:
+    status: ANSYSRunStatus
+    output_dir: Path
+    input_file: Optional[Path] = None
+    log_file: Optional[Path] = None
+    result_files: list[Path] = field(default_factory=list)
+    return_code: Optional[int] = None
+    stdout: str = ""
+    stderr: str = ""
+    error_message: Optional[str] = None
+    duration_seconds: float = 0.0
+
+
+# Standard Windows MAPDL install locations (probed only on Windows).
+def _standard_paths() -> list[Path]:
+    if platform.system() != "Windows":
+        return []
+    roots = [Path(r"C:\Program Files\ANSYS Inc")]
+    exes: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for ver_dir in sorted(root.glob("v*"), reverse=True):
+            exe = ver_dir / "ansys" / "bin" / "winx64" / "MAPDL.exe"
+            if exe.is_file():
+                exes.append(exe)
+    return exes
+
+
+class ANSYSRunner:
+    """Run a prepared APDL script through MAPDL, fail-closed."""
+
+    def __init__(self, config: Optional[ANSYSRunConfig] = None) -> None:
+        self._config = config or ANSYSRunConfig()
+        self._result: Optional[ANSYSRunResult] = None
+
+    def run(self, script_path: Path | str) -> ANSYSRunResult:
+        """Prepare + execute. Falls back to DRY_RUN if no executable is found."""
+        self.prepare(script_path)
+        assert self._result is not None
+        if self._result.status == ANSYSRunStatus.FAILED:
+            return self._result  # e.g. missing script — fail-closed, don't run
+        if not self._config.dry_run and self._detect_executable() is None:
+            self._result.status = ANSYSRunStatus.DRY_RUN
+            self._result.error_message = (
+                "No ANSYS/MAPDL executable found; no results produced"
+            )
+            return self._result
+        return self.execute()
+
+    def prepare(self, script_path: Path | str) -> ANSYSRunResult:
+        script = Path(script_path)
+        output_dir = Path(self._config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self._result = ANSYSRunResult(
+            status=ANSYSRunStatus.PREPARING,
+            output_dir=output_dir,
+            input_file=script,
+        )
+        if not script.is_file():
+            self._result.status = ANSYSRunStatus.FAILED
+            self._result.error_message = f"APDL script not found: {script}"
+        return self._result
+
+    def execute(self) -> ANSYSRunResult:
+        if self._result is None:
+            raise RuntimeError("prepare() must be called before execute()")
+        if self._result.status == ANSYSRunStatus.FAILED:
+            return self._result  # missing script; nothing to run
+
+        start = time.monotonic()
+        if self._config.dry_run:
+            self._result.status = ANSYSRunStatus.DRY_RUN
+            return self._result
+
+        exe = self._detect_executable()
+        if exe is None:
+            self._result.status = ANSYSRunStatus.DRY_RUN
+            self._result.error_message = (
+                "No ANSYS/MAPDL executable found; no results produced"
+            )
+            return self._result
+
+        self._result.status = ANSYSRunStatus.RUNNING
+        out_file = self._result.output_dir / f"{self._result.input_file.stem}.out"
+        argv = [
+            str(exe),
+            "-b",
+            "-i",
+            str(self._result.input_file),
+            "-o",
+            str(out_file),
+            *self._config.extra_args,
+        ]
+        try:
+            proc = subprocess.run(  # noqa: S603 - argv is fixed; script is fs-resolved.
+                argv,
+                cwd=str(self._result.output_dir),
+                capture_output=True,
+                text=True,
+                timeout=self._config.timeout_seconds,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._result.status = ANSYSRunStatus.FAILED
+            self._result.error_message = f"MAPDL invocation failed: {exc}"
+            self._result.duration_seconds = time.monotonic() - start
+            return self._result
+
+        self._result.return_code = proc.returncode
+        self._result.stdout = proc.stdout or ""
+        self._result.stderr = proc.stderr or ""
+        self._result.duration_seconds = time.monotonic() - start
+        self._result.log_file = out_file if out_file.is_file() else None
+        self._result.result_files = self._capture_result_files(self._result.output_dir)
+
+        error = self._detect_error(proc.returncode, out_file)
+        if error is None:
+            self._result.status = ANSYSRunStatus.COMPLETED
+        else:
+            self._result.status = ANSYSRunStatus.FAILED
+            self._result.error_message = error
+        return self._result
+
+    def _detect_executable(self) -> Optional[Path]:
+        configured = self._config.executable_path
+        if configured and Path(configured).is_file():
+            return Path(configured)
+        for env_var in ("ANSYS_MAPDL_PATH", "MAPDL_PATH", "ANSYS_EXECUTABLE"):
+            val = os.environ.get(env_var)
+            if val and Path(val).is_file():
+                return Path(val)
+        for name in ("mapdl", "ansys", "MAPDL.exe", "ansys.exe"):
+            found = shutil.which(name)
+            if found:
+                return Path(found)
+        for std in _standard_paths():
+            return std
+        return None
+
+    def _detect_error(self, return_code: int, out_file: Path) -> Optional[str]:
+        if return_code != 0:
+            return f"MAPDL returned non-zero exit code {return_code}"
+        # MAPDL can return 0 yet write errors to the .out log.
+        if out_file.is_file():
+            text = out_file.read_text(errors="replace")
+            for marker in _ERROR_MARKERS:
+                if marker in text:
+                    return f"MAPDL log reported: {marker}"
+        return None
+
+    @staticmethod
+    def _capture_result_files(output_dir: Path) -> list[Path]:
+        return [
+            p
+            for p in sorted(output_dir.iterdir())
+            if p.is_file() and p.suffix.lower() in _RESULT_SUFFIXES
+        ]
+
+
+def run_ansys(
+    script_path: Path | str,
+    output_dir: Path | str = "output",
+    dry_run: bool = False,
+    timeout_seconds: int = 7200,
+    executable_path: Path | str | None = None,
+    extra_args: Optional[list[str]] = None,
+) -> ANSYSRunResult:
+    """Run a prepared APDL script through MAPDL (module-level convenience)."""
+    config = ANSYSRunConfig(
+        output_dir=Path(output_dir),
+        executable_path=Path(executable_path) if executable_path else None,
+        timeout_seconds=timeout_seconds,
+        dry_run=dry_run,
+        extra_args=list(extra_args or []),
+    )
+    return ANSYSRunner(config).run(script_path)

--- a/src/digitalmodel/ansys/workflow.py
+++ b/src/digitalmodel/ansys/workflow.py
@@ -1,0 +1,102 @@
+"""Engine router for ANSYS Mechanical APDL solves (digitalmodel #940).
+
+``run_ansys`` (requires an ANSYS/MAPDL license) executes a prepared APDL script
+from a single input file, so the licensed-run lane's fixed
+``python -m digitalmodel <input>`` command can drive an ANSYS solve. Fail-closed:
+a silent dry-run fallback (no executable/license) on a real solve request raises,
+so the lane cannot record a false finish.
+
+Input contract::
+
+    basename: ansys
+    ansys:
+      operation: run_ansys
+      script: model.inp        # prepared APDL script (relative to the config dir)
+      output_directory: out
+      dry_run: false
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_SUPPORTED_OPERATIONS = ("run_ansys",)
+
+
+class AnsysWorkflow:
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        settings = cfg.setdefault("ansys", {})
+        operation = settings.get("operation", "run_ansys")
+        if operation == "run_ansys":
+            return self._run_ansys(cfg, settings)
+        raise ValueError(
+            f"Unsupported ansys operation: {operation!r}. "
+            f"Supported operations: {', '.join(_SUPPORTED_OPERATIONS)}"
+        )
+
+    def _run_ansys(
+        self, cfg: dict[str, Any], settings: dict[str, Any]
+    ) -> dict[str, Any]:
+        # Lazy import: only pull the MAPDL-adjacent runner on a solve request.
+        from digitalmodel.ansys.runner import run_ansys
+
+        script_path = self._resolve_script_path(cfg, settings)
+        output_dir = self._resolve_output_dir(cfg, settings)
+        requested_dry_run = bool(settings.get("dry_run", False))
+
+        result = run_ansys(
+            script_path,
+            output_dir=output_dir,
+            dry_run=requested_dry_run,
+            timeout_seconds=int(settings.get("timeout_seconds", 7200)),
+            executable_path=settings.get("executable_path"),
+        )
+
+        status = str(getattr(result.status, "value", result.status)).lower()
+        settings["script_path"] = str(script_path)
+        settings["output_directory"] = str(getattr(result, "output_dir", output_dir))
+        settings["run_status"] = status
+        settings["outputs"] = {
+            "log_file": str(getattr(result, "log_file", "") or ""),
+            "result_files": [str(p) for p in getattr(result, "result_files", []) or []],
+            "return_code": getattr(result, "return_code", None),
+        }
+        if status == "failed":
+            raise RuntimeError(
+                f"ANSYS solve failed: "
+                f"{getattr(result, 'error_message', None) or 'unknown error'}"
+            )
+        # A silent dry-run fallback (no executable/license) must NOT read as success
+        # for a real solve request — the licensed-run lane would record a false finish.
+        if status == "dry_run" and not requested_dry_run:
+            raise RuntimeError(
+                "ANSYS solver unavailable: run fell back to dry-run "
+                "(no ANSYS/MAPDL executable/license found). Run on a licensed host."
+            )
+        return cfg
+
+    @staticmethod
+    def _resolve_script_path(cfg: dict[str, Any], settings: dict[str, Any]) -> Path:
+        script = settings.get("script")
+        if script is None:
+            raise ValueError("ansys.script is required")
+        script_path = Path(script)
+        if script_path.is_absolute():
+            return script_path
+        config_dir = cfg.get("_config_dir_path")
+        if config_dir:
+            return (Path(config_dir) / script_path).resolve()
+        return script_path.resolve()
+
+    @staticmethod
+    def _resolve_output_dir(cfg: dict[str, Any], settings: dict[str, Any]) -> Path:
+        result_folder = cfg.get("Analysis", {}).get("result_folder")
+        base_dir = Path(result_folder) if result_folder else Path.cwd()
+        output = settings.get("output_directory")
+        if output is None:
+            return base_dir.resolve()
+        output_dir = Path(output)
+        if output_dir.is_absolute():
+            return output_dir
+        return (base_dir / output_dir).resolve()

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -147,6 +147,11 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
     elif basename in ["aqwa"]:
         aqwa = Aqwa()
         cfg_base = aqwa.router(cfg_base)
+    elif basename in ["ansys"]:
+        # Licensed ANSYS/MAPDL solve via a prepared APDL script (#940).
+        from digitalmodel.ansys.workflow import AnsysWorkflow
+
+        cfg_base = AnsysWorkflow().router(cfg_base)
     elif basename == "modal_analysis":
         oma = OrcModalAnalysis()
         cfg_base = oma.run_modal_analysis(cfg_base)

--- a/tests/ansys/test_runner.py
+++ b/tests/ansys/test_runner.py
@@ -1,0 +1,106 @@
+"""ANSYS MAPDL solver runner — fail-closed, subprocess-based (digitalmodel #940)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from digitalmodel.ansys.runner import (
+    ANSYSRunConfig,
+    ANSYSRunner,
+    ANSYSRunStatus,
+    run_ansys,
+)
+
+
+def _script(tmp_path: Path) -> Path:
+    script = tmp_path / "model.inp"
+    script.write_text("/PREP7\nFINISH\n")
+    return script
+
+
+def _completed(returncode: int):
+    return SimpleNamespace(returncode=returncode, stdout="ok", stderr="")
+
+
+def test_dry_run_requested_returns_dry_run(tmp_path: Path):
+    result = run_ansys(_script(tmp_path), output_dir=tmp_path / "out", dry_run=True)
+    assert result.status == ANSYSRunStatus.DRY_RUN
+
+
+def test_missing_script_fails_closed(tmp_path: Path):
+    result = run_ansys(tmp_path / "nope.inp", output_dir=tmp_path / "out")
+    assert result.status == ANSYSRunStatus.FAILED
+    assert "not found" in result.error_message
+
+
+def test_no_executable_falls_back_to_dry_run(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(ANSYSRunner, "_detect_executable", lambda self: None)
+    result = run_ansys(_script(tmp_path), output_dir=tmp_path / "out", dry_run=False)
+    assert result.status == ANSYSRunStatus.DRY_RUN
+    assert "No ANSYS/MAPDL executable" in result.error_message
+
+
+def test_successful_solve_marks_completed(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        ANSYSRunner, "_detect_executable", lambda self: Path("/fake/mapdl")
+    )
+    monkeypatch.setattr(
+        "digitalmodel.ansys.runner.subprocess.run",
+        lambda *a, **k: _completed(0),
+    )
+    result = run_ansys(_script(tmp_path), output_dir=tmp_path / "out")
+    assert result.status == ANSYSRunStatus.COMPLETED
+    assert result.return_code == 0
+
+
+def test_nonzero_exit_marks_failed(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        ANSYSRunner, "_detect_executable", lambda self: Path("/fake/mapdl")
+    )
+    monkeypatch.setattr(
+        "digitalmodel.ansys.runner.subprocess.run",
+        lambda *a, **k: _completed(8),
+    )
+    result = run_ansys(_script(tmp_path), output_dir=tmp_path / "out")
+    assert result.status == ANSYSRunStatus.FAILED
+    assert "non-zero exit code 8" in result.error_message
+
+
+def test_solver_error_in_log_marks_failed(tmp_path: Path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "model.out").write_text("... *** ERROR *** element distorted ...")
+    monkeypatch.setattr(
+        ANSYSRunner, "_detect_executable", lambda self: Path("/fake/mapdl")
+    )
+    monkeypatch.setattr(
+        "digitalmodel.ansys.runner.subprocess.run",
+        lambda *a, **k: _completed(0),  # rc=0 but the log has an error
+    )
+    result = run_ansys(_script(tmp_path), output_dir=out_dir)
+    assert result.status == ANSYSRunStatus.FAILED
+    assert "*** ERROR ***" in result.error_message
+
+
+def test_invocation_exception_fails_closed(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        ANSYSRunner, "_detect_executable", lambda self: Path("/fake/mapdl")
+    )
+
+    def boom(*a, **k):
+        raise OSError("exec format error")
+
+    monkeypatch.setattr("digitalmodel.ansys.runner.subprocess.run", boom)
+    result = run_ansys(_script(tmp_path), output_dir=tmp_path / "out")
+    assert result.status == ANSYSRunStatus.FAILED
+    assert "MAPDL invocation failed" in result.error_message
+
+
+def test_config_executable_path_used_when_present(tmp_path: Path):
+    exe = tmp_path / "mapdl"
+    exe.write_text("#!/bin/sh\n")
+    runner = ANSYSRunner(
+        ANSYSRunConfig(output_dir=tmp_path / "out", executable_path=exe)
+    )
+    assert runner._detect_executable() == exe

--- a/tests/ansys/test_workflow_router.py
+++ b/tests/ansys/test_workflow_router.py
@@ -1,0 +1,77 @@
+"""ANSYS workflow router — engine dispatch + fail-closed (digitalmodel #940)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from digitalmodel.ansys.runner import ANSYSRunStatus
+from digitalmodel.ansys.workflow import AnsysWorkflow
+
+
+def _cfg(tmp_path: Path, *, dry_run: bool = True, operation: str = "run_ansys") -> dict:
+    script = tmp_path / "model.inp"
+    script.write_text("/PREP7\nFINISH\n")
+    return {
+        "basename": "ansys",
+        "_config_dir_path": str(tmp_path),
+        "Analysis": {"result_folder": str(tmp_path / "results")},
+        "ansys": {
+            "operation": operation,
+            "script": "model.inp",
+            "output_directory": "out",
+            "dry_run": dry_run,
+        },
+    }
+
+
+def _fake_result(status: ANSYSRunStatus, tmp_path: Path):
+    return SimpleNamespace(
+        status=status,
+        output_dir=tmp_path / "out",
+        log_file=None,
+        result_files=[],
+        return_code=0,
+        error_message="boom",
+    )
+
+
+def test_run_ansys_dry_run_records_status(tmp_path: Path):
+    cfg = AnsysWorkflow().router(_cfg(tmp_path, dry_run=True))
+    settings = cfg["ansys"]
+    assert settings["run_status"] == "dry_run"
+    assert "result_files" in settings["outputs"]
+
+
+def test_unsupported_operation_raises(tmp_path: Path):
+    with pytest.raises(ValueError, match="run_ansys"):
+        AnsysWorkflow().router(_cfg(tmp_path, operation="bogus"))
+
+
+def test_missing_script_raises(tmp_path: Path):
+    cfg = _cfg(tmp_path)
+    cfg["ansys"].pop("script")
+    with pytest.raises(ValueError, match="ansys.script is required"):
+        AnsysWorkflow().router(cfg)
+
+
+def test_failed_status_raises(tmp_path: Path):
+    with patch(
+        "digitalmodel.ansys.runner.run_ansys",
+        return_value=_fake_result(ANSYSRunStatus.FAILED, tmp_path),
+    ):
+        with pytest.raises(RuntimeError, match="ANSYS solve failed"):
+            AnsysWorkflow().router(_cfg(tmp_path, dry_run=False))
+
+
+def test_silent_dry_run_fallback_raises(tmp_path: Path):
+    # Solver unavailable: runner returns DRY_RUN although a real solve was requested.
+    with patch(
+        "digitalmodel.ansys.runner.run_ansys",
+        return_value=_fake_result(ANSYSRunStatus.DRY_RUN, tmp_path),
+    ):
+        with pytest.raises(RuntimeError, match="fell back to dry-run"):
+            AnsysWorkflow().router(_cfg(tmp_path, dry_run=False))


### PR DESCRIPTION
Closes #940 (runner core). Part of the solver-preparedness epic #938 (a). Adds **ANSYS** as a deployable licensed-run program alongside OrcaWave/OrcaFlex/AQWA.

## Decisions (confirmed)
- **Invocation: subprocess `mapdl`** (no PyANSYS hard dependency) — pilot-first, isolated.
- **Analysis scope: padeye/structural + pressure vessel + mudmat/foundation FE** — drives the APDL *templates*, which are follow-up slices (the runner itself is use-case-agnostic: it executes any prepared APDL script).

## What
The `ansys/` module previously only *generated* APDL scripts; this runs them.
- **`ansys/runner.py`** — `ANSYSRunner` + `run_ansys()`: execute a prepared `.inp`/`.ans` via `mapdl -b -i .. -o ..`. **Fail-closed**: no exe/license → `DRY_RUN`; non-zero rc **or** error markers in the `.out` log → `FAILED`; invocation exception → `FAILED`; missing script → `FAILED`. Exe detection: config → env (`ANSYS_MAPDL_PATH`/`MAPDL_PATH`/`ANSYS_EXECUTABLE`) → `which(mapdl/ansys)` → standard Windows install paths. Metadata-only result (heavy `.rst`/`.out` stay on the host).
- **`ansys/workflow.py`** — `AnsysWorkflow.router` (`operation: run_ansys`): a silent dry-run fallback on a *real* solve request **raises** (lane can't record a false finish), mirroring `run_orcawave`/`run_aqwa`.
- **`engine.py`** — `basename: ansys` → `AnsysWorkflow` (lazy import).

Input: `basename: ansys` + `ansys.{operation: run_ansys, script, output_directory, dry_run}`.

## Out of scope (tracked)
- Per-use-case APDL template generation (padeye/PV/mudmat) reusing the existing offline generators — follow-up slices.
- Lane allowlist (`ansys-mechanical-solve`) → deckhand #490; needs the host ANSYS license.

## Tests
13 new (runner: dry-run / missing-script / no-exe fallback / success / non-zero rc / log-error / invocation-exception / configured-exe; workflow: dry-run / unsupported-op / missing-script / failed→raise / silent-fallback→raise). **Full `ansys/` suite 337 passed**; engine imports clean. Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)