### PR TITLE
parametrics: serve sweep-built atlases via parametric_query (FOWT handler) (#975)

### DIFF
--- a/src/digitalmodel/parametric/query.py
+++ b/src/digitalmodel/parametric/query.py
@@ -287,6 +287,9 @@ _HANDLERS: dict[str, Callable[[Atlas, dict[str, Any]], dict[str, Any]]] = {
     "synthetic_rope_mooring_fatigue": _handle_fatigue_bins,
     "code_check": _handle_utilisation,
     "free_span": _handle_utilisation,
+    # FOWT watch-circle vs dynamic-cable MBR utilisation (parametrics atlas #975):
+    # the atlas predicts utilisation directly, threshold at 1.0.
+    "fowt_mooring": _handle_utilisation,
     "rao_tabulation": _handle_rao,
     "pile_capacity": _handle_capacity_demand,
     "anchor_capacity": _handle_capacity_demand,

--- a/tests/parametrics/test_atlas_serving.py
+++ b/tests/parametrics/test_atlas_serving.py
@@ -1,0 +1,77 @@
+"""Serve a sweep-built atlas via the parametric_query workflow (parametrics #975).
+
+End-to-end, offline: parametrics FOWT sweep -> atlas_from_summary -> Atlas.save
+-> parametric_query router serves an interpolated utilisation answer, and gates
+out-of-range points to escalation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from digitalmodel.parametric.query import router as parametric_query
+from digitalmodel.parametrics import ParameterSweep, ParametricStudy
+from digitalmodel.parametrics.atlas_bridge import atlas_from_summary
+from digitalmodel.parametrics.pilots import orcaflex_fowt_watch_circle_sweep
+
+RADII = (15.0, 25.0, 35.0)
+MBR = (4.0, 5.0, 6.0)
+
+
+def _save_fowt_atlas(atlas_root: Path) -> None:
+    summary = orcaflex_fowt_watch_circle_sweep(
+        watch_circle_radii_m=RADII, mbr_limits_m=MBR
+    )
+    study = ParametricStudy(
+        name="orcaflex-fowt-watch-circle",
+        parameters=[
+            ParameterSweep(name="watch_circle_radius", values=list(RADII)),
+            ParameterSweep(name="mbr_limit_m", values=list(MBR)),
+        ],
+    )
+    atlas = atlas_from_summary(
+        study,
+        summary,
+        "max_utilisation",
+        basename="fowt_mooring",
+        atlas_id="fowt-mbr-uc-test",
+    )
+    atlas.save(atlas_root)
+
+
+def _query(atlas_root: Path, point: dict, out_dir: Path) -> dict:
+    cfg = {
+        "basename": "parametric_query",
+        "parametric_query": {
+            "atlas": "fowt_mooring",
+            "atlas_root": str(atlas_root),
+            "point": point,
+            "policy": {"on_out_of_range": "escalate"},
+            "output_dir": str(out_dir),
+        },
+    }
+    return parametric_query(cfg)["parametric_query"]["result"]
+
+
+def test_in_range_query_serves_utilisation(tmp_path: Path):
+    _save_fowt_atlas(tmp_path / "atlases")
+    result = _query(
+        tmp_path / "atlases",
+        {"watch_circle_radius": 20.0, "mbr_limit_m": 4.5},  # interpolated interior
+        tmp_path / "out",
+    )
+    assert result["in_range"] is True
+    assert result["response"] == "utilisation"
+    assert result["screening_status"] == "pass"  # UC ~0.03 << 1.0
+    assert result["value"] > 0.0
+
+
+def test_out_of_range_query_escalates(tmp_path: Path):
+    _save_fowt_atlas(tmp_path / "atlases")
+    result = _query(
+        tmp_path / "atlases",
+        {"watch_circle_radius": 80.0, "mbr_limit_m": 5.0},  # beyond [15, 35]
+        tmp_path / "out",
+    )
+    assert result["in_range"] is False
+    assert "watch_circle_radius" in str(result.get("reason", ""))


### PR DESCRIPTION
Closes #975 (the serving capability). Connects the parametrics atlas (P2, #972) to the **bot-facing `parametric_query` workflow** — instant interpolated answers with the out-of-range rail.

## What
- **`parametric/query.py`**: register `_HANDLERS["fowt_mooring"] = _handle_utilisation` — the FOWT atlas predicts a utilisation, thresholded at 1.0. **Additive**: existing handlers/atlases untouched (53 parametric + parametrics tests pass).
- **End-to-end serve test** (offline, temp `atlas_root`): parametrics FOWT sweep → `atlas_from_summary` → `Atlas.save` → `parametric_query` router serves an interpolated utilisation (in-range → `pass`) and gates an out-of-range point to escalation.

This closes the **sweep → atlas → served-answer** loop for the analytical solver, all license-free.

## Follow-up (tracked in #975; drift-CI entangled, operator/separate)
Commit a *live* FOWT atlas under `atlases/` + register a `parametric.refresh` builder so the atlas-drift gate passes — then a committed `examples/workflows/fowt-mooring-atlas-query/input.yml` runs standalone via `python -m digitalmodel`. Left separate because committing the binary atlas + build recipe touches the shared refresh registry and the drift CI.

Don't self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)