### PR TITLE
feat(naval_architecture): EN400 citation sidecars for 4 more calcs (flywheel batch 2)

### DIFF
--- a/src/digitalmodel/naval_architecture/hydrostatics.py
+++ b/src/digitalmodel/naval_architecture/hydrostatics.py
@@ -6,6 +6,18 @@ Hydrostatics calculations for naval architecture.
 Covers buoyant force, submerged volume, center of gravity shifts,
 and inclining experiment analysis from USNA EN400 Chapters 2-3.
 """
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from digitalmodel.citations.registry import get_en400_reference
+from digitalmodel.citations.schema import CitationResolutionError
+
+# One-shot guard so standalone mode warns once, not per call (mirrors the
+# DNV-OS-E301 mooring pilot's degradation behavior).
+_EN400_STANDALONE_WARNED = False
 
 GAMMA_SW = 64.0  # lb/ft³
 GAMMA_FW = 62.4  # lb/ft³
@@ -19,6 +31,45 @@ def buoyant_force(volume_ft3: float, water: str = "saltwater") -> float:
     """
     gamma = GAMMA_SW if water == "saltwater" else GAMMA_FW
     return gamma * volume_ft3
+
+
+def buoyant_force_cited(
+    volume_ft3: float, water: str = "saltwater", *, repo_root: Optional[Path] = None
+) -> dict:
+    """`buoyant_force` with an EN400 provenance sidecar.
+
+    Mirrors the DNV-OS-E301 mooring pilot's opt-in-by-name design: the legacy
+    `buoyant_force` stays unchanged; callers opt into citation emission by name.
+    Returns ``{"value", "units", "citations"}``.
+
+    Fail-closed: a configured-but-missing/stale wiki page raises
+    CitationResolutionError. Standalone mode (resolver unconfigured) degrades
+    gracefully with a one-shot RuntimeWarning and an empty ``citations`` list.
+    """
+    global _EN400_STANDALONE_WARNED
+    force = buoyant_force(volume_ft3, water)
+    citations: list = []
+    try:
+        cited = get_en400_reference(
+            "Chapter 2 — Hull Form & Buoyancy (F_b = γ·V, Archimedes)",
+            note="buoyant force from displaced volume",
+            repo_root=repo_root,
+        )
+        citations = [cited.citation]
+    except CitationResolutionError as exc:
+        if exc.reason.startswith("resolver_unconfigured"):
+            if not _EN400_STANDALONE_WARNED:
+                warnings.warn(
+                    "digitalmodel standalone mode: EN400 citation unavailable; "
+                    "proceeding without a provenance sidecar.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _EN400_STANDALONE_WARNED = True
+            citations = []
+        else:
+            raise
+    return {"value": force, "units": "lb", "citations": citations}
 
 
 def submerged_volume(

--- a/src/digitalmodel/naval_architecture/resistance.py
+++ b/src/digitalmodel/naval_architecture/resistance.py
@@ -8,6 +8,16 @@ Covers USNA EN400 Chapter 7: Reynolds number, frictional resistance
 """
 
 import math
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from digitalmodel.citations.registry import get_en400_reference
+from digitalmodel.citations.schema import CitationResolutionError
+
+# One-shot guard so standalone mode warns once, not per call (mirrors the
+# DNV-OS-E301 mooring pilot's degradation behavior).
+_EN400_STANDALONE_WARNED = False
 
 KNOTS_TO_FPS = 1.6878  # 1 knot = 1.6878 ft/s
 
@@ -46,6 +56,43 @@ def ittc_1957_cf(rn: float) -> float:
     if rn <= 0:
         raise ValueError("Reynolds number must be positive")
     return 0.075 / (math.log10(rn) - 2) ** 2
+
+
+def ittc_1957_cf_cited(rn: float, *, repo_root: Optional[Path] = None) -> dict:
+    """`ittc_1957_cf` with an EN400 provenance sidecar.
+
+    Mirrors the DNV-OS-E301 mooring pilot's opt-in-by-name design: the legacy
+    `ittc_1957_cf` stays unchanged; callers opt into citation emission by name.
+    Returns ``{"value", "units", "citations"}``.
+
+    Fail-closed: a configured-but-missing/stale wiki page raises
+    CitationResolutionError. Standalone mode (resolver unconfigured) degrades
+    gracefully with a one-shot RuntimeWarning and an empty ``citations`` list.
+    """
+    global _EN400_STANDALONE_WARNED
+    cf = ittc_1957_cf(rn)
+    citations: list = []
+    try:
+        cited = get_en400_reference(
+            "Chapter 7 — Resistance & Powering (ITTC-1957 model–ship correlation friction line)",
+            note="ITTC-1957 friction coefficient",
+            repo_root=repo_root,
+        )
+        citations = [cited.citation]
+    except CitationResolutionError as exc:
+        if exc.reason.startswith("resolver_unconfigured"):
+            if not _EN400_STANDALONE_WARNED:
+                warnings.warn(
+                    "digitalmodel standalone mode: EN400 citation unavailable; "
+                    "proceeding without a provenance sidecar.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _EN400_STANDALONE_WARNED = True
+            citations = []
+        else:
+            raise
+    return {"value": cf, "units": "dimensionless", "citations": citations}
 
 
 def froude_speed_scaling(

--- a/src/digitalmodel/naval_architecture/seakeeping.py
+++ b/src/digitalmodel/naval_architecture/seakeeping.py
@@ -13,6 +13,16 @@ References:
 """
 
 import math
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from digitalmodel.citations.registry import get_en400_reference
+from digitalmodel.citations.schema import CitationResolutionError
+
+# One-shot guard so standalone mode warns once, not per call (mirrors the
+# DNV-OS-E301 mooring pilot's degradation behavior).
+_EN400_STANDALONE_WARNED = False
 
 # Standard gravity and seawater density
 G = 9.81  # m/s²
@@ -53,6 +63,48 @@ def natural_heave_period(
     mass_kg = displacement_tonnes * 1000.0
     stiffness = RHO_SW * G * waterplane_area_m2
     return 2 * math.pi * math.sqrt(mass_kg / stiffness)
+
+
+def natural_heave_period_cited(
+    displacement_tonnes: float,
+    waterplane_area_m2: float,
+    *,
+    repo_root: Optional[Path] = None,
+) -> dict:
+    """`natural_heave_period` with an EN400 provenance sidecar.
+
+    Mirrors the DNV-OS-E301 mooring pilot's opt-in-by-name design: the legacy
+    `natural_heave_period` stays unchanged; callers opt into citation emission
+    by name. Returns ``{"value", "units", "citations"}``.
+
+    Fail-closed: a configured-but-missing/stale wiki page raises
+    CitationResolutionError. Standalone mode (resolver unconfigured) degrades
+    gracefully with a one-shot RuntimeWarning and an empty ``citations`` list.
+    """
+    global _EN400_STANDALONE_WARNED
+    period_s = natural_heave_period(displacement_tonnes, waterplane_area_m2)
+    citations: list = []
+    try:
+        cited = get_en400_reference(
+            "Chapter 8 — Seakeeping (natural heave period)",
+            note="natural heave period from waterplane stiffness",
+            repo_root=repo_root,
+        )
+        citations = [cited.citation]
+    except CitationResolutionError as exc:
+        if exc.reason.startswith("resolver_unconfigured"):
+            if not _EN400_STANDALONE_WARNED:
+                warnings.warn(
+                    "digitalmodel standalone mode: EN400 citation unavailable; "
+                    "proceeding without a provenance sidecar.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _EN400_STANDALONE_WARNED = True
+            citations = []
+        else:
+            raise
+    return {"value": period_s, "units": "s", "citations": citations}
 
 
 def natural_pitch_period(

--- a/src/digitalmodel/naval_architecture/stability.py
+++ b/src/digitalmodel/naval_architecture/stability.py
@@ -8,7 +8,16 @@ and free surface effect from USNA EN400 Chapter 4.
 """
 
 import math
-from typing import Tuple
+import warnings
+from pathlib import Path
+from typing import Optional, Tuple
+
+from digitalmodel.citations.registry import get_en400_reference
+from digitalmodel.citations.schema import CitationResolutionError
+
+# One-shot guard so standalone mode warns once, not per call (mirrors the
+# DNV-OS-E301 mooring pilot's degradation behavior).
+_EN400_STANDALONE_WARNED = False
 
 G = 32.17  # ft/s²
 LT_TO_LB = 2240.0
@@ -27,6 +36,49 @@ def gz_from_cross_curves(
         kg_ft: height of center of gravity above keel
     """
     return kn_ft - kg_ft * math.sin(math.radians(heel_deg))
+
+
+def gz_from_cross_curves_cited(
+    heel_deg: float,
+    kn_ft: float,
+    kg_ft: float,
+    *,
+    repo_root: Optional[Path] = None,
+) -> dict:
+    """`gz_from_cross_curves` with an EN400 provenance sidecar.
+
+    Mirrors the DNV-OS-E301 mooring pilot's opt-in-by-name design: the legacy
+    `gz_from_cross_curves` stays unchanged; callers opt into citation emission
+    by name. Returns ``{"value", "units", "citations"}``.
+
+    Fail-closed: a configured-but-missing/stale wiki page raises
+    CitationResolutionError. Standalone mode (resolver unconfigured) degrades
+    gracefully with a one-shot RuntimeWarning and an empty ``citations`` list.
+    """
+    global _EN400_STANDALONE_WARNED
+    gz = gz_from_cross_curves(heel_deg, kn_ft, kg_ft)
+    citations: list = []
+    try:
+        cited = get_en400_reference(
+            "Chapter 4 — Stability (GZ = KN − KG·sin φ)",
+            note="righting arm from cross curves",
+            repo_root=repo_root,
+        )
+        citations = [cited.citation]
+    except CitationResolutionError as exc:
+        if exc.reason.startswith("resolver_unconfigured"):
+            if not _EN400_STANDALONE_WARNED:
+                warnings.warn(
+                    "digitalmodel standalone mode: EN400 citation unavailable; "
+                    "proceeding without a provenance sidecar.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _EN400_STANDALONE_WARNED = True
+            citations = []
+        else:
+            raise
+    return {"value": gz, "units": "ft", "citations": citations}
 
 
 def gz_with_tcg_correction(

--- a/tests/naval_architecture/test_hydrostatics_citations.py
+++ b/tests/naval_architecture/test_hydrostatics_citations.py
@@ -1,0 +1,65 @@
+"""Citation-emission tests for naval_architecture hydrostatics.
+
+Wires the EN400 (USNA Principles of Ship Performance, Summer 2020) citation
+target to the `buoyant_force` calc, mirroring the fundamentals pilot
+(tests/naval_architecture/test_na_fundamentals_citations.py) and the DNV-OS-E301
+mooring pilot (tests/citations/test_registry.py).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.schema import CitationResolutionError as _CRE
+from digitalmodel.naval_architecture.hydrostatics import (
+    buoyant_force,
+    buoyant_force_cited,
+)
+
+
+def _repo_root() -> Path:
+    # Reuse the vendored citation fixtures tree (shared with tests/citations/).
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_buoyant_force_cited_value_matches_plain():
+    """The cited variant must return the same physical value as the legacy fn."""
+    result = buoyant_force_cited(100.0, repo_root=_repo_root())
+    assert result["value"] == buoyant_force(100.0)
+    assert result["units"] == "lb"
+
+
+def test_buoyant_force_cited_emits_en400_citation():
+    result = buoyant_force_cited(100.0, repo_root=_repo_root())
+    assert len(result["citations"]) == 1
+    c = result["citations"][0]
+    assert c.code_id == "EN400"
+    assert c.publisher == "USNA"
+    assert c.revision == "Summer 2020"
+    assert c.wiki_path.endswith("en400.md")
+    assert "Chapter 2" in c.section
+
+
+def test_buoyant_force_cited_fail_closed_on_missing_page(tmp_path):
+    """Configured repo_root without the page must fail closed, not silently drop."""
+    with pytest.raises(CitationResolutionError) as exc:
+        buoyant_force_cited(100.0, repo_root=tmp_path)
+    assert exc.value.code_id == "EN400"
+    assert exc.value.reason == "page_missing"
+
+
+def test_buoyant_force_cited_standalone_graceful(monkeypatch):
+    """Standalone mode (resolver unconfigured) warns once and emits no citation,
+    while still returning the correct value."""
+    from digitalmodel.naval_architecture import hydrostatics as hydro
+
+    def _unconfigured(*_a, **_k):
+        raise _CRE(code_id="EN400", wiki_path="wikis/...", reason="resolver_unconfigured:test")
+
+    monkeypatch.setattr(hydro, "get_en400_reference", _unconfigured, raising=False)
+    with pytest.warns(RuntimeWarning, match="standalone"):
+        result = buoyant_force_cited(100.0)
+    assert result["value"] == buoyant_force(100.0)
+    assert result["citations"] == []

--- a/tests/naval_architecture/test_resistance_citations.py
+++ b/tests/naval_architecture/test_resistance_citations.py
@@ -1,0 +1,64 @@
+"""Citation-emission tests for naval_architecture resistance.
+
+Wires the EN400 (USNA Principles of Ship Performance, Summer 2020) citation
+target to the ITTC-1957 friction-line calc, mirroring the fundamentals pilot
+(tests/naval_architecture/test_na_fundamentals_citations.py).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.schema import CitationResolutionError as _CRE
+from digitalmodel.naval_architecture.resistance import (
+    ittc_1957_cf,
+    ittc_1957_cf_cited,
+)
+
+
+def _repo_root() -> Path:
+    # Reuse the vendored citation fixtures tree (shared with tests/citations/).
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_ittc_1957_cf_cited_value_matches_plain():
+    """The cited variant must return the same physical value as the legacy fn."""
+    result = ittc_1957_cf_cited(1e9, repo_root=_repo_root())
+    assert result["value"] == ittc_1957_cf(1e9)
+    assert result["units"] == "dimensionless"
+
+
+def test_ittc_1957_cf_cited_emits_en400_citation():
+    result = ittc_1957_cf_cited(1e9, repo_root=_repo_root())
+    assert len(result["citations"]) == 1
+    c = result["citations"][0]
+    assert c.code_id == "EN400"
+    assert c.publisher == "USNA"
+    assert c.revision == "Summer 2020"
+    assert c.wiki_path.endswith("en400.md")
+    assert "Chapter 7" in c.section
+
+
+def test_ittc_1957_cf_cited_fail_closed_on_missing_page(tmp_path):
+    """Configured repo_root without the page must fail closed, not silently drop."""
+    with pytest.raises(CitationResolutionError) as exc:
+        ittc_1957_cf_cited(1e9, repo_root=tmp_path)
+    assert exc.value.code_id == "EN400"
+    assert exc.value.reason == "page_missing"
+
+
+def test_ittc_1957_cf_cited_standalone_graceful(monkeypatch):
+    """Standalone mode (resolver unconfigured) warns once and emits no citation,
+    while still returning the correct value."""
+    from digitalmodel.naval_architecture import resistance as res
+
+    def _unconfigured(*_a, **_k):
+        raise _CRE(code_id="EN400", wiki_path="wikis/...", reason="resolver_unconfigured:test")
+
+    monkeypatch.setattr(res, "get_en400_reference", _unconfigured, raising=False)
+    with pytest.warns(RuntimeWarning, match="standalone"):
+        result = ittc_1957_cf_cited(1e9)
+    assert result["value"] == ittc_1957_cf(1e9)
+    assert result["citations"] == []

--- a/tests/naval_architecture/test_seakeeping_citations.py
+++ b/tests/naval_architecture/test_seakeeping_citations.py
@@ -1,0 +1,65 @@
+"""Citation-emission tests for naval_architecture seakeeping.
+
+Wires the EN400 (USNA Principles of Ship Performance, Summer 2020) citation
+target to the `natural_heave_period` calc, mirroring the fundamentals pilot
+(tests/naval_architecture/test_na_fundamentals_citations.py) and the
+DNV-OS-E301 mooring pilot.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.schema import CitationResolutionError as _CRE
+from digitalmodel.naval_architecture.seakeeping import (
+    natural_heave_period,
+    natural_heave_period_cited,
+)
+
+
+def _repo_root() -> Path:
+    # Reuse the vendored citation fixtures tree (shared with tests/citations/).
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_natural_heave_period_cited_value_matches_plain():
+    """The cited variant must return the same physical value as the legacy fn."""
+    result = natural_heave_period_cited(10000, 2000, repo_root=_repo_root())
+    assert result["value"] == natural_heave_period(10000, 2000)
+    assert result["units"] == "s"
+
+
+def test_natural_heave_period_cited_emits_en400_citation():
+    result = natural_heave_period_cited(10000, 2000, repo_root=_repo_root())
+    assert len(result["citations"]) == 1
+    c = result["citations"][0]
+    assert c.code_id == "EN400"
+    assert c.publisher == "USNA"
+    assert c.revision == "Summer 2020"
+    assert c.wiki_path.endswith("en400.md")
+    assert "Chapter 8" in c.section
+
+
+def test_natural_heave_period_cited_fail_closed_on_missing_page(tmp_path):
+    """Configured repo_root without the page must fail closed, not silently drop."""
+    with pytest.raises(CitationResolutionError) as exc:
+        natural_heave_period_cited(10000, 2000, repo_root=tmp_path)
+    assert exc.value.code_id == "EN400"
+    assert exc.value.reason == "page_missing"
+
+
+def test_natural_heave_period_cited_standalone_graceful(monkeypatch):
+    """Standalone mode (resolver unconfigured) warns once and emits no citation,
+    while still returning the correct value."""
+    from digitalmodel.naval_architecture import seakeeping as sk
+
+    def _unconfigured(*_a, **_k):
+        raise _CRE(code_id="EN400", wiki_path="wikis/...", reason="resolver_unconfigured:test")
+
+    monkeypatch.setattr(sk, "get_en400_reference", _unconfigured, raising=False)
+    with pytest.warns(RuntimeWarning, match="standalone"):
+        result = natural_heave_period_cited(10000, 2000)
+    assert result["value"] == natural_heave_period(10000, 2000)
+    assert result["citations"] == []

--- a/tests/naval_architecture/test_stability_citations.py
+++ b/tests/naval_architecture/test_stability_citations.py
@@ -1,0 +1,64 @@
+"""Citation-emission tests for naval_architecture stability.
+
+Wires the EN400 (USNA Principles of Ship Performance, Summer 2020) citation
+target to the `gz_from_cross_curves` calc, mirroring the fundamentals pilot
+(tests/naval_architecture/test_na_fundamentals_citations.py).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.citations.schema import CitationResolutionError as _CRE
+from digitalmodel.naval_architecture.stability import (
+    gz_from_cross_curves,
+    gz_from_cross_curves_cited,
+)
+
+
+def _repo_root() -> Path:
+    # Reuse the vendored citation fixtures tree (shared with tests/citations/).
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_gz_from_cross_curves_cited_value_matches_plain():
+    """The cited variant must return the same physical value as the legacy fn."""
+    result = gz_from_cross_curves_cited(30, 10, 5, repo_root=_repo_root())
+    assert result["value"] == gz_from_cross_curves(30, 10, 5)
+    assert result["units"] == "ft"
+
+
+def test_gz_from_cross_curves_cited_emits_en400_citation():
+    result = gz_from_cross_curves_cited(30, 10, 5, repo_root=_repo_root())
+    assert len(result["citations"]) == 1
+    c = result["citations"][0]
+    assert c.code_id == "EN400"
+    assert c.publisher == "USNA"
+    assert c.revision == "Summer 2020"
+    assert c.wiki_path.endswith("en400.md")
+    assert "Chapter 4" in c.section
+
+
+def test_gz_from_cross_curves_cited_fail_closed_on_missing_page(tmp_path):
+    """Configured repo_root without the page must fail closed, not silently drop."""
+    with pytest.raises(CitationResolutionError) as exc:
+        gz_from_cross_curves_cited(30, 10, 5, repo_root=tmp_path)
+    assert exc.value.code_id == "EN400"
+    assert exc.value.reason == "page_missing"
+
+
+def test_gz_from_cross_curves_cited_standalone_graceful(monkeypatch):
+    """Standalone mode (resolver unconfigured) warns once and emits no citation,
+    while still returning the correct value."""
+    from digitalmodel.naval_architecture import stability as stab
+
+    def _unconfigured(*_a, **_k):
+        raise _CRE(code_id="EN400", wiki_path="wikis/...", reason="resolver_unconfigured:test")
+
+    monkeypatch.setattr(stab, "get_en400_reference", _unconfigured, raising=False)
+    with pytest.warns(RuntimeWarning, match="standalone"):
+        result = gz_from_cross_curves_cited(30, 10, 5)
+    assert result["value"] == gz_from_cross_curves(30, 10, 5)
+    assert result["citations"] == []


### PR DESCRIPTION
## Summary
Completes the naval-architecture citation flywheel begun in #999. Adds opt-in `*_cited` variants that emit EN400 provenance sidecars for the remaining 4 foundational calcs, mirroring `mass_to_weight_cited` exactly (legacy functions unchanged, fail-closed, one-shot standalone `RuntimeWarning`).

| New function | Module | EN400 section |
|---|---|---|
| `buoyant_force_cited` | hydrostatics.py | Ch2 (Archimedes, F_b = γ·V) |
| `gz_from_cross_curves_cited` | stability.py | Ch4 (GZ = KN − KG·sin φ) |
| `ittc_1957_cf_cited` | resistance.py | Ch7 (ITTC-1957 friction line) |
| `natural_heave_period_cited` | seakeeping.py | Ch8 (seakeeping) |

## Verification
- **16 new tests** (4 per function: value parity, citation emission, fail-closed on missing page, standalone graceful-degrade).
- Full run (new + existing citation/naval_architecture suite): **157 passed, 1 xfailed**.
- `registry.py` not touched (the `get_en400_reference` getter landed in #999); each module imports it at module level for monkeypatch testability.

## Provenance
All cite `EN400` → `wikis/marine-engineering/wiki/standards/en400.md` (llm-wiki #786, merged). Section strings are free-text locators; a Ch8 (Seakeeping) row will be added to that page for completeness.

## Notes
- Implemented via **4 parallel agents** over disjoint module+test pairs; orchestrator verified each artifact and ran the suite centrally before commit (no shared-file races).
- Known pre-existing CI red: Quality Gates abs-path gate on `main` (`wed_adapter.py`) — tracked in #1002, unrelated to this diff.
- Follow-up: a shared `_emit_en400_citation` helper could DRY the 5 near-identical try/except blocks (deferred to keep the parallel batch disjoint).