### PR TITLE
feat(riser-fatigue): dispatchable wave+VIV riser fatigue template (#960)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -91,6 +91,16 @@ workflows:
       - examples/workflows/jumper-installation/results/input_jumper_installation_cases.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[jumper-installation]
     runtime: offline
+  - id: riser-fatigue
+    basename: riser_fatigue
+    title: Combined wave + VIV riser fatigue damage (DNV-RP-C203)
+    input: examples/workflows/riser-fatigue/input.yml
+    outputs:
+      - examples/workflows/riser-fatigue/results/input.yml
+      - examples/workflows/riser-fatigue/results/input_riser_fatigue.csv
+      - examples/workflows/riser-fatigue/results/input_riser_fatigue_summary.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[riser-fatigue]
+    runtime: offline
   - id: mooring-fatigue
     basename: mooring_fatigue
     title: Metallic mooring-line fatigue damage from tension-range bins

--- a/examples/workflows/riser-fatigue/README.md
+++ b/examples/workflows/riser-fatigue/README.md
@@ -1,0 +1,31 @@
+# Riser Fatigue (Wave + VIV)
+
+Combined wave and vortex-induced-vibration (VIV) fatigue screening for a Steel
+Catenary Riser (SCR). For each riser segment the workflow accumulates
+Palmgren-Miner damage from two independent contributions and sums them
+(DNV-RP-C203 bilinear S-N + DNV-OS-F201 DFF):
+
+- **Wave fatigue** — a long-term hot-spot stress-range histogram (cycles per
+  stress bin) with an SCF and the DNV thickness correction, evaluated through
+  the licence-free touchdown-zone fatigue core.
+- **VIV fatigue** — narrow-band lock-in cases, each a (stress range, frequency,
+  annual exposure) triple; cycles = frequency x exposure-seconds x design life.
+
+The governing (worst) segment drives the top-level fatigue life, DFF margin and
+pass/fail verdict.
+
+This template is **offline-analytical and licence-free**. It consumes a stress
+response (real or synthetic) and reimplements no S-N math. The OrcaFlex /
+Shear7 / VIVANA front-ends that *produce* the wave histogram and VIV stress
+amplitudes are a deferred licensed follow-on (see issue #810); wire them in
+front of this workflow when a licence is available.
+
+Run:
+
+```bash
+uv run python -m digitalmodel examples/workflows/riser-fatigue/input.yml
+```
+
+Expected outputs are written to `examples/workflows/riser-fatigue/results/`:
+the resolved result configuration `input.yml`, the per-bin damage CSV
+`input_riser_fatigue.csv`, and the per-segment summary `input_riser_fatigue_summary.csv`.

--- a/examples/workflows/riser-fatigue/input.yml
+++ b/examples/workflows/riser-fatigue/input.yml
@@ -1,0 +1,53 @@
+basename: riser_fatigue
+
+# Combined wave + VIV fatigue screening for a Steel Catenary Riser (SCR).
+# Offline-analytical and licence-free: each segment accumulates Palmgren-Miner
+# damage from a long-term wave stress-range histogram AND one or more
+# narrow-band VIV cases, both evaluated against a DNV-RP-C203 bilinear S-N
+# curve. The OrcaFlex / Shear7 stress front-ends that produce these histograms
+# are a deferred licensed follow-on (see README); here the response is supplied.
+riser_fatigue:
+  design_life_years: 25.0
+  dff: 10.0
+  sn_curve:
+    curve: F1
+    environment: seawater_cp
+  output_dir: results
+  segments:
+    - id: TDZ-sandwave
+      material: API 5L X65
+      outer_diameter_mm: 273.1
+      wall_thickness_mm: 22.2
+      # Wave (first/second-order) long-term stress-range histogram (annual).
+      wave:
+        scf: 1.15
+        histogram_period_years: 1.0
+        stress_ranges_MPa: [6.0, 10.0, 16.0, 24.0, 36.0]
+        cycles: [4.0e6, 6.0e5, 45000.0, 2500.0, 90.0]
+      # Narrow-band VIV cases (current-driven lock-in), annual exposure.
+      viv_cases:
+        - stress_range_MPa: 9.0
+          frequency_hz: 0.42
+          exposure_fraction: 0.02
+        - stress_range_MPa: 12.0
+          frequency_hz: 0.55
+          exposure_hours_per_year: 40.0
+    - id: hangoff
+      material: API 5L X65
+      outer_diameter_mm: 273.1
+      wall_thickness_mm: 25.4
+      wave:
+        scf: 1.10
+        histogram_period_years: 1.0
+        stress_ranges_MPa: [5.0, 9.0, 14.0, 21.0]
+        cycles: [5.0e6, 4.0e5, 25000.0, 900.0]
+      viv_cases:
+        - stress_range_MPa: 8.0
+          frequency_hz: 0.38
+          exposure_fraction: 0.015
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/riser_fatigue/riser_fatigue.yml
+++ b/src/digitalmodel/base_configs/modules/riser_fatigue/riser_fatigue.yml
@@ -1,0 +1,16 @@
+basename: riser_fatigue
+
+riser_fatigue:
+  design_life_years: 25.0
+  dff: 10.0
+  sn_curve:
+    curve: F1
+    environment: seawater_cp
+  output_dir: results
+  segments: []
+
+default:
+  log_level: DEBUG
+  config:
+    overwrite:
+      output: True

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -207,6 +207,10 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.mooring_fatigue.workflow import router as mooring_fatigue
 
         cfg_base = mooring_fatigue(cfg_base)
+    elif basename == "riser_fatigue":
+        from digitalmodel.riser_fatigue.workflow import router as riser_fatigue
+
+        cfg_base = riser_fatigue(cfg_base)
     elif basename == "synthetic_rope_mooring_fatigue":
         from digitalmodel.synthetic_rope_mooring_fatigue.workflow import (
             router as synthetic_rope_mooring_fatigue,

--- a/src/digitalmodel/riser_fatigue/workflow.py
+++ b/src/digitalmodel/riser_fatigue/workflow.py
@@ -1,0 +1,349 @@
+"""Durable workflow for combined wave + VIV riser fatigue screening.
+
+Offline-analytical and licence-free: invoked through the digitalmodel engine
+basename ``riser_fatigue`` via
+
+    uv run python -m digitalmodel examples/workflows/riser-fatigue/input.yml
+
+For each riser segment the workflow accumulates Palmgren-Miner fatigue damage
+from two independent contributions and sums them (DNV-RP-C203 / DNV-OS-F201):
+
+  * **Wave (first/second-order) fatigue** — a long-term stress-range histogram
+    (cycles per stress bin over a histogram period). Evaluated through the
+    license-free :func:`assess_touchdown_fatigue` core (SCF + thickness
+    correction + bilinear S-N + Miner).
+  * **VIV (vortex-induced vibration) fatigue** — one or more narrow-band VIV
+    cases, each a (stress range, frequency, annual exposure) triple. Cycles =
+    frequency x exposure-seconds; damage via the same S-N / Miner engine.
+
+The OrcaFlex / Shear7 / VIVANA front-ends that *produce* the stress histogram
+and the VIV stress amplitudes are a deferred licensed follow-on (issue #810);
+this workflow consumes their (real or synthetic) output and adds no S-N math of
+its own. The cfg output shape mirrors ``mooring_fatigue`` so the deckhand
+report template can render the governing segment and the pass/fail verdict.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from digitalmodel.fatigue.damage import miner_damage
+from digitalmodel.fatigue.sn_curves import get_sn_curve
+from digitalmodel.riser_fatigue.touchdown import (
+    RiserSection,
+    TouchdownFatigueInput,
+    assess_touchdown_fatigue,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SECONDS_PER_YEAR = 365.25 * 24.0 * 3600.0
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("riser_fatigue") or {}
+    design_life_years = _positive_float(settings, "design_life_years")
+    dff = _positive_float(settings, "dff")
+    default_curve, default_env = _curve_settings(settings)
+
+    rows: list[dict[str, Any]] = []
+    summaries: list[dict[str, Any]] = []
+    for segment in _segments(settings):
+        seg_rows, summary = _evaluate_segment(
+            segment, design_life_years, dff, default_curve, default_env
+        )
+        rows.extend(seg_rows)
+        summaries.append(summary)
+
+    governing = max(summaries, key=lambda item: item["total_damage"])
+    csv_path = _results_csv_path(cfg, settings)
+    summary_path = _summary_csv_path(cfg, settings)
+    _write_csv(csv_path, rows)
+    _write_csv(summary_path, summaries)
+
+    cfg["riser_fatigue"] = {
+        "design_life_years": design_life_years,
+        "dff": dff,
+        "sn_curve": {"curve": default_curve, "environment": default_env},
+        "governing_segment": governing["segment_id"],
+        "governing_damage": governing["total_damage"],
+        "governing_wave_damage": governing["wave_damage"],
+        "governing_viv_damage": governing["viv_damage"],
+        "governing_fatigue_life_years": governing["fatigue_life_years"],
+        "governing_dff_margin": governing["dff_margin"],
+        # Top-level pass/fail (governing segment is worst-case): drives the
+        # deckhand report template's mitigation-on-fail section.
+        "screening_status": "pass" if governing["dff_margin"] >= 1.0 else "fail",
+        "segments": summaries,
+        "results_csv": _display_path(csv_path),
+        "summary_csv": _display_path(summary_path),
+    }
+    return cfg
+
+
+def _evaluate_segment(
+    segment: dict[str, Any],
+    design_life_years: float,
+    dff: float,
+    default_curve: str,
+    default_env: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    segment_id = str(segment.get("id", segment.get("name", "segment")))
+    curve, environment = _curve_settings(segment, default_curve, default_env)
+
+    wave_rows, wave_damage = _wave_damage(
+        segment, segment_id, design_life_years, dff, curve, environment
+    )
+    viv_rows, viv_damage = _viv_damage(
+        segment, segment_id, design_life_years, curve, environment
+    )
+    if not wave_rows and not viv_rows:
+        raise ValueError(
+            f"riser_fatigue segment '{segment_id}' has neither a wave histogram"
+            " nor a VIV case"
+        )
+
+    total_damage = wave_damage + viv_damage
+    fatigue_life = _fatigue_life_years(design_life_years, total_damage)
+    required_life = design_life_years * dff
+    dff_margin = _safe_divide(fatigue_life, required_life)
+
+    summary = {
+        "segment_id": segment_id,
+        "material": str(segment.get("material", "API 5L X65")),
+        "wave_damage": wave_damage,
+        "viv_damage": viv_damage,
+        "total_damage": total_damage,
+        "fatigue_life_years": fatigue_life,
+        "required_life_years": required_life,
+        "dff_margin": dff_margin,
+        "passes_dff": dff_margin >= 1.0,
+    }
+    return wave_rows + viv_rows, summary
+
+
+def _wave_damage(
+    segment: dict[str, Any],
+    segment_id: str,
+    design_life_years: float,
+    dff: float,
+    curve: str,
+    environment: str,
+) -> tuple[list[dict[str, Any]], float]:
+    wave = segment.get("wave")
+    if wave is None:
+        return [], 0.0
+
+    stress_ranges = _float_list(wave, "stress_ranges_MPa")
+    cycles = _float_list(wave, "cycles")
+    if len(stress_ranges) != len(cycles):
+        raise ValueError(
+            f"riser_fatigue segment '{segment_id}' wave stress_ranges_MPa and"
+            " cycles must have equal length"
+        )
+    section = RiserSection(
+        outer_diameter_mm=_positive_float(segment, "outer_diameter_mm"),
+        wall_thickness_mm=_positive_float(segment, "wall_thickness_mm"),
+        material=str(segment.get("material", "API 5L X65")),
+    )
+    inp = TouchdownFatigueInput(
+        section=section,
+        stress_ranges_mpa=stress_ranges,
+        cycles=cycles,
+        sn_class=curve,
+        environment=environment,
+        scf=float(wave.get("scf", 1.0)),
+        design_life_years=design_life_years,
+        dff=dff,
+        histogram_period_years=float(wave.get("histogram_period_years", 1.0)),
+    )
+    result = assess_touchdown_fatigue(inp)
+    # Scale the per-period damage to the full design life so wave and VIV
+    # damages are accumulated over a common (design-life) basis.
+    period_years = inp.histogram_period_years
+    life_scale = design_life_years / period_years
+    rows: list[dict[str, Any]] = []
+    for index, b in enumerate(result.bins):
+        rows.append(
+            {
+                "segment_id": segment_id,
+                "contribution": "wave",
+                "bin_index": index,
+                "frequency_hz": math.nan,
+                "stress_range_MPa": b.stress_range_mpa,
+                "stress_corrected_MPa": b.stress_corrected_mpa,
+                "cycles": b.cycles * life_scale,
+                "allowable_cycles": b.allowable_cycles,
+                "damage": b.damage * life_scale,
+            }
+        )
+    return rows, result.design_life_damage
+
+
+def _viv_damage(
+    segment: dict[str, Any],
+    segment_id: str,
+    design_life_years: float,
+    curve: str,
+    environment: str,
+) -> tuple[list[dict[str, Any]], float]:
+    cases = segment.get("viv_cases")
+    if not cases:
+        return [], 0.0
+
+    bins: list[dict[str, float]] = []
+    meta: list[dict[str, float]] = []
+    for case in cases:
+        stress_range = _positive_value(case, ("stress_range_MPa", "stress_range"))
+        frequency_hz = _positive_value(case, ("frequency_hz", "frequency"))
+        exposure_fraction = _fraction(case)
+        cycles = frequency_hz * exposure_fraction * SECONDS_PER_YEAR * design_life_years
+        bins.append({"stress_range": stress_range, "cycles": cycles})
+        meta.append({"frequency_hz": frequency_hz, "stress_range": stress_range})
+
+    sn_curve = get_sn_curve(curve, environment)
+    damage_df = miner_damage(pd.DataFrame(bins), sn_curve)
+    total = float(damage_df.attrs["total_damage"])
+
+    rows: list[dict[str, Any]] = []
+    for index, row in damage_df.iterrows():
+        rows.append(
+            {
+                "segment_id": segment_id,
+                "contribution": "viv",
+                "bin_index": int(index),
+                "frequency_hz": meta[index]["frequency_hz"],
+                "stress_range_MPa": float(row["stress_range"]),
+                "stress_corrected_MPa": float(row["stress_range"]),
+                "cycles": float(row["cycles"]),
+                "allowable_cycles": float(row["allowable_cycles"]),
+                "damage": float(row["damage"]),
+            }
+        )
+    return rows, total
+
+
+def _segments(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    segments = settings.get("segments")
+    if not isinstance(segments, list) or not segments:
+        raise ValueError("riser_fatigue segments must be a non-empty list")
+    return segments
+
+
+def _curve_settings(
+    source: dict[str, Any],
+    default_curve: str = "F1",
+    default_env: str = "seawater_cp",
+) -> tuple[str, str]:
+    curve = source.get("sn_curve")
+    if not isinstance(curve, dict):
+        return default_curve, default_env
+    return (
+        str(curve.get("curve", default_curve)),
+        str(curve.get("environment", default_env)),
+    )
+
+
+def _float_list(source: dict[str, Any], name: str) -> list[float]:
+    values = source.get(name)
+    if not isinstance(values, list) or not values:
+        raise ValueError(f"riser_fatigue {name} must be a non-empty list")
+    return [float(value) for value in values]
+
+
+def _fraction(case: dict[str, Any]) -> float:
+    if case.get("exposure_fraction") is not None:
+        value = float(case["exposure_fraction"])
+    elif case.get("exposure_hours_per_year") is not None:
+        value = float(case["exposure_hours_per_year"]) / (365.25 * 24.0)
+    else:
+        raise ValueError(
+            "riser_fatigue VIV case requires exposure_fraction or"
+            " exposure_hours_per_year"
+        )
+    if not 0.0 < value <= 1.0:
+        raise ValueError("riser_fatigue VIV exposure fraction must be in (0, 1]")
+    return value
+
+
+def _positive_value(source: dict[str, Any], aliases: tuple[str, ...]) -> float:
+    for alias in aliases:
+        if source.get(alias) is not None:
+            value = float(source[alias])
+            if value <= 0.0:
+                raise ValueError(f"riser_fatigue {alias} must be positive")
+            return value
+    raise ValueError(f"riser_fatigue requires one of {aliases}")
+
+
+def _positive_float(source: dict[str, Any], name: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"riser_fatigue {name} is required")
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"riser_fatigue {name} must be positive")
+    return value
+
+
+def _fatigue_life_years(design_life_years: float, damage: float) -> float:
+    if damage <= 0.0:
+        return float("inf")
+    return design_life_years / damage
+
+
+def _safe_divide(numerator: float, denominator: float) -> float:
+    if math.isinf(numerator):
+        return float("inf")
+    return numerator / denominator
+
+
+def _results_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return _output_dir(cfg, settings) / f"{_input_stem(cfg)}_riser_fatigue.csv"
+
+
+def _summary_csv_path(cfg: dict, settings: dict[str, Any]) -> Path:
+    return _output_dir(cfg, settings) / f"{_input_stem(cfg)}_riser_fatigue_summary.csv"
+
+
+def _output_dir(cfg: dict, settings: dict[str, Any]) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "riser_fatigue"))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("riser_fatigue cannot write empty results")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/riser_fatigue/test_riser_fatigue_workflow.py
+++ b/tests/riser_fatigue/test_riser_fatigue_workflow.py
@@ -1,0 +1,108 @@
+"""Offline smoke test for the combined wave + VIV riser-fatigue workflow.
+
+Runs the dispatchable example through the digitalmodel engine
+(``uv run python -m digitalmodel examples/workflows/riser-fatigue/input.yml``)
+with no OrcaFlex / no licence / no network, and asserts a sane fatigue life,
+non-zero wave AND VIV damage, and a consistent governing-segment verdict.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.engine import engine
+from digitalmodel.riser_fatigue.workflow import router
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_INPUT = REPO_ROOT / "examples" / "workflows" / "riser-fatigue" / "input.yml"
+
+
+def test_riser_fatigue_example_runs_offline():
+    cfg = engine(inputfile=str(EXAMPLE_INPUT))
+
+    assert isinstance(cfg, dict)
+    assert cfg["basename"] == "riser_fatigue"
+
+    result = cfg["riser_fatigue"]
+    # Two segments defined in the example.
+    assert len(result["segments"]) == 2
+
+    # Governing (worst) segment drives the top-level verdict.
+    gov_damage = result["governing_damage"]
+    assert 0.0 < gov_damage < 1.0  # sane: damaged but below failure
+    assert result["governing_wave_damage"] > 0.0
+    assert result["governing_viv_damage"] > 0.0
+    assert result["governing_damage"] == pytest.approx(
+        result["governing_wave_damage"] + result["governing_viv_damage"]
+    )
+
+    # Finite, sane fatigue life and a DFF check consistent with the damage.
+    life = result["governing_fatigue_life_years"]
+    assert math.isfinite(life)
+    assert life > result["design_life_years"]
+    expected_status = "pass" if result["governing_dff_margin"] >= 1.0 else "fail"
+    assert result["screening_status"] == expected_status
+
+    # Outputs are written next to the example.
+    results_dir = EXAMPLE_INPUT.parent / "results"
+    assert (results_dir / "input_riser_fatigue.csv").exists()
+    assert (results_dir / "input_riser_fatigue_summary.csv").exists()
+
+
+def test_riser_fatigue_router_sums_wave_and_viv():
+    """A single VIV-only and a single wave-only segment isolate each path."""
+    cfg = {
+        "basename": "riser_fatigue",
+        "_config_dir_path": str(Path(__file__).parent),
+        "riser_fatigue": {
+            "design_life_years": 25.0,
+            "dff": 3.0,
+            "sn_curve": {"curve": "F1", "environment": "seawater_cp"},
+            "output_dir": "_riser_fatigue_unit_results",
+            "segments": [
+                {
+                    "id": "wave-only",
+                    "outer_diameter_mm": 273.1,
+                    "wall_thickness_mm": 22.2,
+                    "wave": {
+                        "scf": 1.0,
+                        "histogram_period_years": 1.0,
+                        "stress_ranges_MPa": [10.0, 20.0],
+                        "cycles": [1.0e6, 5.0e4],
+                    },
+                },
+                {
+                    "id": "viv-only",
+                    "outer_diameter_mm": 273.1,
+                    "wall_thickness_mm": 22.2,
+                    "viv_cases": [
+                        {
+                            "stress_range_MPa": 15.0,
+                            "frequency_hz": 0.5,
+                            "exposure_fraction": 0.05,
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+    out = router(cfg)["riser_fatigue"]
+    by_id = {seg["segment_id"]: seg for seg in out["segments"]}
+
+    assert by_id["wave-only"]["wave_damage"] > 0.0
+    assert by_id["wave-only"]["viv_damage"] == 0.0
+    assert by_id["viv-only"]["viv_damage"] > 0.0
+    assert by_id["viv-only"]["wave_damage"] == 0.0
+
+    for seg in out["segments"]:
+        assert seg["total_damage"] == pytest.approx(
+            seg["wave_damage"] + seg["viv_damage"]
+        )
+
+    # Clean up the unit-test output directory.
+    out_dir = Path(__file__).parent / "_riser_fatigue_unit_results"
+    for child in out_dir.glob("*"):
+        child.unlink()
+    out_dir.rmdir()

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -190,6 +190,34 @@ def test_workflow_registry(workflow, monkeypatch):
         assert results.sort_values("stress_range_MPa")[
             "allowable_cycles"
         ].is_monotonic_decreasing
+    elif workflow["id"] == "riser-fatigue":
+        summary = cfg["riser_fatigue"]
+        results_path = Path(summary["results_csv"])
+        summary_path = Path(summary["summary_csv"])
+        if not results_path.is_absolute():
+            results_path = REPO_ROOT / results_path
+        if not summary_path.is_absolute():
+            summary_path = REPO_ROOT / summary_path
+
+        results = pd.read_csv(results_path)
+        seg_summary = pd.read_csv(summary_path)
+
+        assert summary["governing_segment"] == "TDZ-sandwave"
+        assert 0.0 < summary["governing_damage"] < 1.0
+        assert summary["governing_wave_damage"] > 0.0
+        assert summary["governing_viv_damage"] > 0.0
+        assert summary["governing_damage"] == pytest.approx(
+            summary["governing_wave_damage"] + summary["governing_viv_damage"]
+        )
+        assert summary["governing_fatigue_life_years"] == pytest.approx(
+            summary["design_life_years"] / summary["governing_damage"]
+        )
+        assert summary["screening_status"] == (
+            "pass" if summary["governing_dff_margin"] >= 1.0 else "fail"
+        )
+        assert set(seg_summary["segment_id"]) == {"TDZ-sandwave", "hangoff"}
+        assert set(results["contribution"]) == {"wave", "viv"}
+        assert (results["stress_range_MPa"] > 0.0).all()
     elif workflow["id"] in {
         "mooring-fatigue-atlas-query",
         "synthetic-rope-atlas-query",


### PR DESCRIPTION
## What

Adds a **license-free, offline-analytical** combined wave + VIV riser-fatigue workflow that is dispatchable through the digitalmodel engine:

```bash
uv run python -m digitalmodel examples/workflows/riser-fatigue/input.yml
```

Per riser segment it accumulates Palmgren-Miner fatigue damage from two independent contributions and sums them (DNV-RP-C203 bilinear S-N + DNV-OS-F201 DFF):

- **Wave fatigue** — a long-term hot-spot stress-range histogram (SCF + DNV thickness correction), evaluated through the existing license-free touchdown-zone fatigue core (`riser_fatigue.touchdown`).
- **VIV fatigue** — narrow-band lock-in cases, each a `(stress range, frequency, annual exposure)` triple; cycles = frequency × exposure-seconds × design life.

The governing (worst) segment drives the top-level fatigue life, DFF margin and pass/fail verdict. The cfg output shape mirrors `mooring_fatigue` (`governing_*`, `screening_status`, `segments`) so the deckhand report template renders unchanged.

### Files
- `src/digitalmodel/riser_fatigue/workflow.py` — new `router` (reuses `fatigue.damage`, `fatigue.sn_curves`, `riser_fatigue.touchdown`; **no new S-N math**)
- `src/digitalmodel/engine.py` — wire basename `riser_fatigue` (one `elif`, mirroring `mooring_fatigue`)
- `src/digitalmodel/base_configs/modules/riser_fatigue/riser_fatigue.yml` — module base config (engine requires it)
- `examples/workflows/riser-fatigue/{input.yml,README.md}` — ready demo SCR (passes DFF=10 with margin 1.64, governing fatigue life ~410 yr, total damage ~0.06; non-zero wave AND VIV damage)
- `docs/registry/workflows.yaml` — register `riser-fatigue` (`runtime: offline`)

## Offline vs licensed finding

**Offline-analytical / no license.** Runs end-to-end via `uv run python -m digitalmodel <input.yml>` with no OrcaFlex / no network — confirmed by running it. It reuses the same DNV S-N + Miner core as the READY `mooring-fatigue` example and the existing `riser_fatigue.touchdown` (#810) wave-fatigue helper. The OrcaFlex / Shear7 / VIVANA front-ends that *produce* the wave histogram and VIV stress amplitudes remain a **deferred licensed follow-on (#810)**; this template consumes their (real or synthetic) response, which is the same posture as the merged mooring-fatigue and touchdown work.

## Tests (offline, no license)
- `tests/riser_fatigue/test_riser_fatigue_workflow.py` — engine smoke test (asserts sane finite life, non-zero wave+VIV damage, damage = wave+viv, consistent verdict) + a router unit test isolating the wave-only and VIV-only paths.
- `tests/workflows/test_durable_workflows.py` — added a `riser-fatigue` assertion branch (governing segment, 0 < damage < 1, both contributions present, life formula).

All pass: `uv run python -m pytest "tests/workflows/test_durable_workflows.py::test_workflow_registry[riser-fatigue]" tests/riser_fatigue/ -q` → 10 passed. New `.py` lint clean (black 25.9.0 -l88 + ruff). Existing touchdown / parametric-catalog / registry-versioning / usecase-registry tests still green.

Did **not** touch `src/digitalmodel/usecase_registry/*` — the partial→ready flip is handled separately.

Closes #960. Part of #941 / #938.

**Please don't self-merge** — review and merge on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)