### PR TITLE
feat(floating_wind): global sizing & concept screening — offline core (#1022)

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -30,6 +30,9 @@ of duplicating its detailed issue history.
 | `hydrodynamics` | `src/digitalmodel/hydrodynamics/` | `tests/hydrodynamics/` | `docs/domains/hydrodynamics/` | Wave spectra, RAOs, diffraction, hull library, solver bridges | NumPy, SciPy, OrcaWave/AQWA context |
 | `infrastructure` | `src/digitalmodel/infrastructure/` | `tests/infrastructure/` | `docs/domains/infrastructure/` | Base configs, services, validators, transformations | YAML configs, shared services |
 | `marine_ops` | `src/digitalmodel/marine_ops/` | `tests/marine_ops/` | `docs/domains/marine_ops/` | Marine operations, RAO readers, installation and operational analysis | metocean and vessel data |
+| `floating_wind` | `src/digitalmodel/floating_wind/` | `tests/floating_wind/` | `docs/domains/README.md` | Floating-wind global sizing & concept screening (semi/spar/TLP/barge); `floating_wind_sizing` workflow | hydrostatics, parametric sweeps, OrcaWave/OrcaFlex (solver tier) |
+| `hydrostatics` | `src/digitalmodel/hydrostatics/` | `tests/hydrostatics/` | `docs/domains/README.md` | Fluid-column hydrostatics; seabed/hydrostatic pressure and offshore pressure-unit conversions | NumPy |
+| `mooring_resilience` | `src/digitalmodel/mooring_resilience/` | `tests/` | `docs/domains/README.md` | Mooring-system resilience screening (intact/damaged tension, foundation, fatigue) over pre-computed atlases | mooring atlases, API RP 2SK / DNV-OS-E301 |
 | `naval_architecture` | `src/digitalmodel/naval_architecture/` | `tests/naval_architecture/` | `docs/domains/README.md` | Stability, hull form, compliance, gyradius calculations | naval architecture standards |
 | `nde` | `src/digitalmodel/nde/` | `tests/nde/` | `docs/domains/README.md` | Non-destructive examination workflows and checks | inspection standards |
 | `orcaflex` | `src/digitalmodel/orcaflex/` | `tests/orcaflex/` | `docs/domains/orcaflex/` | Public OrcaFlex APIs, reporting, model and post-processing utilities | OrcFxAPI where licensed, YAML |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -92,6 +92,24 @@ modules:
     owner_wiki: docs/domains/marine_ops/
     key_tests: [tests/marine_ops/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#marine_ops
+  - module: floating_wind
+    entry_point: src/digitalmodel/floating_wind/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/floating_wind/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#floating_wind
+  - module: hydrostatics
+    entry_point: src/digitalmodel/hydrostatics/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/hydrostatics/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#hydrostatics
+  - module: mooring_resilience
+    entry_point: src/digitalmodel/mooring_resilience/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#mooring_resilience
   - module: naval_architecture
     entry_point: src/digitalmodel/naval_architecture/
     maturity: beta

--- a/examples/workflows/floating-wind-sizing/input.yml
+++ b/examples/workflows/floating-wind-sizing/input.yml
@@ -1,0 +1,79 @@
+basename: floating_wind_sizing
+
+# Floating-wind global sizing & concept screening (epic #1022, issues #1023/#1024
+# /#1028). Sweeps parametric floater variants across site load cases and screens
+# each on stability, motion, modal and mooring. Closed-form, licence-free:
+#   uv run python -m digitalmodel examples/workflows/floating-wind-sizing/input.yml
+# Preliminary screen only; the shortlist goes to the licensed OrcaWave/OrcaFlex
+# high-fidelity tier (#1025).
+floating_wind_sizing:
+
+  # Lumped turbine topside (IEA 15 MW class). Floating-wind pitch is dominated by
+  # this high, heavy mass, so it is carried explicitly.
+  topside:
+    rna_mass_t: 1017.0
+    tower_mass_t: 1263.0
+    hub_height_m: 150.0
+    tower_base_above_swl_m: 15.0
+
+  # Site sea states. steady_load_kN = steady horizontal environmental load
+  # (rated wind thrust + current drag) for the mooring offset proxy.
+  load_cases:
+    - {name: operational, hs_m: 2.5, tp_s: 8.0, steady_load_kN: 2400.0}
+    - {name: severe,      hs_m: 6.0, tp_s: 11.0, steady_load_kN: 2800.0}
+    - {name: extreme,     hs_m: 10.0, tp_s: 14.0, steady_load_kN: 3000.0}
+
+  # Acceptance thresholds.
+  criteria:
+    gm_min_m: 1.0
+    daf_limit: 2.0
+    damping_ratio: 0.05
+    modal_band_s: [5.0, 16.0]
+    mooring_stiffness_kN_per_m: 400.0
+    max_offset_m: 30.0
+
+  # One or more concept sweeps. base_params are the fixed model fields; each
+  # sweep varies one field (full-factorial across sweeps within a concept).
+  concepts:
+    - name: semi_screen
+      archetype: semi
+      base_params:
+        n_columns: 3
+        column_diameter: 12.5
+        column_radius: 51.75
+        draft: 20.0
+        pontoon_height: 7.0
+        pontoon_volume: 10000.0
+        steel_mass_t: 4000.0
+      sweeps:
+        - {name: column_diameter, values: [11.0, 12.5, 14.0]}
+        - {name: column_radius, values: [45.0, 51.75]}
+
+    - name: spar_screen
+      archetype: spar
+      base_params:
+        diameter: 20.0
+        draft: 120.0
+        steel_mass_t: 6000.0
+      sweeps:
+        - {name: draft, values: [100.0, 120.0, 140.0]}
+
+    - name: barge_screen
+      archetype: barge
+      base_params:
+        length: 60.0
+        beam: 60.0
+        draft: 12.0
+        steel_mass_t: 5000.0
+      sweeps:
+        - {name: beam, values: [55.0, 60.0, 65.0]}
+
+output:
+  summary_json: examples/workflows/floating-wind-sizing/results/floating_wind_sizing_summary.json
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/floating_wind_sizing/floating_wind_sizing.yml
+++ b/src/digitalmodel/base_configs/modules/floating_wind_sizing/floating_wind_sizing.yml
@@ -1,0 +1,8 @@
+basename: floating_wind_sizing
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -443,6 +443,12 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
         fowt_mooring = FOWTMooringWorkflow()
         cfg_base = fowt_mooring.router(cfg_base)
+    elif basename == "floating_wind_sizing":
+        from digitalmodel.floating_wind.workflow import (
+            FloatingWindSizingWorkflow,
+        )
+
+        cfg_base = FloatingWindSizingWorkflow().router(cfg_base)
     elif basename == "fpso_mooring_full":
         from digitalmodel.marine_ops.marine_engineering.mooring_analysis.fpso_full_workflow import (
             FPSOMooringFullWorkflow,

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -1,0 +1,35 @@
+"""digitalmodel.floating_wind -- floating-wind global sizing & concept screening.
+
+A PyFloatSizer-class capability (epic #1022): hold floater archetypes
+(semi-submersible / spar / TLP / barge) as parametric models, screen design
+variants across site load cases, and surface the trade space. Closed-form /
+licence-free first tier; OrcaWave/OrcaFlex is the high-fidelity tier (#1025).
+"""
+
+from .floaters import (
+    RHO_SEAWATER,
+    G_STANDARD,
+    FloaterArchetype,
+    TurbineTopside,
+    FloaterProperties,
+    SemiSubmersible,
+    Spar,
+    TLP,
+    Barge,
+    build_floater,
+    IEA_15MW_RNA,
+)
+
+__all__ = [
+    "RHO_SEAWATER",
+    "G_STANDARD",
+    "FloaterArchetype",
+    "TurbineTopside",
+    "FloaterProperties",
+    "SemiSubmersible",
+    "Spar",
+    "TLP",
+    "Barge",
+    "build_floater",
+    "IEA_15MW_RNA",
+]

--- a/src/digitalmodel/floating_wind/floaters.py
+++ b/src/digitalmodel/floating_wind/floaters.py
@@ -1,0 +1,592 @@
+"""Parametric floater archetype models for floating-wind concept screening.
+
+Floating-wind *global sizing & concept screening* (issue #1023, epic #1022)
+starts from a handful of floater **archetypes**, each described by a small
+parameter vector, and derives the naval-architecture properties needed to
+screen a design: displacement, mass split, intact stability (``GM``) and the
+rigid-body natural periods that decide whether a hull sits inside or outside the
+wave-energy band.
+
+Four archetypes are modelled, matching the PyFloatSizer-class concept set:
+
+* **Semi-submersible** -- columns piercing the waterline on submerged pontoons.
+  Stability from waterplane area spread over a wide column footprint.
+* **Spar** -- a single deep-draft cylinder. Stability from a low centre of
+  gravity (deep ballast) far below the centre of buoyancy.
+* **TLP** -- columns on pontoons held down by vertical tendons. Vertical-plane
+  stiffness (heave/pitch) comes from the tendons, not the waterplane, so the
+  hydrostatic ``GM`` can be small or negative *by design*.
+* **Barge** -- a shallow-draft rectangular box. Large waterplane area gives a
+  large ``GM`` (stiff in roll/pitch) at the cost of lively heave.
+
+All models are **closed-form and licence-free** -- a preliminary screen.
+Hydrodynamic added mass and radii of gyration are represented by documented
+coefficients with sensible defaults; the final motion picture needs a
+diffraction solve (OrcaWave) and a coupled mooring/motion solve (OrcaFlex),
+which the solver tier (issue #1025) wires in for shortlisted variants.
+
+Sign / datum convention
+-----------------------
+* Lengths in metres, masses in tonnes (1 t = 1000 kg), periods in seconds.
+* The **keel** (lowest point of the hull) is the vertical datum ``z = 0``; all
+  vertical centroids (``KB``, ``KG``) are heights above the keel.
+* The draft ``T`` is the keel-to-waterline distance.
+
+References
+----------
+* Faltinsen, *Sea Loads on Ships and Offshore Structures* (1990) -- hydrostatic
+  stability (``GM = KB + BM - KG``), heave/pitch natural periods.
+* DNV-OS-C301 / DNV-RP-0286 -- floating-wind stability and design practice.
+* Allen et al., *Definition of the UMaine VolturnUS-S Reference Platform* (IEA
+  15 MW reference semi), NREL/TP-5000-76773 (2020) -- order-of-magnitude
+  sanity values for the semi archetype.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = [
+    "RHO_SEAWATER",
+    "G_STANDARD",
+    "FloaterArchetype",
+    "TurbineTopside",
+    "FloaterProperties",
+    "SemiSubmersible",
+    "Spar",
+    "TLP",
+    "Barge",
+    "build_floater",
+    "IEA_15MW_RNA",
+]
+
+# --- physical constants ------------------------------------------------------
+
+RHO_SEAWATER = 1025.0  # kg/m^3, standard seawater density
+G_STANDARD = 9.80665  # m/s^2
+
+_KG_PER_TONNE = 1000.0
+
+
+class FloaterArchetype(str, Enum):
+    """Floater hull archetype for concept screening."""
+
+    SEMI = "semi"
+    SPAR = "spar"
+    TLP = "tlp"
+    BARGE = "barge"
+
+
+# --- topside (turbine) -------------------------------------------------------
+
+
+class TurbineTopside(BaseModel):
+    """Wind-turbine RNA + tower lumped topside carried by the floater.
+
+    Floating-wind pitch behaviour is dominated by the high, heavy turbine, so a
+    concept screen must carry it explicitly rather than fold it into the hull.
+    """
+
+    rna_mass_t: float = Field(
+        ..., gt=0.0, description="Rotor-nacelle-assembly mass (t)"
+    )
+    tower_mass_t: float = Field(..., gt=0.0, description="Tower mass (t)")
+    hub_height_m: float = Field(
+        ...,
+        gt=0.0,
+        description="Hub height above the still-water line (m)",
+    )
+    tower_base_above_swl_m: float = Field(
+        15.0,
+        ge=0.0,
+        description="Tower base (floater interface) above still-water line (m)",
+    )
+
+    @property
+    def total_mass_t(self) -> float:
+        return self.rna_mass_t + self.tower_mass_t
+
+    def cg_above_waterline_m(self) -> float:
+        """Combined RNA + tower vertical CG above the still-water line (m).
+
+        RNA CG is taken at the hub; the tower CG is taken at the midpoint
+        between its base and the hub (uniform-tower idealisation).
+        """
+        tower_cg = 0.5 * (self.tower_base_above_swl_m + self.hub_height_m)
+        moment = (
+            self.rna_mass_t * self.hub_height_m + self.tower_mass_t * tower_cg
+        )
+        return moment / self.total_mass_t
+
+
+# A convenient reference topside (IEA 15 MW class) for examples / sanity tests.
+IEA_15MW_RNA = TurbineTopside(
+    rna_mass_t=1017.0,
+    tower_mass_t=1263.0,
+    hub_height_m=150.0,
+    tower_base_above_swl_m=15.0,
+)
+
+
+# --- derived properties ------------------------------------------------------
+
+
+class FloaterProperties(BaseModel):
+    """Derived naval-architecture properties of a sized floater concept."""
+
+    archetype: FloaterArchetype
+    draft_m: float
+    displacement_t: float = Field(..., description="Displaced mass = buoyancy (t)")
+    steel_mass_t: float
+    ballast_mass_t: float = Field(
+        ..., description="Solid/water ballast to reach equilibrium draft (t)"
+    )
+    topside_mass_t: float
+    total_mass_t: float
+
+    waterplane_area_m2: float
+    KB_m: float = Field(..., description="Centre of buoyancy above keel (m)")
+    BM_m: float = Field(..., description="Metacentric radius I_wp / V (m)")
+    KG_m: float = Field(..., description="Combined centre of gravity above keel (m)")
+    GM_m: float = Field(..., description="Metacentric height KB + BM - KG (m)")
+
+    heave_natural_period_s: float
+    pitch_natural_period_s: float
+
+    tendon_stabilised: bool = Field(
+        False,
+        description="True when vertical stability is tendon- not waterplane-derived (TLP)",
+    )
+    feasible: bool = Field(
+        ...,
+        description="Floats at the requested draft with non-negative ballast",
+    )
+    notes: tuple[str, ...] = ()
+
+
+# --- shared helpers ----------------------------------------------------------
+
+
+def _heave_period(mass_t: float, waterplane_area_m2: float, ca_heave: float) -> float:
+    """Uncoupled heave natural period (s).
+
+    ``T = 2*pi*sqrt((m + a33) / (rho*g*A_wp))`` with added mass
+    ``a33 = ca_heave * m`` (heave added-mass ratio).
+    """
+    if waterplane_area_m2 <= 0.0:
+        return math.inf
+    m = mass_t * _KG_PER_TONNE
+    restoring = RHO_SEAWATER * G_STANDARD * waterplane_area_m2
+    return 2.0 * math.pi * math.sqrt(m * (1.0 + ca_heave) / restoring)
+
+
+def _pitch_period(
+    mass_t: float,
+    displacement_t: float,
+    gm_m: float,
+    radius_gyration_m: float,
+    ca_pitch: float,
+) -> float:
+    """Uncoupled pitch natural period (s).
+
+    ``T = 2*pi*sqrt((I55 + a55) / (rho*g*V*GM_L))`` with mass moment of inertia
+    ``I55 = m * kyy^2``, added inertia ``a55 = ca_pitch * I55`` and (for an
+    axisymmetric or near-square hull) ``GM_L ~ GM``. Returns ``inf`` for a
+    non-positive ``GM`` (the hull is not statically stable in pitch on its
+    waterplane alone -- e.g. a TLP, handled separately).
+    """
+    if gm_m <= 0.0:
+        return math.inf
+    m = mass_t * _KG_PER_TONNE
+    inertia = m * radius_gyration_m**2 * (1.0 + ca_pitch)
+    vol = displacement_t * _KG_PER_TONNE / RHO_SEAWATER
+    restoring = RHO_SEAWATER * G_STANDARD * vol * gm_m
+    return 2.0 * math.pi * math.sqrt(inertia / restoring)
+
+
+def _assemble(
+    *,
+    archetype: FloaterArchetype,
+    draft_m: float,
+    displacement_t: float,
+    steel_mass_t: float,
+    topside: TurbineTopside,
+    waterplane_area_m2: float,
+    kb_m: float,
+    bm_m: float,
+    kg_hull_m: float,
+    topside_cg_above_keel_m: float,
+    radius_gyration_m: float,
+    ca_heave: float,
+    ca_pitch: float,
+    tendon_stabilised: bool = False,
+    tendon_heave_period_s: float | None = None,
+    tendon_pitch_period_s: float | None = None,
+    extra_notes: tuple[str, ...] = (),
+) -> FloaterProperties:
+    """Close the mass balance and assemble a :class:`FloaterProperties`.
+
+    Ballast makes up the difference between buoyancy and the (steel + topside)
+    light weight. A negative ballast means the concept is too heavy to float at
+    the requested draft -> ``feasible = False`` and the ballast is clamped to 0.
+    """
+    notes = list(extra_notes)
+    topside_mass_t = topside.total_mass_t
+    ballast_mass_t = displacement_t - steel_mass_t - topside_mass_t
+    feasible = ballast_mass_t >= 0.0
+    if not feasible:
+        notes.append(
+            f"infeasible: light weight (steel {steel_mass_t:.0f} t + topside "
+            f"{topside_mass_t:.0f} t) exceeds buoyancy {displacement_t:.0f} t "
+            "at this draft"
+        )
+        ballast_mass_t = 0.0
+
+    total_mass_t = steel_mass_t + ballast_mass_t + topside_mass_t
+
+    # Combined CG: steel at hull centroid, ballast assumed at the keel-adjacent
+    # base (conservative-low, typical of floating-wind solid/water ballast),
+    # topside high above the keel.
+    ballast_cg_m = 0.05 * draft_m
+    cg_moment = (
+        steel_mass_t * kg_hull_m
+        + ballast_mass_t * ballast_cg_m
+        + topside_mass_t * topside_cg_above_keel_m
+    )
+    kg_m = cg_moment / total_mass_t if total_mass_t > 0 else kg_hull_m
+    gm_m = kb_m + bm_m - kg_m
+
+    if tendon_stabilised:
+        heave_period = tendon_heave_period_s if tendon_heave_period_s else math.nan
+        pitch_period = tendon_pitch_period_s if tendon_pitch_period_s else math.nan
+    else:
+        heave_period = _heave_period(total_mass_t, waterplane_area_m2, ca_heave)
+        pitch_period = _pitch_period(
+            total_mass_t, displacement_t, gm_m, radius_gyration_m, ca_pitch
+        )
+        if gm_m <= 0.0:
+            notes.append("non-positive GM: statically unstable on waterplane alone")
+
+    return FloaterProperties(
+        archetype=archetype,
+        draft_m=draft_m,
+        displacement_t=displacement_t,
+        steel_mass_t=steel_mass_t,
+        ballast_mass_t=ballast_mass_t,
+        topside_mass_t=topside_mass_t,
+        total_mass_t=total_mass_t,
+        waterplane_area_m2=waterplane_area_m2,
+        KB_m=kb_m,
+        BM_m=bm_m,
+        KG_m=kg_m,
+        GM_m=gm_m,
+        heave_natural_period_s=heave_period,
+        pitch_natural_period_s=pitch_period,
+        tendon_stabilised=tendon_stabilised,
+        feasible=feasible,
+        notes=tuple(notes),
+    )
+
+
+# --- archetype models --------------------------------------------------------
+
+
+class SemiSubmersible(BaseModel):
+    """Column-stabilised semi-submersible floater.
+
+    ``n_columns`` circular columns of diameter ``column_diameter`` sit on a
+    radius ``column_radius`` from the platform centre, supported by submerged
+    pontoons of total volume ``pontoon_volume``. Only the columns pierce the
+    waterline, so the waterplane area is the sum of the column sections and the
+    metacentric radius is dominated by their wide spacing (parallel-axis term).
+    """
+
+    n_columns: int = Field(3, ge=3, le=6)
+    column_diameter: float = Field(..., gt=0.0, description="Column diameter (m)")
+    column_radius: float = Field(
+        ..., gt=0.0, description="Column centre offset from platform centre (m)"
+    )
+    draft: float = Field(..., gt=0.0, description="Draft, keel to waterline (m)")
+    pontoon_height: float = Field(
+        ..., gt=0.0, description="Pontoon vertical height (m)"
+    )
+    pontoon_volume: float = Field(
+        ..., gt=0.0, description="Total submerged pontoon volume (m^3)"
+    )
+    steel_mass_t: float = Field(..., gt=0.0, description="Hull steel mass (t)")
+    steel_vcg_frac: float = Field(
+        0.45, gt=0.0, le=1.0, description="Steel VCG as a fraction of draft"
+    )
+    ca_heave: float = Field(1.0, ge=0.0, description="Heave added-mass ratio a33/m")
+    ca_pitch: float = Field(0.4, ge=0.0, description="Pitch added-inertia ratio")
+    kyy_frac: float = Field(
+        0.42, gt=0.0, description="Pitch radius of gyration / column_radius span"
+    )
+
+    @model_validator(mode="after")
+    def _check_geometry(self) -> "SemiSubmersible":
+        if self.pontoon_height >= self.draft:
+            raise ValueError("pontoon_height must be less than draft")
+        return self
+
+    def properties(self, topside: TurbineTopside) -> FloaterProperties:
+        a_col = math.pi / 4.0 * self.column_diameter**2
+        # Submerged column volume above the pontoon top up to the waterline.
+        col_sub_h = self.draft - self.pontoon_height
+        v_col = self.n_columns * a_col * col_sub_h
+        v = v_col + self.pontoon_volume
+        displacement_t = RHO_SEAWATER * v / _KG_PER_TONNE
+
+        waterplane_area = self.n_columns * a_col
+        # I_wp about a centroidal horizontal axis: own section + parallel axis.
+        # For n columns evenly spread on a ring, mean(r_perp^2) = R^2 / 2.
+        i_own = self.n_columns * (math.pi / 64.0 * self.column_diameter**4)
+        i_spread = a_col * self.column_radius**2 * (self.n_columns / 2.0)
+        i_wp = i_own + i_spread
+        bm = i_wp / v
+
+        # KB: volume-weighted centroid of pontoon block and submerged columns.
+        kb_pontoon = self.pontoon_height / 2.0
+        kb_col = self.pontoon_height + col_sub_h / 2.0
+        kb = (self.pontoon_volume * kb_pontoon + v_col * kb_col) / v
+
+        kg_hull = self.steel_vcg_frac * self.draft
+        topside_cg = self.draft + topside.cg_above_waterline_m()
+        kyy = self.kyy_frac * (2.0 * self.column_radius)
+
+        return _assemble(
+            archetype=FloaterArchetype.SEMI,
+            draft_m=self.draft,
+            displacement_t=displacement_t,
+            steel_mass_t=self.steel_mass_t,
+            topside=topside,
+            waterplane_area_m2=waterplane_area,
+            kb_m=kb,
+            bm_m=bm,
+            kg_hull_m=kg_hull,
+            topside_cg_above_keel_m=topside_cg,
+            radius_gyration_m=kyy,
+            ca_heave=self.ca_heave,
+            ca_pitch=self.ca_pitch,
+        )
+
+
+class Spar(BaseModel):
+    """Deep-draft spar (single cylinder, optional deep ballast).
+
+    A spar's stability is set by a low centre of gravity (deep ballast) rather
+    than its small waterplane. The metacentric radius ``BM = D^2 / (16 T)`` is
+    small, so a positive ``GM`` requires ``KG`` well below ``KB``.
+    """
+
+    diameter: float = Field(..., gt=0.0, description="Cylinder diameter (m)")
+    draft: float = Field(..., gt=0.0, description="Draft, keel to waterline (m)")
+    steel_mass_t: float = Field(..., gt=0.0, description="Hull steel mass (t)")
+    steel_vcg_frac: float = Field(
+        0.55, gt=0.0, le=1.0, description="Steel VCG as a fraction of draft"
+    )
+    ca_heave: float = Field(0.9, ge=0.0, description="Heave added-mass ratio a33/m")
+    ca_pitch: float = Field(0.25, ge=0.0, description="Pitch added-inertia ratio")
+    kyy_frac: float = Field(
+        0.30, gt=0.0, description="Pitch radius of gyration / draft"
+    )
+
+    def properties(self, topside: TurbineTopside) -> FloaterProperties:
+        a_wp = math.pi / 4.0 * self.diameter**2
+        v = a_wp * self.draft
+        displacement_t = RHO_SEAWATER * v / _KG_PER_TONNE
+
+        i_wp = math.pi / 64.0 * self.diameter**4
+        bm = i_wp / v  # = D^2 / (16 T)
+        kb = self.draft / 2.0
+
+        kg_hull = self.steel_vcg_frac * self.draft
+        topside_cg = self.draft + topside.cg_above_waterline_m()
+        kyy = self.kyy_frac * self.draft
+
+        return _assemble(
+            archetype=FloaterArchetype.SPAR,
+            draft_m=self.draft,
+            displacement_t=displacement_t,
+            steel_mass_t=self.steel_mass_t,
+            topside=topside,
+            waterplane_area_m2=a_wp,
+            kb_m=kb,
+            bm_m=bm,
+            kg_hull_m=kg_hull,
+            topside_cg_above_keel_m=topside_cg,
+            radius_gyration_m=kyy,
+            ca_heave=self.ca_heave,
+            ca_pitch=self.ca_pitch,
+        )
+
+
+class TLP(BaseModel):
+    """Tension-leg platform: columns + pontoons restrained by vertical tendons.
+
+    Vertical-plane stiffness comes from ``n_tendons`` tendons of axial stiffness
+    ``EA`` (N) over length ``tendon_length`` (the water depth less draft), not
+    from the waterplane. Hydrostatic ``GM`` is still reported (it is often small
+    or negative -- the tendons carry pitch), and the heave/pitch periods are
+    derived from the tendon stiffness, placing them well below the wave band by
+    design.
+    """
+
+    n_columns: int = Field(4, ge=3, le=6)
+    column_diameter: float = Field(..., gt=0.0, description="Column diameter (m)")
+    column_radius: float = Field(
+        ..., gt=0.0, description="Column centre offset from platform centre (m)"
+    )
+    draft: float = Field(..., gt=0.0, description="Draft, keel to waterline (m)")
+    pontoon_height: float = Field(..., gt=0.0, description="Pontoon height (m)")
+    pontoon_volume: float = Field(
+        ..., gt=0.0, description="Total submerged pontoon volume (m^3)"
+    )
+    steel_mass_t: float = Field(..., gt=0.0, description="Hull steel mass (t)")
+    steel_vcg_frac: float = Field(0.45, gt=0.0, le=1.0)
+    n_tendons: int = Field(4, ge=3, description="Number of tendons")
+    tendon_EA_N: float = Field(
+        ..., gt=0.0, description="Per-tendon axial stiffness EA (N)"
+    )
+    tendon_length_m: float = Field(
+        ..., gt=0.0, description="Tendon free length (water depth - draft) (m)"
+    )
+
+    @model_validator(mode="after")
+    def _check_geometry(self) -> "TLP":
+        if self.pontoon_height >= self.draft:
+            raise ValueError("pontoon_height must be less than draft")
+        return self
+
+    def properties(self, topside: TurbineTopside) -> FloaterProperties:
+        a_col = math.pi / 4.0 * self.column_diameter**2
+        col_sub_h = self.draft - self.pontoon_height
+        v_col = self.n_columns * a_col * col_sub_h
+        v = v_col + self.pontoon_volume
+        displacement_t = RHO_SEAWATER * v / _KG_PER_TONNE
+
+        waterplane_area = self.n_columns * a_col
+        i_own = self.n_columns * (math.pi / 64.0 * self.column_diameter**4)
+        i_spread = a_col * self.column_radius**2 * (self.n_columns / 2.0)
+        bm = (i_own + i_spread) / v
+        kb_pontoon = self.pontoon_height / 2.0
+        kb_col = self.pontoon_height + col_sub_h / 2.0
+        kb = (self.pontoon_volume * kb_pontoon + v_col * kb_col) / v
+
+        kg_hull = self.steel_vcg_frac * self.draft
+        topside_cg = self.draft + topside.cg_above_waterline_m()
+
+        # Tendon-derived vertical-plane periods (the design-driving stiffness).
+        total_light = self.steel_mass_t + topside.total_mass_t
+        # Pretension carries (buoyancy - weight); the moving mass for heave is
+        # the structural + topside + entrained mass.
+        m_heave = (total_light) * _KG_PER_TONNE * 1.3  # +30% heave added mass
+        k_heave = self.n_tendons * self.tendon_EA_N / self.tendon_length_m
+        heave_period = 2.0 * math.pi * math.sqrt(m_heave / k_heave)
+        # Pitch tendon stiffness ~ k_axial * R^2 per tendon pair about centre.
+        k_pitch = (
+            self.n_tendons
+            * (self.tendon_EA_N / self.tendon_length_m)
+            * self.column_radius**2
+            / 2.0
+        )
+        kyy = 0.45 * (2.0 * self.column_radius)
+        i_pitch = total_light * _KG_PER_TONNE * kyy**2 * 1.3
+        pitch_period = 2.0 * math.pi * math.sqrt(i_pitch / k_pitch)
+
+        return _assemble(
+            archetype=FloaterArchetype.TLP,
+            draft_m=self.draft,
+            displacement_t=displacement_t,
+            steel_mass_t=self.steel_mass_t,
+            topside=topside,
+            waterplane_area_m2=waterplane_area,
+            kb_m=kb,
+            bm_m=bm,
+            kg_hull_m=kg_hull,
+            topside_cg_above_keel_m=topside_cg,
+            radius_gyration_m=kyy,
+            ca_heave=0.0,
+            ca_pitch=0.0,
+            tendon_stabilised=True,
+            tendon_heave_period_s=heave_period,
+            tendon_pitch_period_s=pitch_period,
+            extra_notes=(
+                "tendon-stabilised: heave/pitch periods set by tendon axial "
+                "stiffness, kept below the wave band by design",
+            ),
+        )
+
+
+class Barge(BaseModel):
+    """Shallow-draft rectangular barge floater.
+
+    A large waterplane gives a large ``BM`` (stiff in roll/pitch) but a lively
+    heave. Block and waterplane coefficients capture the departure from a pure
+    box.
+    """
+
+    length: float = Field(..., gt=0.0, description="Overall length (m)")
+    beam: float = Field(..., gt=0.0, description="Overall beam (m)")
+    draft: float = Field(..., gt=0.0, description="Draft, keel to waterline (m)")
+    block_coeff: float = Field(0.95, gt=0.0, le=1.0, description="Block coefficient")
+    waterplane_coeff: float = Field(
+        1.0, gt=0.0, le=1.0, description="Waterplane area coefficient"
+    )
+    steel_mass_t: float = Field(..., gt=0.0, description="Hull steel mass (t)")
+    steel_vcg_frac: float = Field(0.50, gt=0.0, le=1.0)
+    ca_heave: float = Field(0.8, ge=0.0)
+    ca_pitch: float = Field(0.3, ge=0.0)
+
+    def properties(self, topside: TurbineTopside) -> FloaterProperties:
+        v = self.length * self.beam * self.draft * self.block_coeff
+        displacement_t = RHO_SEAWATER * v / _KG_PER_TONNE
+        a_wp = self.length * self.beam * self.waterplane_coeff
+        # Transverse waterplane inertia governs the smaller (roll) GM; use it as
+        # the conservative screening value.
+        i_wp = self.waterplane_coeff * self.length * self.beam**3 / 12.0
+        bm = i_wp / v
+        kb = self.draft / 2.0
+        kg_hull = self.steel_vcg_frac * self.draft
+        topside_cg = self.draft + topside.cg_above_waterline_m()
+        kyy = 0.30 * self.beam
+
+        return _assemble(
+            archetype=FloaterArchetype.BARGE,
+            draft_m=self.draft,
+            displacement_t=displacement_t,
+            steel_mass_t=self.steel_mass_t,
+            topside=topside,
+            waterplane_area_m2=a_wp,
+            kb_m=kb,
+            bm_m=bm,
+            kg_hull_m=kg_hull,
+            topside_cg_above_keel_m=topside_cg,
+            radius_gyration_m=kyy,
+            ca_heave=self.ca_heave,
+            ca_pitch=self.ca_pitch,
+        )
+
+
+# --- factory -----------------------------------------------------------------
+
+_ARCHETYPE_MODELS: dict[FloaterArchetype, type[BaseModel]] = {
+    FloaterArchetype.SEMI: SemiSubmersible,
+    FloaterArchetype.SPAR: Spar,
+    FloaterArchetype.TLP: TLP,
+    FloaterArchetype.BARGE: Barge,
+}
+
+
+def build_floater(archetype: FloaterArchetype | str, **params):
+    """Construct the floater model for ``archetype`` from keyword parameters.
+
+    A small dispatch helper so callers (the screening orchestrator, the UV
+    workflow) can build any archetype from a parameter dict without importing
+    each class.
+    """
+    arch = FloaterArchetype(archetype)
+    return _ARCHETYPE_MODELS[arch](**params)

--- a/src/digitalmodel/floating_wind/floaters.py
+++ b/src/digitalmodel/floating_wind/floaters.py
@@ -184,24 +184,22 @@ def _heave_period(mass_t: float, waterplane_area_m2: float, ca_heave: float) -> 
 
 
 def _pitch_period(
-    mass_t: float,
+    inertia_t_m2: float,
     displacement_t: float,
     gm_m: float,
-    radius_gyration_m: float,
     ca_pitch: float,
 ) -> float:
     """Uncoupled pitch natural period (s).
 
     ``T = 2*pi*sqrt((I55 + a55) / (rho*g*V*GM_L))`` with mass moment of inertia
-    ``I55 = m * kyy^2``, added inertia ``a55 = ca_pitch * I55`` and (for an
-    axisymmetric or near-square hull) ``GM_L ~ GM``. Returns ``inf`` for a
-    non-positive ``GM`` (the hull is not statically stable in pitch on its
+    ``I55`` about the combined CG, added inertia ``a55 = ca_pitch * I55`` and
+    (for an axisymmetric or near-square hull) ``GM_L ~ GM``. Returns ``inf`` for
+    a non-positive ``GM`` (the hull is not statically stable in pitch on its
     waterplane alone -- e.g. a TLP, handled separately).
     """
     if gm_m <= 0.0:
         return math.inf
-    m = mass_t * _KG_PER_TONNE
-    inertia = m * radius_gyration_m**2 * (1.0 + ca_pitch)
+    inertia = inertia_t_m2 * _KG_PER_TONNE * (1.0 + ca_pitch)
     vol = displacement_t * _KG_PER_TONNE / RHO_SEAWATER
     restoring = RHO_SEAWATER * G_STANDARD * vol * gm_m
     return 2.0 * math.pi * math.sqrt(inertia / restoring)
@@ -219,7 +217,7 @@ def _assemble(
     bm_m: float,
     kg_hull_m: float,
     topside_cg_above_keel_m: float,
-    radius_gyration_m: float,
+    k_horizontal_m: float,
     ca_heave: float,
     ca_pitch: float,
     tendon_stabilised: bool = False,
@@ -259,13 +257,26 @@ def _assemble(
     kg_m = cg_moment / total_mass_t if total_mass_t > 0 else kg_hull_m
     gm_m = kb_m + bm_m - kg_m
 
+    # Pitch mass moment of inertia about the combined CG (t.m^2). The vertical
+    # term -- each lumped mass at its height above the CG -- is dominant for a
+    # floating-wind unit because the high, heavy turbine has a long lever arm.
+    # The horizontal term captures the hull's in-plane mass spread (column
+    # footprint for a semi/TLP, hull breadth for a barge, ~0 for a spar).
+    i_vertical = (
+        steel_mass_t * (kg_hull_m - kg_m) ** 2
+        + ballast_mass_t * (ballast_cg_m - kg_m) ** 2
+        + topside_mass_t * (topside_cg_above_keel_m - kg_m) ** 2
+    )
+    i_horizontal = total_mass_t * k_horizontal_m**2
+    i55_t_m2 = i_vertical + i_horizontal
+
     if tendon_stabilised:
         heave_period = tendon_heave_period_s if tendon_heave_period_s else math.nan
         pitch_period = tendon_pitch_period_s if tendon_pitch_period_s else math.nan
     else:
         heave_period = _heave_period(total_mass_t, waterplane_area_m2, ca_heave)
         pitch_period = _pitch_period(
-            total_mass_t, displacement_t, gm_m, radius_gyration_m, ca_pitch
+            i55_t_m2, displacement_t, gm_m, ca_pitch
         )
         if gm_m <= 0.0:
             notes.append("non-positive GM: statically unstable on waterplane alone")
@@ -322,10 +333,6 @@ class SemiSubmersible(BaseModel):
     )
     ca_heave: float = Field(1.0, ge=0.0, description="Heave added-mass ratio a33/m")
     ca_pitch: float = Field(0.4, ge=0.0, description="Pitch added-inertia ratio")
-    kyy_frac: float = Field(
-        0.42, gt=0.0, description="Pitch radius of gyration / column_radius span"
-    )
-
     @model_validator(mode="after")
     def _check_geometry(self) -> "SemiSubmersible":
         if self.pontoon_height >= self.draft:
@@ -355,7 +362,8 @@ class SemiSubmersible(BaseModel):
 
         kg_hull = self.steel_vcg_frac * self.draft
         topside_cg = self.draft + topside.cg_above_waterline_m()
-        kyy = self.kyy_frac * (2.0 * self.column_radius)
+        # Horizontal mass spread: columns sit at radius R; rms offset ~ R/sqrt(2).
+        k_horiz = self.column_radius / math.sqrt(2.0)
 
         return _assemble(
             archetype=FloaterArchetype.SEMI,
@@ -368,7 +376,7 @@ class SemiSubmersible(BaseModel):
             bm_m=bm,
             kg_hull_m=kg_hull,
             topside_cg_above_keel_m=topside_cg,
-            radius_gyration_m=kyy,
+            k_horizontal_m=k_horiz,
             ca_heave=self.ca_heave,
             ca_pitch=self.ca_pitch,
         )
@@ -390,9 +398,6 @@ class Spar(BaseModel):
     )
     ca_heave: float = Field(0.9, ge=0.0, description="Heave added-mass ratio a33/m")
     ca_pitch: float = Field(0.25, ge=0.0, description="Pitch added-inertia ratio")
-    kyy_frac: float = Field(
-        0.30, gt=0.0, description="Pitch radius of gyration / draft"
-    )
 
     def properties(self, topside: TurbineTopside) -> FloaterProperties:
         a_wp = math.pi / 4.0 * self.diameter**2
@@ -405,7 +410,8 @@ class Spar(BaseModel):
 
         kg_hull = self.steel_vcg_frac * self.draft
         topside_cg = self.draft + topside.cg_above_waterline_m()
-        kyy = self.kyy_frac * self.draft
+        # A spar is slender: in-plane mass spread ~ cylinder radius of gyration.
+        k_horiz = self.diameter / 4.0
 
         return _assemble(
             archetype=FloaterArchetype.SPAR,
@@ -418,7 +424,7 @@ class Spar(BaseModel):
             bm_m=bm,
             kg_hull_m=kg_hull,
             topside_cg_above_keel_m=topside_cg,
-            radius_gyration_m=kyy,
+            k_horizontal_m=k_horiz,
             ca_heave=self.ca_heave,
             ca_pitch=self.ca_pitch,
         )
@@ -508,7 +514,7 @@ class TLP(BaseModel):
             bm_m=bm,
             kg_hull_m=kg_hull,
             topside_cg_above_keel_m=topside_cg,
-            radius_gyration_m=kyy,
+            k_horizontal_m=kyy,
             ca_heave=0.0,
             ca_pitch=0.0,
             tendon_stabilised=True,
@@ -552,7 +558,8 @@ class Barge(BaseModel):
         kb = self.draft / 2.0
         kg_hull = self.steel_vcg_frac * self.draft
         topside_cg = self.draft + topside.cg_above_waterline_m()
-        kyy = 0.30 * self.beam
+        # Roll (beam-governed) is the conservative screening axis; rms ~ B/sqrt(12).
+        k_horiz = self.beam / math.sqrt(12.0)
 
         return _assemble(
             archetype=FloaterArchetype.BARGE,
@@ -565,7 +572,7 @@ class Barge(BaseModel):
             bm_m=bm,
             kg_hull_m=kg_hull,
             topside_cg_above_keel_m=topside_cg,
-            radius_gyration_m=kyy,
+            k_horizontal_m=k_horiz,
             ca_heave=self.ca_heave,
             ca_pitch=self.ca_pitch,
         )

--- a/src/digitalmodel/floating_wind/screening.py
+++ b/src/digitalmodel/floating_wind/screening.py
@@ -1,0 +1,346 @@
+"""Floating-wind concept-screening orchestrator (issue #1024, epic #1022).
+
+The workhorse loop of floating-wind concept design: sweep a grid of floater
+**variants** (issue #1023 archetype models) across a set of site **load cases**,
+run four closed-form screening checks on each, and roll the result up into a
+tidy table with a per-variant verdict.
+
+Checks (closed-form / licence-free first tier)
+----------------------------------------------
+1. **Stability** -- intact ``GM`` against a minimum (DNV-OS-C301 style floor).
+2. **Motion** -- a dynamic-amplification proxy: the rigid-body natural period vs
+   the load-case peak wave period ``Tp``. A hull resonant with the sea state
+   amplifies; one well separated does not.
+3. **Mooring** -- a steady-offset watch-circle proxy: environmental load over
+   the mooring horizontal stiffness vs an allowable offset (optional; skipped
+   when no mooring stiffness is given).
+4. **Modal** -- the rigid-body natural periods must avoid the site's energetic
+   wave band (semis/spars sit above it, TLPs below it; a barge that lands inside
+   it is correctly flagged).
+
+This is a *screen*, not a design of record. Shortlisted variants go to the
+high-fidelity OrcaWave/OrcaFlex tier (issue #1025), which replaces these proxies
+with diffraction- and time-domain-derived responses.
+
+The variant grid reuses :class:`digitalmodel.orcaflex.batch_parametric.ParametricStudy`;
+the mooring proxy can defer to the FOWT watch-circle check in
+:mod:`digitalmodel.orcaflex.mooring_design_fowt`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from digitalmodel.floating_wind.floaters import (
+    FloaterArchetype,
+    FloaterProperties,
+    TurbineTopside,
+    build_floater,
+)
+from digitalmodel.orcaflex.batch_parametric import ParameterSweep, ParametricStudy
+
+__all__ = [
+    "LoadCase",
+    "ScreeningCriteria",
+    "CheckResult",
+    "VariantScreening",
+    "ScreeningResults",
+    "screen_concept",
+    "screen_concepts",
+]
+
+
+class LoadCase(BaseModel):
+    """A site sea state (+ steady environmental load) to screen against."""
+
+    name: str
+    hs_m: float = Field(..., gt=0.0, description="Significant wave height (m)")
+    tp_s: float = Field(..., gt=0.0, description="Spectral peak period (s)")
+    steady_load_kN: float = Field(
+        0.0,
+        ge=0.0,
+        description="Steady horizontal environmental load (wind thrust + "
+        "current drag) for the mooring offset proxy (kN)",
+    )
+
+
+class ScreeningCriteria(BaseModel):
+    """Acceptance thresholds for the four screening checks."""
+
+    gm_min_m: float = Field(1.0, description="Minimum intact metacentric height (m)")
+    daf_limit: float = Field(
+        2.0, gt=1.0, description="Max acceptable dynamic-amplification factor"
+    )
+    damping_ratio: float = Field(
+        0.05, gt=0.0, lt=1.0, description="Rigid-body damping ratio for the DAF proxy"
+    )
+    modal_band_s: tuple[float, float] = Field(
+        (5.0, 16.0),
+        description="Energetic wave-period band the natural periods must avoid (s); "
+        "semis/spars target periods above it, TLPs below it",
+    )
+    mooring_stiffness_kN_per_m: float | None = Field(
+        None, description="Horizontal mooring stiffness for the offset proxy (kN/m)"
+    )
+    max_offset_m: float | None = Field(
+        None, description="Allowable steady horizontal offset (m)"
+    )
+
+
+class CheckResult(BaseModel):
+    """One screening check on one variant × load case."""
+
+    name: str
+    value: float
+    limit: float
+    passed: bool
+    margin: float = Field(
+        ..., description="Signed margin; >= 0 means the check passes"
+    )
+    basis: str = ""
+
+
+def _daf(natural_period_s: float, tp_s: float, zeta: float) -> float:
+    """Dynamic amplification factor of a 1-DOF oscillator at forcing period Tp.
+
+    ``DAF = 1 / sqrt((1 - r^2)^2 + (2*zeta*r)^2)`` with ``r = Tn / Tp`` (the
+    forcing-to-natural frequency ratio is ``Tn/Tp``). Returns 1.0 for an
+    infinite natural period (rigid / statically unstable handled upstream).
+    """
+    if not math.isfinite(natural_period_s):
+        return 1.0
+    r = natural_period_s / tp_s
+    return 1.0 / math.sqrt((1.0 - r**2) ** 2 + (2.0 * zeta * r) ** 2)
+
+
+def _stability_check(p: FloaterProperties, c: ScreeningCriteria) -> CheckResult:
+    margin = p.GM_m - c.gm_min_m
+    return CheckResult(
+        name="stability",
+        value=p.GM_m,
+        limit=c.gm_min_m,
+        passed=margin >= 0.0,
+        margin=margin,
+        basis="intact GM vs minimum (DNV-OS-C301)",
+    )
+
+
+def _motion_check(
+    p: FloaterProperties, lc: LoadCase, c: ScreeningCriteria
+) -> CheckResult:
+    daf_heave = _daf(p.heave_natural_period_s, lc.tp_s, c.damping_ratio)
+    daf_pitch = _daf(p.pitch_natural_period_s, lc.tp_s, c.damping_ratio)
+    governing = max(daf_heave, daf_pitch)
+    margin = c.daf_limit - governing
+    return CheckResult(
+        name="motion",
+        value=governing,
+        limit=c.daf_limit,
+        passed=margin >= 0.0,
+        margin=margin,
+        basis=f"max(heave,pitch) DAF at Tp={lc.tp_s:g}s",
+    )
+
+
+def _modal_check(p: FloaterProperties, c: ScreeningCriteria) -> CheckResult:
+    low, high = c.modal_band_s
+    periods = [p.heave_natural_period_s, p.pitch_natural_period_s]
+    inside = [
+        per for per in periods if math.isfinite(per) and low <= per <= high
+    ]
+    if inside:
+        # Negative margin = how far inside the band the worst period sits.
+        worst = min(inside, key=lambda per: min(per - low, high - per))
+        margin = -min(worst - low, high - worst)
+        passed = False
+        value = worst
+    else:
+        # Distance of the nearest finite period to the band edge.
+        finite = [per for per in periods if math.isfinite(per)]
+        if finite:
+            value = min(finite, key=lambda per: min(abs(per - low), abs(per - high)))
+            margin = min(abs(value - low), abs(value - high))
+        else:
+            value = math.inf
+            margin = math.inf
+        passed = True
+    return CheckResult(
+        name="modal",
+        value=value,
+        limit=high,
+        passed=passed,
+        margin=margin,
+        basis=f"natural periods vs wave band {low:g}-{high:g}s",
+    )
+
+
+def _mooring_check(
+    lc: LoadCase, c: ScreeningCriteria
+) -> CheckResult | None:
+    if c.mooring_stiffness_kN_per_m is None or c.max_offset_m is None:
+        return None
+    offset = lc.steady_load_kN / c.mooring_stiffness_kN_per_m
+    margin = c.max_offset_m - offset
+    return CheckResult(
+        name="mooring",
+        value=offset,
+        limit=c.max_offset_m,
+        passed=margin >= 0.0,
+        margin=margin,
+        basis="steady offset = load / mooring stiffness vs allowable",
+    )
+
+
+class VariantScreening(BaseModel):
+    """Screening outcome for one floater variant across all load cases."""
+
+    case_id: str
+    archetype: FloaterArchetype
+    params: dict[str, Any]
+    properties: FloaterProperties
+    checks: list[CheckResult]
+    feasible: bool = Field(..., description="Hull floats at draft with valid ballast")
+    passed: bool = Field(..., description="Feasible and every check passes")
+    governing_check: str = Field(
+        ..., description="Name of the check with the smallest margin"
+    )
+    governing_margin: float
+
+
+class ScreeningResults(BaseModel):
+    """Full screening result set for a concept sweep."""
+
+    archetype: FloaterArchetype
+    n_variants: int
+    n_passed: int
+    load_cases: list[str]
+    variants: list[VariantScreening]
+
+    def passing(self) -> list[VariantScreening]:
+        return [v for v in self.variants if v.passed]
+
+    def to_rows(self) -> list[dict[str, Any]]:
+        """Flatten to one row per variant × check (tidy long form)."""
+        rows: list[dict[str, Any]] = []
+        for v in self.variants:
+            for chk in v.checks:
+                rows.append(
+                    {
+                        "case_id": v.case_id,
+                        "archetype": v.archetype.value,
+                        **{f"param_{k}": val for k, val in v.params.items()},
+                        "check": chk.name,
+                        "value": chk.value,
+                        "limit": chk.limit,
+                        "passed": chk.passed,
+                        "margin": chk.margin,
+                    }
+                )
+        return rows
+
+
+def _screen_one(
+    *,
+    case_id: str,
+    archetype: FloaterArchetype,
+    params: dict[str, Any],
+    topside: TurbineTopside,
+    load_cases: list[LoadCase],
+    criteria: ScreeningCriteria,
+) -> VariantScreening:
+    floater = build_floater(archetype, **params)
+    props = floater.properties(topside)
+
+    checks: list[CheckResult] = [_stability_check(props, criteria)]
+    checks.append(_modal_check(props, criteria))
+    # Motion + mooring are per-load-case; keep the governing (worst) per check.
+    motion = min(
+        (_motion_check(props, lc, criteria) for lc in load_cases),
+        key=lambda r: r.margin,
+    )
+    checks.append(motion)
+    moorings = [
+        m for m in (_mooring_check(lc, criteria) for lc in load_cases) if m
+    ]
+    if moorings:
+        checks.append(min(moorings, key=lambda r: r.margin))
+
+    governing = min(checks, key=lambda r: r.margin)
+    feasible = props.feasible
+    passed = feasible and all(chk.passed for chk in checks)
+
+    return VariantScreening(
+        case_id=case_id,
+        archetype=archetype,
+        params=params,
+        properties=props,
+        checks=checks,
+        feasible=feasible,
+        passed=passed,
+        governing_check=governing.name,
+        governing_margin=governing.margin,
+    )
+
+
+def screen_concept(
+    archetype: FloaterArchetype | str,
+    base_params: dict[str, Any],
+    sweeps: list[ParameterSweep],
+    topside: TurbineTopside,
+    load_cases: list[LoadCase],
+    criteria: ScreeningCriteria | None = None,
+    *,
+    study_name: str = "floating_wind_screen",
+) -> ScreeningResults:
+    """Screen a grid of one-archetype variants across site load cases.
+
+    Builds the full-factorial variant matrix from ``base_params`` + ``sweeps``
+    (reusing :class:`ParametricStudy`), then evaluates the four screening checks
+    on each variant.
+    """
+    arch = FloaterArchetype(archetype)
+    criteria = criteria or ScreeningCriteria()
+
+    study = ParametricStudy(
+        name=study_name, parameters=sweeps, base_config=dict(base_params)
+    )
+    configs = study.generate_case_configs()
+
+    variants: list[VariantScreening] = []
+    for cfg in configs:
+        case_id = cfg.pop("case_id")
+        params = {**base_params, **cfg}
+        variants.append(
+            _screen_one(
+                case_id=case_id,
+                archetype=arch,
+                params=params,
+                topside=topside,
+                load_cases=load_cases,
+                criteria=criteria,
+            )
+        )
+
+    return ScreeningResults(
+        archetype=arch,
+        n_variants=len(variants),
+        n_passed=sum(v.passed for v in variants),
+        load_cases=[lc.name for lc in load_cases],
+        variants=variants,
+    )
+
+
+def screen_concepts(
+    concepts: list[tuple[FloaterArchetype | str, dict[str, Any], list[ParameterSweep]]],
+    topside: TurbineTopside,
+    load_cases: list[LoadCase],
+    criteria: ScreeningCriteria | None = None,
+) -> list[ScreeningResults]:
+    """Screen several archetypes in one call (one ScreeningResults each)."""
+    return [
+        screen_concept(arch, base, sweeps, topside, load_cases, criteria)
+        for arch, base, sweeps in concepts
+    ]

--- a/src/digitalmodel/floating_wind/tradespace.py
+++ b/src/digitalmodel/floating_wind/tradespace.py
@@ -1,0 +1,231 @@
+"""Trade-space analysis for floating-wind concept screening (issue #1026).
+
+Turn a screening result set (issue #1024) of hundreds-thousands of variants into
+a decision:
+
+* :func:`pareto_front` -- the non-dominated set over chosen objectives
+  (e.g. minimise steel mass *and* peak motion *and* maximise robustness margin).
+* :func:`correlation_map` -- Pearson correlations between the swept parameters
+  and the response metrics, exposing which knobs drive which responses.
+
+Both consume :class:`digitalmodel.floating_wind.screening.ScreeningResults` (or a
+plain list of variants) and operate on a flat per-variant **metric record** that
+merges the swept parameters with the derived responses. Licence-free.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Iterable, Literal
+
+from pydantic import BaseModel, Field
+
+from digitalmodel.floating_wind.screening import ScreeningResults, VariantScreening
+
+__all__ = [
+    "Objective",
+    "variant_metrics",
+    "metric_records",
+    "pareto_front",
+    "correlation_map",
+]
+
+Direction = Literal["min", "max"]
+
+
+class Objective(BaseModel):
+    """One trade-space objective: a metric key and the direction that is better."""
+
+    key: str
+    direction: Direction = "min"
+
+
+def variant_metrics(v: VariantScreening) -> dict[str, Any]:
+    """Flatten one variant to a metric record (swept params + responses).
+
+    Parameter columns are prefixed ``param_`` to avoid clashing with response
+    metric names. Non-finite periods (statically unstable / rigid) are dropped
+    to ``None`` so they neither dominate nor anchor correlations.
+    """
+    p = v.properties
+
+    def _finite(x: float) -> float | None:
+        return x if math.isfinite(x) else None
+
+    rec: dict[str, Any] = {
+        "case_id": v.case_id,
+        "archetype": v.archetype.value,
+        "feasible": v.feasible,
+        "passed": v.passed,
+        "displacement_t": p.displacement_t,
+        "steel_mass_t": p.steel_mass_t,
+        "ballast_mass_t": p.ballast_mass_t,
+        "GM_m": p.GM_m,
+        "heave_period_s": _finite(p.heave_natural_period_s),
+        "pitch_period_s": _finite(p.pitch_natural_period_s),
+        "governing_margin": v.governing_margin,
+    }
+    for k, val in v.params.items():
+        rec[f"param_{k}"] = val
+    return rec
+
+
+def _variants(
+    results: ScreeningResults | Iterable[VariantScreening],
+) -> list[VariantScreening]:
+    if isinstance(results, ScreeningResults):
+        return list(results.variants)
+    return list(results)
+
+
+def metric_records(
+    results: ScreeningResults | Iterable[VariantScreening],
+    *,
+    feasible_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Flat metric records for all (optionally feasible-only) variants."""
+    variants = _variants(results)
+    if feasible_only:
+        variants = [v for v in variants if v.feasible]
+    return [variant_metrics(v) for v in variants]
+
+
+def _dominates(a: dict, b: dict, objectives: list[Objective]) -> bool:
+    """True if record ``a`` Pareto-dominates ``b`` over ``objectives``.
+
+    ``a`` dominates ``b`` if it is no worse on every objective and strictly
+    better on at least one. Records missing a value on any objective cannot
+    dominate (a missing response is treated as not-comparable-favourable).
+    """
+    not_worse_all = True
+    strictly_better_any = False
+    for obj in objectives:
+        av, bv = a.get(obj.key), b.get(obj.key)
+        if av is None:
+            return False
+        if bv is None:
+            # b is undefined on this objective; a is at least as good here.
+            strictly_better_any = True
+            continue
+        if obj.direction == "min":
+            better = av < bv
+            worse = av > bv
+        else:
+            better = av > bv
+            worse = av < bv
+        if worse:
+            not_worse_all = False
+            break
+        if better:
+            strictly_better_any = True
+    return not_worse_all and strictly_better_any
+
+
+def pareto_front(
+    results: ScreeningResults | Iterable[VariantScreening],
+    objectives: list[Objective] | list[tuple[str, str]] | list[dict],
+    *,
+    passed_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Return the non-dominated metric records over ``objectives``.
+
+    ``objectives`` accepts :class:`Objective` instances, ``(key, direction)``
+    tuples or ``{"key", "direction"}`` dicts. By default the front is taken over
+    all *feasible* variants; set ``passed_only`` to restrict to variants that
+    passed every screening check.
+    """
+    objs = _coerce_objectives(objectives)
+    variants = _variants(results)
+    variants = [v for v in variants if v.feasible]
+    if passed_only:
+        variants = [v for v in variants if v.passed]
+    records = [variant_metrics(v) for v in variants]
+
+    front: list[dict[str, Any]] = []
+    for i, rec in enumerate(records):
+        dominated = any(
+            _dominates(other, rec, objs)
+            for j, other in enumerate(records)
+            if j != i
+        )
+        if not dominated:
+            front.append(rec)
+    return front
+
+
+def _coerce_objectives(objectives) -> list[Objective]:
+    out: list[Objective] = []
+    for o in objectives:
+        if isinstance(o, Objective):
+            out.append(o)
+        elif isinstance(o, dict):
+            out.append(Objective(**o))
+        else:  # (key, direction) tuple/list
+            key, direction = o
+            out.append(Objective(key=key, direction=direction))
+    return out
+
+
+def correlation_map(
+    results: ScreeningResults | Iterable[VariantScreening],
+    *,
+    columns: list[str] | None = None,
+    feasible_only: bool = True,
+) -> dict[str, dict[str, float]]:
+    """Pearson correlation matrix over the numeric metric columns.
+
+    Returns a nested dict ``{col: {col2: r}}``. Columns that are constant across
+    the variant set (zero variance, e.g. a fixed parameter) are dropped, since
+    their correlation is undefined. By default every numeric column is used;
+    pass ``columns`` to restrict (e.g. swept params vs a single response).
+    """
+    records = metric_records(results, feasible_only=feasible_only)
+    if not records:
+        return {}
+
+    numeric = _numeric_columns(records, columns)
+    series = {
+        col: [r[col] for r in records]
+        for col in numeric
+        if all(isinstance(r.get(col), (int, float)) and r.get(col) is not None for r in records)
+    }
+    # Drop zero-variance columns.
+    series = {col: vals for col, vals in series.items() if _variance(vals) > 0.0}
+
+    cols = list(series)
+    out: dict[str, dict[str, float]] = {a: {} for a in cols}
+    for a in cols:
+        for b in cols:
+            out[a][b] = _pearson(series[a], series[b])
+    return out
+
+
+def _numeric_columns(records: list[dict], columns: list[str] | None) -> list[str]:
+    if columns is not None:
+        return columns
+    cols: list[str] = []
+    skip = {"case_id", "archetype", "feasible", "passed"}
+    for col in records[0]:
+        if col in skip:
+            continue
+        cols.append(col)
+    return cols
+
+
+def _variance(xs: list[float]) -> float:
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    mean = sum(xs) / n
+    return sum((x - mean) ** 2 for x in xs) / (n - 1)
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float:
+    n = len(xs)
+    mx, my = sum(xs) / n, sum(ys) / n
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    sx = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    sy = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if sx == 0.0 or sy == 0.0:
+        return float("nan")
+    return cov / (sx * sy)

--- a/src/digitalmodel/floating_wind/workflow.py
+++ b/src/digitalmodel/floating_wind/workflow.py
@@ -1,0 +1,133 @@
+"""UV-workflow router for floating-wind concept screening (issue #1028).
+
+Makes the offline concept-screening capability (issues #1023/#1024) dispatchable
+from a committed ``input.yml`` via::
+
+    uv run python -m digitalmodel examples/workflows/floating-wind-sizing/input.yml
+
+(basename ``floating_wind_sizing``), licence-free. It builds the turbine
+topside, site load cases, screening criteria and one-or-more concept sweeps from
+the config, runs the screen and writes a JSON summary with the passing shortlist
+per archetype. The high-fidelity OrcaWave/OrcaFlex tier (issue #1025) is a
+separate, licensed step that consumes the shortlist.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.floating_wind.floaters import TurbineTopside
+from digitalmodel.floating_wind.screening import (
+    LoadCase,
+    ScreeningCriteria,
+    ScreeningResults,
+    screen_concept,
+)
+from digitalmodel.orcaflex.batch_parametric import ParameterSweep
+
+__all__ = ["FloatingWindSizingWorkflow"]
+
+
+class FloatingWindSizingWorkflow:
+    """Run a floating-wind concept screen from a cfg dict."""
+
+    def router(self, cfg: dict) -> dict:
+        spec = cfg.get("floating_wind_sizing") or {}
+
+        topside = TurbineTopside(**spec["topside"])
+        load_cases = [LoadCase(**lc) for lc in spec["load_cases"]]
+        criteria = ScreeningCriteria(**(spec.get("criteria") or {}))
+
+        results: list[ScreeningResults] = []
+        for concept in spec["concepts"]:
+            sweeps = [ParameterSweep(**s) for s in concept.get("sweeps", [])]
+            results.append(
+                screen_concept(
+                    concept["archetype"],
+                    dict(concept["base_params"]),
+                    sweeps,
+                    topside,
+                    load_cases,
+                    criteria,
+                    study_name=concept.get("name", "floating_wind_screen"),
+                )
+            )
+
+        summary = self._summarise(results, load_cases)
+        cfg["floating_wind_sizing"] = {**spec, "result": summary}
+
+        summary_path = self._write_summary(cfg, summary)
+        if summary_path is not None:
+            cfg.setdefault("outputs", {})["summary_json"] = str(summary_path)
+        return cfg
+
+    # -- summary ------------------------------------------------------------
+
+    def _summarise(
+        self, results: list[ScreeningResults], load_cases: list[LoadCase]
+    ) -> dict[str, Any]:
+        concepts = []
+        for res in results:
+            shortlist = [
+                self._variant_row(v)
+                for v in sorted(
+                    res.passing(),
+                    key=lambda v: v.governing_margin,
+                    reverse=True,
+                )
+            ]
+            concepts.append(
+                {
+                    "archetype": res.archetype.value,
+                    "n_variants": res.n_variants,
+                    "n_passed": res.n_passed,
+                    "shortlist": shortlist,
+                }
+            )
+        return {
+            "load_cases": [lc.name for lc in load_cases],
+            "n_concepts": len(results),
+            "total_variants": sum(r.n_variants for r in results),
+            "total_passed": sum(r.n_passed for r in results),
+            "concepts": concepts,
+        }
+
+    def _variant_row(self, v) -> dict[str, Any]:
+        p = v.properties
+        return {
+            "case_id": v.case_id,
+            "params": self._json_safe(v.params),
+            "displacement_t": round(p.displacement_t, 1),
+            "steel_mass_t": round(p.steel_mass_t, 1),
+            "ballast_mass_t": round(p.ballast_mass_t, 1),
+            "GM_m": round(p.GM_m, 3),
+            "heave_period_s": self._json_safe(p.heave_natural_period_s),
+            "pitch_period_s": self._json_safe(p.pitch_natural_period_s),
+            "governing_check": v.governing_check,
+            "governing_margin": round(v.governing_margin, 4),
+        }
+
+    def _json_safe(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: self._json_safe(val) for k, val in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [self._json_safe(val) for val in obj]
+        if isinstance(obj, float):
+            if math.isinf(obj):
+                return "inf"
+            if math.isnan(obj):
+                return None
+            return obj
+        return obj
+
+    def _write_summary(self, cfg: dict, summary: dict) -> Path | None:
+        output_path = (cfg.get("output") or {}).get("summary_json")
+        if not output_path:
+            return None
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(summary, indent=2))
+        return path

--- a/src/digitalmodel/usecase_registry/registry.yaml
+++ b/src/digitalmodel/usecase_registry/registry.yaml
@@ -287,6 +287,18 @@ usecases:
     analysis: [dynamic]
     readiness: ready
     notes: FOWT watch-circle screen; offline `fowt_mooring` workflow, no license (#964).
+  - id: floating-wind-sizing
+    domain: orcaflex/floating-wind
+    solver: orcaflex
+    basename: floating_wind_sizing
+    operation: null
+    template: examples/workflows/floating-wind-sizing/input.yml
+    analysis: [static, stability, modal]
+    readiness: ready
+    notes: >-
+      Floating-wind global sizing & concept screening (semi/spar/TLP/barge) --
+      offline closed-form first tier (#1023/#1024/#1028). High-fidelity
+      OrcaWave/OrcaFlex solver tier is #1025.
   - id: riser-fatigue
     domain: orcaflex/riser
     solver: orcaflex

--- a/tests/floating_wind/test_floaters.py
+++ b/tests/floating_wind/test_floaters.py
@@ -1,0 +1,141 @@
+"""Tests for the parametric floater archetype models (issue #1023).
+
+Closed-form / licence-free: no OrcaFlex or OrcaWave required. Assertions check
+physical relationships and plausible ranges rather than exact magic numbers,
+since the models are coefficient-based concept-screening estimates.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.floating_wind import (
+    Barge,
+    FloaterArchetype,
+    IEA_15MW_RNA,
+    SemiSubmersible,
+    Spar,
+    TLP,
+    TurbineTopside,
+    build_floater,
+)
+
+
+@pytest.fixture
+def topside() -> TurbineTopside:
+    return IEA_15MW_RNA
+
+
+def test_topside_cg_between_base_and_hub():
+    t = IEA_15MW_RNA
+    assert t.total_mass_t == pytest.approx(2280.0)
+    cg = t.cg_above_waterline_m()
+    assert t.tower_base_above_swl_m < cg < t.hub_height_m
+
+
+def test_semi_is_stable_and_in_plausible_period_band(topside):
+    semi = SemiSubmersible(
+        n_columns=3,
+        column_diameter=12.5,
+        column_radius=51.75,
+        draft=20.0,
+        pontoon_height=7.0,
+        pontoon_volume=10000.0,
+        steel_mass_t=4000.0,
+    )
+    p = semi.properties(topside)
+    assert p.archetype is FloaterArchetype.SEMI
+    assert p.feasible
+    assert p.GM_m > 0
+    # GM = KB + BM - KG identity holds.
+    assert p.GM_m == pytest.approx(p.KB_m + p.BM_m - p.KG_m)
+    # Mass balance closes: steel + ballast + topside == total == displacement.
+    assert p.total_mass_t == pytest.approx(
+        p.steel_mass_t + p.ballast_mass_t + p.topside_mass_t
+    )
+    assert p.total_mass_t == pytest.approx(p.displacement_t)
+    # Column-stabilised semis sit above the wave band in heave and pitch.
+    assert 15.0 < p.heave_natural_period_s < 28.0
+    assert 18.0 < p.pitch_natural_period_s < 40.0
+
+
+def test_well_sized_spar_is_stable_with_long_heave(topside):
+    spar = Spar(diameter=20.0, draft=120.0, steel_mass_t=6000.0)
+    p = spar.properties(topside)
+    assert p.feasible
+    assert p.GM_m > 0
+    # Spar BM is small (= D^2 / 16T); stability comes from KG far below KB.
+    assert p.BM_m == pytest.approx(20.0**2 / (16 * 120.0), rel=1e-6)
+    assert p.KG_m < p.KB_m
+    assert p.heave_natural_period_s > 20.0
+
+
+def test_slim_spar_with_heavy_topside_is_statically_unstable(topside):
+    # A too-slim spar cannot carry a 15 MW topside: the screen must flag it.
+    spar = Spar(diameter=14.0, draft=90.0, steel_mass_t=3500.0)
+    p = spar.properties(topside)
+    assert p.GM_m < 0
+    assert math.isinf(p.pitch_natural_period_s)
+    assert any("non-positive GM" in n for n in p.notes)
+
+
+def test_tlp_is_tendon_stabilised_below_wave_band(topside):
+    tlp = TLP(
+        n_columns=4,
+        column_diameter=10.0,
+        column_radius=30.0,
+        draft=30.0,
+        pontoon_height=8.0,
+        pontoon_volume=6000.0,
+        steel_mass_t=3000.0,
+        n_tendons=4,
+        tendon_EA_N=1.2e9,
+        tendon_length_m=170.0,
+    )
+    p = tlp.properties(topside)
+    assert p.tendon_stabilised
+    # Tendon stiffness places heave and pitch well below the wave-energy band.
+    assert 0.0 < p.heave_natural_period_s < 6.0
+    assert 0.0 < p.pitch_natural_period_s < 6.0
+    assert any("tendon-stabilised" in n for n in p.notes)
+
+
+def test_barge_is_stiff_with_large_gm(topside):
+    barge = Barge(length=60.0, beam=60.0, draft=12.0, steel_mass_t=5000.0)
+    p = barge.properties(topside)
+    assert p.feasible
+    # Large waterplane -> large BM -> large, very stiff GM.
+    assert p.GM_m > 10.0
+    # And a livelier (shorter) heave than a semi.
+    assert p.heave_natural_period_s < 12.0
+
+
+def test_infeasible_when_lightweight_exceeds_buoyancy(topside):
+    # Tiny barge cannot float a heavy topside: ballast would be negative.
+    barge = Barge(length=20.0, beam=20.0, draft=4.0, steel_mass_t=3000.0)
+    p = barge.properties(topside)
+    assert not p.feasible
+    assert p.ballast_mass_t == 0.0
+    assert any("infeasible" in n for n in p.notes)
+
+
+def test_pontoon_height_must_be_less_than_draft():
+    with pytest.raises(ValueError):
+        SemiSubmersible(
+            n_columns=3,
+            column_diameter=12.5,
+            column_radius=51.75,
+            draft=8.0,
+            pontoon_height=8.0,
+            pontoon_volume=10000.0,
+            steel_mass_t=4000.0,
+        )
+
+
+def test_build_floater_factory(topside):
+    f = build_floater("spar", diameter=20.0, draft=120.0, steel_mass_t=6000.0)
+    p = f.properties(topside)
+    assert p.archetype is FloaterArchetype.SPAR
+    # Unknown archetype raises.
+    with pytest.raises(ValueError):
+        build_floater("monohull", foo=1)

--- a/tests/floating_wind/test_screening.py
+++ b/tests/floating_wind/test_screening.py
@@ -1,0 +1,152 @@
+"""Tests for the concept-screening orchestrator (issue #1024).
+
+Closed-form / licence-free. Verifies the variant grid, the four checks, the
+governing-margin verdict and the tidy row export.
+"""
+
+import pytest
+
+from digitalmodel.floating_wind.floaters import IEA_15MW_RNA
+from digitalmodel.floating_wind.screening import (
+    LoadCase,
+    ScreeningCriteria,
+    screen_concept,
+)
+from digitalmodel.orcaflex.batch_parametric import ParameterSweep
+
+
+@pytest.fixture
+def load_cases() -> list[LoadCase]:
+    return [
+        LoadCase(name="operational", hs_m=2.5, tp_s=8.0, steady_load_kN=2400.0),
+        LoadCase(name="extreme", hs_m=10.0, tp_s=14.0, steady_load_kN=3000.0),
+    ]
+
+
+SEMI_BASE = dict(
+    n_columns=3,
+    column_diameter=12.5,
+    column_radius=51.75,
+    draft=20.0,
+    pontoon_height=7.0,
+    pontoon_volume=10000.0,
+    steel_mass_t=4000.0,
+)
+
+
+def test_grid_is_full_factorial(load_cases):
+    res = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[
+            ParameterSweep(name="column_diameter", values=[11.0, 12.5, 14.0]),
+            ParameterSweep(name="column_radius", values=[45.0, 51.75]),
+        ],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    assert res.n_variants == 6  # 3 x 2 full factorial
+    assert res.archetype.value == "semi"
+    assert res.load_cases == ["operational", "extreme"]
+
+
+def test_a_well_proportioned_semi_passes(load_cases):
+    res = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    v = res.variants[0]
+    assert v.feasible
+    assert v.passed
+    assert res.n_passed == 1
+    # Every check present and passing; stability + modal are per-variant,
+    # motion is per-load-case.
+    names = {c.name for c in v.checks}
+    assert {"stability", "modal", "motion"} <= names
+
+
+def test_barge_is_flagged_for_wave_band_resonance(load_cases):
+    # A barge's natural periods land inside the energetic wave band.
+    res = screen_concept(
+        "barge",
+        dict(length=60.0, beam=60.0, draft=12.0, steel_mass_t=5000.0),
+        sweeps=[ParameterSweep(name="draft", values=[10.0, 12.0])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    assert res.n_passed == 0
+    for v in res.variants:
+        assert not v.passed
+        assert v.governing_check in {"modal", "motion"}
+
+
+def test_governing_check_has_smallest_margin(load_cases):
+    res = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    v = res.variants[0]
+    smallest = min(v.checks, key=lambda c: c.margin)
+    assert v.governing_check == smallest.name
+    assert v.governing_margin == pytest.approx(smallest.margin)
+
+
+def test_mooring_check_only_when_criteria_given(load_cases):
+    without = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    assert "mooring" not in {c.name for c in without.variants[0].checks}
+
+    with_moor = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+        criteria=ScreeningCriteria(
+            mooring_stiffness_kN_per_m=400.0, max_offset_m=30.0
+        ),
+    )
+    moor = [c for c in with_moor.variants[0].checks if c.name == "mooring"]
+    assert len(moor) == 1
+    # Offset = governing (largest) steady load / stiffness = 3000 / 400 = 7.5 m.
+    assert moor[0].value == pytest.approx(3000.0 / 400.0)
+
+
+def test_infeasible_variant_does_not_pass(load_cases):
+    res = screen_concept(
+        "barge",
+        dict(length=20.0, beam=20.0, draft=4.0, steel_mass_t=3000.0),
+        sweeps=[ParameterSweep(name="draft", values=[4.0])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    v = res.variants[0]
+    assert not v.feasible
+    assert not v.passed
+
+
+def test_to_rows_is_tidy_long_form(load_cases):
+    res = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[11.0, 12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+    )
+    rows = res.to_rows()
+    # One row per variant x check.
+    assert len(rows) == sum(len(v.checks) for v in res.variants)
+    row = rows[0]
+    assert {"case_id", "archetype", "check", "value", "passed", "margin"} <= set(row)
+    assert "param_column_diameter" in row

--- a/tests/floating_wind/test_tradespace.py
+++ b/tests/floating_wind/test_tradespace.py
@@ -1,0 +1,111 @@
+"""Tests for trade-space analysis (issue #1026): Pareto front + correlation map."""
+
+import math
+
+import pytest
+
+from digitalmodel.floating_wind.floaters import IEA_15MW_RNA
+from digitalmodel.floating_wind.screening import LoadCase, screen_concept
+from digitalmodel.floating_wind.tradespace import (
+    Objective,
+    correlation_map,
+    metric_records,
+    pareto_front,
+)
+from digitalmodel.orcaflex.batch_parametric import ParameterSweep
+
+SEMI_BASE = dict(
+    n_columns=3,
+    column_diameter=12.5,
+    column_radius=51.75,
+    draft=20.0,
+    pontoon_height=7.0,
+    pontoon_volume=10000.0,
+    steel_mass_t=4000.0,
+)
+
+
+@pytest.fixture
+def results():
+    return screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[
+            ParameterSweep(name="column_diameter", values=[11.0, 12.5, 14.0]),
+            ParameterSweep(name="column_radius", values=[45.0, 51.75, 58.0]),
+        ],
+        topside=IEA_15MW_RNA,
+        load_cases=[
+            LoadCase(name="operational", hs_m=2.5, tp_s=8.0),
+            LoadCase(name="extreme", hs_m=10.0, tp_s=14.0),
+        ],
+    )
+
+
+def test_pareto_front_is_nonempty_and_nondominated(results):
+    objectives = [
+        Objective(key="steel_mass_t", direction="min"),
+        Objective(key="governing_margin", direction="max"),
+    ]
+    front = pareto_front(results, objectives)
+    assert front
+    # No front member dominates another on both objectives simultaneously.
+    for a in front:
+        for b in front:
+            if a is b:
+                continue
+            strictly_lighter = a["steel_mass_t"] < b["steel_mass_t"]
+            strictly_tougher = a["governing_margin"] > b["governing_margin"]
+            at_least_as_light = a["steel_mass_t"] <= b["steel_mass_t"]
+            at_least_as_tough = a["governing_margin"] >= b["governing_margin"]
+            dominates = (
+                at_least_as_light
+                and at_least_as_tough
+                and (strictly_lighter or strictly_tougher)
+            )
+            assert not dominates
+
+
+def test_pareto_accepts_tuple_objectives(results):
+    front_tuples = pareto_front(results, [("displacement_t", "min")])
+    # A single-objective front is the unique optimum (ties allowed).
+    best = min(r["displacement_t"] for r in metric_records(results))
+    assert all(r["displacement_t"] == pytest.approx(best) for r in front_tuples)
+
+
+def test_pareto_passed_only_subsets_the_front(results):
+    objs = [Objective(key="steel_mass_t", direction="min")]
+    all_front = pareto_front(results, objs)
+    passed_front = pareto_front(results, objs, passed_only=True)
+    assert len(passed_front) <= len(all_front)
+    assert all(r["passed"] for r in passed_front)
+
+
+def test_correlation_map_recovers_known_relationships(results):
+    cmap = correlation_map(results)
+    # Self-correlation is 1 (displacement varies with the swept column diameter).
+    assert cmap["displacement_t"]["displacement_t"] == pytest.approx(1.0)
+    # GM rises with column spread (radius) -- strong positive correlation.
+    assert cmap["param_column_radius"]["GM_m"] > 0.5
+    # Symmetry.
+    assert cmap["GM_m"]["param_column_radius"] == pytest.approx(
+        cmap["param_column_radius"]["GM_m"]
+    )
+
+
+def test_correlation_drops_constant_columns(results):
+    cmap = correlation_map(results)
+    # draft is fixed across the sweep -> zero variance -> dropped.
+    assert "param_draft" not in cmap
+
+
+def test_metric_records_can_include_infeasible():
+    res = screen_concept(
+        "barge",
+        dict(length=20.0, beam=20.0, draft=4.0, steel_mass_t=3000.0),
+        sweeps=[ParameterSweep(name="draft", values=[4.0])],
+        topside=IEA_15MW_RNA,
+        load_cases=[LoadCase(name="op", hs_m=2.0, tp_s=7.0)],
+    )
+    assert metric_records(res, feasible_only=True) == []
+    assert len(metric_records(res, feasible_only=False)) == 1

--- a/tests/floating_wind/test_workflow.py
+++ b/tests/floating_wind/test_workflow.py
@@ -1,0 +1,60 @@
+"""Offline smoke test for the floating-wind-sizing workflow (issue #1028).
+
+Dispatches the committed example ``input.yml`` through the digitalmodel engine
+(basename ``floating_wind_sizing``) and asserts a sane screening summary.
+Closed-form / solver-free: no OrcaFlex or OrcaWave licence required.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.engine import engine
+from digitalmodel.usecase_registry import load_usecases, validate_registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INPUT_YML = (
+    REPO_ROOT / "examples" / "workflows" / "floating-wind-sizing" / "input.yml"
+)
+SUMMARY_JSON = (
+    REPO_ROOT
+    / "examples"
+    / "workflows"
+    / "floating-wind-sizing"
+    / "results"
+    / "floating_wind_sizing_summary.json"
+)
+
+
+def test_floating_wind_sizing_workflow_offline():
+    assert INPUT_YML.exists(), f"missing example input: {INPUT_YML}"
+
+    cfg = engine(inputfile=str(INPUT_YML))
+
+    result = cfg["floating_wind_sizing"]["result"]
+    assert result["n_concepts"] == 3
+    assert result["total_variants"] == 12  # 6 semi + 3 spar + 3 barge
+    assert 0 < result["total_passed"] <= result["total_variants"]
+
+    archetypes = {c["archetype"] for c in result["concepts"]}
+    assert archetypes == {"semi", "spar", "barge"}
+
+    # The spar concept should produce a passing shortlist; the barge (resonant
+    # with the wave band) should not.
+    by_arch = {c["archetype"]: c for c in result["concepts"]}
+    assert by_arch["spar"]["n_passed"] >= 1
+    assert by_arch["barge"]["n_passed"] == 0
+
+    # Summary JSON is written and round-trips.
+    assert SUMMARY_JSON.exists()
+    on_disk = json.loads(SUMMARY_JSON.read_text())
+    assert on_disk["total_variants"] == 12
+
+
+def test_registry_entry_is_valid_and_resolves():
+    # The floating-wind-sizing use-case is registered and its template resolves.
+    assert validate_registry() == []
+    fw = [u for u in load_usecases() if u.id == "floating-wind-sizing"]
+    assert len(fw) == 1
+    assert fw[0].template_path().exists()


### PR DESCRIPTION
Builds the **offline, licence-free core** of the floating-wind global sizing & concept-screening capability (epic #1022), a PyFloatSizer-class tool grounded in the existing FOWT/parametric/mooring machinery. Four of the six sub-issues; the licensed solver tier (#1025) and the report-backbone Concept Data Sheet (#1027) follow.

## What's here
- **#1023 — parametric floater archetype models** (`floating_wind/floaters.py`): semi-sub, spar, TLP, barge. Each maps a small parameter vector → displacement, mass split, intact stability (`GM = KB + BM - KG`) and rigid-body heave/pitch natural periods, closing the mass balance against a lumped turbine topside (RNA + tower). Closed-form.
- **#1024 — concept-screening orchestrator** (`screening.py`): sweep variants × site load cases through four checks — **stability** (GM floor), **motion** (dynamic-amplification proxy at the load-case Tp), **modal** (natural periods vs the energetic wave band) and an optional **mooring** steady-offset watch-circle proxy — rolling up a per-variant verdict with the governing (smallest-margin) check. Variant grid reuses `ParametricStudy`.
- **#1026 — trade-space analysis** (`tradespace.py`): `pareto_front()` (non-dominated set over min/max objectives) + `correlation_map()` (parameter↔response Pearson correlations, zero-variance columns dropped).
- **#1028 — dispatch + registry + example**: `floating_wind_sizing` UV-workflow + engine wiring + base config + `usecase_registry` entry (template resolves, `validate_registry` green) + a runnable multi-archetype example.

## Run it
```
uv run python -m digitalmodel examples/workflows/floating-wind-sizing/input.yml
```
Screens 12 variants (6 semi / 3 spar / 3 barge) across operational/severe/extreme sea states → `results/floating_wind_sizing_summary.json`. The screen discriminates correctly: spar 3/3 pass, semi 4/6, barge 0/3 (its natural periods land in the wave band).

## Physics note
The pitch natural period uses the full mass moment of inertia about the CG (vertical lever of the high turbine topside + hull horizontal spread), not a crude radius-of-gyration fraction — without it a deep spar's pitch period fell spuriously inside the wave band.

## Tests
`tests/floating_wind/` — 22 tests + registry invariant, all green via the project venv. Closed-form / no OrcaFlex/OrcaWave licence.

## Scope / honesty
- First tier is a **screen**, not a design of record. Hydrodynamic added mass and radii of gyration are documented coefficients; final responses need the diffraction/time-domain tier (#1025).
- Offline workflow registered like the existing `fowt-mooring` precedent (`solver: orcaflex`, `operation: null`).
- Working tree in the shared clone also held a concurrent session's reporting-backbone changes; only `floating_wind` / engine / registry paths are in this branch.

Closes #1023, closes #1024, closes #1026, closes #1028. Part of #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
