### PR TITLE
feat(orcaflex): J-lay + reel-lay pipelay workflow templates (#958)

### DIFF
--- a/examples/workflows/jlay-pipelay/input.yml
+++ b/examples/workflows/jlay-pipelay/input.yml
@@ -1,0 +1,38 @@
+basename: pipelay
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+# Deepwater J-lay pipelay screening (offline, analytical -- no OrcaFlex license).
+# Near-vertical departure: the sagbend is the governing stress concern.
+pipelay:
+  case:
+    id: registry_jlay_pipelay
+    description: J-lay sagbend screening for a deepwater rigid pipeline
+  method: J-Lay
+  config:
+    water_depth_m: 1500.0
+    tower_angle_deg: 3.0           # tower angle from vertical (deg)
+    top_tension_kN: 3000.0         # top tension at the J-lay tower
+    allowable_sagbend_strain: 0.003
+    allowable_overbend_strain: 0.002
+  pipe:
+    outer_diameter: 0.3238         # 12.75 in
+    wall_thickness: 0.0206
+    youngs_modulus: 207.0e9
+    smys: 448.0e6
+    coating_thickness: 0.06
+    coating_density: 2400.0
+    seawater_density: 1025.0
+  operability:
+    max_hs_lay: 3.0
+    max_hs_welding: 2.5
+    max_hs_aband_recovery: 4.0
+    lay_rate_calm: 3.0
+    lay_rate_degradation: 0.5
+  outputs:
+    directory: results
+    summary_json: jlay_pipelay_summary.json

--- a/examples/workflows/reel-lay-pipelay/input.yml
+++ b/examples/workflows/reel-lay-pipelay/input.yml
@@ -1,0 +1,40 @@
+basename: pipelay
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+# Reel-lay pipelay screening (offline, analytical -- no OrcaFlex license).
+# The pipe is spooled onto a reel and plastically bent, then straightened.
+# Screens reeling strain vs the plastic-strain limit and reports the residual
+# curvature / out-of-straightness after the straightener.
+pipelay:
+  case:
+    id: registry_reel_lay_pipelay
+    description: Reel-lay reeling-strain and residual-curvature screening
+  method: Reel-Lay
+  config:
+    reel_core_radius_m: 8.0                  # reel hub radius
+    allowable_reeling_strain: 0.02           # 2% plastic strain limit
+    straightener_efficiency: 0.95            # fraction of reel curvature removed
+    residual_out_of_straightness_span_m: 12.0
+    allowable_overbend_strain: 0.002
+  pipe:
+    outer_diameter: 0.2731                   # 10.75 in (reelable size)
+    wall_thickness: 0.0191
+    youngs_modulus: 207.0e9
+    smys: 448.0e6
+    coating_thickness: 0.0                   # reeled pipe: no concrete coating
+    coating_density: 0.0
+    seawater_density: 1025.0
+  operability:
+    max_hs_lay: 4.0
+    max_hs_welding: 3.0
+    max_hs_aband_recovery: 4.5
+    lay_rate_calm: 6.0
+    lay_rate_degradation: 0.8
+  outputs:
+    directory: results
+    summary_json: reel_lay_pipelay_summary.json

--- a/src/digitalmodel/base_configs/modules/pipelay/pipelay.yml
+++ b/src/digitalmodel/base_configs/modules/pipelay/pipelay.yml
@@ -1,0 +1,9 @@
+basename: pipelay
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+pipelay: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -257,6 +257,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         )
 
         cfg_base = span_rectification(cfg_base)
+    elif basename == "pipelay":
+        from digitalmodel.pipelay.workflow import router as pipelay
+
+        cfg_base = pipelay(cfg_base)
     elif basename == "cathodic_protection":
         cp = CathodicProtection()
         cfg_base = cp.router(cfg_base)

--- a/src/digitalmodel/pipelay/__init__.py
+++ b/src/digitalmodel/pipelay/__init__.py
@@ -1,0 +1,10 @@
+"""Pipelay durable workflows (J-lay, reel-lay).
+
+Thin, offline workflow router over the analytical pipelay pre-processing
+utilities in ``digitalmodel.orcaflex.pipelay_analysis``. No OrcFxAPI / OrcaFlex
+license is required.
+"""
+
+from digitalmodel.pipelay.workflow import router
+
+__all__ = ["router"]

--- a/src/digitalmodel/pipelay/workflow.py
+++ b/src/digitalmodel/pipelay/workflow.py
@@ -1,0 +1,203 @@
+"""Durable workflow: J-lay and reel-lay pipelay screening (offline).
+
+Routes a ``basename: pipelay`` input through the analytical pipelay
+pre-processing utilities in :mod:`digitalmodel.orcaflex.pipelay_analysis`.
+The whole workflow is analytical and runs OFFLINE -- it never imports or
+calls OrcFxAPI, so no OrcaFlex license is required.
+
+Two lay methods are supported, selected by ``pipelay.method``:
+
+- ``J-Lay``: near-vertical sagbend catenary geometry (deepwater), via
+  :class:`~digitalmodel.orcaflex.pipelay_analysis.JLayConfig`. Reports the
+  catenary parameter, sagbend radius / strain / stress, touchdown offset and
+  suspended length, and screens the sagbend bending strain against an
+  allowable strain limit.
+- ``Reel-Lay``: reel + straightener residual-curvature screening. The pipe is
+  spooled onto a reel of given core radius, then passed through a
+  straightener. The reeling bending strain ``D / (2 * R_reel)`` must stay below
+  the plastic-strain limit, and the residual ovalisation / out-of-straightness
+  after straightening is reported.
+
+References:
+    - Bai & Bai (2014): Subsea Pipeline Design, Analysis and Installation,
+      Ch. 5 (J-lay) and Ch. 6 (reel-lay).
+    - DNV-OS-F101: Submarine Pipeline Systems, Section 11 (installation).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from digitalmodel.orcaflex.pipelay_analysis import (
+    JLayConfig,
+    LayMethod,
+    LayOperability,
+    PipelayPipeProperties,
+    calculate_stinger_radius,
+)
+
+
+def _pipe_from_cfg(pipe_cfg: Dict[str, Any]) -> PipelayPipeProperties:
+    """Build pipe properties, accepting only known fields."""
+    allowed = set(PipelayPipeProperties.model_fields)
+    filtered = {k: v for k, v in (pipe_cfg or {}).items() if k in allowed}
+    return PipelayPipeProperties(**filtered)
+
+
+def _operability(operability_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Run the lay-rate vs sea-state operability assessment, if requested."""
+    allowed = set(LayOperability.model_fields)
+    filtered = {k: v for k, v in (operability_cfg or {}).items() if k in allowed}
+    op = LayOperability(**filtered)
+    return {
+        "max_hs_lay_m": op.max_hs_lay,
+        "max_hs_welding_m": op.max_hs_welding,
+        "max_hs_abandonment_recovery_m": op.max_hs_aband_recovery,
+        "lay_rate_table": op.generate_operability_table(),
+    }
+
+
+def run_jlay(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """J-lay sagbend screening (offline, analytical)."""
+    pipe = _pipe_from_cfg(settings.get("pipe", {}))
+    config = settings.get("config", {})
+
+    jlay = JLayConfig(
+        water_depth=float(config.get("water_depth_m", 1500.0)),
+        pipe=pipe,
+        tower_angle=float(config.get("tower_angle_deg", 0.0)),
+        top_tension=float(config.get("top_tension_kN", 800.0)),
+    )
+    sagbend = jlay.calculate_sagbend()
+
+    strain_limit = float(config.get("allowable_sagbend_strain", 0.002))
+    sagbend_strain = sagbend["sagbend_bending_strain"]
+    utilisation = sagbend_strain / strain_limit if strain_limit > 0 else float("inf")
+
+    result: Dict[str, Any] = {
+        "method": LayMethod.J_LAY.value,
+        "water_depth_m": jlay.water_depth,
+        "tower_angle_deg": jlay.tower_angle,
+        "top_tension_kN": jlay.top_tension,
+        "pipe_outer_diameter_m": pipe.outer_diameter,
+        "pipe_submerged_weight_N_per_m": round(pipe.submerged_weight_per_m, 3),
+        "sagbend": sagbend,
+        "allowable_sagbend_strain": strain_limit,
+        "sagbend_strain_utilisation": round(utilisation, 4),
+        "screening_status": "pass" if utilisation <= 1.0 else "fail",
+    }
+    if "operability" in settings:
+        result["operability"] = _operability(settings["operability"])
+    return result
+
+
+def run_reel_lay(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Reel-lay reeling-strain + residual-curvature screening (offline).
+
+    The reeling bending strain is ``epsilon = D / (2 * R_reel)`` where
+    ``R_reel`` is the reel core radius plus the part of the pipe already
+    wound on. The pipe yields plastically on the reel (this is intended in
+    reel-lay) but must stay below an allowable plastic strain. After
+    straightening, a residual curvature remains; the residual
+    out-of-straightness over a span is reported.
+
+    Reference: Bai & Bai (2014) Ch. 6.
+    """
+    pipe = _pipe_from_cfg(settings.get("pipe", {}))
+    config = settings.get("config", {})
+
+    reel_core_radius = float(config.get("reel_core_radius_m", 8.0))
+    if reel_core_radius <= 0.0:
+        raise ValueError("reel_core_radius_m must be positive")
+    allowable_reeling_strain = float(config.get("allowable_reeling_strain", 0.02))
+    straightener_efficiency = float(config.get("straightener_efficiency", 0.95))
+    if not 0.0 <= straightener_efficiency <= 1.0:
+        raise ValueError("straightener_efficiency must be in [0, 1]")
+    residual_span_m = float(config.get("residual_out_of_straightness_span_m", 12.0))
+
+    D = pipe.outer_diameter
+
+    # Reeling bending strain at the reel core (worst case = innermost wrap).
+    reeling_strain = D / (2.0 * reel_core_radius)
+    reeling_utilisation = (
+        reeling_strain / allowable_reeling_strain
+        if allowable_reeling_strain > 0
+        else float("inf")
+    )
+
+    # Residual curvature after the straightener removes most of the reeling
+    # curvature. kappa_reel = 1/R_reel; residual = (1 - efficiency) * kappa_reel.
+    reel_curvature = 1.0 / reel_core_radius
+    residual_curvature = (1.0 - straightener_efficiency) * reel_curvature
+    residual_radius = (
+        1.0 / residual_curvature if residual_curvature > 0 else float("inf")
+    )
+    residual_strain = D / (2.0 * residual_radius) if residual_radius > 0 else 0.0
+
+    # Out-of-straightness (mid-span sagitta) over a measurement span from the
+    # residual curvature: delta = kappa * L^2 / 8.
+    residual_oos_m = residual_curvature * residual_span_m**2 / 8.0
+
+    result: Dict[str, Any] = {
+        "method": LayMethod.REEL_LAY.value,
+        "reel_core_radius_m": reel_core_radius,
+        "pipe_outer_diameter_m": D,
+        "pipe_submerged_weight_N_per_m": round(pipe.submerged_weight_per_m, 3),
+        "reeling_bending_strain": round(reeling_strain, 6),
+        "allowable_reeling_strain": allowable_reeling_strain,
+        "reeling_strain_utilisation": round(reeling_utilisation, 4),
+        "straightener_efficiency": straightener_efficiency,
+        "residual_curvature_1_per_m": round(residual_curvature, 8),
+        "residual_radius_m": round(residual_radius, 1),
+        "residual_bending_strain": round(residual_strain, 6),
+        "residual_out_of_straightness_span_m": residual_span_m,
+        "residual_out_of_straightness_m": round(residual_oos_m, 5),
+        "screening_status": "pass" if reeling_utilisation <= 1.0 else "fail",
+    }
+    if "operability" in settings:
+        result["operability"] = _operability(settings["operability"])
+    return result
+
+
+def router(cfg: dict) -> dict:
+    """Engine entry point for ``basename: pipelay``."""
+    settings = cfg.get("pipelay") or {}
+    method = str(settings.get("method", LayMethod.J_LAY.value)).strip().lower()
+
+    if method in ("j-lay", "jlay", "j_lay"):
+        result = run_jlay(settings)
+    elif method in ("reel-lay", "reel_lay", "reellay", "reel"):
+        result = run_reel_lay(settings)
+    else:
+        raise ValueError(
+            f"Unknown pipelay method '{settings.get('method')}'. "
+            "Use 'J-Lay' or 'Reel-Lay'."
+        )
+
+    # Minimum stinger radius is a useful reference for any method.
+    result["min_stinger_radius_m"] = round(
+        calculate_stinger_radius(
+            result["pipe_outer_diameter_m"],
+            float(settings.get("config", {}).get("allowable_overbend_strain", 0.002)),
+        ),
+        1,
+    )
+
+    summary_path = _write_summary(cfg, settings.get("outputs", {}), result)
+    result["summary_json"] = str(summary_path)
+
+    cfg["pipelay"] = {**settings, **result}
+    cfg["screening_status"] = result["screening_status"]
+    return cfg
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: Dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/pipelay"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get("summary_json", "pipelay_summary.json")
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path

--- a/tests/pipelay/test_pipelay_workflow.py
+++ b/tests/pipelay/test_pipelay_workflow.py
@@ -1,0 +1,122 @@
+"""Offline smoke tests for the J-lay / reel-lay pipelay workflows (#958).
+
+These run the dispatchable templates through the engine end-to-end. The whole
+workflow is analytical (no OrcFxAPI / OrcaFlex license), so the tests run
+offline in CI.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.engine import engine
+from digitalmodel.pipelay.workflow import run_jlay, run_reel_lay, router
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JLAY_INPUT = REPO_ROOT / "examples/workflows/jlay-pipelay/input.yml"
+REEL_INPUT = REPO_ROOT / "examples/workflows/reel-lay-pipelay/input.yml"
+
+
+def _summary(cfg):
+    summary_path = Path(cfg["pipelay"]["summary_json"])
+    if not summary_path.is_absolute():
+        summary_path = REPO_ROOT / summary_path
+    return json.loads(summary_path.read_text())
+
+
+def test_jlay_template_runs_offline():
+    cfg = engine(inputfile=str(JLAY_INPUT))
+
+    assert cfg["basename"] == "pipelay"
+    result = cfg["pipelay"]
+    assert result["method"] == "J-Lay"
+    assert result["screening_status"] == "pass"
+
+    sagbend = result["sagbend"]
+    # near-vertical departure: a positive, finite catenary parameter / radius
+    assert sagbend["catenary_parameter_m"] > 0.0
+    assert sagbend["sagbend_radius_m"] == pytest.approx(sagbend["catenary_parameter_m"])
+    assert math.isfinite(sagbend["sagbend_radius_m"])
+    # suspended length must exceed the water depth (slant >= vertical)
+    assert sagbend["suspended_length_m"] > result["water_depth_m"]
+
+    # utilisation is consistent with the reported strain and limit, and passes
+    util = result["sagbend_strain_utilisation"]
+    assert util == pytest.approx(
+        sagbend["sagbend_bending_strain"] / result["allowable_sagbend_strain"],
+        rel=1e-3,
+    )
+    assert util <= 1.0
+
+    # operability table is monotonically non-increasing and cut off above Hs limit
+    rates = [
+        row["lay_rate_km_per_day"] for row in result["operability"]["lay_rate_table"]
+    ]
+    assert rates[0] > 0.0
+    assert rates[-1] == 0.0
+    in_band = [r for r in rates if r > 0.0]
+    assert all(b >= a for a, b in zip(in_band[1:], in_band[:-1]))
+
+    summary = _summary(cfg)
+    assert summary["screening_status"] == "pass"
+    assert summary["method"] == "J-Lay"
+
+
+def test_reel_lay_template_runs_offline():
+    cfg = engine(inputfile=str(REEL_INPUT))
+
+    assert cfg["basename"] == "pipelay"
+    result = cfg["pipelay"]
+    assert result["method"] == "Reel-Lay"
+    assert result["screening_status"] == "pass"
+
+    # reeling strain = D / (2 * R_reel)
+    expected_strain = result["pipe_outer_diameter_m"] / (
+        2.0 * result["reel_core_radius_m"]
+    )
+    assert result["reeling_bending_strain"] == pytest.approx(expected_strain, rel=1e-4)
+    assert result["reeling_strain_utilisation"] == pytest.approx(
+        expected_strain / result["allowable_reeling_strain"], rel=1e-3
+    )
+    assert result["reeling_strain_utilisation"] <= 1.0
+
+    # straightener removes most curvature -> residual << reeling curvature
+    assert 0.0 < result["residual_bending_strain"] < result["reeling_bending_strain"]
+    assert result["residual_radius_m"] > result["reel_core_radius_m"]
+    assert result["residual_out_of_straightness_m"] > 0.0
+
+    summary = _summary(cfg)
+    assert summary["method"] == "Reel-Lay"
+    assert summary["screening_status"] == "pass"
+
+
+def test_reeling_strain_exceeding_limit_fails():
+    # a tight reel core drives the reeling strain over the plastic-strain limit
+    result = run_reel_lay(
+        {
+            "config": {
+                "reel_core_radius_m": 3.0,
+                "allowable_reeling_strain": 0.02,
+            },
+            "pipe": {"outer_diameter": 0.3238, "wall_thickness": 0.0206},
+        }
+    )
+    assert result["reeling_strain_utilisation"] > 1.0
+    assert result["screening_status"] == "fail"
+
+
+def test_router_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unknown pipelay method"):
+        router({"pipelay": {"method": "Tow-Lay"}})
+
+
+def test_jlay_higher_tension_reduces_sagbend_strain():
+    # higher top tension -> larger catenary radius -> lower sagbend strain
+    low = run_jlay({"config": {"top_tension_kN": 1500.0, "tower_angle_deg": 3.0}})
+    high = run_jlay({"config": {"top_tension_kN": 3000.0, "tower_angle_deg": 3.0}})
+    assert (
+        high["sagbend"]["sagbend_bending_strain"]
+        < low["sagbend"]["sagbend_bending_strain"]
+    )


### PR DESCRIPTION
## What

Adds dispatchable J-lay and reel-lay pipelay templates, wired through a new `basename: pipelay` engine workflow.

- `src/digitalmodel/pipelay/workflow.py` — `router(cfg)` over the **existing** analytical utilities in `digitalmodel.orcaflex.pipelay_analysis` (`JLayConfig`, `PipelayPipeProperties`, `LayOperability`). J-lay reuses the library directly; reel-lay adds a small analytical reeling-strain + residual-curvature screen (the library had `LayMethod.REEL_LAY` but no reel config). `pipelay_analysis.py` was **not** modified.
- `src/digitalmodel/engine.py` — adds the `pipelay` branch; `base_configs/modules/pipelay/pipelay.yml` base config.
- `examples/workflows/jlay-pipelay/input.yml` and `examples/workflows/reel-lay-pipelay/input.yml` — run via `uv run python -m digitalmodel <input.yml>`.
- `tests/pipelay/test_pipelay_workflow.py` — 5 offline smoke tests.

## Offline-vs-licensed finding (per case)

Both cases are **OFFLINE / analytical — no OrcaFlex license required**. The underlying `pipelay_analysis` module is purely analytical ("Does NOT require OrcFxAPI") and there was no workflow-router entry invoking it; this PR adds that router so both run end-to-end via the standard `uv run python -m digitalmodel <input.yml>` path.

- **J-lay**: near-vertical sagbend catenary screening (catenary parameter, sagbend radius/strain/stress, touchdown offset, suspended length) vs an allowable sagbend strain. Template passes (R_sag ≈ 95 m, utilisation ≈ 0.57).
- **Reel-lay**: reeling bending strain `D/(2·R_reel)` vs the plastic-strain limit, plus residual curvature / out-of-straightness after the straightener. Template passes (utilisation ≈ 0.85).

Each template also includes the optional lay-rate vs sea-state operability table.

## Tests

5 offline smoke tests (`tests/pipelay/`), all passing: J-lay + reel-lay engine end-to-end, reel-strain-exceeds-limit fail path, unknown-method rejection, and a J-lay tension monotonicity check. Lint clean (black 25.9.0, ruff).

The `src/digitalmodel/usecase_registry/*` flip to `ready` is intentionally **not** included here (handled in the consolidated registry PR).

Closes #958. Refs #941, #938.

Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)