### PR TITLE
parametrics P2 (first cut): bridge a sweep into the parametric Atlas (#971)

### DIFF
--- a/examples/parametrics/build_fowt_atlas.py
+++ b/examples/parametrics/build_fowt_atlas.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""P2 demo: build a FOWT MBR-utilisation atlas from an offline sweep, then query.
+
+    uv run python examples/parametrics/build_fowt_atlas.py
+
+Sweeps watch-circle radius x cable MBR limit (closed-form, no licence), builds a
+parametric.Atlas from the results, then serves instant interpolated answers with
+the out-of-range rail.
+"""
+
+from __future__ import annotations
+
+from digitalmodel.parametrics import ParameterSweep, ParametricStudy
+from digitalmodel.parametrics.atlas_bridge import atlas_from_summary
+from digitalmodel.parametrics.pilots import orcaflex_fowt_watch_circle_sweep
+
+RADII = (15.0, 25.0, 35.0)
+MBR = (4.0, 5.0, 6.0)
+
+
+def main() -> None:
+    summary = orcaflex_fowt_watch_circle_sweep(
+        watch_circle_radii_m=RADII, mbr_limits_m=MBR
+    )
+    study = ParametricStudy(
+        name="orcaflex-fowt-watch-circle",
+        parameters=[
+            ParameterSweep(name="watch_circle_radius", values=list(RADII)),
+            ParameterSweep(name="mbr_limit_m", values=list(MBR)),
+        ],
+    )
+    atlas = atlas_from_summary(
+        study,
+        summary,
+        "max_utilisation",
+        basename="fowt_mooring",
+        atlas_id="fowt-mbr-uc-v0",
+    )
+    print(f"built atlas '{atlas.atlas_id}' over {len(atlas.grid)} grid points")
+
+    for point in (
+        {"watch_circle_radius": 25.0, "mbr_limit_m": 5.0},  # grid node
+        {"watch_circle_radius": 20.0, "mbr_limit_m": 4.5},  # interpolated
+        {"watch_circle_radius": 80.0, "mbr_limit_m": 5.0},  # out of range
+    ):
+        pred = atlas.predict(point)
+        if pred.in_range:
+            print(f"  {point} -> UC={pred.value:.4f}")
+        else:
+            print(f"  {point} -> out of range ({pred.reason}); escalate to a run")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/parametrics/atlas_bridge.py
+++ b/src/digitalmodel/parametrics/atlas_bridge.py
@@ -1,0 +1,80 @@
+"""Bridge a parametric sweep into the parametric Atlas (parametrics P2, #971).
+
+Turns a completed ``ParametricResultsSummary`` over a full-factorial
+``ParametricStudy`` grid into a ``parametric.Atlas`` — the existing atlas /
+interpolation artifact (#794). No new atlas engine: the swept parameters become
+the atlas axes and the chosen result field becomes the response, so
+``Atlas.predict`` serves instant interpolated answers with the built-in
+out-of-range rail.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from digitalmodel.orcaflex.batch_parametric import (
+    ParametricResultsSummary,
+    ParametricStudy,
+)
+from digitalmodel.parametric.atlas import Atlas, Axis
+
+
+def atlas_from_summary(
+    study: ParametricStudy,
+    summary: ParametricResultsSummary,
+    response: str,
+    *,
+    basename: str,
+    atlas_id: str,
+    physics: str = "linear",
+    scales: Optional[dict[str, str]] = None,
+) -> Atlas:
+    """Build a ``parametric.Atlas`` from a swept study + its results.
+
+    ``response`` is the ``CaseResult`` field to interpolate (e.g.
+    ``max_utilisation``). Requires a complete (full-factorial) grid of completed
+    cases — raises if cases are missing/failed so the atlas is never built over a
+    hole.
+    """
+    df = summary.to_dataframe()
+    df = df[df["status"] == "completed"]
+
+    axis_names = [p.name for p in study.parameters]
+    if not axis_names:
+        raise ValueError("study has no parameters to build axes from")
+    if response not in df.columns:
+        raise ValueError(
+            f"response {response!r} not in result columns {sorted(df.columns)}"
+        )
+
+    expected = 1
+    axes: list[Axis] = []
+    scales = scales or {}
+    for param in study.parameters:
+        values = sorted(param.get_values())
+        expected *= len(values)
+        axes.append(
+            Axis(name=param.name, scale=scales.get(param.name, "linear"), grid=values)
+        )
+
+    if len(df) != expected:
+        raise ValueError(
+            f"atlas grid is not full-factorial: {len(df)} completed cases vs "
+            f"{expected} expected ({' x '.join(str(len(a.grid)) for a in axes)})"
+        )
+    if df[response].isna().any():
+        raise ValueError(
+            f"response {response!r} has missing values; cannot build atlas"
+        )
+
+    grid = df[axis_names + [response]].reset_index(drop=True)
+    return Atlas(
+        basename=basename,
+        atlas_id=atlas_id,
+        physics=physics,
+        response=response,
+        axes=axes,
+        grid=grid,
+        validation={"max_rel_error": 0.0},
+        provenance={"source": "parametrics_sweep", "study": study.name},
+    )

--- a/src/digitalmodel/parametrics/pilots.py
+++ b/src/digitalmodel/parametrics/pilots.py
@@ -128,9 +128,12 @@ def orcawave_depth_sweep(
 def orcaflex_fowt_watch_circle_sweep(
     *,
     watch_circle_radii_m=(15.0, 25.0, 35.0),
+    mbr_limits_m=(4.5,),
     cable=None,
 ):
-    """Sweep FOWT watch-circle radius -> closed-form MBR check per case (offline)."""
+    """Sweep FOWT watch-circle radius x cable MBR limit -> closed-form MBR check
+    per case (offline). A single ``mbr_limits_m`` value gives a 1-D sweep; several
+    give a 2-D response grid (atlas-ready, P2)."""
     from digitalmodel.orcaflex.fowt_mooring_workflow import FOWTMooringWorkflow
 
     base_cable = cable or {
@@ -146,7 +149,8 @@ def orcaflex_fowt_watch_circle_sweep(
         parameters=[
             ParameterSweep(
                 name="watch_circle_radius", values=list(watch_circle_radii_m), unit="m"
-            )
+            ),
+            ParameterSweep(name="mbr_limit_m", values=list(mbr_limits_m), unit="m"),
         ],
     )
 
@@ -154,7 +158,7 @@ def orcaflex_fowt_watch_circle_sweep(
         wf_cfg = {
             "fowt_mooring": {
                 "watch_circle_radius": cfg["watch_circle_radius"],
-                "cable": dict(base_cable),
+                "cable": {**base_cable, "mbr_limit_m": cfg["mbr_limit_m"]},
             }
         }
         out = FOWTMooringWorkflow().router(wf_cfg)
@@ -163,7 +167,10 @@ def orcaflex_fowt_watch_circle_sweep(
         limit = float(r["mbr_limit_m"])
         return CaseResult(
             case_id=cfg["case_id"],
-            parameters={"watch_circle_radius": cfg["watch_circle_radius"]},
+            parameters={
+                "watch_circle_radius": cfg["watch_circle_radius"],
+                "mbr_limit_m": cfg["mbr_limit_m"],
+            },
             status="completed",
             min_clearance_m=round(float(r["margin_m"]), 3),
             max_utilisation=round(limit / governing, 4) if governing else None,

--- a/tests/parametrics/test_atlas_bridge.py
+++ b/tests/parametrics/test_atlas_bridge.py
@@ -1,0 +1,82 @@
+"""Bridge a parametric sweep into the parametric Atlas (parametrics P2, #971)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.parametrics.atlas_bridge import atlas_from_summary
+from digitalmodel.parametrics.pilots import orcaflex_fowt_watch_circle_sweep
+
+
+def _fowt_atlas():
+    study_radii = (15.0, 25.0, 35.0)
+    study_mbr = (4.0, 5.0, 6.0)
+    summary = orcaflex_fowt_watch_circle_sweep(
+        watch_circle_radii_m=study_radii, mbr_limits_m=study_mbr
+    )
+    # Rebuild the matching study for axis definitions (same params/values).
+    from digitalmodel.parametrics import ParameterSweep, ParametricStudy
+
+    study = ParametricStudy(
+        name="orcaflex-fowt-watch-circle",
+        parameters=[
+            ParameterSweep(name="watch_circle_radius", values=list(study_radii)),
+            ParameterSweep(name="mbr_limit_m", values=list(study_mbr)),
+        ],
+    )
+    atlas = atlas_from_summary(
+        study,
+        summary,
+        "max_utilisation",
+        basename="fowt_mooring",
+        atlas_id="fowt-mbr-uc-v0",
+    )
+    return atlas, summary
+
+
+def test_atlas_builds_with_two_axes():
+    atlas, _ = _fowt_atlas()
+    assert atlas.response == "max_utilisation"
+    assert [ax.name for ax in atlas.axes] == ["watch_circle_radius", "mbr_limit_m"]
+    assert len(atlas.grid) == 9  # 3 x 3 full factorial
+
+
+def test_predict_at_grid_node_matches_swept_value():
+    atlas, summary = _fowt_atlas()
+    df = summary.to_dataframe()
+    row = df[(df["watch_circle_radius"] == 25.0) & (df["mbr_limit_m"] == 5.0)].iloc[0]
+    pred = atlas.predict({"watch_circle_radius": 25.0, "mbr_limit_m": 5.0})
+    assert pred.in_range
+    assert pred.value == pytest.approx(float(row["max_utilisation"]), rel=1e-6)
+
+
+def test_predict_interpolates_interior_point():
+    atlas, _ = _fowt_atlas()
+    pred = atlas.predict({"watch_circle_radius": 20.0, "mbr_limit_m": 4.5})
+    assert pred.in_range
+    # UC is linear in mbr_limit; 4.5 is the midpoint of 4.0 and 6.0 nodes at r=20.
+    lo = atlas.predict({"watch_circle_radius": 20.0, "mbr_limit_m": 4.0}).value
+    hi = atlas.predict({"watch_circle_radius": 20.0, "mbr_limit_m": 6.0}).value
+    assert lo < pred.value < hi
+
+
+def test_predict_out_of_range_is_gated():
+    atlas, _ = _fowt_atlas()
+    pred = atlas.predict({"watch_circle_radius": 80.0, "mbr_limit_m": 5.0})
+    assert not pred.in_range
+    assert "watch_circle_radius" in pred.reason
+
+
+def test_atlas_from_summary_rejects_unknown_response():
+    atlas, summary = _fowt_atlas()
+    from digitalmodel.parametrics import ParameterSweep, ParametricStudy
+
+    study = ParametricStudy(
+        name="x",
+        parameters=[
+            ParameterSweep(name="watch_circle_radius", values=[15.0, 25.0, 35.0]),
+            ParameterSweep(name="mbr_limit_m", values=[4.0, 5.0, 6.0]),
+        ],
+    )
+    with pytest.raises(ValueError, match="not in result columns"):
+        atlas_from_summary(study, summary, "no_such_metric", basename="b", atlas_id="i")


### PR DESCRIPTION
Closes #971. Closes the **P0 → P2 loop offline** for the analytical solver, under the parametrics plan (#943 / epic #938 c).

## What
- **`parametrics/atlas_bridge.py`** — `atlas_from_summary(study, summary, response)` builds the **existing** `parametric.Atlas` (#794) from a sweep's results: swept params → atlas axes, the chosen `CaseResult` field → response. **No new atlas engine.** Full-factorial completeness is enforced (raises on missing/failed cases, NaN response, or unknown response) so an atlas is never built over a hole.
- **`parametrics/pilots.py`** — the FOWT pilot is generalized to a 2-D grid (`watch_circle_radius × mbr_limit_m`); a single `mbr` value preserves the 1-D P0 behavior (no regression).
- **`examples/parametrics/build_fowt_atlas.py`** — sweep → atlas → `Atlas.predict`: grid-node lookup, interpolated interior point, and the out-of-range rail.

## Verified offline
9-point FOWT atlas; interior query `(r=20, mbr=4.5) → UC=0.0317`; out-of-range `(r=80 outside [15,35])` is gated → "escalate to a run". 10 parametrics tests pass (incl. the unchanged P0 ones); lint clean.

## Scope
This is the analytical path end-to-end (sweep→atlas→interpolated answer), all license-free. **P1** (lane-dispatched licensed sweeps feeding atlases for OrcaWave/ANSYS) still needs deckhand #489 (numeric result-return). Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)