### PR TITLE
docs(cad-inventory): seat-export batch package + OSS native-reader findings (#1012)

### DIFF
--- a/docs/cad-inventory/adapters/seat-export/README.md
+++ b/docs/cad-inventory/adapters/seat-export/README.md
@@ -1,0 +1,45 @@
+# Seat-Export Package — unlock native SolidWorks/Inventor into the pipeline
+
+**Issue:** adapter epic [#1011](https://github.com/vamseeachanta/digitalmodel/issues/1011) ([#1012](https://github.com/vamseeachanta/digitalmodel/issues/1012)). **State of readiness:** ready-to-run batch macros so a licensed
+**SolidWorks**/**Inventor** seat can export the native estate to STEP, which then flows through the existing
+**dedup → glTF → Blender → index** pipeline (validated in [pilot-tier0-results.md](../../pilot-tier0-results.md) /
+[blender-unlock.md](../blender-unlock.md)). Privacy: project-specific batch lists (real paths) are kept private on the
+share; the tooling here is generic.
+
+## Why a seat is needed (verified hands-on)
+There is **no open-source reader for native SolidWorks/Inventor/Parasolid**:
+- FreeCAD 0.21 built-in **cannot open** `.sldprt` or `.ipt` (tested — both error).
+- The FreeCAD **InventorLoader** addon can read *some* `.ipt` (parts, not assemblies) but is unproven here and
+  requires installing external code — see `test_inventorloader.sh` to evaluate it before committing seat time.
+- SolidWorks/Parasolid: commercial only (Datakit CrossCad/Ware) or the vendor seat.
+
+→ A **one-time batch STEP export from a seat** is the reliable unlock; afterward everything is license-free.
+
+## Contents
+| File | What |
+|---|---|
+| `batch_export_solidworks.bas` | SolidWorks VBA macro — list-driven batch STEP export (AP214 default; AP242 option) |
+| `batch_export_inventor.bas` | Inventor VBA macro — same via the STEP Translator AddIn |
+| `gen_native_batches.py` | (runs on the file server) generates per-project batch lists from the readability index |
+| `test_inventorloader.sh` | user-initiated eval of the OSS Inventor reader on the file server's FreeCAD |
+
+## Procedure (Windows seat)
+1. **Map the share** as a drive so paths resolve — `Z:\` → the share root (matches `SRC_ROOT="Z:\"` in the macros).
+2. **Generate + copy batch lists:** run `gen_native_batches.py` on the file server (writes `<priority>_<project>.{sw,inv}.txt`
+   of Windows-mapped paths to a private `_step-export/batches/`), copy them to `C:\step-export\`.
+3. **Edit the macro CONFIG** (`LIST_FILE`, `OUT_ROOT`, `SRC_ROOT`, `STEP_AP`).
+4. **TEST first** on a 5-line list; open the resulting `.step` in a viewer; then run full batches.
+5. **Run in priority order** (filename prefix): the **curated 3D library** and **active project trees** first — they have
+   **intact assembly references** and the real engineering value — and any **personal-backup archive last** (lower value,
+   possibly unresolved references).
+6. **Output** mirrors under `OUT_ROOT`; copy it to the share's `_step-export/out/`.
+
+## Ingestion (automatic, on the file server)
+New STEP under `_step-export/out/` is just new STEP files:
+1. `batch_convert.py` → adds `.glb` to the library; 2. `build_cad_index.py` → flips those rows to **oss-3d readable** and
+links the glb; 3. (optional) `dedup_index.py`. Or tell the agent "the seat export is on the share".
+
+## Notes
+- **Assemblies need their parts to resolve** — that's why curated/active trees go first.
+- An **assembly** STEP captures the whole product; export **parts** too only if you need them individually.
+- `STEP_AP=214` is the safe default; OCCT 7.9 reads/writes **AP242** (PMI) too if your seat supports exporting it.

--- a/docs/cad-inventory/adapters/seat-export/batch_export_inventor.bas
+++ b/docs/cad-inventory/adapters/seat-export/batch_export_inventor.bas
@@ -1,0 +1,77 @@
+' ============================================================================
+'  Batch STEP export for Autodesk Inventor  (state-of-readiness macro)
+'  Reads a text file of full .ipt/.iam paths (one per line) and exports each to
+'  STEP via the Inventor STEP Translator AddIn, mirroring the source tree.
+'
+'  HOW TO RUN (Windows machine with a licensed Inventor seat):
+'    1. Tools > VBA Editor.  Insert > Module.  Paste this in.
+'    2. Edit the CONFIG constants (LIST_FILE, OUT_ROOT, SRC_ROOT, STEP_AP).
+'    3. Run main.  TEST on a 5-line list first; verify the .stp files, then run all.
+'
+'  Output: <OUT_ROOT>\<relative path>\<name>.stp  + a .log next to LIST_FILE.
+'  Notes:
+'    - Assemblies (.iam) resolve referenced .ipt; run from a tree with intact refs.
+'    - ApplicationProtocolType: 2=AP203, 3=AP214, 4=AP242 (if supported).
+' ============================================================================
+Const LIST_FILE As String = "C:\step-export\batch_list.txt"
+Const OUT_ROOT  As String = "C:\step-export\out"
+Const SRC_ROOT  As String = "Z:\"                  ' share drive mapping
+Const STEP_AP   As Long   = 3                      ' 3=AP214, 4=AP242
+
+Public Sub main()
+    Dim app As Inventor.Application: Set app = ThisApplication
+    Dim fso As Object: Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim ts As Object: Set ts = fso.OpenTextFile(LIST_FILE, 1)
+    Dim logf As Object: Set logf = fso.CreateTextFile(LIST_FILE & ".log", True)
+
+    ' STEP translator add-in
+    Dim stepAddIn As TranslatorAddIn
+    Set stepAddIn = app.ApplicationAddIns.ItemById("{90AF7F40-0C01-11D5-8E83-0010B541CD80}")
+
+    Dim nOk As Long, nErr As Long, line As String
+    Do Until ts.AtEndOfStream
+        line = Trim(ts.ReadLine)
+        If Len(line) > 0 Then
+            On Error Resume Next
+            Dim doc As Inventor.Document
+            Set doc = app.Documents.Open(line, False)   ' open invisible
+            If Not doc Is Nothing Then
+                Dim ctx As TranslationContext: Set ctx = app.TransientObjects.CreateTranslationContext
+                ctx.Type = kFileBrowseIOMechanism
+                Dim opts As NameValueMap: Set opts = app.TransientObjects.CreateNameValueMap
+                Dim med As DataMedium: Set med = app.TransientObjects.CreateDataMedium
+                If stepAddIn.HasSaveCopyAsOptions(doc, ctx, opts) Then
+                    opts.Value("ApplicationProtocolType") = STEP_AP
+                End If
+
+                Dim rel As String: rel = line
+                If InStr(1, LCase(line), LCase(SRC_ROOT)) = 1 Then rel = Mid(line, Len(SRC_ROOT) + 1)
+                Dim outPath As String: outPath = OUT_ROOT & "\" & rel
+                outPath = Left(outPath, InStrRev(outPath, ".") - 1) & ".stp"
+                EnsureDir fso, fso.GetParentFolderName(outPath)
+                med.FileName = outPath
+
+                stepAddIn.SaveCopyAs doc, ctx, opts, med
+                If Err.Number = 0 Then nOk = nOk + 1 Else nErr = nErr + 1
+                logf.WriteLine IIf(Err.Number = 0, "OK   ", "FAIL ") & line & " -> " & outPath
+                doc.Close (True)
+            Else
+                nErr = nErr + 1: logf.WriteLine "OPENFAIL " & line
+            End If
+            Err.Clear
+            On Error GoTo 0
+        End If
+    Loop
+    ts.Close
+    logf.WriteLine "DONE ok=" & nOk & " err=" & nErr
+    logf.Close
+    MsgBox "Inventor batch STEP export done. OK=" & nOk & " ERR=" & nErr
+End Sub
+
+Sub EnsureDir(fso As Object, path As String)
+    If Len(path) = 0 Then Exit Sub
+    If Not fso.FolderExists(path) Then
+        EnsureDir fso, fso.GetParentFolderName(path)
+        fso.CreateFolder path
+    End If
+End Sub

--- a/docs/cad-inventory/adapters/seat-export/batch_export_solidworks.bas
+++ b/docs/cad-inventory/adapters/seat-export/batch_export_solidworks.bas
@@ -1,0 +1,80 @@
+' ============================================================================
+'  Batch STEP export for SolidWorks  (state-of-readiness macro)
+'  Reads a text file of full part/assembly paths (one per line) and exports
+'  each to STEP, mirroring the source tree under an output root.
+'
+'  HOW TO RUN (on a Windows machine with a licensed SolidWorks seat):
+'    1. Tools > Macro > New ... paste this in, or Tools > Macro > Edit this .bas
+'    2. Edit the three CONFIG constants below (LIST_FILE, OUT_ROOT, SRC_ROOT).
+'    3. Tools > Macro > Run.  TEST on a 5-line list first, verify the .step files
+'       open in a viewer, THEN run the full batch.
+'
+'  Output: <OUT_ROOT>\<relative path>\<name>.step   + a log file next to LIST_FILE.
+'  Notes:
+'    - Assemblies (.sldasm) require their referenced parts to resolve; run from a
+'      tree whose references are intact (the active/curated project copies).
+'    - AP214 is the default (broadest compatibility). Set STEP_AP = 242 for
+'      AP242 (PMI) if your SolidWorks version supports it.
+' ============================================================================
+Dim swApp As Object
+
+Const LIST_FILE As String = "C:\step-export\batch_list.txt"   ' <-- one source path per line
+Const OUT_ROOT  As String = "C:\step-export\out"              ' <-- mirror output here
+Const SRC_ROOT  As String = "Z:\"                             ' <-- drive mapping to the share root (e.g. \\ace-linux-1\ace)
+Const STEP_AP   As Long   = 214                               ' 214 or 242
+
+Sub main()
+    Set swApp = Application.SldWorks
+    swApp.SetUserPreferenceIntegerValue swUserPreferenceIntegerValue_e.swStepAP, STEP_AP
+    swApp.SetUserPreferenceToggle swUserPreferenceToggle_e.swStepExportOption3DCurves, True
+
+    Dim fso As Object: Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim ts As Object: Set ts = fso.OpenTextFile(LIST_FILE, 1)   ' ForReading
+    Dim logf As Object: Set logf = fso.CreateTextFile(LIST_FILE & ".log", True)
+    Dim nOk As Long, nErr As Long, line As String
+
+    Do Until ts.AtEndOfStream
+        line = Trim(ts.ReadLine)
+        If Len(line) > 0 Then
+            On Error Resume Next
+            Dim ext As String: ext = LCase(Right(line, 7))
+            Dim docType As Long
+            If InStr(ext, ".sldasm") > 0 Then docType = swDocASSEMBLY Else docType = swDocPART
+
+            Dim errs As Long, warns As Long
+            Dim doc As Object
+            Set doc = swApp.OpenDoc6(line, docType, swOpenDocOptions_Silent, "", errs, warns)
+
+            If Not doc Is Nothing Then
+                ' build mirrored output path
+                Dim rel As String: rel = line
+                If InStr(1, LCase(line), LCase(SRC_ROOT)) = 1 Then rel = Mid(line, Len(SRC_ROOT) + 1)
+                Dim outPath As String: outPath = OUT_ROOT & "\" & rel
+                outPath = Left(outPath, InStrRev(outPath, ".") - 1) & ".step"
+                EnsureDir fso, fso.GetParentFolderName(outPath)
+
+                Dim sErr As Long, sWarn As Long
+                doc.Extension.SaveAs outPath, 0, 1, Nothing, sErr, sWarn   ' silent SaveAs (.step from extension)
+                If sErr = 0 Then nOk = nOk + 1 Else nErr = nErr + 1
+                logf.WriteLine IIf(sErr = 0, "OK   ", "FAIL ") & line & " -> " & outPath
+                swApp.CloseDoc doc.GetTitle
+            Else
+                nErr = nErr + 1
+                logf.WriteLine "OPENFAIL " & line
+            End If
+            On Error GoTo 0
+        End If
+    Loop
+    ts.Close
+    logf.WriteLine "DONE  ok=" & nOk & "  err=" & nErr
+    logf.Close
+    swApp.SendMsgToUser "Batch STEP export done. OK=" & nOk & "  ERR=" & nErr
+End Sub
+
+Sub EnsureDir(fso As Object, path As String)
+    If Len(path) = 0 Then Exit Sub
+    If Not fso.FolderExists(path) Then
+        EnsureDir fso, fso.GetParentFolderName(path)
+        fso.CreateFolder path
+    End If
+End Sub

--- a/docs/cad-inventory/adapters/seat-export/gen_native_batches.py
+++ b/docs/cad-inventory/adapters/seat-export/gen_native_batches.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate per-project batch lists of native seat-only CAD for STEP export.
+
+From the readability index, split native files by project and by tool
+(SolidWorks vs Inventor), as Windows-mapped paths (Z:\\ = the share root), so a
+licensed seat can run the batch_export macros incrementally, active/curated
+projects first (intact assembly refs), the ri-hoard last.
+PRIVATE output (real paths) under /mnt/ace/_step-export/.
+"""
+import csv, os, re, collections, json
+IDX = "/mnt/ace/_cad-index/cad-readability-index.tsv"
+OUT = "/mnt/ace/_step-export/batches"; os.makedirs(OUT, exist_ok=True)
+
+SW = {"sldprt","sldasm"}
+INV = {"ipt","iam"}
+OTHER_SEAT = {"prt","catpart","x_t","x_b","f3d","f3z"}   # listed separately (no macro)
+
+def winpath(p):
+    return "Z:\\" + p.replace("/mnt/ace/","",1).replace("/","\\")
+def safe(name):
+    return re.sub(r"[^A-Za-z0-9._-]","_", name)[:80]
+# export priority: active/curated first, hoard last
+def prio(proj):
+    if "ri-hoard" in proj: return 9
+    if proj.startswith("digitalmodel/subsea-risers"): return 1
+    if "preexisting" in proj: return 7
+    if proj.startswith("docs/"): return 2
+    return 3
+
+sw = collections.defaultdict(list); inv = collections.defaultdict(list); other = collections.defaultdict(list)
+for r in csv.DictReader(open(IDX), delimiter="\t"):
+    if r["readability"] != "seat-only": continue
+    f = r["format"]; pj = r["project"]
+    if f in SW: sw[pj].append(r["path"])
+    elif f in INV: inv[pj].append(r["path"])
+    elif f in OTHER_SEAT: other[pj].append(r["path"])
+
+projects = sorted(set(list(sw)+list(inv)+list(other)), key=lambda p:(prio(p), p))
+manifest = []
+for pj in projects:
+    base = f"{prio(pj)}_{safe(pj)}"
+    rec = {"project": pj, "priority": prio(pj), "sw": len(sw.get(pj,[])),
+           "inv": len(inv.get(pj,[])), "other": len(other.get(pj,[]))}
+    for tag, d in (("sw",sw),("inv",inv),("other",other)):
+        if d.get(pj):
+            fn = os.path.join(OUT, f"{base}.{tag}.txt")
+            with open(fn,"w") as o: o.write("\r\n".join(winpath(p) for p in d[pj]) + "\r\n")
+            rec[tag+"_file"] = os.path.basename(fn)
+    manifest.append(rec)
+
+tot = {"sw": sum(r["sw"] for r in manifest), "inv": sum(r["inv"] for r in manifest),
+       "other": sum(r["other"] for r in manifest), "projects": len(projects)}
+json.dump({"totals": tot, "batches": manifest}, open(os.path.join(OUT,"_manifest.json"),"w"), indent=1)
+print(json.dumps(tot, indent=1))
+print("priority order (first 12):")
+for r in manifest[:12]:
+    print(f"  P{r['priority']} {r['project']}: SW={r['sw']} INV={r['inv']} other={r['other']}")
+print(f"\nbatches written to {OUT}")

--- a/docs/cad-inventory/adapters/seat-export/test_inventorloader.sh
+++ b/docs/cad-inventory/adapters/seat-export/test_inventorloader.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ============================================================================
+#  Evaluate the OSS Inventor reader (FreeCAD InventorLoader) — RUN ON ace-linux-2.
+#  This installs an EXTERNAL FreeCAD addon (jmplonka/InventorLoader) into the
+#  FreeCAD Mod auto-load dir, then headless-tests reading a sample .ipt.
+#  It is provided as a USER-initiated script (an agent was not permitted to
+#  auto-install external auto-load code). Review before running.
+#
+#  Usage:  ./test_inventorloader.sh [/path/to/sample.ipt]
+#  If it prints INVENTORLOADER_OK with shapes>0, the OSS path can read that part;
+#  then a1 can convert .ipt -> STEP/glTF via FreeCAD headless WITHOUT a seat
+#  (parts only; assemblies .iam are typically not supported by the addon).
+# ============================================================================
+set -e
+MOD="$HOME/.local/share/FreeCAD/Mod"
+mkdir -p "$MOD"; cd "$MOD"
+if [ ! -d InventorLoader ]; then
+  echo ">> cloning InventorLoader (external addon)…"
+  git clone --depth 1 https://github.com/jmplonka/InventorLoader
+fi
+SAMPLE="${1:-/tmp/test_part.ipt}"
+cat > /tmp/il_test.py <<'PY'
+import FreeCAD, sys
+p = sys.argv[-1]
+try:
+    d = FreeCAD.open(p)
+    shapes = [o for o in d.Objects if getattr(o, "Shape", None) is not None and o.Shape.Solids]
+    nsolid = sum(len(o.Shape.Solids) for o in shapes)
+    print("INVENTORLOADER_OK file=%s objects=%d solids=%d" % (p.split('/')[-1], len(d.Objects), nsolid))
+except Exception as e:
+    print("INVENTORLOADER_FAIL %s: %s" % (type(e).__name__, str(e)[:140]))
+PY
+echo ">> testing on: $SAMPLE"
+freecadcmd /tmp/il_test.py "$SAMPLE" 2>&1 | grep -E "INVENTORLOADER_(OK|FAIL)"
+echo ">> If OK: install pattern proven; we can batch .ipt -> STEP via freecadcmd on a2,"
+echo ">>        feeding the same dedup/glTF/index pipeline, no Inventor seat for parts."


### PR DESCRIPTION
Ready-to-run package so a licensed SolidWorks/Inventor seat can batch-export the native estate (59,955 SW + 182,197 Inventor + 815 Parasolid) to STEP, which flows into the existing dedup→glTF→Blender→index pipeline. Includes both batch macros, a per-project batch-list generator, an OSS InventorLoader eval script, and a de-identified runbook. OSS finding (tested): no OSS reader for native SW/Inventor/Parasolid (FreeCAD built-in errors on both; InventorLoader is partial/unproven) → the seat export is the reliable unlock. Private per-project batch lists stay on the share. Refs #1004 #1011 #1012