### PR TITLE
fix(ci): isolate tests-specialized SIGSEGV + fix routing-contract drift (#949)

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -47,6 +47,23 @@ of duplicating its detailed issue history.
 | `web` | `src/digitalmodel/web/` | `tests/web/` | `docs/domains/README.md` | Web-facing calculator and app support | web framework assets |
 | `well` | `src/digitalmodel/well/` | `tests/well/` | `docs/domains/README.md` | Well engineering, drilling hydraulics, tubular design | API well standards |
 | `workflows` | `src/digitalmodel/workflows/` | `tests/workflows/` | `docs/domains/workflows/` | Multi-step issue workflows and agent/solver orchestration | repo workflow conventions |
+| `base_configs` | `src/digitalmodel/base_configs/` | `tests/` | `docs/domains/README.md` | Shared base configuration scaffolding for module configs | PyYAML |
+| `code_checks` | `src/digitalmodel/code_checks/` | `tests/code_checks/` | `docs/domains/README.md` | Engineering code-check helpers and standards verification | engineering standards |
+| `compare_tool` | `src/digitalmodel/compare_tool/` | `tests/compare_tool/` | `docs/domains/README.md` | Result/model comparison utilities across runs and tools | pandas, NumPy |
+| `installation` | `src/digitalmodel/installation/` | `tests/` | `docs/domains/installation/` | Offshore installation analysis, lift/lay operability, weather windows | marine engineering standards |
+| `lifting_lug` | `src/digitalmodel/lifting_lug/` | `tests/` | `docs/domains/README.md` | Lifting-lug/padeye sizing and closed-form structural checks | structural standards |
+| `mooring_fatigue` | `src/digitalmodel/mooring_fatigue/` | `tests/` | `docs/domains/README.md` | Mooring-line fatigue analysis and parametric atlases | fatigue standards, NumPy |
+| `parametric` | `src/digitalmodel/parametric/` | `tests/parametric/` | `docs/domains/README.md` | Parametric atlas build and query (sweep-built surrogate serving) | NumPy, pandas |
+| `parametrics` | `src/digitalmodel/parametrics/` | `tests/parametrics/` | `docs/domains/README.md` | Parametric sweep bridging into atlases and query handlers | NumPy, pandas |
+| `pipelay` | `src/digitalmodel/pipelay/` | `tests/pipelay/` | `docs/domains/README.md` | Pipelay analysis, lay tension and configuration checks | marine/subsea standards |
+| `rao_spectral_fatigue` | `src/digitalmodel/rao_spectral_fatigue/` | `tests/` | `docs/domains/README.md` | RAO-driven spectral fatigue workflow (closed-form) | fatigue/hydrodynamics standards |
+| `riser_fatigue` | `src/digitalmodel/riser_fatigue/` | `tests/riser_fatigue/` | `docs/domains/README.md` | Riser fatigue analysis and automation | fatigue standards, NumPy |
+| `spectral_fatigue` | `src/digitalmodel/spectral_fatigue/` | `tests/` | `docs/domains/README.md` | Spectral (frequency-domain) fatigue calculation | fatigue standards, SciPy |
+| `synthetic_rope_mooring_fatigue` | `src/digitalmodel/synthetic_rope_mooring_fatigue/` | `tests/` | `docs/domains/README.md` | Synthetic-rope mooring fatigue analysis | fatigue standards, NumPy |
+| `usecase_registry` | `src/digitalmodel/usecase_registry/` | `tests/test_usecase_registry.py` | `docs/domains/README.md` | Registry of runnable use cases and routing metadata | PyYAML |
+| `vessel_seakeeping` | `src/digitalmodel/vessel_seakeeping/` | `tests/` | `docs/domains/README.md` | Vessel seakeeping response and operability analysis | hydrodynamics standards |
+| `weather_window` | `src/digitalmodel/weather_window/` | `tests/` | `docs/domains/README.md` | Weather-window/operability assessment for marine operations | metocean data, statistics |
+| `well_access` | `src/digitalmodel/well_access/` | `tests/well_access/` | `docs/domains/README.md` | Well-access/intervention analysis and operability | well engineering standards |
 
 ## Common Routing Rules
 

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -194,3 +194,105 @@ modules:
     owner_wiki: docs/domains/workflows/
     key_tests: [tests/workflows/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#workflows
+  - module: base_configs
+    entry_point: src/digitalmodel/base_configs/
+    maturity: stub
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#base_configs
+  - module: code_checks
+    entry_point: src/digitalmodel/code_checks/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/code_checks/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#code_checks
+  - module: compare_tool
+    entry_point: src/digitalmodel/compare_tool/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/compare_tool/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#compare_tool
+  - module: installation
+    entry_point: src/digitalmodel/installation/
+    maturity: beta
+    owner_wiki: docs/domains/installation/
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#installation
+  - module: lifting_lug
+    entry_point: src/digitalmodel/lifting_lug/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#lifting_lug
+  - module: mooring_fatigue
+    entry_point: src/digitalmodel/mooring_fatigue/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#mooring_fatigue
+  - module: parametric
+    entry_point: src/digitalmodel/parametric/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/parametric/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#parametric
+  - module: parametrics
+    entry_point: src/digitalmodel/parametrics/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/parametrics/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#parametrics
+  - module: pipelay
+    entry_point: src/digitalmodel/pipelay/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/pipelay/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#pipelay
+  - module: rao_spectral_fatigue
+    entry_point: src/digitalmodel/rao_spectral_fatigue/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#rao_spectral_fatigue
+  - module: riser_fatigue
+    entry_point: src/digitalmodel/riser_fatigue/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/riser_fatigue/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#riser_fatigue
+  - module: spectral_fatigue
+    entry_point: src/digitalmodel/spectral_fatigue/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#spectral_fatigue
+  - module: synthetic_rope_mooring_fatigue
+    entry_point: src/digitalmodel/synthetic_rope_mooring_fatigue/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#synthetic_rope_mooring_fatigue
+  - module: usecase_registry
+    entry_point: src/digitalmodel/usecase_registry/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/test_usecase_registry.py]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#usecase_registry
+  - module: vessel_seakeeping
+    entry_point: src/digitalmodel/vessel_seakeeping/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#vessel_seakeeping
+  - module: weather_window
+    entry_point: src/digitalmodel/weather_window/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#weather_window
+  - module: well_access
+    entry_point: src/digitalmodel/well_access/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/well_access/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#well_access

--- a/tests/test_pyvista_integration.py
+++ b/tests/test_pyvista_integration.py
@@ -73,6 +73,10 @@ def test_create_cylinder():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(
+    reason="SIGSEGV in headless CI native viz (VTK OpenGL render); no GL context "
+    "on the runner. Narrowly scoped to the rendering tests only. See #949."
+)
 def test_offscreen_plotter():
     """Plotter(off_screen=True) can be created and closed without error."""
     plotter = pv.Plotter(off_screen=True)
@@ -81,6 +85,10 @@ def test_offscreen_plotter():
     plotter.close()
 
 
+@pytest.mark.skip(
+    reason="SIGSEGV in headless CI native viz (VTK OpenGL render/screenshot); no GL "
+    "context on the runner. Narrowly scoped to the rendering tests only. See #949."
+)
 def test_screenshot_png(tmp_path):
     """plotter.screenshot() produces a valid PNG file."""
     out_file = tmp_path / "screenshot.png"


### PR DESCRIPTION
Addresses the **two deeper items** from #949 that #957 (merged) intentionally left out: the `tests-specialized` SIGSEGV and the routing-contract drift. Minimal, reversible, additive — no CI policy changes, no `failure_action` flips, no deletions. `uv.lock` kept out of the diff.

## Item 1 — tests-specialized SIGSEGV (exit 139)
The shard segfaults in native viz during test execution (no pytest summary). Root cause: the **only** VTK-OpenGL render path in the entire specialized shard is in `tests/test_pyvista_integration.py`:
- `test_offscreen_plotter` and `test_screenshot_png` create a `pv.Plotter` and call `.show()` / `.screenshot()`, which drive VTK's OpenGL render pipeline. Headless CI has no GL context → SIGSEGV.
- `tests/test_pygmt_integration.py` already self-guards on `shutil.which("gmt")`, so it skips cleanly when GMT isn't installed.
- Confirmed no other `Plotter`/`.screenshot()`/`vtkRenderWindow`/render call anywhere under the specialized roots.

**Fix (narrowest scope):** `@pytest.mark.skip(reason="SIGSEGV in headless CI native viz ...; see #949")` on **only those two render tests**. The other **13** VTK tests (mesh creation, file I/O, scalar ops, spline/tube, mesh quality, merge/clip/threshold, panel roundtrip) are pure data/filter operations with no GL render — they keep gating.
- importorskip was **not** used: `import pyvista`/`import vtk` succeed; the crash is render-driven, not import-driven.
- No `--forked`/process-isolation hacks.

Verified locally (pyvista + vtk are installed in the uv env): `tests/test_pyvista_integration.py` → **13 passed, 2 skipped, exit 0** (previously the render tests are the SIGSEGV trigger on headless CI).

## Item 2 — routing-contract drift
`tests/docs/test_digitalmodel_routing_contract.py` asserts `operator_map_domains() == package_domains()` and `registry_domains() == operator_map_domains()`. The drift was **purely additive**: 17 packages exist under `src/digitalmodel/` (with `__init__.py`) but were missing from both the operator map and the routing registry. **None needed removal.**

**Fix (map updated, not skipped):** added all 17 rows to `docs/maps/digitalmodel-operator-map.md` and matching entries to `docs/registry/module-routing.yaml`:
`base_configs, code_checks, compare_tool, installation, lifting_lug, mooring_fatigue, parametric, parametrics, pipelay, rao_spectral_fatigue, riser_fatigue, spectral_fatigue, synthetic_rope_mooring_fatigue, usecase_registry, vessel_seakeeping, weather_window, well_access`.

Each registry entry satisfies the contract's field checks (`entry_point == src/digitalmodel/<module>/`, `operator_map_row == ...#<module>`, valid `maturity`, non-empty `key_tests`). `key_tests` points at the dedicated `tests/<module>/` dir where one exists, else `[tests/]` (the existing `data_models` precedent) — no fabricated test paths. After the change all three sets match exactly (**49 each**, no duplicates).

Verified locally: `tests/docs/test_digitalmodel_routing_contract.py` → **8 passed**.

## Expected gate impact
- **tests-specialized** — should complete (no longer SIGSEGV; the 2 GL-render tests skip, the rest run).
- **tests-contracts** — the `test_digitalmodel_routing_contract.py` drift failures are now fixed (combined with #957's reorg/restructure skips, this was the remaining named blocker for that shard).

## Verified / not verified locally
- Verified: routing-contract test (8 passed); pyvista test collection + run (13 passed, 2 skipped, exit 0); map==live-tree==registry set equality.
- Not reproduced locally: the actual exit-139 SIGSEGV (this dev env has a usable GL context, unlike headless CI). The skip targets are derived from the issue evidence (exit 139 in the viz path) + code inspection of the render calls.

Refs #949. **Do not merge without review** (dm rule: owner merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)