### PR TITLE
feat: pore-pressure, dual-gradient, loading-computer, concept-data-sheet (#1034/#1037/#1035/#1027)

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -33,7 +33,8 @@ of duplicating its detailed issue history.
 | `floating_wind` | `src/digitalmodel/floating_wind/` | `tests/floating_wind/` | `docs/domains/README.md` | Floating-wind global sizing & concept screening (semi/spar/TLP/barge); `floating_wind_sizing` workflow | hydrostatics, parametric sweeps, OrcaWave/OrcaFlex (solver tier) |
 | `hydrostatics` | `src/digitalmodel/hydrostatics/` | `tests/hydrostatics/` | `docs/domains/README.md` | Fluid-column hydrostatics; seabed/hydrostatic pressure and offshore pressure-unit conversions | NumPy |
 | `mooring_resilience` | `src/digitalmodel/mooring_resilience/` | `tests/` | `docs/domains/README.md` | Mooring-system resilience screening (intact/damaged tension, foundation, fatigue) over pre-computed atlases | mooring atlases, API RP 2SK / DNV-OS-E301 |
-| `naval_architecture` | `src/digitalmodel/naval_architecture/` | `tests/naval_architecture/` | `docs/domains/README.md` | Stability, hull form, compliance, gyradius calculations | naval architecture standards |
+| `naval_architecture` | `src/digitalmodel/naval_architecture/` | `tests/naval_architecture/` | `docs/domains/README.md` | Stability, hull form, compliance, gyradius calculations; loading computer (#1035) | naval architecture standards |
+| `reporting` | `src/digitalmodel/reporting/` | `tests/reporting/` | `docs/domains/README.md` | Shared report block library / backbone (report-as-backbone, #1018) | pydantic, HTML rendering |
 | `nde` | `src/digitalmodel/nde/` | `tests/nde/` | `docs/domains/README.md` | Non-destructive examination workflows and checks | inspection standards |
 | `orcaflex` | `src/digitalmodel/orcaflex/` | `tests/orcaflex/` | `docs/domains/orcaflex/` | Public OrcaFlex APIs, reporting, model and post-processing utilities | OrcFxAPI where licensed, YAML |
 | `orcawave` | `src/digitalmodel/orcawave/` | `tests/orcawave/` | `docs/domains/orcawave/` | OrcaWave package utilities, reporting, hydrodynamic inputs/outputs | OrcaWave, hydrodynamics |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -116,6 +116,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/naval_architecture/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#naval_architecture
+  - module: reporting
+    entry_point: src/digitalmodel/reporting/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/reporting/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#reporting
   - module: nde
     entry_point: src/digitalmodel/nde/
     maturity: development

--- a/examples/workflows/dual-gradient/input.yml
+++ b/examples/workflows/dual-gradient/input.yml
@@ -1,0 +1,39 @@
+basename: dual_gradient
+
+# Deepwater dual-gradient / narrow-window drilling screen (issue #1037).
+# Closed-form, license-free:
+#   uv run python -m digitalmodel examples/workflows/dual-gradient/input.yml
+#
+# Conventional single-gradient (one mud column from the rig floor) vs
+# dual-gradient drilling (seawater above the mud line, heavy mud below). In a
+# narrow deepwater pore/fracture window DGD widens the effective window
+# (window_dgd = window_conv * D / (D - Dml)) and needs fewer casing strings.
+# All depths are TVD from the rig floor (RKB); gradients are EMW in ppg.
+dual_gradient:
+  case:
+    id: registry_dual_gradient
+    description: 2000 m water depth, narrow-window frontier-basin deepwater well
+
+  geometry:
+    water_depth_ft: 6561.7        # ~2000 m sea level -> mud line
+    air_gap_ft: 75.0             # rig floor above mean sea level
+    seawater_emw_ppg: 8.55       # seawater equivalent mud weight
+
+  # Pore-pressure / fracture-gradient profile (EMW ppg referenced to RKB).
+  # Razor-thin near the seabed (fracture barely above seawater), widening with
+  # depth as geopressure climbs. Supply explicit arrays or a 'gradients' block.
+  window:
+    depths_ft:        [6611.7, 8561.7, 11561.7, 14561.7, 17561.7]
+    pore_emw_ppg:     [8.6,    9.2,    10.6,    12.4,    13.8]
+    fracture_emw_ppg: [9.6,    11.4,   12.9,    14.4,    15.6]
+
+  margins:
+    kick_margin_ppg: 0.3         # EMW kept above pore by this much
+    fracture_margin_ppg: 0.3     # EMW kept below fracture by this much
+
+  step_ft: 250.0                 # open-hole sampling step for the casing screen
+  mud_weight_ppg: 12.4           # operating deep mud weight for the riser-margin check
+
+  outputs:
+    directory: results/dual_gradient
+    summary_json: dual_gradient_summary.json

--- a/examples/workflows/loading-computer/input.yml
+++ b/examples/workflows/loading-computer/input.yml
@@ -1,0 +1,59 @@
+# ABOUTME: Loadicator example — a box barge with cargo plus one damage case.
+# ABOUTME: Screening tier: equilibrium, IMO intact, lost-buoyancy, SF/BM.
+basename: loading_computer
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+loading_computer:
+  # Rectangular (box) barge. Longitudinal x runs from the aft end (0) forward.
+  hull:
+    length_m: 90.0
+    beam_m: 27.0
+    depth_m: 6.0
+  water_density_t_m3: 1.025   # seawater
+
+  # GZ curve resolution for the intact check.
+  max_heel_deg: 60.0
+  heel_step_deg: 5.0
+
+  weight_items:
+    - name: lightship
+      weight_t: 2500.0
+      lcg_m: 45.0           # at midship
+      vcg_m: 3.0
+      length_m: 90.0        # spread over the full length
+    - name: cargo_fwd
+      weight_t: 1500.0
+      lcg_m: 63.0
+      vcg_m: 4.5
+      length_m: 24.0
+    - name: cargo_aft
+      weight_t: 1500.0
+      lcg_m: 27.0
+      vcg_m: 4.5
+      length_m: 24.0
+    - name: ballast
+      weight_t: 500.0
+      lcg_m: 45.0
+      vcg_m: 1.0
+      length_m: 30.0
+
+  longitudinal_strength:
+    n_stations: 201
+    allowable_bending_t_m: 60000.0   # screening allowable (still-water)
+
+  damage_cases:
+    - name: side_compartment_amidships
+      length_m: 15.0
+      x_center_m: 45.0
+      permeability: 0.95
+      # breadth_m omitted -> full beam flooded
+
+  outputs:
+    directory: results/loading_computer
+    summary_json: loading_computer_summary.json

--- a/examples/workflows/pore-pressure/input.yml
+++ b/examples/workflows/pore-pressure/input.yml
@@ -1,0 +1,51 @@
+basename: pore_pressure
+
+# Pore-pressure prediction with uncertainty bands + safe drilling window
+# (issue #1034). Closed-form, license-free:
+#   uv run python -m digitalmodel examples/workflows/pore-pressure/input.yml
+#
+# Two independent predictors (Eaton 1975 resistivity, Bowers 1995 velocity) are
+# combined into a P10/P50/P90 distribution, calibrated to an offset-well RFT
+# point, then expressed as a safe mud-weight window (pore <= MW <= fracture) for
+# static and dynamic (ECD) conditions. Feeds swab/surge + hydraulics (#1036).
+pore_pressure:
+  case:
+    id: registry_pore_pressure
+    description: Pore-pressure screen at 12,000 ft TVD with offset-well calibration
+
+  inputs:
+    tvd: 12000.0                  # true vertical depth, ft
+    overburden_emw_ppg: 18.0      # overburden / vertical-stress gradient Sv
+    normal_pressure_emw_ppg: 8.6  # normal (hydrostatic) pore pressure Pn
+
+    eaton:
+      method: resistivity         # resistivity | sonic
+      observed: 1.1               # R_obs at depth, ohm.m (below trend = overpressure)
+      normal: 2.0                 # R_normal from the compaction trend, ohm.m
+      exponent: 1.2               # Eaton resistivity exponent
+
+    bowers:
+      sonic_velocity_ft_s: 8200.0 # compressional velocity Vp at depth, ft/s
+      v0_ft_s: 5000.0             # mudline velocity intercept V0
+      a: 9.0                      # Bowers loading-curve A
+      b: 0.75                     # Bowers loading-curve B
+
+  ensemble:
+    model_sigma_ppg: 0.6          # within-method model uncertainty (1 sigma)
+
+  calibration:
+    mode: shift                   # shift | scale | none
+    measured_pore_pressure_emw_ppg: 12.4   # offset-well RFT/MDT at this depth
+
+  fracture:
+    p50_emw_ppg: 15.5             # fracture-gradient best estimate (LOT/FIT)
+    sigma_ppg: 0.5               # fracture uncertainty (1 sigma)
+
+  window:
+    ecd_delta_ppg: 0.5            # circulating ECD rise (annular friction)
+    kick_margin_ppg: 0.3          # trip/kick margin on the pore-pressure floor
+    loss_margin_ppg: 0.3          # loss/riser margin on the fracture ceiling
+
+  outputs:
+    directory: results/pore_pressure
+    summary_json: pore_pressure_summary.json

--- a/src/digitalmodel/base_configs/modules/dual_gradient/dual_gradient.yml
+++ b/src/digitalmodel/base_configs/modules/dual_gradient/dual_gradient.yml
@@ -1,0 +1,10 @@
+basename: dual_gradient
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+dual_gradient: {}

--- a/src/digitalmodel/base_configs/modules/loading_computer/loading_computer.yml
+++ b/src/digitalmodel/base_configs/modules/loading_computer/loading_computer.yml
@@ -1,0 +1,12 @@
+# ABOUTME: Base config for the loading computer / loadicator screening workflow.
+# ABOUTME: Box-hull equilibrium, intact + damage stability, longitudinal strength.
+basename: loading_computer
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+loading_computer: {}

--- a/src/digitalmodel/base_configs/modules/pore_pressure/pore_pressure.yml
+++ b/src/digitalmodel/base_configs/modules/pore_pressure/pore_pressure.yml
@@ -1,0 +1,10 @@
+basename: pore_pressure
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+pore_pressure: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -553,6 +553,24 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         from digitalmodel.well.workflow import run_swab_surge
 
         cfg_base = run_swab_surge(cfg_base)
+    elif basename == "pore_pressure":
+        from digitalmodel.well.drilling.pore_pressure import (
+            router as run_pore_pressure,
+        )
+
+        cfg_base = run_pore_pressure(cfg_base)
+    elif basename == "dual_gradient":
+        from digitalmodel.well.drilling.dual_gradient import (
+            router as run_dual_gradient,
+        )
+
+        cfg_base = run_dual_gradient(cfg_base)
+    elif basename == "loading_computer":
+        from digitalmodel.naval_architecture.loading_computer import (
+            router as run_loading_computer,
+        )
+
+        cfg_base = run_loading_computer(cfg_base)
     elif basename == "wellpath":
         from digitalmodel.well.wellpath.workflow import router as wellpath
 

--- a/src/digitalmodel/floating_wind/report.py
+++ b/src/digitalmodel/floating_wind/report.py
@@ -1,0 +1,505 @@
+"""Concept Data Sheet renderer for floating-wind concept screening (issue #1027).
+
+The closing piece of the floating-wind concept-screening epic (#1022): a
+standardized, **provenance-stamped one-page data sheet** per shortlisted floater
+concept, built *on the shared reporting backbone* (:mod:`digitalmodel.reporting`,
+issue #1018) rather than as a parallel renderer.
+
+For one :class:`~digitalmodel.floating_wind.screening.VariantScreening` the sheet
+presents, in a fixed causal order:
+
+* **Identity** -- archetype, case id and the screening verdict badge.
+* **Parameter vector** -- the swept/base parameters that define the variant
+  (issue #1023 archetype inputs).
+* **Derived properties** -- displacement, the steel/ballast/topside mass split,
+  the hydrostatic stack (``KB``, ``BM``, ``KG``, ``GM``) and the rigid-body
+  natural periods (issue #1023).
+* **Screening verdict** -- the stability / motion / modal / mooring check table
+  with values, limits, signed margins and the governing check (issue #1024),
+  evaluated across the site load cases.
+* **Trade-space position** -- Pareto rank and key parameter→response
+  correlations, when supplied from the trade-space study (issue #1026).
+* **Provenance** -- the inputs, the solver tier used (closed-form vs the
+  OrcaWave/OrcaFlex high-fidelity tier, issue #1025) and tool versions
+  (mandatory provenance intent, issues #1018-#1019).
+
+Reporting-backbone reuse
+------------------------
+This module is a *consumer* of the single-source-of-truth report block library.
+It declares a module-level :class:`~digitalmodel.reporting.ReportBackbone` of
+keyed :class:`~digitalmodel.reporting.ReportSection` builders, renders the
+ordered section HTML with :meth:`ReportBackbone.render`, and wraps the document
+with :class:`~digitalmodel.reporting.ReportRenderer` -- mirroring the diffraction
+report-generator adoption (#1018) and the fatigue tracer-bullet migration
+(#1020). It does **not** re-implement any document/section assembly.
+
+References
+----------
+* digitalmodel reporting block library (#1018) -- shared report backbone.
+* DNV-OS-C301 / DNV-RP-0286 -- floating-wind stability & design practice.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from digitalmodel.floating_wind.screening import VariantScreening
+from digitalmodel.reporting import (
+    ReportBackbone,
+    ReportDataModel,
+    ReportRenderer,
+    ReportSection,
+    SectionMode,
+)
+
+__all__ = [
+    "ConceptProvenance",
+    "ConceptDataSheetData",
+    "concept_data_sheet",
+    "render_concept_data_sheet_html",
+    "write_concept_data_sheet",
+    "CONCEPT_DATA_SHEET_BACKBONE",
+]
+
+
+# --- provenance / envelope models -------------------------------------------
+
+
+def _digitalmodel_version() -> str:
+    """Best-effort installed ``digitalmodel`` version (``"unknown"`` if absent)."""
+    try:  # pragma: no cover - trivial metadata lookup
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("digitalmodel")
+        except PackageNotFoundError:
+            return "unknown"
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+class ConceptProvenance(BaseModel):
+    """Mandatory provenance stamp for a Concept Data Sheet (#1018-#1019).
+
+    Records *where the numbers came from*: the inputs that defined the variant,
+    the solver tier that produced the responses (the licence-free closed-form
+    screen of #1024, or the high-fidelity OrcaWave/OrcaFlex tier of #1025), and
+    the tool versions for reproducibility.
+    """
+
+    solver_tier: str = Field(
+        "closed-form (licence-free screen)",
+        description="Tier that produced the responses: closed-form vs "
+        "OrcaWave/OrcaFlex high-fidelity (#1025)",
+    )
+    high_fidelity: bool = Field(
+        False,
+        description="True when any response was replaced by a solved "
+        "OrcaWave/OrcaFlex value (#1025)",
+    )
+    load_cases: list[str] = Field(
+        default_factory=list,
+        description="Site load cases the variant was screened against (#1024)",
+    )
+    inputs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form input record (criteria, topside, environment)",
+    )
+    digitalmodel_version: str = Field(default_factory=_digitalmodel_version)
+    tool_versions: dict[str, str] = Field(
+        default_factory=dict,
+        description="Solver/tool versions (e.g. OrcaWave, OrcaFlex) when used",
+    )
+    references: tuple[str, ...] = (
+        "DNV-OS-C301 / DNV-RP-0286 (floating-wind stability)",
+        "digitalmodel reporting block library (#1018)",
+    )
+
+
+class ConceptDataSheetData(ReportDataModel):
+    """Report envelope for one Concept Data Sheet.
+
+    A thin :class:`~digitalmodel.reporting.ReportDataModel` carrying the screened
+    variant plus the optional trade-space position and the provenance stamp. The
+    backbone section builders read only from this envelope.
+    """
+
+    variant: VariantScreening
+    tradespace_rank: int | None = Field(
+        None, description="Pareto rank (1 = on the non-dominated front), if known"
+    )
+    pareto_front_size: int | None = Field(
+        None, description="Size of the Pareto front the rank is taken within"
+    )
+    correlations: dict[str, float] = Field(
+        default_factory=dict,
+        description="Key parameter→response Pearson correlations (#1026)",
+    )
+    provenance: ConceptProvenance = Field(default_factory=ConceptProvenance)
+    title: str = "Concept Data Sheet"
+
+
+# --- formatting helpers ------------------------------------------------------
+
+
+def _num(x: float, fmt: str = ".2f") -> str:
+    """Format a float for the sheet, rendering non-finite periods as a glyph."""
+    if x is None:
+        return "—"
+    if not math.isfinite(x):
+        return "∞" if x > 0 or math.isinf(x) else "—"
+    return format(x, fmt)
+
+
+def _verdict_badge(passed: bool, feasible: bool) -> str:
+    if not feasible:
+        text, color = "INFEASIBLE", "#7f8c8d"
+    elif passed:
+        text, color = "PASS", "#27ae60"
+    else:
+        text, color = "FAIL", "#c0392b"
+    return (
+        '<span style="display:inline-block;padding:3px 12px;border-radius:4px;'
+        f'color:#fff;font-weight:700;background:{color}">{text}</span>'
+    )
+
+
+def _section(title: str, body: str, *, anchor: str) -> str:
+    return f'<div class="section" id="{anchor}"><h2>{title}</h2>{body}</div>'
+
+
+# --- section builders: (data, **kwargs) -> str over the envelope -------------
+
+
+def _sec_header(data: ConceptDataSheetData, **_: Any) -> str:
+    v = data.variant
+    badge = _verdict_badge(v.passed, v.feasible)
+    rank = ""
+    if data.tradespace_rank is not None:
+        rank = f' &nbsp;·&nbsp; Pareto rank {data.tradespace_rank}'
+    return (
+        '<div class="report-header">'
+        f"<h1>{html.escape(data.title)}</h1>"
+        f'<div class="subtitle">{html.escape(v.archetype.value.upper())} '
+        f"— {html.escape(v.case_id)}</div>"
+        f'<div class="meta">Verdict: {badge}'
+        f" &nbsp;·&nbsp; governing check: "
+        f"<strong>{html.escape(v.governing_check)}</strong> "
+        f"(margin {_num(v.governing_margin, '+.3f')}){rank}</div>"
+        "</div>"
+    )
+
+
+def _sec_parameters(data: ConceptDataSheetData, **_: Any) -> str:
+    v = data.variant
+    rows = []
+    for k in sorted(v.params):
+        val = v.params[k]
+        val_str = _num(val, ".4g") if isinstance(val, (int, float)) else str(val)
+        rows.append(
+            f"<tr><td>{html.escape(str(k))}</td>"
+            f"<td>{html.escape(val_str)}</td></tr>"
+        )
+    body = (
+        "<table><thead><tr><th>Parameter</th><th>Value</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+    return _section(
+        f"Parameter Vector — {html.escape(v.archetype.value)} archetype",
+        body,
+        anchor="parameters",
+    )
+
+
+def _sec_derived(data: ConceptDataSheetData, **_: Any) -> str:
+    p = data.variant.properties
+    rows = [
+        ("Draft", _num(p.draft_m), "m"),
+        ("Displacement", _num(p.displacement_t, ".0f"), "t"),
+        ("Steel mass", _num(p.steel_mass_t, ".0f"), "t"),
+        ("Ballast mass", _num(p.ballast_mass_t, ".0f"), "t"),
+        ("Topside mass", _num(p.topside_mass_t, ".0f"), "t"),
+        ("Total mass", _num(p.total_mass_t, ".0f"), "t"),
+        ("Waterplane area", _num(p.waterplane_area_m2, ".1f"), "m²"),
+        ("KB (centre of buoyancy)", _num(p.KB_m), "m"),
+        ("BM (metacentric radius)", _num(p.BM_m), "m"),
+        ("KG (centre of gravity)", _num(p.KG_m), "m"),
+        ("GM (metacentric height)", _num(p.GM_m), "m"),
+        ("Heave natural period", _num(p.heave_natural_period_s), "s"),
+        ("Pitch natural period", _num(p.pitch_natural_period_s), "s"),
+        ("Pitch radius of gyration", _num(p.pitch_radius_gyration_m), "m"),
+    ]
+    body_rows = "".join(
+        f"<tr><td>{html.escape(name)}</td><td>{val}</td>"
+        f"<td>{html.escape(unit)}</td></tr>"
+        for name, val, unit in rows
+    )
+    note = ""
+    if p.tendon_stabilised:
+        note = (
+            '<p class="skipped-note">Tendon-stabilised (TLP): heave/pitch '
+            "periods are set by tendon axial stiffness; hydrostatic GM may be "
+            "small or negative by design.</p>"
+        )
+    if p.notes:
+        items = "".join(f"<li>{html.escape(n)}</li>" for n in p.notes)
+        note += f"<ul>{items}</ul>"
+    body = (
+        "<table><thead><tr><th>Property</th><th>Value</th><th>Unit</th></tr>"
+        f"</thead><tbody>{body_rows}</tbody></table>{note}"
+    )
+    return _section("Derived Naval-Architecture Properties", body, anchor="derived")
+
+
+def _sec_verdict(data: ConceptDataSheetData, **_: Any) -> str:
+    v = data.variant
+    rows = []
+    for chk in v.checks:
+        status = (
+            '<span style="color:#27ae60;font-weight:700">PASS</span>'
+            if chk.passed
+            else '<span style="color:#c0392b;font-weight:700">FAIL</span>'
+        )
+        governing = " ★" if chk.name == v.governing_check else ""
+        rows.append(
+            f"<tr><td>{html.escape(chk.name)}{governing}</td>"
+            f"<td>{_num(chk.value, '.3g')}</td>"
+            f"<td>{_num(chk.limit, '.3g')}</td>"
+            f"<td>{_num(chk.margin, '+.3f')}</td>"
+            f"<td>{status}</td>"
+            f"<td>{html.escape(chk.basis)}</td></tr>"
+        )
+    lcs = ", ".join(data.provenance.load_cases) or "—"
+    body = (
+        f"<p>Load cases screened: <strong>{html.escape(lcs)}</strong>. "
+        "The governing check (★) has the smallest signed margin.</p>"
+        "<table><thead><tr><th>Check</th><th>Value</th><th>Limit</th>"
+        "<th>Margin</th><th>Status</th><th>Basis</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+    return _section("Screening Verdict", body, anchor="verdict")
+
+
+def _sec_tradespace(data: ConceptDataSheetData, **_: Any) -> str:
+    if data.tradespace_rank is None and not data.correlations:
+        return ""  # nothing to show -> section omitted (backbone drops "")
+    parts: list[str] = []
+    if data.tradespace_rank is not None:
+        within = (
+            f" of {data.pareto_front_size}"
+            if data.pareto_front_size is not None
+            else ""
+        )
+        on_front = (
+            "on the non-dominated Pareto front"
+            if data.tradespace_rank == 1
+            else "dominated by lower-rank concepts"
+        )
+        parts.append(
+            f"<p>Trade-space rank: <strong>{data.tradespace_rank}{within}"
+            f"</strong> ({on_front}).</p>"
+        )
+    if data.correlations:
+        rows = "".join(
+            f"<tr><td>{html.escape(str(k))}</td><td>{_num(r, '+.3f')}</td></tr>"
+            for k, r in data.correlations.items()
+        )
+        parts.append(
+            "<table><thead><tr><th>Driver</th><th>Pearson r</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table>"
+        )
+    return _section("Trade-space Position", "".join(parts), anchor="tradespace")
+
+
+def _sec_provenance(data: ConceptDataSheetData, **_: Any) -> str:
+    prov = data.provenance
+    rows = [
+        ("Solver tier", html.escape(prov.solver_tier)),
+        ("High-fidelity solve", "yes" if prov.high_fidelity else "no"),
+        ("digitalmodel version", html.escape(prov.digitalmodel_version)),
+    ]
+    for name, ver in prov.tool_versions.items():
+        rows.append((f"{html.escape(str(name))} version", html.escape(str(ver))))
+    for k, val in prov.inputs.items():
+        rows.append((f"input · {html.escape(str(k))}", html.escape(str(val))))
+    table = (
+        "<table><thead><tr><th>Provenance</th><th>Value</th></tr></thead>"
+        "<tbody>"
+        + "".join(f"<tr><td>{name}</td><td>{val}</td></tr>" for name, val in rows)
+        + "</tbody></table>"
+    )
+    refs = ""
+    if prov.references:
+        items = "".join(f"<li>{html.escape(r)}</li>" for r in prov.references)
+        refs = f"<h3>References</h3><ul>{items}</ul>"
+    return _section("Provenance", table + refs, anchor="provenance")
+
+
+# --- backbone declaration ----------------------------------------------------
+
+CONCEPT_DATA_SHEET_BACKBONE = ReportBackbone(
+    title="Concept Data Sheet",
+    sections=[
+        ReportSection("header", "Identity & Verdict", SectionMode.ALWAYS, _sec_header),
+        ReportSection(
+            "parameters", "Parameter Vector", SectionMode.ALWAYS, _sec_parameters
+        ),
+        ReportSection(
+            "derived", "Derived Properties", SectionMode.ALWAYS, _sec_derived
+        ),
+        ReportSection(
+            "verdict", "Screening Verdict", SectionMode.ALWAYS, _sec_verdict
+        ),
+        ReportSection(
+            "tradespace",
+            "Trade-space Position",
+            SectionMode.COMPACT_SKIP,
+            _sec_tradespace,
+        ),
+        ReportSection(
+            "provenance", "Provenance", SectionMode.ALWAYS, _sec_provenance
+        ),
+    ],
+)
+
+
+# Self-contained CSS (mirrors the diffraction report look-and-feel; #1018).
+_CONCEPT_CSS = """\
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial,
+                 sans-serif;
+    margin: 0; padding: 0; color: #333; background: #f8f9fa;
+    font-size: 14px; line-height: 1.5;
+  }
+  .container { max-width: 1000px; margin: 0 auto; padding: 1.5em 2em; }
+  .report-header {
+    background: #2c3e50; color: #fff; padding: 1.2em 2em;
+    margin-bottom: 1.5em; border-radius: 6px;
+  }
+  .report-header h1 { margin: 0 0 0.3em; font-size: 1.6em; }
+  .report-header .subtitle {
+    font-size: 1.1em; opacity: 0.9; margin-bottom: 0.5em; font-weight: 300;
+  }
+  .report-header .meta { font-size: 0.9em; opacity: 0.9; }
+  .section {
+    background: #fff; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    margin-bottom: 1.5em; padding: 1.2em 1.5em;
+  }
+  .section h2 {
+    margin: 0 0 0.8em; font-size: 1.2em; color: #2c3e50;
+    border-bottom: 2px solid #3498db; padding-bottom: 0.3em;
+  }
+  .section h3 { font-size: 1.0em; color: #2c3e50; margin: 0.8em 0 0.3em; }
+  table { border-collapse: collapse; margin: 0.5em 0; font-size: 0.9em; width: 100%; }
+  th, td { border: 1px solid #ddd; padding: 0.45em 0.7em; text-align: left; }
+  th {
+    background: #34495e; color: #fff; font-weight: 600; font-size: 0.85em;
+    text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  tbody tr:nth-child(even) { background: #f8f9fa; }
+  .skipped-note {
+    font-size: 0.85em; color: #8a6d00; margin: 0.5em 0;
+    padding: 0.3em 0.6em; background: #fef9e7;
+    border-left: 3px solid #f0c674; border-radius: 2px;
+  }
+"""
+
+
+# --- public API --------------------------------------------------------------
+
+
+def concept_data_sheet(
+    variant: VariantScreening,
+    *,
+    tradespace_rank: int | None = None,
+    pareto_front_size: int | None = None,
+    correlations: dict[str, float] | None = None,
+    provenance: ConceptProvenance | None = None,
+    load_cases: list[str] | None = None,
+    inputs: dict[str, Any] | None = None,
+    high_fidelity: bool = False,
+    solver_tier: str | None = None,
+    title: str | None = None,
+    mode: str = "full",
+) -> list[str]:
+    """Render a Concept Data Sheet to the backbone's ordered section HTML.
+
+    Returns exactly what the reporting backbone returns: the ordered list of
+    non-empty section HTML strings (the trade-space section is omitted when no
+    trade-space position is supplied). Use :func:`render_concept_data_sheet_html`
+    or :func:`write_concept_data_sheet` to wrap it in a standalone document.
+
+    Parameters
+    ----------
+    variant
+        The screened variant to summarise (issue #1024).
+    tradespace_rank, pareto_front_size, correlations
+        Optional trade-space position from issue #1026.
+    provenance
+        A fully-built :class:`ConceptProvenance`. If omitted, one is assembled
+        from ``load_cases`` / ``inputs`` / ``high_fidelity`` / ``solver_tier``.
+    mode
+        ``"full"`` (default) or ``"compact"`` -- compact drops the trade-space
+        section per the backbone's ``COMPACT_SKIP`` rule.
+    """
+    if provenance is None:
+        kwargs: dict[str, Any] = {
+            "high_fidelity": high_fidelity,
+            "load_cases": load_cases or [],
+            "inputs": inputs or {},
+        }
+        if solver_tier is not None:
+            kwargs["solver_tier"] = solver_tier
+        provenance = ConceptProvenance(**kwargs)
+
+    data = ConceptDataSheetData(
+        variant=variant,
+        tradespace_rank=tradespace_rank,
+        pareto_front_size=pareto_front_size,
+        correlations=correlations or {},
+        provenance=provenance,
+        title=title or "Concept Data Sheet",
+    )
+    return CONCEPT_DATA_SHEET_BACKBONE.render(data, mode=mode)
+
+
+def render_concept_data_sheet_html(
+    variant: VariantScreening, *, mode: str = "full", **kwargs: Any
+) -> str:
+    """Render a complete standalone HTML Concept Data Sheet document.
+
+    Thin wrapper: builds the section HTML via :func:`concept_data_sheet` and
+    wraps it with the shared :class:`~digitalmodel.reporting.ReportRenderer`
+    (no parallel document assembly). Extra keyword arguments are forwarded to
+    :func:`concept_data_sheet`.
+    """
+    sections = concept_data_sheet(variant, mode=mode, **kwargs)
+    title = kwargs.get("title") or "Concept Data Sheet"
+    archetype = variant.archetype.value
+    renderer = ReportRenderer()
+    return renderer.render_html(
+        sections,
+        title=f"{title} — {archetype} {variant.case_id}",
+        css=_CONCEPT_CSS,
+        plotlyjs_src="",
+        container_class="container",
+    )
+
+
+def write_concept_data_sheet(
+    variant: VariantScreening,
+    output_path: str | Path,
+    *,
+    mode: str = "full",
+    **kwargs: Any,
+) -> Path:
+    """Render and write a Concept Data Sheet HTML file; return its path."""
+    html_doc = render_concept_data_sheet_html(variant, mode=mode, **kwargs)
+    return ReportRenderer().write_html(html_doc, Path(output_path))

--- a/src/digitalmodel/naval_architecture/loading_computer.py
+++ b/src/digitalmodel/naval_architecture/loading_computer.py
@@ -1,0 +1,594 @@
+# ABOUTME: Closed-form loading computer / loadicator for a parametric box hull.
+# ABOUTME: Equilibrium, intact + damage stability, and longitudinal strength.
+"""Loading computer ("loadicator") — screening tier, license-free.
+
+Given a parametric box / barge hull and a loading condition (a set of weight
+items), this module returns:
+
+* **Equilibrium** — mean draft and trim so that buoyancy balances total weight
+  and the longitudinal centre of buoyancy lines up under the centre of gravity.
+* **Intact stability** — transverse ``GM`` and a wall-sided (Scribanti) ``GZ``
+  righting-arm curve, checked against IMO IS Code 2008 criteria.
+* **Damage stability** — lost-buoyancy method for one flooded compartment
+  (parallel sinkage + the loss of waterplane inertia reduces ``GM``).
+* **Longitudinal strength** — the still-water shear-force and bending-moment
+  distribution from the weight − buoyancy load curve along the length, reported
+  against an allowable.
+
+Everything is closed-form for a rectangular (box) hull, so the capability is
+self-contained and testable without an external 3-D mesh. The hydrostatic
+relations for a box hull are::
+
+    V (displaced volume)  = W / rho
+    T (mean draft)        = V / (L * B)
+    KB                    = T / 2
+    BM_T (transverse)     = I_T / V = (L * B^3 / 12) / V = B^2 / (12 T)
+    BM_L (longitudinal)   = I_L / V = (B * L^3 / 12) / V = L^2 / (12 T)
+    KM                    = KB + BM
+    GM                    = KM - KG
+
+The GZ curve uses the wall-sided / Scribanti formula, valid up to deck-edge
+immersion::
+
+    GZ(phi) = (GM + 0.5 * BM_T * tan^2(phi)) * sin(phi)
+
+This module REUSES the SI-unit primitives in
+``digitalmodel.naval_architecture.damage_stability`` for the IMO criteria, GZ
+area integration / interpolation, and lost-buoyancy parallel sinkage.
+
+Units are SI throughout: lengths in metres, mass / weight in tonnes (t),
+forces reported as tonnes-force (t) and bending moments as tonne-metres (t·m)
+(plus kN·m), water density in t/m^3 (1.025 for seawater).
+
+References:
+- IMO Resolution MSC.267(85) — International Code on Intact Stability, 2008.
+- Lewis (ed.), *Principles of Naval Architecture*, Vol. I (Stability and
+  Strength), SNAME — hydrostatics, wall-sided GZ, lost-buoyancy method, and the
+  still-water shear-force / bending-moment load-curve integration.
+- D.R. Derrett & C.B. Barrass, *Ship Stability for Masters and Mates* —
+  box-barge worked relations (BM = B^2/12T, lost buoyancy, trim).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# REUSE: SI-unit stability primitives already in the naval_architecture package.
+from digitalmodel.naval_architecture.damage_stability import (
+    check_imo_intact_stability,
+    gz_area_under_curve,
+    interpolate_gz,
+    lost_buoyancy_sinkage,
+)
+
+RHO_SEAWATER_T_M3 = 1.025  # t/m^3
+RHO_FRESHWATER_T_M3 = 1.000  # t/m^3
+G_M_S2 = 9.81  # m/s^2 (for tonnes-force -> kN)
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+@dataclass
+class BoxHull:
+    """A rectangular (box / barge) hull form.
+
+    The longitudinal coordinate ``x`` runs from the aft end (x = 0) to the
+    forward end (x = length_m). Midship is at length_m / 2.
+    """
+
+    length_m: float
+    beam_m: float
+    depth_m: float
+
+    def __post_init__(self) -> None:
+        if min(self.length_m, self.beam_m, self.depth_m) <= 0.0:
+            raise ValueError("hull length, beam and depth must be positive")
+
+
+@dataclass
+class WeightItem:
+    """A single weight in the loading condition.
+
+    ``lcg_m`` is the longitudinal centre of gravity measured from the aft end
+    (x = 0). ``vcg_m`` is the vertical centre of gravity above the keel.
+    ``length_m`` is the longitudinal extent over which the weight is spread for
+    the longitudinal-strength load curve (defaults to a short block centred on
+    ``lcg_m``); use the full hull length for lightship.
+    """
+
+    name: str
+    weight_t: float
+    lcg_m: float
+    vcg_m: float
+    length_m: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.weight_t < 0.0:
+            raise ValueError(f"weight_t must be non-negative for {self.name!r}")
+
+
+@dataclass
+class DamageCase:
+    """One flooded compartment for the lost-buoyancy method."""
+
+    name: str
+    length_m: float  # longitudinal extent of the compartment
+    x_center_m: float  # longitudinal centre of the compartment from aft end
+    permeability: float = 0.95  # fraction of volume floodable
+    breadth_m: float | None = None  # defaults to full beam
+
+
+# --------------------------------------------------------------------------- #
+# Results
+# --------------------------------------------------------------------------- #
+@dataclass
+class Equilibrium:
+    displacement_t: float
+    volume_m3: float
+    draft_m: float
+    trim_m: float  # positive = by the bow, negative = by the stern
+    trim_direction: str
+    lcg_m: float
+    lcb_m: float
+    kg_m: float
+    kb_m: float
+    bm_t_m: float  # transverse BM
+    bm_l_m: float  # longitudinal BM
+    km_m: float
+    gm_t_m: float  # transverse metacentric height
+    gm_l_m: float  # longitudinal metacentric height
+
+
+@dataclass
+class IntactStability:
+    gm_m: float
+    angles_deg: list[float]
+    gz_m: list[float]
+    max_gz_m: float
+    angle_max_gz_deg: float
+    area_0_30_m_rad: float
+    area_0_40_m_rad: float
+    imo_check: dict
+    screening_status: str
+
+
+@dataclass
+class DamageStability:
+    case: str
+    sinkage_m: float
+    damaged_draft_m: float
+    intact_gm_m: float
+    damaged_gm_m: float
+    lost_waterplane_inertia_m4: float
+    gm_reduction_m: float
+    screening_status: str
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LongitudinalStrength:
+    n_stations: int
+    x_m: list[float]
+    weight_per_m_t: list[float]
+    buoyancy_per_m_t: list[float]
+    shear_force_t: list[float]
+    bending_moment_t_m: list[float]
+    max_shear_t: float
+    x_max_shear_m: float
+    max_bending_t_m: float
+    x_max_bending_m: float
+    max_bending_kn_m: float
+    allowable_bending_t_m: float | None
+    shear_end_residual_t: float  # should be ~0 in equilibrium
+    moment_end_residual_t_m: float  # should be ~0 in equilibrium
+    screening_status: str
+
+
+# --------------------------------------------------------------------------- #
+# Core calculations
+# --------------------------------------------------------------------------- #
+def total_weight_and_centroids(items: list[WeightItem]) -> tuple[float, float, float]:
+    """Total weight, longitudinal CG and vertical CG (KG) of the condition."""
+    w = sum(it.weight_t for it in items)
+    if w <= 0.0:
+        raise ValueError("total weight must be positive")
+    lcg = sum(it.weight_t * it.lcg_m for it in items) / w
+    kg = sum(it.weight_t * it.vcg_m for it in items) / w
+    return w, lcg, kg
+
+
+def solve_equilibrium(
+    hull: BoxHull,
+    items: list[WeightItem],
+    rho_t_m3: float = RHO_SEAWATER_T_M3,
+) -> Equilibrium:
+    """Solve floating equilibrium (draft + trim) for a box hull.
+
+    Buoyancy = weight fixes the mean draft; the hull then trims until the
+    longitudinal centre of buoyancy lies under the centre of gravity. For a box
+    hull the closed forms above apply.
+    """
+    w, lcg, kg = total_weight_and_centroids(items)
+    volume = w / rho_t_m3
+    draft = volume / (hull.length_m * hull.beam_m)
+    if draft > hull.depth_m:
+        raise ValueError(
+            f"draft {draft:.3f} m exceeds hull depth {hull.depth_m} m — vessel sinks"
+        )
+
+    kb = draft / 2.0
+    bm_t = hull.beam_m**2 / (12.0 * draft)
+    bm_l = hull.length_m**2 / (12.0 * draft)
+    km = kb + bm_t
+    gm_t = km - kg
+    gm_l = kb + bm_l - kg
+
+    # Trim: LCB at midship for a box on even keel. The trimming lever (LCG-LCB)
+    # is resisted by the longitudinal metacentric height. Trim over the length:
+    #   tan(theta) = (LCG - LCB) / GM_L ;  trim = L * tan(theta)
+    lcb = hull.length_m / 2.0
+    trim = hull.length_m * (lcg - lcb) / gm_l
+    if abs(trim) < 1e-9:
+        direction = "even keel"
+    elif trim > 0:
+        direction = "by the bow"
+    else:
+        direction = "by the stern"
+
+    return Equilibrium(
+        displacement_t=w,
+        volume_m3=volume,
+        draft_m=draft,
+        trim_m=trim,
+        trim_direction=direction,
+        lcg_m=lcg,
+        lcb_m=lcb,
+        kg_m=kg,
+        kb_m=kb,
+        bm_t_m=bm_t,
+        bm_l_m=bm_l,
+        km_m=km,
+        gm_t_m=gm_t,
+        gm_l_m=gm_l,
+    )
+
+
+def gz_wall_sided(gm_m: float, bm_t_m: float, heel_deg: float) -> float:
+    """Wall-sided (Scribanti) righting arm.
+
+    GZ = (GM + 0.5 * BM_T * tan^2(phi)) * sin(phi)
+
+    Valid until the deck edge immerses or the bilge emerges; adequate for a
+    box-hull screening curve. See PNA Vol. I, statical stability at large angles.
+    """
+    phi = math.radians(heel_deg)
+    return (gm_m + 0.5 * bm_t_m * math.tan(phi) ** 2) * math.sin(phi)
+
+
+def intact_stability(
+    eq: Equilibrium,
+    max_heel_deg: float = 60.0,
+    step_deg: float = 5.0,
+) -> IntactStability:
+    """Build the GZ curve and check IMO IS Code 2008 intact criteria."""
+    n = int(round(max_heel_deg / step_deg))
+    angles = [i * step_deg for i in range(n + 1)]
+    gz = [gz_wall_sided(eq.gm_t_m, eq.bm_t_m, a) for a in angles]
+
+    max_gz = max(gz)
+    angle_max = angles[gz.index(max_gz)]
+    area_30 = gz_area_under_curve(angles, gz, 30.0)
+    area_40 = gz_area_under_curve(angles, gz, 40.0)
+    imo = check_imo_intact_stability(angles, gz, eq.gm_t_m)
+
+    return IntactStability(
+        gm_m=eq.gm_t_m,
+        angles_deg=angles,
+        gz_m=gz,
+        max_gz_m=max_gz,
+        angle_max_gz_deg=angle_max,
+        area_0_30_m_rad=area_30,
+        area_0_40_m_rad=area_40,
+        imo_check=imo,
+        screening_status="pass" if imo["overall_pass"] else "fail",
+    )
+
+
+def damage_stability(
+    hull: BoxHull,
+    eq: Equilibrium,
+    damage: DamageCase,
+    rho_t_m3: float = RHO_SEAWATER_T_M3,
+) -> DamageStability:
+    """Lost-buoyancy assessment for one flooded compartment.
+
+    Lost-buoyancy method (PNA Vol. I / Derrett & Barrass): the flooded
+    compartment is treated as open to the sea, so the volume of buoyancy it used
+    to provide is lost and must be regained by parallel sinkage over the intact
+    waterplane. The compartment's waterplane no longer contributes to the
+    waterplane moment of inertia, so the transverse BM (and hence GM) drops::
+
+        sinkage   = mu * v_compartment / A_wp                 (parallel rise)
+        I_lost    = mu * (l * b^3 / 12)                        (own-centroid)
+        GM_damage = KB' + (I_T - I_lost)/V - KG
+
+    Displacement and KG are unchanged (lost buoyancy, not added weight).
+    """
+    breadth = damage.breadth_m if damage.breadth_m is not None else hull.beam_m
+    if breadth > hull.beam_m:
+        raise ValueError("damaged breadth cannot exceed the hull beam")
+    if not 0.0 <= damage.permeability <= 1.0:
+        raise ValueError("permeability must be 0.0-1.0")
+
+    a_wp = hull.length_m * hull.beam_m
+    # Volume of the compartment up to the intact waterline.
+    comp_volume = damage.length_m * breadth * eq.draft_m
+    # REUSE: parallel sinkage from the lost-buoyancy helper.
+    sinkage = lost_buoyancy_sinkage(comp_volume, damage.permeability, a_wp)
+    damaged_draft = eq.draft_m + sinkage
+
+    # Lost waterplane transverse inertia (compartment's own contribution).
+    i_intact = hull.length_m * hull.beam_m**3 / 12.0
+    i_lost = damage.permeability * (damage.length_m * breadth**3 / 12.0)
+    i_damaged = i_intact - i_lost
+
+    kb_damaged = damaged_draft / 2.0
+    bm_damaged = i_damaged / eq.volume_m3
+    gm_damaged = kb_damaged + bm_damaged - eq.kg_m
+    gm_reduction = eq.gm_t_m - gm_damaged
+
+    notes: list[str] = []
+    status = "pass"
+    if gm_damaged <= 0.0:
+        status = "fail"
+        notes.append("damaged GM <= 0 — vessel is unstable after flooding")
+    elif gm_damaged < 0.05:
+        status = "fail"
+        notes.append("damaged GM below 0.05 m residual-stability floor")
+    if damaged_draft > hull.depth_m:
+        status = "fail"
+        notes.append("damaged draft exceeds hull depth — downflooding/loss")
+
+    return DamageStability(
+        case=damage.name,
+        sinkage_m=sinkage,
+        damaged_draft_m=damaged_draft,
+        intact_gm_m=eq.gm_t_m,
+        damaged_gm_m=gm_damaged,
+        lost_waterplane_inertia_m4=i_lost,
+        gm_reduction_m=gm_reduction,
+        screening_status=status,
+        notes=notes,
+    )
+
+
+def _cumulative_trapz(y: list[float], x: list[float]) -> list[float]:
+    """Cumulative trapezoidal integral, same length as inputs, starting at 0."""
+    out = [0.0]
+    for i in range(1, len(x)):
+        dx = x[i] - x[i - 1]
+        out.append(out[-1] + 0.5 * (y[i] + y[i - 1]) * dx)
+    return out
+
+
+def longitudinal_strength(
+    hull: BoxHull,
+    items: list[WeightItem],
+    eq: Equilibrium,
+    n_stations: int = 201,
+    allowable_bending_t_m: float | None = None,
+) -> LongitudinalStrength:
+    """Still-water shear-force and bending-moment distribution.
+
+    The weight per unit length is built by smearing each item uniformly over its
+    longitudinal extent. The buoyancy per unit length is a linear (trapezoidal)
+    distribution whose total equals the displacement and whose centroid equals
+    the LCG — i.e. the trimmed buoyancy of a box hull. The net load is
+    integrated twice::
+
+        q(x)  = b(x) - w(x)          [t/m]   (load curve)
+        SF(x) = integral_0^x q dx    [t]     (shear force)
+        BM(x) = integral_0^x SF dx   [t·m]   (bending moment)
+
+    In equilibrium total weight = total buoyancy and the first moments match, so
+    both SF and BM vanish at the free ends (PNA Vol. I, longitudinal strength).
+    """
+    if n_stations < 3:
+        raise ValueError("n_stations must be >= 3")
+
+    L = hull.length_m
+    x = [i * L / (n_stations - 1) for i in range(n_stations)]
+
+    # --- weight per unit length (smear each item over its extent) ---
+    w_per_m = [0.0] * n_stations
+    for it in items:
+        extent = it.length_m if it.length_m else L / (n_stations - 1)
+        x0 = it.lcg_m - extent / 2.0
+        x1 = it.lcg_m + extent / 2.0
+        # Clip to hull, keep the density so total integrates back to weight.
+        x0c, x1c = max(0.0, x0), min(L, x1)
+        span = x1c - x0c
+        if span <= 0.0:
+            # Point falls outside; lump onto nearest station.
+            idx = min(range(n_stations), key=lambda k: abs(x[k] - it.lcg_m))
+            dx = x[1] - x[0]
+            w_per_m[idx] += it.weight_t / dx
+            continue
+        density = it.weight_t / span  # t/m over the (un-clipped) extent
+        for k in range(n_stations):
+            if x0c <= x[k] <= x1c:
+                w_per_m[k] += density
+
+    # --- buoyancy per unit length: linear (trimmed box waterplane) ---
+    # b(x) = a + c*(x - L/2). The continuous closed form is a = W/L and
+    # c = 12 W (LCG - L/2) / L^3. We instead pin (a, c) so the *discrete*
+    # trapezoidal force and moment of the buoyancy exactly match those of the
+    # discretised weight curve — this makes SF and BM vanish at both free ends
+    # to floating-point regardless of how the weight blocks fall on the grid.
+    phi = [xi - L / 2.0 for xi in x]
+    ones = [1.0] * n_stations
+
+    def _double_end(y: list[float]) -> float:
+        """End value of the double cumulative-trapezoidal integral (~∫∫y)."""
+        return _cumulative_trapz(_cumulative_trapz(y, x), x)[-1]
+
+    A1 = _cumulative_trapz(ones, x)[-1]
+    P1 = _cumulative_trapz(phi, x)[-1]
+    Sw = _cumulative_trapz(w_per_m, x)[-1]
+    A2 = _double_end(ones)
+    P2 = _double_end(phi)
+    Bw = _double_end(w_per_m)
+
+    det = A1 * P2 - P1 * A2
+    if abs(det) < 1e-12:
+        # Degenerate grid — fall back to the closed-form trimmed distribution.
+        a = eq.displacement_t / L
+        c = 12.0 * eq.displacement_t * (eq.lcg_m - L / 2.0) / L**3
+    else:
+        a = (Sw * P2 - P1 * Bw) / det
+        c = (A1 * Bw - Sw * A2) / det
+    b_per_m = [a + c * pi for pi in phi]
+    # A box waterplane cannot carry negative buoyancy; deep trim would need a
+    # non-linear waterplane, out of scope for this screening load curve.
+
+    # --- integrate ---
+    q = [b_per_m[k] - w_per_m[k] for k in range(n_stations)]
+    sf = _cumulative_trapz(q, x)
+    bm = _cumulative_trapz(sf, x)
+
+    max_sf = max(sf, key=abs)
+    x_max_sf = x[sf.index(max_sf)]
+    max_bm = max(bm, key=abs)
+    x_max_bm = x[bm.index(max_bm)]
+
+    status = "pass"
+    if allowable_bending_t_m is not None and abs(max_bm) > allowable_bending_t_m:
+        status = "fail"
+
+    return LongitudinalStrength(
+        n_stations=n_stations,
+        x_m=x,
+        weight_per_m_t=w_per_m,
+        buoyancy_per_m_t=b_per_m,
+        shear_force_t=sf,
+        bending_moment_t_m=bm,
+        max_shear_t=max_sf,
+        x_max_shear_m=x_max_sf,
+        max_bending_t_m=max_bm,
+        x_max_bending_m=x_max_bm,
+        max_bending_kn_m=max_bm * G_M_S2,
+        allowable_bending_t_m=allowable_bending_t_m,
+        shear_end_residual_t=sf[-1],
+        moment_end_residual_t_m=bm[-1],
+        screening_status=status,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Router
+# --------------------------------------------------------------------------- #
+def _parse_items(raw: list[dict]) -> list[WeightItem]:
+    return [
+        WeightItem(
+            name=it["name"],
+            weight_t=float(it["weight_t"]),
+            lcg_m=float(it["lcg_m"]),
+            vcg_m=float(it["vcg_m"]),
+            length_m=(None if it.get("length_m") is None else float(it["length_m"])),
+        )
+        for it in raw
+    ]
+
+
+def run_loading_computer(settings: dict) -> dict:
+    """Run the full loadicator from a settings dict and return a result dict."""
+    hull_cfg = settings["hull"]
+    hull = BoxHull(
+        length_m=float(hull_cfg["length_m"]),
+        beam_m=float(hull_cfg["beam_m"]),
+        depth_m=float(hull_cfg["depth_m"]),
+    )
+    rho = float(settings.get("water_density_t_m3", RHO_SEAWATER_T_M3))
+    items = _parse_items(settings["weight_items"])
+
+    eq = solve_equilibrium(hull, items, rho)
+    intact = intact_stability(
+        eq,
+        max_heel_deg=float(settings.get("max_heel_deg", 60.0)),
+        step_deg=float(settings.get("heel_step_deg", 5.0)),
+    )
+
+    ls_cfg = settings.get("longitudinal_strength", {})
+    strength = longitudinal_strength(
+        hull,
+        items,
+        eq,
+        n_stations=int(ls_cfg.get("n_stations", 201)),
+        allowable_bending_t_m=(
+            None
+            if ls_cfg.get("allowable_bending_t_m") is None
+            else float(ls_cfg["allowable_bending_t_m"])
+        ),
+    )
+
+    damage_results: list[dict] = []
+    for dmg in settings.get("damage_cases", []) or []:
+        case = DamageCase(
+            name=dmg["name"],
+            length_m=float(dmg["length_m"]),
+            x_center_m=float(dmg["x_center_m"]),
+            permeability=float(dmg.get("permeability", 0.95)),
+            breadth_m=(None if dmg.get("breadth_m") is None else float(dmg["breadth_m"])),
+        )
+        damage_results.append(asdict(damage_stability(hull, eq, case, rho)))
+
+    statuses = [intact.screening_status, strength.screening_status]
+    statuses += [d["screening_status"] for d in damage_results]
+    overall = "fail" if "fail" in statuses else "pass"
+
+    return {
+        "hull": asdict(hull),
+        "water_density_t_m3": rho,
+        "equilibrium": asdict(eq),
+        "intact_stability": asdict(intact),
+        "damage_stability": damage_results,
+        "longitudinal_strength": asdict(strength),
+        "screening_status": overall,
+    }
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/loading_computer"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get(
+        "summary_json", "loading_computer_summary.json"
+    )
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path
+
+
+def router(cfg: dict) -> dict:
+    """Workflow entry point reading ``cfg["loading_computer"]``.
+
+    Mirrors the self-contained router pattern used by ``inspection_planning``:
+    runs the loadicator, writes a JSON summary, stamps ``screening_status`` on
+    both the module payload and the top-level cfg, and returns cfg.
+    """
+    settings = cfg.get("loading_computer") or {}
+    result = run_loading_computer(settings)
+
+    payload = {**settings, "result": result}
+    payload["screening_status"] = result["screening_status"]
+    payload["summary_json"] = str(
+        _write_summary(cfg, settings.get("outputs", {}), payload)
+    )
+    cfg["loading_computer"] = payload
+    cfg["screening_status"] = result["screening_status"]
+    return cfg

--- a/src/digitalmodel/well/drilling/dual_gradient.py
+++ b/src/digitalmodel/well/drilling/dual_gradient.py
@@ -1,0 +1,557 @@
+# ABOUTME: DualGradient — deepwater single- vs dual-gradient drilling narrow-window screen.
+# ABOUTME: Reference: Smith, Gault, Witt & Weddle (SPE/IADC 79880) DGD; Schubert et al.; API RP 92.
+
+"""
+DualGradient
+============
+
+Closed-form, license-free screen comparing **conventional single-gradient**
+drilling against **dual-gradient drilling (DGD)** in deepwater, where the
+pore-pressure / fracture-gradient window is narrow.
+
+Why deepwater is different
+--------------------------
+Above the mud line the only overburden is a tall column of seawater, so the
+formation fracture gradient at the seabed is barely above the seawater
+hydrostatic, while pore pressure deep in the well climbs with geopressure.
+The drillable mud-weight window between them is razor-thin, forcing many
+casing strings.
+
+Conventional single-gradient
+----------------------------
+A single mud column of weight ``MW`` runs from the rig floor to total depth, so
+the equivalent mud weight (EMW) the formation sees is constant with depth::
+
+    BHP_conv(D) = 0.052 * MW * D            [psi]
+    EMW_conv(D) = MW                        [ppg]
+
+Dual-gradient (the "u-tube" effect)
+-----------------------------------
+Returns are taken at the mud line, so the column above the mud line is
+seawater and only the column below the mud line carries the heavy mud::
+
+    BHP_dgd(D) = 0.052 * SW * Dml + 0.052 * MW * (D - Dml)         [psi]
+    EMW_dgd(D) = BHP_dgd(D) / (0.052 * D)
+               = [ SW * Dml + MW * (D - Dml) ] / D                 [ppg]
+
+where ``SW`` is the seawater EMW, ``Dml`` the mud-line depth below the rig
+floor and ``D`` the true vertical depth (both referenced to the rig floor /
+RKB, as are the pore and fracture EMW profiles).
+
+The drillable window transform
+------------------------------
+Requiring ``pore + kick_margin <= EMW <= frac - frac_margin`` at every depth
+maps to bounds on the deep mud weight ``MW``. For DGD the admissible
+mud-weight band is the conventional band scaled by ``D / (D - Dml) > 1``::
+
+    window_dgd(D) = window_conv(D) * D / (D - Dml)
+
+so the effective window is always wider, and dramatically so just below the
+mud line (where ``D`` is close to ``Dml``) — exactly where the deepwater
+problem bites. A wider window means fewer casing strings to reach TD.
+
+Riser margin
+------------
+If the riser is lost, the mud above the mud line is replaced by seawater and
+the bottom-hole pressure drops to the dual-gradient value. The well stays dead
+only if ``EMW_dgd(TD) >= pore(TD)``. In deepwater the conventional "riser
+margin" needed to satisfy this is often impractically large (it would fracture
+the shallow hole), whereas a DGD well already operates at that condition and is
+inherently riser-margin safe.
+
+Closed-form screening tier (concept level). A transient / managed-pressure
+hydraulics model is a follow-up.
+
+Units: depth in feet (TVD from rig floor), mud weight / gradients in ppg,
+pressure in psi.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "SEAWATER_EMW_PPG",
+    "PressurePoint",
+    "DrillingWindow",
+    "CasingDesign",
+    "RiserMargin",
+    "DualGradientScreen",
+    "router",
+]
+
+_PSI_PER_PPG_FT = 0.052
+SEAWATER_EMW_PPG = 8.55  # typical drilling-fluid seawater EMW, ppg
+
+
+def _interp(x: float, xs: list[float], ys: list[float]) -> float:
+    """Linear interpolation of ``ys(xs)`` at ``x``, clamped at the ends."""
+    if x <= xs[0]:
+        return ys[0]
+    if x >= xs[-1]:
+        return ys[-1]
+    lo = 0
+    hi = len(xs) - 1
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if xs[mid] <= x:
+            lo = mid
+        else:
+            hi = mid
+    span = xs[hi] - xs[lo]
+    if span == 0.0:
+        return ys[lo]
+    frac = (x - xs[lo]) / span
+    return ys[lo] + frac * (ys[hi] - ys[lo])
+
+
+class PressurePoint:
+    """Single-depth comparison of conventional vs dual-gradient EMW/BHP."""
+
+    def __init__(
+        self,
+        *,
+        depth_ft: float,
+        pore_emw_ppg: float,
+        fracture_emw_ppg: float,
+        emw_conventional_ppg: float,
+        emw_dual_gradient_ppg: float,
+        bhp_conventional_psi: float,
+        bhp_dual_gradient_psi: float,
+    ) -> None:
+        self.depth_ft = depth_ft
+        self.pore_emw_ppg = pore_emw_ppg
+        self.fracture_emw_ppg = fracture_emw_ppg
+        self.emw_conventional_ppg = emw_conventional_ppg
+        self.emw_dual_gradient_ppg = emw_dual_gradient_ppg
+        self.bhp_conventional_psi = bhp_conventional_psi
+        self.bhp_dual_gradient_psi = bhp_dual_gradient_psi
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "depth_ft": self.depth_ft,
+            "pore_emw_ppg": self.pore_emw_ppg,
+            "fracture_emw_ppg": self.fracture_emw_ppg,
+            "emw_conventional_ppg": self.emw_conventional_ppg,
+            "emw_dual_gradient_ppg": self.emw_dual_gradient_ppg,
+            "bhp_conventional_psi": self.bhp_conventional_psi,
+            "bhp_dual_gradient_psi": self.bhp_dual_gradient_psi,
+        }
+
+
+class DrillingWindow:
+    """Pore-pressure / fracture-gradient profile (EMW, ppg) vs depth (ft, RKB)."""
+
+    def __init__(
+        self,
+        *,
+        depths_ft: list[float],
+        pore_emw_ppg: list[float],
+        fracture_emw_ppg: list[float],
+    ) -> None:
+        if not (len(depths_ft) == len(pore_emw_ppg) == len(fracture_emw_ppg)):
+            raise ValueError("depths, pore and fracture arrays must be equal length")
+        if len(depths_ft) < 2:
+            raise ValueError("need at least two depth points")
+        if any(b <= a for a, b in zip(depths_ft, depths_ft[1:])):
+            raise ValueError("depths_ft must be strictly increasing")
+        for pp, fg in zip(pore_emw_ppg, fracture_emw_ppg):
+            if fg < pp:
+                raise ValueError("fracture EMW must be >= pore EMW at every depth")
+        self.depths_ft = [float(d) for d in depths_ft]
+        self.pore_emw_ppg = [float(p) for p in pore_emw_ppg]
+        self.fracture_emw_ppg = [float(f) for f in fracture_emw_ppg]
+
+    @classmethod
+    def from_gradients(
+        cls,
+        *,
+        top_depth_ft: float,
+        bottom_depth_ft: float,
+        pore_top_ppg: float,
+        pore_bottom_ppg: float,
+        fracture_top_ppg: float,
+        fracture_bottom_ppg: float,
+    ) -> "DrillingWindow":
+        """Build a two-point (linear) window from top/bottom EMW gradients."""
+        return cls(
+            depths_ft=[top_depth_ft, bottom_depth_ft],
+            pore_emw_ppg=[pore_top_ppg, pore_bottom_ppg],
+            fracture_emw_ppg=[fracture_top_ppg, fracture_bottom_ppg],
+        )
+
+    @property
+    def td_ft(self) -> float:
+        return self.depths_ft[-1]
+
+    def pore_at(self, depth_ft: float) -> float:
+        return _interp(depth_ft, self.depths_ft, self.pore_emw_ppg)
+
+    def fracture_at(self, depth_ft: float) -> float:
+        return _interp(depth_ft, self.depths_ft, self.fracture_emw_ppg)
+
+
+class CasingDesign:
+    """Casing-string estimate for one drilling mode (conventional or DGD)."""
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        n_strings: int,
+        seat_depths_ft: list[float],
+        section_mud_weights_ppg: list[float],
+        window_violated: bool,
+    ) -> None:
+        self.mode = mode
+        self.n_strings = n_strings
+        self.seat_depths_ft = seat_depths_ft
+        self.section_mud_weights_ppg = section_mud_weights_ppg
+        self.window_violated = window_violated  # window closed somewhere even for DGD
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "n_strings": self.n_strings,
+            "seat_depths_ft": self.seat_depths_ft,
+            "section_mud_weights_ppg": self.section_mud_weights_ppg,
+            "window_violated": self.window_violated,
+        }
+
+
+class RiserMargin:
+    """Riser-margin (keep-the-well-dead-on-riser-loss) check at a depth."""
+
+    def __init__(
+        self,
+        *,
+        depth_ft: float,
+        mud_weight_ppg: float,
+        pore_emw_ppg: float,
+        emw_after_riser_loss_ppg: float,
+        margin_ppg: float,
+        well_dead_after_loss: bool,
+    ) -> None:
+        self.depth_ft = depth_ft
+        self.mud_weight_ppg = mud_weight_ppg
+        self.pore_emw_ppg = pore_emw_ppg
+        self.emw_after_riser_loss_ppg = emw_after_riser_loss_ppg
+        self.margin_ppg = margin_ppg
+        self.well_dead_after_loss = well_dead_after_loss
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "depth_ft": self.depth_ft,
+            "mud_weight_ppg": self.mud_weight_ppg,
+            "pore_emw_ppg": self.pore_emw_ppg,
+            "emw_after_riser_loss_ppg": self.emw_after_riser_loss_ppg,
+            "margin_ppg": self.margin_ppg,
+            "well_dead_after_loss": self.well_dead_after_loss,
+        }
+
+
+class DualGradientScreen:
+    """Single-gradient vs dual-gradient deepwater drilling-window screen."""
+
+    def __init__(
+        self,
+        *,
+        water_depth_ft: float,
+        window: DrillingWindow,
+        air_gap_ft: float = 75.0,
+        seawater_emw_ppg: float = SEAWATER_EMW_PPG,
+        kick_margin_ppg: float = 0.3,
+        fracture_margin_ppg: float = 0.3,
+    ) -> None:
+        if water_depth_ft <= 0:
+            raise ValueError("water_depth_ft must be > 0")
+        if air_gap_ft < 0:
+            raise ValueError("air_gap_ft must be >= 0")
+        if seawater_emw_ppg <= 0:
+            raise ValueError("seawater_emw_ppg must be > 0")
+        if kick_margin_ppg < 0 or fracture_margin_ppg < 0:
+            raise ValueError("margins must be >= 0")
+        self.water_depth_ft = float(water_depth_ft)
+        self.air_gap_ft = float(air_gap_ft)
+        self.seawater_emw_ppg = float(seawater_emw_ppg)
+        self.window = window
+        self.kick_margin_ppg = float(kick_margin_ppg)
+        self.fracture_margin_ppg = float(fracture_margin_ppg)
+
+        self.mud_line_depth_ft = self.air_gap_ft + self.water_depth_ft
+        if window.td_ft <= self.mud_line_depth_ft:
+            raise ValueError("window TD must be below the mud line")
+
+    # -- pressure / EMW profiles ------------------------------------------
+
+    def bhp_conventional(self, depth_ft: float, mud_weight_ppg: float) -> float:
+        """Bottom-hole pressure for a single mud column from the rig floor, psi."""
+        return _PSI_PER_PPG_FT * mud_weight_ppg * depth_ft
+
+    def emw_conventional(self, depth_ft: float, mud_weight_ppg: float) -> float:
+        """Equivalent mud weight seen by the formation (constant = MW), ppg."""
+        return mud_weight_ppg
+
+    def bhp_dual_gradient(self, depth_ft: float, mud_weight_ppg: float) -> float:
+        """Bottom-hole pressure with seawater above and mud below mud line, psi."""
+        dml = self.mud_line_depth_ft
+        if depth_ft <= dml:
+            return _PSI_PER_PPG_FT * self.seawater_emw_ppg * depth_ft
+        return _PSI_PER_PPG_FT * (
+            self.seawater_emw_ppg * dml + mud_weight_ppg * (depth_ft - dml)
+        )
+
+    def emw_dual_gradient(self, depth_ft: float, mud_weight_ppg: float) -> float:
+        """Equivalent mud weight of the dual-gradient column, ppg."""
+        if depth_ft <= self.mud_line_depth_ft:
+            return self.seawater_emw_ppg
+        return self.bhp_dual_gradient(depth_ft, mud_weight_ppg) / (
+            _PSI_PER_PPG_FT * depth_ft
+        )
+
+    def pressure_point(self, depth_ft: float, mud_weight_ppg: float) -> PressurePoint:
+        """Side-by-side conventional vs DGD point at one depth."""
+        return PressurePoint(
+            depth_ft=depth_ft,
+            pore_emw_ppg=self.window.pore_at(depth_ft),
+            fracture_emw_ppg=self.window.fracture_at(depth_ft),
+            emw_conventional_ppg=self.emw_conventional(depth_ft, mud_weight_ppg),
+            emw_dual_gradient_ppg=self.emw_dual_gradient(depth_ft, mud_weight_ppg),
+            bhp_conventional_psi=self.bhp_conventional(depth_ft, mud_weight_ppg),
+            bhp_dual_gradient_psi=self.bhp_dual_gradient(depth_ft, mud_weight_ppg),
+        )
+
+    # -- mud-weight window per mode ---------------------------------------
+
+    def mud_weight_bounds(
+        self, mode: str, depth_ft: float
+    ) -> tuple[float, float]:
+        """Admissible deep mud-weight band ``(lo, hi)`` at a depth, ppg.
+
+        ``lo`` keeps EMW above pore + kick margin; ``hi`` keeps EMW below
+        fracture - fracture margin. For DGD the conventional band is scaled
+        by ``D / (D - Dml)``.
+        """
+        lo_emw = self.window.pore_at(depth_ft) + self.kick_margin_ppg
+        hi_emw = self.window.fracture_at(depth_ft) - self.fracture_margin_ppg
+        if mode == "conventional":
+            return lo_emw, hi_emw
+        if mode == "dual_gradient":
+            dml = self.mud_line_depth_ft
+            denom = depth_ft - dml
+            if denom <= 0:
+                # at/above mud line any deep MW is admissible (seawater column)
+                return float("-inf"), float("inf")
+            lo = (lo_emw * depth_ft - self.seawater_emw_ppg * dml) / denom
+            hi = (hi_emw * depth_ft - self.seawater_emw_ppg * dml) / denom
+            return lo, hi
+        raise ValueError("mode must be 'conventional' or 'dual_gradient'")
+
+    def available_window_ppg(self, mode: str, depth_ft: float) -> float:
+        """Width of the admissible mud-weight band at a depth, ppg (can be < 0)."""
+        lo, hi = self.mud_weight_bounds(mode, depth_ft)
+        return hi - lo
+
+    def min_available_window_ppg(
+        self, mode: str, step_ft: float = 250.0
+    ) -> float:
+        """Narrowest mud-weight band over the open hole (mud line -> TD), ppg."""
+        worst = float("inf")
+        for d in self._open_hole_grid(step_ft):
+            worst = min(worst, self.available_window_ppg(mode, d))
+        return worst
+
+    # -- casing-string estimate -------------------------------------------
+
+    def _open_hole_grid(self, step_ft: float) -> list[float]:
+        """Sampling grid from just below the mud line to TD (inclusive)."""
+        if step_ft <= 0:
+            raise ValueError("step_ft must be > 0")
+        start = self.mud_line_depth_ft + step_ft
+        td = self.window.td_ft
+        grid: list[float] = []
+        d = start
+        while d < td:
+            grid.append(d)
+            d += step_ft
+        grid.append(td)
+        # merge in the supplied profile depths that fall inside the open hole
+        for dp in self.window.depths_ft:
+            if start <= dp <= td:
+                grid.append(dp)
+        grid = sorted(set(grid))
+        return grid
+
+    def _interval_feasible(
+        self, mode: str, depths: list[float]
+    ) -> tuple[bool, float]:
+        """Is one mud weight admissible across ``depths``? Return (ok, chosen MW)."""
+        max_lo = float("-inf")
+        min_hi = float("inf")
+        for d in depths:
+            lo, hi = self.mud_weight_bounds(mode, d)
+            max_lo = max(max_lo, lo)
+            min_hi = min(min_hi, hi)
+        return (max_lo <= min_hi, max_lo)
+
+    def casing_design(self, mode: str, step_ft: float = 250.0) -> CasingDesign:
+        """Greedy casing-seat count keeping EMW inside the window per section.
+
+        Walks top-down from the mud line, extending each open-hole section as
+        deep as one mud weight allows, then sets a casing string. Fewer
+        sections == fewer strings == cheaper well.
+        """
+        grid = self._open_hole_grid(step_ft)
+        n = len(grid)
+        n_strings = 0
+        seats: list[float] = []
+        muds: list[float] = []
+        window_violated = False
+        start = 0
+        while start < n:
+            j = start
+            # extend while [start..j] stays feasible
+            while j + 1 <= n - 1 and self._interval_feasible(
+                mode, grid[start : j + 2]
+            )[0]:
+                j += 1
+            ok, mw = self._interval_feasible(mode, grid[start : j + 1])
+            if not ok:
+                # even a single point has no admissible mud weight
+                window_violated = True
+            n_strings += 1
+            seats.append(grid[j])
+            muds.append(mw)
+            start = j + 1
+        return CasingDesign(
+            mode=mode,
+            n_strings=n_strings,
+            seat_depths_ft=seats,
+            section_mud_weights_ppg=muds,
+            window_violated=window_violated,
+        )
+
+    # -- riser margin ------------------------------------------------------
+
+    def riser_margin(
+        self, mud_weight_ppg: float, depth_ft: float | None = None
+    ) -> RiserMargin:
+        """Can the well stay dead if the riser is lost (mud -> seawater above ML)?
+
+        On riser loss the column above the mud line becomes seawater, so BHP
+        falls to the dual-gradient value. The well stays dead if that EMW still
+        exceeds the pore pressure.
+        """
+        depth = self.window.td_ft if depth_ft is None else depth_ft
+        emw_after = self.emw_dual_gradient(depth, mud_weight_ppg)
+        pore = self.window.pore_at(depth)
+        margin = emw_after - pore
+        return RiserMargin(
+            depth_ft=depth,
+            mud_weight_ppg=mud_weight_ppg,
+            pore_emw_ppg=pore,
+            emw_after_riser_loss_ppg=emw_after,
+            margin_ppg=margin,
+            well_dead_after_loss=margin >= 0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Router (engine entry point)
+# ---------------------------------------------------------------------------
+
+
+def _build_window(window_cfg: dict[str, Any]) -> DrillingWindow:
+    if "depths_ft" in window_cfg:
+        return DrillingWindow(
+            depths_ft=[float(d) for d in window_cfg["depths_ft"]],
+            pore_emw_ppg=[float(p) for p in window_cfg["pore_emw_ppg"]],
+            fracture_emw_ppg=[float(f) for f in window_cfg["fracture_emw_ppg"]],
+        )
+    g = window_cfg["gradients"]
+    return DrillingWindow.from_gradients(
+        top_depth_ft=float(g["top_depth_ft"]),
+        bottom_depth_ft=float(g["bottom_depth_ft"]),
+        pore_top_ppg=float(g["pore_top_ppg"]),
+        pore_bottom_ppg=float(g["pore_bottom_ppg"]),
+        fracture_top_ppg=float(g["fracture_top_ppg"]),
+        fracture_bottom_ppg=float(g["fracture_bottom_ppg"]),
+    )
+
+
+def _write_summary(cfg: dict, output_cfg: dict, payload: dict[str, Any]) -> Path:
+    directory = Path(output_cfg.get("directory", "results/dual_gradient"))
+    if not directory.is_absolute():
+        directory = Path(cfg.get("_config_dir_path", Path.cwd())) / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get(
+        "summary_json", "dual_gradient_summary.json"
+    )
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return summary_path
+
+
+def router(cfg: dict) -> dict:
+    """Run the deepwater dual-gradient drilling-window screen from ``cfg``."""
+    settings = cfg.get("dual_gradient") or {}
+    geom = settings["geometry"]
+    window = _build_window(settings["window"])
+    margins = settings.get("margins", {})
+
+    screen = DualGradientScreen(
+        water_depth_ft=float(geom["water_depth_ft"]),
+        window=window,
+        air_gap_ft=float(geom.get("air_gap_ft", 75.0)),
+        seawater_emw_ppg=float(geom.get("seawater_emw_ppg", SEAWATER_EMW_PPG)),
+        kick_margin_ppg=float(margins.get("kick_margin_ppg", 0.3)),
+        fracture_margin_ppg=float(margins.get("fracture_margin_ppg", 0.3)),
+    )
+
+    step_ft = float(settings.get("step_ft", 250.0))
+    mud_weight = float(settings.get("mud_weight_ppg", window.pore_at(window.td_ft) + 0.5))
+
+    conv = screen.casing_design("conventional", step_ft=step_ft)
+    dgd = screen.casing_design("dual_gradient", step_ft=step_ft)
+
+    # depth profile for the JSON (mud line + each window depth + TD)
+    profile_depths = sorted(
+        {screen.mud_line_depth_ft, *window.depths_ft, window.td_ft}
+    )
+    profile = [
+        screen.pressure_point(d, mud_weight).as_dict() for d in profile_depths
+    ]
+
+    result = {
+        "mud_line_depth_ft": screen.mud_line_depth_ft,
+        "td_ft": window.td_ft,
+        "operating_mud_weight_ppg": mud_weight,
+        "casing_design": {
+            "conventional": conv.as_dict(),
+            "dual_gradient": dgd.as_dict(),
+            "strings_saved_by_dgd": conv.n_strings - dgd.n_strings,
+        },
+        "min_window_ppg": {
+            "conventional": screen.min_available_window_ppg(
+                "conventional", step_ft=step_ft
+            ),
+            "dual_gradient": screen.min_available_window_ppg(
+                "dual_gradient", step_ft=step_ft
+            ),
+        },
+        "riser_margin": {
+            "conventional": screen.riser_margin(mud_weight).as_dict(),
+            # DGD already operates at the riser-lost hydrostatic, so it is
+            # inherently riser-margin safe (same check, shown for contrast).
+            "dual_gradient_inherently_safe": True,
+        },
+        "pressure_profile": profile,
+    }
+
+    payload = {"calculation": "dual_gradient", **settings, "result": result}
+    payload["summary_json"] = str(
+        _write_summary(cfg, settings.get("outputs", {}), payload)
+    )
+    cfg["dual_gradient"] = payload
+    return cfg

--- a/src/digitalmodel/well/drilling/pore_pressure.py
+++ b/src/digitalmodel/well/drilling/pore_pressure.py
@@ -1,0 +1,641 @@
+# ABOUTME: PorePressure — multi-method pore-pressure prediction with uncertainty bands + safe drilling window
+# ABOUTME: References: Eaton (1975) SPE 5544; Bowers (1995) SPE 27488; Mouchet & Mitchell (1989).
+
+"""
+PorePressure
+============
+
+Closed-form, license-free pore-pressure prediction with *explicit* uncertainty
+and a communicated safe-drilling (mud-weight) window. Inspired by the
+Geoprovider/Havtil report *"Pore Pressure Uncertainty & Communication"* which
+ties well-control incidents on the NCS to poorly-communicated uncertainty
+(issue #1034).
+
+    "Uncertainty is unavoidable. Poorly understood (or poorly communicated)
+    uncertainty is not."
+
+Methods
+-------
+Two independent, industry-standard pore-pressure predictors are implemented and
+then *combined into a distribution* (P10 / P50 / P90) rather than a single
+deterministic curve.
+
+**Eaton's method** (Eaton, 1975) — empirical, driven by the departure of a
+porosity-sensitive log (resistivity or sonic) from its normal-compaction
+trend::
+
+    resistivity:  Pp = Sv - (Sv - Pn) * (R_obs   / R_normal)^n     (n ~ 1.2)
+    sonic:        Pp = Sv - (Sv - Pn) * (dt_normal / dt_obs)^n      (n ~ 3.0)
+
+where ``Sv`` is the overburden (vertical-stress) gradient, ``Pn`` the normal
+(hydrostatic) pore-pressure gradient, and ``n`` the Eaton exponent. In an
+overpressured (undercompacted) zone resistivity falls below trend and sonic
+transit time rises above trend, so both ratios drop below 1 and ``Pp`` climbs
+toward ``Sv``.
+
+**Bowers' method** (Bowers, 1995) — effective-stress / velocity based. The
+virgin (loading) curve relates sonic velocity to vertical effective stress::
+
+    Vp = V0 + A * sigma_e^B          ->   sigma_e = ((Vp - V0) / A)^(1/B)
+    Pp = Sv - sigma_e
+
+with ``V0`` ~ mudline velocity (~5000 ft/s), and ``A``, ``B`` calibrated
+constants. (The unloading branch for centroid/uplift effects is a follow-up;
+this screening tier uses the loading curve.)
+
+Distribution & calibration
+---------------------------
+Method point estimates are combined into a normal distribution whose spread
+carries (a) the *between-method* disagreement and (b) an assumed *within-method*
+model uncertainty ``model_sigma``. P10/P50/P90 follow from the standard-normal
+quantiles (z = +/-1.2816). A simple **calibration** shifts or scales the
+distribution to honour a measured point (offset-well RFT/MDT or LOT/FIT).
+
+Safe drilling window
+--------------------
+The mud-weight window is communicated as ``pore (kick bound) <= MW <= fracture
+(loss bound)`` in EMW (ppg), conservatively built from the *high* pore pressure
+(P90) and *low* fracture gradient (P10), for both **static** and **dynamic**
+(ECD) conditions. This is the bound fed to swab/surge and hydraulics (#1036).
+
+Units: depth ft, mud weight / gradients EMW ppg, pressure psi, sonic transit
+time us/ft, velocity ft/s, resistivity ohm.m.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "PorePressureDistribution",
+    "SafeDrillingWindow",
+    "eaton_pore_pressure",
+    "bowers_pore_pressure",
+    "combine_methods",
+    "calibrate",
+    "safe_drilling_window",
+    "router",
+]
+
+# Pressure / gradient conversion: gradient [psi/ft] = 0.052 * EMW [ppg].
+_PSI_PER_PPG_FT = 0.052
+# Standard-normal quantile for the 10th / 90th percentile (P10 / P90).
+_Z_P90 = 1.2815515594
+
+
+# ---------------------------------------------------------------------------
+# Result objects (plain classes, mirroring swab_surge.py style)
+# ---------------------------------------------------------------------------
+
+
+class PorePressureDistribution:
+    """Pore-pressure estimate as a distribution in EMW (ppg).
+
+    ``p10 < p50 < p90`` by construction (low / median / high pore pressure).
+    """
+
+    def __init__(
+        self,
+        *,
+        p50: float,
+        sigma: float,
+        methods: dict[str, float] | None = None,
+        between_method_sigma: float = 0.0,
+        model_sigma: float = 0.0,
+        calibration: dict[str, Any] | None = None,
+    ) -> None:
+        if sigma < 0:
+            raise ValueError("sigma must be >= 0")
+        self.p50 = float(p50)
+        self.sigma = float(sigma)
+        self.p10 = self.p50 - _Z_P90 * self.sigma
+        self.p90 = self.p50 + _Z_P90 * self.sigma
+        self.methods = dict(methods or {})
+        self.between_method_sigma = float(between_method_sigma)
+        self.model_sigma = float(model_sigma)
+        self.calibration = calibration
+
+    @property
+    def mean(self) -> float:
+        """Mean of the (symmetric) normal distribution = P50."""
+        return self.p50
+
+    def shifted(self, delta: float) -> "PorePressureDistribution":
+        """Return a copy translated by ``delta`` ppg (spread unchanged)."""
+        out = PorePressureDistribution(
+            p50=self.p50 + delta,
+            sigma=self.sigma,
+            methods={k: v + delta for k, v in self.methods.items()},
+            between_method_sigma=self.between_method_sigma,
+            model_sigma=self.model_sigma,
+        )
+        return out
+
+    def scaled(self, factor: float) -> "PorePressureDistribution":
+        """Return a copy scaled by ``factor`` about zero (mean and spread)."""
+        return PorePressureDistribution(
+            p50=self.p50 * factor,
+            sigma=self.sigma * abs(factor),
+            methods={k: v * factor for k, v in self.methods.items()},
+            between_method_sigma=self.between_method_sigma * abs(factor),
+            model_sigma=self.model_sigma * abs(factor),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "p10_emw_ppg": self.p10,
+            "p50_emw_ppg": self.p50,
+            "p90_emw_ppg": self.p90,
+            "sigma_ppg": self.sigma,
+            "between_method_sigma_ppg": self.between_method_sigma,
+            "model_sigma_ppg": self.model_sigma,
+            "methods": self.methods,
+        }
+        if self.calibration is not None:
+            out["calibration"] = self.calibration
+        return out
+
+
+class SafeDrillingWindow:
+    """Mud-weight (EMW, ppg) window between the kick and loss bounds.
+
+    Conservative bounds use the *high* pore pressure (P90) for the kick floor
+    and the *low* fracture gradient (P10) for the loss ceiling. The dynamic
+    ceiling is reduced by the circulating ECD so that BHP while pumping stays
+    below the fracture gradient.
+    """
+
+    def __init__(
+        self,
+        *,
+        static_low_emw_ppg: float,
+        static_high_emw_ppg: float,
+        dynamic_low_emw_ppg: float,
+        dynamic_high_emw_ppg: float,
+        nominal_low_emw_ppg: float,
+        nominal_high_emw_ppg: float,
+        ecd_delta_ppg: float,
+        kick_margin_ppg: float,
+        loss_margin_ppg: float,
+    ) -> None:
+        self.static_low_emw_ppg = static_low_emw_ppg
+        self.static_high_emw_ppg = static_high_emw_ppg
+        self.dynamic_low_emw_ppg = dynamic_low_emw_ppg
+        self.dynamic_high_emw_ppg = dynamic_high_emw_ppg
+        self.nominal_low_emw_ppg = nominal_low_emw_ppg
+        self.nominal_high_emw_ppg = nominal_high_emw_ppg
+        self.ecd_delta_ppg = ecd_delta_ppg
+        self.kick_margin_ppg = kick_margin_ppg
+        self.loss_margin_ppg = loss_margin_ppg
+
+    @property
+    def static_width_ppg(self) -> float:
+        return self.static_high_emw_ppg - self.static_low_emw_ppg
+
+    @property
+    def dynamic_width_ppg(self) -> float:
+        return self.dynamic_high_emw_ppg - self.dynamic_low_emw_ppg
+
+    @property
+    def static_feasible(self) -> bool:
+        """True if a non-empty static mud-weight window exists."""
+        return self.static_width_ppg > 0.0
+
+    @property
+    def dynamic_feasible(self) -> bool:
+        """True if a non-empty dynamic (circulating) window exists."""
+        return self.dynamic_width_ppg > 0.0
+
+    def recommended_mud_weight_ppg(self) -> float | None:
+        """Centre of the dynamic window, or ``None`` if it is empty."""
+        if not self.dynamic_feasible:
+            return None
+        return 0.5 * (self.dynamic_low_emw_ppg + self.dynamic_high_emw_ppg)
+
+    def as_dict(self) -> dict[str, Any]:
+        rec = self.recommended_mud_weight_ppg()
+        return {
+            "static_low_emw_ppg": self.static_low_emw_ppg,
+            "static_high_emw_ppg": self.static_high_emw_ppg,
+            "static_width_ppg": self.static_width_ppg,
+            "static_feasible": self.static_feasible,
+            "dynamic_low_emw_ppg": self.dynamic_low_emw_ppg,
+            "dynamic_high_emw_ppg": self.dynamic_high_emw_ppg,
+            "dynamic_width_ppg": self.dynamic_width_ppg,
+            "dynamic_feasible": self.dynamic_feasible,
+            "nominal_low_emw_ppg": self.nominal_low_emw_ppg,
+            "nominal_high_emw_ppg": self.nominal_high_emw_ppg,
+            "ecd_delta_ppg": self.ecd_delta_ppg,
+            "kick_margin_ppg": self.kick_margin_ppg,
+            "loss_margin_ppg": self.loss_margin_ppg,
+            "recommended_mud_weight_ppg": rec,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Methods
+# ---------------------------------------------------------------------------
+
+
+def eaton_pore_pressure(
+    *,
+    overburden_emw_ppg: float,
+    normal_pressure_emw_ppg: float,
+    observed: float,
+    normal: float,
+    log_type: str = "resistivity",
+    exponent: float | None = None,
+) -> float:
+    """Eaton (1975) pore-pressure gradient, EMW ppg.
+
+    Parameters
+    ----------
+    overburden_emw_ppg : float
+        Overburden / vertical-stress gradient ``Sv`` at the depth, EMW ppg.
+    normal_pressure_emw_ppg : float
+        Normal (hydrostatic) pore-pressure gradient ``Pn``, EMW ppg
+        (~8.5-8.9 for typical formation water / seawater).
+    observed : float
+        Observed log value at the depth: resistivity ``R_obs`` (ohm.m) for
+        ``log_type='resistivity'`` or sonic transit time ``dt_obs`` (us/ft)
+        for ``log_type='sonic'``.
+    normal : float
+        Normal-compaction-trend value at the depth (``R_normal`` or
+        ``dt_normal``), same units as ``observed``.
+    log_type : {'resistivity', 'sonic'}
+        Selects the ratio form.
+    exponent : float, optional
+        Eaton exponent. Defaults to 1.2 (resistivity) or 3.0 (sonic).
+
+    Notes
+    -----
+    Resistivity ratio is ``(R_obs / R_normal)``; sonic ratio is the inverse
+    ``(dt_normal / dt_obs)`` because transit time *rises* with undercompaction
+    while resistivity *falls*. In a normally-compacted interval the ratio is 1
+    and ``Pp = Pn``.
+    """
+    if log_type not in ("resistivity", "sonic"):
+        raise ValueError("log_type must be 'resistivity' or 'sonic'")
+    if observed <= 0 or normal <= 0:
+        raise ValueError("observed and normal log values must be > 0")
+    if overburden_emw_ppg <= normal_pressure_emw_ppg:
+        raise ValueError("overburden must exceed the normal pore pressure")
+
+    if log_type == "resistivity":
+        n = 1.2 if exponent is None else float(exponent)
+        ratio = observed / normal
+    else:  # sonic
+        n = 3.0 if exponent is None else float(exponent)
+        ratio = normal / observed
+
+    pp = overburden_emw_ppg - (
+        overburden_emw_ppg - normal_pressure_emw_ppg
+    ) * (ratio ** n)
+    return pp
+
+
+def bowers_pore_pressure(
+    *,
+    overburden_emw_ppg: float,
+    tvd_ft: float,
+    velocity_ft_s: float | None = None,
+    sonic_dt_us_ft: float | None = None,
+    v0_ft_s: float = 5000.0,
+    a: float = 9.0,
+    b: float = 0.75,
+) -> float:
+    """Bowers (1995) loading-curve pore-pressure gradient, EMW ppg.
+
+    Uses the virgin compaction relation ``Vp = V0 + A*sigma_e^B`` to recover the
+    vertical effective stress ``sigma_e`` from sonic velocity, then
+    ``Pp = Sv - sigma_e`` (Terzaghi). Velocity may be supplied directly
+    (``velocity_ft_s``) or derived from sonic transit time
+    (``Vp = 1e6 / dt`` for ``sonic_dt_us_ft``).
+
+    Parameters
+    ----------
+    overburden_emw_ppg : float
+        Overburden gradient ``Sv`` at the depth, EMW ppg.
+    tvd_ft : float
+        True vertical depth, ft (needed to convert stress psi <-> gradient).
+    velocity_ft_s, sonic_dt_us_ft : float, optional
+        Provide exactly one. Compressional velocity (ft/s) or transit time
+        (us/ft).
+    v0_ft_s : float
+        Mudline / fluid velocity intercept ``V0``, ft/s.
+    a, b : float
+        Bowers loading-curve constants ``A`` and ``B``.
+    """
+    if tvd_ft <= 0:
+        raise ValueError("tvd_ft must be > 0")
+    if (velocity_ft_s is None) == (sonic_dt_us_ft is None):
+        raise ValueError("provide exactly one of velocity_ft_s or sonic_dt_us_ft")
+    if a <= 0 or b <= 0:
+        raise ValueError("Bowers a and b must be > 0")
+
+    if velocity_ft_s is None:
+        if sonic_dt_us_ft <= 0:
+            raise ValueError("sonic_dt_us_ft must be > 0")
+        velocity_ft_s = 1.0e6 / sonic_dt_us_ft
+
+    if velocity_ft_s <= v0_ft_s:
+        # At/below the fluid velocity there is no skeleton stress; pore
+        # pressure rises to the overburden (fully overpressured screen).
+        return overburden_emw_ppg
+
+    sigma_e_psi = ((velocity_ft_s - v0_ft_s) / a) ** (1.0 / b)
+    overburden_psi = _PSI_PER_PPG_FT * overburden_emw_ppg * tvd_ft
+    pp_psi = overburden_psi - sigma_e_psi
+    pp_emw = pp_psi / (_PSI_PER_PPG_FT * tvd_ft)
+    # Floor at the fluid (normal) line is not enforced here; the caller may
+    # clamp. Cap at overburden to keep it physical.
+    return min(pp_emw, overburden_emw_ppg)
+
+
+# ---------------------------------------------------------------------------
+# Distribution & calibration
+# ---------------------------------------------------------------------------
+
+
+def combine_methods(
+    estimates: dict[str, float],
+    *,
+    model_sigma_ppg: float = 0.5,
+) -> PorePressureDistribution:
+    """Combine per-method point estimates into a P10/P50/P90 distribution.
+
+    The P50 is the mean of the method estimates. The total spread combines the
+    *between-method* scatter (population std-dev of the estimates) with an
+    assumed *within-method* model uncertainty ``model_sigma_ppg`` in
+    quadrature::
+
+        sigma = sqrt(between^2 + model_sigma^2)
+
+    A single method therefore yields ``sigma = model_sigma_ppg`` (the model
+    uncertainty alone), never zero — honest uncertainty communication.
+    """
+    if not estimates:
+        raise ValueError("estimates must contain at least one method")
+    if model_sigma_ppg < 0:
+        raise ValueError("model_sigma_ppg must be >= 0")
+
+    values = list(estimates.values())
+    p50 = statistics.fmean(values)
+    between = statistics.pstdev(values) if len(values) > 1 else 0.0
+    sigma = math.hypot(between, model_sigma_ppg)
+    return PorePressureDistribution(
+        p50=p50,
+        sigma=sigma,
+        methods=dict(estimates),
+        between_method_sigma=between,
+        model_sigma=model_sigma_ppg,
+    )
+
+
+def calibrate(
+    dist: PorePressureDistribution,
+    *,
+    measured_emw_ppg: float,
+    mode: str = "shift",
+) -> PorePressureDistribution:
+    """Calibrate a distribution to a measured pore pressure (RFT/MDT, LOT/FIT).
+
+    ``mode='shift'`` translates the distribution so its P50 hits the measured
+    value (offset bias). ``mode='scale'`` multiplies by ``measured / P50``
+    (proportional correction). ``mode='none'`` returns the input unchanged.
+    The calibration delta/factor is recorded on the returned object.
+    """
+    if mode == "none":
+        return dist
+    if mode == "shift":
+        delta = measured_emw_ppg - dist.p50
+        out = dist.shifted(delta)
+        out.calibration = {
+            "mode": "shift",
+            "measured_emw_ppg": measured_emw_ppg,
+            "delta_ppg": delta,
+        }
+        return out
+    if mode == "scale":
+        if dist.p50 == 0:
+            raise ValueError("cannot scale-calibrate a zero P50")
+        factor = measured_emw_ppg / dist.p50
+        out = dist.scaled(factor)
+        out.calibration = {
+            "mode": "scale",
+            "measured_emw_ppg": measured_emw_ppg,
+            "factor": factor,
+        }
+        return out
+    raise ValueError("mode must be 'shift', 'scale', or 'none'")
+
+
+def safe_drilling_window(
+    pore_pressure: PorePressureDistribution,
+    fracture: PorePressureDistribution,
+    *,
+    ecd_delta_ppg: float = 0.0,
+    kick_margin_ppg: float = 0.0,
+    loss_margin_ppg: float = 0.0,
+) -> SafeDrillingWindow:
+    """Safe mud-weight window between kick (pore) and loss (fracture) bounds.
+
+    Conservative bounds:
+        * floor  = pore-pressure **P90** + ``kick_margin`` (highest credible
+          pore pressure -> avoid influx/kick),
+        * ceiling = fracture **P10** - ``loss_margin`` (lowest credible
+          fracture gradient -> avoid losses).
+
+    The static window applies these directly. The dynamic window lowers the
+    ceiling by ``ecd_delta_ppg`` so that BHP while circulating (MW + ECD) stays
+    below the fracture gradient; the floor is unchanged because the static MW
+    must still kill the well during connections. The nominal window is the
+    P50-to-P50 span for reference.
+
+    Parameters
+    ----------
+    pore_pressure, fracture : PorePressureDistribution
+        Pore-pressure and fracture-gradient distributions, EMW ppg.
+    ecd_delta_ppg : float
+        Equivalent circulating-density rise from annular friction, ppg.
+    kick_margin_ppg, loss_margin_ppg : float
+        Operational safety margins (trip/kick and loss/riser margins), ppg.
+    """
+    if ecd_delta_ppg < 0:
+        raise ValueError("ecd_delta_ppg must be >= 0")
+    if kick_margin_ppg < 0 or loss_margin_ppg < 0:
+        raise ValueError("margins must be >= 0")
+
+    static_low = pore_pressure.p90 + kick_margin_ppg
+    static_high = fracture.p10 - loss_margin_ppg
+    dynamic_low = static_low
+    dynamic_high = static_high - ecd_delta_ppg
+    nominal_low = pore_pressure.p50
+    nominal_high = fracture.p50
+
+    return SafeDrillingWindow(
+        static_low_emw_ppg=static_low,
+        static_high_emw_ppg=static_high,
+        dynamic_low_emw_ppg=dynamic_low,
+        dynamic_high_emw_ppg=dynamic_high,
+        nominal_low_emw_ppg=nominal_low,
+        nominal_high_emw_ppg=nominal_high,
+        ecd_delta_ppg=ecd_delta_ppg,
+        kick_margin_ppg=kick_margin_ppg,
+        loss_margin_ppg=loss_margin_ppg,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config-driven helpers
+# ---------------------------------------------------------------------------
+
+
+def _fracture_distribution(
+    frac_cfg: dict[str, Any], model_sigma_ppg: float
+) -> PorePressureDistribution:
+    """Build the fracture-gradient distribution from config.
+
+    Accepts an explicit ``p50_emw_ppg`` (+ optional ``sigma_ppg``) or, for
+    convenience, a single ``emw_ppg`` value.
+    """
+    if "p50_emw_ppg" in frac_cfg:
+        p50 = float(frac_cfg["p50_emw_ppg"])
+    elif "emw_ppg" in frac_cfg:
+        p50 = float(frac_cfg["emw_ppg"])
+    else:
+        raise KeyError("fracture config needs 'p50_emw_ppg' or 'emw_ppg'")
+    sigma = float(frac_cfg.get("sigma_ppg", model_sigma_ppg))
+    return PorePressureDistribution(p50=p50, sigma=sigma, methods={"fracture": p50})
+
+
+def _estimates_from_config(inputs: dict[str, Any]) -> dict[str, float]:
+    """Run the configured methods and return ``{method: pore_pressure_emw}``."""
+    obg = float(inputs["overburden_emw_ppg"])
+    pn = float(inputs["normal_pressure_emw_ppg"])
+    tvd = float(inputs["tvd"])
+    estimates: dict[str, float] = {}
+
+    eaton_cfg = inputs.get("eaton")
+    if eaton_cfg:
+        estimates["eaton"] = eaton_pore_pressure(
+            overburden_emw_ppg=obg,
+            normal_pressure_emw_ppg=pn,
+            observed=float(eaton_cfg["observed"]),
+            normal=float(eaton_cfg["normal"]),
+            log_type=eaton_cfg.get("method", "resistivity"),
+            exponent=(
+                float(eaton_cfg["exponent"]) if "exponent" in eaton_cfg else None
+            ),
+        )
+
+    bowers_cfg = inputs.get("bowers")
+    if bowers_cfg:
+        estimates["bowers"] = bowers_pore_pressure(
+            overburden_emw_ppg=obg,
+            tvd_ft=tvd,
+            velocity_ft_s=(
+                float(bowers_cfg["sonic_velocity_ft_s"])
+                if "sonic_velocity_ft_s" in bowers_cfg
+                else None
+            ),
+            sonic_dt_us_ft=(
+                float(bowers_cfg["sonic_dt_us_ft"])
+                if "sonic_dt_us_ft" in bowers_cfg
+                else None
+            ),
+            v0_ft_s=float(bowers_cfg.get("v0_ft_s", 5000.0)),
+            a=float(bowers_cfg.get("a", 9.0)),
+            b=float(bowers_cfg.get("b", 0.75)),
+        )
+
+    if not estimates:
+        raise ValueError("at least one of 'eaton' or 'bowers' must be configured")
+    return estimates
+
+
+def _resolve_dir(cfg: dict[str, Any], value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(cfg.get("_config_dir_path", Path.cwd())) / path
+
+
+def _write_summary(
+    cfg: dict[str, Any],
+    output_cfg: dict[str, Any],
+    payload: dict[str, Any],
+    default_directory: str,
+    default_filename: str,
+) -> Path:
+    directory = _resolve_dir(cfg, output_cfg.get("directory", default_directory))
+    directory.mkdir(parents=True, exist_ok=True)
+    summary_path = directory / output_cfg.get("summary_json", default_filename)
+    summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    cfg.setdefault("outputs", {})["directory"] = str(directory)
+    cfg["outputs"]["summary_json"] = str(summary_path)
+    return summary_path
+
+
+def router(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Engine router for ``basename: pore_pressure``.
+
+    Reads ``cfg['pore_pressure']``, runs the configured methods, builds the
+    P10/P50/P90 distribution, optionally calibrates it, derives the safe
+    drilling window, writes a JSON summary, and returns ``cfg`` with the result
+    under ``cfg['pore_pressure']['result']`` (mirrors ``run_swab_surge``).
+    """
+    params = cfg.get("pore_pressure", {})
+    inputs = params["inputs"]
+
+    ensemble_cfg = params.get("ensemble", {})
+    model_sigma = float(ensemble_cfg.get("model_sigma_ppg", 0.5))
+
+    estimates = _estimates_from_config(inputs)
+    dist = combine_methods(estimates, model_sigma_ppg=model_sigma)
+
+    calib_cfg = params.get("calibration")
+    if calib_cfg and calib_cfg.get("mode", "none") != "none":
+        dist = calibrate(
+            dist,
+            measured_emw_ppg=float(calib_cfg["measured_pore_pressure_emw_ppg"]),
+            mode=calib_cfg.get("mode", "shift"),
+        )
+
+    result: dict[str, Any] = {"pore_pressure": dist.as_dict()}
+
+    window_cfg = params.get("window")
+    frac_cfg = params.get("fracture")
+    if frac_cfg is not None:
+        frac_dist = _fracture_distribution(frac_cfg, model_sigma)
+        result["fracture"] = frac_dist.as_dict()
+        wcfg = window_cfg or {}
+        window = safe_drilling_window(
+            dist,
+            frac_dist,
+            ecd_delta_ppg=float(wcfg.get("ecd_delta_ppg", 0.0)),
+            kick_margin_ppg=float(wcfg.get("kick_margin_ppg", 0.0)),
+            loss_margin_ppg=float(wcfg.get("loss_margin_ppg", 0.0)),
+        )
+        result["drilling_window"] = window.as_dict()
+
+    summary = {
+        "calculation": "pore_pressure",
+        "inputs": dict(inputs),
+        "result": result,
+    }
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            params.get("outputs", {}),
+            summary,
+            "results/pore_pressure",
+            "pore_pressure_summary.json",
+        )
+    )
+    cfg["pore_pressure"] = {**params, "result": result, "summary": summary}
+    return cfg

--- a/tests/floating_wind/test_report.py
+++ b/tests/floating_wind/test_report.py
@@ -1,0 +1,164 @@
+"""Tests for the Concept Data Sheet renderer (issue #1027).
+
+Builds a real :class:`VariantScreening` via ``screen_concept`` (mirroring
+``tests/floating_wind/test_screening.py``), generates a data sheet on the shared
+reporting backbone (#1018), and asserts the key fields are present and that it
+renders to a standalone HTML document without error.
+"""
+
+import pytest
+
+from digitalmodel.floating_wind.floaters import IEA_15MW_RNA
+from digitalmodel.floating_wind.report import (
+    CONCEPT_DATA_SHEET_BACKBONE,
+    ConceptProvenance,
+    concept_data_sheet,
+    render_concept_data_sheet_html,
+    write_concept_data_sheet,
+)
+from digitalmodel.floating_wind.screening import (
+    LoadCase,
+    ScreeningCriteria,
+    screen_concept,
+)
+from digitalmodel.reporting import ReportBackbone
+from digitalmodel.orcaflex.batch_parametric import ParameterSweep
+
+
+SEMI_BASE = dict(
+    n_columns=3,
+    column_diameter=12.5,
+    column_radius=51.75,
+    draft=20.0,
+    pontoon_height=7.0,
+    pontoon_volume=10000.0,
+    steel_mass_t=4000.0,
+)
+
+
+@pytest.fixture
+def load_cases() -> list[LoadCase]:
+    return [
+        LoadCase(name="operational", hs_m=2.5, tp_s=8.0, steady_load_kN=2400.0),
+        LoadCase(name="extreme", hs_m=10.0, tp_s=14.0, steady_load_kN=3000.0),
+    ]
+
+
+@pytest.fixture
+def variant(load_cases):
+    res = screen_concept(
+        "semi",
+        SEMI_BASE,
+        sweeps=[ParameterSweep(name="column_diameter", values=[12.5])],
+        topside=IEA_15MW_RNA,
+        load_cases=load_cases,
+        criteria=ScreeningCriteria(
+            mooring_stiffness_kN_per_m=400.0, max_offset_m=30.0
+        ),
+    )
+    return res.variants[0]
+
+
+def test_builds_on_the_reporting_backbone():
+    # The renderer must consume the shared backbone, not a parallel one.
+    assert isinstance(CONCEPT_DATA_SHEET_BACKBONE, ReportBackbone)
+    keys = [s.key for s in CONCEPT_DATA_SHEET_BACKBONE.sections]
+    assert keys == [
+        "header",
+        "parameters",
+        "derived",
+        "verdict",
+        "tradespace",
+        "provenance",
+    ]
+
+
+def test_sheet_contains_key_fields(variant, load_cases):
+    sections = concept_data_sheet(
+        variant,
+        load_cases=[lc.name for lc in load_cases],
+    )
+    assert isinstance(sections, list)
+    assert all(isinstance(s, str) for s in sections)
+    blob = "".join(sections)
+
+    # Archetype + identity.
+    assert "SEMI" in blob
+    assert variant.case_id in blob
+    # Verdict + governing check.
+    assert variant.governing_check in blob
+    # Derived properties: GM + natural periods.
+    assert "GM (metacentric height)" in blob
+    assert "Heave natural period" in blob
+    assert "Pitch natural period" in blob
+    # Screening verdict table covers the checks across load cases.
+    for chk in variant.checks:
+        assert chk.name in blob
+    assert "operational" in blob and "extreme" in blob
+    # Provenance: solver tier + version.
+    assert "Provenance" in blob
+    assert "closed-form" in blob
+    assert "digitalmodel version" in blob
+
+
+def test_tradespace_section_present_when_supplied(variant):
+    sections = concept_data_sheet(
+        variant,
+        tradespace_rank=1,
+        pareto_front_size=5,
+        correlations={"param_column_diameter": 0.82, "GM_m": -0.41},
+    )
+    blob = "".join(sections)
+    assert "Trade-space Position" in blob
+    assert "Pareto" in blob
+    assert "param_column_diameter" in blob
+
+
+def test_tradespace_section_omitted_when_absent(variant):
+    # No trade-space info -> the section builder returns "" and the backbone
+    # drops it from the ordered output.
+    sections = concept_data_sheet(variant)
+    blob = "".join(sections)
+    assert "Trade-space Position" not in blob
+
+
+def test_compact_mode_skips_tradespace(variant):
+    # COMPACT_SKIP: even with data, compact mode drops the trade-space section.
+    full = "".join(concept_data_sheet(variant, tradespace_rank=1))
+    compact = "".join(concept_data_sheet(variant, tradespace_rank=1, mode="compact"))
+    assert "Trade-space Position" in full
+    assert "Trade-space Position" not in compact
+
+
+def test_high_fidelity_provenance_stamp(variant):
+    prov = ConceptProvenance(
+        solver_tier="OrcaWave diffraction + OrcaFlex motion",
+        high_fidelity=True,
+        tool_versions={"OrcaWave": "11.4", "OrcaFlex": "11.4"},
+    )
+    blob = "".join(concept_data_sheet(variant, provenance=prov))
+    assert "OrcaWave diffraction + OrcaFlex motion" in blob
+    assert "OrcaWave version" in blob
+    assert "11.4" in blob
+
+
+def test_renders_standalone_html_document(variant, load_cases):
+    doc = render_concept_data_sheet_html(
+        variant, load_cases=[lc.name for lc in load_cases]
+    )
+    assert doc.startswith("<!DOCTYPE html>")
+    assert "</html>" in doc
+    assert "<title>" in doc
+    assert "<style>" in doc  # backbone renderer injected the CSS
+    assert "Concept Data Sheet" in doc
+    assert variant.case_id in doc
+
+
+def test_writes_html_file(variant, tmp_path):
+    out = tmp_path / "sheet.html"
+    written = write_concept_data_sheet(variant, out, tradespace_rank=1)
+    assert written == out
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert text.startswith("<!DOCTYPE html>")
+    assert "Trade-space Position" in text

--- a/tests/naval_architecture/test_loading_computer.py
+++ b/tests/naval_architecture/test_loading_computer.py
@@ -1,0 +1,271 @@
+# ABOUTME: Tests for the box-hull loading computer / loadicator.
+# ABOUTME: Equilibrium, intact + damage stability, longitudinal SF/BM, router.
+"""Tests for ``digitalmodel.naval_architecture.loading_computer``.
+
+Covers: equilibrium balances weight = buoyancy; intact GM is positive and the
+IMO check passes for a stable load; damage flooding reduces GM; the SF/BM load
+curve integrates correctly (BM is the integral of SF, both ~0 at the free ends);
+and ``router(cfg)`` runs end-to-end and writes a JSON summary.
+"""
+
+import json
+import math
+
+import pytest
+
+from digitalmodel.naval_architecture.loading_computer import (
+    BoxHull,
+    DamageCase,
+    WeightItem,
+    _cumulative_trapz,
+    damage_stability,
+    intact_stability,
+    longitudinal_strength,
+    router,
+    run_loading_computer,
+    solve_equilibrium,
+)
+
+RHO = 1.025
+
+
+def _barge_hull() -> BoxHull:
+    return BoxHull(length_m=90.0, beam_m=27.0, depth_m=6.0)
+
+
+def _balanced_items() -> list[WeightItem]:
+    # Symmetric about midship (x=45) -> even keel.
+    return [
+        WeightItem("lightship", 2500.0, 45.0, 3.0, length_m=90.0),
+        WeightItem("cargo_fwd", 1500.0, 63.0, 4.5, length_m=24.0),
+        WeightItem("cargo_aft", 1500.0, 27.0, 4.5, length_m=24.0),
+        WeightItem("ballast", 500.0, 45.0, 1.0, length_m=30.0),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Equilibrium
+# --------------------------------------------------------------------------- #
+def test_equilibrium_balances_weight_and_buoyancy():
+    hull = _barge_hull()
+    items = _balanced_items()
+    eq = solve_equilibrium(hull, items, RHO)
+
+    total_weight = sum(it.weight_t for it in items)
+    assert eq.displacement_t == pytest.approx(total_weight)
+    # Buoyancy of the displaced box volume equals the total weight.
+    buoyancy = eq.volume_m3 * RHO
+    assert buoyancy == pytest.approx(total_weight, rel=1e-12)
+    # Closed-form box draft T = V / (L*B).
+    assert eq.draft_m == pytest.approx(
+        eq.volume_m3 / (hull.length_m * hull.beam_m)
+    )
+    # KB = T/2, BM_T = B^2/(12T), KM = KB + BM_T.
+    assert eq.kb_m == pytest.approx(eq.draft_m / 2.0)
+    assert eq.bm_t_m == pytest.approx(hull.beam_m**2 / (12.0 * eq.draft_m))
+    assert eq.km_m == pytest.approx(eq.kb_m + eq.bm_t_m)
+
+
+def test_symmetric_load_is_even_keel_and_asymmetric_trims():
+    hull = _barge_hull()
+    eq_sym = solve_equilibrium(hull, _balanced_items(), RHO)
+    assert eq_sym.trim_m == pytest.approx(0.0, abs=1e-9)
+    assert eq_sym.trim_direction == "even keel"
+
+    # Move weight forward -> trims by the bow.
+    fwd = [
+        WeightItem("lightship", 2500.0, 45.0, 3.0, length_m=90.0),
+        WeightItem("cargo", 3000.0, 70.0, 4.5, length_m=24.0),
+    ]
+    eq_fwd = solve_equilibrium(hull, fwd, RHO)
+    assert eq_fwd.lcg_m > hull.length_m / 2.0
+    assert eq_fwd.trim_m > 0.0
+    assert eq_fwd.trim_direction == "by the bow"
+
+
+def test_overload_sinks_the_box_raises():
+    hull = BoxHull(length_m=50.0, beam_m=10.0, depth_m=2.0)
+    # Draft would exceed depth.
+    heavy = [WeightItem("brick", 5000.0, 25.0, 1.0, length_m=50.0)]
+    with pytest.raises(ValueError):
+        solve_equilibrium(hull, heavy, RHO)
+
+
+# --------------------------------------------------------------------------- #
+# Intact stability
+# --------------------------------------------------------------------------- #
+def test_intact_stability_positive_gm_and_passes_imo():
+    hull = _barge_hull()
+    eq = solve_equilibrium(hull, _balanced_items(), RHO)
+    intact = intact_stability(eq)
+
+    assert eq.gm_t_m > 0.0
+    assert intact.gm_m == pytest.approx(eq.gm_t_m)
+    assert intact.gz_m[0] == pytest.approx(0.0)  # GZ(0) = 0
+    assert intact.max_gz_m > 0.0
+    assert intact.imo_check["overall_pass"] is True
+    assert intact.screening_status == "pass"
+
+
+def test_high_kg_reduces_gm_and_can_fail():
+    hull = _barge_hull()
+    low = solve_equilibrium(hull, _balanced_items(), RHO)
+    # Same weights but very high VCG -> smaller GM.
+    high_items = [
+        WeightItem("lightship", 2500.0, 45.0, 5.8, length_m=90.0),
+        WeightItem("cargo_fwd", 1500.0, 63.0, 5.8, length_m=24.0),
+        WeightItem("cargo_aft", 1500.0, 27.0, 5.8, length_m=24.0),
+        WeightItem("ballast", 500.0, 45.0, 5.8, length_m=30.0),
+    ]
+    high = solve_equilibrium(hull, high_items, RHO)
+    assert high.gm_t_m < low.gm_t_m
+
+
+# --------------------------------------------------------------------------- #
+# Damage stability
+# --------------------------------------------------------------------------- #
+def test_damage_reduces_gm_and_increases_draft():
+    hull = _barge_hull()
+    eq = solve_equilibrium(hull, _balanced_items(), RHO)
+    dmg = DamageCase("amidships", length_m=15.0, x_center_m=45.0, permeability=0.95)
+    ds = damage_stability(hull, eq, dmg, RHO)
+
+    assert ds.intact_gm_m == pytest.approx(eq.gm_t_m)
+    assert ds.damaged_gm_m < eq.gm_t_m  # flooding reduces GM
+    assert ds.gm_reduction_m > 0.0
+    assert ds.sinkage_m > 0.0
+    assert ds.damaged_draft_m > eq.draft_m  # parallel sinkage
+    assert ds.lost_waterplane_inertia_m4 > 0.0
+
+
+def test_bigger_damage_loses_more_gm():
+    hull = _barge_hull()
+    eq = solve_equilibrium(hull, _balanced_items(), RHO)
+    small = damage_stability(
+        hull, eq, DamageCase("s", 10.0, 45.0, 0.95), RHO
+    )
+    big = damage_stability(
+        hull, eq, DamageCase("b", 30.0, 45.0, 0.95), RHO
+    )
+    assert big.gm_reduction_m > small.gm_reduction_m
+    assert big.sinkage_m > small.sinkage_m
+
+
+# --------------------------------------------------------------------------- #
+# Longitudinal strength
+# --------------------------------------------------------------------------- #
+def test_sf_bm_zero_at_free_ends():
+    hull = _barge_hull()
+    items = _balanced_items()
+    eq = solve_equilibrium(hull, items, RHO)
+    ls = longitudinal_strength(hull, items, eq, n_stations=201)
+
+    # Free-free beam in equilibrium: SF and BM vanish at both ends.
+    assert ls.shear_force_t[0] == pytest.approx(0.0, abs=1e-9)
+    assert ls.bending_moment_t_m[0] == pytest.approx(0.0, abs=1e-9)
+    assert ls.shear_force_t[-1] == pytest.approx(0.0, abs=1e-6)
+    assert ls.bending_moment_t_m[-1] == pytest.approx(0.0, abs=1e-4)
+    assert ls.shear_end_residual_t == pytest.approx(0.0, abs=1e-6)
+    assert ls.moment_end_residual_t_m == pytest.approx(0.0, abs=1e-4)
+
+
+def test_bm_is_the_integral_of_sf():
+    hull = _barge_hull()
+    items = _balanced_items()
+    eq = solve_equilibrium(hull, items, RHO)
+    ls = longitudinal_strength(hull, items, eq, n_stations=151)
+
+    recomputed_bm = _cumulative_trapz(ls.shear_force_t, ls.x_m)
+    for got, expect in zip(ls.bending_moment_t_m, recomputed_bm):
+        assert got == pytest.approx(expect, abs=1e-9)
+
+
+def test_buoyancy_integrates_to_displacement():
+    hull = _barge_hull()
+    items = _balanced_items()
+    eq = solve_equilibrium(hull, items, RHO)
+    ls = longitudinal_strength(hull, items, eq, n_stations=201)
+
+    total_buoyancy = _cumulative_trapz(ls.buoyancy_per_m_t, ls.x_m)[-1]
+    total_weight = _cumulative_trapz(ls.weight_per_m_t, ls.x_m)[-1]
+    # Buoyancy is pinned to the discrete weight so the ends balance exactly.
+    assert total_buoyancy == pytest.approx(total_weight, rel=1e-9)
+    # Both are within discretization error of the true displacement.
+    assert total_buoyancy == pytest.approx(eq.displacement_t, rel=1e-2)
+
+
+def test_bending_allowable_governs_status():
+    hull = _barge_hull()
+    items = _balanced_items()
+    eq = solve_equilibrium(hull, items, RHO)
+    ls_loose = longitudinal_strength(
+        hull, items, eq, n_stations=201, allowable_bending_t_m=1e9
+    )
+    ls_tight = longitudinal_strength(
+        hull, items, eq, n_stations=201, allowable_bending_t_m=1.0
+    )
+    assert ls_loose.screening_status == "pass"
+    assert ls_tight.screening_status == "fail"
+    assert ls_tight.max_bending_kn_m == pytest.approx(
+        ls_tight.max_bending_t_m * 9.81
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Router
+# --------------------------------------------------------------------------- #
+def _settings() -> dict:
+    return {
+        "hull": {"length_m": 90.0, "beam_m": 27.0, "depth_m": 6.0},
+        "water_density_t_m3": 1.025,
+        "weight_items": [
+            {"name": "lightship", "weight_t": 2500.0, "lcg_m": 45.0, "vcg_m": 3.0,
+             "length_m": 90.0},
+            {"name": "cargo_fwd", "weight_t": 1500.0, "lcg_m": 63.0, "vcg_m": 4.5,
+             "length_m": 24.0},
+            {"name": "cargo_aft", "weight_t": 1500.0, "lcg_m": 27.0, "vcg_m": 4.5,
+             "length_m": 24.0},
+            {"name": "ballast", "weight_t": 500.0, "lcg_m": 45.0, "vcg_m": 1.0,
+             "length_m": 30.0},
+        ],
+        "longitudinal_strength": {"n_stations": 201,
+                                  "allowable_bending_t_m": 60000.0},
+        "damage_cases": [
+            {"name": "amidships", "length_m": 15.0, "x_center_m": 45.0,
+             "permeability": 0.95},
+        ],
+    }
+
+
+def test_run_loading_computer_returns_full_result():
+    result = run_loading_computer(_settings())
+    assert set(result) >= {
+        "equilibrium",
+        "intact_stability",
+        "damage_stability",
+        "longitudinal_strength",
+        "screening_status",
+    }
+    assert result["equilibrium"]["displacement_t"] == pytest.approx(6000.0)
+    assert len(result["damage_stability"]) == 1
+    assert result["screening_status"] in {"pass", "fail"}
+
+
+def test_router_writes_summary_and_stamps_status(tmp_path):
+    cfg = {
+        "_config_dir_path": str(tmp_path),
+        "loading_computer": {
+            **_settings(),
+            "outputs": {"directory": "results/loading_computer",
+                        "summary_json": "summary.json"},
+        },
+    }
+    out = router(cfg)
+
+    assert out["screening_status"] in {"pass", "fail"}
+    assert out["loading_computer"]["screening_status"] == out["screening_status"]
+    summary_path = tmp_path / "results" / "loading_computer" / "summary.json"
+    assert summary_path.exists()
+    data = json.loads(summary_path.read_text())
+    assert data["result"]["equilibrium"]["displacement_t"] == pytest.approx(6000.0)
+    assert not math.isnan(data["result"]["intact_stability"]["gm_m"])

--- a/tests/well/test_dual_gradient.py
+++ b/tests/well/test_dual_gradient.py
@@ -1,0 +1,255 @@
+"""Tests for the deepwater dual-gradient drilling-window screen (issue #1037).
+
+Closed-form / license-free. Physical-relationship checks (DGD pressure profile,
+wider window, fewer casing strings, riser margin) plus a direct ``router(cfg)``
+test that does NOT go through engine.py.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.well.drilling.dual_gradient import (
+    SEAWATER_EMW_PPG,
+    DrillingWindow,
+    DualGradientScreen,
+    router,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INPUT_YML = REPO_ROOT / "examples" / "workflows" / "dual-gradient" / "input.yml"
+
+# Realistic 2000 m water-depth narrow window (TVD from rig floor, EMW ppg).
+_AIR_GAP = 75.0
+_WATER_DEPTH = 6561.7
+_DML = _AIR_GAP + _WATER_DEPTH  # mud line depth, ft
+
+
+def _window():
+    return DrillingWindow(
+        depths_ft=[_DML + 50, _DML + 2000, _DML + 5000, _DML + 8000, _DML + 11000],
+        pore_emw_ppg=[8.6, 9.2, 10.6, 12.4, 13.8],
+        fracture_emw_ppg=[9.6, 11.4, 12.9, 14.4, 15.6],
+    )
+
+
+def _screen(**overrides):
+    base = dict(
+        water_depth_ft=_WATER_DEPTH,
+        window=_window(),
+        air_gap_ft=_AIR_GAP,
+        seawater_emw_ppg=SEAWATER_EMW_PPG,
+        kick_margin_ppg=0.3,
+        fracture_margin_ppg=0.3,
+    )
+    base.update(overrides)
+    return DualGradientScreen(**base)
+
+
+# -- pressure / EMW profile -------------------------------------------------
+
+
+def test_dual_gradient_emw_below_conventional_for_same_mud():
+    """Below the mud line the seawater column pulls the DGD EMW below the
+    constant single-gradient EMW for the same deep mud weight."""
+    s = _screen()
+    mw = 12.0
+    d = _DML + 5000
+    assert s.emw_dual_gradient(d, mw) < s.emw_conventional(d, mw)
+    assert s.emw_conventional(d, mw) == pytest.approx(mw)
+
+
+def test_dual_gradient_above_mud_line_is_seawater():
+    s = _screen()
+    d = _DML - 500  # above the mud line: pure seawater column
+    assert s.emw_dual_gradient(d, 14.0) == pytest.approx(SEAWATER_EMW_PPG)
+
+
+def test_dual_gradient_bhp_matches_two_column_hydrostatic():
+    s = _screen()
+    mw = 13.0
+    d = _DML + 6000
+    expected = 0.052 * (SEAWATER_EMW_PPG * _DML + mw * (d - _DML))
+    assert s.bhp_dual_gradient(d, mw) == pytest.approx(expected)
+    # and the DGD BHP is below the single-gradient BHP for the same mud
+    assert s.bhp_dual_gradient(d, mw) < s.bhp_conventional(d, mw)
+
+
+def test_dgd_emw_approaches_mud_weight_at_great_depth():
+    s = _screen()
+    mw = 13.0
+    shallow = s.emw_dual_gradient(_DML + 500, mw)
+    deep = s.emw_dual_gradient(_DML + 30000, mw)
+    assert shallow < deep < mw  # converges toward MW but never reaches it
+
+
+# -- window widening --------------------------------------------------------
+
+
+def test_window_scaling_factor():
+    """DGD admissible mud-weight band == conventional band * D / (D - Dml)."""
+    s = _screen()
+    for d in (_DML + 250, _DML + 3000, _DML + 9000):
+        conv = s.available_window_ppg("conventional", d)
+        dgd = s.available_window_ppg("dual_gradient", d)
+        assert dgd == pytest.approx(conv * d / (d - _DML))
+        assert dgd > conv  # strictly wider below the mud line
+
+
+def test_dgd_min_window_at_least_as_wide():
+    s = _screen()
+    assert s.min_available_window_ppg("dual_gradient") >= s.min_available_window_ppg(
+        "conventional"
+    )
+
+
+# -- casing strings ---------------------------------------------------------
+
+
+def test_dgd_needs_fewer_or_equal_casing_strings():
+    s = _screen()
+    conv = s.casing_design("conventional")
+    dgd = s.casing_design("dual_gradient")
+    assert dgd.n_strings <= conv.n_strings
+
+
+def test_dgd_strictly_fewer_strings_in_narrow_window():
+    s = _screen()
+    conv = s.casing_design("conventional")
+    dgd = s.casing_design("dual_gradient")
+    assert dgd.n_strings < conv.n_strings
+    # window stays open for both modes with these inputs
+    assert not conv.window_violated
+    assert not dgd.window_violated
+    # seats are ordered and reach TD
+    assert conv.seat_depths_ft == sorted(conv.seat_depths_ft)
+    assert conv.seat_depths_ft[-1] == pytest.approx(s.window.td_ft)
+    assert dgd.seat_depths_ft[-1] == pytest.approx(s.window.td_ft)
+
+
+# -- riser margin -----------------------------------------------------------
+
+
+def test_riser_margin_equals_dual_gradient_emw():
+    """Losing the riser replaces mud above the mud line with seawater, i.e. the
+    BHP falls to the dual-gradient value."""
+    s = _screen()
+    mw = 12.4
+    rm = s.riser_margin(mw)
+    assert rm.emw_after_riser_loss_ppg == pytest.approx(
+        s.emw_dual_gradient(s.window.td_ft, mw)
+    )
+
+
+def test_deepwater_conventional_lacks_riser_margin():
+    """In this narrow deepwater window the conventional operating mud cannot
+    keep the well dead if the riser is lost (classic deepwater problem)."""
+    s = _screen()
+    rm = s.riser_margin(12.4)
+    assert rm.margin_ppg < 0.0
+    assert rm.well_dead_after_loss is False
+
+
+def test_riser_margin_well_dead_when_emw_exceeds_pore():
+    s = _screen()
+    # A very heavy deep mud restores the dual-gradient EMW above pore at TD.
+    rm = s.riser_margin(20.0)
+    assert rm.well_dead_after_loss is True
+    assert rm.margin_ppg >= 0.0
+
+
+# -- validation -------------------------------------------------------------
+
+
+def test_window_rejects_fracture_below_pore():
+    with pytest.raises(ValueError):
+        DrillingWindow(
+            depths_ft=[7000.0, 9000.0],
+            pore_emw_ppg=[9.0, 10.0],
+            fracture_emw_ppg=[8.5, 11.0],
+        )
+
+
+def test_screen_rejects_td_above_mud_line():
+    w = DrillingWindow(
+        depths_ft=[100.0, 500.0],
+        pore_emw_ppg=[8.6, 8.7],
+        fracture_emw_ppg=[9.0, 9.5],
+    )
+    with pytest.raises(ValueError):
+        DualGradientScreen(water_depth_ft=_WATER_DEPTH, window=w)
+
+
+# -- router (direct, not via engine.py) -------------------------------------
+
+
+def test_router_runs_and_writes_summary(tmp_path):
+    cfg = {
+        "_config_dir_path": str(tmp_path),
+        "dual_gradient": {
+            "geometry": {
+                "water_depth_ft": _WATER_DEPTH,
+                "air_gap_ft": _AIR_GAP,
+                "seawater_emw_ppg": SEAWATER_EMW_PPG,
+            },
+            "window": {
+                "depths_ft": [_DML + 50, _DML + 2000, _DML + 5000, _DML + 8000, _DML + 11000],
+                "pore_emw_ppg": [8.6, 9.2, 10.6, 12.4, 13.8],
+                "fracture_emw_ppg": [9.6, 11.4, 12.9, 14.4, 15.6],
+            },
+            "margins": {"kick_margin_ppg": 0.3, "fracture_margin_ppg": 0.3},
+            "step_ft": 250.0,
+            "mud_weight_ppg": 12.4,
+            "outputs": {"directory": "results/dual_gradient"},
+        },
+    }
+    out = router(cfg)
+    result = out["dual_gradient"]["result"]
+
+    cd = result["casing_design"]
+    assert cd["dual_gradient"]["n_strings"] < cd["conventional"]["n_strings"]
+    assert cd["strings_saved_by_dgd"] == (
+        cd["conventional"]["n_strings"] - cd["dual_gradient"]["n_strings"]
+    )
+    assert (
+        result["min_window_ppg"]["dual_gradient"]
+        >= result["min_window_ppg"]["conventional"]
+    )
+    assert result["riser_margin"]["conventional"]["well_dead_after_loss"] is False
+
+    summary_path = Path(out["dual_gradient"]["summary_json"])
+    assert summary_path.exists()
+    assert summary_path.name == "dual_gradient_summary.json"
+
+
+def test_router_accepts_linear_gradient_block(tmp_path):
+    cfg = {
+        "_config_dir_path": str(tmp_path),
+        "dual_gradient": {
+            "geometry": {"water_depth_ft": _WATER_DEPTH, "air_gap_ft": _AIR_GAP},
+            "window": {
+                "gradients": {
+                    "top_depth_ft": _DML + 50,
+                    "bottom_depth_ft": _DML + 11000,
+                    "pore_top_ppg": 8.6,
+                    "pore_bottom_ppg": 13.8,
+                    "fracture_top_ppg": 9.6,
+                    "fracture_bottom_ppg": 15.6,
+                }
+            },
+        },
+    }
+    out = router(cfg)
+    assert out["dual_gradient"]["result"]["casing_design"]["dual_gradient"][
+        "n_strings"
+    ] >= 1
+
+
+def test_example_input_yaml_parses_and_runs(tmp_path):
+    cfg = yaml.safe_load(INPUT_YML.read_text())
+    cfg["_config_dir_path"] = str(tmp_path)
+    assert cfg["basename"] == "dual_gradient"
+    out = router(cfg)
+    cd = out["dual_gradient"]["result"]["casing_design"]
+    assert cd["dual_gradient"]["n_strings"] < cd["conventional"]["n_strings"]

--- a/tests/well/test_pore_pressure.py
+++ b/tests/well/test_pore_pressure.py
@@ -1,0 +1,294 @@
+"""Tests for the pore-pressure prediction module (issue #1034).
+
+Closed-form / license-free. Covers the Eaton and Bowers predictors, the
+P10/P50/P90 ensemble, calibration, the safe-drilling-window logic, and the
+config-driven ``router`` (the engine basename wiring is applied by the
+integrator, so the router is exercised directly).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.well.drilling.pore_pressure import (
+    PorePressureDistribution,
+    bowers_pore_pressure,
+    calibrate,
+    combine_methods,
+    eaton_pore_pressure,
+    router,
+    safe_drilling_window,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INPUT_YML = REPO_ROOT / "examples" / "workflows" / "pore-pressure" / "input.yml"
+
+
+# ---------------------------------------------------------------------------
+# Eaton
+# ---------------------------------------------------------------------------
+
+
+def test_eaton_resistivity_normal_trend_gives_normal_pressure():
+    # R_obs == R_normal -> ratio 1 -> Pp == Pn.
+    pp = eaton_pore_pressure(
+        overburden_emw_ppg=18.0,
+        normal_pressure_emw_ppg=8.6,
+        observed=2.0,
+        normal=2.0,
+    )
+    assert pp == pytest.approx(8.6)
+
+
+def test_eaton_resistivity_below_trend_is_overpressured():
+    # R_obs < R_normal (undercompaction) -> pore pressure above normal.
+    pp = eaton_pore_pressure(
+        overburden_emw_ppg=18.0,
+        normal_pressure_emw_ppg=8.6,
+        observed=1.0,
+        normal=2.0,
+    )
+    assert 8.6 < pp < 18.0
+
+
+def test_eaton_pressure_bounded_by_overburden():
+    # Very low resistivity ratio still cannot exceed the overburden.
+    pp = eaton_pore_pressure(
+        overburden_emw_ppg=18.0,
+        normal_pressure_emw_ppg=8.6,
+        observed=0.001,
+        normal=2.0,
+    )
+    assert pp < 18.0
+
+
+def test_eaton_sonic_uses_inverse_ratio():
+    # Sonic: dt_obs > dt_normal (slower) -> overpressure.
+    pp_over = eaton_pore_pressure(
+        overburden_emw_ppg=18.0,
+        normal_pressure_emw_ppg=8.6,
+        observed=120.0,  # dt_obs us/ft, above trend
+        normal=90.0,     # dt_normal
+        log_type="sonic",
+    )
+    pp_normal = eaton_pore_pressure(
+        overburden_emw_ppg=18.0,
+        normal_pressure_emw_ppg=8.6,
+        observed=90.0,
+        normal=90.0,
+        log_type="sonic",
+    )
+    assert pp_normal == pytest.approx(8.6)
+    assert pp_over > pp_normal
+
+
+def test_eaton_rejects_bad_inputs():
+    with pytest.raises(ValueError):
+        eaton_pore_pressure(
+            overburden_emw_ppg=8.0,  # not above normal
+            normal_pressure_emw_ppg=8.6,
+            observed=1.0,
+            normal=2.0,
+        )
+    with pytest.raises(ValueError):
+        eaton_pore_pressure(
+            overburden_emw_ppg=18.0,
+            normal_pressure_emw_ppg=8.6,
+            observed=-1.0,
+            normal=2.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bowers
+# ---------------------------------------------------------------------------
+
+
+def test_bowers_higher_velocity_gives_lower_pore_pressure():
+    # Faster rock -> more effective stress -> lower pore pressure.
+    fast = bowers_pore_pressure(
+        overburden_emw_ppg=18.0, tvd_ft=12000.0, velocity_ft_s=10000.0
+    )
+    slow = bowers_pore_pressure(
+        overburden_emw_ppg=18.0, tvd_ft=12000.0, velocity_ft_s=7000.0
+    )
+    assert slow > fast
+
+
+def test_bowers_velocity_at_v0_is_full_overpressure():
+    pp = bowers_pore_pressure(
+        overburden_emw_ppg=18.0, tvd_ft=12000.0, velocity_ft_s=5000.0, v0_ft_s=5000.0
+    )
+    assert pp == pytest.approx(18.0)
+
+
+def test_bowers_from_sonic_dt_matches_velocity():
+    dt = 125.0  # us/ft -> 8000 ft/s
+    by_dt = bowers_pore_pressure(
+        overburden_emw_ppg=18.0, tvd_ft=12000.0, sonic_dt_us_ft=dt
+    )
+    by_v = bowers_pore_pressure(
+        overburden_emw_ppg=18.0, tvd_ft=12000.0, velocity_ft_s=1.0e6 / dt
+    )
+    assert by_dt == pytest.approx(by_v)
+
+
+def test_bowers_requires_exactly_one_velocity_input():
+    with pytest.raises(ValueError):
+        bowers_pore_pressure(overburden_emw_ppg=18.0, tvd_ft=12000.0)
+    with pytest.raises(ValueError):
+        bowers_pore_pressure(
+            overburden_emw_ppg=18.0,
+            tvd_ft=12000.0,
+            velocity_ft_s=8000.0,
+            sonic_dt_us_ft=125.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ensemble distribution
+# ---------------------------------------------------------------------------
+
+
+def test_distribution_orders_p10_p50_p90():
+    dist = combine_methods({"eaton": 12.0, "bowers": 13.0}, model_sigma_ppg=0.6)
+    assert dist.p10 < dist.p50 < dist.p90
+    assert dist.p50 == pytest.approx(12.5)  # mean of the two methods
+
+
+def test_single_method_still_has_model_uncertainty():
+    dist = combine_methods({"eaton": 12.0}, model_sigma_ppg=0.6)
+    assert dist.between_method_sigma == pytest.approx(0.0)
+    assert dist.sigma == pytest.approx(0.6)  # model uncertainty alone, not zero
+    assert dist.p10 < dist.p50 < dist.p90
+
+
+def test_disagreeing_methods_widen_the_band():
+    tight = combine_methods({"eaton": 12.0, "bowers": 12.1}, model_sigma_ppg=0.5)
+    wide = combine_methods({"eaton": 11.0, "bowers": 14.0}, model_sigma_ppg=0.5)
+    assert wide.sigma > tight.sigma
+    assert (wide.p90 - wide.p10) > (tight.p90 - tight.p10)
+
+
+def test_combine_methods_rejects_empty():
+    with pytest.raises(ValueError):
+        combine_methods({})
+
+
+# ---------------------------------------------------------------------------
+# Calibration
+# ---------------------------------------------------------------------------
+
+
+def test_shift_calibration_matches_measured_p50_preserves_spread():
+    dist = combine_methods({"eaton": 12.0, "bowers": 13.0}, model_sigma_ppg=0.6)
+    cal = calibrate(dist, measured_emw_ppg=12.4, mode="shift")
+    assert cal.p50 == pytest.approx(12.4)
+    assert cal.sigma == pytest.approx(dist.sigma)  # shift does not change spread
+    assert cal.calibration["mode"] == "shift"
+
+
+def test_scale_calibration_hits_measured_and_scales_spread():
+    dist = combine_methods({"eaton": 12.0, "bowers": 13.0}, model_sigma_ppg=0.6)
+    cal = calibrate(dist, measured_emw_ppg=12.5, mode="scale")
+    assert cal.p50 == pytest.approx(12.5)
+    factor = 12.5 / dist.p50
+    assert cal.sigma == pytest.approx(dist.sigma * factor)
+
+
+def test_calibration_none_is_noop():
+    dist = combine_methods({"eaton": 12.0}, model_sigma_ppg=0.6)
+    assert calibrate(dist, measured_emw_ppg=99.0, mode="none") is dist
+
+
+# ---------------------------------------------------------------------------
+# Safe drilling window
+# ---------------------------------------------------------------------------
+
+
+def _pp_and_frac():
+    pp = PorePressureDistribution(p50=12.0, sigma=0.6)
+    frac = PorePressureDistribution(p50=15.5, sigma=0.5)
+    return pp, frac
+
+
+def test_window_uses_conservative_bounds():
+    pp, frac = _pp_and_frac()
+    w = safe_drilling_window(pp, frac)
+    # Floor = pore P90 (high), ceiling = fracture P10 (low).
+    assert w.static_low_emw_ppg == pytest.approx(pp.p90)
+    assert w.static_high_emw_ppg == pytest.approx(frac.p10)
+    assert w.static_feasible
+
+
+def test_dynamic_window_is_narrower_by_ecd():
+    pp, frac = _pp_and_frac()
+    w = safe_drilling_window(pp, frac, ecd_delta_ppg=0.5)
+    assert w.dynamic_high_emw_ppg == pytest.approx(w.static_high_emw_ppg - 0.5)
+    assert w.dynamic_low_emw_ppg == pytest.approx(w.static_low_emw_ppg)
+    assert w.dynamic_width_ppg < w.static_width_ppg
+
+
+def test_margins_tighten_the_window():
+    pp, frac = _pp_and_frac()
+    base = safe_drilling_window(pp, frac)
+    tight = safe_drilling_window(pp, frac, kick_margin_ppg=0.3, loss_margin_ppg=0.3)
+    assert tight.static_low_emw_ppg == pytest.approx(base.static_low_emw_ppg + 0.3)
+    assert tight.static_high_emw_ppg == pytest.approx(base.static_high_emw_ppg - 0.3)
+
+
+def test_infeasible_window_when_pore_exceeds_fracture():
+    pp = PorePressureDistribution(p50=15.0, sigma=0.6)
+    frac = PorePressureDistribution(p50=15.2, sigma=0.5)
+    w = safe_drilling_window(pp, frac, ecd_delta_ppg=0.5)
+    assert not w.dynamic_feasible
+    assert w.recommended_mud_weight_ppg() is None
+
+
+def test_recommended_mud_weight_inside_dynamic_window():
+    pp, frac = _pp_and_frac()
+    w = safe_drilling_window(pp, frac, ecd_delta_ppg=0.5)
+    rec = w.recommended_mud_weight_ppg()
+    assert w.dynamic_low_emw_ppg <= rec <= w.dynamic_high_emw_ppg
+
+
+# ---------------------------------------------------------------------------
+# Router (config-driven; engine basename wiring applied by integrator)
+# ---------------------------------------------------------------------------
+
+
+def _example_cfg(tmp_path):
+    cfg = yaml.safe_load(INPUT_YML.read_text())
+    cfg["_config_dir_path"] = str(tmp_path)
+    return cfg
+
+
+def test_router_runs_example_and_writes_summary(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    out = router(cfg)
+
+    result = out["pore_pressure"]["result"]
+    pp = result["pore_pressure"]
+    assert pp["p10_emw_ppg"] < pp["p50_emw_ppg"] < pp["p90_emw_ppg"]
+    # Two methods configured in the example.
+    assert set(pp["methods"]) == {"eaton", "bowers"}
+    # Calibrated to the offset-well measured point.
+    assert pp["p50_emw_ppg"] == pytest.approx(12.4)
+    assert pp["calibration"]["mode"] == "shift"
+
+    window = result["drilling_window"]
+    assert window["dynamic_high_emw_ppg"] < window["static_high_emw_ppg"]
+
+    summary_json = Path(out["pore_pressure"]["summary"]["summary_json"])
+    assert summary_json.is_file()
+
+
+def test_router_without_fracture_skips_window(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    cfg["pore_pressure"].pop("fracture", None)
+    cfg["pore_pressure"].pop("window", None)
+    out = router(cfg)
+    result = out["pore_pressure"]["result"]
+    assert "pore_pressure" in result
+    assert "drilling_window" not in result


### PR DESCRIPTION
Four independent engineering capabilities built in parallel (one agent each) from the LinkedIn intake batch, plus the final piece of the floating-wind epic. Each is closed-form, license-free, and dispatchable via `uv run python -m digitalmodel <input.yml>`.

## Features (one commit each)
- **#1034 — pore-pressure with uncertainty + safe-drilling-window** (`well/drilling/pore_pressure.py`, basename `pore_pressure`). Eaton + Bowers ensemble → P10/P50/P90, offset-well calibration, static + dynamic(ECD) mud-weight window (pore-kick / fracture-loss bounds). *23 tests.* Source: Havtil/Geoprovider report.
- **#1037 — deepwater dual-gradient / narrow-window screen** (`well/drilling/dual_gradient.py`, basename `dual_gradient`). Conventional vs DGD BHP profile, drillable-window margin, casing-string count, riser margin; DGD widens the window by `D/(D−Dml)`. *16 tests.* Source: Radmir Ganiev.
- **#1035 — loading computer (loadicator)** (`naval_architecture/loading_computer.py`, basename `loading_computer`). Equilibrium, intact stability (GZ + IMO IS Code, reusing `damage_stability` primitives), damage stability (lost-buoyancy), longitudinal strength (SF/BM). *13 tests.* Source: Jishnu PV "Navload".
- **#1027 — Concept Data Sheet** (`floating_wind/report.py`). Per-concept data sheet on the shared `digitalmodel.reporting` backbone (#1018): properties + screening verdict + trade-space position + provenance. **Completes epic #1022 (6/6).** *8 tests.*

Plus a wiring commit: engine dispatch for the three new basenames, and registration of the `reporting` package (merged via #1030) in the operator map + module-routing registry to keep the routing-contract invariant green.

## Verification
60 new tests pass together; routing contract passes; all three new examples run end-to-end through the engine. Run via the project venv (`.venv/bin/python -m pytest`).

## Notes
- New code lives inside existing packages (`well/drilling/`, `naval_architecture/`, `floating_wind/`) — routers are self-contained in their modules. Screening tiers (closed-form); high-fidelity solver coupling is future work per each issue.
- digitalmodel main CI is baseline-red (engine/native-segfault; identical failing set on every PR) — this PR adds no regression and fixes the `reporting` routing-contract gap left by #1030.

Closes #1034, closes #1035, closes #1037, closes #1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
