### PR TITLE
fix(ci): burn down quality-gates baseline debt (refs #949)

### DIFF
--- a/src/digitalmodel/subsea/catenary_riser/legacy/catenaryMethods.py
+++ b/src/digitalmodel/subsea/catenary_riser/legacy/catenaryMethods.py
@@ -49,7 +49,7 @@ def catenaryEquation(data):
         return data
 
     elif data["X"] != None:
-        raise ("Not implemented yet")
+        raise NotImplementedError("Not implemented yet")
 
     elif data["q"] != None:
         tanq = math.tan(math.radians(90 - data["q"]))

--- a/src/digitalmodel/subsea/cross_sections/io.py
+++ b/src/digitalmodel/subsea/cross_sections/io.py
@@ -15,7 +15,7 @@ def _read_data(path: Path) -> dict[str, Any]:
     if path.suffix.lower() == ".json":
         return json.loads(path.read_text())
     yaml = YAML(typ="safe")
-    data = yaml.safe_load(path.read_text())
+    data = yaml.load(path.read_text())
     if not isinstance(data, dict):
         raise ValueError(f"fixture {path} must contain a mapping")
     return data

--- a/tests/solver/smoke_test.py
+++ b/tests/solver/smoke_test.py
@@ -221,11 +221,19 @@ def run_l01_smoke_test() -> bool:
 
 def test_l00_smoke():
     """Pytest wrapper for L00 smoke test."""
+    import pytest
+
+    # OrcFxAPI is a licensed C-extension absent on CI runners; skip there. See #949.
+    pytest.importorskip("OrcFxAPI", reason="OrcFxAPI not available (licensed); see #949")
     assert run_l00_smoke_test(), "L00 smoke test failed"
 
 
 def test_l01_smoke():
     """Pytest wrapper for L01 smoke test."""
+    import pytest
+
+    # OrcFxAPI is a licensed C-extension absent on CI runners; skip there. See #949.
+    pytest.importorskip("OrcFxAPI", reason="OrcFxAPI not available (licensed); see #949")
     assert run_l01_smoke_test(), "L01 smoke test failed"
 
 

--- a/tests/test_module_reorganization.py
+++ b/tests/test_module_reorganization.py
@@ -8,6 +8,13 @@ import pytest
 import sys
 from pathlib import Path
 
+# stale: asserts a marine_analysis reorg / output layout that diverged from the
+# current tree (old `tests/outputs`, version 2.1.0, profiling/extraction/etc.
+# __init__ expectations). Skip until rewritten against the real layout. See #949.
+pytestmark = pytest.mark.skip(
+    reason="stale: asserts removed/diverged module layout; see #949"
+)
+
 
 class TestModuleStructure:
     """Test that the new module structure is correctly organized."""

--- a/tests/test_plate_capacity.py
+++ b/tests/test_plate_capacity.py
@@ -15,8 +15,17 @@ from pathlib import Path
 import tempfile
 import os
 
+import pytest
+
 # Add src directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# stale: digitalmodel.analysis.* was removed in the package reorg; skip until
+# the test is migrated to the current module layout. See #949.
+pytest.importorskip(
+    "digitalmodel.analysis.plate_capacity",
+    reason="stale: digitalmodel.analysis module removed; see #949",
+)
 
 from digitalmodel.analysis.plate_capacity import (
     PlateProperties, AppliedLoads, BucklingConstants, BucklingResults,

--- a/tests/test_restructure_compat.py
+++ b/tests/test_restructure_compat.py
@@ -13,6 +13,13 @@ import warnings
 
 import pytest
 
+# stale: asserts that old `digitalmodel.modules.X` paths still resolve, but that
+# compat shim package was removed in the flattening reorg. Skip until rewritten
+# against the current layout. See #949.
+pytestmark = pytest.mark.skip(
+    reason="stale: digitalmodel.modules compat shim removed; see #949"
+)
+
 
 class TestCompatModule:
     """Test the _compat registration and alias machinery."""

--- a/tests/test_solver_benchmarks.py
+++ b/tests/test_solver_benchmarks.py
@@ -8,6 +8,15 @@ import logging
 from pathlib import Path
 from typing import List
 
+# stale: this suite targets the pre-reorg base_solvers benchmark API. The
+# package moved to digitalmodel.infrastructure.base_solvers and its API drifted
+# (PerformanceMetrics is no longer exported from benchmarks.__init__; the mock
+# solvers here use the removed `set_input` method, now `set_input_data`). Skip
+# the whole module until it is rewritten against the current API. See #949.
+pytestmark = pytest.mark.skip(
+    reason="stale: pre-reorg base_solvers benchmark API drifted; see #949"
+)
+
 from digitalmodel.base_solvers.base import BaseSolver, AnalysisSolver, SolverStatus
 from digitalmodel.base_solvers.benchmarks import (
     SolverBenchmarks,


### PR DESCRIPTION
Bounded, **safe + additive** subset of the cleanup diagnosed in #949. No CI policy changes, no deletions, no `failure_action` flips — only product-bug fixes and **reversible** skip/guard markers. uv.lock intentionally kept out of the diff.

## Product bug fixes (real, small, verified)
- **`src/digitalmodel/subsea/cross_sections/io.py:18`** — `YAML(typ="safe").safe_load(...)` → `.load(...)`. `safe_load` is the PyYAML API; ruamel's `YAML` object has no such method. Verified: `tests/subsea/cross_sections/` now **33 passed** (was 4 collection errors / 15+ failures).
- **`src/digitalmodel/subsea/catenary_riser/legacy/catenaryMethods.py:52`** — `raise "<str>"` → `raise NotImplementedError("Not implemented yet")` (exceptions must derive from `BaseException`).

## Stale-test quarantine (skip markers — reversible, reviewable; modules removed in the reorg)
- **`tests/test_plate_capacity.py:21`** — `pytest.importorskip("digitalmodel.analysis.plate_capacity")` (the `digitalmodel.analysis` package was removed). Unblocks **tests-structural** collection (this was the sole collection error in that shard).
- **`tests/test_module_reorganization.py`** — module-level `pytest.mark.skip` (asserts a marine_analysis reorg / output layout that diverged). [contracts shard]
- **`tests/test_restructure_compat.py`** — module-level skip (`digitalmodel.modules` compat shim removed). [contracts shard]
- **`tests/test_solver_benchmarks.py`** — module-level skip. `base_solvers` still resolves via a `_compat` alias, so it isn't a collection error; the real failures are API drift: `PerformanceMetrics` is no longer exported from `infrastructure/base_solvers/benchmarks/__init__`, and the test's mock solvers use the removed `set_input` (now `set_input_data`). [solver-smoke shard]

## Licensed-dep guard
- **`tests/solver/smoke_test.py`** — `pytest.importorskip("OrcFxAPI", ...)` in both `test_l00_smoke` / `test_l01_smoke` wrappers (licensed C-ext absent on CI runners; imports are function-local so collection already succeeded, but the tests errored at run).

## Verification
`uv run --no-sources --with-editable . pytest <touched files>` → all touched modules clean: **33 passed** (subsea cross_sections) + **87 skipped, 0 failed, 0 errors** across the five quarantined/guarded modules.

## Expected gate impact
- **Should go green** (their named blockers are now removed): `tests-structural` (plate_capacity collection fixed), `tests-subsea` (io.py + catenaryMethods fixes — assuming no other independent subsea failures), the named portions of `tests-contracts` (reorg + restructure_compat skipped) and `tests-solver-smoke` (OrcFxAPI guarded + solver_benchmarks skipped).
- **May remain red** (out of this safe scope, left deliberately):
  - **`tests-contracts`** also has `tests/docs/test_digitalmodel_routing_contract.py` — a real operator-map vs live-tree **drift** failure (not a stale module). Needs a deliberate fix, not a blind skip.
  - **`tests-infrastructure-core` / `-other`, `tests-misc`, `tests-orcaflex-solver`** — scattered genuine failures per #949; not addressed here.
  - **`tests-specialized`** — SIGSEGV in native viz deps (`vtk`/`pyvista`/`pygmt`). Deeper effort; **not touched** (the segfault is in test bodies, not a guardable top-level import).

Refs #949. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)