### PR TITLE
feat(orcaflex): FOWT mooring watch-circle template (dispatchable input.yml) (#959)

### DIFF
--- a/examples/workflows/fowt-mooring/input.yml
+++ b/examples/workflows/fowt-mooring/input.yml
@@ -1,0 +1,33 @@
+basename: fowt_mooring
+
+# FOWT (floating offshore wind turbine) watch-circle vs dynamic export-cable
+# minimum-bend-radius (MBR) feasibility screen. Closed-form, solver-free
+# (mooring_design_fowt). Runs offline with no OrcaFlex licence:
+#   uv run python -m digitalmodel examples/workflows/fowt-mooring/input.yml
+# Preliminary screen only; final dynamic-cable curvature design needs a
+# licensed FE / lumped-mass dynamic solver.
+fowt_mooring:
+  # Max horizontal platform offset under environmental loading (watch-circle
+  # radius, m). Worst case = floater drifts this far toward the touchdown,
+  # shrinking the suspended-cable chord and tightening the bend.
+  watch_circle_radius: 25.0
+
+  cable:
+    # Suspended dynamic-cable span geometry (hang-off to touchdown), all metres.
+    suspended_length: 320.0
+    hang_off_elevation: 90.0
+    nominal_horizontal_span: 260.0
+    # DNV-RP-0360 design-factored cable minimum bend radius (cable-specific input).
+    mbr_limit_m: 4.5
+    mooring_type: hybrid   # catenary | taut | hybrid (lazy-wave host)
+    floater_type: semi     # spar | semi | tlp
+
+output:
+  summary_json: examples/workflows/fowt-mooring/results/fowt_mooring_summary.json
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/fowt_mooring/fowt_mooring.yml
+++ b/src/digitalmodel/base_configs/modules/fowt_mooring/fowt_mooring.yml
@@ -1,0 +1,8 @@
+basename: fowt_mooring
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -428,6 +428,13 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         fmw = FPSOMooringWorkflow()
         cfg_base = fmw.router(cfg_base)
+    elif basename == "fowt_mooring":
+        from digitalmodel.orcaflex.fowt_mooring_workflow import (
+            FOWTMooringWorkflow,
+        )
+
+        fowt_mooring = FOWTMooringWorkflow()
+        cfg_base = fowt_mooring.router(cfg_base)
     elif basename == "fpso_mooring_full":
         from digitalmodel.marine_ops.marine_engineering.mooring_analysis.fpso_full_workflow import (
             FPSOMooringFullWorkflow,

--- a/src/digitalmodel/orcaflex/fowt_mooring_workflow.py
+++ b/src/digitalmodel/orcaflex/fowt_mooring_workflow.py
@@ -1,0 +1,68 @@
+"""UV-workflow router for the offline FOWT watch-circle vs dynamic-cable check.
+
+Wraps the closed-form, solver-free ``mooring_design_fowt`` watch-circle check so
+it is dispatchable from a committed ``input.yml`` via
+``uv run python -m digitalmodel <input.yml>`` (basename ``fowt_mooring``), with no
+OrcaFlex licence required. This is a preliminary feasibility screen; final
+dynamic-cable curvature design needs a licensed FE/lumped-mass dynamic solver
+(see ``mooring_design_fowt`` module docstring).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.orcaflex.mooring_design_fowt import (
+    DynamicCableConfig,
+    FloaterType,
+    MooringType,
+    check_watch_circle_vs_cable,
+)
+
+
+class FOWTMooringWorkflow:
+    """Run the FOWT watch-circle vs dynamic-cable MBR check from a cfg dict."""
+
+    def router(self, cfg: dict) -> dict:
+        fowt = cfg.get("fowt_mooring") or {}
+        watch_circle_radius = float(fowt["watch_circle_radius"])
+
+        cable_cfg = self._build_cable(fowt)
+        result = check_watch_circle_vs_cable(watch_circle_radius, cable_cfg)
+
+        cfg["fowt_mooring"] = {
+            **fowt,
+            "result": self._json_safe(result.model_dump()),
+        }
+        summary_path = self._write_summary(cfg)
+        if summary_path is not None:
+            cfg.setdefault("outputs", {})["summary_json"] = str(summary_path)
+        return cfg
+
+    def _build_cable(self, fowt: dict) -> DynamicCableConfig:
+        cable = dict(fowt["cable"])
+        if "mooring_type" in cable:
+            cable["mooring_type"] = MooringType(cable["mooring_type"])
+        if "floater_type" in cable:
+            cable["floater_type"] = FloaterType(cable["floater_type"])
+        return DynamicCableConfig(**cable)
+
+    def _json_safe(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: self._json_safe(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [self._json_safe(v) for v in obj]
+        if isinstance(obj, (MooringType, FloaterType)):
+            return obj.value
+        return obj
+
+    def _write_summary(self, cfg: dict) -> Path | None:
+        output_path = (cfg.get("output") or {}).get("summary_json")
+        if not output_path:
+            return None
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cfg["fowt_mooring"], indent=2))
+        return path

--- a/tests/orcaflex/test_fowt_mooring_workflow.py
+++ b/tests/orcaflex/test_fowt_mooring_workflow.py
@@ -1,0 +1,53 @@
+"""Offline smoke test for the FOWT watch-circle vs dynamic-cable workflow.
+
+Dispatches the committed ``examples/workflows/fowt-mooring/input.yml`` through
+the digitalmodel engine (basename ``fowt_mooring``) and asserts a sane result.
+Closed-form / solver-free: no OrcaFlex licence required.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.engine import engine
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INPUT_YML = REPO_ROOT / "examples" / "workflows" / "fowt-mooring" / "input.yml"
+SUMMARY_JSON = (
+    REPO_ROOT
+    / "examples"
+    / "workflows"
+    / "fowt-mooring"
+    / "results"
+    / "fowt_mooring_summary.json"
+)
+
+
+def test_fowt_mooring_workflow_offline(tmp_path, monkeypatch):
+    assert INPUT_YML.exists(), f"missing example input: {INPUT_YML}"
+
+    cfg = engine(inputfile=str(INPUT_YML))
+
+    assert isinstance(cfg, dict)
+    assert cfg["basename"] == "fowt_mooring"
+
+    result = cfg["fowt_mooring"]["result"]
+    # Healthy feasibility screen: governing bend radius well above the MBR limit.
+    assert result["passes"] is True
+    assert result["governing_bend_radius_m"] == pytest.approx(136.554, abs=1e-2)
+    assert result["mbr_limit_m"] == pytest.approx(4.5)
+    assert result["margin_m"] == pytest.approx(132.054, abs=1e-2)
+    assert result["governing_offset_m"] == pytest.approx(25.0)
+    # Watch-circle drift toward touchdown shrinks the chord below the still-water span.
+    assert (
+        result["governing_chord_m"]
+        < cfg["fowt_mooring"]["cable"]["nominal_horizontal_span"]
+    )
+    assert result["mooring_type"] == "hybrid"
+    assert result["floater_type"] == "semi"
+
+    # Summary JSON written to the committed results dir.
+    assert SUMMARY_JSON.exists()
+    written = json.loads(SUMMARY_JSON.read_text())
+    assert written["result"]["passes"] is True


### PR DESCRIPTION
## What

Wires the existing closed-form FOWT (floating offshore wind turbine) watch-circle vs dynamic-export-cable minimum-bend-radius (MBR) check (`mooring_design_fowt`) to a committed, dispatchable workflow.

- `examples/workflows/fowt-mooring/input.yml` — runnable example (semi floater, hybrid/lazy-wave host, DNV-RP-0360 cable MBR).
- `src/digitalmodel/orcaflex/fowt_mooring_workflow.py` — thin `FOWTMooringWorkflow.router(cfg)` wrapping `check_watch_circle_vs_cable`, mirroring `FPSOMooringWorkflow`.
- `src/digitalmodel/engine.py` — dispatch new basename `fowt_mooring` (one `elif`, next to `fpso_mooring`).
- `src/digitalmodel/base_configs/modules/fowt_mooring/fowt_mooring.yml` — engine application-template lookup (required by `unify_application_and_default_and_custom_yamls`).
- `tests/orcaflex/test_fowt_mooring_workflow.py` — offline smoke test.

## Offline vs licensed finding

**Fully offline / no licence.** `mooring_design_fowt` is a closed-form, solver-free geometric screen (circular-arc suspended-cable idealisation), not an OrcaFlex model run. The example dispatches end-to-end via:

```
uv run python -m digitalmodel examples/workflows/fowt-mooring/input.yml
```

Before this PR the module existed but was not wired to any engine basename or template (library-only). This PR adds the router wiring + base config so it is dispatchable. Result for the shipped example: `passes=True`, governing bend radius 136.554 m vs 4.5 m MBR limit (margin 132.054 m). This is a preliminary feasibility screen — final dynamic-cable curvature design still needs a licensed FE / lumped-mass dynamic solver (noted in the module docstring and the input.yml header).

## Tests

`uv run python -m pytest tests/orcaflex/test_fowt_mooring_workflow.py -q` → 1 passed (offline, no licence). Dispatches the committed input.yml through the engine and asserts a sane PASS (governing radius >> MBR, chord shrinks under watch-circle drift, summary JSON written).

Lint: black==25.9.0 -l88 + ruff check clean on the two new `.py` files.

Flips `usecase_registry` `fowt-mooring` partial → ready; the registry edit itself is handled separately per #941.

Closes #959. Part of #941 / #938.

Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)