### PR TITLE
feat(orcaflex): offline extreme-value post-process example (Gumbel/Weibull) (#961)

### DIFF
--- a/examples/workflows/extreme-value-post/.gitignore
+++ b/examples/workflows/extreme-value-post/.gitignore
@@ -1,0 +1,2 @@
+# Generated output of run.py — not committed.
+results/

--- a/examples/workflows/extreme-value-post/README.md
+++ b/examples/workflows/extreme-value-post/README.md
@@ -1,0 +1,49 @@
+# Extreme-Value Post-Processing (Gumbel / Weibull)
+
+Fits **Gumbel (Type I)** and **3-parameter Weibull** extreme-value
+distributions to a set of **block maxima** and reports **return-period
+extremes** (10 / 50 / 100 / 1000-yr). This is the offline, license-free demo
+for the `extreme-value-post` use case (issues #961, #941, #938).
+
+- **Gumbel return value**: `x_T = μ + σ · (−ln(−ln(1 − 1/T)))`
+- **Weibull return value**: inverse CDF `weibull_min.ppf(1 − 1/T)` (3-param, `loc=0`)
+- Goodness-of-fit reported via a Kolmogorov–Smirnov statistic and p-value.
+
+Block maxima are the inputs (one maximum per block — e.g. per storm-year of an
+OrcaFlex dynamic mooring/riser campaign). How they were produced is out of
+scope here; the calculation is pure `numpy` + `scipy` over a numeric array.
+
+## Fully offline / license-free
+
+This example uses **only** `digitalmodel.orcaflex.postprocessor.fit_gumbel` /
+`fit_weibull` over a committed synthetic CSV
+(`data/block_maxima.csv`). There is **NO** `OrcFxAPI`, **NO** OrcaFlex `.sim`,
+and **NO** license requirement. The synthetic data is illustrative — not from
+any real vessel or client model.
+
+## Run
+
+```bash
+uv run python examples/workflows/extreme-value-post/run.py
+```
+
+This prints the fitted parameters and return-period extremes for each
+distribution and writes `results/extreme_value_post/extreme_value_summary.json`.
+
+## Invocation finding / router follow-up
+
+The postprocessor is a **library API** (`fit_gumbel` / `fit_weibull`), not a
+workflow-router basename of its own. The registry entry `extreme-value-post`
+currently maps to basename `orcaflex_post_process`, which the engine routes
+through the OrcaFlex path (`requires-license`) — so it **cannot** drive this
+offline demo today. Hence this example ships a small runnable `run.py` plus an
+`input.yml` describing the inputs.
+
+**Follow-up (ref #941 / #938):** wire a dedicated *offline* router basename
+(e.g. `extreme_value_post`) in `digitalmodel.engine` that loads block maxima
+from the `input.yml` `extreme_value_post:` block and calls the postprocessor
+directly, so the use case becomes dispatchable via
+`uv run python -m digitalmodel <input.yml>` without a license. The registry
+flip (`src/digitalmodel/usecase_registry/*`) is handled separately.
+
+References: Gumbel (1958); DNV-RP-C205 Sec. 3.4; API RP 2SK.

--- a/examples/workflows/extreme-value-post/data/block_maxima.csv
+++ b/examples/workflows/extreme-value-post/data/block_maxima.csv
@@ -1,0 +1,41 @@
+# Synthetic block-maxima dataset for offline extreme-value post-processing.
+#
+# Each row is the maximum effective tension (kN) observed in one block
+# (here: one storm year) of an OrcaFlex dynamic mooring/riser simulation
+# campaign. Generated synthetically (Gumbel-like) so the demo is fully
+# offline and license-free; values are illustrative, not from any real
+# vessel or client model.
+#
+# block = sequential block index (e.g. storm-year number)
+# effective_tension_kN = block maximum of effective tension
+block,effective_tension_kN
+1,1842.6
+2,1798.3
+3,1925.1
+4,1880.7
+5,2010.4
+6,1764.9
+7,1956.2
+8,1872.0
+9,2088.5
+10,1813.7
+11,1990.8
+12,1748.5
+13,1903.6
+14,2155.9
+15,1837.2
+16,1921.4
+17,1859.8
+18,2042.3
+19,1786.1
+20,1968.7
+21,1895.0
+22,2110.6
+23,1822.9
+24,1944.5
+25,1877.3
+26,2023.8
+27,1801.2
+28,1933.1
+29,2071.4
+30,1866.7

--- a/examples/workflows/extreme-value-post/input.yml
+++ b/examples/workflows/extreme-value-post/input.yml
@@ -1,0 +1,45 @@
+# Extreme-value post-processing — OFFLINE, LICENSE-FREE workflow.
+#
+# Fits Gumbel (Type I) and 3-parameter Weibull extreme-value distributions
+# to a committed block-maxima dataset and reports return-period extremes
+# (10 / 50 / 100 / 1000-yr). Uses ONLY digitalmodel.orcaflex.postprocessor
+# (numpy + scipy over numeric arrays) — NO OrcFxAPI, NO OrcaFlex .sim, NO
+# license. Block maxima are the inputs; how they were produced (OrcaFlex
+# dynamic seeds, measured data, etc.) is out of scope here.
+#
+# INVOCATION
+# ----------
+# The postprocessor is a *library API* (fit_gumbel / fit_weibull), not a
+# router basename of its own. The registry id `extreme-value-post` currently
+# maps to basename `orcaflex_post_process`, which routes through the
+# OrcaFlex engine path (requires-license) — so it cannot drive this offline
+# demo today. Until a dedicated offline router basename is wired
+# (follow-up to #941 / #938), run this example directly:
+#
+#     uv run python examples/workflows/extreme-value-post/run.py
+#
+# See README.md for details and the router-wiring follow-up note.
+#
+# References: Gumbel (1958); DNV-RP-C205 Sec. 3.4; API RP 2SK.
+
+meta:
+  basename: extreme_value_post          # logical name; offline library demo
+  runtime: offline
+  library: digitalmodel
+  label: Gumbel/Weibull extreme-value return-period post-processing
+
+extreme_value_post:
+  # Block-maxima input (one maximum per block / storm-year).
+  data:
+    source: csv
+    path: data/block_maxima.csv
+    column: effective_tension_kN
+    variable_name: Effective tension (kN)
+  # Distributions to fit.
+  distributions: [gumbel, weibull]
+  # Return periods in the same units as the block duration (here: years).
+  return_periods: [10, 50, 100, 1000]
+
+outputs:
+  directory: results/extreme_value_post
+  summary_json: extreme_value_summary.json

--- a/examples/workflows/extreme-value-post/run.py
+++ b/examples/workflows/extreme-value-post/run.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Offline extreme-value post-processing demo (issue #961).
+
+Fits Gumbel (Type I) and 3-parameter Weibull extreme-value distributions to a
+committed synthetic block-maxima dataset and reports return-period extremes
+(10 / 50 / 100 / 1000-yr) using ``digitalmodel.orcaflex.postprocessor``.
+
+Fully OFFLINE and LICENSE-FREE: no OrcFxAPI, no OrcaFlex ``.sim``, no license.
+The postprocessor operates on a numeric array of block maxima; this script
+just loads that array from CSV (per the sibling ``input.yml``), calls
+``fit_gumbel`` / ``fit_weibull``, and writes a JSON summary.
+
+Run::
+
+    uv run python examples/workflows/extreme-value-post/run.py
+
+References: Gumbel (1958); DNV-RP-C205 Sec. 3.4; API RP 2SK.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import yaml
+
+from digitalmodel.orcaflex.postprocessor import (
+    ExtremeValueResult,
+    fit_gumbel,
+    fit_weibull,
+)
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_block_maxima(csv_path: Path, column: str) -> np.ndarray:
+    """Load a single column of block maxima from a (comment-tolerant) CSV."""
+    values: List[float] = []
+    with csv_path.open(newline="") as fh:
+        rows = (line for line in fh if not line.lstrip().startswith("#"))
+        reader = csv.DictReader(rows)
+        for row in reader:
+            raw = row.get(column)
+            if raw is None or raw.strip() == "":
+                continue
+            values.append(float(raw))
+    if not values:
+        raise ValueError(f"No values found in column '{column}' of {csv_path}")
+    return np.asarray(values, dtype=float)
+
+
+def run(input_yml: Path = HERE / "input.yml") -> Dict[str, ExtremeValueResult]:
+    """Execute the offline extreme-value workflow described by ``input_yml``.
+
+    Returns a mapping of distribution name -> ExtremeValueResult and writes a
+    JSON summary to the configured output directory.
+    """
+    cfg = yaml.safe_load(input_yml.read_text())
+    spec = cfg["extreme_value_post"]
+
+    data_cfg = spec["data"]
+    csv_path = (HERE / data_cfg["path"]).resolve()
+    maxima = load_block_maxima(csv_path, data_cfg["column"])
+    return_periods = [float(t) for t in spec["return_periods"]]
+
+    fitters = {"gumbel": fit_gumbel, "weibull": fit_weibull}
+    results: Dict[str, ExtremeValueResult] = {}
+    for dist in spec["distributions"]:
+        fitter = fitters[dist.lower()]
+        results[dist.lower()] = fitter(maxima, return_periods=return_periods)
+
+    # Write summary JSON.
+    out_dir = (HERE / cfg["outputs"]["directory"]).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / cfg["outputs"]["summary_json"]
+    summary = {
+        "variable_name": data_cfg.get("variable_name", ""),
+        "n_blocks": int(maxima.size),
+        "return_periods": return_periods,
+        "fits": {name: res.model_dump() for name, res in results.items()},
+    }
+    out_path.write_text(json.dumps(summary, indent=2))
+
+    return results
+
+
+def main() -> None:
+    results = run()
+    print("Extreme-value post-processing (offline, license-free) — issue #961")
+    print("=" * 66)
+    for name, res in results.items():
+        print(f"\n{res.distribution} fit:")
+        print(f"  location={res.location}  scale={res.scale}  shape={res.shape}")
+        print(f"  KS stat={res.ks_statistic}  p-value={res.ks_pvalue}")
+        print("  return-period extremes:")
+        for period, value in res.return_values.items():
+            print(f"    {period:>5}-yr : {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/orcaflex/test_extreme_value_post_example.py
+++ b/tests/orcaflex/test_extreme_value_post_example.py
@@ -1,0 +1,81 @@
+"""Offline smoke test for the extreme-value-post example workflow (#961).
+
+Runs the committed example end-to-end with NO OrcaFlex / NO license and
+asserts the return-period extremes are finite, monotonic, and that the
+distribution fits succeeded.
+"""
+
+import importlib.util
+import math
+from pathlib import Path
+
+from digitalmodel.orcaflex.postprocessor import ExtremeValueResult
+
+EXAMPLE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "workflows"
+    / "extreme-value-post"
+)
+
+
+def _load_run_module():
+    """Import the example's run.py as a module."""
+    run_path = EXAMPLE_DIR / "run.py"
+    spec = importlib.util.spec_from_file_location("extreme_value_post_run", run_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_dir_exists():
+    assert EXAMPLE_DIR.is_dir(), f"missing example dir: {EXAMPLE_DIR}"
+    assert (EXAMPLE_DIR / "input.yml").is_file()
+    assert (EXAMPLE_DIR / "run.py").is_file()
+    assert (EXAMPLE_DIR / "data" / "block_maxima.csv").is_file()
+
+
+def test_block_maxima_loads():
+    run = _load_run_module()
+    maxima = run.load_block_maxima(
+        EXAMPLE_DIR / "data" / "block_maxima.csv", "effective_tension_kN"
+    )
+    assert maxima.size >= 20
+    assert all(math.isfinite(v) for v in maxima)
+    assert (maxima > 0).all()
+
+
+def test_run_offline_produces_sane_extremes():
+    run = _load_run_module()
+    results = run.run()
+
+    assert set(results) == {"gumbel", "weibull"}
+
+    for name, res in results.items():
+        assert isinstance(res, ExtremeValueResult)
+        # Fit succeeded: scale must be positive and finite.
+        assert math.isfinite(res.scale) and res.scale > 0, name
+        assert math.isfinite(res.ks_statistic)
+
+        rv = res.return_values
+        assert {"10", "50", "100", "1000"}.issubset(rv.keys()), name
+        values = [rv["10"], rv["50"], rv["100"], rv["1000"]]
+        assert all(math.isfinite(v) for v in values), name
+        # Return-period extremes increase with return period.
+        assert values == sorted(values), name
+        # Specifically: 100-yr >= 10-yr (the headline assertion).
+        assert rv["100"] >= rv["10"], name
+        # Extremes should sit at or above the sample (block maxima are < extremes).
+        assert rv["10"] > 0
+
+
+def test_summary_json_written():
+    run = _load_run_module()
+    run.run()
+    out = EXAMPLE_DIR / "results" / "extreme_value_post" / "extreme_value_summary.json"
+    assert out.is_file()
+    import json
+
+    data = json.loads(out.read_text())
+    assert data["n_blocks"] >= 20
+    assert "gumbel" in data["fits"] and "weibull" in data["fits"]


### PR DESCRIPTION
## What

Adds a **license-free, offline** example workflow under `examples/workflows/extreme-value-post/` that fits **Gumbel (Type I)** and **3-parameter Weibull** extreme-value distributions to a committed synthetic block-maxima dataset and reports **return-period extremes** (10 / 50 / 100 / 1000-yr) using `digitalmodel.orcaflex.postprocessor.fit_gumbel` / `fit_weibull` (numpy + scipy over a numeric array).

Files:
- `data/block_maxima.csv` — 30 synthetic storm-year maxima of effective tension (illustrative, not from any real model)
- `run.py` — loads maxima per `input.yml`, calls the postprocessor, writes a JSON summary
- `input.yml` — describes inputs + documents the invocation finding
- `README.md` — math, offline guarantee, router-wiring follow-up
- `tests/orcaflex/test_extreme_value_post_example.py` — offline smoke test

**No** `OrcFxAPI`, **no** OrcaFlex `.sim`, **no** license. `src/digitalmodel/usecase_registry/*` and `postprocessor.py` are untouched.

## Invocation finding

The postprocessor is a **library API** (`fit_gumbel` / `fit_weibull`), not a workflow-router basename of its own. The registry entry `extreme-value-post` (registry.yaml id #299) currently maps to basename `orcaflex_post_process`, which `engine.py` routes through the OrcaFlex path (`requires-license`) — so it cannot drive this offline demo today. Hence the example ships a runnable `run.py` + descriptive `input.yml`, with the offline router basename noted as a **follow-up** (ref #941 / #938). Run it directly:

\`\`\`bash
uv run python examples/workflows/extreme-value-post/run.py
\`\`\`

## Tests

\`\`\`
uv run python -m pytest tests/orcaflex/test_extreme_value_post_example.py -q
# 4 passed
\`\`\`

Asserts: fits succeed (scale > 0, finite KS), return values finite, monotonic in return period, and **100-yr >= 10-yr**. Lint clean on new `.py` (black 25.9.0 -l88 + ruff).

Closes #961. Refs #941, #938.

Please don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)