### PR TITLE
feat(calcs): DNV-OS-F101 local-buckling/collapse + S-lay %SMYS checks (epic llm-wiki#767)

### DIFF
--- a/src/digitalmodel/code_checks/dnv_os_f101.py
+++ b/src/digitalmodel/code_checks/dnv_os_f101.py
@@ -1,0 +1,360 @@
+"""DNV-OS-F101 pipe local-buckling and external-pressure resistance checks.
+
+Generic, standard-based screening calculations for a submarine pipeline per
+DNV-OS-F101 (Submarine Pipeline Systems). Three methods are implemented:
+
+1. **Local-buckling — load-controlled condition (LCC)** combined-loading
+   utilisation for bending moment + effective tension + net internal/external
+   pressure (the installation/operation feasibility check; UF < 1 passes).
+2. **External-pressure collapse** characteristic resistance Pc — the real root
+   of the DNV collapse cubic that blends elastic and plastic (yield) collapse
+   with the initial ovality.
+3. **Propagation-buckling** pressure Pprop and the propagation-arrest /
+   initiation check.
+
+All functions are unit-consistent: pass diameters/thicknesses, stresses and
+pressures in the same unit system (e.g. mm / MPa / MPa, giving moments in
+N.mm and forces in N when areas are mm^2). No internal unit conversion is done.
+
+References
+----------
+- DNV-OS-F101 (2013), Sec.5 D — Local buckling:
+    * Load-controlled (Sec.5 D404/D405) combined-loading criteria.
+    * External-pressure collapse Pc (Sec.5 D401, the collapse cubic).
+    * Propagation buckling Pprop (Sec.5 D501).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+SQRT3 = math.sqrt(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Plastic capacities (used by the load-controlled combined-loading check)
+# ---------------------------------------------------------------------------
+
+
+def plastic_axial_capacity(diameter: float, t: float, f_y: float) -> float:
+    """Plastic axial-force capacity ``Sp = fy * pi * (D - t) * t`` [force]."""
+    return f_y * math.pi * (diameter - t) * t
+
+
+def plastic_moment_capacity(diameter: float, t: float, f_y: float) -> float:
+    """Plastic moment capacity ``Mp = fy * (D - t)^2 * t`` [moment]."""
+    return f_y * (diameter - t) ** 2 * t
+
+
+def pressure_containment_resistance(diameter: float, t: float, f_y: float, f_u: float) -> float:
+    """Burst (pressure-containment) resistance ``Pb = (2 t / (D - t)) * fcb * 2/sqrt(3)``.
+
+    Uses ``fcb = min(fy, fu / 1.15)`` as the characteristic strength.
+    """
+    fcb = min(f_y, f_u / 1.15)
+    return (2.0 * t / (diameter - t)) * fcb * (2.0 / SQRT3)
+
+
+# ---------------------------------------------------------------------------
+# 1. Local buckling — load-controlled condition (LCC) combined loading
+# ---------------------------------------------------------------------------
+#
+# DNV-OS-F101 Sec.5 D combined-loading criterion. With characteristic plastic
+# capacities Sp (axial) and Mp (moment) and pressure-containment Pb, the
+# load-controlled utilisation for the two net-pressure regimes is:
+#
+# INTERNAL net overpressure (pi > pe):
+#   UF = { gamma_m*gamma_SC*(|Md|/Mp) + [(gamma_m*gamma_SC*Sd)/Sp]^2 }^2
+#        + [ gamma_m*gamma_SC*(pi - pe)/Pb ]^2
+#
+# EXTERNAL net overpressure (pe > pi):
+#   UF = { gamma_m*gamma_SC*(|Md|/Mp) + [(gamma_m*gamma_SC*Sd)/Sp]^2 }^2
+#        + [ gamma_m*gamma_SC*(pe - pmin)/Pc ]^2
+#
+# UF <= 1 passes (the bracketed "moment + tension" group is squared, the
+# pressure group is added in quadrature). gamma_m and gamma_SC are the material
+# and safety-class resistance factors; the load effects Md, Sd are factored
+# design values supplied by the caller.
+
+
+@dataclass(frozen=True)
+class LocalBucklingResult:
+    """Result of a DNV-OS-F101 local-buckling load-controlled check."""
+
+    utilisation: float  # combined-loading utilisation factor (UF)
+    passes: bool  # True if UF <= 1.0
+
+
+def local_buckling_lcc(
+    design_moment: float,
+    design_effective_tension: float,
+    pressure_internal: float,
+    pressure_external: float,
+    moment_capacity: float,
+    axial_capacity: float,
+    pressure_capacity: float,
+    gamma_m: float = 1.15,
+    gamma_sc: float = 1.14,
+) -> LocalBucklingResult:
+    """DNV-OS-F101 local-buckling, load-controlled combined-loading utilisation.
+
+    Parameters
+    ----------
+    design_moment : float
+        Design bending moment Md (factored) [moment].
+    design_effective_tension : float
+        Design effective (axial) tension Sd (factored) [force].
+    pressure_internal : float
+        Internal pressure pi [pressure].
+    pressure_external : float
+        External pressure pe [pressure]. For the external-pressure regime this
+        is the (collapse) pressure acting; ``pressure_capacity`` should then be
+        the collapse resistance Pc. For the internal regime it is the minimum
+        internal pressure pmin / external pressure, and ``pressure_capacity``
+        should be the burst resistance Pb.
+    moment_capacity : float
+        Plastic moment capacity Mp [moment].
+    axial_capacity : float
+        Plastic axial capacity Sp [force].
+    pressure_capacity : float
+        Pressure resistance — burst Pb for the internal regime, collapse Pc for
+        the external regime [pressure].
+    gamma_m : float, optional
+        Material resistance factor. Default 1.15 (ULS).
+    gamma_sc : float, optional
+        Safety-class resistance factor. Default 1.14 (normal safety class).
+
+    Returns
+    -------
+    LocalBucklingResult
+        Combined-loading utilisation and pass/fail flag.
+    """
+    if moment_capacity <= 0.0 or axial_capacity <= 0.0 or pressure_capacity <= 0.0:
+        raise ValueError("capacities must be positive")
+
+    g = gamma_m * gamma_sc
+    moment_term = g * abs(design_moment) / moment_capacity
+    tension_term = (g * design_effective_tension / axial_capacity) ** 2
+    group = (moment_term + tension_term) ** 2
+
+    net = pressure_internal - pressure_external
+    pressure_term = (g * abs(net) / pressure_capacity) ** 2
+
+    uf = group + pressure_term
+    return LocalBucklingResult(utilisation=uf, passes=uf <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. External-pressure collapse (the DNV collapse cubic)
+# ---------------------------------------------------------------------------
+#
+# Elastic collapse pressure (thin-shell):
+#       Pel = 2 E (t/D)^3 / (1 - nu^2)
+# Plastic (yield) collapse pressure:
+#       Pp  = fy * alpha_fab * 2 (t/D)
+# Characteristic collapse resistance Pc is the solution of the implicit cubic:
+#       (Pc - Pel)(Pc^2 - Pp^2) = Pc * Pel * Pp * f0 * D / t
+# with initial ovality f0 = (Dmax - Dmin)/D (>= 0.005 per code minimum).
+# Pc is taken as the relevant (smallest positive) real root.
+
+
+def elastic_collapse_pressure(
+    diameter: float, t: float, youngs_modulus: float, poisson_ratio: float = 0.3
+) -> float:
+    """Elastic (thin-shell) collapse pressure ``Pel = 2 E (t/D)^3 / (1 - nu^2)``."""
+    return 2.0 * youngs_modulus * (t / diameter) ** 3 / (1.0 - poisson_ratio**2)
+
+
+def plastic_collapse_pressure(
+    diameter: float, t: float, f_y: float, alpha_fab: float = 1.0
+) -> float:
+    """Plastic (yield) collapse pressure ``Pp = fy * alpha_fab * 2 (t/D)``.
+
+    ``alpha_fab`` is the fabrication (manufacturing-process) factor (1.0 for
+    seamless, < 1 for welded; supplied by the caller).
+    """
+    return f_y * alpha_fab * 2.0 * (t / diameter)
+
+
+def collapse_pressure(
+    diameter: float,
+    t: float,
+    f_y: float,
+    youngs_modulus: float,
+    ovality: float = 0.005,
+    poisson_ratio: float = 0.3,
+    alpha_fab: float = 1.0,
+) -> float:
+    """DNV-OS-F101 characteristic external-pressure collapse resistance Pc.
+
+    Solves the collapse cubic
+
+        (Pc - Pel)(Pc^2 - Pp^2) = Pc * Pel * Pp * f0 * (D / t)
+
+    for the smallest positive real root (the governing collapse pressure).
+
+    Parameters
+    ----------
+    diameter : float
+        Outer diameter D [length].
+    t : float
+        Wall thickness (characteristic / t1) [length].
+    f_y : float
+        Yield strength [stress].
+    youngs_modulus : float
+        Young's modulus [stress].
+    ovality : float, optional
+        Initial ovality f0 = (Dmax - Dmin)/D. Default 0.005 (code minimum).
+    poisson_ratio : float, optional
+        Poisson's ratio. Default 0.3.
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+
+    Returns
+    -------
+    float
+        Characteristic collapse resistance Pc [pressure].
+    """
+    if ovality < 0.005:
+        ovality = 0.005  # DNV code minimum imperfection
+
+    pel = elastic_collapse_pressure(diameter, t, youngs_modulus, poisson_ratio)
+    pp = plastic_collapse_pressure(diameter, t, f_y, alpha_fab)
+
+    # Expand to a monic cubic in Pc:
+    #   Pc^3 - Pel*Pc^2 - (Pp^2 + Pp*Pel*f0*D/t)*Pc + Pel*Pp^2 = 0
+    b = -pel
+    c = -(pp**2 + pp * pel * ovality * diameter / t)
+    d = pel * pp**2
+
+    roots = _real_cubic_roots(1.0, b, c, d)
+    positive = [r for r in roots if r > 0.0]
+    if not positive:
+        raise ValueError("no positive real root for the collapse cubic")
+    return min(positive)
+
+
+def _real_cubic_roots(a: float, b: float, c: float, d: float) -> list[float]:
+    """Real roots of ``a x^3 + b x^2 + c x + d = 0`` (a != 0).
+
+    Uses the depressed-cubic / trigonometric method; returns only real roots.
+    """
+    if a == 0.0:
+        raise ValueError("not a cubic: a must be non-zero")
+    # Normalise: x^3 + p2 x^2 + p1 x + p0
+    p2 = b / a
+    p1 = c / a
+    p0 = d / a
+    # Depress: x = y - p2/3 -> y^3 + p*y + q = 0
+    shift = p2 / 3.0
+    p = p1 - p2**2 / 3.0
+    q = 2.0 * p2**3 / 27.0 - p2 * p1 / 3.0 + p0
+
+    disc = (q / 2.0) ** 2 + (p / 3.0) ** 3
+    roots: list[float] = []
+    if disc > 0.0:
+        # one real root
+        sqrt_disc = math.sqrt(disc)
+        u = math.cbrt(-q / 2.0 + sqrt_disc)
+        v = math.cbrt(-q / 2.0 - sqrt_disc)
+        roots.append(u + v - shift)
+    else:
+        # three real roots (trig method); handle p ~ 0 degenerate case
+        if abs(p) < 1e-300:
+            roots.append(math.cbrt(-q) - shift)
+        else:
+            r = math.sqrt(-(p**3) / 27.0)
+            cos_arg = max(-1.0, min(1.0, -q / (2.0 * r)))
+            phi = math.acos(cos_arg)
+            m = 2.0 * math.sqrt(-p / 3.0)
+            for k in range(3):
+                roots.append(m * math.cos((phi + 2.0 * math.pi * k) / 3.0) - shift)
+    return roots
+
+
+# ---------------------------------------------------------------------------
+# 3. Propagation buckling
+# ---------------------------------------------------------------------------
+#
+# Once a local buckle forms, it can propagate along the line if the external
+# overpressure exceeds the propagation pressure:
+#       Ppr = 35 * fy * alpha_fab * (t/D)^2.5      (DNV-OS-F101 Sec.5 D501)
+# Acceptance against propagation (no buckle arrestors): pe - pmin <= Ppr / gamma.
+
+
+def propagation_pressure(
+    diameter: float, t: float, f_y: float, alpha_fab: float = 1.0
+) -> float:
+    """Propagation-buckling pressure ``Ppr = 35 * fy * alpha_fab * (t/D)^2.5``.
+
+    Parameters
+    ----------
+    diameter : float
+        Outer diameter D [length].
+    t : float
+        Wall thickness [length].
+    f_y : float
+        Yield strength [stress].
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+
+    Returns
+    -------
+    float
+        Propagation-buckling pressure [pressure].
+    """
+    return 35.0 * f_y * alpha_fab * (t / diameter) ** 2.5
+
+
+@dataclass(frozen=True)
+class PropagationCheck:
+    """Result of a propagation-buckling acceptance check."""
+
+    net_external_pressure: float  # pe - pmin [pressure]
+    propagation_resistance: float  # Ppr / gamma [pressure]
+    utilisation: float  # net / resistance [-]
+    propagates: bool  # True if a buckle would propagate (utilisation > 1)
+
+
+def propagation_check(
+    net_external_pressure: float,
+    diameter: float,
+    t: float,
+    f_y: float,
+    alpha_fab: float = 1.0,
+    gamma_m: float = 1.15,
+    gamma_sc: float = 1.14,
+) -> PropagationCheck:
+    """Check net external overpressure against the propagation resistance.
+
+    A buckle propagates if ``(pe - pmin) > Ppr / (gamma_m * gamma_SC)``. When it
+    would propagate, buckle arrestors (or a thicker wall) are required.
+
+    Parameters
+    ----------
+    net_external_pressure : float
+        Net external overpressure pe - pmin [pressure].
+    diameter, t, f_y : float
+        Outer diameter, wall thickness and yield strength.
+    alpha_fab : float, optional
+        Fabrication factor. Default 1.0.
+    gamma_m, gamma_sc : float, optional
+        Material and safety-class resistance factors. Defaults 1.15 / 1.14.
+
+    Returns
+    -------
+    PropagationCheck
+        Net pressure, factored resistance, utilisation and propagate flag.
+    """
+    ppr = propagation_pressure(diameter, t, f_y, alpha_fab)
+    resistance = ppr / (gamma_m * gamma_sc)
+    if resistance <= 0.0:
+        raise ValueError("propagation resistance must be positive")
+    util = net_external_pressure / resistance
+    return PropagationCheck(
+        net_external_pressure=net_external_pressure,
+        propagation_resistance=resistance,
+        utilisation=util,
+        propagates=util > 1.0,
+    )

--- a/src/digitalmodel/installation/pipelay/__init__.py
+++ b/src/digitalmodel/installation/pipelay/__init__.py
@@ -20,10 +20,21 @@ from digitalmodel.installation.pipelay.integrity import (
     top_lay_tension,
     weld_repair_allowable_length,
 )
+from digitalmodel.installation.pipelay.stress import (
+    SmysCheck,
+    allowable_bend_radius,
+    axial_stress,
+    bending_stress_from_radius,
+    smys_stress_check,
+)
 
 __all__ = [
     "CrushingCheck",
+    "SmysCheck",
+    "allowable_bend_radius",
+    "axial_stress",
     "bending_strain_from_radius",
+    "bending_stress_from_radius",
     "concrete_crushing_check",
     "concrete_crushing_strain",
     "displaced_weight_per_length",
@@ -31,6 +42,7 @@ __all__ = [
     "is_weld_repair_acceptable",
     "minimum_route_radius",
     "route_radius_factor_of_safety",
+    "smys_stress_check",
     "submerged_weight_per_length",
     "top_lay_tension",
     "weld_repair_allowable_length",

--- a/src/digitalmodel/installation/pipelay/stress.py
+++ b/src/digitalmodel/installation/pipelay/stress.py
@@ -1,0 +1,196 @@
+"""Overbend / sagbend longitudinal-stress (%SMYS) acceptance check for S-lay.
+
+Generic, method-based screening check used during conventional S-lay pipeline
+installation. In S-lay the pipe forms two high-curvature zones — the supported
+**overbend** over the stinger and the unsupported **sagbend** suspended span.
+The outer-fibre longitudinal stress (or, equivalently, strain) in each zone is
+checked against an allowable expressed as a percentage of the steel's Specified
+Minimum Yield Strength (SMYS).
+
+The outer-fibre longitudinal stress combines the axial (membrane) stress from
+effective/wall tension and the bending stress from curvature:
+
+    sigma_axial = N / A
+    sigma_bend  = E * (OD / 2) / R          (= E * curvature * neutral-axis dist)
+    sigma_long  = sigma_axial + sigma_bend
+
+The acceptance criterion is
+
+    sigma_long <= allowable_fraction * SMYS
+
+with typical allowable fractions of 85% in the overbend and 72% in the sagbend
+(exposed as parameters here so any project's acceptance values can be supplied).
+
+A pure-bending strain form is also provided for the strain-based screening that
+some methods use:
+
+    eps_bend = (OD / 2) / R
+    eps_long <= (allowable_fraction * SMYS) / E
+
+All functions are unit-consistent: pass E, SMYS and the resulting stresses in
+the same unit system (e.g. MPa with N in newtons and A in m^2, or psi with N in
+lbf and A in in^2). No internal unit conversion is performed.
+
+References
+----------
+- DNV-ST-F101 / DNV-OS-F101 — Submarine Pipeline Systems (installation
+  longitudinal-stress %SMYS acceptance in the over/sagbend).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Common installation %SMYS acceptance values (fractions, not percentages).
+DEFAULT_OVERBEND_FRACTION: float = 0.85
+DEFAULT_SAGBEND_FRACTION: float = 0.72
+
+
+def bending_stress_from_radius(
+    outer_diameter: float, bend_radius: float, youngs_modulus: float
+) -> float:
+    """Outer-fibre longitudinal bending stress of a tube bent to a radius.
+
+    ``sigma = E * (OD / 2) / R`` — Young's modulus times the outer-fibre
+    bending strain (neutral-axis-to-fibre distance times the curvature ``1/R``).
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Outer diameter of the steel pipe [length].
+    bend_radius : float
+        Radius of curvature of the bent pipe [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+
+    Returns
+    -------
+    float
+        Outer-fibre bending stress [stress].
+    """
+    if bend_radius <= 0.0:
+        raise ValueError("bend_radius must be positive")
+    return youngs_modulus * (outer_diameter / 2.0) / bend_radius
+
+
+def axial_stress(axial_force: float, steel_area: float) -> float:
+    """Membrane (axial) stress ``sigma = N / A``.
+
+    Parameters
+    ----------
+    axial_force : float
+        Wall (axial) force carried by the steel cross-section [force].
+    steel_area : float
+        Steel cross-sectional area [length^2].
+    """
+    if steel_area <= 0.0:
+        raise ValueError("steel_area must be positive")
+    return axial_force / steel_area
+
+
+@dataclass(frozen=True)
+class SmysCheck:
+    """Result of an over/sagbend longitudinal-stress %SMYS acceptance check."""
+
+    longitudinal_stress: float  # combined outer-fibre longitudinal stress [stress]
+    allowable_stress: float  # allowable_fraction * SMYS [stress]
+    utilisation: float  # longitudinal_stress / allowable_stress [-]
+    percent_smys: float  # longitudinal_stress / SMYS * 100 [%]
+    passes: bool  # True if longitudinal_stress <= allowable_stress
+
+
+def smys_stress_check(
+    outer_diameter: float,
+    bend_radius: float,
+    youngs_modulus: float,
+    smys: float,
+    allowable_fraction: float,
+    axial_force: float = 0.0,
+    steel_area: float | None = None,
+) -> SmysCheck:
+    """Longitudinal-stress %SMYS acceptance check for an over/sagbend section.
+
+    Combines the outer-fibre bending stress from the section curvature with an
+    optional axial (membrane) stress, and compares the total against
+    ``allowable_fraction * SMYS``.
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Steel-pipe outer diameter [length].
+    bend_radius : float
+        Radius of curvature of the section (overbend or sagbend) [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+    smys : float
+        Specified minimum yield strength [stress].
+    allowable_fraction : float
+        Allowable longitudinal stress as a fraction of SMYS (e.g. 0.85 overbend,
+        0.72 sagbend). Must be in (0, 1].
+    axial_force : float, optional
+        Wall (axial) force carried by the steel section [force]. Default 0.
+    steel_area : float, optional
+        Steel cross-sectional area [length^2]. Required only when
+        ``axial_force`` is non-zero.
+
+    Returns
+    -------
+    SmysCheck
+        Combined stress, allowable, utilisation, %SMYS and pass/fail flag.
+    """
+    if not 0.0 < allowable_fraction <= 1.0:
+        raise ValueError("allowable_fraction must be in (0, 1]")
+    if smys <= 0.0:
+        raise ValueError("smys must be positive")
+
+    sigma_bend = bending_stress_from_radius(outer_diameter, bend_radius, youngs_modulus)
+    sigma_axial = 0.0
+    if axial_force != 0.0:
+        if steel_area is None:
+            raise ValueError("steel_area is required when axial_force is non-zero")
+        sigma_axial = axial_stress(axial_force, steel_area)
+
+    sigma_long = sigma_axial + sigma_bend
+    allowable = allowable_fraction * smys
+    return SmysCheck(
+        longitudinal_stress=sigma_long,
+        allowable_stress=allowable,
+        utilisation=sigma_long / allowable,
+        percent_smys=sigma_long / smys * 100.0,
+        passes=sigma_long <= allowable,
+    )
+
+
+def allowable_bend_radius(
+    outer_diameter: float,
+    youngs_modulus: float,
+    smys: float,
+    allowable_fraction: float,
+) -> float:
+    """Minimum bend radius for pure bending to stay within ``f * SMYS``.
+
+    Solving ``E * (OD/2) / R <= f * SMYS`` for R gives the smallest admissible
+    radius ``R_min = E * (OD/2) / (f * SMYS)``. (Axial stress not included; this
+    is the pure-bending screening radius.)
+
+    Parameters
+    ----------
+    outer_diameter : float
+        Steel-pipe outer diameter [length].
+    youngs_modulus : float
+        Young's modulus of the steel [stress].
+    smys : float
+        Specified minimum yield strength [stress].
+    allowable_fraction : float
+        Allowable bending stress as a fraction of SMYS. Must be in (0, 1].
+
+    Returns
+    -------
+    float
+        Minimum admissible bend radius [length].
+    """
+    if not 0.0 < allowable_fraction <= 1.0:
+        raise ValueError("allowable_fraction must be in (0, 1]")
+    if smys <= 0.0:
+        raise ValueError("smys must be positive")
+    return youngs_modulus * (outer_diameter / 2.0) / (allowable_fraction * smys)

--- a/tests/code_checks/test_dnv_os_f101.py
+++ b/tests/code_checks/test_dnv_os_f101.py
@@ -1,0 +1,229 @@
+"""Tests for DNV-OS-F101 local-buckling and external-pressure checks.
+
+Expected values are computed by hand from the closed-form formulas with generic
+round-number inputs (no client data used as an oracle). The collapse-cubic root
+is verified against the implicit DNV equation it must satisfy, not against any
+project result.
+
+A consistent unit set is used throughout: length in mm, stress/pressure in MPa,
+force in N (= MPa * mm^2), moment in N.mm (= MPa * mm^3).
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.code_checks.dnv_os_f101 import (
+    LocalBucklingResult,
+    PropagationCheck,
+    collapse_pressure,
+    elastic_collapse_pressure,
+    local_buckling_lcc,
+    plastic_axial_capacity,
+    plastic_collapse_pressure,
+    plastic_moment_capacity,
+    pressure_containment_resistance,
+    propagation_check,
+    propagation_pressure,
+)
+
+
+# --- plastic capacities -----------------------------------------------------
+
+
+def test_plastic_axial_capacity():
+    # Sp = fy * pi * (D - t) * t = 450 * pi * (500-20) * 20 = 450*pi*9600
+    assert plastic_axial_capacity(500.0, 20.0, 450.0) == pytest.approx(
+        450.0 * math.pi * 480.0 * 20.0
+    )
+
+
+def test_plastic_moment_capacity():
+    # Mp = fy * (D - t)^2 * t = 450 * 480^2 * 20 = 450 * 230400 * 20
+    assert plastic_moment_capacity(500.0, 20.0, 450.0) == pytest.approx(
+        450.0 * 480.0**2 * 20.0
+    )
+
+
+def test_pressure_containment_resistance():
+    # fcb = min(450, 535/1.15) = min(450, 465.2..) = 450
+    # Pb = (2*20/480) * 450 * 2/sqrt(3)
+    fcb = min(450.0, 535.0 / 1.15)
+    expected = (2.0 * 20.0 / 480.0) * fcb * (2.0 / math.sqrt(3.0))
+    assert pressure_containment_resistance(500.0, 20.0, 450.0, 535.0) == pytest.approx(
+        expected
+    )
+    assert fcb == 450.0  # yield governs here
+
+
+# --- local buckling (LCC) ---------------------------------------------------
+
+
+def test_local_buckling_zero_load_passes():
+    res = local_buckling_lcc(
+        design_moment=0.0,
+        design_effective_tension=0.0,
+        pressure_internal=10.0,
+        pressure_external=10.0,
+        moment_capacity=1.0e9,
+        axial_capacity=1.0e7,
+        pressure_capacity=30.0,
+    )
+    assert isinstance(res, LocalBucklingResult)
+    assert res.utilisation == pytest.approx(0.0)
+    assert res.passes is True
+
+
+def test_local_buckling_pure_pressure_term():
+    # No moment/tension; net = pe - pi = 20 - 5 = 15 external.
+    # g = 1.0 * 1.0 = 1.0 ; pressure_term = (1 * 15 / 30)^2 = 0.25
+    res = local_buckling_lcc(
+        design_moment=0.0,
+        design_effective_tension=0.0,
+        pressure_internal=5.0,
+        pressure_external=20.0,
+        moment_capacity=1.0e9,
+        axial_capacity=1.0e7,
+        pressure_capacity=30.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(0.25)
+    assert res.passes is True
+
+
+def test_local_buckling_combined_handcalc():
+    # Choose round capacities so terms are exact.
+    # g = 1.0 ; Md/Mp = 100/200 = 0.5 ; (Sd/Sp)^2 = (30/100)^2 = 0.09
+    # group = (0.5 + 0.09)^2 = 0.59^2 = 0.3481
+    # net = pi - pe = 25 - 5 = 20 ; (20/40)^2 = 0.25
+    # UF = 0.3481 + 0.25 = 0.5981
+    res = local_buckling_lcc(
+        design_moment=100.0,
+        design_effective_tension=30.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(0.5981)
+    assert res.passes is True
+
+
+def test_local_buckling_fails():
+    # g = 1.0 ; Md/Mp = 1.0 ; tension 0 ; group = 1.0 ; pressure (20/40)^2=0.25
+    # UF = 1.25 > 1 -> fail
+    res = local_buckling_lcc(
+        design_moment=200.0,
+        design_effective_tension=0.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+        gamma_m=1.0,
+        gamma_sc=1.0,
+    )
+    assert res.utilisation == pytest.approx(1.25)
+    assert res.passes is False
+
+
+def test_local_buckling_safety_factors_applied():
+    # g = 1.15 * 1.14 = 1.311
+    # moment_term = 1.311 * 100/200 = 0.6555
+    # tension_term = (1.311 * 30/100)^2 = (0.3933)^2 = 0.15468489
+    # group = (0.6555 + 0.15468489)^2
+    # pressure_term = (1.311 * 20/40)^2 = (0.6555)^2 = 0.42968025
+    g = 1.15 * 1.14
+    group = (g * 0.5 + (g * 0.3) ** 2) ** 2
+    pterm = (g * 0.5) ** 2
+    res = local_buckling_lcc(
+        design_moment=100.0,
+        design_effective_tension=30.0,
+        pressure_internal=25.0,
+        pressure_external=5.0,
+        moment_capacity=200.0,
+        axial_capacity=100.0,
+        pressure_capacity=40.0,
+    )
+    assert res.utilisation == pytest.approx(group + pterm)
+
+
+def test_local_buckling_invalid_capacity():
+    with pytest.raises(ValueError):
+        local_buckling_lcc(0.0, 0.0, 0.0, 0.0, -1.0, 1.0, 1.0)
+
+
+# --- external-pressure collapse --------------------------------------------
+
+# Reference geometry: D=500, t=20, fy=450, E=210000, nu=0.3.
+_D, _T, _FY, _E = 500.0, 20.0, 450.0, 210000.0
+
+
+def test_elastic_collapse_pressure():
+    # Pel = 2E(t/D)^3/(1-nu^2) = 2*210000*0.04^3/0.91
+    expected = 2.0 * _E * (0.04**3) / (1.0 - 0.3**2)
+    assert elastic_collapse_pressure(_D, _T, _E) == pytest.approx(expected)
+    assert expected == pytest.approx(29.538461538, rel=1e-9)
+
+
+def test_plastic_collapse_pressure():
+    # Pp = fy * 1.0 * 2 * (t/D) = 450 * 2 * 0.04 = 36.0
+    assert plastic_collapse_pressure(_D, _T, _FY) == pytest.approx(36.0)
+
+
+def test_collapse_pressure_satisfies_cubic():
+    # Verify Pc satisfies the implicit DNV collapse equation, not a fixed number.
+    f0 = 0.005
+    pc = collapse_pressure(_D, _T, _FY, _E, ovality=f0)
+    pel = elastic_collapse_pressure(_D, _T, _E)
+    pp = plastic_collapse_pressure(_D, _T, _FY)
+    lhs = (pc - pel) * (pc**2 - pp**2)
+    rhs = pc * pel * pp * f0 * (_D / _T)
+    assert lhs == pytest.approx(rhs, abs=1e-6)
+    # And it is below both bounding pressures (real collapse < min(Pel, Pp)).
+    assert pc < min(pel, pp)
+    assert pc == pytest.approx(24.733652743, rel=1e-9)
+
+
+def test_collapse_pressure_decreases_with_ovality():
+    pc_low = collapse_pressure(_D, _T, _FY, _E, ovality=0.005)
+    pc_high = collapse_pressure(_D, _T, _FY, _E, ovality=0.02)
+    assert pc_high < pc_low
+
+
+def test_collapse_pressure_clamps_minimum_ovality():
+    # Ovality below 0.005 is clamped to 0.005 (code minimum).
+    pc_zero = collapse_pressure(_D, _T, _FY, _E, ovality=0.0)
+    pc_min = collapse_pressure(_D, _T, _FY, _E, ovality=0.005)
+    assert pc_zero == pytest.approx(pc_min)
+
+
+# --- propagation buckling ---------------------------------------------------
+
+
+def test_propagation_pressure():
+    # Ppr = 35 * fy * 1.0 * (t/D)^2.5 = 35 * 450 * 0.04^2.5
+    expected = 35.0 * 450.0 * (0.04**2.5)
+    assert propagation_pressure(_D, _T, _FY) == pytest.approx(expected)
+    assert expected == pytest.approx(5.04, rel=1e-9)
+
+
+def test_propagation_check_no_propagation():
+    # resistance = Ppr / (gm*gsc) = 5.04 / (1.15*1.14) = 5.04 / 1.311
+    res = propagation_check(net_external_pressure=2.0, diameter=_D, t=_T, f_y=_FY)
+    expected_resistance = 5.04 / (1.15 * 1.14)
+    assert isinstance(res, PropagationCheck)
+    assert res.propagation_resistance == pytest.approx(expected_resistance)
+    assert res.utilisation == pytest.approx(2.0 / expected_resistance)
+    assert res.propagates is False  # 2.0 < ~3.845
+
+
+def test_propagation_check_propagates():
+    # Large net external pressure exceeds the resistance.
+    res = propagation_check(net_external_pressure=10.0, diameter=_D, t=_T, f_y=_FY)
+    assert res.utilisation > 1.0
+    assert res.propagates is True

--- a/tests/installation/test_pipelay_stress.py
+++ b/tests/installation/test_pipelay_stress.py
@@ -1,0 +1,150 @@
+"""Tests for over/sagbend longitudinal-stress (%SMYS) acceptance checks.
+
+All expected values are computed by hand from generic round-number inputs and
+the closed-form formulas (no client data used as an oracle).
+"""
+
+import pytest
+
+from digitalmodel.installation.pipelay import (
+    SmysCheck,
+    allowable_bend_radius,
+    axial_stress,
+    bending_stress_from_radius,
+    smys_stress_check,
+)
+from digitalmodel.installation.pipelay.stress import (
+    DEFAULT_OVERBEND_FRACTION,
+    DEFAULT_SAGBEND_FRACTION,
+)
+
+
+# --- bending stress from radius ---------------------------------------------
+
+
+def test_bending_stress_from_radius():
+    # sigma = E * (OD/2) / R = 200000 * (0.5/2) / 250 = 200000 * 0.001 = 200.0
+    assert bending_stress_from_radius(0.5, 250.0, 200000.0) == pytest.approx(200.0)
+
+
+def test_bending_stress_invalid_radius():
+    with pytest.raises(ValueError):
+        bending_stress_from_radius(0.5, 0.0, 200000.0)
+
+
+# --- axial stress -----------------------------------------------------------
+
+
+def test_axial_stress():
+    # sigma = N / A = 1000 / 0.01 = 100000
+    assert axial_stress(1000.0, 0.01) == pytest.approx(100000.0)
+
+
+def test_axial_stress_invalid_area():
+    with pytest.raises(ValueError):
+        axial_stress(1000.0, 0.0)
+
+
+# --- %SMYS acceptance check -------------------------------------------------
+
+
+def test_smys_check_pure_bending_passes():
+    # sigma_bend = 200000 * (0.5/2) / 250 = 200.0
+    # allowable = 0.85 * 450 = 382.5 ; 200 <= 382.5 -> pass
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_OVERBEND_FRACTION,
+    )
+    assert isinstance(res, SmysCheck)
+    assert res.longitudinal_stress == pytest.approx(200.0)
+    assert res.allowable_stress == pytest.approx(382.5)
+    assert res.utilisation == pytest.approx(200.0 / 382.5)
+    assert res.percent_smys == pytest.approx(200.0 / 450.0 * 100.0)
+    assert res.passes is True
+
+
+def test_smys_check_with_axial_term():
+    # sigma_bend = 200000 * (0.5/2) / 250 = 200.0
+    # sigma_axial = 50000 / 0.01 = 5_000_000?  -> use consistent N, m^2, MPa? keep generic
+    # Use stress units directly: axial_force in (stress*area) consistent set.
+    # N = 3000 (force), A = 0.02 -> sigma_axial = 150000 ... too large.
+    # Choose so total is round: sigma_axial = N/A = 1.0/0.02 = 50.0
+    # total = 50 + 200 = 250.0 ; allowable = 0.72 * 450 = 324.0 ; pass
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=250.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_SAGBEND_FRACTION,
+        axial_force=1.0,
+        steel_area=0.02,
+    )
+    assert res.longitudinal_stress == pytest.approx(250.0)
+    assert res.allowable_stress == pytest.approx(324.0)
+    assert res.passes is True
+
+
+def test_smys_check_fails_when_overstressed():
+    # sigma_bend = 200000 * (0.5/2) / 100 = 500.0 ; allowable = 0.85*450 = 382.5 -> fail
+    res = smys_stress_check(
+        outer_diameter=0.5,
+        bend_radius=100.0,
+        youngs_modulus=200000.0,
+        smys=450.0,
+        allowable_fraction=DEFAULT_OVERBEND_FRACTION,
+    )
+    assert res.longitudinal_stress == pytest.approx(500.0)
+    assert res.utilisation > 1.0
+    assert res.passes is False
+
+
+def test_smys_check_axial_requires_area():
+    with pytest.raises(ValueError):
+        smys_stress_check(
+            outer_diameter=0.5,
+            bend_radius=250.0,
+            youngs_modulus=200000.0,
+            smys=450.0,
+            allowable_fraction=0.85,
+            axial_force=1.0,
+        )
+
+
+def test_smys_check_invalid_fraction():
+    with pytest.raises(ValueError):
+        smys_stress_check(0.5, 250.0, 200000.0, 450.0, 0.0)
+
+
+def test_smys_check_invalid_smys():
+    with pytest.raises(ValueError):
+        smys_stress_check(0.5, 250.0, 200000.0, 0.0, 0.85)
+
+
+def test_default_fractions():
+    assert DEFAULT_OVERBEND_FRACTION == 0.85
+    assert DEFAULT_SAGBEND_FRACTION == 0.72
+
+
+# --- minimum admissible bend radius -----------------------------------------
+
+
+def test_allowable_bend_radius():
+    # R_min = E*(OD/2)/(f*SMYS) = 200000*(0.5/2)/(0.85*450)
+    #       = 200000*0.25/382.5 = 50000/382.5
+    expected = 200000.0 * 0.25 / (0.85 * 450.0)
+    assert allowable_bend_radius(0.5, 200000.0, 450.0, 0.85) == pytest.approx(expected)
+
+
+def test_allowable_bend_radius_consistent_with_check():
+    # At exactly R_min, pure-bending stress equals allowable -> utilisation ~ 1.
+    r_min = allowable_bend_radius(0.5, 200000.0, 450.0, 0.85)
+    res = smys_stress_check(0.5, r_min, 200000.0, 450.0, 0.85)
+    assert res.utilisation == pytest.approx(1.0)
+
+
+def test_allowable_bend_radius_invalid():
+    with pytest.raises(ValueError):
+        allowable_bend_radius(0.5, 200000.0, 450.0, 1.5)


### PR DESCRIPTION
## DNV-OS-F101 pipeline checks + S-lay %SMYS (epic llm-wiki#767, #779)

Continues the corpus calculator port (follows the merged 8-calculator PR #970). Adds de-identified, generic standard-based methods:
- `code_checks/dnv_os_f101.py` — plastic axial/moment capacities, pressure-containment resistance, **local-buckling load-controlled combined-loading UF**, **collapse pressure** (solves the DNV collapse cubic), **propagation-buckling** pressure + check.
- `installation/pipelay/stress.py` — **overbend/sagbend %SMYS** outer-fibre check (0.85/0.72 allowables as params) + minimum admissible bend radius.

**31 new tests pass** (`uv run pytest`), hand-computed generic oracles (collapse cubic verified against the implicit DNV equation, residual ~1e-12). No client/project content (de-id grep clean).
