### PR TITLE
feat(calcs): DNV-OS-F101 local-buckling/collapse + S-lay %SMYS checks (epic llm-wiki#767)

### DIFF
--- a/src/digitalmodel/code_checks/dnv_os_f101.py
+++ b/src/digitalmodel/code_checks/dnv_os_f101.py
@@ -1,0 +1,360 @@
+"""DNV-OS-F101 pipe local-buckling and external-pressure resistance checks.
+
+Generic, standard-based screening calculations for a submarine pipeline per
+DNV-OS-F101 (Submarine Pipeline Systems). Three methods are implemented:
+
+1. **Local-buckling — load-controlled condition (LCC)** combined-loading
+   utilisation for bending moment + effective tension + net internal/external
+   pressure (the installation/operation feasibility check; UF < 1 passes).
+2. **External-pressure collapse** characteristic resistance Pc — the real root
+   of the DNV collapse cubic that blends elastic and plastic (yield) collapse
+   with the initial ovality.
+3. **Propagation-buckling** pressure Pprop and the propagation-arrest /
+   initiation check.
+
+All functions are unit-consistent: pass diameters/thicknesses, stresses and
+pressures in the same unit system (e.g. mm / MPa / MPa, giving moments in
+N.mm and forces in N when areas are mm^2). No internal unit conversion is done.
+
+References
+----------
+- DNV-OS-F101 (2013), Sec.5 D — Local buckling:
+    * Load-controlled (Sec.5 D404/D405) combined-loading criteria.
+    * External-pressure collapse Pc (Sec.5 D401, the collapse cubic).
+    * Propagation buckling Pprop (Sec.5 D501).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+SQRT3 = math.sqrt(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Plastic capacities (used by the load-controlled combined-loading check)
+# ---------------------------------------------------------------------------
+
+
+def plastic_axial_capacity(diameter: float, t: float, f_y: float) -> float:
+    """Plastic axial-force capacity ``Sp = fy * pi * (D - t) * t`` [force]."""
+    return f_y * math.pi * (diameter - t) * t
+
+
+def plastic_moment_capacity(diameter: float, t: float, f_y: float) -> float:
+    """Plastic moment capacity ``Mp = fy * (D - t)^2 * t`` [moment]."""
+    return f_y * (diameter - t) ** 2 * t
+
+
+def pressure_containment_resistance(diameter: float, t: float, f_y: float, f_u: float) -> float:
+    """Burst (pressure-containment) resistance ``Pb = (2 t / (D - t)) * fcb * 2/sqrt(3)``.
+
+    Uses ``fcb = min(fy, fu / 1.15)`` as the characteristic strength.
+    """
+    fcb = min(f_y, f_u / 1.15)
+    return (2.0 * t / (diameter - t)) * fcb * (2.0 / SQRT3)
+
+
+# ---------------------------------------------------------------------------
+# 1. Local buckling — load-controlled condition (LCC) combined loading
+# ---------------------------------------------------------------------------
+#
+# DNV-OS-F101 Sec.5 D combined-loading criterion. With characteristic plastic
+# capacities Sp (axial) and Mp (moment) and pressure-containment Pb, the
+# load-controlled utilisation for the two net-pressure regimes is:
+#
+# INTERNAL net overpressure (pi > pe):
+#   UF = { gamma_m*gamma_SC*(|Md|/Mp) + [(gamma_m*gamma_SC*Sd)/Sp]^2 }^2
+#        + [ gamma_m*gamma_SC*(pi - pe)/Pb ]^2
+#
+# EXTERNAL net overpressure (pe > pi):
+#   UF = { gamma_m*gamma_SC*(|Md|/Mp) + [(gamma_m*gamma_SC*Sd)/Sp]^2 }^2
+#        + [ gamma_m*gamma_SC*(pe - pmin)/Pc ]^2
+#
+# UF <= 1 passes (the bracketed "moment + tension" group is squared, the
+# pressure group is added in quadrature). gamma_m and gamma_SC are the material
+# and safety-class resistance factors; the load effects Md, Sd are factored
+# design values supplied by the caller.
+
+
+@dataclass(frozen=True)
+class LocalBucklingResult:
+    """Result of a DNV-OS-F101 local-buckling load-controlled check."""
+
+    utilisation: float  # combined-loading utilisation factor (UF)
+    passes: bool  # True if UF <= 1.0
+
+
+def local_buckling_lcc(
+    design_moment: float,
+    design_effective_tension: float,
+    pressure_internal: float,
+    pressure_external: float,
+    moment_capacity: float,
+    axial_capacity: float,
+    pressure_capacity: float,
+    gamma_m: float = 1.15,
+    gamma_sc: float = 1.14,
+) -> LocalBucklingResult:
+    """DNV-OS-F101 local-buckling, load-controlled combined-loading utilisation.
+
+    Parameters
+    ----------
+    design_moment : float
+        Design bending moment Md (factored) [moment].
+    design_effective_tension : float
+        Design effective (axial) tension Sd (factored) [force].
+    pressure_internal : float
+        Internal pressure pi [pressure].
+    pressure_external : float
+        External pressure pe [pressure]. For the external-pressure regime this
+        is the (collapse) pressure acting; ``pressure_capacity`` should then be
+        the collapse resistance Pc. For the internal regime it is the minimum
+        internal pressure pmin / external pressure, and ``pressure_capacity``
+        should be the burst resistance Pb.
+    moment_capacity : float
+        Plastic moment capacity Mp [moment].
+    axial_capacity : float
+        Plastic axial capacity Sp [force].
+    pressure_capacity : float
+        Pressure resistance — burst Pb for the internal regime, collapse Pc for
+        the external regime [pressure].
+    gamma_m : float, optional
+        Material resistance factor. Default 1.15 (ULS).
+    gamma_sc : float, optional
+        Safety-class resistance factor. Default 1.14 (normal safety class).
+
+    Returns
+    -------
+    LocalBucklingResult
+        Combined-loading utilisation and pass/fail flag.
+    """
+    if moment_capacity <= 0.0 or axial_capacity <= 0.0 or pressure_capacity <= 0.0:
+        raise ValueError("capacities must be positive")
+
+    g = gamma_m * gamma_sc
+    moment_term = g * abs(design_moment) / moment_capacity
+    tension_term = (g * design_effective_tension / axial_capacity) ** 2
+    group = (moment_term + tension_term) ** 2
+
+    net = pressure_internal - pressure_external
+    pressure_term = (g * abs(net) / pressure_capacity) ** 2
+
+    uf = group + pressure_term
+    return LocalBucklingResult(utilisation=uf, passes=uf <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. External-pressure collapse (the DNV collapse cubic)
+# ---------------------------------------------------------------------------
+#
+# Elastic collapse pressure (thin-shell):
+#       Pel = 2 E (t/D)^3 / (1 - nu^2)
+# Plastic (yield) collapse pressure:
+#       Pp  = fy * alpha_fab * 2 (t/D)
+# Characteristic collapse resistance Pc is the solution of the implicit cubic:
+#       (Pc - Pel)(Pc^2 - Pp^2) = Pc * Pel * Pp * f0 * D / t
+# with initial ovality f0 = (Dmax - Dmin)/D (>= 0.005 per code minimum).
+# Pc is taken as the relevant (smallest positive) real root.
+
+
+def elastic_collapse_pressure(
+    diameter: float, t: float, youngs_modulus: float, poisson_ratio: float = 0.3
+) -> float:
+    """Elastic (thin-shell) collapse pressure ``Pel = 2 E (t/D)^3 / (1 - nu^2)``."""
+    return 2.0 * youngs_modulus * (t / diameter) ** 3 / (1.0 - poisson_ratio**2)
+
+
+def plastic_collapse_pressure(
+    diameter: float, t: float, f_y: float, alpha_fab: float = 1.0
+) -> float:
+    """Plastic (yield) collapse pressure ``Pp = fy * alpha_fab * 2 (t/D)``.
+
+    ``alpha_fab`` is the fabrication (manufacturing-process) factor (1.0 for
+    seamless, < 1 for welded; supplied by the caller).
+    """
+    return f_y * alpha_fab * 2.0 * (t / diameter)
+
+
+def collapse_pressure(
+    diameter: float,
+    t: float,
+    f_y: float,
+    youngs_modulus: float,
+    ovality: float = 0.005,
+    poisson_ratio: float = 0.3,
+    alpha_fab: float = 1.0,
+) -> float:
+    """DNV-OS-F101 characteristic external-pressure collapse resistance Pc.
+
+    Solves the collapse cubic
+
+        (Pc - Pel)(Pc^2 - Pp^2) = Pc * Pel * Pp * f0 * (D / t)
+
+    for the smallest positive real root (the governing collapse pressure).
+
+    Parameters
+    ----------
+    diameter : float
+        Outer diameter D [length].
+    t : float
+        Wall thickness (characteristic / t1) [length].
+    f_y : float
+        Yield strength [stress].
+    youngs_modulus : float
+        Young's modulus [stress].
+    ovality : float, optional
+        Initial ovality f0 = (Dmax - Dmin)/D. Default 0.005 (code minimum).
+    poisson_ratio : float, optional
+        Poisson's ratio. Default 0.3.
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+
+    Returns
+    -------
+    float
+        Characteristic collapse resistance Pc [pressure].
+    """
+    if ovality < 0.005:
+        ovality = 0.005  # DNV code minimum imperfection
+
+    pel = elastic_collapse_pressure(diameter, t, youngs_modulus, poisson_ratio)
+    pp = plastic_collapse_pressure(diameter, t, f_y, alpha_fab)
+
+    # Expand to a monic cubic in Pc:
+    #   Pc^3 - Pel*Pc^2 - (Pp^2 + Pp*Pel*f0*D/t)*Pc + Pel*Pp^2 = 0
+    b = -pel
+    c = -(pp**2 + pp * pel * ovality * diameter / t)
+    d = pel * pp**2
+
+    roots = _real_cubic_roots(1.0, b, c, d)
+    positive = [r for r in roots if r > 0.0]
+    if not positive:
+        raise ValueError("no positive real root for the collapse cubic")
+    return min(positive)
+
+
+def _real_cubic_roots(a: float, b: float, c: float, d: float) -> list[float]:
+    """Real roots of ``a x^3 + b x^2 + c x + d = 0`` (a != 0).
+
+    Uses the depressed-cubic / trigonometric method; returns only real roots.
+    """
+    if a == 0.0:
+        raise ValueError("not a cubic: a must be non-zero")
+    # Normalise: x^3 + p2 x^2 + p1 x + p0
+    p2 = b / a
+    p1 = c / a
+    p0 = d / a
+    # Depress: x = y - p2/3 -> y^3 + p*y + q = 0
+    shift = p2 / 3.0
+    p = p1 - p2**2 / 3.0
+    q = 2.0 * p2**3 / 27.0 - p2 * p1 / 3.0 + p0
+
+    disc = (q / 2.0) ** 2 + (p / 3.0) ** 3
+    roots: list[float] = []
+    if disc > 0.0:
+        # one real root
+        sqrt_disc = math.sqrt(disc)
+        u = math.cbrt(-q / 2.0 + sqrt_disc)
+        v = math.cbrt(-q / 2.0 - sqrt_disc)
+        roots.append(u + v - shift)
+    else:
+        # three real roots (trig method); handle p ~ 0 degenerate case
+        if abs(p) < 1e-300:
+            roots.append(math.cbrt(-q) - shift)
+        else:
+            r = math.sqrt(-(p**3) / 27.0)
+            cos_arg = max(-1.0, min(1.0, -q / (2.0 * r)))
+            phi = math.acos(cos_arg)
+            m = 2.0 * math.sqrt(-p / 3.0)
+            for k in range(3):
+                roots.append(m * math.cos((phi + 2.0 * math.pi * k) / 3.0) - shift)
+    return roots
+
+
+# ---------------------------------------------------------------------------
+# 3. Propagation buckling
+# ---------------------------------------------------------------------------
+#
+# Once a local buckle forms, it can propagate along the line if the external
+# overpressure exceeds the propagation pressure:
+#       Ppr = 35 * fy * alpha_fab * (t/D)^2.5      (DNV-OS-F101 Sec.5 D501)
+# Acceptance against propagation (no buckle arrestors): pe - pmin <= Ppr / gamma.
+
+
+def propagation_pressure(
+    diameter: float, t: float, f_y: float, alpha_fab: float = 1.0
+) -> float:
+    """Propagation-buckling pressure ``Ppr = 35 * fy * alpha_fab * (t/D)^2.5``.
+
+    Parameters
+    ----------
+    diameter : float
+        Outer diameter D [length].
+    t : float
+        Wall thickness [length].
+    f_y : float
+        Yield strength [stress].
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+
+    Returns
+    -------
+    float
+        Propagation-buckling pressure [pressure].
+    """
+    return 35.0 * f_y * alpha_fab * (t / diameter) ** 2.5
+
+
+@dataclass(frozen=True)
+class PropagationCheck:
+    """Result of a propagation-buckling acceptance check."""
+
+    net_external_pressure: float  # pe - pmin [pressure]
+    propagation_resistance: float  # Ppr / gamma [pressure]
+    utilisation: float  # net / resistance [-]
+    propagates: bool  # True if a buckle would propagate (utilisation > 1)
+
+
+def propagation_check(
+    net_external_pressure: float,
+    diameter: float,
+    t: float,
+    f_y: float,
+    alpha_fab: float = 1.0,
+    gamma_m: float = 1.15,
+    gamma_sc: float = 1.14,
+) -> PropagationCheck:
+    """Check net external overpressure against the propagation resistance.
+
+    A buckle propagates if ``(pe - pmin) > Ppr / (gamma_m * gamma_SC)``. When it
+    would propagate, buckle arrestors (or a thicker wall) are required.
+
+    Parameters
+    ----------
+    net_external_pressure : float
+        Net external overpressure pe - pmin [pressure].
+    diameter, t, f_y : float
+        Outer diameter, wall thickness and yield strength.
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+    gamma_m, gamma_sc : float, optional
+        Material and safety-class resistance factors. Defaults 1.15 / 1.14.
+
+    Returns
+    -------
+    PropagationCheck
+        Net pressure, factored resistance, utilisation and propagate flag.
+    """
+    ppr = propagation_pressure(diameter, t, f_y, alpha_fab)
+    resistance = ppr / (gamma_m * gamma_sc)
+    if resistance <= 0.0:
+        raise ValueError("propagation resistance must be positive")
+    util = net_external_pressure / resistance
+    return PropagationCheck(
+        net_external_pressure=net_external_pressure,
+        propagation_resistance=resistance,
+        utilisation=util,
+        propagates=util > 1.0,
+    )

--- a/src/digitalmodel/code_checks/dnv_os_f201_lrfd_wsd.py
+++ b/src/digitalmodel/code_checks/dnv_os_f201_lrfd_wsd.py
@@ -1,0 +1,246 @@
+"""DNV-OS-F201 limit-state code checks — LRFD vs WSD (combined loading).
+
+Implements the core DNV-OS-F201 (Dynamic Risers) combined-loading limit-state
+check for a tubular member subjected to bending moment, effective tension and
+net (internal or external) overpressure, in both the partial-safety-factor
+(LRFD) and the working-stress-design (WSD) formats.
+
+Two design formats share the same characteristic resistances:
+    - Plastic bending-moment resistance  Mk = fy * alpha_c * (D - t2)^2 * t2
+    - Plastic axial-force resistance      Tk = fy * alpha_c * pi * (D - t2) * t2
+    - Bursting (containment) resistance   Pb = (2/sqrt(3)) * (2 t2 / (D - t2)) * min(fy, fu/1.15)
+
+with the flow-stress / strain-hardening coefficient:
+    alpha_c = (1 - beta) + beta * (fu / fy)
+    qh      = ((pi - pe) / Pb) * (2/sqrt(3))   for pi > pe, else 0
+    beta    = 0.4 + qh                         for D/t2 < 15
+            = (0.4 + qh) * (60 - D/t2) / 45    for 15 <= D/t2 <= 60
+            = 0                                for D/t2 > 60
+
+Combined-loading criteria (utilisation, pass when <= limit):
+
+INTERNAL net overpressure (pi > pe):
+    LRFD:  gamma_SC * gamma_m * [ (|Md|/Mk) * sqrt(1 - ((pi-pe)/Pb)^2)
+                                  + (Td/Tk)^2 ] + ((pi-pe)/Pb)^2  <= 1
+    WSD:   same expression without gamma_SC*gamma_m, limit = eta^2
+
+EXTERNAL net overpressure (pe > pi):
+    LRFD:  (gamma_SC*gamma_m)^2 * [ ((|Md|/Mk) + (Td/Tk)^2)^2
+                                    + ((pe - pmin)/Pc)^2 ]  <= 1
+    WSD:   same expression without (gamma_SC*gamma_m)^2, limit = eta^2
+
+For LRFD the load effects (Md, Td) are factored design values
+(gamma_F * functional + gamma_E * environmental + gamma_A * accidental);
+for WSD they are the unfactored sums. gamma_SC and gamma_m are the safety-class
+and material resistance factors; eta is the WSD usage factor.
+
+All functions are unit-consistent: pass resistances and load effects in the
+same unit system (e.g. ksi / kips-ft / kips, or MPa / kN.m / kN). The module
+performs no internal unit conversion.
+
+References:
+    - DNV-OS-F201 (2010), Section 5 (limit-state combined-loading criteria,
+      Eqs 5.25-5.26 for Mk/Tk; combined-loading clause D).
+    - DNV-OS-F101 for the bursting/collapse resistance and tolerance thicknesses.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+SQRT3 = math.sqrt(3.0)
+
+# Partial safety factors per limit-state category (DNV-OS-F201 Sec.5).
+# (gamma_F functional, gamma_E environmental, gamma_A accidental)
+LOAD_FACTORS: dict[str, tuple[float, float, float]] = {
+    "ULS": (1.1, 1.3, 0.0),
+    "FLS": (1.0, 1.0, 0.0),
+    "SLS": (1.0, 1.0, 1.0),
+    "ALS": (1.0, 1.0, 1.0),
+}
+
+# Safety-class resistance factor gamma_SC.
+SAFETY_CLASS_FACTOR: dict[str, float] = {"low": 1.04, "normal": 1.14, "high": 1.26}
+
+# WSD usage factor eta by safety class.
+WSD_USAGE_FACTOR: dict[str, float] = {"low": 0.83, "normal": 0.79, "high": 0.75}
+
+
+class OverpressureMode(str, Enum):
+    """Net-overpressure regime governing the combined-loading criterion."""
+
+    INTERNAL = "internal"  # pi > pe (burst-dominated)
+    EXTERNAL = "external"  # pe > pi (collapse-dominated)
+
+
+@dataclass(frozen=True)
+class CombinedLoadingResult:
+    """Result of a DNV-OS-F201 combined-loading limit-state check."""
+
+    utilisation: float  # left-hand side of the criterion
+    limit: float  # right-hand side (1.0 for LRFD, eta^2 for WSD)
+    passes: bool  # utilisation <= limit
+
+
+def yield_strength(smys: float, f_y_temp_derating: float, alpha_u: float) -> float:
+    """Characteristic yield strength fy = (SMYS - f_y,temp) * alpha_u.
+
+    Parameters
+    ----------
+    smys : float
+        Specified minimum yield strength [stress].
+    f_y_temp_derating : float
+        Temperature de-rating on yield stress [stress] (0 below the de-rating
+        onset temperature).
+    alpha_u : float
+        Material strength factor [-] (e.g. 0.96 normal, 1.0 with supplementary
+        requirement U).
+    """
+    return (smys - f_y_temp_derating) * alpha_u
+
+
+def tensile_strength(smts: float, f_u_temp_derating: float, alpha_u: float) -> float:
+    """Characteristic tensile strength fu = (SMTS - f_u,temp) * alpha_u."""
+    return (smts - f_u_temp_derating) * alpha_u
+
+
+def plastic_moment_resistance(
+    diameter: float, t2: float, f_y: float, alpha_c: float
+) -> float:
+    """Plastic bending-moment resistance Mk = fy * alpha_c * (D - t2)^2 * t2.
+
+    Returns a moment in [stress * length^3]. With diameter/thickness in inches
+    and fy in ksi this gives inch-kips.
+    """
+    return f_y * alpha_c * (diameter - t2) ** 2 * t2
+
+
+def plastic_axial_resistance(
+    diameter: float, t2: float, f_y: float, alpha_c: float
+) -> float:
+    """Plastic axial-force resistance Tk = fy * alpha_c * pi * (D - t2) * t2."""
+    return f_y * alpha_c * math.pi * (diameter - t2) * t2
+
+
+def bursting_resistance(diameter: float, t2: float, f_y: float, f_u: float) -> float:
+    """Bursting (containment) resistance Pb.
+
+    Pb = (2/sqrt(3)) * (2 t2 / (D - t2)) * min(fy, fu/1.15).
+    """
+    return (2.0 / SQRT3) * (2.0 * t2 / (diameter - t2) * min(f_y, f_u / 1.15))
+
+
+def flow_stress_coefficient(
+    diameter: float,
+    t2: float,
+    f_y: float,
+    f_u: float,
+    p_internal: float,
+    p_external: float,
+    bursting_resistance_value: float,
+) -> float:
+    """Flow-stress / strain-hardening coefficient alpha_c.
+
+    alpha_c = (1 - beta) + beta * (fu / fy), with beta a function of D/t2 and
+    the pressure-utilisation term qh.
+
+    Parameters
+    ----------
+    diameter, t2 : float
+        Outer diameter and characteristic (resistance) wall thickness.
+    f_y, f_u : float
+        Characteristic yield and tensile strengths.
+    p_internal, p_external : float
+        Internal and external pressures (same unit as bursting resistance).
+    bursting_resistance_value : float
+        Pre-computed bursting resistance Pb.
+    """
+    d_over_t = diameter / t2
+    if p_internal > p_external:
+        qh = ((p_internal - p_external) / bursting_resistance_value) * (2.0 / SQRT3)
+    else:
+        qh = 0.0
+
+    if d_over_t < 15.0:
+        beta = 0.4 + qh
+    elif d_over_t <= 60.0:
+        beta = (0.4 + qh) * (60.0 - d_over_t) / 45.0
+    else:
+        beta = 0.0
+    return (1.0 - beta) + beta * (f_u / f_y)
+
+
+def combined_loading_internal_overpressure(
+    design_moment: float,
+    moment_resistance: float,
+    design_tension: float,
+    axial_resistance: float,
+    p_internal: float,
+    p_external: float,
+    bursting_resistance_value: float,
+    gamma_sc: float = 1.0,
+    gamma_m: float = 1.0,
+    usage_factor: float | None = None,
+) -> CombinedLoadingResult:
+    """Combined-loading check for internal net overpressure (pi > pe).
+
+    LRFD (gamma_SC, gamma_m > 1, usage_factor=None): limit = 1.0.
+    WSD (gamma_SC = gamma_m = 1, usage_factor=eta): limit = eta^2.
+
+    util = gamma_SC*gamma_m * [ (|Md|/Mk) * sqrt(1 - ((pi-pe)/Pb)^2)
+                                + (Td/Tk)^2 ] + ((pi-pe)/Pb)^2
+    """
+    pressure_ratio = (p_internal - p_external) / bursting_resistance_value
+    util = gamma_sc * gamma_m * (
+        (abs(design_moment) / moment_resistance) * math.sqrt(1.0 - pressure_ratio**2)
+        + (design_tension / axial_resistance) ** 2
+    ) + pressure_ratio**2
+    limit = 1.0 if usage_factor is None else usage_factor**2
+    return CombinedLoadingResult(util, limit, util <= limit)
+
+
+def combined_loading_external_overpressure(
+    design_moment: float,
+    moment_resistance: float,
+    design_tension: float,
+    axial_resistance: float,
+    p_external: float,
+    p_min_internal: float,
+    collapse_resistance: float,
+    gamma_sc: float = 1.0,
+    gamma_m: float = 1.0,
+    usage_factor: float | None = None,
+) -> CombinedLoadingResult:
+    """Combined-loading check for external net overpressure (pe > pi).
+
+    LRFD (gamma_SC, gamma_m > 1, usage_factor=None): limit = 1.0.
+    WSD (gamma_SC = gamma_m = 1, usage_factor=eta): limit = eta^2.
+
+    util = (gamma_SC*gamma_m)^2 * [ ((|Md|/Mk) + (Td/Tk)^2)^2
+                                    + ((pe - pmin)/Pc)^2 ]
+    """
+    pressure_ratio = (p_external - p_min_internal) / collapse_resistance
+    util = (gamma_sc * gamma_m) ** 2 * (
+        ((abs(design_moment) / moment_resistance) + (design_tension / axial_resistance) ** 2) ** 2
+        + pressure_ratio**2
+    )
+    limit = 1.0 if usage_factor is None else usage_factor**2
+    return CombinedLoadingResult(util, limit, util <= limit)
+
+
+def factored_load_effect(
+    functional: float,
+    environmental: float,
+    accidental: float,
+    gamma_f: float,
+    gamma_e: float,
+    gamma_a: float,
+) -> float:
+    """LRFD factored design load effect.
+
+    design = gamma_F * functional + gamma_E * environmental + gamma_A * accidental.
+    For WSD use gamma_F = gamma_E = gamma_A = 1 (i.e. the unfactored sum).
+    """
+    return gamma_f * functional + gamma_e * environmental + gamma_a * accidental

--- a/src/digitalmodel/drilling_riser/__init__.py
+++ b/src/digitalmodel/drilling_riser/__init__.py
@@ -10,6 +10,15 @@ from digitalmodel.drilling_riser.operability import (
     significant_wave_height_limit,
     watch_circle_radius_m,
 )
+from digitalmodel.drilling_riser.section import (
+    SectionProperties,
+    cross_sectional_area,
+    moment_of_inertia,
+    polar_moment_of_inertia,
+    section_properties,
+    section_properties_imperial,
+    shear_modulus,
+)
 from digitalmodel.drilling_riser.stackup import (
     effective_tension,
     minimum_slip_ring_tension,
@@ -44,4 +53,11 @@ __all__ = [
     "normalize_riser_component_record",
     "register_riser_components",
     "compute_riser_string_weight_kn",
+    "SectionProperties",
+    "cross_sectional_area",
+    "moment_of_inertia",
+    "polar_moment_of_inertia",
+    "shear_modulus",
+    "section_properties",
+    "section_properties_imperial",
 ]

--- a/src/digitalmodel/drilling_riser/section.py
+++ b/src/digitalmodel/drilling_riser/section.py
@@ -1,0 +1,146 @@
+"""Drilling-riser section properties and stiffness stack-up.
+
+Computes the cross-sectional and stiffness properties of a tubular riser
+section (area, second moment of area, polar moment, axial / bending /
+torsional stiffness) from its outer and inner diameter, Young's modulus and
+Poisson's ratio. These feed the per-joint stack-up that prepares an
+OrcaFlex line-type input for a drilling riser string.
+
+Geometry conventions (consistent-unit; no internal unit conversion unless a
+helper explicitly converts):
+    A   = pi/4 * (OD^2 - ID^2)
+    I   = pi/64 * (OD^4 - ID^4)
+    J   = 2 * I                       (polar second moment, thin/thick tube)
+    G   = E / (2 * (1 + nu))          (shear modulus)
+    EA  = E * A                       (axial stiffness)
+    EI  = E * I                       (bending stiffness)
+    GJ  = G * J                       (torsional stiffness)
+
+References:
+    - Roark's Formulas for Stress and Strain (hollow circular section).
+    - API RP 16Q / 2RD tubular section properties.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Imperial -> SI helper constants (used by the *_imperial convenience layer).
+INCH_TO_METER: float = 0.0254
+KSI_TO_PA: float = 6_894_757.293178  # 1 ksi = 6.894757293178e6 Pa
+
+
+@dataclass(frozen=True)
+class SectionProperties:
+    """Cross-sectional and stiffness properties of a tubular section.
+
+    All values are in the unit system implied by the inputs:
+    if OD/ID are in metres and E in Pa, then area is m^2, I and J are m^4,
+    EA is N, EI and GJ are N.m^2.
+    """
+
+    area: float  # cross-sectional steel area [length^2]
+    moment_of_inertia: float  # second moment of area I [length^4]
+    polar_moment: float  # polar second moment J = 2I [length^4]
+    shear_modulus: float  # G = E / (2(1+nu)) [force/length^2]
+    axial_stiffness: float  # EA [force]
+    bending_stiffness: float  # EI [force.length^2]
+    torsional_stiffness: float  # GJ [force.length^2]
+
+
+def cross_sectional_area(outer_diameter: float, inner_diameter: float) -> float:
+    """Steel area of a hollow circular section: A = pi/4 (OD^2 - ID^2)."""
+    return math.pi / 4.0 * (outer_diameter**2 - inner_diameter**2)
+
+
+def moment_of_inertia(outer_diameter: float, inner_diameter: float) -> float:
+    """Second moment of area of a hollow circular section.
+
+    I = pi/64 (OD^4 - ID^4).
+    """
+    return math.pi / 64.0 * (outer_diameter**4 - inner_diameter**4)
+
+
+def polar_moment_of_inertia(outer_diameter: float, inner_diameter: float) -> float:
+    """Polar second moment of area: J = 2 * I for a circular section."""
+    return 2.0 * moment_of_inertia(outer_diameter, inner_diameter)
+
+
+def shear_modulus(youngs_modulus: float, poisson_ratio: float) -> float:
+    """Shear modulus G = E / (2 (1 + nu))."""
+    return youngs_modulus / (2.0 * (1.0 + poisson_ratio))
+
+
+def section_properties(
+    outer_diameter: float,
+    inner_diameter: float,
+    youngs_modulus: float,
+    poisson_ratio: float,
+) -> SectionProperties:
+    """Compute full section-property set for a tubular riser section.
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Outer diameter [length].
+    inner_diameter : float
+        Inner diameter [length].
+    youngs_modulus : float
+        Young's modulus E [force/length^2].
+    poisson_ratio : float
+        Poisson's ratio nu [-].
+
+    Returns
+    -------
+    SectionProperties
+        Area, I, J, G, EA, EI, GJ in the consistent unit system of the inputs.
+    """
+    area = cross_sectional_area(outer_diameter, inner_diameter)
+    inertia = moment_of_inertia(outer_diameter, inner_diameter)
+    polar = 2.0 * inertia
+    g = shear_modulus(youngs_modulus, poisson_ratio)
+    return SectionProperties(
+        area=area,
+        moment_of_inertia=inertia,
+        polar_moment=polar,
+        shear_modulus=g,
+        axial_stiffness=youngs_modulus * area,
+        bending_stiffness=youngs_modulus * inertia,
+        torsional_stiffness=g * polar,
+    )
+
+
+def section_properties_imperial(
+    outer_diameter_in: float,
+    inner_diameter_in: float,
+    youngs_modulus_ksi: float,
+    poisson_ratio: float,
+) -> SectionProperties:
+    """Section properties from imperial inputs, returned in SI units.
+
+    Diameters in inches are converted to metres and E in ksi to Pa, so the
+    returned area is m^2, I/J are m^4, EA is N and EI/GJ are N.m^2.
+
+    Parameters
+    ----------
+    outer_diameter_in : float
+        Outer diameter [inch].
+    inner_diameter_in : float
+        Inner diameter [inch].
+    youngs_modulus_ksi : float
+        Young's modulus [ksi].
+    poisson_ratio : float
+        Poisson's ratio [-].
+
+    Returns
+    -------
+    SectionProperties
+        Properties in SI units (m, m^2, m^4, Pa, N, N.m^2).
+    """
+    return section_properties(
+        outer_diameter=outer_diameter_in * INCH_TO_METER,
+        inner_diameter=inner_diameter_in * INCH_TO_METER,
+        youngs_modulus=youngs_modulus_ksi * KSI_TO_PA,
+        poisson_ratio=poisson_ratio,
+    )

--- a/src/digitalmodel/fatigue/__init__.py
+++ b/src/digitalmodel/fatigue/__init__.py
@@ -17,6 +17,11 @@ Extended with 8 additional modules (v2.0):
 
 from .sn_curves import get_sn_curve, DNV_CURVES
 from .damage import miner_damage, design_life_check, thickness_correction
+from .sn_endurance import (
+    sn_curve_parameters,
+    endurance_cycles,
+    stress_range_at_cycles,
+)
 from .crack_growth import paris_law_life, stress_intensity_factor, inspection_interval
 from .woehler_fitting import fit_woehler_curve, design_curve
 from .rainflow import rainflow_count, stress_histogram, fatigue_life
@@ -90,6 +95,9 @@ __all__ = [
     "miner_damage",
     "design_life_check",
     "thickness_correction",
+    "sn_curve_parameters",
+    "endurance_cycles",
+    "stress_range_at_cycles",
     "paris_law_life",
     "stress_intensity_factor",
     "inspection_interval",

--- a/src/digitalmodel/fatigue/sn_endurance.py
+++ b/src/digitalmodel/fatigue/sn_endurance.py
@@ -1,0 +1,198 @@
+"""
+DNV-RP-C203 bi-linear S-N endurance — closed-form forward / inverse.
+====================================================================
+
+A small, dependency-light companion to :mod:`sn_curves` and
+:mod:`sn_library_api` that exposes the S-N relation in its raw
+log-log form, exactly as it appears in standard DNV-RP-C203 design
+spreadsheets::
+
+    log10(N) = log10(a) - m * log10(Δσ)        (forward)
+        Δσ  = 10 ** ((log10(a) - log10(N)) / m) (inverse)
+
+The curve is bi-linear about the knee point N_D = 1e7 cycles:
+
+    * N <= 1e7  -> first segment   (m1, log_a1)
+    * N >  1e7  -> second segment  (m2, log_a2)
+
+Equivalently in the stress domain the high-stress branch (Δσ above the
+fatigue limit at the knee) uses (m1, log_a1) and the low-stress branch
+uses (m2, log_a2).
+
+This module deliberately *reuses* the DNV curve constants already held
+in :data:`digitalmodel.fatigue.sn_curves.DNV_CURVES` and the
+:func:`digitalmodel.fatigue.damage.thickness_correction` helper rather
+than re-declaring them.  It adds only the closed-form endurance/inverse
+pair, which the existing pyLife-backed API does not expose directly.
+
+References
+----------
+- DNV-RP-C203, Fatigue Design of Offshore Steel Structures,
+  Tables 2-1 (in air) and 2-2 (seawater with cathodic protection),
+  S-N relation eq. (2.4.1) and thickness effect eq. (2.4.3).
+
+Issue: corpus calculators epic #767 / #779.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Union
+
+import numpy as np
+
+from .sn_curves import (
+    _RAW_CURVES,
+    _SEAWATER_CP_ADJUSTMENTS,
+    _FREE_CORROSION_LOG_A,
+    _ND,
+)
+from .damage import thickness_correction  # re-export the DNV thickness rule
+
+__all__ = [
+    "sn_curve_parameters",
+    "endurance_cycles",
+    "stress_range_at_cycles",
+    "thickness_correction",
+]
+
+ArrayLike = Union[float, np.ndarray]
+
+
+def sn_curve_parameters(name: str, environment: str = "air") -> dict:
+    """Return the bi-linear S-N parameters for a DNV-RP-C203 detail class.
+
+    Parameters
+    ----------
+    name : str
+        Detail category, e.g. ``"D"``, ``"F"``, ``"B1"`` (case-insensitive).
+    environment : str
+        One of ``"air"``, ``"seawater_cp"``, ``"free_corrosion"``.
+
+    Returns
+    -------
+    dict
+        Keys ``m1``, ``log_a1``, ``m2``, ``log_a2``, ``nd`` (knee cycles).
+        For ``free_corrosion`` the curve is single-slope, so the second
+        segment mirrors the first.
+    """
+    key = name.upper()
+    if key not in _RAW_CURVES:
+        raise ValueError(
+            f"Unknown curve '{name}'. Available: {sorted(_RAW_CURVES)}"
+        )
+    base = _RAW_CURVES[key]
+    m1 = base["k_1"]
+
+    if environment == "air":
+        log_a1 = base["log_a1"]
+        m2 = base["k_2"]
+        log_a2 = base["log_a2"]
+    elif environment == "seawater_cp":
+        adj = _SEAWATER_CP_ADJUSTMENTS[key]
+        log_a1 = adj["log_a1"]
+        m2 = base["k_2"]
+        log_a2 = adj["log_a2"]
+    elif environment == "free_corrosion":
+        log_a1 = _FREE_CORROSION_LOG_A[key]
+        # single slope throughout — no endurance knee
+        m2 = m1
+        log_a2 = log_a1
+    else:
+        raise ValueError(
+            f"Unknown environment '{environment}'. Use 'air', "
+            "'seawater_cp', or 'free_corrosion'."
+        )
+
+    return {
+        "m1": m1,
+        "log_a1": log_a1,
+        "m2": m2,
+        "log_a2": log_a2,
+        "nd": _ND,
+    }
+
+
+def _stress_at_knee(params: dict) -> float:
+    """Stress range at the knee point N_D (the fatigue limit there)."""
+    return 10 ** ((params["log_a1"] - math.log10(params["nd"])) / params["m1"])
+
+
+def endurance_cycles(
+    stress_range: ArrayLike,
+    name: str,
+    environment: str = "air",
+) -> ArrayLike:
+    """Allowable cycles N for a stress range Δσ (DNV-RP-C203 S-N).
+
+    Forward relation ``log10(N) = log10(a) - m * log10(Δσ)`` with the
+    bi-linear segment selected by whether Δσ lies above or below the
+    fatigue limit at the knee (N_D = 1e7).
+
+    Parameters
+    ----------
+    stress_range : float or array-like
+        Stress range Δσ in MPa.
+    name : str
+        DNV detail category.
+    environment : str
+        ``"air"``, ``"seawater_cp"`` or ``"free_corrosion"``.
+
+    Returns
+    -------
+    float or np.ndarray
+        Allowable cycles N. ``inf`` for non-positive stress.
+    """
+    p = sn_curve_parameters(name, environment)
+    s = np.asarray(stress_range, dtype=float)
+    scalar = s.ndim == 0
+    s = np.atleast_1d(s)
+
+    s_knee = _stress_at_knee(p)
+    N = np.full_like(s, np.inf, dtype=float)
+    pos = s > 0
+    high = pos & (s >= s_knee)
+    low = pos & (s < s_knee)
+
+    N[high] = 10 ** (p["log_a1"] - p["m1"] * np.log10(s[high]))
+    N[low] = 10 ** (p["log_a2"] - p["m2"] * np.log10(s[low]))
+
+    return float(N[0]) if scalar else N
+
+
+def stress_range_at_cycles(
+    cycles: ArrayLike,
+    name: str,
+    environment: str = "air",
+) -> ArrayLike:
+    """Stress range Δσ that fails at N cycles (inverse S-N).
+
+    ``Δσ = 10 ** ((log10(a) - log10(N)) / m)`` with the segment chosen
+    by the knee ``N_D = 1e7`` (N <= N_D -> segment 1, else segment 2).
+
+    Parameters
+    ----------
+    cycles : float or array-like
+        Number of cycles to failure N.
+    name : str
+        DNV detail category.
+    environment : str
+        ``"air"``, ``"seawater_cp"`` or ``"free_corrosion"``.
+
+    Returns
+    -------
+    float or np.ndarray
+        Stress range Δσ in MPa.
+    """
+    p = sn_curve_parameters(name, environment)
+    n = np.asarray(cycles, dtype=float)
+    scalar = n.ndim == 0
+    n = np.atleast_1d(n)
+
+    s = np.full_like(n, np.nan, dtype=float)
+    seg1 = n <= p["nd"]
+    seg2 = ~seg1
+    s[seg1] = 10 ** ((p["log_a1"] - np.log10(n[seg1])) / p["m1"])
+    s[seg2] = 10 ** ((p["log_a2"] - np.log10(n[seg2])) / p["m2"])
+
+    return float(s[0]) if scalar else s

--- a/src/digitalmodel/hydrostatics/__init__.py
+++ b/src/digitalmodel/hydrostatics/__init__.py
@@ -1,0 +1,42 @@
+"""
+digitalmodel.hydrostatics — Fluid-column hydrostatics
+
+Seabed / hydrostatic pressure of a fluid column (``Δp = rho * g * h``)
+plus offshore pressure-unit conversions (ppg, ft, psi, bar, Pa).
+"""
+
+from .fluid_column import (
+    G_STANDARD,
+    PPG_TO_KG_M3,
+    FT_TO_M,
+    PSI_TO_PA,
+    PA_TO_PSI,
+    BAR_TO_PSI,
+    PSI_TO_BAR,
+    ppg_to_kg_m3,
+    ft_to_m,
+    psi_to_pa,
+    pa_to_psi,
+    bar_to_psi,
+    psi_to_bar,
+    hydrostatic_pressure,
+    seabed_pressure,
+)
+
+__all__ = [
+    "G_STANDARD",
+    "PPG_TO_KG_M3",
+    "FT_TO_M",
+    "PSI_TO_PA",
+    "PA_TO_PSI",
+    "BAR_TO_PSI",
+    "PSI_TO_BAR",
+    "ppg_to_kg_m3",
+    "ft_to_m",
+    "psi_to_pa",
+    "pa_to_psi",
+    "bar_to_psi",
+    "psi_to_bar",
+    "hydrostatic_pressure",
+    "seabed_pressure",
+]

--- a/src/digitalmodel/hydrostatics/fluid_column.py
+++ b/src/digitalmodel/hydrostatics/fluid_column.py
@@ -1,0 +1,147 @@
+"""
+Fluid-column hydrostatics — seabed / hydrostatic pressure.
+==========================================================
+
+Closed-form helpers for the static pressure of a fluid column and the
+pressure-unit conversions that go with offshore well / riser pressure
+calculations.
+
+Core relation (gauge / hydrostatic pressure of a column)::
+
+    Δp = rho * g * h            [Pa]   (rho in kg/m^3, h in m)
+
+and the seabed (absolute) pressure of a fluid column below a surface
+pressure::
+
+    p_seabed = p_surface + rho * g * h
+
+Mud / fluid density is frequently quoted in pounds-per-gallon (ppg) and
+depths in feet, so unit converters are included.  Pressures convert
+between Pa, bar and psi.
+
+References
+----------
+- Generic hydrostatics (Pascal's law); standard offshore drilling /
+  riser pressure practice.
+
+Issue: corpus calculators epic #767 / #779.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+__all__ = [
+    "G_STANDARD",
+    "PPG_TO_KG_M3",
+    "FT_TO_M",
+    "PSI_TO_PA",
+    "PA_TO_PSI",
+    "BAR_TO_PSI",
+    "PSI_TO_BAR",
+    "ppg_to_kg_m3",
+    "ft_to_m",
+    "psi_to_pa",
+    "pa_to_psi",
+    "bar_to_psi",
+    "psi_to_bar",
+    "hydrostatic_pressure",
+    "seabed_pressure",
+]
+
+ArrayLike = Union[float, "object"]  # float or numpy ndarray (numpy not required)
+
+# Standard gravity (m/s^2)
+G_STANDARD = 9.81
+
+# Unit conversion constants (match the corpus design-sheet factors)
+PPG_TO_KG_M3 = 119.826426627972   # 1 lb/US-gal -> kg/m^3
+FT_TO_M = 0.3048                  # 1 ft -> m
+PSI_TO_PA = 6894.74482549401      # 1 psi -> Pa
+PA_TO_PSI = 1.0 / PSI_TO_PA
+# 1 bar = 1e5 Pa  -> psi
+BAR_TO_PSI = 1.0e5 * PA_TO_PSI
+PSI_TO_BAR = 1.0 / BAR_TO_PSI
+
+
+def ppg_to_kg_m3(density_ppg: ArrayLike) -> ArrayLike:
+    """Convert fluid density from pounds-per-gallon (ppg) to kg/m^3."""
+    return density_ppg * PPG_TO_KG_M3
+
+
+def ft_to_m(depth_ft: ArrayLike) -> ArrayLike:
+    """Convert a depth/length from feet to metres."""
+    return depth_ft * FT_TO_M
+
+
+def psi_to_pa(pressure_psi: ArrayLike) -> ArrayLike:
+    """Convert pressure from psi to pascals."""
+    return pressure_psi * PSI_TO_PA
+
+
+def pa_to_psi(pressure_pa: ArrayLike) -> ArrayLike:
+    """Convert pressure from pascals to psi."""
+    return pressure_pa * PA_TO_PSI
+
+
+def bar_to_psi(pressure_bar: ArrayLike) -> ArrayLike:
+    """Convert pressure from bar to psi."""
+    return pressure_bar * BAR_TO_PSI
+
+
+def psi_to_bar(pressure_psi: ArrayLike) -> ArrayLike:
+    """Convert pressure from psi to bar."""
+    return pressure_psi * PSI_TO_BAR
+
+
+def hydrostatic_pressure(
+    density: ArrayLike,
+    height: ArrayLike,
+    gravity: float = G_STANDARD,
+) -> ArrayLike:
+    """Hydrostatic pressure of a fluid column, ``Δp = rho * g * h``.
+
+    Parameters
+    ----------
+    density : float or array-like
+        Fluid density in kg/m^3.
+    height : float or array-like
+        Column height (depth) in metres.
+    gravity : float
+        Gravitational acceleration in m/s^2 (default 9.81).
+
+    Returns
+    -------
+    float or np.ndarray
+        Pressure in pascals (Pa).
+    """
+    return density * gravity * height
+
+
+def seabed_pressure(
+    density: ArrayLike,
+    height: ArrayLike,
+    surface_pressure: ArrayLike = 0.0,
+    gravity: float = G_STANDARD,
+) -> ArrayLike:
+    """Absolute pressure at the bottom of a fluid column.
+
+    ``p_seabed = p_surface + rho * g * h``
+
+    Parameters
+    ----------
+    density : float or array-like
+        Fluid density in kg/m^3.
+    height : float or array-like
+        Column height (depth) in metres.
+    surface_pressure : float or array-like
+        Pressure at the top of the column in Pa (default 0 = gauge).
+    gravity : float
+        Gravitational acceleration in m/s^2 (default 9.81).
+
+    Returns
+    -------
+    float or np.ndarray
+        Seabed (bottom) pressure in pascals (Pa).
+    """
+    return surface_pressure + hydrostatic_pressure(density, height, gravity)

--- a/src/digitalmodel/installation/pipelay/__init__.py
+++ b/src/digitalmodel/installation/pipelay/__init__.py
@@ -1,0 +1,37 @@
+"""S-lay pipelay installation integrity calculations.
+
+Generic, method-based screening checks for conventional S-lay pipeline
+installation: concrete-coating crushing (Verley & Ness limiting strain),
+minimum stable route/lay radius, allowable weld-repair length, and S-lay
+submerged weight / lay tension.
+"""
+
+from digitalmodel.installation.pipelay.integrity import (
+    CrushingCheck,
+    bending_strain_from_radius,
+    concrete_crushing_check,
+    concrete_crushing_strain,
+    displaced_weight_per_length,
+    horizontal_lay_tension,
+    is_weld_repair_acceptable,
+    minimum_route_radius,
+    route_radius_factor_of_safety,
+    submerged_weight_per_length,
+    top_lay_tension,
+    weld_repair_allowable_length,
+)
+
+__all__ = [
+    "CrushingCheck",
+    "bending_strain_from_radius",
+    "concrete_crushing_check",
+    "concrete_crushing_strain",
+    "displaced_weight_per_length",
+    "horizontal_lay_tension",
+    "is_weld_repair_acceptable",
+    "minimum_route_radius",
+    "route_radius_factor_of_safety",
+    "submerged_weight_per_length",
+    "top_lay_tension",
+    "weld_repair_allowable_length",
+]

--- a/src/digitalmodel/installation/pipelay/__init__.py
+++ b/src/digitalmodel/installation/pipelay/__init__.py
@@ -20,10 +20,21 @@ from digitalmodel.installation.pipelay.integrity import (
     top_lay_tension,
     weld_repair_allowable_length,
 )
+from digitalmodel.installation.pipelay.stress import (
+    SmysCheck,
+    allowable_bend_radius,
+    axial_stress,
+    bending_stress_from_radius,
+    smys_stress_check,
+)
 
 __all__ = [
     "CrushingCheck",
+    "SmysCheck",
+    "allowable_bend_radius",
+    "axial_stress",
     "bending_strain_from_radius",
+    "bending_stress_from_radius",
     "concrete_crushing_check",
     "concrete_crushing_strain",
     "displaced_weight_per_length",
@@ -31,6 +42,7 @@ __all__ = [
     "is_weld_repair_acceptable",
     "minimum_route_radius",
     "route_radius_factor_of_safety",
+    "smys_stress_check",
     "submerged_weight_per_length",
     "top_lay_tension",
     "weld_repair_allowable_length",

--- a/src/digitalmodel/installation/pipelay/integrity.py
+++ b/src/digitalmodel/installation/pipelay/integrity.py
@@ -1,0 +1,363 @@
+"""S-lay pipelay installation integrity calculations.
+
+Generic, code/method-based screening calculations used when analysing the
+installation of a rigid subsea pipeline by conventional S-lay from a lay
+barge. The four methods ported here are:
+
+1. Concrete-coating crushing check (Verley & Ness limiting-strain criterion).
+2. Minimum stable route / lay radius: ``R = F / (S * W)``.
+3. Allowable weld-repair / cut-out length (DNV-ST-F101 percentage limits).
+4. S-lay submerged pipe weight and lay (top) tension from a catenary.
+
+All formulas are consistent-unit unless a docstring states otherwise. No unit
+conversion is performed internally except where a function explicitly says so.
+
+References
+----------
+- Verley, R. & Ness, T. (1995) — concrete-coating crushing / composite-section
+  limiting-strain behaviour of concrete-weight-coated (CWC) pipe in the
+  overbend. The practical design check is a limiting compressive bending strain
+  in the concrete relative to its crushing strain.
+- DNV-ST-F101 — Submarine Pipeline Systems (weld-repair allowable length).
+- Standard buoyancy (Archimedes) for submerged weight and the steel/free-hanging
+  catenary relation for lay-tension estimation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Standard acceleration of gravity [m/s^2].
+G_STANDARD: float = 9.80665
+
+
+# ---------------------------------------------------------------------------
+# 1. Concrete-coating crushing check (Verley & Ness limiting-strain criterion)
+# ---------------------------------------------------------------------------
+#
+# Bending of the steel pipe over the stinger (overbend) is transferred through
+# the anti-corrosion coating into the concrete weight coating. Excessive
+# compressive strain crushes the concrete. For a section bent to a radius of
+# curvature R, the outer-fibre bending strain of the steel at the concrete
+# interface is approximately:
+#
+#       eps_bend = (OD_steel / 2) / R            (= curvature * neutral-axis dist)
+#
+# The Verley & Ness work shows the strain in the concrete is amplified relative
+# to the steel by a strain-concentration factor SCF (>= 1) arising from the
+# composite (steel + corrosion-coat + concrete) section response and sliding at
+# the interface. The crushing check compares the concentrated concrete strain
+# against the concrete crushing strain (with a factor of safety):
+#
+#       eps_concrete = SCF * eps_bend
+#       utilisation  = eps_concrete / (eps_crush / FoS)
+#
+# A utilisation < 1 passes. This is the practical, hand-verifiable form of the
+# limiting-strain criterion (the full Verley & Ness sectional model derives SCF
+# and eps_crush from the material non-linearities; here they are supplied as
+# inputs so the screening check is exact and transparent).
+
+
+def bending_strain_from_radius(outer_diameter: float, bend_radius: float) -> float:
+    """Outer-fibre bending strain of a tube bent to a radius of curvature.
+
+    ``eps = (OD / 2) / R``, i.e. the neutral-axis-to-fibre distance times the
+    curvature ``1/R``.
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Outer diameter of the steel pipe [length].
+    bend_radius : float
+        Radius of curvature of the bent pipe [length].
+
+    Returns
+    -------
+    float
+        Dimensionless outer-fibre bending strain.
+    """
+    if bend_radius <= 0.0:
+        raise ValueError("bend_radius must be positive")
+    return (outer_diameter / 2.0) / bend_radius
+
+
+def concrete_crushing_strain(bending_strain: float, strain_concentration_factor: float) -> float:
+    """Compressive strain seen by the concrete coating.
+
+    ``eps_concrete = SCF * eps_bend`` where ``SCF >= 1`` is the strain
+    concentration factor from the composite-section (Verley & Ness) response.
+    """
+    if strain_concentration_factor < 1.0:
+        raise ValueError("strain_concentration_factor must be >= 1.0")
+    return strain_concentration_factor * bending_strain
+
+
+@dataclass(frozen=True)
+class CrushingCheck:
+    """Result of a concrete-coating crushing check."""
+
+    bending_strain: float  # outer-fibre steel bending strain [-]
+    concrete_strain: float  # concentrated concrete strain [-]
+    allowable_strain: float  # crushing strain / FoS [-]
+    utilisation: float  # concrete_strain / allowable_strain [-]
+    passes: bool  # True if utilisation < 1
+
+
+def concrete_crushing_check(
+    outer_diameter: float,
+    bend_radius: float,
+    crushing_strain_limit: float,
+    strain_concentration_factor: float = 1.0,
+    factor_of_safety: float = 1.0,
+) -> CrushingCheck:
+    """Verley & Ness concrete-crushing limiting-strain check in the overbend.
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Steel-pipe outer diameter [length].
+    bend_radius : float
+        Overbend radius of curvature [length].
+    crushing_strain_limit : float
+        Concrete crushing strain (e.g. ~0.002 = 0.2%) [-].
+    strain_concentration_factor : float, optional
+        Composite-section strain amplification SCF (>= 1). Default 1.0.
+    factor_of_safety : float, optional
+        Factor of safety applied to the crushing strain. Default 1.0.
+
+    Returns
+    -------
+    CrushingCheck
+        Strains, allowable, utilisation and pass/fail flag.
+    """
+    if factor_of_safety <= 0.0:
+        raise ValueError("factor_of_safety must be positive")
+    eps_bend = bending_strain_from_radius(outer_diameter, bend_radius)
+    eps_conc = concrete_crushing_strain(eps_bend, strain_concentration_factor)
+    allowable = crushing_strain_limit / factor_of_safety
+    util = eps_conc / allowable
+    return CrushingCheck(
+        bending_strain=eps_bend,
+        concrete_strain=eps_conc,
+        allowable_strain=allowable,
+        utilisation=util,
+        passes=util < 1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Minimum stable route / lay radius:  R = F / (S * W)
+# ---------------------------------------------------------------------------
+#
+# Where the route has curves/turning points, the laid pipe must not slip
+# laterally off the planned radius under bottom (touch-down) tension. The
+# minimum stable radius balances the lateral component of the bottom tension
+# against the available pipe-soil friction:
+#
+#       R_min = F / (S * W)
+#
+#   R_min = minimum stable route radius
+#   F     = touch-down (bottom) tension
+#   S     = coefficient of lateral pipe-soil friction
+#   W     = submerged unit weight of the pipeline (force per unit length)
+
+
+def minimum_route_radius(
+    bottom_tension: float, lateral_friction: float, submerged_weight_per_length: float
+) -> float:
+    """Minimum stable route / lay radius ``R = F / (S * W)``.
+
+    Parameters
+    ----------
+    bottom_tension : float
+        Touch-down (bottom) tension F [force].
+    lateral_friction : float
+        Coefficient of lateral pipe-soil friction S [-].
+    submerged_weight_per_length : float
+        Submerged unit weight W of the pipeline [force/length].
+
+    Returns
+    -------
+    float
+        Minimum stable route radius [length].
+    """
+    if lateral_friction <= 0.0:
+        raise ValueError("lateral_friction must be positive")
+    if submerged_weight_per_length <= 0.0:
+        raise ValueError("submerged_weight_per_length must be positive")
+    return bottom_tension / (lateral_friction * submerged_weight_per_length)
+
+
+def route_radius_factor_of_safety(planned_radius: float, minimum_radius: float) -> float:
+    """Factor of safety of a planned route radius against the minimum stable one.
+
+    ``FoS = planned_radius / minimum_radius`` (target ~1.5).
+    """
+    if minimum_radius <= 0.0:
+        raise ValueError("minimum_radius must be positive")
+    return planned_radius / minimum_radius
+
+
+# ---------------------------------------------------------------------------
+# 3. Allowable weld-repair / cut-out length (DNV-ST-F101 percentage limits)
+# ---------------------------------------------------------------------------
+#
+# The maximum length of girth weld that may be removed/repaired in place is
+# limited to a fraction of the total weld length, subject to an absolute minimum
+# repair length. Typical limiting criteria (per DNV-ST-F101):
+#   - Partial-penetration repair: max 30% of total weld length.
+#   - Full-penetration repair:    max 20% of total weld length.
+#   - Minimum weld-repair length:  50 mm.
+
+PARTIAL_PENETRATION_FRACTION: float = 0.30
+FULL_PENETRATION_FRACTION: float = 0.20
+DEFAULT_MIN_REPAIR_LENGTH: float = 0.050  # 50 mm in metres
+
+
+def weld_repair_allowable_length(
+    total_weld_length: float,
+    allowable_fraction: float,
+    minimum_repair_length: float = DEFAULT_MIN_REPAIR_LENGTH,
+) -> float:
+    """Allowable weld-repair (cut-out) length.
+
+    The allowable length is the larger of the fractional limit and the absolute
+    minimum repair length (you cannot make a useful repair shorter than the
+    minimum, so the minimum governs the *floor* of the allowable length).
+
+    Parameters
+    ----------
+    total_weld_length : float
+        Total girth-weld length (e.g. pi * OD) [length].
+    allowable_fraction : float
+        Permitted fraction of the total weld length (0 < f <= 1), e.g. 0.30 for
+        partial-penetration or 0.20 for full-penetration repairs.
+    minimum_repair_length : float, optional
+        Absolute minimum weld-repair length [length]. Default 50 mm.
+
+    Returns
+    -------
+    float
+        Allowable weld-repair length [length].
+    """
+    if not 0.0 < allowable_fraction <= 1.0:
+        raise ValueError("allowable_fraction must be in (0, 1]")
+    return max(allowable_fraction * total_weld_length, minimum_repair_length)
+
+
+def is_weld_repair_acceptable(
+    repair_length: float,
+    total_weld_length: float,
+    allowable_fraction: float,
+    minimum_repair_length: float = DEFAULT_MIN_REPAIR_LENGTH,
+) -> bool:
+    """True if a proposed repair length is between the minimum and the fractional limit."""
+    fractional_limit = allowable_fraction * total_weld_length
+    return minimum_repair_length <= repair_length <= fractional_limit
+
+
+# ---------------------------------------------------------------------------
+# 4. S-lay submerged pipe weight and lay (top) tension
+# ---------------------------------------------------------------------------
+#
+# Submerged (wet) weight per unit length of a pipe is the dry weight minus the
+# buoyancy of the displaced water (Archimedes), using the *total* outer diameter
+# of the laid pipe (including any coatings):
+#
+#       w_sub = w_dry - rho_water * g * (pi/4) * OD_total^2
+#
+# For a free-hanging suspended span (catenary) of a near-neutrally-stiff line in
+# water depth d, with horizontal tension H, the top (lay) tension is:
+#
+#       T_top = H + w_sub * d
+#
+# where H = w_sub * R is the horizontal tension implied by the sagbend radius R
+# at touch-down (H = w_sub * R for a catenary whose minimum radius is R).
+
+
+def displaced_weight_per_length(
+    outer_diameter: float, water_density: float, gravity: float = G_STANDARD
+) -> float:
+    """Buoyancy force per unit length of a fully submerged circular pipe.
+
+    ``b = rho_water * g * (pi/4) * OD^2`` [force/length].
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Total outer diameter of the laid pipe (incl. coatings) [m].
+    water_density : float
+        Water density [kg/m^3].
+    gravity : float, optional
+        Gravitational acceleration [m/s^2]. Default 9.80665.
+    """
+    return water_density * gravity * (math.pi / 4.0) * outer_diameter**2
+
+
+def submerged_weight_per_length(
+    dry_weight_per_length: float,
+    outer_diameter: float,
+    water_density: float,
+    gravity: float = G_STANDARD,
+) -> float:
+    """Submerged (wet) unit weight ``w_sub = w_dry - buoyancy``.
+
+    Parameters
+    ----------
+    dry_weight_per_length : float
+        Dry (in-air) weight per unit length [N/m].
+    outer_diameter : float
+        Total outer diameter of the laid pipe (incl. coatings) [m].
+    water_density : float
+        Water density [kg/m^3].
+    gravity : float, optional
+        Gravitational acceleration [m/s^2]. Default 9.80665.
+
+    Returns
+    -------
+    float
+        Submerged unit weight [N/m] (positive = net-down / bottom-stable).
+    """
+    return dry_weight_per_length - displaced_weight_per_length(
+        outer_diameter, water_density, gravity
+    )
+
+
+def horizontal_lay_tension(submerged_weight_per_length: float, sagbend_radius: float) -> float:
+    """Horizontal tension of a catenary sagbend ``H = w_sub * R``.
+
+    Parameters
+    ----------
+    submerged_weight_per_length : float
+        Submerged unit weight w_sub [force/length].
+    sagbend_radius : float
+        Minimum (touch-down) radius of curvature of the sagbend [length].
+    """
+    return submerged_weight_per_length * sagbend_radius
+
+
+def top_lay_tension(
+    submerged_weight_per_length: float, water_depth: float, sagbend_radius: float
+) -> float:
+    """Top (lay) tension of a free-hanging catenary span.
+
+    ``T_top = H + w_sub * d = w_sub * (R + d)`` for a catenary of minimum radius
+    R laid in water depth d.
+
+    Parameters
+    ----------
+    submerged_weight_per_length : float
+        Submerged unit weight w_sub [force/length].
+    water_depth : float
+        Water depth d [length].
+    sagbend_radius : float
+        Minimum (touch-down) sagbend radius R [length].
+
+    Returns
+    -------
+    float
+        Top tension at the lay vessel [force].
+    """
+    h = horizontal_lay_tension(submerged_weight_per_length, sagbend_radius)
+    return h + submerged_weight_per_length * water_depth

--- a/src/digitalmodel/installation/pipelay/stress.py
+++ b/src/digitalmodel/installation/pipelay/stress.py
@@ -1,0 +1,196 @@
+"""Overbend / sagbend longitudinal-stress (%SMYS) acceptance check for S-lay.
+
+Generic, method-based screening check used during conventional S-lay pipeline
+installation. In S-lay the pipe forms two high-curvature zones — the supported
+**overbend** over the stinger and the unsupported **sagbend** suspended span.
+The outer-fibre longitudinal stress (or, equivalently, strain) in each zone is
+checked against an allowable expressed as a percentage of the steel's Specified
+Minimum Yield Strength (SMYS).
+
+The outer-fibre longitudinal stress combines the axial (membrane) stress from
+effective/wall tension and the bending stress from curvature:
+
+    sigma_axial = N / A
+    sigma_bend  = E * (OD / 2) / R          (= E * curvature * neutral-axis dist)
+    sigma_long  = sigma_axial + sigma_bend
+
+The acceptance criterion is
+
+    sigma_long <= allowable_fraction * SMYS
+
+with typical allowable fractions of 85% in the overbend and 72% in the sagbend
+(exposed as parameters here so any project's acceptance values can be supplied).
+
+A pure-bending strain form is also provided for the strain-based screening that
+some methods use:
+
+    eps_bend = (OD / 2) / R
+    eps_long <= (allowable_fraction * SMYS) / E
+
+All functions are unit-consistent: pass E, SMYS and the resulting stresses in
+the same unit system (e.g. MPa with N in newtons and A in m^2, or psi with N in
+lbf and A in in^2). No internal unit conversion is performed.
+
+References
+----------
+- DNV-ST-F101 / DNV-OS-F101 — Submarine Pipeline Systems (installation
+  longitudinal-stress %SMYS acceptance in the over/sagbend).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Common installation %SMYS acceptance values (fractions, not percentages).
+DEFAULT_OVERBEND_FRACTION: float = 0.85
+DEFAULT_SAGBEND_FRACTION: float = 0.72
+
+
+def bending_stress_from_radius(
+    outer_diameter: float, bend_radius: float, youngs_modulus: float
+) -> float:
+    """Outer-fibre longitudinal bending stress of a tube bent to a radius.
+
+    ``sigma = E * (OD / 2) / R`` — Young's modulus times the outer-fibre
+    bending strain (neutral-axis-to-fibre distance times the curvature ``1/R``).
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Outer diameter of the steel pipe [length].
+    bend_radius : float
+        Radius of curvature of the bent pipe [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+
+    Returns
+    -------
+    float
+        Outer-fibre bending stress [stress].
+    """
+    if bend_radius <= 0.0:
+        raise ValueError("bend_radius must be positive")
+    return youngs_modulus * (outer_diameter / 2.0) / bend_radius
+
+
+def axial_stress(axial_force: float, steel_area: float) -> float:
+    """Membrane (axial) stress ``sigma = N / A``.
+
+    Parameters
+    ----------
+    axial_force : float
+        Wall (axial) force carried by the steel cross-section [force].
+    steel_area : float
+        Steel cross-sectional area [length^2].
+    """
+    if steel_area <= 0.0:
+        raise ValueError("steel_area must be positive")
+    return axial_force / steel_area
+
+
+@dataclass(frozen=True)
+class SmysCheck:
+    """Result of an over/sagbend longitudinal-stress %SMYS acceptance check."""
+
+    longitudinal_stress: float  # combined outer-fibre longitudinal stress [stress]
+    allowable_stress: float  # allowable_fraction * SMYS [stress]
+    utilisation: float  # longitudinal_stress / allowable_stress [-]
+    percent_smys: float  # longitudinal_stress / SMYS * 100 [%]
+    passes: bool  # True if longitudinal_stress <= allowable_stress
+
+
+def smys_stress_check(
+    outer_diameter: float,
+    bend_radius: float,
+    youngs_modulus: float,
+    smys: float,
+    allowable_fraction: float,
+    axial_force: float = 0.0,
+    steel_area: float | None = None,
+) -> SmysCheck:
+    """Longitudinal-stress %SMYS acceptance check for an over/sagbend section.
+
+    Combines the outer-fibre bending stress from the section curvature with an
+    optional axial (membrane) stress, and compares the total against
+    ``allowable_fraction * SMYS``.
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Steel-pipe outer diameter [length].
+    bend_radius : float
+        Radius of curvature of the section (overbend or sagbend) [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+    smys : float
+        Specified minimum yield strength [stress].
+    allowable_fraction : float
+        Allowable longitudinal stress as a fraction of SMYS (e.g. 0.85 overbend,
+        0.72 sagbend). Must be in (0, 1].
+    axial_force : float, optional
+        Wall (axial) force carried by the steel section [force]. Default 0.
+    steel_area : float, optional
+        Steel cross-sectional area [length^2]. Required only when
+        ``axial_force`` is non-zero.
+
+    Returns
+    -------
+    SmysCheck
+        Combined stress, allowable, utilisation, %SMYS and pass/fail flag.
+    """
+    if not 0.0 < allowable_fraction <= 1.0:
+        raise ValueError("allowable_fraction must be in (0, 1]")
+    if smys <= 0.0:
+        raise ValueError("smys must be positive")
+
+    sigma_bend = bending_stress_from_radius(outer_diameter, bend_radius, youngs_modulus)
+    sigma_axial = 0.0
+    if axial_force != 0.0:
+        if steel_area is None:
+            raise ValueError("steel_area is required when axial_force is non-zero")
+        sigma_axial = axial_stress(axial_force, steel_area)
+
+    sigma_long = sigma_axial + sigma_bend
+    allowable = allowable_fraction * smys
+    return SmysCheck(
+        longitudinal_stress=sigma_long,
+        allowable_stress=allowable,
+        utilisation=sigma_long / allowable,
+        percent_smys=sigma_long / smys * 100.0,
+        passes=sigma_long <= allowable,
+    )
+
+
+def allowable_bend_radius(
+    outer_diameter: float,
+    youngs_modulus: float,
+    smys: float,
+    allowable_fraction: float,
+) -> float:
+    """Minimum bend radius for pure bending to stay within ``f * SMYS``.
+
+    Solving ``E * (OD/2) / R <= f * SMYS`` for R gives the smallest admissible
+    radius ``R_min = E * (OD/2) / (f * SMYS)``. (Axial stress not included; this
+    is the pure-bending screening radius.)
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Steel-pipe outer diameter [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+    smys : float
+        Specified minimum yield strength [stress].
+    allowable_fraction : float
+        Allowable bending stress as a fraction of SMYS. Must be in (0, 1].
+
+    Returns
+    -------
+    float
+        Minimum admissible bend radius [length].
+    """
+    if not 0.0 < allowable_fraction <= 1.0:
+        raise ValueError("allowable_fraction must be in (0, 1]")
+    if smys <= 0.0:
+        raise ValueError("smys must be positive")
+    return youngs_modulus * (outer_diameter / 2.0) / (allowable_fraction * smys)

--- a/tests/code_checks/test_dnv_os_f101.py
+++ b/tests/code_checks/test_dnv_os_f101.py
@@ -1,0 +1,229 @@
+"""Tests for DNV-OS-F101 local-buckling and external-pressure checks.
+
+Expected values are computed by hand from the closed-form formulas with generic
+round-number inputs (no client data used as an oracle). The collapse-cubic root
+is verified against the implicit DNV equation it must satisfy, not against any
+project result.
+
+A consistent unit set is used throughout: length in mm, stress/pressure in MPa,
+force in N (= MPa * mm^2), moment in N.mm (= MPa * mm^3).
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.code_checks.dnv_os_f101 import (
+    LocalBucklingResult,
+    PropagationCheck,
+    collapse_pressure,
+    elastic_collapse_pressure,
+    local_buckling_lcc,
+    plastic_axial_capacity,
+    plastic_collapse_pressure,
+    plastic_moment_capacity,
+    pressure_containment_resistance,
+    propagation_check,
+    propagation_pressure,
+)
+
+
+# --- plastic capacities -----------------------------------------------------
+
+
+def test_plastic_axial_capacity():
+    # Sp = fy * pi * (D - t) * t = 450 * pi * (500-20) * 20 = 450*pi*9600
+    assert plastic_axial_capacity(500.0, 20.0, 450.0) == pytest.approx(
+        450.0 * math.pi * 480.0 * 20.0
+    )
+
+
+def test_plastic_moment_capacity():
+    # Mp = fy * (D - t)^2 * t = 450 * 480^2 * 20 = 450 * 230400 * 20
+    assert plastic_moment_capacity(500.0, 20.0, 450.0) == pytest.approx(
+        450.0 * 480.0**2 * 20.0
+    )
+
+
+def test_pressure_containment_resistance():
+    # fcb = min(450, 535/1.15) = min(450, 465.2..) = 450
+    # Pb = (2*20/480) * 450 * 2/sqrt(3)
+    fcb = min(450.0, 535.0 / 1.15)
+    expected = (2.0 * 20.0 / 480.0) * fcb * (2.0 / math.sqrt(3.0))
+    assert pressure_containment_resistance(500.0, 20.0, 450.0, 535.0) == pytest.approx(
+        expected
+    )
+    assert fcb == 450.0  # yield governs here
+
+
+# --- local buckling (LCC) ---------------------------------------------------
+
+
+def test_local_buckling_zero_load_passes():
+    res = local_buckling_lcc(
+        design_moment=0.0,
+        design_effective_tension=0.0,
+        pressure_internal=10.0,
+        pressure_external=10.0,
+        moment_capacity=1.0e9,
+        axial_capacity=1.0e7,
+        pressure_capacity=30.0,
+    )
+    assert isinstance(res, LocalBucklingResult)
+    assert res.utilisation == pytest.approx(0.0)
+    assert res.passes is True
+
+
+def test_local_buckling_pure_pressure_term():
+    # No moment/tension; net = pe - pi = 20 - 5 = 15 external.
+    # g = 1.0 * 1.0 = 1.0 ; pressure_term = (1 * 15 / 30)^2 = 0.25
+    res = local_buckling_lcc(
+        design_moment=0.0,
+        design_effective_tension=0.0,
+        pressure_internal=5.0,
+        pressure_external=20.0,
+        moment_capacity=1.0e9,
+        axial_capacity=1.0e7,
+        pressure_capacity=30.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(0.25)
+    assert res.passes is True
+
+
+def test_local_buckling_combined_handcalc():
+    # Choose round capacities so terms are exact.
+    # g = 1.0 ; Md/Mp = 100/200 = 0.5 ; (Sd/Sp)^2 = (30/100)^2 = 0.09
+    # group = (0.5 + 0.09)^2 = 0.59^2 = 0.3481
+    # net = pi - pe = 25 - 5 = 20 ; (20/40)^2 = 0.25
+    # UF = 0.3481 + 0.25 = 0.5981
+    res = local_buckling_lcc(
+        design_moment=100.0,
+        design_effective_tension=30.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(0.5981)
+    assert res.passes is True
+
+
+def test_local_buckling_fails():
+    # g = 1.0 ; Md/Mp = 1.0 ; tension 0 ; group = 1.0 ; pressure (20/40)^2=0.25
+    # UF = 1.25 > 1 -> fail
+    res = local_buckling_lcc(
+        design_moment=200.0,
+        design_effective_tension=0.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(1.25)
+    assert res.passes is False
+
+
+def test_local_buckling_safety_factors_applied():
+    # g = 1.15 * 1.14 = 1.311
+    # moment_term = 1.311 * 100/200 = 0.6555
+    # tension_term = (1.311 * 30/100)^2 = (0.3933)^2 = 0.15468489
+    # group = (0.6555 + 0.15468489)^2
+    # pressure_term = (1.311 * 20/40)^2 = (0.6555)^2 = 0.42968025
+    g = 1.15 * 1.14
+    group = (g * 0.5 + (g * 0.3) ** 2) ** 2
+    pterm = (g * 0.5) ** 2
+    res = local_buckling_lcc(
+        design_moment=100.0,
+        design_effective_tension=30.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+    )
+    assert res.utilisation == pytest.approx(group + pterm)
+
+
+def test_local_buckling_invalid_capacity():
+    with pytest.raises(ValueError):
+        local_buckling_lcc(0.0, 0.0, 0.0, 0.0, -1.0, 1.0, 1.0)
+
+
+# --- external-pressure collapse --------------------------------------------
+
+# Reference geometry: D=500, t=20, fy=450, E=210000, nu=0.3.
+_D, _T, _FY, _E = 500.0, 20.0, 450.0, 210000.0
+
+
+def test_elastic_collapse_pressure():
+    # Pel = 2E(t/D)^3/(1-nu^2) = 2*210000*0.04^3/0.91
+    expected = 2.0 * _E * (0.04**3) / (1.0 - 0.3**2)
+    assert elastic_collapse_pressure(_D, _T, _E) == pytest.approx(expected)
+    assert expected == pytest.approx(29.538461538, rel=1e-9)
+
+
+def test_plastic_collapse_pressure():
+    # Pp = fy * 1.0 * 2 * (t/D) = 450 * 2 * 0.04 = 36.0
+    assert plastic_collapse_pressure(_D, _T, _FY) == pytest.approx(36.0)
+
+
+def test_collapse_pressure_satisfies_cubic():
+    # Verify Pc satisfies the implicit DNV collapse equation, not a fixed number.
+    f0 = 0.005
+    pc = collapse_pressure(_D, _T, _FY, _E, ovality=f0)
+    pel = elastic_collapse_pressure(_D, _T, _E)
+    pp = plastic_collapse_pressure(_D, _T, _FY)
+    lhs = (pc - pel) * (pc**2 - pp**2)
+    rhs = pc * pel * pp * f0 * (_D / _T)
+    assert lhs == pytest.approx(rhs, abs=1e-6)
+    # And it is below both bounding pressures (real collapse < min(Pel, Pp)).
+    assert pc < min(pel, pp)
+    assert pc == pytest.approx(24.733652743, rel=1e-9)
+
+
+def test_collapse_pressure_decreases_with_ovality():
+    pc_low = collapse_pressure(_D, _T, _FY, _E, ovality=0.005)
+    pc_high = collapse_pressure(_D, _T, _FY, _E, ovality=0.02)
+    assert pc_high < pc_low
+
+
+def test_collapse_pressure_clamps_minimum_ovality():
+    # Ovality below 0.005 is clamped to 0.005 (code minimum).
+    pc_zero = collapse_pressure(_D, _T, _FY, _E, ovality=0.0)
+    pc_min = collapse_pressure(_D, _T, _FY, _E, ovality=0.005)
+    assert pc_zero == pytest.approx(pc_min)
+
+
+# --- propagation buckling ---------------------------------------------------
+
+
+def test_propagation_pressure():
+    # Ppr = 35 * fy * 1.0 * (t/D)^2.5 = 35 * 450 * 0.04^2.5
+    expected = 35.0 * 450.0 * (0.04**2.5)
+    assert propagation_pressure(_D, _T, _FY) == pytest.approx(expected)
+    assert expected == pytest.approx(5.04, rel=1e-9)
+
+
+def test_propagation_check_no_propagation():
+    # resistance = Ppr / (gm*gsc) = 5.04 / (1.15*1.14) = 5.04 / 1.311
+    res = propagation_check(net_external_pressure=2.0, diameter=_D, t=_T, f_y=_FY)
+    expected_resistance = 5.04 / (1.15 * 1.14)
+    assert isinstance(res, PropagationCheck)
+    assert res.propagation_resistance == pytest.approx(expected_resistance)
+    assert res.utilisation == pytest.approx(2.0 / expected_resistance)
+    assert res.propagates is False  # 2.0 < ~3.845
+
+
+def test_propagation_check_propagates():
+    # Large net external pressure exceeds the resistance.
+    res = propagation_check(net_external_pressure=10.0, diameter=_D, t=_T, f_y=_FY)
+    assert res.utilisation > 1.0
+    assert res.propagates is True

--- a/tests/code_checks/test_dnv_os_f201_lrfd_wsd.py
+++ b/tests/code_checks/test_dnv_os_f201_lrfd_wsd.py
@@ -1,0 +1,174 @@
+"""Oracle tests for DNV-OS-F201 LRFD/WSD combined-loading limit-state checks.
+
+Oracle values reproduce a corpus WSD-vs-LRFD DNV-OS-F201 comparison spreadsheet
+(generic pipe; no client/project identifiers). Working unit set is imperial
+(ksi / kips-ft / kips) as used in the source sheet; checks at rtol ~1e-3.
+
+Reference load case (internal-overpressure sheet, governing column):
+    D = 20 in, t = 1.063 in, tcorr = 0.23622 in -> t2(operation) = 0.82678 in
+    SMYS = 65 ksi (X65), SMTS = 77 ksi, alpha_u = 0.96
+    Design pressure pi = 3 ksi, pe = 0, no temperature de-rating
+    Safety class High: gamma_SC = 1.26, gamma_m = 1.0 (ULS), eta = 0.75
+    Factored design Md = -1252.8 kips-ft, Td = 0 kips
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.code_checks.dnv_os_f201_lrfd_wsd import (
+    bursting_resistance,
+    combined_loading_external_overpressure,
+    combined_loading_internal_overpressure,
+    factored_load_effect,
+    flow_stress_coefficient,
+    plastic_axial_resistance,
+    plastic_moment_resistance,
+    tensile_strength,
+    yield_strength,
+)
+
+RTOL = 1e-3
+
+# --- shared reference inputs (internal-overpressure sheet) -------------------
+D = 20.0  # in
+T2 = 0.82678  # in (t2 operation)
+SMYS = 65.0  # ksi (X65)
+SMTS = 77.0  # ksi
+ALPHA_U = 0.96
+PI = 3.0  # ksi internal design pressure
+PE = 0.0  # ksi external
+GAMMA_SC = 1.26  # High
+GAMMA_M = 1.0  # ULS
+ETA = 0.75  # WSD usage factor, High
+MD = -1252.8  # kips-ft factored design moment
+TD = 0.0  # kips factored design tension
+
+
+def test_yield_and_tensile_strength_oracle():
+    # fy = (65 - 0) * 0.96 = 62.4 ksi (R118); fu = (77 - 0)*0.96 = 73.92 ksi (R120)
+    assert yield_strength(SMYS, 0.0, ALPHA_U) == pytest.approx(62.4, rel=RTOL)
+    assert tensile_strength(SMTS, 0.0, ALPHA_U) == pytest.approx(73.92, rel=RTOL)
+
+
+def test_bursting_resistance_oracle():
+    fy = yield_strength(SMYS, 0.0, ALPHA_U)
+    fu = tensile_strength(SMTS, 0.0, ALPHA_U)
+    # Pb = 6.214109 ksi (R129)
+    assert bursting_resistance(D, T2, fy, fu) == pytest.approx(6.214109, rel=RTOL)
+
+
+def test_flow_stress_coefficient_oracle():
+    fy = yield_strength(SMYS, 0.0, ALPHA_U)
+    fu = tensile_strength(SMTS, 0.0, ALPHA_U)
+    pb = bursting_resistance(D, T2, fy, fu)
+    # alpha_c = 1.140662 (R155)
+    alpha_c = flow_stress_coefficient(D, T2, fy, fu, PI, PE, pb)
+    assert alpha_c == pytest.approx(1.140662, rel=RTOL)
+
+
+def _resistances():
+    fy = yield_strength(SMYS, 0.0, ALPHA_U)
+    fu = tensile_strength(SMTS, 0.0, ALPHA_U)
+    pb = bursting_resistance(D, T2, fy, fu)
+    alpha_c = flow_stress_coefficient(D, T2, fy, fu, PI, PE, pb)
+    mk_in = plastic_moment_resistance(D, T2, fy, alpha_c)  # inch-kips
+    mk_ft = mk_in / 12.0  # ft-kips (sheet expresses Md in kips-ft)
+    tk = plastic_axial_resistance(D, T2, fy, alpha_c)  # kips
+    return fy, fu, pb, alpha_c, mk_ft, tk
+
+
+def test_plastic_resistances_oracle():
+    _, _, _, _, mk_ft, tk = _resistances()
+    # Mk = 1802.77008 ft-kips (R111); Tk = 3544.674857 kips (R114)
+    assert mk_ft == pytest.approx(1802.77008, rel=RTOL)
+    assert tk == pytest.approx(3544.674857, rel=RTOL)
+
+
+def test_factored_load_effect_oracle():
+    # Md = 1.1*(-522) + 1.3*(-522) + 1.0*0 = -1252.8 kips-ft (R158, ULS factors)
+    md = factored_load_effect(-522.0, -522.0, 0.0, 1.1, 1.3, 1.0)
+    assert md == pytest.approx(-1252.8, rel=RTOL)
+
+
+def test_combined_internal_lrfd_oracle():
+    _, _, pb, _, mk_ft, tk = _resistances()
+    res = combined_loading_internal_overpressure(
+        design_moment=MD,
+        moment_resistance=mk_ft,
+        design_tension=TD,
+        axial_resistance=tk,
+        p_internal=PI,
+        p_external=PE,
+        bursting_resistance_value=pb,
+        gamma_sc=GAMMA_SC,
+        gamma_m=GAMMA_M,
+    )
+    # LRFD utilisation = 0.999883 (R171), limit 1.0 -> ACCEPTED
+    assert res.utilisation == pytest.approx(0.999883, rel=RTOL)
+    assert res.limit == 1.0
+    assert res.passes is True
+
+
+def test_combined_internal_wsd_oracle():
+    _, _, pb, _, mk_ft, tk = _resistances()
+    # WSD uses unfactored load effects: M = -522 + -522 = -1044 kips-ft (R163)
+    m_wsd = factored_load_effect(-522.0, -522.0, 0.0, 1.0, 1.0, 1.0)
+    res = combined_loading_internal_overpressure(
+        design_moment=m_wsd,
+        moment_resistance=mk_ft,
+        design_tension=0.0,
+        axial_resistance=tk,
+        p_internal=PI,
+        p_external=PE,
+        bursting_resistance_value=pb,
+        gamma_sc=1.0,
+        gamma_m=1.0,
+        usage_factor=ETA,
+    )
+    # WSD utilisation = 0.740221 (R179), limit eta^2 = 0.5625 -> NOT ACCEPTED
+    assert res.utilisation == pytest.approx(0.740221, rel=RTOL)
+    assert res.limit == pytest.approx(0.5625, rel=RTOL)
+    assert res.passes is False
+
+
+def test_combined_external_lrfd_oracle():
+    # External-overpressure sheet governing column oracle values:
+    #   Md = -1207.908894 kips-ft, Mk = 1759.625046 ft-kips, Tk = 3459.841457 kips
+    #   pe = 1 ksi, pmin = 0, Pc (collapse) = 2.507218511 ksi
+    #   gamma_SC = 1.26, gamma_m = 1.0
+    res = combined_loading_external_overpressure(
+        design_moment=-1207.908894,
+        moment_resistance=1759.625046,
+        design_tension=0.0,
+        axial_resistance=3459.841457,
+        p_external=1.0,
+        p_min_internal=0.0,
+        collapse_resistance=2.507218511,
+        gamma_sc=1.26,
+        gamma_m=1.0,
+    )
+    # External LRFD utilisation = 1.000672 (R169), limit 1.0 -> just NOT ACCEPTED
+    assert res.utilisation == pytest.approx(1.000672, rel=RTOL)
+    assert res.passes is False
+
+
+def test_wsd_unfactored_equals_lrfd_without_factors():
+    # Sanity: WSD format with gamma=1 and usage_factor None reduces to the
+    # bracketed expression with limit 1.0.
+    _, _, pb, _, mk_ft, tk = _resistances()
+    res = combined_loading_internal_overpressure(
+        design_moment=-1044.0,
+        moment_resistance=mk_ft,
+        design_tension=0.0,
+        axial_resistance=tk,
+        p_internal=PI,
+        p_external=PE,
+        bursting_resistance_value=pb,
+        gamma_sc=1.0,
+        gamma_m=1.0,
+    )
+    # No gamma, no eta -> 0.841652 (sheet R174 "NO Ysc & Ym" uses factored Md;
+    # here unfactored Md gives the WSD bracket value 0.740221)
+    assert res.utilisation == pytest.approx(0.740221, rel=RTOL)
+    assert res.limit == 1.0

--- a/tests/drilling_riser/test_section_properties.py
+++ b/tests/drilling_riser/test_section_properties.py
@@ -1,0 +1,87 @@
+"""Oracle tests for drilling-riser section stiffness properties.
+
+Oracle values reproduce a corpus drilling-riser section-stiffness spreadsheet
+(generic tubular joints; no client/project identifiers). Values are checked
+against the spreadsheet's computed cells at rtol ~1e-3.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.drilling_riser.section import (
+    cross_sectional_area,
+    moment_of_inertia,
+    polar_moment_of_inertia,
+    section_properties,
+    section_properties_imperial,
+    shear_modulus,
+)
+
+RTOL = 1e-3
+
+
+def test_cross_sectional_area_matches_oracle():
+    # OD=23.75 in, ID=18.75 in -> A=166.8971097 sq-in (spreadsheet F3)
+    assert cross_sectional_area(23.75, 18.75) == pytest.approx(166.8971097, rel=RTOL)
+    # OD=21 in, ID=19 in -> 62.83185307 sq-in (F5)
+    assert cross_sectional_area(21.0, 19.0) == pytest.approx(62.83185307, rel=RTOL)
+
+
+def test_moment_of_inertia_matches_oracle():
+    # OD=23.75, ID=18.75 -> I=9550.947881 qu-in (H3)
+    assert moment_of_inertia(23.75, 18.75) == pytest.approx(9550.947881, rel=RTOL)
+    # OD=21, ID=19 -> 3149.446635 qu-in (H5)
+    assert moment_of_inertia(21.0, 19.0) == pytest.approx(3149.446635, rel=RTOL)
+
+
+def test_polar_moment_is_twice_inertia():
+    # J = 2I (J3 = 19101.89576 qu-in)
+    assert polar_moment_of_inertia(23.75, 18.75) == pytest.approx(
+        19101.89576, rel=RTOL
+    )
+    assert polar_moment_of_inertia(23.75, 18.75) == pytest.approx(
+        2.0 * moment_of_inertia(23.75, 18.75), rel=1e-12
+    )
+
+
+def test_shear_modulus_from_E_and_nu():
+    # G = E / (2(1+nu)); E=30750 ksi, nu=0.293
+    expected = 30750.0 / (2.0 * (1.0 + 0.293))
+    assert shear_modulus(30750.0, 0.293) == pytest.approx(expected, rel=1e-12)
+
+
+def test_imperial_stiffness_in_SI_matches_oracle():
+    # Joint: OD=23.75 in, ID=18.75 in, E=30750 ksi, nu=0.293
+    # Oracle (spreadsheet, meter/Pa columns):
+    #   area  G3 = 0.1076753393 m^2
+    #   I     I3 = 0.003975404652 m^4
+    #   EA    P3 = 2.2828656428e10 N
+    #   EI    R3 = 8.428405942e8 N.m^2
+    #   GJ    T3 = 6.518488741e8 N.m^2
+    props = section_properties_imperial(23.75, 18.75, 30750.0, 0.293)
+    assert props.area == pytest.approx(0.1076753393, rel=RTOL)
+    assert props.moment_of_inertia == pytest.approx(0.003975404652, rel=RTOL)
+    assert props.axial_stiffness == pytest.approx(2.2828656428e10, rel=RTOL)
+    assert props.bending_stiffness == pytest.approx(8.428405942e8, rel=RTOL)
+    assert props.torsional_stiffness == pytest.approx(6.518488741e8, rel=RTOL)
+
+
+def test_imperial_thinner_joint_oracle():
+    # Buoyancy joint: OD=21 in, ID=19.25 in, E=30750 ksi, nu=0.293
+    #   EA P8 = 7.567028175e9 ; EI R8 = 2.476251621e8 ; GJ T8 = 1.91512113e8
+    props = section_properties_imperial(21.0, 19.25, 30750.0, 0.293)
+    assert props.axial_stiffness == pytest.approx(7.567028175e9, rel=RTOL)
+    assert props.bending_stiffness == pytest.approx(2.476251621e8, rel=RTOL)
+    assert props.torsional_stiffness == pytest.approx(1.91512113e8, rel=RTOL)
+
+
+def test_consistent_unit_path_agrees_with_helpers():
+    od, idia, e, nu = 0.508, 0.4566, 2.0e11, 0.3
+    p = section_properties(od, idia, e, nu)
+    assert p.area == pytest.approx(cross_sectional_area(od, idia), rel=1e-12)
+    assert p.axial_stiffness == pytest.approx(e * p.area, rel=1e-12)
+    assert p.bending_stiffness == pytest.approx(e * p.moment_of_inertia, rel=1e-12)
+    assert p.torsional_stiffness == pytest.approx(
+        shear_modulus(e, nu) * p.polar_moment, rel=1e-12
+    )

--- a/tests/fatigue/test_sn_endurance.py
+++ b/tests/fatigue/test_sn_endurance.py
@@ -1,0 +1,114 @@
+"""Tests for DNV-RP-C203 closed-form S-N endurance / inverse.
+
+Oracle values are the computed cells of a generic DNV-RP-C203 S-N
+design spreadsheet (in-air "Data(air)" / seawater "Data(Sea water)"
+tables and the curve-C Miner's-rule worksheet). All inputs are generic
+standard quantities — no project- or client-specific data.
+
+Method validated:
+    forward:  log10(N) = log10(a) - m * log10(Δσ)
+    inverse:  Δσ = 10 ** ((log10(a) - log10(N)) / m)
+bi-linear about the knee N_D = 1e7.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.fatigue.sn_endurance import (
+    endurance_cycles,
+    stress_range_at_cycles,
+    thickness_correction,
+)
+
+# --- Oracle: in-air stress range Δσ (MPa) at a given N (cycles) -------
+# Source sheet "Data(air)": first segment (N <= 1e7) and second segment.
+AIR_STRESS_AT_N = {
+    # N : {curve: Δσ}
+    1000.0: {
+        "B1": 1069.6704538393997, "B2": 935.9442919496431,
+        "C": 1575.1914046947927, "C1": 1411.4537979479337,
+        "C2": 1259.8920436675346, "D": 1134.139996909264,
+        "E": 1007.7048141361054, "F": 894.6778113577494,
+        "F1": 793.718799182992, "F3": 705.7756434983849,
+        "G": 629.9895321764905,
+    },
+    1.0e7: {  # knee point -> fatigue limit
+        "B1": 106.97, "B2": 93.59, "C": 73.1, "C1": 65.5, "C2": 58.48,
+        "D": 52.63, "E": 46.78, "F": 41.52, "F1": 36.84, "F3": 32.75,
+        "G": 29.24,
+    },
+    1.0e12: {  # second segment (m2 = 5)
+        "B1": 10.695473105661607, "B2": 9.358365248668006,
+        "C": 7.311390542378577, "C1": 6.549376752971101,
+        "C2": 5.847900373612855, "D": 5.262595094543776,
+        "E": 4.677350851590015, "F": 4.151451219202678,
+        "F1": 3.684681301929866, "F3": 3.2749141660714516,
+        "G": 2.9241517930132117,
+    },
+}
+
+# --- Oracle: seawater-with-CP stress range Δσ (MPa) at given N --------
+# Source sheet "Data(Sea water)" first segment at N = 1000.
+SEAWATER_STRESS_AT_N_1000 = {
+    "B1": 953.344795478314, "B2": 834.1612282410433,
+    "C": 1158.7773561551273, "C1": 1038.3250539880407,
+    "C2": 926.8298233793498, "D": 834.3213041991821,
+    "E": 741.3102413009176, "F": 658.1628021622323,
+    "F1": 583.8930868379755, "F3": 519.1983855258562,
+}
+
+
+class TestInverseStressRangeAtCycles:
+    @pytest.mark.parametrize("N,table", list(AIR_STRESS_AT_N.items()))
+    def test_air_stress_range(self, N, table):
+        for curve, expected in table.items():
+            got = stress_range_at_cycles(N, curve, environment="air")
+            np.testing.assert_allclose(got, expected, rtol=1e-3)
+
+    @pytest.mark.parametrize("curve,expected", list(SEAWATER_STRESS_AT_N_1000.items()))
+    def test_seawater_stress_range_at_1000(self, curve, expected):
+        got = stress_range_at_cycles(1000.0, curve, environment="seawater_cp")
+        np.testing.assert_allclose(got, expected, rtol=1e-3)
+
+    def test_vectorised(self):
+        cycles = np.array([1000.0, 1.0e7, 1.0e12])
+        got = stress_range_at_cycles(cycles, "C", environment="air")
+        expected = [1575.1914046947927, 73.1, 7.311390542378577]
+        np.testing.assert_allclose(got, expected, rtol=1e-3)
+
+
+class TestForwardEnduranceCycles:
+    def test_air_roundtrip_first_segment(self):
+        # Δσ for curve C at N=1000 must map back to ~1000 cycles.
+        s = AIR_STRESS_AT_N[1000.0]["C"]
+        assert endurance_cycles(s, "C", "air") == pytest.approx(1000.0, rel=1e-3)
+
+    def test_air_roundtrip_second_segment(self):
+        # Below the fatigue limit -> second (m2) segment.
+        s = AIR_STRESS_AT_N[1.0e12]["D"]
+        assert endurance_cycles(s, "D", "air") == pytest.approx(1.0e12, rel=1e-2)
+
+    def test_known_curve_c_failure_cycles(self):
+        # Curve-C Miner's worksheet: Δσ ~339.36 MPa -> N ~ 1e5 cycles.
+        assert endurance_cycles(339.3647005714516, "C", "air") == pytest.approx(
+            1.0e5, rel=1e-3
+        )
+
+    def test_zero_stress_infinite_life(self):
+        assert endurance_cycles(0.0, "F", "air") == np.inf
+
+
+class TestThicknessCorrectionReuse:
+    """The DNV thickness rule is reused from fatigue.damage.thickness_correction."""
+
+    def test_above_ref(self):
+        # Generic: F detail, t=30 mm, t_ref=25 mm, k=0.25.
+        s = np.array([100.0])
+        got = thickness_correction(s, t_actual=30.0, t_ref=25.0, k=0.25)
+        expected = 100.0 * (30.0 / 25.0) ** 0.25
+        np.testing.assert_allclose(got, [expected], rtol=1e-10)
+
+    def test_below_ref_no_change(self):
+        s = np.array([100.0, 80.0])
+        got = thickness_correction(s, t_actual=20.0, t_ref=25.0, k=0.25)
+        np.testing.assert_array_equal(got, s)

--- a/tests/hydrostatics/test_fluid_column.py
+++ b/tests/hydrostatics/test_fluid_column.py
@@ -1,0 +1,87 @@
+"""Tests for fluid-column hydrostatics.
+
+Oracle values are the computed cells of a generic "Fluid Column and
+Pressure" design spreadsheet (seabed-pressure worksheet). All inputs
+are generic round numbers — no project- or client-specific data.
+
+Worksheet scenario (generic):
+    density        = 18.0 ppg          -> 2156.875679 kg/m^3
+    water depth    = 10000 ft          -> 3048 m
+    seabed pressure= 20000 psi         -> 137894896.5 Pa
+    surface press. = seabed - rho*g*h  -> 73402415.65 Pa = 10646.13956 psi
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrostatics.fluid_column import (
+    ppg_to_kg_m3,
+    ft_to_m,
+    psi_to_pa,
+    pa_to_psi,
+    bar_to_psi,
+    psi_to_bar,
+    hydrostatic_pressure,
+    seabed_pressure,
+)
+
+
+class TestUnitConversions:
+    def test_ppg_to_kg_m3(self):
+        assert ppg_to_kg_m3(18.0) == pytest.approx(2156.875679, rel=1e-6)
+
+    def test_ft_to_m(self):
+        assert ft_to_m(10000.0) == pytest.approx(3048.0, rel=1e-9)
+
+    def test_psi_to_pa(self):
+        assert psi_to_pa(20000.0) == pytest.approx(137894896.5, rel=1e-6)
+
+    def test_pa_to_psi_roundtrip(self):
+        assert pa_to_psi(137894896.5) == pytest.approx(20000.0, rel=1e-6)
+
+    def test_surface_pressure_pa_to_psi(self):
+        # 73402415.65 Pa -> 10646.13956 psi (worksheet)
+        assert pa_to_psi(73402415.65) == pytest.approx(10646.13956, rel=1e-6)
+
+    def test_bar_psi_roundtrip(self):
+        # 1 bar = 1e5 Pa -> ~14.5038 psi (uses the sheet's psi<->Pa factor,
+        # so it agrees with the literature 14.5037738 to ~1e-5, not exactly).
+        assert bar_to_psi(1.0) == pytest.approx(14.5037738, rel=1e-5)
+        # round-trip must be exact regardless of the constant chosen
+        assert psi_to_bar(bar_to_psi(1.0)) == pytest.approx(1.0, rel=1e-12)
+
+
+class TestHydrostaticPressure:
+    def test_rho_g_h(self):
+        rho = 2156.875679       # kg/m^3 (18 ppg)
+        h = 3048.0              # m (10000 ft)
+        # worksheet: seabed - surface = rho*g*h
+        expected = 137894896.5 - 73402415.65
+        assert hydrostatic_pressure(rho, h, gravity=9.81) == pytest.approx(
+            expected, rel=1e-4
+        )
+
+    def test_vectorised(self):
+        rho = 1025.0
+        h = np.array([0.0, 100.0, 1000.0])
+        got = hydrostatic_pressure(rho, h)
+        expected = rho * 9.81 * h
+        np.testing.assert_allclose(got, expected, rtol=1e-12)
+
+
+class TestSeabedPressure:
+    def test_matches_worksheet(self):
+        # surface + rho*g*h -> seabed pressure (all in Pa)
+        rho = ppg_to_kg_m3(18.0)
+        h = ft_to_m(10000.0)
+        surface_pa = 73402415.65
+        got = seabed_pressure(rho, h, surface_pressure=surface_pa, gravity=9.81)
+        assert got == pytest.approx(137894896.5, rel=1e-4)
+        # and in psi -> 20000 psi
+        assert pa_to_psi(got) == pytest.approx(20000.0, rel=1e-3)
+
+    def test_zero_surface_is_gauge(self):
+        rho, h = 1025.0, 50.0
+        assert seabed_pressure(rho, h) == pytest.approx(
+            hydrostatic_pressure(rho, h), rel=1e-12
+        )

--- a/tests/installation/test_pipelay_integrity.py
+++ b/tests/installation/test_pipelay_integrity.py
@@ -1,0 +1,171 @@
+"""Tests for S-lay pipelay installation integrity calculations.
+
+All expected values are computed by hand from generic round-number inputs and
+the closed-form formulas (no client data used as an oracle).
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.installation.pipelay import (
+    bending_strain_from_radius,
+    concrete_crushing_check,
+    concrete_crushing_strain,
+    displaced_weight_per_length,
+    horizontal_lay_tension,
+    is_weld_repair_acceptable,
+    minimum_route_radius,
+    route_radius_factor_of_safety,
+    submerged_weight_per_length,
+    top_lay_tension,
+    weld_repair_allowable_length,
+)
+from digitalmodel.installation.pipelay.integrity import G_STANDARD
+
+
+# --- 1. Concrete-coating crushing (Verley & Ness limiting strain) -----------
+
+
+def test_bending_strain_from_radius():
+    # eps = (OD/2)/R = (0.5/2)/250 = 0.25/250 = 0.001
+    assert bending_strain_from_radius(0.5, 250.0) == pytest.approx(0.001)
+
+
+def test_bending_strain_invalid_radius():
+    with pytest.raises(ValueError):
+        bending_strain_from_radius(0.5, 0.0)
+
+
+def test_concrete_crushing_strain_scf():
+    # SCF * eps = 2.0 * 0.001 = 0.002
+    assert concrete_crushing_strain(0.001, 2.0) == pytest.approx(0.002)
+
+
+def test_concrete_crushing_strain_invalid_scf():
+    with pytest.raises(ValueError):
+        concrete_crushing_strain(0.001, 0.9)
+
+
+def test_concrete_crushing_check_passes():
+    # OD=0.5, R=250 -> eps_bend=0.001; SCF=1 -> eps_conc=0.001
+    # crush limit 0.002, FoS=1 -> allowable=0.002; util=0.5 -> passes
+    res = concrete_crushing_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        crushing_strain_limit=0.002,
+        strain_concentration_factor=1.0,
+        factor_of_safety=1.0,
+    )
+    assert res.bending_strain == pytest.approx(0.001)
+    assert res.concrete_strain == pytest.approx(0.001)
+    assert res.allowable_strain == pytest.approx(0.002)
+    assert res.utilisation == pytest.approx(0.5)
+    assert res.passes is True
+
+
+def test_concrete_crushing_check_fails_with_fos():
+    # Same geometry but FoS=2 -> allowable=0.001, util=1.0 -> NOT < 1 -> fails
+    res = concrete_crushing_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        crushing_strain_limit=0.002,
+        strain_concentration_factor=1.0,
+        factor_of_safety=2.0,
+    )
+    assert res.allowable_strain == pytest.approx(0.001)
+    assert res.utilisation == pytest.approx(1.0)
+    assert res.passes is False
+
+
+def test_concrete_crushing_check_scf_drives_failure():
+    # SCF=3 -> eps_conc=0.003 > allowable 0.002 -> util=1.5 -> fails
+    res = concrete_crushing_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        crushing_strain_limit=0.002,
+        strain_concentration_factor=3.0,
+    )
+    assert res.concrete_strain == pytest.approx(0.003)
+    assert res.utilisation == pytest.approx(1.5)
+    assert res.passes is False
+
+
+# --- 2. Minimum route / lay radius:  R = F / (S * W) ------------------------
+
+
+def test_minimum_route_radius():
+    # R = F/(S*W) = 100000/(0.5*2000) = 100000/1000 = 100
+    assert minimum_route_radius(100_000.0, 0.5, 2000.0) == pytest.approx(100.0)
+
+
+def test_minimum_route_radius_invalid():
+    with pytest.raises(ValueError):
+        minimum_route_radius(100_000.0, 0.0, 2000.0)
+    with pytest.raises(ValueError):
+        minimum_route_radius(100_000.0, 0.5, 0.0)
+
+
+def test_route_radius_factor_of_safety():
+    # planned 150 / min 100 = 1.5
+    assert route_radius_factor_of_safety(150.0, 100.0) == pytest.approx(1.5)
+
+
+# --- 3. Weld-repair allowable length (DNV-ST-F101 limits) -------------------
+
+
+def test_weld_repair_fraction_governs():
+    # total 1.0 m, partial 30% -> 0.30 m (> 50 mm minimum)
+    assert weld_repair_allowable_length(1.0, 0.30) == pytest.approx(0.30)
+
+
+def test_weld_repair_minimum_governs():
+    # total 0.1 m, full 20% -> 0.02 m < 50 mm minimum -> floor at 0.05
+    assert weld_repair_allowable_length(0.1, 0.20) == pytest.approx(0.05)
+
+
+def test_weld_repair_invalid_fraction():
+    with pytest.raises(ValueError):
+        weld_repair_allowable_length(1.0, 0.0)
+    with pytest.raises(ValueError):
+        weld_repair_allowable_length(1.0, 1.5)
+
+
+def test_is_weld_repair_acceptable():
+    # total 1.0, fraction 0.30 -> limit 0.30, min 0.05
+    assert is_weld_repair_acceptable(0.20, 1.0, 0.30) is True  # within band
+    assert is_weld_repair_acceptable(0.40, 1.0, 0.30) is False  # over fractional
+    assert is_weld_repair_acceptable(0.04, 1.0, 0.30) is False  # under minimum
+
+
+# --- 4. S-lay submerged weight and lay tension ------------------------------
+
+
+def test_displaced_weight_per_length():
+    # b = rho*g*(pi/4)*OD^2 = 1025*9.80665*(pi/4)*0.5^2
+    expected = 1025.0 * G_STANDARD * (math.pi / 4.0) * 0.5**2
+    assert displaced_weight_per_length(0.5, 1025.0) == pytest.approx(expected)
+    # sanity: ~1973.7 N/m
+    assert displaced_weight_per_length(0.5, 1025.0) == pytest.approx(1973.67, abs=0.5)
+
+
+def test_submerged_weight_per_length():
+    # w_sub = w_dry - buoyancy = 3000 - rho*g*(pi/4)*OD^2
+    buoyancy = 1025.0 * G_STANDARD * (math.pi / 4.0) * 0.5**2
+    expected = 3000.0 - buoyancy
+    assert submerged_weight_per_length(3000.0, 0.5, 1025.0) == pytest.approx(expected)
+
+
+def test_horizontal_lay_tension():
+    # H = w_sub * R = 1000 * 300 = 300000
+    assert horizontal_lay_tension(1000.0, 300.0) == pytest.approx(300_000.0)
+
+
+def test_top_lay_tension():
+    # T_top = H + w_sub*d = 1000*300 + 1000*100 = 300000 + 100000 = 400000
+    assert top_lay_tension(1000.0, 100.0, 300.0) == pytest.approx(400_000.0)
+
+
+def test_top_lay_tension_equals_wsub_times_R_plus_d():
+    w_sub, d, r = 1500.0, 80.0, 220.0
+    assert top_lay_tension(w_sub, d, r) == pytest.approx(w_sub * (r + d))

--- a/tests/installation/test_pipelay_stress.py
+++ b/tests/installation/test_pipelay_stress.py
@@ -1,0 +1,150 @@
+"""Tests for over/sagbend longitudinal-stress (%SMYS) acceptance checks.
+
+All expected values are computed by hand from generic round-number inputs and
+the closed-form formulas (no client data used as an oracle).
+"""
+
+import pytest
+
+from digitalmodel.installation.pipelay import (
+    SmysCheck,
+    allowable_bend_radius,
+    axial_stress,
+    bending_stress_from_radius,
+    smys_stress_check,
+)
+from digitalmodel.installation.pipelay.stress import (
+    DEFAULT_OVERBEND_FRACTION,
+    DEFAULT_SAGBEND_FRACTION,
+)
+
+
+# --- bending stress from radius ---------------------------------------------
+
+
+def test_bending_stress_from_radius():
+    # sigma = E * (OD/2) / R = 200000 * (0.5/2) / 250 = 200000 * 0.001 = 200.0
+    assert bending_stress_from_radius(0.5, 250.0, 200000.0) == pytest.approx(200.0)
+
+
+def test_bending_stress_invalid_radius():
+    with pytest.raises(ValueError):
+        bending_stress_from_radius(0.5, 0.0, 200000.0)
+
+
+# --- axial stress -----------------------------------------------------------
+
+
+def test_axial_stress():
+    # sigma = N / A = 1000 / 0.01 = 100000
+    assert axial_stress(1000.0, 0.01) == pytest.approx(100000.0)
+
+
+def test_axial_stress_invalid_area():
+    with pytest.raises(ValueError):
+        axial_stress(1000.0, 0.0)
+
+
+# --- %SMYS acceptance check -------------------------------------------------
+
+
+def test_smys_check_pure_bending_passes():
+    # sigma_bend = 200000 * (0.5/2) / 250 = 200.0
+    # allowable = 0.85 * 450 = 382.5 ; 200 <= 382.5 -> pass
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_OVERBEND_FRACTION,
+    )
+    assert isinstance(res, SmysCheck)
+    assert res.longitudinal_stress == pytest.approx(200.0)
+    assert res.allowable_stress == pytest.approx(382.5)
+    assert res.utilisation == pytest.approx(200.0 / 382.5)
+    assert res.percent_smys == pytest.approx(200.0 / 450.0 * 100.0)
+    assert res.passes is True
+
+
+def test_smys_check_with_axial_term():
+    # sigma_bend = 200000 * (0.5/2) / 250 = 200.0
+    # sigma_axial = 50000 / 0.01 = 5_000_000?  -> use consistent N, m^2, MPa? keep generic
+    # Use stress units directly: axial_force in (stress*area) consistent set.
+    # N = 3000 (force), A = 0.02 -> sigma_axial = 150000 ... too large.
+    # Choose so total is round: sigma_axial = N/A = 1.0/0.02 = 50.0
+    # total = 50 + 200 = 250.0 ; allowable = 0.72 * 450 = 324.0 ; pass
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_SAGBEND_FRACTION,
+        axial_force=1.0,
+        steel_area=0.02,
+    )
+    assert res.longitudinal_stress == pytest.approx(250.0)
+    assert res.allowable_stress == pytest.approx(324.0)
+    assert res.passes is True
+
+
+def test_smys_check_fails_when_overstressed():
+    # sigma_bend = 200000 * (0.5/2) / 100 = 500.0 ; allowable = 0.85*450 = 382.5 -> fail
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=100.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_OVERBEND_FRACTION,
+    )
+    assert res.longitudinal_stress == pytest.approx(500.0)
+    assert res.utilisation > 1.0
+    assert res.passes is False
+
+
+def test_smys_check_axial_requires_area():
+    with pytest.raises(ValueError):
+        smys_stress_check(
+            outer_diameter=0.5,
+            bend_radius=250.0,
+            youngs_modulus=200000.0,
+            smys=450.0,
+            allowable_fraction=0.85,
+            axial_force=1.0,
+        )
+
+
+def test_smys_check_invalid_fraction():
+    with pytest.raises(ValueError):
+        smys_stress_check(0.5, 250.0, 200000.0, 450.0, 0.0)
+
+
+def test_smys_check_invalid_smys():
+    with pytest.raises(ValueError):
+        smys_stress_check(0.5, 250.0, 200000.0, 0.0, 0.85)
+
+
+def test_default_fractions():
+    assert DEFAULT_OVERBEND_FRACTION == 0.85
+    assert DEFAULT_SAGBEND_FRACTION == 0.72
+
+
+# --- minimum admissible bend radius -----------------------------------------
+
+
+def test_allowable_bend_radius():
+    # R_min = E*(OD/2)/(f*SMYS) = 200000*(0.5/2)/(0.85*450)
+    #       = 200000*0.25/382.5 = 50000/382.5
+    expected = 200000.0 * 0.25 / (0.85 * 450.0)
+    assert allowable_bend_radius(0.5, 200000.0, 450.0, 0.85) == pytest.approx(expected)
+
+
+def test_allowable_bend_radius_consistent_with_check():
+    # At exactly R_min, pure-bending stress equals allowable -> utilisation ~ 1.
+    r_min = allowable_bend_radius(0.5, 200000.0, 450.0, 0.85)
+    res = smys_stress_check(0.5, r_min, 200000.0, 450.0, 0.85)
+    assert res.utilisation == pytest.approx(1.0)
+
+
+def test_allowable_bend_radius_invalid():
+    with pytest.raises(ValueError):
+        allowable_bend_radius(0.5, 200000.0, 450.0, 1.5)


### PR DESCRIPTION
## DNV-OS-F101 pipeline checks + S-lay %SMYS (epic llm-wiki#767, #779)

Continues the corpus calculator port (follows the merged 8-calculator PR #970). Adds de-identified, generic standard-based methods:
- `code_checks/dnv_os_f101.py` — plastic axial/moment capacities, pressure-containment resistance, **local-buckling load-controlled combined-loading UF**, **collapse pressure** (solves the DNV collapse cubic), **propagation-buckling** pressure + check.
- `installation/pipelay/stress.py` — **overbend/sagbend %SMYS** outer-fibre check (0.85/0.72 allowables as params) + minimum admissible bend radius.

**31 new tests pass** (`uv run pytest`), hand-computed generic oracles (collapse cubic verified against the implicit DNV equation, residual ~1e-12). No client/project content (de-id grep clean).
