### PR TITLE
parametrics P0: sweep harness + one offline pilot per solver (#968)

### DIFF
--- a/examples/parametrics/run_pilots.py
+++ b/examples/parametrics/run_pilots.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Run the parametrics P0 pilots (one sweep per solver), all offline.
+
+    uv run python examples/parametrics/run_pilots.py [--out /tmp/parametrics]
+
+ANSYS padeye + OrcaWave depth sweeps PREPARE per-case inputs (the solve is the
+licensed P1 step); the OrcaFlex FOWT watch-circle sweep runs the closed-form
+check and reports real results. No licence required.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from digitalmodel.parametrics.pilots import (
+    ansys_padeye_sweep,
+    orcaflex_fowt_watch_circle_sweep,
+    orcawave_depth_sweep,
+)
+
+
+def _print(summary) -> None:
+    print(f"\n## {summary.study_name}  ({len(summary.results)} cases)")
+    for r in summary.results:
+        params = ", ".join(f"{k}={v}" for k, v in r.parameters.items())
+        extra = ""
+        if r.max_utilisation is not None:
+            extra = f"  UC={r.max_utilisation}  margin={r.min_clearance_m}"
+        print(f"  [{r.status:9}] {r.case_id}  {params}{extra}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=Path("/tmp/parametrics-p0"))
+    args = ap.parse_args()
+
+    _print(ansys_padeye_sweep(args.out / "ansys-padeye"))
+    _print(orcawave_depth_sweep(args.out / "orcawave-depth"))
+    _print(orcaflex_fowt_watch_circle_sweep())
+    print(f"\nprepared inputs under {args.out}/  (solve licensed cases on the host)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/parametrics/__init__.py
+++ b/src/digitalmodel/parametrics/__init__.py
@@ -1,0 +1,34 @@
+"""Parametric sweeps over ready solver use-cases (parametrics P0, #968 / #943).
+
+Thin harness that REUSES the existing solver-agnostic case-matrix expander
+(``orcaflex.batch_parametric.ParametricStudy`` — no OrcFxAPI) rather than adding
+a new parametric engine: a study (parameter sweeps + base config) expands to a
+full-factorial case matrix; ``run_sweep`` applies a per-case runner and collects
+``CaseResult``s into a ``ParametricResultsSummary``.
+
+Pilots (one per solver, all offline / no license) live in ``pilots``:
+- ANSYS padeye geometry sweep -> a per-case APDL ``.inp`` (status ``prepared``;
+  the MAPDL solve is the licensed P1 step).
+- OrcaWave water-depth sweep -> a per-case validated diffraction spec (status
+  ``prepared``; the OrcaWave solve is the licensed P1 step).
+- OrcaFlex FOWT watch-circle sweep -> real closed-form results (status
+  ``completed``), since that workflow is analytical and runs offline.
+"""
+
+from digitalmodel.orcaflex.batch_parametric import (
+    CaseResult,
+    ParameterSweep,
+    ParametricResultsSummary,
+    ParametricStudy,
+)
+
+from digitalmodel.parametrics.sweep import CaseRunner, run_sweep
+
+__all__ = [
+    "CaseResult",
+    "ParameterSweep",
+    "ParametricResultsSummary",
+    "ParametricStudy",
+    "CaseRunner",
+    "run_sweep",
+]

--- a/src/digitalmodel/parametrics/pilots.py
+++ b/src/digitalmodel/parametrics/pilots.py
@@ -1,0 +1,173 @@
+"""One offline parametric pilot per solver (parametrics P0, #968).
+
+Each pilot builds a ``ParametricStudy`` over a *ready* use-case and a per-case
+runner, then returns a ``ParametricResultsSummary``. All run offline / no licence.
+ANSYS + OrcaWave produce per-case *inputs* (status ``prepared`` — the solve is the
+licensed P1 step); the analytical OrcaFlex FOWT check produces real results
+(status ``completed``).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from digitalmodel.orcaflex.batch_parametric import (
+    CaseResult,
+    ParameterSweep,
+    ParametricStudy,
+)
+from digitalmodel.parametrics.sweep import run_sweep
+
+# Ready templates this P0 sweeps over (registry ids in parentheses).
+_ORCAWAVE_BASE_SPEC = Path(
+    "examples/workflows/orcawave-diffraction-solve/spec.yml"
+)  # orcawave-unit-box
+
+
+# --- ANSYS: padeye geometry sweep -> per-case APDL .inp ----------------------
+
+
+def ansys_padeye_sweep(
+    out_dir: str | Path,
+    *,
+    thicknesses_mm=(30.0, 40.0, 50.0),
+    hole_diameters_mm=(70.0, 90.0),
+):
+    """Sweep padeye plate thickness x hole diameter -> one .inp per case."""
+    from digitalmodel.ansys.padeye import PadeyeGeometry, write_padeye_inp
+
+    out_dir = Path(out_dir)
+    study = ParametricStudy(
+        name="ansys-padeye",
+        parameters=[
+            ParameterSweep(name="thickness_mm", values=list(thicknesses_mm), unit="mm"),
+            ParameterSweep(
+                name="hole_diameter_mm", values=list(hole_diameters_mm), unit="mm"
+            ),
+        ],
+        output_dir=str(out_dir),
+    )
+
+    def runner(cfg: dict) -> CaseResult:
+        geom = PadeyeGeometry(
+            thickness_mm=cfg["thickness_mm"],
+            hole_diameter_mm=cfg["hole_diameter_mm"],
+        )
+        inp = write_padeye_inp(geom, out_dir / cfg["case_id"] / "padeye.inp")
+        return CaseResult(
+            case_id=cfg["case_id"],
+            parameters={
+                "thickness_mm": cfg["thickness_mm"],
+                "hole_diameter_mm": cfg["hole_diameter_mm"],
+            },
+            status="prepared",
+            notes=str(inp),
+        )
+
+    return run_sweep(study, runner)
+
+
+# --- OrcaWave: water-depth sweep -> per-case validated diffraction spec -------
+
+
+def orcawave_depth_sweep(
+    out_dir: str | Path,
+    *,
+    water_depths_m=(100.0, 250.0, 500.0),
+    repo_root: str | Path | None = None,
+):
+    """Sweep OrcaWave water depth -> one validated diffraction spec per case."""
+    from digitalmodel.hydrodynamics.diffraction.spec_converter import SpecConverter
+
+    root = Path(repo_root) if repo_root else Path.cwd()
+    base_spec = root / _ORCAWAVE_BASE_SPEC
+    base_dir = base_spec.parent
+    spec_dict = yaml.safe_load(base_spec.read_text())
+    mesh_file = spec_dict["vessel"]["geometry"]["mesh_file"]
+    out_dir = Path(out_dir)
+
+    study = ParametricStudy(
+        name="orcawave-water-depth",
+        parameters=[
+            ParameterSweep(name="water_depth", values=list(water_depths_m), unit="m")
+        ],
+        output_dir=str(out_dir),
+    )
+
+    def runner(cfg: dict) -> CaseResult:
+        case_dir = out_dir / cfg["case_id"]
+        case_dir.mkdir(parents=True, exist_ok=True)
+        # Copy the mesh next to the per-case spec so relative refs resolve.
+        shutil.copy(base_dir / mesh_file, case_dir / mesh_file)
+        case_spec = dict(spec_dict)
+        case_spec["environment"] = {
+            **spec_dict["environment"],
+            "water_depth": cfg["water_depth"],
+        }
+        spec_path = case_dir / "spec.yml"
+        spec_path.write_text(yaml.safe_dump(case_spec, sort_keys=False))
+
+        issues = SpecConverter(spec_path).validate()
+        status = "prepared" if not issues else "failed"
+        return CaseResult(
+            case_id=cfg["case_id"],
+            parameters={"water_depth": cfg["water_depth"]},
+            status=status,
+            notes=str(spec_path) if not issues else "; ".join(issues),
+        )
+
+    return run_sweep(study, runner)
+
+
+# --- OrcaFlex: FOWT watch-circle sweep -> real analytical results ------------
+
+
+def orcaflex_fowt_watch_circle_sweep(
+    *,
+    watch_circle_radii_m=(15.0, 25.0, 35.0),
+    cable=None,
+):
+    """Sweep FOWT watch-circle radius -> closed-form MBR check per case (offline)."""
+    from digitalmodel.orcaflex.fowt_mooring_workflow import FOWTMooringWorkflow
+
+    base_cable = cable or {
+        "suspended_length": 320.0,
+        "hang_off_elevation": 90.0,
+        "nominal_horizontal_span": 260.0,
+        "mbr_limit_m": 4.5,
+        "mooring_type": "hybrid",
+        "floater_type": "semi",
+    }
+    study = ParametricStudy(
+        name="orcaflex-fowt-watch-circle",
+        parameters=[
+            ParameterSweep(
+                name="watch_circle_radius", values=list(watch_circle_radii_m), unit="m"
+            )
+        ],
+    )
+
+    def runner(cfg: dict) -> CaseResult:
+        wf_cfg = {
+            "fowt_mooring": {
+                "watch_circle_radius": cfg["watch_circle_radius"],
+                "cable": dict(base_cable),
+            }
+        }
+        out = FOWTMooringWorkflow().router(wf_cfg)
+        r = out["fowt_mooring"]["result"]
+        governing = float(r["governing_bend_radius_m"])
+        limit = float(r["mbr_limit_m"])
+        return CaseResult(
+            case_id=cfg["case_id"],
+            parameters={"watch_circle_radius": cfg["watch_circle_radius"]},
+            status="completed",
+            min_clearance_m=round(float(r["margin_m"]), 3),
+            max_utilisation=round(limit / governing, 4) if governing else None,
+            notes=f"passes={r['passes']} governing_bend_radius_m={governing}",
+        )
+
+    return run_sweep(study, runner)

--- a/src/digitalmodel/parametrics/sweep.py
+++ b/src/digitalmodel/parametrics/sweep.py
@@ -1,0 +1,43 @@
+"""Generic parametric-sweep driver (parametrics P0).
+
+``run_sweep`` expands a ``ParametricStudy`` to its full-factorial case matrix and
+applies a per-case runner, collecting results fail-soft (a runner exception marks
+that one case ``failed`` and the sweep continues). It adds NO new case-matrix or
+parameter machinery — that all comes from ``ParametricStudy`` / ``ParameterSweep``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from digitalmodel.orcaflex.batch_parametric import (
+    CaseResult,
+    ParametricResultsSummary,
+    ParametricStudy,
+)
+
+# A runner turns one expanded case config (base_config + injected params, plus
+# ``case_id``) into a CaseResult.
+CaseRunner = Callable[[dict], CaseResult]
+
+
+def run_sweep(
+    study: ParametricStudy, case_runner: CaseRunner
+) -> ParametricResultsSummary:
+    """Run ``case_runner`` over every case in ``study``; collect a summary."""
+    summary = ParametricResultsSummary(study_name=study.name)
+    param_names = [p.name for p in study.parameters]
+    for cfg in study.generate_case_configs():
+        case_id = str(cfg["case_id"])
+        params = {name: cfg[name] for name in param_names}
+        try:
+            result = case_runner(cfg)
+        except Exception as exc:  # noqa: BLE001 - one bad case must not kill the sweep
+            result = CaseResult(
+                case_id=case_id,
+                parameters=params,
+                status="failed",
+                notes=f"{type(exc).__name__}: {exc}",
+            )
+        summary.results.append(result)
+    return summary

--- a/tests/parametrics/test_pilots.py
+++ b/tests/parametrics/test_pilots.py
@@ -1,0 +1,51 @@
+"""Offline per-solver parametric pilots (parametrics P0, #968)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from digitalmodel.parametrics.pilots import (
+    ansys_padeye_sweep,
+    orcaflex_fowt_watch_circle_sweep,
+    orcawave_depth_sweep,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_ansys_padeye_sweep_prepares_inp_per_case(tmp_path: Path):
+    summary = ansys_padeye_sweep(
+        tmp_path, thicknesses_mm=(30.0, 40.0, 50.0), hole_diameters_mm=(70.0, 90.0)
+    )
+    assert len(summary.results) == 6  # 3 x 2
+    assert all(r.status == "prepared" for r in summary.results)
+    for r in summary.results:
+        inp = Path(r.notes)
+        assert inp.is_file()
+        assert "PLANE182" in inp.read_text()
+
+
+def test_orcawave_depth_sweep_prepares_validated_specs(tmp_path: Path):
+    summary = orcawave_depth_sweep(
+        tmp_path, water_depths_m=(100.0, 250.0, 500.0), repo_root=REPO_ROOT
+    )
+    assert len(summary.results) == 3
+    assert all(r.status == "prepared" for r in summary.results), [
+        (r.case_id, r.notes) for r in summary.results
+    ]
+    for r in summary.results:
+        spec = Path(r.notes)
+        assert spec.is_file() and spec.name == "spec.yml"
+
+
+def test_orcaflex_fowt_sweep_returns_real_results(tmp_path: Path):
+    summary = orcaflex_fowt_watch_circle_sweep(watch_circle_radii_m=(15.0, 25.0, 35.0))
+    assert len(summary.results) == 3
+    assert all(r.status == "completed" for r in summary.results)
+    # A larger watch circle tightens the governing bend -> higher MBR utilisation.
+    ucs = [r.max_utilisation for r in summary.results]
+    assert all(u is not None for u in ucs)
+    assert ucs[0] < ucs[-1]
+    # Critical case is the largest watch-circle radius.
+    critical = summary.get_critical_case("max_utilisation")
+    assert critical.parameters["watch_circle_radius"] == 35.0

--- a/tests/parametrics/test_sweep.py
+++ b/tests/parametrics/test_sweep.py
@@ -1,0 +1,54 @@
+"""Generic parametric-sweep driver (parametrics P0, #968)."""
+
+from __future__ import annotations
+
+from digitalmodel.parametrics import (
+    CaseResult,
+    ParameterSweep,
+    ParametricStudy,
+    run_sweep,
+)
+
+
+def _study() -> ParametricStudy:
+    return ParametricStudy(
+        name="t",
+        parameters=[
+            ParameterSweep(name="a", values=[1.0, 2.0]),
+            ParameterSweep(name="b", values=[10.0, 20.0, 30.0]),
+        ],
+    )
+
+
+def test_run_sweep_covers_full_factorial_matrix():
+    study = _study()
+
+    def runner(cfg: dict) -> CaseResult:
+        return CaseResult(
+            case_id=cfg["case_id"],
+            parameters={"a": cfg["a"], "b": cfg["b"]},
+            status="completed",
+            max_utilisation=cfg["a"] * cfg["b"],
+        )
+
+    summary = run_sweep(study, runner)
+    assert len(summary.results) == 6  # 2 x 3 full factorial
+    assert all(r.status == "completed" for r in summary.results)
+    critical = summary.get_critical_case("max_utilisation")
+    assert critical is not None
+    assert critical.max_utilisation == 60.0  # a=2 * b=30
+
+
+def test_run_sweep_is_fail_soft_per_case():
+    study = _study()
+
+    def runner(cfg: dict) -> CaseResult:
+        if cfg["a"] == 2.0 and cfg["b"] == 20.0:
+            raise ValueError("boom")
+        return CaseResult(case_id=cfg["case_id"], parameters={}, status="completed")
+
+    summary = run_sweep(study, runner)
+    failed = [r for r in summary.results if r.status == "failed"]
+    assert len(failed) == 1
+    assert "boom" in failed[0].notes
+    assert len([r for r in summary.results if r.status == "completed"]) == 5


### PR DESCRIPTION
Closes #968. First slice of the parametrics plan (`docs/plans/parametrics-preparedness.md`, #943), under epic #938(c).

## What
- **`parametrics/sweep.py`** — `run_sweep(study, case_runner)` expands a `ParametricStudy` to its full-factorial matrix and applies a per-case runner, collecting `CaseResult`s into a `ParametricResultsSummary`, **fail-soft** (one bad case is marked `failed`, the sweep continues). It **reuses** the existing solver-agnostic `ParametricStudy`/`ParameterSweep`/`ParametricResultsSummary` (in `orcaflex/batch_parametric`, no OrcFxAPI) — **no 4th parametric engine**, per the plan.
- **`parametrics/pilots.py`** — one offline pilot per solver over a *ready* registry use-case:
  - **ANSYS** padeye thickness × hole-dia sweep → a per-case APDL `.inp` (status `prepared`; MAPDL solve is the licensed P1 step).
  - **OrcaWave** water-depth sweep → a per-case **validated** diffraction spec (status `prepared`; OrcaWave solve is P1).
  - **OrcaFlex** FOWT watch-circle sweep → **real closed-form results** (status `completed`) — that workflow is analytical and runs offline.
- **`examples/parametrics/run_pilots.py`** — runs all three, no licence.

## Verified end-to-end (offline)
ANSYS 6 cases, OrcaWave 3 validated specs, OrcaFlex 3 with real numbers — MBR utilisation rises `0.0305 → 0.033 → 0.0353` and margin shrinks `143 → 133 → 123 m` as the watch circle grows (physically correct). `summary.get_critical_case("max_utilisation")` picks the worst case.

## Honest scope
P0 = sweep + *prepare* per-case inputs; the analytical OrcaFlex case also *solves*. **P1** = bulk-dispatch the `prepared` licensed cases through the lane (needs deckhand #489 result-return); **P2** = atlases (#794). 5 tests; black/ruff clean. Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)