### PR TITLE
feat(naval_architecture): EN400 citation sidecar for mass_to_weight (TDD pilot)

### DIFF
--- a/src/digitalmodel/citations/registry.py
+++ b/src/digitalmodel/citations/registry.py
@@ -37,6 +37,13 @@ _DNV_RP_F103_CITATION_TEMPLATE: Final = {
     "wiki_path": "wikis/engineering-standards/wiki/standards/dnv-rp-f103.md",
 }
 
+_EN400_CITATION_TEMPLATE: Final = {
+    "code_id": "EN400",
+    "publisher": "USNA",
+    "revision": "Summer 2020",
+    "wiki_path": "wikis/marine-engineering/wiki/standards/en400.md",
+}
+
 # DNV-OS-E301 Section 2.2 design load factors for mooring systems.
 # Values are industry-standard and also appear in API RP 2SK Table C-1.
 _MOORING_SAFETY_FACTORS: Final[dict[MooringCondition, tuple[float, str]]] = {
@@ -119,6 +126,24 @@ def get_dnv_f103_reference(
         section=section,
         note=note,
         **_DNV_RP_F103_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=1.0, citation=citation, units="reference")
+
+
+def get_en400_reference(
+    section: str, *, note: str = "", repo_root: Optional[Path] = None
+) -> CitedValue:
+    """Return a validated EN400 reference citation.
+
+    EN400 (USNA *Principles of Ship Performance*, Summer 2020) is the teaching
+    source the naval_architecture fundamentals/hydrostatics/stability/resistance
+    calcs derive from. The value is a sentinel; the citation is the payload.
+    """
+    citation = Citation(
+        section=section,
+        note=note,
+        **_EN400_CITATION_TEMPLATE,
     )
     validate_citation(citation, repo_root=repo_root)
     return CitedValue(value=1.0, citation=citation, units="reference")

--- a/src/digitalmodel/naval_architecture/fundamentals.py
+++ b/src/digitalmodel/naval_architecture/fundamentals.py
@@ -6,6 +6,18 @@ Naval architecture engineering fundamentals.
 Covers unit conversions, water properties, and basic buoyancy calculations
 from USNA EN400 Chapter 1.
 """
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from digitalmodel.citations.registry import get_en400_reference
+from digitalmodel.citations.schema import CitationResolutionError
+
+# One-shot guard so standalone mode warns once, not per call (mirrors the
+# DNV-OS-E301 mooring pilot's degradation behavior).
+_EN400_STANDALONE_WARNED = False
 
 G = 32.17  # ft/s², gravitational acceleration
 GAMMA_SW = 64.0  # lb/ft³, specific weight of salt water
@@ -35,6 +47,45 @@ def mass_to_weight(mass_slug: float) -> float:
     W = m * g
     """
     return mass_slug * G
+
+
+def mass_to_weight_cited(
+    mass_slug: float, *, repo_root: Optional[Path] = None
+) -> dict:
+    """`mass_to_weight` with an EN400 provenance sidecar.
+
+    Mirrors the DNV-OS-E301 mooring pilot's opt-in-by-name design: the legacy
+    `mass_to_weight` stays unchanged; callers opt into citation emission by name.
+    Returns ``{"value", "units", "citations"}``.
+
+    Fail-closed: a configured-but-missing/stale wiki page raises
+    CitationResolutionError. Standalone mode (resolver unconfigured) degrades
+    gracefully with a one-shot RuntimeWarning and an empty ``citations`` list.
+    """
+    global _EN400_STANDALONE_WARNED
+    weight = mass_to_weight(mass_slug)
+    citations: list = []
+    try:
+        cited = get_en400_reference(
+            "Chapter 1 — Fundamentals (W = m·g, g = 32.17 ft/s²)",
+            note="mass-to-weight unit conversion",
+            repo_root=repo_root,
+        )
+        citations = [cited.citation]
+    except CitationResolutionError as exc:
+        if exc.reason.startswith("resolver_unconfigured"):
+            if not _EN400_STANDALONE_WARNED:
+                warnings.warn(
+                    "digitalmodel standalone mode: EN400 citation unavailable; "
+                    "proceeding without a provenance sidecar.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _EN400_STANDALONE_WARNED = True
+            citations = []
+        else:
+            raise
+    return {"value": weight, "units": "lb", "citations": citations}
 
 
 def displaced_volume_to_weight_lt(

--- a/tests/citations/fixtures/knowledge/wikis/marine-engineering/wiki/standards/en400.md
+++ b/tests/citations/fixtures/knowledge/wikis/marine-engineering/wiki/standards/en400.md
@@ -1,0 +1,18 @@
+---
+title: "EN400 — Principles of Ship Performance (USNA)"
+slug: en400
+code_id: EN400
+publisher: USNA
+revision: Summer 2020
+domain: marine-engineering
+---
+
+# EN400 — Principles of Ship Performance (USNA)
+
+Test fixture mirroring the production citation target
+`wikis/marine-engineering/wiki/standards/en400.md` in vamseeachanta/llm-wiki.
+Vendored into the test tree (workspace-hub #2580 pattern) so the citation
+resolver validates regardless of how digitalmodel is checked out.
+
+Only the `code_id` / `publisher` / `revision` frontmatter is asserted by
+`validate_citation`; the body is illustrative.

--- a/tests/naval_architecture/test_na_fundamentals_citations.py
+++ b/tests/naval_architecture/test_na_fundamentals_citations.py
@@ -1,0 +1,68 @@
+"""Citation-emission tests for naval_architecture fundamentals.
+
+Wires the EN400 (USNA Principles of Ship Performance, Summer 2020) citation
+target to the foundational `mass_to_weight` calc, mirroring the DNV-OS-E301
+mooring pilot (tests/citations/test_registry.py, tests/orcaflex/test_mooring_design_citations.py).
+
+TDD pilot for the naval-architecture citation flywheel: concept/standards
+wiki pages -> calc provenance sidecars (calc-citation-contract).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.schema import CitationResolutionError as _CRE
+from digitalmodel.naval_architecture.fundamentals import (
+    G,
+    mass_to_weight,
+    mass_to_weight_cited,
+)
+
+
+def _repo_root() -> Path:
+    # Reuse the vendored citation fixtures tree (shared with tests/citations/).
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_mass_to_weight_cited_value_matches_plain():
+    """The cited variant must return the same physical value as the legacy fn."""
+    result = mass_to_weight_cited(10.0, repo_root=_repo_root())
+    assert result["value"] == mass_to_weight(10.0) == 10.0 * G
+    assert result["units"] == "lb"
+
+
+def test_mass_to_weight_cited_emits_en400_citation():
+    result = mass_to_weight_cited(10.0, repo_root=_repo_root())
+    assert len(result["citations"]) == 1
+    c = result["citations"][0]
+    assert c.code_id == "EN400"
+    assert c.publisher == "USNA"
+    assert c.revision == "Summer 2020"
+    assert c.wiki_path.endswith("en400.md")
+    assert "Chapter 1" in c.section
+
+
+def test_mass_to_weight_cited_fail_closed_on_missing_page(tmp_path):
+    """Configured repo_root without the page must fail closed, not silently drop."""
+    with pytest.raises(CitationResolutionError) as exc:
+        mass_to_weight_cited(10.0, repo_root=tmp_path)
+    assert exc.value.code_id == "EN400"
+    assert exc.value.reason == "page_missing"
+
+
+def test_mass_to_weight_cited_standalone_graceful(monkeypatch):
+    """Standalone mode (resolver unconfigured) warns once and emits no citation,
+    while still returning the correct value."""
+    from digitalmodel.naval_architecture import fundamentals as fund
+
+    def _unconfigured(*_a, **_k):
+        raise _CRE(code_id="EN400", wiki_path="wikis/...", reason="resolver_unconfigured:test")
+
+    monkeypatch.setattr(fund, "get_en400_reference", _unconfigured, raising=False)
+    with pytest.warns(RuntimeWarning, match="standalone"):
+        result = mass_to_weight_cited(10.0)
+    assert result["value"] == 10.0 * G
+    assert result["citations"] == []


### PR DESCRIPTION
## Summary
First slice of the **naval-architecture citation flywheel**: wire foundational `naval_architecture` calcs to emit wiki provenance sidecars per the calc-citation contract, mirroring the existing DNV-OS-E301 mooring pilot.

This pilot wires **one** function (`mass_to_weight`) to the **EN400** teaching source (USNA *Principles of Ship Performance*, Summer 2020) — the source the `naval_architecture` worked examples (`test_en400_worked_examples.py`) already derive from.

## Changes
- **`citations/registry.py`**: `_EN400_CITATION_TEMPLATE` + `get_en400_reference(section, *, note, repo_root)` (reference-getter pattern, mirrors `get_dnv_f103_reference`).
- **`naval_architecture/fundamentals.py`**: `mass_to_weight_cited()` → `{value, units, citations}`. **Legacy `mass_to_weight()` is unchanged** (opt-in by name, same design as `check_mbl` vs `check_mbl_with_safety_factor`). Fail-closed on missing/stale page; one-shot `RuntimeWarning` + empty citations in standalone mode.
- **Tests**: 4 new (value parity, citation emission, fail-closed, standalone graceful-degrade) + vendored EN400 fixture page.

## Verification
- New tests: **4 passed**.
- Regression: **97 passed, 1 xfailed** across `tests/citations/` + `tests/naval_architecture/{test_na_fundamentals,test_en400_worked_examples}` — no import cycle introduced by the new `citations` dependency in foundational `fundamentals.py`.

## Provenance
Citation target `wikis/marine-engineering/wiki/standards/en400.md` landed in **llm-wiki#786** (merged), so the citation resolves in production (concept pages aren't citation targets — they lack `code_id`; the standards page is the resolver target).

## Notes / governance
- Investigation was done by parallel read-only agents (citation-pattern map + ranked calc-target shortlist); this is candidate #1 of 5 (`buoyant_force`, `gz_from_cross_curves`, `ittc_1957_cf`, `natural_heave_period` are the follow-ons).
- Done at the user's explicit direction. A backing GitHub issue should be filed for traceability (digitalmodel gate) — agent `gh issue create` is currently classifier-blocked; happy to file on request or it can be added retroactively.