### PR TITLE
feat(mooring): cite foundation safety factor to DNV-OS-E301 (#1000)

### DIFF
--- a/src/digitalmodel/citations/registry.py
+++ b/src/digitalmodel/citations/registry.py
@@ -106,6 +106,28 @@ def get_mooring_safety_factor(
     return CitedValue(value=value, citation=citation, units="dimensionless")
 
 
+# DNV-OS-E301 anchor / foundation resistance (geotechnical) safety factor.
+_ANCHOR_SAFETY_FACTOR: Final[tuple[float, str]] = (
+    1.5, "Section 2 (anchor resistance, geotechnical safety factor)")
+
+
+def get_anchor_safety_factor(*, repo_root: Optional[Path] = None) -> CitedValue:
+    """Return the DNV-OS-E301 anchor/foundation geotechnical safety factor.
+
+    Representative value for screening (the exact partial factor in DNV-OS-E301
+    varies with anchor type and consequence class). Fail-closed when the cited
+    wiki page is missing/mismatched; defers to the resolver when repo_root is None.
+    """
+    value, section = _ANCHOR_SAFETY_FACTOR
+    citation = Citation(
+        section=section,
+        note="Foundation/anchor resistance safety factor (screening)",
+        **_DNV_OS_E301_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="dimensionless")
+
+
 def get_dnv_f103_reference(
     section: str, *, note: str = "", repo_root: Optional[Path] = None
 ) -> CitedValue:

--- a/src/digitalmodel/mooring_resilience/screening.py
+++ b/src/digitalmodel/mooring_resilience/screening.py
@@ -188,18 +188,19 @@ _CITATION_WARNED = False
 
 
 def safety_factor_citations(repo_root: Optional[Path] = None) -> dict:
-    """Return ``{"intact": CitedValue, "damaged": CitedValue}`` for the mooring
-    tension safety factors, sourced from the existing DNV-OS-E301 registry.
+    """Return ``{"intact", "damaged", "foundation"}`` CitedValues for the mooring
+    safety factors, sourced from the existing DNV-OS-E301 registry.
 
-    The values match :class:`ResilienceFactors` (``fos_intact`` / ``fos_damaged``).
-    In standalone mode (no resolvable wiki page) it degrades gracefully: emits a
-    one-shot warning and returns ``{}`` rather than failing — mirroring
-    ``offshore_container.factor_citations``. Where the wiki resolves, a missing or
-    mismatched page fails closed (raises).
+    The values match :class:`ResilienceFactors` (``fos_intact`` / ``fos_damaged``
+    / ``fos_foundation``). In standalone mode (no resolvable wiki page) it degrades
+    gracefully: emits a one-shot warning and returns ``{}`` rather than failing —
+    mirroring ``offshore_container.factor_citations``. Where the wiki resolves, a
+    missing or mismatched page fails closed (raises).
     """
     global _CITATION_WARNED
     from digitalmodel.citations.registry import (
         MooringCondition,
+        get_anchor_safety_factor,
         get_mooring_safety_factor,
     )
     from digitalmodel.citations.schema import CitationResolutionError
@@ -210,6 +211,7 @@ def safety_factor_citations(repo_root: Optional[Path] = None) -> dict:
                 MooringCondition.INTACT_QUASI_STATIC, repo_root=repo_root),
             "damaged": get_mooring_safety_factor(
                 MooringCondition.DAMAGED_QUASI_STATIC, repo_root=repo_root),
+            "foundation": get_anchor_safety_factor(repo_root=repo_root),
         }
     except CitationResolutionError as exc:
         if not _CITATION_WARNED:

--- a/tests/unit/marine_ops/test_mooring_resilience.py
+++ b/tests/unit/marine_ops/test_mooring_resilience.py
@@ -142,7 +142,9 @@ def test_safety_factor_citations_resolve_and_match_factors(tmp_path):
     f = ResilienceFactors()
     assert cites["intact"].value == f.fos_intact == 1.67
     assert cites["damaged"].value == f.fos_damaged == 1.25
+    assert cites["foundation"].value == f.fos_foundation == 1.5
     assert cites["intact"].citation.code_id == "DNV-OS-E301"
+    assert cites["foundation"].citation.code_id == "DNV-OS-E301"
 
 
 def test_safety_factor_citations_degrade_gracefully(tmp_path):


### PR DESCRIPTION
Closes #1000. Completes mooring-resilience citation coverage (follow-up to #996).

Adds `get_anchor_safety_factor()` (DNV-OS-E301 anchor resistance, geotechnical) and includes it in `safety_factor_citations()` under `foundation` — so intact (1.67), damaged (1.25) **and foundation (1.5)** are now all citation-backed. Value matches `ResilienceFactors.fos_foundation`; graceful-degrade/fail-closed unchanged.

Tests: 64 passed / 6 atlas-skipped (incl. updated resolve test asserting the foundation citation). Runs in `tests-marine-ops-other` (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)