### PR TITLE
feat(reporting): shared digitalmodel.reporting block library (#1018)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/report_data_models.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_data_models.py
@@ -6,6 +6,9 @@ ABOUTME: Pydantic data models and constants for diffraction report data.
 Extracted from report_generator.py as part of WRK-591 God Object split.
 
 No imports from other report_* modules — this is the leaf dependency.
+The models inherit the shared ``ReportDataModel`` marker base from the
+reusable ``digitalmodel.reporting`` block library (#1018); this is a marker
+only and does not change validation or serialization behaviour.
 """
 
 from __future__ import annotations
@@ -13,14 +16,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from digitalmodel.reporting import ReportDataModel
 
 DOF_NAMES = ["surge", "sway", "heave", "roll", "pitch", "yaw"]
 DOF_UNITS = ["m/m", "m/m", "m/m", "deg/m", "deg/m", "deg/m"]
 LOAD_RAO_UNITS = ["N/m", "N/m", "N/m", "N.m/m", "N.m/m", "N.m/m"]
 
 
-class HydrostaticData(BaseModel):
+class HydrostaticData(ReportDataModel):
     """Hydrostatic properties extracted from OrcaWave."""
 
     volume: float = Field(description="Displaced volume (m^3)")
@@ -43,7 +48,7 @@ class HydrostaticData(BaseModel):
         arbitrary_types_allowed = True
 
 
-class RollDampingData(BaseModel):
+class RollDampingData(ReportDataModel):
     """Roll critical damping analysis data."""
 
     frequencies_rad_s: List[float]
@@ -66,7 +71,7 @@ class RollDampingData(BaseModel):
         arbitrary_types_allowed = True
 
 
-class LoadRAOData(BaseModel):
+class LoadRAOData(ReportDataModel):
     """Wave excitation force/moment (load RAOs) from diffraction."""
 
     method: str = Field(description="Calculation method: diffraction or haskind")
@@ -84,7 +89,7 @@ class LoadRAOData(BaseModel):
         arbitrary_types_allowed = True
 
 
-class MeshQualityData(BaseModel):
+class MeshQualityData(ReportDataModel):
     """Panel mesh quality summary."""
 
     panel_count: int
@@ -98,7 +103,7 @@ class MeshQualityData(BaseModel):
         arbitrary_types_allowed = True
 
 
-class DiffractionReportData(BaseModel):
+class DiffractionReportData(ReportDataModel):
     """Complete data model for a standardized diffraction report."""
 
     schema_version: str = "1.0"

--- a/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_generator.py
@@ -20,6 +20,13 @@ import html
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from digitalmodel.reporting import (
+    ReportBackbone,
+    ReportRenderer,
+    ReportSection,
+    SectionMode,
+)
+
 # --- Re-exports from report_data_models ---
 from digitalmodel.hydrodynamics.diffraction.report_data_models import (
     DOF_NAMES,
@@ -190,148 +197,72 @@ def _build_assumptions_html(ledger: "AssumptionLedger") -> str:
     )
 
 
-def generate_diffraction_report(
-    report_data: DiffractionReportData,
-    output_path: Path,
-    include_plotlyjs: str = "cdn",
-    mode: str = "full",
-    validation_report: Optional[dict[str, Any]] = None,
-    assumption_ledger: Optional["AssumptionLedger"] = None,
-) -> Path:
-    """Generate a self-contained HTML diffraction report.
+# ---------------------------------------------------------------------------
+# Report block library adoption (#1018)
+#
+# The section ordering / conditional rules below are expressed declaratively
+# via a module-level ``ReportBackbone``; the document wrapper is assembled via
+# ``ReportRenderer``. Builder bodies are NOT modified — each section adapter is
+# a thin wrapper that swallows backbone kwargs and forwards to the existing
+# ``_build_*_html`` builder. Output is byte-identical to the pre-library code
+# (proven by tests/.../test_report_generator_golden.py).
+# ---------------------------------------------------------------------------
 
-    Sections follow the physics causal chain:
-    Geometry -> Hydrostatics -> Stability -> Natural Periods ->
-    Coefficients -> Excitation -> Response -> Damping -> Summary
+# Exact CSS from the original wrapper (base, always present).
+_BASE_CSS = """\
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 Roboto, Arial, sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle { font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }
+  .report-header .meta { font-size: 0.9em; opacity: 0.85; }
+  .nav-bar {
+    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
+    display: flex; gap: 1.5em; font-size: 0.9em;
+  }
+  .nav-bar a { color: #fff; text-decoration: none; opacity: 0.8; }
+  .nav-bar a:hover { opacity: 1; text-decoration: underline; }
+  .nav-bar .active { opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  table {
+    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
+  }
+  th {
+    background: #34495e; color: #fff; font-weight: 600;
+    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  tbody tr:hover { background: #ebf5fb; }
+  td { vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }
+  .matrix-table td { text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .matrix-table th { text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .highlight { background: #ffeaa7 !important; font-weight: 600; }
+  .plot-container { margin: 1em 0; }
+"""
 
-    Args:
-        report_data: Populated DiffractionReportData.
-        output_path: Path for the output HTML file.
-        include_plotlyjs: 'cdn' for CDN link, True for inline JS.
-        mode: 'full' for all sections, 'compact' for executive summary only.
-        validation_report: Optional pre-computed validation report dict. When
-            provided, a sanity-check section is rendered near the executive
-            summary. This NEVER re-runs validation (no ``OutputValidator`` is
-            instantiated here).
-        assumption_ledger: Optional assumption provenance ledger. When
-            provided, an Assumptions section is rendered.
-
-    Returns:
-        Path to the generated HTML file.
-    """
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Override mode from report_data if set
-    effective_mode = mode if mode != "full" else report_data.mode
-    compact = effective_mode == "compact"
-
-    bm = report_data.benchmark_html_sections or {}
-    sections = []
-
-    # S0: Table of Contents
-    sections.append(_build_toc_html(report_data))
-
-    # S1: Header
-    sections.append(_build_header_html(report_data))
-
-    # S2: Executive Summary (always shown)
-    sections.append(_build_executive_summary_html(report_data))
-
-    # S2b: Validation sanity check (only when a report is supplied; rendered,
-    # never recomputed — see #625).
-    if validation_report is not None:
-        sections.append(_build_validation_sanity_html(validation_report))
-
-    if assumption_ledger is not None:
-        sections.append(_build_assumptions_html(assumption_ledger))
-
-    if not compact:
-        # S3: Hull Description & Mesh Quality
-        sections.append(_build_hull_description_html(report_data))
-
-    # S3b: Mesh schematic (BENCHMARK ONLY)
-    if bm.get("mesh_schematic"):
-        sections.append(f'<div class="section">{bm["mesh_schematic"]}</div>')
-
-    # S4: Input Configuration (BENCHMARK ONLY)
-    if bm.get("input_comparison"):
-        sections.append(f'<div class="section">{bm["input_comparison"]}</div>')
-    if bm.get("input_files"):
-        sections.append(f'<div class="section">{bm["input_files"]}</div>')
-
-    # S5: Hydrostatic Properties & Stability
-    if report_data.hydrostatics:
-        sections.append(_build_stability_html(report_data))
-
-    if not compact:
-        # S6: Natural Period Estimates
-        sections.append(_build_natural_periods_html(report_data))
-
-        # S7: Hydrodynamic Coefficients
-        sections.append(_build_added_mass_diagonal_html(report_data))
-        sections.append(_build_damping_diagonal_html(report_data))
-
-        if report_data.coupling_significance:
-            sections.append(_build_coupling_assessment_html(report_data))
-
-        if report_data.infinite_freq_added_mass:
-            sections.append(
-                _build_infinite_added_mass_html(report_data.infinite_freq_added_mass)
-            )
-
-    # S7e: Solver correlation heatmaps (BENCHMARK ONLY)
-    if bm.get("hydro_coefficients"):
-        sections.append(f'<div class="section">{bm["hydro_coefficients"]}</div>')
-
-    if not compact:
-        # S8: Wave Excitation Forces (Load RAOs)
-        if report_data.load_raos:
-            sections.append(
-                _build_load_raos_html(report_data.load_raos, include_plotlyjs)
-            )
-
-    # S9: Displacement RAOs — consensus + per-DOF (BENCHMARK ONLY)
-    if bm.get("consensus_summary"):
-        sections.append(f'<div class="section">{bm["consensus_summary"]}</div>')
-    if bm.get("dof_sections"):
-        sections.append(f'<div class="section">{bm["dof_sections"]}</div>')
-
-    # S10: Roll Damping
-    if report_data.roll_damping:
-        sections.append(
-            _build_roll_damping_html(report_data.roll_damping, include_plotlyjs)
-        )
-
-    # S11: Raw Data & Overlay Plots (BENCHMARK ONLY)
-    if bm.get("raw_rao_data"):
-        sections.append(f'<div class="section">{bm["raw_rao_data"]}</div>')
-    if bm.get("overlay_plots"):
-        sections.append(f'<div class="section">{bm["overlay_plots"]}</div>')
-
-    # S11b: Notes (benchmark or standalone)
-    if report_data.notes:
-        notes_items = "\n".join(f"<li>{n}</li>" for n in report_data.notes)
-        sections.append(
-            f'<div class="section"><h2>Notes</h2><ul>{notes_items}</ul></div>'
-        )
-
-    if not compact:
-        # S12: Phase interpretation guide
-        sections.append(_build_phase_guide_html())
-
-        # S13: Appendices
-        sections.append(_build_appendices_html())
-
-    plotly_src = (
-        '<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>'
-        if include_plotlyjs == "cdn"
-        else ""
-    )
-
-    benchmark_css = ""
-    if bm:
-        benchmark_css = """
+# Exact benchmark-only CSS (appended only when benchmark sections present).
+_BENCHMARK_CSS = """
   /* Benchmark-specific styles */
   .report-header .consensus-overall {
     display: inline-block; padding: 4px 12px; border-radius: 4px;
@@ -416,74 +347,207 @@ def generate_diffraction_report(
   @media (max-width: 900px) { .dof-grid { grid-template-columns: 1fr; } }
 """
 
-    html = f"""\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Diffraction Report - {report_data.vessel_name}</title>
-{plotly_src}
-<style>
-  * {{ box-sizing: border-box; }}
-  body {{
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
-                 Roboto, Arial, sans-serif;
-    margin: 0; padding: 0; color: #333; background: #f8f9fa;
-    font-size: 14px; line-height: 1.5;
-  }}
-  .container {{ max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }}
-  .report-header {{
-    background: #2c3e50; color: #fff; padding: 1.2em 2em;
-    margin-bottom: 1.5em; border-radius: 6px;
-  }}
-  .report-header h1 {{ margin: 0 0 0.3em; font-size: 1.6em; }}
-  .report-header .subtitle {{ font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }}
-  .report-header .meta {{ font-size: 0.9em; opacity: 0.85; }}
-  .nav-bar {{
-    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
-    display: flex; gap: 1.5em; font-size: 0.9em;
-  }}
-  .nav-bar a {{ color: #fff; text-decoration: none; opacity: 0.8; }}
-  .nav-bar a:hover {{ opacity: 1; text-decoration: underline; }}
-  .nav-bar .active {{ opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }}
-  .section {{
-    background: #fff; border-radius: 6px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-    margin-bottom: 1.5em; padding: 1.2em 1.5em;
-  }}
-  .section h2 {{
-    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
-    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
-  }}
-  table {{
-    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
-    width: 100%;
-  }}
-  th, td {{
-    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
-  }}
-  th {{
-    background: #34495e; color: #fff; font-weight: 600;
-    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
-  }}
-  tbody tr:nth-child(even) {{ background: #f8f9fa; }}
-  tbody tr:hover {{ background: #ebf5fb; }}
-  td {{ vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }}
-  .matrix-table td {{ text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }}
-  .matrix-table th {{ text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }}
-  .highlight {{ background: #ffeaa7 !important; font-weight: 600; }}
-  .plot-container {{ margin: 1em 0; }}
-{benchmark_css}</style>
-</head>
-<body>
-<div class="container">
-{''.join(sections)}
-</div>
-</body>
-</html>"""
 
-    output_path.write_text(html, encoding="utf-8")
-    return output_path
+# --- Section adapters: uniform (data, **kwargs) -> str over the builders. ---
+# Each adapter mirrors the conditional rule the original orchestrator applied
+# to its builder. Returning "" omits the section (joined output is identical).
+
+
+def _sec_toc(data, **_):
+    return _build_toc_html(data)
+
+
+def _sec_header(data, **_):
+    return _build_header_html(data)
+
+
+def _sec_executive_summary(data, **_):
+    return _build_executive_summary_html(data)
+
+
+def _sec_validation(data, *, validation_report=None, **_):
+    if validation_report is not None:
+        return _build_validation_sanity_html(validation_report)
+    return ""
+
+
+def _sec_assumptions(data, *, assumption_ledger=None, **_):
+    if assumption_ledger is not None:
+        return _build_assumptions_html(assumption_ledger)
+    return ""
+
+
+def _sec_hull_description(data, **_):
+    return _build_hull_description_html(data)
+
+
+def _sec_stability(data, **_):
+    if data.hydrostatics:
+        return _build_stability_html(data)
+    return ""
+
+
+def _sec_natural_periods(data, **_):
+    return _build_natural_periods_html(data)
+
+
+def _sec_added_mass(data, **_):
+    return _build_added_mass_diagonal_html(data)
+
+
+def _sec_damping(data, **_):
+    return _build_damping_diagonal_html(data)
+
+
+def _sec_coupling(data, **_):
+    if data.coupling_significance:
+        return _build_coupling_assessment_html(data)
+    return ""
+
+
+def _sec_infinite_added_mass(data, **_):
+    if data.infinite_freq_added_mass:
+        return _build_infinite_added_mass_html(data.infinite_freq_added_mass)
+    return ""
+
+
+def _sec_load_raos(data, *, include_plotlyjs="cdn", **_):
+    if data.load_raos:
+        return _build_load_raos_html(data.load_raos, include_plotlyjs)
+    return ""
+
+
+def _sec_roll_damping(data, *, include_plotlyjs="cdn", **_):
+    if data.roll_damping:
+        return _build_roll_damping_html(data.roll_damping, include_plotlyjs)
+    return ""
+
+
+def _sec_notes(data, **_):
+    if not data.notes:
+        return ""
+    notes_items = "\n".join(f"<li>{n}</li>" for n in data.notes)
+    return f'<div class="section"><h2>Notes</h2><ul>{notes_items}</ul></div>'
+
+
+def _sec_phase_guide(data, **_):
+    return _build_phase_guide_html()
+
+
+def _sec_appendices(data, **_):
+    return _build_appendices_html()
+
+
+def _benchmark_block(key: str):
+    """Builder for a BENCHMARK_ONLY section: wrap the fragment for ``key``."""
+
+    def _builder(data, *, benchmark_sections=None, **_):
+        frag = (benchmark_sections or {}).get(key)
+        return f'<div class="section">{frag}</div>' if frag else ""
+
+    return _builder
+
+
+# Module-level backbone: the diffraction physics causal chain.
+# Geometry -> Hydrostatics -> Stability -> Natural Periods ->
+# Coefficients -> Excitation -> Response -> Damping -> Summary.
+_DIFFRACTION_BACKBONE = ReportBackbone(
+    title="Diffraction Analysis Report",
+    sections=[
+        ReportSection("toc", "Table of Contents", SectionMode.ALWAYS, _sec_toc),
+        ReportSection("header", "Header & Identification", SectionMode.ALWAYS, _sec_header),
+        ReportSection("executive_summary", "Executive Summary", SectionMode.ALWAYS, _sec_executive_summary),
+        ReportSection("validation_sanity", "Validation Sanity Check", SectionMode.ALWAYS, _sec_validation),
+        ReportSection("assumptions", "Assumptions", SectionMode.ALWAYS, _sec_assumptions),
+        ReportSection("hull_description", "Hull Description & Mesh Quality", SectionMode.COMPACT_SKIP, _sec_hull_description),
+        ReportSection("mesh_schematic", "Mesh Schematic", SectionMode.BENCHMARK_ONLY, _benchmark_block("mesh_schematic")),
+        ReportSection("input_comparison", "Input Comparison", SectionMode.BENCHMARK_ONLY, _benchmark_block("input_comparison")),
+        ReportSection("input_files", "Input Files", SectionMode.BENCHMARK_ONLY, _benchmark_block("input_files")),
+        ReportSection("stability", "Hydrostatic Properties & Stability", SectionMode.ALWAYS, _sec_stability),
+        ReportSection("natural_periods", "Natural Period Estimates", SectionMode.COMPACT_SKIP, _sec_natural_periods),
+        ReportSection("added_mass_diagonal", "Added Mass Diagonal", SectionMode.COMPACT_SKIP, _sec_added_mass),
+        ReportSection("damping_diagonal", "Radiation Damping Diagonal", SectionMode.COMPACT_SKIP, _sec_damping),
+        ReportSection("coupling_assessment", "Coupling Assessment", SectionMode.COMPACT_SKIP, _sec_coupling),
+        ReportSection("infinite_added_mass", "Infinite Frequency Added Mass", SectionMode.COMPACT_SKIP, _sec_infinite_added_mass),
+        ReportSection("hydro_coefficients", "Hydrodynamic Coefficients", SectionMode.BENCHMARK_ONLY, _benchmark_block("hydro_coefficients")),
+        ReportSection("load_raos", "Wave Excitation Forces (Load RAOs)", SectionMode.COMPACT_SKIP, _sec_load_raos),
+        ReportSection("consensus_summary", "Displacement RAOs — Consensus", SectionMode.BENCHMARK_ONLY, _benchmark_block("consensus_summary")),
+        ReportSection("dof_sections", "Displacement RAOs — Per-DOF", SectionMode.BENCHMARK_ONLY, _benchmark_block("dof_sections")),
+        ReportSection("roll_damping", "Roll Critical Damping Analysis", SectionMode.ALWAYS, _sec_roll_damping),
+        ReportSection("raw_rao_data", "Raw Data", SectionMode.BENCHMARK_ONLY, _benchmark_block("raw_rao_data")),
+        ReportSection("overlay_plots", "Overlay Plots", SectionMode.BENCHMARK_ONLY, _benchmark_block("overlay_plots")),
+        ReportSection("notes", "Notes", SectionMode.ALWAYS, _sec_notes),
+        ReportSection("phase_guide", "Phase Interpretation Guide", SectionMode.COMPACT_SKIP, _sec_phase_guide),
+        ReportSection("appendices", "Appendices", SectionMode.COMPACT_SKIP, _sec_appendices),
+    ],
+)
+
+
+def generate_diffraction_report(
+    report_data: DiffractionReportData,
+    output_path: Path,
+    include_plotlyjs: str = "cdn",
+    mode: str = "full",
+    validation_report: Optional[dict[str, Any]] = None,
+    assumption_ledger: Optional["AssumptionLedger"] = None,
+) -> Path:
+    """Generate a self-contained HTML diffraction report.
+
+    Sections follow the physics causal chain:
+    Geometry -> Hydrostatics -> Stability -> Natural Periods ->
+    Coefficients -> Excitation -> Response -> Damping -> Summary
+
+    Args:
+        report_data: Populated DiffractionReportData.
+        output_path: Path for the output HTML file.
+        include_plotlyjs: 'cdn' for CDN link, True for inline JS.
+        mode: 'full' for all sections, 'compact' for executive summary only.
+        validation_report: Optional pre-computed validation report dict. When
+            provided, a sanity-check section is rendered near the executive
+            summary. This NEVER re-runs validation (no ``OutputValidator`` is
+            instantiated here).
+        assumption_ledger: Optional assumption provenance ledger. When
+            provided, an Assumptions section is rendered.
+
+    Returns:
+        Path to the generated HTML file.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Override mode from report_data if set.
+    effective_mode = mode if mode != "full" else report_data.mode
+
+    bm = report_data.benchmark_html_sections or {}
+
+    # Build the ordered section list declaratively via the shared backbone.
+    sections = _DIFFRACTION_BACKBONE.render(
+        report_data,
+        mode=effective_mode,
+        benchmark_sections=bm,
+        include_plotlyjs=include_plotlyjs,
+        validation_report=validation_report,
+        assumption_ledger=assumption_ledger,
+    )
+
+    plotly_src = (
+        '<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>'
+        if include_plotlyjs == "cdn"
+        else ""
+    )
+
+    # Benchmark CSS is appended only when benchmark sections are present.
+    css = _BASE_CSS + (_BENCHMARK_CSS if bm else "")
+
+    renderer = ReportRenderer()
+    html = renderer.render_html(
+        sections,
+        title=f"Diffraction Report - {report_data.vessel_name}",
+        css=css,
+        plotlyjs_src=plotly_src,
+        container_class="container",
+    )
+    return renderer.write_html(html, output_path)
 
 
 # ---------------------------------------------------------------------------

--- a/src/digitalmodel/reporting/__init__.py
+++ b/src/digitalmodel/reporting/__init__.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""digitalmodel.reporting — reusable report block library.
+
+ABOUTME: A small, domain-agnostic toolkit for assembling self-contained HTML
+reports from ordered, keyed section builders. Extracted from the diffraction
+report generator (#1018) so other modules can reuse the same pattern.
+
+Public API:
+  * ``ReportDataModel``  — marker base for report envelope (pydantic) models.
+  * ``ReportBlock``      — runtime-checkable protocol for block-shaped objects.
+  * ``ReportBlockFn``    — ``Callable[..., str]`` alias (builders are functions).
+  * ``SectionMode``      — ALWAYS / COMPACT_SKIP / BENCHMARK_ONLY.
+  * ``ReportSection``    — a keyed builder with a render mode.
+  * ``ReportBackbone``   — ordered sections -> list[str] of section HTML.
+  * ``ReportRenderer``   — wrap sections in an HTML document + write to disk.
+"""
+
+from __future__ import annotations
+
+from digitalmodel.reporting._backbone import (
+    ReportBackbone,
+    ReportSection,
+    SectionMode,
+)
+from digitalmodel.reporting._base import (
+    ReportBlock,
+    ReportBlockFn,
+    ReportDataModel,
+)
+from digitalmodel.reporting._renderer import ReportRenderer
+
+__all__ = [
+    "ReportDataModel",
+    "ReportBlock",
+    "ReportBlockFn",
+    "SectionMode",
+    "ReportSection",
+    "ReportBackbone",
+    "ReportRenderer",
+]

--- a/src/digitalmodel/reporting/_backbone.py
+++ b/src/digitalmodel/reporting/_backbone.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Reporting block library — section backbone.
+
+ABOUTME: Declarative, ordered list of report sections with mode/benchmark
+rules. Generalized from the diffraction report orchestration (#1018) so that
+``render`` reproduces the diffraction section-ordering behaviour exactly while
+staying domain-agnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+
+class SectionMode(Enum):
+    """How a section participates in rendering."""
+
+    ALWAYS = "always"
+    # Skipped when ``mode == "compact"``.
+    COMPACT_SKIP = "compact_skip"
+    # Rendered only when this section's benchmark fragment is present.
+    BENCHMARK_ONLY = "benchmark_only"
+
+
+@dataclass
+class ReportSection:
+    """One ordered section: a keyed builder plus its render mode.
+
+    ``builder`` is any ``Callable[..., str]`` (a plain function or a callable
+    block). It is invoked as ``builder(data, mode=..., benchmark_sections=...,
+    **builder_kwargs)`` and is expected to return an HTML fragment (possibly
+    the empty string, which is omitted from the output).
+    """
+
+    key: str
+    label: str
+    mode: SectionMode
+    builder: Callable[..., str]
+
+
+@dataclass
+class ReportBackbone:
+    """Ordered collection of report sections.
+
+    ``render`` produces the list of section HTML strings, applying the
+    per-section mode rules and — mirroring the diffraction orchestrator —
+    injecting any benchmark fragment whose key matches a rendered section.
+    """
+
+    title: str
+    sections: List[ReportSection]
+
+    def render(
+        self,
+        data: Any,
+        *,
+        mode: str = "full",
+        benchmark_sections: Optional[Dict[str, str]] = None,
+        **builder_kwargs: Any,
+    ) -> List[str]:
+        """Return the ordered list of non-empty section HTML strings.
+
+        Rules (mirroring the diffraction report generator):
+          * ``COMPACT_SKIP`` sections are dropped when ``mode == "compact"``.
+          * ``BENCHMARK_ONLY`` sections render only when a truthy benchmark
+            fragment exists for their ``key`` (regardless of compact mode).
+          * After any non-benchmark section whose ``key`` has a truthy
+            benchmark fragment, that fragment is appended wrapped in
+            ``<div class="section">...</div>``.
+        """
+        bm = benchmark_sections or {}
+        out: List[str] = []
+
+        for section in self.sections:
+            if section.mode is SectionMode.COMPACT_SKIP and mode == "compact":
+                continue
+
+            if section.mode is SectionMode.BENCHMARK_ONLY:
+                # Render only when this section's benchmark fragment exists.
+                if not bm.get(section.key):
+                    continue
+                html = section.builder(
+                    data, mode=mode, benchmark_sections=bm, **builder_kwargs
+                )
+                if html:
+                    out.append(html)
+                continue
+
+            # ALWAYS, or COMPACT_SKIP while not in compact mode.
+            html = section.builder(
+                data, mode=mode, benchmark_sections=bm, **builder_kwargs
+            )
+            if html:
+                out.append(html)
+
+            # Benchmark injection: after a rendered section whose key has a
+            # fragment, append that fragment as a standalone section.
+            frag = bm.get(section.key)
+            if frag:
+                out.append(f'<div class="section">{frag}</div>')
+
+        return out

--- a/src/digitalmodel/reporting/_base.py
+++ b/src/digitalmodel/reporting/_base.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Reporting block library — base types.
+
+ABOUTME: Marker base model and the report-block protocol for the reusable
+reporting block library (``digitalmodel.reporting``). Generalized from the
+diffraction report-builder pattern (#1018).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ReportDataModel(BaseModel):
+    """Marker base for report envelope (data) models.
+
+    Subclass this for any pydantic model that serves as the data envelope
+    passed to report block builders. ``arbitrary_types_allowed`` is enabled so
+    envelopes may carry numpy arrays or other non-pydantic field types without
+    extra per-model configuration.
+
+    This is a *marker* base only — it intentionally adds no fields, validators
+    or serialization behaviour beyond the permissive ``model_config``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+@runtime_checkable
+class ReportBlock(Protocol):
+    """Structural protocol for a report block.
+
+    Any object exposing ``render(self, data, **kwargs) -> str`` satisfies it.
+    Because it is ``runtime_checkable`` you may use
+    ``isinstance(obj, ReportBlock)`` to detect block-shaped objects at runtime.
+    """
+
+    def render(self, data, **kwargs) -> str:  # pragma: no cover - protocol stub
+        ...
+
+
+# Diffraction-style builders are plain functions ``(data, **kwargs) -> str``;
+# the backbone must accept either a ReportBlock or a plain callable, so we
+# expose this alias as the canonical "builder is just a function" type.
+ReportBlockFn = Callable[..., str]

--- a/src/digitalmodel/reporting/_renderer.py
+++ b/src/digitalmodel/reporting/_renderer.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Reporting block library — HTML document renderer.
+
+ABOUTME: Wraps an ordered list of section HTML strings in a parameterized,
+self-contained HTML document and writes it to disk. With the diffraction
+report's exact CSS/head pieces it reproduces that document byte-for-byte
+(#1018). PDF rendering is intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+
+class ReportRenderer:
+    """Assemble section HTML into a standalone HTML document and write it."""
+
+    def render_html(
+        self,
+        sections: List[str],
+        *,
+        title: str,
+        head_extra: str = "",
+        css: str = "",
+        plotlyjs_src: str = "",
+        container_class: str = "container",
+        container_max_width: Optional[str] = None,
+    ) -> str:
+        """Wrap ``sections`` in a complete ``<!DOCTYPE html>`` document.
+
+        The template is intentionally parameterized so callers can reproduce
+        an existing document wrapper exactly:
+
+          * ``title`` populates ``<title>``.
+          * ``plotlyjs_src`` is emitted on its own line in ``<head>`` (pass an
+            empty string for no script — the line is still emitted, matching
+            the diffraction wrapper).
+          * ``head_extra`` is inserted immediately before ``<style>``.
+          * ``css`` is placed verbatim between ``<style>`` and ``</style>``.
+          * ``container_class`` / ``container_max_width`` control the wrapping
+            ``<div>`` (an inline ``max-width`` is only added when provided).
+        """
+        body_inner = "".join(sections)
+        container_style = (
+            f' style="max-width: {container_max_width};"'
+            if container_max_width
+            else ""
+        )
+        return (
+            "<!DOCTYPE html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            '<meta charset="utf-8">\n'
+            f"<title>{title}</title>\n"
+            f"{plotlyjs_src}\n"
+            f"{head_extra}<style>\n"
+            f"{css}</style>\n"
+            "</head>\n"
+            "<body>\n"
+            f'<div class="{container_class}"{container_style}>\n'
+            f"{body_inner}\n"
+            "</div>\n"
+            "</body>\n"
+            "</html>"
+        )
+
+    def write_html(self, html: str, output_path: Path) -> Path:
+        """Write ``html`` to ``output_path`` (utf-8), creating parent dirs."""
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html, encoding="utf-8")
+        return output_path

--- a/tests/hydrodynamics/diffraction/fixtures/golden/benchmark.html
+++ b/tests/hydrodynamics/diffraction/fixtures/golden/benchmark.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diffraction Report - golden_benchmark</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 Roboto, Arial, sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle { font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }
+  .report-header .meta { font-size: 0.9em; opacity: 0.85; }
+  .nav-bar {
+    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
+    display: flex; gap: 1.5em; font-size: 0.9em;
+  }
+  .nav-bar a { color: #fff; text-decoration: none; opacity: 0.8; }
+  .nav-bar a:hover { opacity: 1; text-decoration: underline; }
+  .nav-bar .active { opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  table {
+    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
+  }
+  th {
+    background: #34495e; color: #fff; font-weight: 600;
+    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  tbody tr:hover { background: #ebf5fb; }
+  td { vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }
+  .matrix-table td { text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .matrix-table th { text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .highlight { background: #ffeaa7 !important; font-weight: 600; }
+  .plot-container { margin: 1em 0; }
+
+  /* Benchmark-specific styles */
+  .report-header .consensus-overall {
+    display: inline-block; padding: 4px 12px; border-radius: 4px;
+    font-weight: 700; margin-left: 1em; font-size: 0.85em;
+  }
+  .input-table .param-label { font-weight: 600; }
+  .section-row td {
+    background: #2c3e50 !important; color: #fff;
+    font-weight: 700; font-size: 0.8em; text-transform: uppercase;
+    letter-spacing: 0.5px; padding: 0.5em 0.7em;
+  }
+  .file-viewer { margin-bottom: 1.5em; }
+  .file-viewer-header {
+    display: flex; justify-content: space-between; align-items: center;
+    background: #34495e; color: #fff; padding: 0.5em 1em;
+    border-radius: 4px 4px 0 0; font-size: 0.85em;
+  }
+  .file-viewer-header .file-path {
+    font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+    font-size: 0.9em; word-break: break-all;
+  }
+  .file-viewer-header .solver-label {
+    font-weight: 700; margin-right: 0.8em; white-space: nowrap;
+  }
+  .file-viewer-header button {
+    background: #3498db; color: #fff; border: none; padding: 4px 12px;
+    border-radius: 3px; cursor: pointer; font-size: 0.85em; white-space: nowrap;
+  }
+  .file-viewer-header button:hover { background: #2980b9; }
+  .file-content {
+    max-height: 400px; overflow-y: auto; overflow-x: auto;
+    border: 1px solid #ddd; border-top: none;
+    border-radius: 0 0 4px 4px; background: #fafafa; margin: 0;
+  }
+  .file-content pre {
+    margin: 0; padding: 0.8em 1em; font-size: 12px; line-height: 1.5;
+    font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+    counter-reset: line;
+  }
+  .file-content pre .line { display: block; }
+  .file-content pre .line::before {
+    counter-increment: line; content: counter(line);
+    display: inline-block; width: 3.5em; text-align: right;
+    margin-right: 1em; color: #999; font-size: 0.85em;
+    border-right: 1px solid #ddd; padding-right: 0.5em;
+    -webkit-user-select: none; user-select: none;
+  }
+  .dof-section { border-top: 2px solid #ecf0f1; padding-top: 1em; margin-top: 1em; }
+  .dof-section:first-child { border-top: none; margin-top: 0; }
+  .dof-title { font-size: 1.1em; color: #2c3e50; margin: 0 0 0.6em; }
+  .dof-grid { display: grid; grid-template-columns: 45% 55%; gap: 1em; align-items: start; }
+  .dof-text { font-size: 0.85em; }
+  .dof-plot { min-height: 340px; }
+  .consensus-badge {
+    display: inline-block; padding: 3px 10px; border-radius: 3px;
+    color: #fff; font-size: 0.8em; font-weight: 700; margin-bottom: 0.5em;
+  }
+  .mono { font-family: 'SF Mono', 'Cascadia Code', 'Consolas', 'Fira Code', monospace; }
+  .stats-table { width: 100%; margin-bottom: 0.6em; }
+  .stats-table td:last-child {
+    text-align: right; font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+  }
+  .solver-table { width: 100%; margin-bottom: 0.5em; }
+  .solver-table th { font-size: 0.75em; text-align: center; padding: 0.3em 0.4em; }
+  .solver-table td {
+    text-align: right; font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+    font-size: 0.8em; padding: 0.25em 0.4em;
+  }
+  .solver-table td:first-child { text-align: left; font-family: inherit; font-weight: 600; }
+  .dof-text h4 {
+    margin: 0.7em 0 0.3em; font-size: 0.9em; color: #2c3e50;
+    border-bottom: 1px solid #ddd; padding-bottom: 0.15em;
+  }
+  .observations p { margin: 0.3em 0; line-height: 1.4; }
+  .skipped-note {
+    font-size: 0.8em; color: #888; font-style: italic; margin-top: 0.5em;
+    padding: 0.3em 0.5em; background: #fef9e7;
+    border-left: 3px solid #f0c674; border-radius: 2px;
+  }
+  .plot-links { column-count: 2; font-size: 0.85em; }
+  .plot-links li { margin-bottom: 0.3em; }
+  @media (max-width: 900px) { .dof-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+<div class="section" id="toc">
+  <h2>Table of Contents</h2>
+  <ul style="list-style:none;padding:0;column-count:2;font-size:0.9em;">
+    <li><a href="#header">0. Header & Identification</a></li><li><a href="#executive-summary">1. Executive Summary</a></li><li><a href="#hull-mesh">2. Hull Description & Mesh Quality</a></li><li><a href="#input-config">3. Input Configuration</a></li><li><a href="#hydrostatics">4. Hydrostatic Properties & Stability</a></li><li><a href="#natural-periods">5. Natural Period Estimates</a></li><li><a href="#hydro-coefficients">6. Hydrodynamic Coefficients</a></li><li><a href="#load-raos">7. Wave Excitation Forces (Load RAOs)</a></li><li><a href="#displacement-raos">8. Displacement RAOs (Motion Response)</a></li><li><a href="#roll-damping">9. Roll Damping Assessment</a></li><li><a href="#raw-data">10. Raw Data & Overlay Plots</a></li><li><a href="#appendices">11. Appendices</a></li>
+  </ul>
+</div>
+<div class="report-header">
+  <h1>Diffraction Analysis Report &mdash; golden_benchmark</h1>
+  
+  <div class="meta">
+    Generated: 2026-01-01 00:00:00 |
+    Frequencies: 3 |
+    Headings: 3 (0.0, 90.0, 180.0&deg;) |
+    Solver(s): OrcaWave, AQWA |
+    Source: bench.owr
+  </div>
+  
+</div>
+<div class="section" id="executive-summary">
+  <h2>Executive Summary</h2>
+  
+  
+  
+  
+</div>
+<div class="section" id="hull-mesh">
+<h2>Hull Description & Mesh Quality</h2>
+<h3>Hull Metadata</h3>
+<table style="max-width:600px;"><thead><tr><th>Property</th><th>Value</th></tr></thead><tbody><tr><td>Vessel Name</td><td>golden_benchmark</td></tr><tr><td>Solver(s)</td><td>OrcaWave, AQWA</td></tr><tr><td>Source File</td><td>bench.owr</td></tr></tbody></table>
+</div><div class="section"><h2>Mesh</h2><p>BENCH_MESH</p></div><div class="section"><h2>Input Comparison</h2><p>BENCH_INPUT</p></div><div class="section"><h2>Input Files</h2><p>BENCH_FILES</p></div><div class="section"><h2>Coefficients</h2><p>BENCH_COEFFS</p></div><div class="section"><h2>Consensus</h2><p>BENCH_CONSENSUS</p></div><div class="section"><h2>Per-DOF</h2><p>BENCH_DOF</p></div><div class="section"><h2>Raw Data</h2><p>BENCH_RAW</p></div><div class="section"><h2>Overlay</h2><p>BENCH_OVERLAY</p></div><div class="section"><h2>Notes</h2><ul><li>Note one</li>
+<li>Note two</li></ul></div><div class="section">
+  <h3>Phase Interpretation Guide</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li><strong>Phase = 0 deg</strong>: Response in-phase with wave (crest at origin = peak response)</li>
+    <li><strong>Phase = -90 deg</strong>: Lagging (response peaks after wave crest passes)</li>
+    <li><strong>Phase = +90 deg</strong>: Leading (response peaks before wave crest arrives)</li>
+    <li><strong>~180 deg jump near resonance</strong>: Transition from quasi-static to resonant regime</li>
+    <li><strong>Phase at near-zero amplitude</strong>: Physically meaningless -- ignore phase when amplitude is insignificant</li>
+  </ul>
+</div>
+<div class="section" id="appendices">
+  <h2>Appendices</h2>
+
+  <h3>A. Notation & Conventions</h3>
+  <table style="max-width:600px;font-size:0.85em;">
+    <thead><tr><th>Symbol</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td>DOF 1-6</td><td>Surge, Sway, Heave, Roll, Pitch, Yaw</td></tr>
+      <tr><td>Coordinate System</td><td>x-forward, z-up, right-hand rule</td></tr>
+      <tr><td>A_ii(omega)</td><td>Frequency-dependent added mass (diagonal)</td></tr>
+      <tr><td>B_ii(omega)</td><td>Frequency-dependent radiation damping (diagonal)</td></tr>
+      <tr><td>C_ii</td><td>Hydrostatic restoring stiffness (diagonal)</td></tr>
+      <tr><td>GM_T</td><td>Transverse metacentric height (metres)</td></tr>
+      <tr><td>T_n</td><td>Natural period (seconds)</td></tr>
+      <tr><td>zeta</td><td>Critical damping ratio (%)</td></tr>
+      <tr><td>RAO</td><td>Response Amplitude Operator</td></tr>
+    </tbody>
+  </table>
+
+  <h3 style="margin-top:1em;">B. Key Formulas</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li>T_n = 2pi * sqrt((M_ii + A_ii(omega_n)) / C_ii)</li>
+    <li>zeta(omega) = B_ii(omega) / (2 * sqrt((M_ii + A_ii(omega)) * C_ii))</li>
+    <li>GM_T = C_44 / (rho * g * V), where rho=1025 kg/m3, g=9.81 m/s2</li>
+    <li>BM_T = I_xx / V; GM_T = KB + BM_T - KG (cross-check)</li>
+  </ul>
+
+  <h3 style="margin-top:1em;">C. References</h3>
+  <ol style="font-size:0.85em;color:#555;">
+    <li>Newman, J.N. (1977). <em>Marine Hydrodynamics</em>. MIT Press.</li>
+    <li>Faltinsen, O.M. (1990). <em>Sea Loads on Ships and Offshore Structures</em>. Cambridge.</li>
+    <li>Journee, J.M.J. & Massie, W.W. (2001). <em>Offshore Hydromechanics</em>. TU Delft.</li>
+    <li>Lee, C.H. (1995). <em>WAMIT Theory Manual</em>. MIT.</li>
+    <li>Chakrabarti, S.K. (2005). <em>Handbook of Offshore Engineering</em>. Elsevier.</li>
+    <li>DNV-RP-C205 (2021). <em>Environmental Conditions and Environmental Loads</em>.</li>
+    <li>DNV-OS-C301. <em>Stability and Watertight Integrity</em>.</li>
+  </ol>
+</div>
+
+</div>
+</body>
+</html>

--- a/tests/hydrodynamics/diffraction/fixtures/golden/compact.html
+++ b/tests/hydrodynamics/diffraction/fixtures/golden/compact.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diffraction Report - golden_barge_compact</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 Roboto, Arial, sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle { font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }
+  .report-header .meta { font-size: 0.9em; opacity: 0.85; }
+  .nav-bar {
+    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
+    display: flex; gap: 1.5em; font-size: 0.9em;
+  }
+  .nav-bar a { color: #fff; text-decoration: none; opacity: 0.8; }
+  .nav-bar a:hover { opacity: 1; text-decoration: underline; }
+  .nav-bar .active { opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  table {
+    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
+  }
+  th {
+    background: #34495e; color: #fff; font-weight: 600;
+    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  tbody tr:hover { background: #ebf5fb; }
+  td { vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }
+  .matrix-table td { text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .matrix-table th { text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .highlight { background: #ffeaa7 !important; font-weight: 600; }
+  .plot-container { margin: 1em 0; }
+</style>
+</head>
+<body>
+<div class="container">
+<div class="section" id="toc">
+  <h2>Table of Contents</h2>
+  <ul style="list-style:none;padding:0;column-count:2;font-size:0.9em;">
+    <li><a href="#header">0. Header & Identification</a></li><li><a href="#executive-summary">1. Executive Summary</a></li><li><a href="#hull-mesh">2. Hull Description & Mesh Quality</a></li><li><a href="#hydrostatics">4. Hydrostatic Properties & Stability</a></li><li><a href="#natural-periods">5. Natural Period Estimates</a></li><li><a href="#hydro-coefficients">6. Hydrodynamic Coefficients</a></li><li><a href="#load-raos">7. Wave Excitation Forces (Load RAOs)</a></li><li><a href="#displacement-raos">8. Displacement RAOs (Motion Response)</a></li><li><a href="#roll-damping">9. Roll Damping Assessment</a></li><li><a href="#raw-data">10. Raw Data & Overlay Plots</a></li><li><a href="#appendices">11. Appendices</a></li>
+  </ul>
+</div>
+<div class="report-header">
+  <h1>Diffraction Analysis Report &mdash; golden_barge_compact</h1>
+  <div class="subtitle">Characterization fixture</div>
+  <div class="meta">
+    Generated: 2026-01-01 00:00:00 |
+    Frequencies: 4 |
+    Headings: 3 (0.0, 45.0, 90.0&deg;) |
+    Solver(s): OrcaWave |
+    Source: golden.owr
+  </div>
+  
+</div>
+<div class="section" id="executive-summary">
+  <h2>Executive Summary</h2>
+  <table style="max-width:700px;"><thead><tr><th>Item</th><th>Value</th><th>Status</th></tr></thead><tbody><tr><td>Mesh Quality</td><td>520 panels, ratio 4.0</td><td style='color:#27ae60;font-weight:bold'>PASS</td></tr><tr><td>GM_T (transverse)</td><td>10.000 m</td><td style='color:#27ae60;font-weight:bold'>OK</td></tr><tr><td>GM_L (longitudinal)</td><td>155.000 m</td><td>-</td></tr></tbody></table>
+  
+  <div style="background:#fef9e7;border-left:4px solid #f39c12;padding:0.8em 1em;margin-top:1em;border-radius:4px;"><strong>Warnings & Alerts</strong><ul style="margin:0.3em 0;"><li style="margin:0.3em 0;">NOTE: Example warning for characterization.</li></ul></div>
+  
+</div>
+<div class="section" id="hydrostatics">
+  <h2>Hydrostatic Properties & Stability</h2>
+  <h3>Hydrostatic Properties</h3>
+<table style="max-width:600px;">
+  <thead><tr><th>Property</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td>Displaced Volume</td><td>16000.0000 m3</td></tr>
+    <tr><td>Mass</td><td>16400000.0000</td></tr>
+    <tr><td>Centre of Buoyancy (x, y, z)</td><td>0.0000, 0.0000, -4.0000</td></tr>
+    <tr><td>Centre of Mass (x, y, z)</td><td>0.0000, 0.0000, -3.0000</td></tr>
+    <tr><td>Waterplane Area (Awp)</td><td>2000.0000 m2</td></tr>
+    <tr><td>Waterplane I_xx</td><td>266666.6670</td></tr>
+    <tr><td>Waterplane I_yy</td><td>6666666.6670</td></tr>
+    <tr><td>Centre of Floatation (x, y)</td><td>0.0000, 0.0000</td></tr>
+  </tbody>
+</table>
+  <h3 style="margin-top:1em;">Stability Assessment</h3><table style="max-width:700px;"><thead><tr><th>Parameter</th><th>Value</th><th>Status</th></tr></thead><tbody><tr><td>GM_T (transverse metacentric height)</td><td>10.0000 m</td><td style='color:#27ae60;font-weight:bold'>OK</td></tr><tr><td>GM_L (longitudinal metacentric height)</td><td>155.0000 m</td><td>-</td></tr><tr><td>BM_T (transverse)</td><td>16.6700 m</td><td>-</td></tr><tr><td>BM_L (longitudinal)</td><td>416.6700 m</td><td>-</td></tr><tr><td>KB (vertical centre of buoyancy)</td><td>-4.0000 m</td><td>-</td></tr></tbody></table><p style="font-size:0.85em;color:#666;">Reference: DNV-OS-C301 requires GM_T &gt; 1.0m for intact stability of mobile offshore units.</p><p style="font-size:0.85em;color:#666;margin-top:0.5em;">Cross-check: KB + BM_T - KG = -4.000 + 16.670 - (-3.000) = 15.670 m (vs GM_T = 10.000 m, diff = 5.6700 m)</p>
+  <h3 style="margin-top:1em;">Radii of Gyration</h3><table style="max-width:400px;"><thead><tr><th>Parameter</th><th>Value</th></tr></thead><tbody><tr><td>r_xx (roll)</td><td>7.8100 m</td></tr><tr><td>r_yy (pitch)</td><td>30.2400 m</td></tr><tr><td>r_zz (yaw)</td><td>29.2100 m</td></tr></tbody></table>
+  <h3 style="margin-top:1em;">Restoring Matrix C (Hydrostatic Stiffness)</h3>
+<table class="matrix-table">
+  <thead><tr><th></th><th>Surge</th><th>Sway</th><th>Heave</th><th>Roll</th><th>Pitch</th><th>Yaw</th></tr></thead>
+  <tbody><tr><th>Surge</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Sway</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Heave</th><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>20110500.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Roll</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>1608000000.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Pitch</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>25000000000.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Yaw</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+</tbody>
+</table>
+<p style="font-size:0.85em;color:#666;">
+  Heave (C_33), Roll (C_44), and Pitch (C_55) have hydrostatic restoring.
+  Surge, Sway, and Yaw are neutrally stable -- restoring comes from mooring (not modelled in diffraction).
+</p>
+  <h3 style="margin-top:1em;">Inertia Matrix</h3>
+<table class="matrix-table">
+  <thead><tr><th></th><th>Surge</th><th>Sway</th><th>Heave</th><th>Roll</th><th>Pitch</th><th>Yaw</th></tr></thead>
+  <tbody><tr><th>Surge</th><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Sway</th><td class=''>0.0000e+00</td><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Heave</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Roll</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.0000e+09</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Pitch</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.5000e+10</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Yaw</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.4000e+10</td></tr>
+</tbody>
+</table>
+  <div style="background:#eaf2f8;border-left:4px solid #3498db;padding:0.6em 1em;margin-top:0.8em;border-radius:4px;font-size:0.85em;"><strong>Hull Type Note (barge):</strong> Wide beam typically gives large GM_T. Resonance peaks at roll natural period are the primary concern, not stability.</div>
+</div>
+
+</div>
+</body>
+</html>

--- a/tests/hydrodynamics/diffraction/fixtures/golden/full_basic.html
+++ b/tests/hydrodynamics/diffraction/fixtures/golden/full_basic.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diffraction Report - golden_barge</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 Roboto, Arial, sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle { font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }
+  .report-header .meta { font-size: 0.9em; opacity: 0.85; }
+  .nav-bar {
+    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
+    display: flex; gap: 1.5em; font-size: 0.9em;
+  }
+  .nav-bar a { color: #fff; text-decoration: none; opacity: 0.8; }
+  .nav-bar a:hover { opacity: 1; text-decoration: underline; }
+  .nav-bar .active { opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  table {
+    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
+  }
+  th {
+    background: #34495e; color: #fff; font-weight: 600;
+    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  tbody tr:hover { background: #ebf5fb; }
+  td { vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }
+  .matrix-table td { text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .matrix-table th { text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .highlight { background: #ffeaa7 !important; font-weight: 600; }
+  .plot-container { margin: 1em 0; }
+</style>
+</head>
+<body>
+<div class="container">
+<div class="section" id="toc">
+  <h2>Table of Contents</h2>
+  <ul style="list-style:none;padding:0;column-count:2;font-size:0.9em;">
+    <li><a href="#header">0. Header & Identification</a></li><li><a href="#executive-summary">1. Executive Summary</a></li><li><a href="#hull-mesh">2. Hull Description & Mesh Quality</a></li><li><a href="#hydrostatics">4. Hydrostatic Properties & Stability</a></li><li><a href="#natural-periods">5. Natural Period Estimates</a></li><li><a href="#hydro-coefficients">6. Hydrodynamic Coefficients</a></li><li><a href="#load-raos">7. Wave Excitation Forces (Load RAOs)</a></li><li><a href="#displacement-raos">8. Displacement RAOs (Motion Response)</a></li><li><a href="#roll-damping">9. Roll Damping Assessment</a></li><li><a href="#raw-data">10. Raw Data & Overlay Plots</a></li><li><a href="#appendices">11. Appendices</a></li>
+  </ul>
+</div>
+<div class="report-header">
+  <h1>Diffraction Analysis Report &mdash; golden_barge</h1>
+  <div class="subtitle">Characterization fixture</div>
+  <div class="meta">
+    Generated: 2026-01-01 00:00:00 |
+    Frequencies: 4 |
+    Headings: 3 (0.0, 45.0, 90.0&deg;) |
+    Solver(s): OrcaWave |
+    Source: golden.owr
+  </div>
+  
+</div>
+<div class="section" id="executive-summary">
+  <h2>Executive Summary</h2>
+  <table style="max-width:700px;"><thead><tr><th>Item</th><th>Value</th><th>Status</th></tr></thead><tbody><tr><td>Mesh Quality</td><td>520 panels, ratio 4.0</td><td style='color:#27ae60;font-weight:bold'>PASS</td></tr><tr><td>GM_T (transverse)</td><td>10.000 m</td><td style='color:#27ae60;font-weight:bold'>OK</td></tr><tr><td>GM_L (longitudinal)</td><td>155.000 m</td><td>-</td></tr></tbody></table>
+  
+  <div style="background:#fef9e7;border-left:4px solid #f39c12;padding:0.8em 1em;margin-top:1em;border-radius:4px;"><strong>Warnings & Alerts</strong><ul style="margin:0.3em 0;"><li style="margin:0.3em 0;">NOTE: Example warning for characterization.</li></ul></div>
+  
+</div>
+<div class="section" id="hull-mesh">
+<h2>Hull Description & Mesh Quality</h2>
+<h3>Hull Metadata</h3>
+<p><strong>Hull Type:</strong> barge</p>
+<table style="max-width:600px;"><thead><tr><th>Property</th><th>Value</th></tr></thead><tbody><tr><td>Vessel Name</td><td>golden_barge</td></tr><tr><td>Solver(s)</td><td>OrcaWave</td></tr><tr><td>Source File</td><td>golden.owr</td></tr></tbody></table>
+<h3 style="margin-top:1em;">Mesh Quality Assessment</h3>
+<table style="max-width:600px;">
+  <thead><tr><th>Property</th><th>Value</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td>Panel Count</td><td>520</td>
+        <td style="color:#27ae60;font-weight:bold">PASS</td></tr>
+    <tr><td>Vertex Count</td><td>1100</td><td>-</td></tr>
+    <tr><td>Mean Panel Area</td><td>1.250000 m2</td><td>-</td></tr>
+    <tr><td>Min Panel Area</td><td>0.600000 m2</td><td>-</td></tr>
+    <tr><td>Max Panel Area</td><td>2.400000 m2</td><td>-</td></tr>
+    <tr><td>Area Ratio (max/min)</td><td>4.00</td><td>-</td></tr>
+  </tbody>
+</table>
+<p style="font-size:0.85em;color:#666;margin-top:0.5em;">
+  Mesh quality directly affects accuracy of added mass, damping, and wave excitation forces.
+  The key metric is the <strong>adjacent panel ratio</strong> (size ratio between neighboring panels) --
+  gradual size variation is acceptable even with a large global min/max ratio.
+  Only abrupt transitions between adjacent panels degrade BEM solver accuracy.
+  Advanced mesh quality metrics (Jacobian, aspect ratio, skewness, orthogonality)
+  are available via the gmsh meshing tool.
+</p>
+</div><div class="section" id="hydrostatics">
+  <h2>Hydrostatic Properties & Stability</h2>
+  <h3>Hydrostatic Properties</h3>
+<table style="max-width:600px;">
+  <thead><tr><th>Property</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td>Displaced Volume</td><td>16000.0000 m3</td></tr>
+    <tr><td>Mass</td><td>16400000.0000</td></tr>
+    <tr><td>Centre of Buoyancy (x, y, z)</td><td>0.0000, 0.0000, -4.0000</td></tr>
+    <tr><td>Centre of Mass (x, y, z)</td><td>0.0000, 0.0000, -3.0000</td></tr>
+    <tr><td>Waterplane Area (Awp)</td><td>2000.0000 m2</td></tr>
+    <tr><td>Waterplane I_xx</td><td>266666.6670</td></tr>
+    <tr><td>Waterplane I_yy</td><td>6666666.6670</td></tr>
+    <tr><td>Centre of Floatation (x, y)</td><td>0.0000, 0.0000</td></tr>
+  </tbody>
+</table>
+  <h3 style="margin-top:1em;">Stability Assessment</h3><table style="max-width:700px;"><thead><tr><th>Parameter</th><th>Value</th><th>Status</th></tr></thead><tbody><tr><td>GM_T (transverse metacentric height)</td><td>10.0000 m</td><td style='color:#27ae60;font-weight:bold'>OK</td></tr><tr><td>GM_L (longitudinal metacentric height)</td><td>155.0000 m</td><td>-</td></tr><tr><td>BM_T (transverse)</td><td>16.6700 m</td><td>-</td></tr><tr><td>BM_L (longitudinal)</td><td>416.6700 m</td><td>-</td></tr><tr><td>KB (vertical centre of buoyancy)</td><td>-4.0000 m</td><td>-</td></tr></tbody></table><p style="font-size:0.85em;color:#666;">Reference: DNV-OS-C301 requires GM_T &gt; 1.0m for intact stability of mobile offshore units.</p><p style="font-size:0.85em;color:#666;margin-top:0.5em;">Cross-check: KB + BM_T - KG = -4.000 + 16.670 - (-3.000) = 15.670 m (vs GM_T = 10.000 m, diff = 5.6700 m)</p>
+  <h3 style="margin-top:1em;">Radii of Gyration</h3><table style="max-width:400px;"><thead><tr><th>Parameter</th><th>Value</th></tr></thead><tbody><tr><td>r_xx (roll)</td><td>7.8100 m</td></tr><tr><td>r_yy (pitch)</td><td>30.2400 m</td></tr><tr><td>r_zz (yaw)</td><td>29.2100 m</td></tr></tbody></table>
+  <h3 style="margin-top:1em;">Restoring Matrix C (Hydrostatic Stiffness)</h3>
+<table class="matrix-table">
+  <thead><tr><th></th><th>Surge</th><th>Sway</th><th>Heave</th><th>Roll</th><th>Pitch</th><th>Yaw</th></tr></thead>
+  <tbody><tr><th>Surge</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Sway</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Heave</th><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>20110500.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Roll</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>1608000000.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Pitch</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class='highlight'>25000000000.0000</td><td class=''>0.0000</td></tr>
+<tr><th>Yaw</th><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td><td class=''>0.0000</td></tr>
+</tbody>
+</table>
+<p style="font-size:0.85em;color:#666;">
+  Heave (C_33), Roll (C_44), and Pitch (C_55) have hydrostatic restoring.
+  Surge, Sway, and Yaw are neutrally stable -- restoring comes from mooring (not modelled in diffraction).
+</p>
+  <h3 style="margin-top:1em;">Inertia Matrix</h3>
+<table class="matrix-table">
+  <thead><tr><th></th><th>Surge</th><th>Sway</th><th>Heave</th><th>Roll</th><th>Pitch</th><th>Yaw</th></tr></thead>
+  <tbody><tr><th>Surge</th><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Sway</th><td class=''>0.0000e+00</td><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Heave</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.6400e+07</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Roll</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.0000e+09</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Pitch</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.5000e+10</td><td class=''>0.0000e+00</td></tr>
+<tr><th>Yaw</th><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class=''>0.0000e+00</td><td class='highlight'>1.4000e+10</td></tr>
+</tbody>
+</table>
+  <div style="background:#eaf2f8;border-left:4px solid #3498db;padding:0.6em 1em;margin-top:0.8em;border-radius:4px;font-size:0.85em;"><strong>Hull Type Note (barge):</strong> Wide beam typically gives large GM_T. Resonance peaks at roll natural period are the primary concern, not stability.</div>
+</div>
+<div class="section">
+  <h3>Phase Interpretation Guide</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li><strong>Phase = 0 deg</strong>: Response in-phase with wave (crest at origin = peak response)</li>
+    <li><strong>Phase = -90 deg</strong>: Lagging (response peaks after wave crest passes)</li>
+    <li><strong>Phase = +90 deg</strong>: Leading (response peaks before wave crest arrives)</li>
+    <li><strong>~180 deg jump near resonance</strong>: Transition from quasi-static to resonant regime</li>
+    <li><strong>Phase at near-zero amplitude</strong>: Physically meaningless -- ignore phase when amplitude is insignificant</li>
+  </ul>
+</div>
+<div class="section" id="appendices">
+  <h2>Appendices</h2>
+
+  <h3>A. Notation & Conventions</h3>
+  <table style="max-width:600px;font-size:0.85em;">
+    <thead><tr><th>Symbol</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td>DOF 1-6</td><td>Surge, Sway, Heave, Roll, Pitch, Yaw</td></tr>
+      <tr><td>Coordinate System</td><td>x-forward, z-up, right-hand rule</td></tr>
+      <tr><td>A_ii(omega)</td><td>Frequency-dependent added mass (diagonal)</td></tr>
+      <tr><td>B_ii(omega)</td><td>Frequency-dependent radiation damping (diagonal)</td></tr>
+      <tr><td>C_ii</td><td>Hydrostatic restoring stiffness (diagonal)</td></tr>
+      <tr><td>GM_T</td><td>Transverse metacentric height (metres)</td></tr>
+      <tr><td>T_n</td><td>Natural period (seconds)</td></tr>
+      <tr><td>zeta</td><td>Critical damping ratio (%)</td></tr>
+      <tr><td>RAO</td><td>Response Amplitude Operator</td></tr>
+    </tbody>
+  </table>
+
+  <h3 style="margin-top:1em;">B. Key Formulas</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li>T_n = 2pi * sqrt((M_ii + A_ii(omega_n)) / C_ii)</li>
+    <li>zeta(omega) = B_ii(omega) / (2 * sqrt((M_ii + A_ii(omega)) * C_ii))</li>
+    <li>GM_T = C_44 / (rho * g * V), where rho=1025 kg/m3, g=9.81 m/s2</li>
+    <li>BM_T = I_xx / V; GM_T = KB + BM_T - KG (cross-check)</li>
+  </ul>
+
+  <h3 style="margin-top:1em;">C. References</h3>
+  <ol style="font-size:0.85em;color:#555;">
+    <li>Newman, J.N. (1977). <em>Marine Hydrodynamics</em>. MIT Press.</li>
+    <li>Faltinsen, O.M. (1990). <em>Sea Loads on Ships and Offshore Structures</em>. Cambridge.</li>
+    <li>Journee, J.M.J. & Massie, W.W. (2001). <em>Offshore Hydromechanics</em>. TU Delft.</li>
+    <li>Lee, C.H. (1995). <em>WAMIT Theory Manual</em>. MIT.</li>
+    <li>Chakrabarti, S.K. (2005). <em>Handbook of Offshore Engineering</em>. Elsevier.</li>
+    <li>DNV-RP-C205 (2021). <em>Environmental Conditions and Environmental Loads</em>.</li>
+    <li>DNV-OS-C301. <em>Stability and Watertight Integrity</em>.</li>
+  </ol>
+</div>
+
+</div>
+</body>
+</html>

--- a/tests/hydrodynamics/diffraction/fixtures/golden/validation_assumptions.html
+++ b/tests/hydrodynamics/diffraction/fixtures/golden/validation_assumptions.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Diffraction Report - golden_validation</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 Roboto, Arial, sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1400px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle { font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300; }
+  .report-header .meta { font-size: 0.9em; opacity: 0.85; }
+  .nav-bar {
+    margin-top: 1.2em; padding-top: 1em; border-top: 1px solid rgba(255,255,255,0.15);
+    display: flex; gap: 1.5em; font-size: 0.9em;
+  }
+  .nav-bar a { color: #fff; text-decoration: none; opacity: 0.8; }
+  .nav-bar a:hover { opacity: 1; text-decoration: underline; }
+  .nav-bar .active { opacity: 1; font-weight: 600; border-bottom: 2px solid #3498db; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  table {
+    border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left;
+  }
+  th {
+    background: #34495e; color: #fff; font-weight: 600;
+    font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  tbody tr:hover { background: #ebf5fb; }
+  td { vertical-align: top; font-family: 'Cascadia Code', 'Fira Code', monospace; }
+  .matrix-table td { text-align: right; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .matrix-table th { text-align: center; padding: 0.3em 0.5em; font-size: 0.8em; }
+  .highlight { background: #ffeaa7 !important; font-weight: 600; }
+  .plot-container { margin: 1em 0; }
+</style>
+</head>
+<body>
+<div class="container">
+<div class="section" id="toc">
+  <h2>Table of Contents</h2>
+  <ul style="list-style:none;padding:0;column-count:2;font-size:0.9em;">
+    <li><a href="#header">0. Header & Identification</a></li><li><a href="#executive-summary">1. Executive Summary</a></li><li><a href="#hull-mesh">2. Hull Description & Mesh Quality</a></li><li><a href="#hydrostatics">4. Hydrostatic Properties & Stability</a></li><li><a href="#natural-periods">5. Natural Period Estimates</a></li><li><a href="#hydro-coefficients">6. Hydrodynamic Coefficients</a></li><li><a href="#load-raos">7. Wave Excitation Forces (Load RAOs)</a></li><li><a href="#displacement-raos">8. Displacement RAOs (Motion Response)</a></li><li><a href="#roll-damping">9. Roll Damping Assessment</a></li><li><a href="#raw-data">10. Raw Data & Overlay Plots</a></li><li><a href="#appendices">11. Appendices</a></li>
+  </ul>
+</div>
+<div class="report-header">
+  <h1>Diffraction Analysis Report &mdash; golden_validation</h1>
+  
+  <div class="meta">
+    Generated: 2026-01-01 00:00:00 |
+    Frequencies: 3 |
+    Headings: 1 (0.0&deg;) |
+    Solver(s): N/A |
+    Source: N/A
+  </div>
+  
+</div>
+<div class="section" id="executive-summary">
+  <h2>Executive Summary</h2>
+  
+  
+  
+  
+</div>
+<div class="section" id="validation-sanity"><h2>Validation Sanity Check</h2><p>Overall verdict: <span style="display:inline-block;padding:3px 12px;border-radius:4px;color:#fff;font-weight:700;background:#f39c12">WARNING</span> &nbsp;(2 issue(s))</p><table><thead><tr><th>Category</th><th>Count</th><th>Representative issues</th></tr></thead><tbody><tr><td>physical_validity</td><td>1</td><td>raos: Surge: Maximum RAO magnitude 6.0 exceeds typical range</td></tr><tr><td>frequency_coverage</td><td>1</td><td>discretization: Only 3 frequencies - may be insufficient</td></tr></tbody></table></div><div class="section" id="assumptions"><h2>Assumptions</h2><table><thead><tr><th>Field</th><th>Value</th><th>Source</th><th>Basis</th><th>Reference</th><th>Confidence</th></tr></thead><tbody><tr><td>water_depth</td><td>1500.0</td><td>assumed_default</td><td>Deepwater default</td><td>DNV-RP-C205</td><td>medium</td></tr><tr><td>density</td><td>1025.0</td><td>assumed_default</td><td>Seawater standard</td><td></td><td>high</td></tr></tbody></table></div><div class="section" id="hull-mesh">
+<h2>Hull Description & Mesh Quality</h2>
+<h3>Hull Metadata</h3>
+<table style="max-width:600px;"><thead><tr><th>Property</th><th>Value</th></tr></thead><tbody><tr><td>Vessel Name</td><td>golden_validation</td></tr></tbody></table>
+</div><div class="section">
+  <h3>Phase Interpretation Guide</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li><strong>Phase = 0 deg</strong>: Response in-phase with wave (crest at origin = peak response)</li>
+    <li><strong>Phase = -90 deg</strong>: Lagging (response peaks after wave crest passes)</li>
+    <li><strong>Phase = +90 deg</strong>: Leading (response peaks before wave crest arrives)</li>
+    <li><strong>~180 deg jump near resonance</strong>: Transition from quasi-static to resonant regime</li>
+    <li><strong>Phase at near-zero amplitude</strong>: Physically meaningless -- ignore phase when amplitude is insignificant</li>
+  </ul>
+</div>
+<div class="section" id="appendices">
+  <h2>Appendices</h2>
+
+  <h3>A. Notation & Conventions</h3>
+  <table style="max-width:600px;font-size:0.85em;">
+    <thead><tr><th>Symbol</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td>DOF 1-6</td><td>Surge, Sway, Heave, Roll, Pitch, Yaw</td></tr>
+      <tr><td>Coordinate System</td><td>x-forward, z-up, right-hand rule</td></tr>
+      <tr><td>A_ii(omega)</td><td>Frequency-dependent added mass (diagonal)</td></tr>
+      <tr><td>B_ii(omega)</td><td>Frequency-dependent radiation damping (diagonal)</td></tr>
+      <tr><td>C_ii</td><td>Hydrostatic restoring stiffness (diagonal)</td></tr>
+      <tr><td>GM_T</td><td>Transverse metacentric height (metres)</td></tr>
+      <tr><td>T_n</td><td>Natural period (seconds)</td></tr>
+      <tr><td>zeta</td><td>Critical damping ratio (%)</td></tr>
+      <tr><td>RAO</td><td>Response Amplitude Operator</td></tr>
+    </tbody>
+  </table>
+
+  <h3 style="margin-top:1em;">B. Key Formulas</h3>
+  <ul style="font-size:0.85em;color:#555;">
+    <li>T_n = 2pi * sqrt((M_ii + A_ii(omega_n)) / C_ii)</li>
+    <li>zeta(omega) = B_ii(omega) / (2 * sqrt((M_ii + A_ii(omega)) * C_ii))</li>
+    <li>GM_T = C_44 / (rho * g * V), where rho=1025 kg/m3, g=9.81 m/s2</li>
+    <li>BM_T = I_xx / V; GM_T = KB + BM_T - KG (cross-check)</li>
+  </ul>
+
+  <h3 style="margin-top:1em;">C. References</h3>
+  <ol style="font-size:0.85em;color:#555;">
+    <li>Newman, J.N. (1977). <em>Marine Hydrodynamics</em>. MIT Press.</li>
+    <li>Faltinsen, O.M. (1990). <em>Sea Loads on Ships and Offshore Structures</em>. Cambridge.</li>
+    <li>Journee, J.M.J. & Massie, W.W. (2001). <em>Offshore Hydromechanics</em>. TU Delft.</li>
+    <li>Lee, C.H. (1995). <em>WAMIT Theory Manual</em>. MIT.</li>
+    <li>Chakrabarti, S.K. (2005). <em>Handbook of Offshore Engineering</em>. Elsevier.</li>
+    <li>DNV-RP-C205 (2021). <em>Environmental Conditions and Environmental Loads</em>.</li>
+    <li>DNV-OS-C301. <em>Stability and Watertight Integrity</em>.</li>
+  </ol>
+</div>
+
+</div>
+</body>
+</html>

--- a/tests/hydrodynamics/diffraction/test_report_generator_golden.py
+++ b/tests/hydrodynamics/diffraction/test_report_generator_golden.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Golden / characterization tests for the diffraction report generator.
+
+These tests pin the EXACT HTML output of ``generate_diffraction_report`` for a
+set of representative fixtures. They exist to prove that extracting the shared
+``digitalmodel.reporting`` block library (#1018) is a ZERO behavior change:
+the refactored generator must reproduce these committed golden files
+byte-for-byte.
+
+The golden files under ``fixtures/golden/`` were generated from the
+PRE-refactor code. Regenerate intentionally with::
+
+    uv run python tests/hydrodynamics/diffraction/test_report_generator_golden.py
+
+Fixtures are deterministic on purpose: ``report_date`` is pinned and no
+plotly-backed sections are exercised (those builders emit non-deterministic
+div ids), so the golden bytes are stable across runs and machines.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.hydrodynamics.diffraction.report_generator import (
+    DiffractionReportData,
+    HydrostaticData,
+    MeshQualityData,
+    generate_diffraction_report,
+)
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "golden"
+
+_FIXED_DATE = "2026-01-01 00:00:00"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _hydrostatics() -> HydrostaticData:
+    C = [[0.0] * 6 for _ in range(6)]
+    C[2][2] = 1025.0 * 9.81 * 2000.0
+    C[3][3] = 1.608e9
+    C[4][4] = 2.5e10
+    I = [[0.0] * 6 for _ in range(6)]
+    I[0][0] = I[1][1] = I[2][2] = 16400000.0
+    I[3][3] = 1.0e9
+    I[4][4] = 1.5e10
+    I[5][5] = 1.4e10
+    return HydrostaticData(
+        volume=16000.0,
+        mass=16400000.0,
+        centre_of_buoyancy=[0.0, 0.0, -4.0],
+        centre_of_mass=[0.0, 0.0, -3.0],
+        waterplane_area=2000.0,
+        Lxx=266666.667,
+        Lyy=6666666.667,
+        Lxy=0.0,
+        centre_of_floatation=[0.0, 0.0],
+        restoring_matrix=C,
+        inertia_matrix=I,
+    )
+
+
+def _full_basic() -> Tuple[DiffractionReportData, Dict[str, Any]]:
+    data = DiffractionReportData(
+        vessel_name="golden_barge",
+        report_date=_FIXED_DATE,
+        report_subtitle="Characterization fixture",
+        hull_type="barge",
+        solver_names=["OrcaWave"],
+        source_file="golden.owr",
+        frequencies_rad_s=[0.3, 0.6, 0.9, 1.2],
+        periods_s=[20.94, 10.47, 6.98, 5.24],
+        headings_deg=[0.0, 45.0, 90.0],
+        hydrostatics=_hydrostatics(),
+        mesh_quality=MeshQualityData(
+            panel_count=520,
+            mean_area=1.25,
+            min_area=0.6,
+            max_area=2.4,
+            area_ratio=4.0,
+            vertex_count=1100,
+        ),
+        gm_transverse=10.0,
+        gm_longitudinal=155.0,
+        bm_transverse=16.67,
+        bm_longitudinal=416.67,
+        kb=-4.0,
+        radii_of_gyration={"r_xx": 7.81, "r_yy": 30.24, "r_zz": 29.21},
+        executive_warnings=["NOTE: Example warning for characterization."],
+    )
+    return data, {}
+
+
+def _compact() -> Tuple[DiffractionReportData, Dict[str, Any]]:
+    data, _ = _full_basic()
+    data.vessel_name = "golden_barge_compact"
+    return data, {"mode": "compact"}
+
+
+def _benchmark() -> Tuple[DiffractionReportData, Dict[str, Any]]:
+    data = DiffractionReportData(
+        vessel_name="golden_benchmark",
+        report_date=_FIXED_DATE,
+        solver_names=["OrcaWave", "AQWA"],
+        source_file="bench.owr",
+        frequencies_rad_s=[0.5, 1.0, 1.5],
+        periods_s=[12.57, 6.28, 4.19],
+        headings_deg=[0.0, 90.0, 180.0],
+        benchmark_html_sections={
+            "mesh_schematic": "<h2>Mesh</h2><p>BENCH_MESH</p>",
+            "input_comparison": "<h2>Input Comparison</h2><p>BENCH_INPUT</p>",
+            "input_files": "<h2>Input Files</h2><p>BENCH_FILES</p>",
+            "hydro_coefficients": "<h2>Coefficients</h2><p>BENCH_COEFFS</p>",
+            "consensus_summary": "<h2>Consensus</h2><p>BENCH_CONSENSUS</p>",
+            "dof_sections": "<h2>Per-DOF</h2><p>BENCH_DOF</p>",
+            "raw_rao_data": "<h2>Raw Data</h2><p>BENCH_RAW</p>",
+            "overlay_plots": "<h2>Overlay</h2><p>BENCH_OVERLAY</p>",
+            # Intentionally empty -> must NOT produce a section div.
+            "input_extra_empty": "",
+        },
+        notes=["Note one", "Note two"],
+    )
+    return data, {}
+
+
+def _validation_assumptions() -> Tuple[DiffractionReportData, Dict[str, Any]]:
+    data = DiffractionReportData(
+        vessel_name="golden_validation",
+        report_date=_FIXED_DATE,
+        frequencies_rad_s=[0.5, 1.0, 1.5],
+        periods_s=[12.57, 6.28, 4.19],
+        headings_deg=[0.0],
+    )
+    validation_report = {
+        "overall_status": "WARNING",
+        "vessel_name": "golden_validation",
+        "physical_validity": {
+            "raos": ["Surge: Maximum RAO magnitude 6.0 exceeds typical range"],
+            "added_mass": [],
+        },
+        "frequency_coverage": {
+            "discretization": ["Only 3 frequencies - may be insufficient"],
+        },
+    }
+    ledger = AssumptionLedger()
+    ledger.record(
+        field="water_depth",
+        value=1500.0,
+        source=AssumptionSource.ASSUMED_DEFAULT,
+        basis="Deepwater default",
+        confidence=Confidence.MEDIUM,
+        reference="DNV-RP-C205",
+    )
+    ledger.record(
+        field="density",
+        value=1025.0,
+        source=AssumptionSource.ASSUMED_DEFAULT,
+        basis="Seawater standard",
+        confidence=Confidence.HIGH,
+    )
+    return data, {
+        "validation_report": validation_report,
+        "assumption_ledger": ledger,
+    }
+
+
+FIXTURES = {
+    "full_basic": _full_basic,
+    "compact": _compact,
+    "benchmark": _benchmark,
+    "validation_assumptions": _validation_assumptions,
+}
+
+
+def _render(name: str, tmp_dir: Path) -> str:
+    data, kwargs = FIXTURES[name]()
+    out = tmp_dir / f"{name}.html"
+    result = generate_diffraction_report(data, out, **kwargs)
+    return result.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(FIXTURES))
+def test_output_matches_golden(name: str, tmp_path: Path) -> None:
+    """Refactored output must be byte-identical to the committed golden file."""
+    golden_path = GOLDEN_DIR / f"{name}.html"
+    assert golden_path.exists(), (
+        f"Missing golden file {golden_path}. Regenerate with: "
+        "uv run python tests/hydrodynamics/diffraction/"
+        "test_report_generator_golden.py"
+    )
+    expected = golden_path.read_text(encoding="utf-8")
+    actual = _render(name, tmp_path)
+    assert actual == expected, (
+        f"Diffraction report output for fixture '{name}' diverged from the "
+        f"golden snapshot (zero-behavior-change violated)."
+    )
+
+
+def _regenerate() -> None:
+    """Write golden files from the CURRENT generator implementation."""
+    import tempfile
+
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for name in sorted(FIXTURES):
+            html = _render(name, tmp)
+            (GOLDEN_DIR / f"{name}.html").write_text(html, encoding="utf-8")
+            print(f"wrote {name}.html ({len(html)} bytes)")
+
+
+if __name__ == "__main__":
+    _regenerate()

--- a/tests/reporting/test_reporting_library.py
+++ b/tests/reporting/test_reporting_library.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Unit tests for the reusable digitalmodel.reporting block library (#1018)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.reporting import (
+    ReportBackbone,
+    ReportBlock,
+    ReportBlockFn,
+    ReportDataModel,
+    ReportRenderer,
+    ReportSection,
+    SectionMode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _section(key, mode, fragment=None):
+    """A simple section whose builder emits a keyed marker (or a fragment)."""
+
+    def _builder(data, **kwargs):
+        if fragment is not None:
+            return fragment
+        return f"<div>{key}</div>"
+
+    return ReportSection(key=key, label=key.title(), mode=mode, builder=_builder)
+
+
+# ---------------------------------------------------------------------------
+# ReportBackbone: ordering
+# ---------------------------------------------------------------------------
+
+
+class TestBackboneOrdering:
+    def test_sections_render_in_declared_order(self):
+        backbone = ReportBackbone(
+            title="T",
+            sections=[
+                _section("a", SectionMode.ALWAYS),
+                _section("b", SectionMode.ALWAYS),
+                _section("c", SectionMode.ALWAYS),
+            ],
+        )
+        out = backbone.render(object())
+        assert out == ["<div>a</div>", "<div>b</div>", "<div>c</div>"]
+
+    def test_empty_builder_output_is_omitted(self):
+        backbone = ReportBackbone(
+            title="T",
+            sections=[
+                _section("a", SectionMode.ALWAYS),
+                _section("blank", SectionMode.ALWAYS, fragment=""),
+                _section("c", SectionMode.ALWAYS),
+            ],
+        )
+        out = backbone.render(object())
+        assert out == ["<div>a</div>", "<div>c</div>"]
+
+    def test_builder_receives_mode_and_kwargs(self):
+        seen = {}
+
+        def _builder(data, *, mode=None, benchmark_sections=None, flavor=None, **_):
+            seen["mode"] = mode
+            seen["flavor"] = flavor
+            return "<x/>"
+
+        backbone = ReportBackbone(
+            title="T",
+            sections=[ReportSection("x", "X", SectionMode.ALWAYS, _builder)],
+        )
+        backbone.render(object(), mode="compact", flavor="spicy")
+        assert seen == {"mode": "compact", "flavor": "spicy"}
+
+
+# ---------------------------------------------------------------------------
+# ReportBackbone: COMPACT_SKIP
+# ---------------------------------------------------------------------------
+
+
+class TestCompactSkip:
+    def _backbone(self):
+        return ReportBackbone(
+            title="T",
+            sections=[
+                _section("always", SectionMode.ALWAYS),
+                _section("detail", SectionMode.COMPACT_SKIP),
+            ],
+        )
+
+    def test_full_mode_includes_compact_skip(self):
+        out = self._backbone().render(object(), mode="full")
+        assert out == ["<div>always</div>", "<div>detail</div>"]
+
+    def test_compact_mode_drops_compact_skip(self):
+        out = self._backbone().render(object(), mode="compact")
+        assert out == ["<div>always</div>"]
+
+    def test_benchmark_only_renders_in_compact_mode(self):
+        backbone = ReportBackbone(
+            title="T",
+            sections=[
+                _section("always", SectionMode.ALWAYS),
+                _section("detail", SectionMode.COMPACT_SKIP),
+                _section("bench", SectionMode.BENCHMARK_ONLY),
+            ],
+        )
+        out = backbone.render(
+            object(), mode="compact", benchmark_sections={"bench": "frag"}
+        )
+        # COMPACT_SKIP dropped, BENCHMARK_ONLY still renders.
+        assert out == ["<div>always</div>", "<div>bench</div>"]
+
+
+# ---------------------------------------------------------------------------
+# ReportBackbone: BENCHMARK_ONLY + benchmark injection
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmark:
+    def test_benchmark_only_skipped_without_fragment(self):
+        backbone = ReportBackbone(
+            title="T",
+            sections=[_section("bench", SectionMode.BENCHMARK_ONLY)],
+        )
+        assert backbone.render(object()) == []
+        assert backbone.render(object(), benchmark_sections={}) == []
+
+    def test_benchmark_only_rendered_with_fragment(self):
+        # A typical benchmark builder wraps the fragment for its key.
+        def _wrap(data, *, benchmark_sections=None, **_):
+            frag = (benchmark_sections or {}).get("bench")
+            return f'<div class="section">{frag}</div>' if frag else ""
+
+        backbone = ReportBackbone(
+            title="T",
+            sections=[ReportSection("bench", "B", SectionMode.BENCHMARK_ONLY, _wrap)],
+        )
+        out = backbone.render(object(), benchmark_sections={"bench": "<p>X</p>"})
+        assert out == ['<div class="section"><p>X</p></div>']
+
+    def test_empty_string_fragment_omitted(self):
+        def _wrap(data, *, benchmark_sections=None, **_):
+            frag = (benchmark_sections or {}).get("bench")
+            return f'<div class="section">{frag}</div>' if frag else ""
+
+        backbone = ReportBackbone(
+            title="T",
+            sections=[ReportSection("bench", "B", SectionMode.BENCHMARK_ONLY, _wrap)],
+        )
+        out = backbone.render(object(), benchmark_sections={"bench": ""})
+        assert out == []
+
+    def test_injection_after_matching_regular_section(self):
+        """A fragment keyed to a rendered regular section is appended after it."""
+        backbone = ReportBackbone(
+            title="T",
+            sections=[
+                _section("intro", SectionMode.ALWAYS),
+                _section("outro", SectionMode.ALWAYS),
+            ],
+        )
+        out = backbone.render(
+            object(), benchmark_sections={"intro": "<p>injected</p>"}
+        )
+        assert out == [
+            "<div>intro</div>",
+            '<div class="section"><p>injected</p></div>',
+            "<div>outro</div>",
+        ]
+
+    def test_no_injection_when_key_absent(self):
+        backbone = ReportBackbone(
+            title="T", sections=[_section("intro", SectionMode.ALWAYS)]
+        )
+        out = backbone.render(
+            object(), benchmark_sections={"other": "<p>nope</p>"}
+        )
+        assert out == ["<div>intro</div>"]
+
+
+# ---------------------------------------------------------------------------
+# ReportRenderer
+# ---------------------------------------------------------------------------
+
+
+class TestReportRenderer:
+    def test_render_html_structure(self):
+        renderer = ReportRenderer()
+        html = renderer.render_html(
+            ["<div>one</div>", "<div>two</div>"],
+            title="My Report",
+            css="  body { color: red; }\n",
+            plotlyjs_src="<script></script>",
+        )
+        assert html.startswith("<!DOCTYPE html>\n")
+        assert html.endswith("</html>")
+        assert "<title>My Report</title>" in html
+        assert "<script></script>\n<style>" in html
+        assert "  body { color: red; }\n</style>" in html
+        assert '<div class="container">\n<div>one</div><div>two</div>\n</div>' in html
+
+    def test_render_html_defaults_no_plotly_line_blank(self):
+        renderer = ReportRenderer()
+        html = renderer.render_html([], title="T")
+        # plotlyjs_src defaults to "" -> the line is blank, then <style>.
+        assert "<title>T</title>\n\n<style>\n</style>" in html
+        assert '<div class="container">' in html
+
+    def test_container_max_width_inline_style(self):
+        renderer = ReportRenderer()
+        html = renderer.render_html(
+            [], title="T", container_class="wrap", container_max_width="900px"
+        )
+        assert '<div class="wrap" style="max-width: 900px;">' in html
+
+    def test_head_extra_inserted_before_style(self):
+        renderer = ReportRenderer()
+        html = renderer.render_html(
+            [], title="T", head_extra='<meta name="x" content="y">\n'
+        )
+        assert '<meta name="x" content="y">\n<style>' in html
+
+    def test_write_html_round_trip(self, tmp_path):
+        renderer = ReportRenderer()
+        html = renderer.render_html(["<p>hi</p>"], title="T")
+        out = tmp_path / "nested" / "dir" / "report.html"
+        result = renderer.write_html(html, out)
+        assert result == out
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == html
+
+    def test_write_html_accepts_str_path(self, tmp_path):
+        renderer = ReportRenderer()
+        html = renderer.render_html([], title="T")
+        target = tmp_path / "r.html"
+        result = renderer.write_html(html, str(target))
+        assert isinstance(result, Path)
+        assert result.read_text(encoding="utf-8") == html
+
+
+# ---------------------------------------------------------------------------
+# ReportBlock protocol + ReportBlockFn
+# ---------------------------------------------------------------------------
+
+
+class TestReportBlockProtocol:
+    def test_object_with_render_satisfies_protocol(self):
+        class Block:
+            def render(self, data, **kwargs) -> str:
+                return "<x/>"
+
+        assert isinstance(Block(), ReportBlock)
+
+    def test_object_without_render_does_not_satisfy(self):
+        class NotABlock:
+            def other(self):  # pragma: no cover - shape only
+                return "x"
+
+        assert not isinstance(NotABlock(), ReportBlock)
+
+    def test_runtime_checkable_marker(self):
+        # Protocol is runtime_checkable -> isinstance must not raise.
+        assert isinstance(object(), ReportBlock) is False
+
+    def test_report_block_fn_is_callable_alias(self):
+        def builder(data, **kwargs) -> str:
+            return ""
+
+        fn: ReportBlockFn = builder
+        assert callable(fn)
+
+
+# ---------------------------------------------------------------------------
+# ReportDataModel
+# ---------------------------------------------------------------------------
+
+
+class TestReportDataModel:
+    def test_subclassing_and_validation(self):
+        class MyData(ReportDataModel):
+            name: str
+            count: int = 0
+
+        m = MyData(name="abc")
+        assert m.name == "abc"
+        assert m.count == 0
+        assert m.model_dump() == {"name": "abc", "count": 0}
+
+    def test_arbitrary_types_allowed(self):
+        class Holder:
+            pass
+
+        class MyData(ReportDataModel):
+            payload: Holder
+
+        h = Holder()
+        m = MyData(payload=h)
+        assert m.payload is h
+
+    def test_is_pydantic_model(self):
+        from pydantic import BaseModel
+
+        class MyData(ReportDataModel):
+            x: int
+
+        assert issubclass(MyData, BaseModel)
+        with pytest.raises(Exception):
+            MyData()  # missing required field


### PR DESCRIPTION
Closes #1018 (keystone of the report-as-backbone initiative).

## What
Extracts a reusable `digitalmodel.reporting` package by generalizing the report-builder pattern that previously lived only in `hydrodynamics/diffraction/`:

- `ReportBlock` protocol (`@runtime_checkable`) + `ReportBlockFn` alias — diffraction builders are plain functions, so the backbone accepts callables.
- `ReportDataModel` — pydantic v2 marker base for report envelope models.
- `SectionMode` / `ReportSection` / `ReportBackbone` — declarative section ordering with compact-skip and benchmark-injection rules.
- `ReportRenderer` — HTML document assembly + `write_html`. **No PDF** (deferred; diffraction emits HTML only today).

## Zero behavior change (proven)
The diffraction module adopts the library:
- 5 report data models now inherit `ReportDataModel` instead of `BaseModel` (marker only).
- `generate_diffraction_report` assembles via a module-level `ReportBackbone` + `ReportRenderer`.
- **Builder function bodies untouched**; public signatures of `generate_diffraction_report` / `generate_report_from_owr` unchanged.

A **golden/characterization test** (`test_report_generator_golden.py`, 4 fixtures: full / compact / benchmark / validation+assumptions) asserts the refactored output is **byte-identical** to snapshots captured from the pre-refactor code.

## Tests
- `uv run pytest tests/reporting/ -q` → **24 passed**
- `uv run pytest tests/hydrodynamics/diffraction/test_report_generator.py test_report_generator_golden.py test_report_data_models.py -q` → **101 passed** (incl. 4 golden)
- Targeted runs only — repo CI baseline is red (unrelated); compare this PR's check set vs bare main.

## Follow-ups (separate issues, not in this PR)
- #1019 single-source-of-truth data contract + provenance
- #1020 migrate `fatigue_reporting` onto the backbone (tracer)
- #1021 skeleton-first report CLI
- PDF renderer for `ReportRenderer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)