### PR TITLE
feat(well_access): calibrate to worldenergydata intervention access-gap figures (#890)

### DIFF
--- a/src/digitalmodel/base_configs/modules/well_access/wed_intervention_snapshot.yml
+++ b/src/digitalmodel/base_configs/modules/well_access/wed_intervention_snapshot.yml
@@ -1,0 +1,225 @@
+# ABOUTME: Dated SNAPSHOT of worldenergydata BSEE intervention access-gap figures.
+# ABOUTME: The cross-repo bridge — digitalmodel cannot import worldenergydata, so this
+# ABOUTME: committed, dated snapshot is the calibration input for well_access (W7).
+#
+# PROVENANCE / SCOPE HONESTY
+# --------------------------
+# This file is a hand-carried copy of figures produced ON THE worldenergydata SIDE.
+# It is NOT a live feed. Re-snapshot when the upstream YAMLs change.
+#
+#   source_repo:  vamseeachanta/worldenergydata
+#   source_issue: worldenergydata#638 (capstone of epic #626) ; feeds digitalmodel#890
+#   source_commit: adbd44c0  (PR worldenergydata#639, branch feat/* — not yet on main)
+#   source_files:
+#     - bsee/analysis/intervention/data/access_gap.yml            (worldenergydata#638)
+#     - bsee/analysis/intervention/data/intervention_demand.yml   (worldenergydata#630)
+#     - vessel_fleet/data/intervention_fleet_catalog.yml          (worldenergydata#598)
+#     - bsee/analysis/intervention/data/intervention_economics.yml(worldenergydata#629)
+#   as_of: '2026-06-26'              # date this snapshot was carried into digitalmodel
+#   dayrate_snapshot_as_of: '2026-02-19'
+#
+# LOAD-BEARING CAVEATS (carry these everywhere downstream — see wed_calibration.py)
+# - FORWARD-LOOKING ACCESS RISK, not a measured demand/supply crossover. A
+#   utilization_ratio > 1 is an access-risk indicator, NOT an observed shortfall.
+# - FLOOR (WAR ~6%): WATER_DEPTH is populated on only ~6% of WAR rows (#627/#630);
+#   every band-resolved empirical count is a hard lower bound, not a total. The
+#   #630 empirical interventions/well is a lifetime UPPER proxy on that 6% subset,
+#   NOT an annual lambda.
+# - GEOGRAPHY (#628): GoM has ~0 RESIDENT dedicated LIGHT-intervention fleet — this
+#   is geography (the global RLWI fleet is elsewhere) + the 6% WAR coverage, NOT
+#   evidence that deepwater light intervention is avoided. ~3 GoM-resident dedicated
+#   units total. The GoM-resident view is the BINDING supply constraint.
+# - PRESSURE CLASS ABSENT: bands are WATER-DEPTH only; HPHT / 20k-psi service
+#   capability is not resolved here (only 2 rigs worldwide rated to 20,000 psi).
+# - UNKNOWN 44.5% (#627): a large share of WAR service-type is unclassified.
+
+meta:
+  source_repo: vamseeachanta/worldenergydata
+  source_issue: 'worldenergydata#638'
+  feeds_issue: 'digitalmodel#890'
+  source_commit: adbd44c0
+  source_pr: 'worldenergydata#639'
+  as_of: '2026-06-26'
+  dayrate_snapshot_as_of: '2026-02-19'
+  framing: >-
+    FORWARD-LOOKING ACCESS RISK, not a measured crossover. Per band: intervention
+    demand rig-days/yr (subsea wells x parameterized frequency x band-effective
+    heavy-intervention duration) vs available fleet rig-days/yr (eligible fleet x
+    utilization x 365), with a binding GoM-resident-only variant.
+  headline: >-
+    5,000-10,000 ft holds 270 subsea wells but only 2 GoM-resident heavy-
+    intervention units: forward demand would need ~4.4x the rig-days resident
+    supply can provide (access-RISK indicator, NOT a measured crossover).
+  confidence: forward_looking_risk
+
+# Planning parameters used to derive the figures (cited, overridable upstream).
+parameters:
+  intervention_frequency_per_well_per_yr: {low: 0.1, central: 0.15, high: 0.2}
+  intervention_frequency_source: >-
+    [engineering-assumption] ~0.1-0.2 interventions per subsea well per year (one
+    every 5-10 yr); planning-grade from subsea reliability / operator norms, NOT a
+    measured BSEE rate.
+  fleet_utilization: {low: 0.6, central: 0.7, high: 0.8}
+  fleet_utilization_source: >-
+    [engineering-assumption] practical sustained fleet utilization 60-80%.
+  days_per_year: 365
+  heavy_deepwater_classes: [modu_drillship, modu_semisub, heavy_intervention_semi]
+  gom_resident_dedicated_total: 3
+
+# Fleet supply (deduped distinct hulls; GoM-resident is the binding constraint).
+fleet_supply:
+  scope_note: >-
+    by_asset_class counts are GLOBAL distinct hulls (#599 identity resolver), NOT
+    GoM-resident. The binding GoM intervention supply is gom_resident.
+  global_eligible_fleet_count: 471          # modu_drillship 161 + modu_semisub 305 + heavy_intervention_semi 5
+  eligible_classes:
+    modu_drillship: 161
+    modu_semisub: 305
+    heavy_intervention_semi: 5
+  rig_days_per_yr_global: {low: 103149.0, central: 120340.5, high: 137532.0}
+  gom_resident_dedicated_total: 3            # ~2-4 soft; Helix Q4000/Q5000 (heavy) + Island Performer (light)
+  gom_resident_eligible_heavy_count: 2       # Helix Q4000, Helix Q5000 (heavy-intervention semis)
+  gom_resident_eligible_heavy_units: [Helix Q4000, Helix Q5000]
+  rig_days_per_yr_gom_resident: {low: 438.0, central: 511.0, high: 584.0}
+  gom_resident_light_intervention_count: 0   # GEOGRAPHY (#628): ~0 resident dedicated LIGHT-intervention fleet
+  confidence: soft
+
+# Indicative public dayrates (#596 snapshot) for the heavy-deepwater servicing pool.
+dayrates:
+  modu_drillship:
+    median_usd_per_day: 457000
+    band_low_usd_per_day: 300000
+    band_high_usd_per_day: 530000
+    rate_disclosed: true
+    confidence_labels: [analyst, on_record, reported]
+  modu_semisub:
+    median_usd_per_day: 465000
+    band_low_usd_per_day: 452000
+    band_high_usd_per_day: 490000
+    rate_disclosed: true
+    confidence_labels: [on_record]
+  heavy_intervention_semi:
+    median_usd_per_day: null               # Helix Q-class not public
+    rate_disclosed: false
+    confidence_labels: [not_public]
+  mpsv_osv:
+    median_usd_per_day: 37500
+    band_low_usd_per_day: 22000
+    band_high_usd_per_day: 80000
+    rate_disclosed: true
+    confidence_labels: [analyst, reported]
+
+# Per water-depth band: empirical demand cross-check + forward demand/supply/gap + $ exposure.
+bands:
+  shelf_lt_500:
+    label: < 500 ft (shelf)
+    modu_servicing: false
+    subsea_wells: 0
+    empirical:                              # #630 FLOOR (6% depth-stamped WAR subset)
+      distinct_wells: 3705
+      interventions: 17687
+      interventions_per_well: 4.774         # lifetime UPPER proxy, NOT annual lambda
+      total_rig_days_floor: 121738
+    heavy_duration_days: {low: 30, median: 45, high: 60}
+    demand_rig_days_per_yr: {low: 0.0, central: 0.0, high: 0.0}
+    interventions_per_yr: {low: 0.0, central: 0.0, high: 0.0}
+    gap_vs_global_rig_days_per_yr: {conservative: -103149.0, central: -120340.5, optimistic: -137532.0}
+    gap_vs_gom_resident_rig_days_per_yr: {conservative: -438.0, central: -511.0, optimistic: -584.0}
+    utilization_ratio_global: {conservative: 0.0, central: 0.0, optimistic: 0.0}
+    utilization_ratio_gom_resident: {conservative: 0.0, central: 0.0, optimistic: 0.0}
+    exposure_usd_per_yr: null
+    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    confidence: forward_looking_risk
+  band_500_3000:
+    label: 500-3,000 ft
+    modu_servicing: true
+    subsea_wells: 114
+    empirical:
+      distinct_wells: 372
+      interventions: 2508
+      interventions_per_well: 6.742
+      total_rig_days_floor: 16777
+    heavy_duration_days: {low: 32, median: 48, high: 65}
+    demand_rig_days_per_yr: {low: 364.8, central: 820.8, high: 1482.0}
+    interventions_per_yr: {low: 11.4, central: 17.1, high: 22.8}
+    gap_vs_global_rig_days_per_yr: {conservative: -101667.0, central: -119519.7, optimistic: -137167.2}
+    gap_vs_gom_resident_rig_days_per_yr: {conservative: 1044.0, central: 309.8, optimistic: -219.2}
+    utilization_ratio_global: {conservative: 0.014, central: 0.007, optimistic: 0.003}
+    utilization_ratio_gom_resident: {conservative: 3.384, central: 1.606, optimistic: 0.625}
+    exposure_usd_per_yr: {low: 109440000, central: 375105600, high: 785460000}
+    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    confidence: forward_looking_risk
+  band_3000_5000:
+    label: 3,000-5,000 ft
+    modu_servicing: true
+    subsea_wells: 209
+    empirical:
+      distinct_wells: 249
+      interventions: 1876
+      interventions_per_well: 7.534
+      total_rig_days_floor: 12648
+    heavy_duration_days: {low: 34, median: 51, high: 69}
+    demand_rig_days_per_yr: {low: 710.6, central: 1598.8, high: 2884.2}
+    interventions_per_yr: {low: 20.9, central: 31.35, high: 41.8}
+    gap_vs_global_rig_days_per_yr: {conservative: -100264.8, central: -118741.7, optimistic: -136821.4}
+    gap_vs_gom_resident_rig_days_per_yr: {conservative: 2446.2, central: 1087.8, optimistic: 126.6}
+    utilization_ratio_global: {conservative: 0.028, central: 0.013, optimistic: 0.005}
+    utilization_ratio_gom_resident: {conservative: 6.585, central: 3.129, optimistic: 1.217}
+    exposure_usd_per_yr: {low: 213180000, central: 730674450, high: 1528626000}
+    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    confidence: forward_looking_risk
+  band_5000_10000:
+    label: 5,000-10,000 ft
+    modu_servicing: true
+    subsea_wells: 270
+    empirical:
+      distinct_wells: 129
+      interventions: 830
+      interventions_per_well: 6.434
+      total_rig_days_floor: 5511
+    heavy_duration_days: {low: 37, median: 55, high: 74}
+    demand_rig_days_per_yr: {low: 999.0, central: 2227.5, high: 3996.0}
+    interventions_per_yr: {low: 27.0, central: 40.5, high: 54.0}
+    gap_vs_global_rig_days_per_yr: {conservative: -99153.0, central: -118113.0, optimistic: -136533.0}
+    gap_vs_gom_resident_rig_days_per_yr: {conservative: 3558.0, central: 1716.5, optimistic: 415.0}
+    utilization_ratio_global: {conservative: 0.039, central: 0.019, optimistic: 0.007}
+    utilization_ratio_gom_resident: {conservative: 9.123, central: 4.359, optimistic: 1.711}
+    exposure_usd_per_yr: {low: 299700000, central: 1017967500, high: 2117880000}
+    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    confidence: forward_looking_risk
+  band_gt_10000:
+    label: '> 10,000 ft'
+    modu_servicing: true
+    subsea_wells: 0
+    empirical:
+      distinct_wells: 1
+      interventions: 10
+      interventions_per_well: 10.0
+      total_rig_days_floor: 70
+    heavy_duration_days: {low: 40, median: 59, high: 80}
+    demand_rig_days_per_yr: {low: 0.0, central: 0.0, high: 0.0}
+    interventions_per_yr: {low: 0.0, central: 0.0, high: 0.0}
+    gap_vs_global_rig_days_per_yr: {conservative: -103149.0, central: -120340.5, optimistic: -137532.0}
+    gap_vs_gom_resident_rig_days_per_yr: {conservative: 0.0, central: 0.0, optimistic: 0.0}
+    utilization_ratio_global: {conservative: 0.0, central: 0.0, optimistic: 0.0}
+    utilization_ratio_gom_resident: {conservative: null, central: null, optimistic: null}
+    exposure_usd_per_yr: {low: 0, central: 0, high: 0}
+    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    confidence: forward_looking_risk
+
+method: >-
+  DEMAND rig-days/yr = subsea_wells x frequency x band-effective heavy_dead_well
+  duration (#629, depth-scaled). SUPPLY rig-days/yr = eligible_fleet x utilization
+  x 365 for BOTH the global heavy-deepwater roster and the binding GoM-resident-only
+  fleet. GAP = DEMAND - SUPPLY; utilization_ratio = DEMAND / SUPPLY. $ exposure/yr =
+  (subsea_wells x frequency) x band heavy $/intervention (#629).
+
+caveats:
+- 'FORWARD-LOOKING: access RISK, not a measured demand/supply crossover; frequency and utilization are cited planning assumptions.'
+- 'FLOOR (WAR ~6%): empirical interventions/well is a lifetime upper proxy on the ~6% depth-stamped WAR subset, NOT an annual lambda.'
+- 'GEOGRAPHY (#628): GoM has ~0 resident dedicated LIGHT-intervention fleet (geography + 6% WAR coverage), NOT evidence light intervention is avoided.'
+- 'PRESSURE CLASS ABSENT: bands are water-depth only; HPHT / 20k-psi capability not resolved (only 2 rigs worldwide rated to 20,000 psi).'
+- 'UNKNOWN 44.5% (#627): a large share of WAR service-type is unclassified.'
+- 'Demand uses the HEAVY heavy_dead_well duration for all interventions (upper bound on rig-days); real campaigns mix lighter scopes.'
+- 'Global-roster supply is a worldwide pool a GoM operator competes for; the GoM-resident view is the binding constraint.'
+- 'Dayrates are a point-in-time PUBLIC snapshot (#596); Helix Q-class intervention semis have no public per-day figure.'

--- a/src/digitalmodel/base_configs/modules/well_access/wed_intervention_snapshot.yml
+++ b/src/digitalmodel/base_configs/modules/well_access/wed_intervention_snapshot.yml
@@ -128,7 +128,7 @@ bands:
     utilization_ratio_global: {conservative: 0.0, central: 0.0, optimistic: 0.0}
     utilization_ratio_gom_resident: {conservative: 0.0, central: 0.0, optimistic: 0.0}
     exposure_usd_per_yr: null
-    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    heavy_dead_well_cost_usd: {low: null, median: null, high: null}  # shelf jackup-serviced; deepwater-MODU rate N/A (source #629)
     confidence: forward_looking_risk
   band_500_3000:
     label: 500-3,000 ft
@@ -147,7 +147,7 @@ bands:
     utilization_ratio_global: {conservative: 0.014, central: 0.007, optimistic: 0.003}
     utilization_ratio_gom_resident: {conservative: 3.384, central: 1.606, optimistic: 0.625}
     exposure_usd_per_yr: {low: 109440000, central: 375105600, high: 785460000}
-    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    heavy_dead_well_cost_usd: {low: 9600000, median: 21936000, high: 34450000}  # band-varying, source #629/#638
     confidence: forward_looking_risk
   band_3000_5000:
     label: 3,000-5,000 ft
@@ -166,7 +166,7 @@ bands:
     utilization_ratio_global: {conservative: 0.028, central: 0.013, optimistic: 0.005}
     utilization_ratio_gom_resident: {conservative: 6.585, central: 3.129, optimistic: 1.217}
     exposure_usd_per_yr: {low: 213180000, central: 730674450, high: 1528626000}
-    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    heavy_dead_well_cost_usd: {low: 10200000, median: 23307000, high: 36570000}  # band-varying, source #629/#638
     confidence: forward_looking_risk
   band_5000_10000:
     label: 5,000-10,000 ft
@@ -185,7 +185,7 @@ bands:
     utilization_ratio_global: {conservative: 0.039, central: 0.019, optimistic: 0.007}
     utilization_ratio_gom_resident: {conservative: 9.123, central: 4.359, optimistic: 1.711}
     exposure_usd_per_yr: {low: 299700000, central: 1017967500, high: 2117880000}
-    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    heavy_dead_well_cost_usd: {low: 11100000, median: 25135000, high: 39220000}  # band-varying, source #629/#638
     confidence: forward_looking_risk
   band_gt_10000:
     label: '> 10,000 ft'
@@ -204,7 +204,7 @@ bands:
     utilization_ratio_global: {conservative: 0.0, central: 0.0, optimistic: 0.0}
     utilization_ratio_gom_resident: {conservative: null, central: null, optimistic: null}
     exposure_usd_per_yr: {low: 0, central: 0, high: 0}
-    heavy_dead_well_cost_usd: {low: 9000000, median: 20565000, high: 31800000}
+    heavy_dead_well_cost_usd: {low: 12000000, median: 26963000, high: 42400000}  # band-varying, source #629/#638
     confidence: forward_looking_risk
 
 method: >-

--- a/src/digitalmodel/well_access/__init__.py
+++ b/src/digitalmodel/well_access/__init__.py
@@ -29,6 +29,12 @@ from .intervention_rates import (
 from .resource_queue import compute_resource_demand
 from .uptime_rollup import rollup_uptime
 from .lifecycle_summary import run_lifecycle, compare_architectures
+from .wed_calibration import (
+    WedCalibration,
+    BandDemand,
+    FleetSupply,
+    load_wed_calibration,
+)
 from .router import router
 
 __all__ = [
@@ -49,5 +55,9 @@ __all__ = [
     "rollup_uptime",
     "run_lifecycle",
     "compare_architectures",
+    "WedCalibration",
+    "BandDemand",
+    "FleetSupply",
+    "load_wed_calibration",
     "router",
 ]

--- a/src/digitalmodel/well_access/router.py
+++ b/src/digitalmodel/well_access/router.py
@@ -30,6 +30,7 @@ import yaml
 
 from .lifecycle_summary import compare_architectures, run_lifecycle
 from .models import AccessClass, WellProgram
+from .wed_calibration import load_wed_calibration
 
 
 def _jsonable(value: Any) -> Any:
@@ -177,6 +178,29 @@ def router(cfg: dict[str, Any]) -> dict[str, Any]:
     resources_cfg = params.get("resources", [])
     deferred_loss = float(params.get("deferred_loss_per_event_days", 30.0))
 
+    # Optional, additive: calibrate to the committed worldenergydata access-gap
+    # snapshot (digitalmodel#890). Default OFF — only engages when a `wed_calibration`
+    # block is present. When `use_wed_supply` is set and no resources are supplied,
+    # the heavy pool's available-days are taken from the REAL (binding GoM-resident
+    # or global) fleet supply instead of an assumed capacity. A provenance/empirical
+    # block is attached to the payload either way. FORWARD-LOOKING RISK, not measured.
+    wed_cfg = params.get("wed_calibration")
+    wed_block: dict[str, Any] | None = None
+    if wed_cfg:
+        if not isinstance(wed_cfg, dict):
+            wed_cfg = {}
+        wed = load_wed_calibration(wed_cfg.get("snapshot_path"))
+        if wed_cfg.get("use_wed_supply") and not resources_cfg:
+            resources_cfg = wed.calibrated_resource_pools(
+                resource_class=str(wed_cfg.get("resource_class", "modu")),
+                supply_scope=str(wed_cfg.get("supply_scope", "gom_resident")),
+            )
+        wed_block = {
+            "provenance": wed.provenance,
+            "empirical_demand": wed.empirical_demand_summary(),
+            "caveats": wed.caveats,
+        }
+
     primary = run_lifecycle(
         well_program, calibration, access_table, resources_cfg, deferred_loss
     )
@@ -187,6 +211,8 @@ def router(cfg: dict[str, Any]) -> dict[str, Any]:
         "deferred_loss_per_event_days": deferred_loss,
         "primary": _jsonable(primary),
     }
+    if wed_block is not None:
+        payload["wed_calibration"] = wed_block
 
     # Optional dry-tree vs subsea comparison block.
     cmp_cfg = params.get("comparison")

--- a/src/digitalmodel/well_access/wed_calibration.py
+++ b/src/digitalmodel/well_access/wed_calibration.py
@@ -1,0 +1,369 @@
+# ABOUTME: W7 adapter — loads the dated worldenergydata intervention access-gap SNAPSHOT.
+# ABOUTME: Exposes empirical band demand, fleet supply (GoM-resident binding), dayrate/cost.
+"""
+digitalmodel.well_access.wed_calibration
+========================================
+
+Cross-repo calibration bridge for the W7 well-access model.
+
+``digitalmodel`` cannot import the ``worldenergydata`` package, so the empirical
+BSEE intervention access-gap figures are carried in as a **committed, dated
+snapshot** (``base_configs/modules/well_access/wed_intervention_snapshot.yml``).
+This module loads that snapshot and exposes it as structured calibration so the
+well-access model (``intervention_rates`` / ``resource_queue``) can be calibrated
+to REAL figures instead of bare engineering assumptions.
+
+It is purely **additive** — nothing here changes default ``well_access`` behavior.
+Callers opt in by loading a :class:`WedCalibration` and passing its derived inputs.
+
+Load-bearing caveats (carried from worldenergydata#638; preserved on every object)
+----------------------------------------------------------------------------------
+* **FORWARD-LOOKING ACCESS RISK, not a measured crossover.** A per-band
+  ``utilization_ratio > 1`` is an access-risk *indicator*, never an observed
+  shortfall. Derived access multipliers inherit ``confidence='forward_looking_risk'``.
+* **FLOOR (WAR ~6%).** The empirical interventions/well figure is a lifetime UPPER
+  proxy on the ~6% depth-stamped WAR subset (#627/#630), NOT an annual lambda — do
+  not feed it directly as an NHPP rate.
+* **GEOGRAPHY (#628).** GoM has ~0 RESIDENT dedicated LIGHT-intervention fleet
+  (geography + the 6% WAR coverage), NOT evidence that deepwater light intervention
+  is avoided. The GoM-resident heavy fleet (~2 units) is the BINDING supply
+  constraint; the global roster (471) is a pool a GoM operator merely competes for.
+* **PRESSURE CLASS ABSENT.** Bands are water-depth only; HPHT / 20k-psi service
+  capability is not resolved (only two rigs worldwide are rated to 20,000 psi).
+
+Confidence labels from the snapshot are preserved verbatim on the returned objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+# Snapshot lives in the shipped base_configs tree (sibling to well_access.yml).
+_DEFAULT_SNAPSHOT = (
+    Path(__file__).resolve().parents[1]
+    / "base_configs"
+    / "modules"
+    / "well_access"
+    / "wed_intervention_snapshot.yml"
+)
+
+
+def _triple(d: Optional[dict], *keys: str) -> Optional[float]:
+    """Pull the first present key from a low/central/high (or conservative/...) dict."""
+    if not d:
+        return None
+    for k in keys:
+        if k in d and d[k] is not None:
+            return float(d[k])
+    return None
+
+
+@dataclass(frozen=True)
+class BandDemand:
+    """Empirical + forward intervention demand for one water-depth band.
+
+    ``interventions_per_well`` is the #630 lifetime UPPER proxy on the ~6%
+    depth-stamped WAR subset — a FLOOR cross-check, NOT an annual lambda.
+    ``utilization_ratio_gom_resident`` > 1 is a FORWARD access-risk indicator.
+    """
+
+    band: str
+    label: str
+    modu_servicing: bool
+    subsea_wells: int
+    interventions_per_well_floor: Optional[float]
+    interventions_floor: Optional[int]
+    distinct_wells_floor: Optional[int]
+    total_rig_days_floor: Optional[int]
+    heavy_duration_days_median: Optional[float]
+    demand_rig_days_per_yr_central: Optional[float]
+    interventions_per_yr_central: Optional[float]
+    gap_vs_global_rig_days_per_yr_central: Optional[float]
+    gap_vs_gom_resident_rig_days_per_yr_central: Optional[float]
+    utilization_ratio_global_central: Optional[float]
+    utilization_ratio_gom_resident_central: Optional[float]
+    exposure_usd_per_yr_central: Optional[float]
+    heavy_dead_well_cost_usd_median: Optional[float]
+    confidence: str = "forward_looking_risk"
+
+
+@dataclass(frozen=True)
+class FleetSupply:
+    """Eligible heavy-deepwater fleet supply; GoM-resident is the BINDING constraint.
+
+    ``gom_resident_light_intervention_count == 0`` is GEOGRAPHY (#628), not avoidance.
+    """
+
+    global_eligible_fleet_count: int
+    eligible_classes: dict
+    rig_days_per_yr_global_central: float
+    gom_resident_dedicated_total: int
+    gom_resident_eligible_heavy_count: int
+    gom_resident_eligible_heavy_units: list
+    rig_days_per_yr_gom_resident_central: float
+    gom_resident_light_intervention_count: int
+    fleet_utilization_central: float
+    confidence: str = "soft"
+
+
+@dataclass(frozen=True)
+class WedCalibration:
+    """Loaded worldenergydata intervention access-gap snapshot (the calibration bridge)."""
+
+    meta: dict
+    parameters: dict
+    bands: list[BandDemand]
+    fleet: FleetSupply
+    dayrates: dict
+    caveats: list[str]
+    method: str
+    source_path: str = ""
+
+    # ---- construction -----------------------------------------------------
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> "WedCalibration":
+        """Load the snapshot YAML (defaults to the shipped base_configs copy)."""
+        p = Path(path) if path is not None else _DEFAULT_SNAPSHOT
+        with open(p, "r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+        return cls.from_dict(raw, source_path=str(p))
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any], source_path: str = "") -> "WedCalibration":
+        bands: list[BandDemand] = []
+        for key, b in (raw.get("bands") or {}).items():
+            emp = b.get("empirical") or {}
+            bands.append(
+                BandDemand(
+                    band=str(b.get("band", key)),
+                    label=str(b.get("label", key)),
+                    modu_servicing=bool(b.get("modu_servicing", False)),
+                    subsea_wells=int(b.get("subsea_wells", 0)),
+                    interventions_per_well_floor=(
+                        float(emp["interventions_per_well"])
+                        if emp.get("interventions_per_well") is not None
+                        else None
+                    ),
+                    interventions_floor=(
+                        int(emp["interventions"])
+                        if emp.get("interventions") is not None
+                        else None
+                    ),
+                    distinct_wells_floor=(
+                        int(emp["distinct_wells"])
+                        if emp.get("distinct_wells") is not None
+                        else None
+                    ),
+                    total_rig_days_floor=(
+                        int(emp["total_rig_days_floor"])
+                        if emp.get("total_rig_days_floor") is not None
+                        else None
+                    ),
+                    heavy_duration_days_median=_triple(
+                        b.get("heavy_duration_days"), "median", "central"
+                    ),
+                    demand_rig_days_per_yr_central=_triple(
+                        b.get("demand_rig_days_per_yr"), "central"
+                    ),
+                    interventions_per_yr_central=_triple(
+                        b.get("interventions_per_yr"), "central"
+                    ),
+                    gap_vs_global_rig_days_per_yr_central=_triple(
+                        b.get("gap_vs_global_rig_days_per_yr"), "central"
+                    ),
+                    gap_vs_gom_resident_rig_days_per_yr_central=_triple(
+                        b.get("gap_vs_gom_resident_rig_days_per_yr"), "central"
+                    ),
+                    utilization_ratio_global_central=_triple(
+                        b.get("utilization_ratio_global"), "central"
+                    ),
+                    utilization_ratio_gom_resident_central=_triple(
+                        b.get("utilization_ratio_gom_resident"), "central"
+                    ),
+                    exposure_usd_per_yr_central=_triple(
+                        b.get("exposure_usd_per_yr"), "central"
+                    ),
+                    heavy_dead_well_cost_usd_median=_triple(
+                        b.get("heavy_dead_well_cost_usd"), "median", "central"
+                    ),
+                    confidence=str(b.get("confidence", "forward_looking_risk")),
+                )
+            )
+
+        fs = raw.get("fleet_supply") or {}
+        params = raw.get("parameters") or {}
+        fleet = FleetSupply(
+            global_eligible_fleet_count=int(fs.get("global_eligible_fleet_count", 0)),
+            eligible_classes=dict(fs.get("eligible_classes") or {}),
+            rig_days_per_yr_global_central=float(
+                _triple(fs.get("rig_days_per_yr_global"), "central") or 0.0
+            ),
+            gom_resident_dedicated_total=int(fs.get("gom_resident_dedicated_total", 0)),
+            gom_resident_eligible_heavy_count=int(
+                fs.get("gom_resident_eligible_heavy_count", 0)
+            ),
+            gom_resident_eligible_heavy_units=list(
+                fs.get("gom_resident_eligible_heavy_units") or []
+            ),
+            rig_days_per_yr_gom_resident_central=float(
+                _triple(fs.get("rig_days_per_yr_gom_resident"), "central") or 0.0
+            ),
+            gom_resident_light_intervention_count=int(
+                fs.get("gom_resident_light_intervention_count", 0)
+            ),
+            fleet_utilization_central=float(
+                _triple(params.get("fleet_utilization"), "central") or 0.0
+            ),
+            confidence=str(fs.get("confidence", "soft")),
+        )
+
+        return cls(
+            meta=dict(raw.get("meta") or {}),
+            parameters=dict(params),
+            bands=bands,
+            fleet=fleet,
+            dayrates=dict(raw.get("dayrates") or {}),
+            caveats=list(raw.get("caveats") or []),
+            method=str(raw.get("method", "")),
+            source_path=source_path,
+        )
+
+    # ---- accessors --------------------------------------------------------
+
+    def band(self, name: str) -> BandDemand:
+        """Return the :class:`BandDemand` for a band key (e.g. ``band_5000_10000``)."""
+        for b in self.bands:
+            if b.band == name:
+                return b
+        raise KeyError(f"unknown band {name!r}; have {[b.band for b in self.bands]}")
+
+    @property
+    def as_of(self) -> str:
+        return str(self.meta.get("as_of", ""))
+
+    @property
+    def provenance(self) -> dict:
+        """Source repo / issue / commit / dates for downstream attribution."""
+        m = self.meta
+        return {
+            "source_repo": m.get("source_repo"),
+            "source_issue": m.get("source_issue"),
+            "feeds_issue": m.get("feeds_issue"),
+            "source_commit": m.get("source_commit"),
+            "as_of": m.get("as_of"),
+            "dayrate_snapshot_as_of": m.get("dayrate_snapshot_as_of"),
+            "confidence": m.get("confidence", "forward_looking_risk"),
+        }
+
+    def empirical_demand_summary(self) -> list[dict]:
+        """Per-band empirical demand + forward gap, FLOOR/forward-risk labels carried."""
+        out: list[dict] = []
+        for b in self.bands:
+            out.append(
+                {
+                    "band": b.band,
+                    "label": b.label,
+                    "subsea_wells": b.subsea_wells,
+                    "interventions_per_well_floor": b.interventions_per_well_floor,
+                    "demand_rig_days_per_yr_central": b.demand_rig_days_per_yr_central,
+                    "utilization_ratio_gom_resident_central": (
+                        b.utilization_ratio_gom_resident_central
+                    ),
+                    "exposure_usd_per_yr_central": b.exposure_usd_per_yr_central,
+                    "confidence": b.confidence,
+                    "floor_note": (
+                        "interventions_per_well is a lifetime UPPER proxy on the ~6% "
+                        "depth-stamped WAR subset (#627/#630), NOT an annual lambda"
+                    ),
+                }
+            )
+        return out
+
+    # ---- calibration derivations (opt-in; additive) -----------------------
+
+    def heavy_pool_available_days_per_year(
+        self, supply_scope: str = "gom_resident"
+    ) -> float:
+        """Available rig-days/yr for the heavy-deepwater intervention pool.
+
+        ``supply_scope='gom_resident'`` (default) returns the BINDING GoM-resident
+        constraint (~2 units); ``'global'`` returns the worldwide pool a GoM
+        operator competes for (not exclusively available). See GEOGRAPHY caveat.
+        """
+        if supply_scope == "global":
+            return self.fleet.rig_days_per_yr_global_central
+        if supply_scope == "gom_resident":
+            return self.fleet.rig_days_per_yr_gom_resident_central
+        raise ValueError(
+            f"supply_scope must be 'gom_resident' or 'global', got {supply_scope!r}"
+        )
+
+    def calibrated_resource_pools(
+        self,
+        resource_class: str = "modu",
+        supply_scope: str = "gom_resident",
+        mobilisation_lead_days: float = 45.0,
+        batch_campaign: bool = True,
+    ) -> list[dict]:
+        """Resource-pool config calibrated to the empirical fleet supply.
+
+        Returns a ``resources_cfg``-shaped list (consumable by
+        ``lifecycle_summary._build_pools`` / ``resource_queue``) whose
+        ``available_days_per_year`` is the real fleet supply for ``supply_scope``
+        rather than an assumed capacity. Additive — callers choose to use it.
+        """
+        return [
+            {
+                "resource_class": resource_class,
+                "available_days_per_year": self.heavy_pool_available_days_per_year(
+                    supply_scope
+                ),
+                "mobilisation_lead_days": mobilisation_lead_days,
+                "batch_campaign": batch_campaign,
+                "_wed_supply_scope": supply_scope,
+            }
+        ]
+
+    def access_multiplier_from_supply_ratio(
+        self, band: str, supply_scope: str = "gom_resident"
+    ) -> dict:
+        """Empirically-anchored access multiplier for a band (m_access = min(1, supply/demand)).
+
+        A FORWARD-LOOKING access-risk multiplier: where forward demand exceeds the
+        binding supply (``utilization_ratio > 1``), access is capped at
+        ``supply / demand`` (= ``1 / utilization_ratio``). This is an access-RISK
+        indicator, NOT a measured crossover — the result carries
+        ``confidence='forward_looking_risk'``.
+        """
+        b = self.band(band)
+        ratio = (
+            b.utilization_ratio_gom_resident_central
+            if supply_scope == "gom_resident"
+            else b.utilization_ratio_global_central
+        )
+        if ratio is None or ratio <= 0:
+            m = 1.0  # no demand (or undefined) -> no access suppression signal
+        else:
+            m = min(1.0, 1.0 / ratio)
+        return {
+            "band": band,
+            "supply_scope": supply_scope,
+            "utilization_ratio": ratio,
+            "m_access": round(m, 4),
+            "confidence": "forward_looking_risk",
+            "caveat": (
+                "FORWARD-LOOKING access RISK, not a measured crossover; binding "
+                "supply is the GoM-resident fleet (GEOGRAPHY #628). Pressure class "
+                "(HPHT/20k psi) is NOT resolved by water-depth bands."
+            ),
+        }
+
+
+def load_wed_calibration(path: str | Path | None = None) -> WedCalibration:
+    """Convenience loader for the shipped (or a custom) worldenergydata snapshot."""
+    return WedCalibration.load(path)

--- a/tests/well_access/test_wed_calibration.py
+++ b/tests/well_access/test_wed_calibration.py
@@ -1,0 +1,215 @@
+# ABOUTME: Tests for the worldenergydata intervention access-gap calibration adapter.
+# ABOUTME: Asserts snapshot loads + band/fleet/cost figures surface + caveats preserved.
+"""Tests for digitalmodel.well_access.wed_calibration (W7 cross-repo bridge)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.well_access import (
+    WedCalibration,
+    BandDemand,
+    FleetSupply,
+    load_wed_calibration,
+)
+
+
+@pytest.fixture()
+def wed() -> WedCalibration:
+    return load_wed_calibration()
+
+
+class TestLoad:
+    def test_loads_shipped_snapshot(self, wed):
+        assert isinstance(wed, WedCalibration)
+        assert wed.bands  # non-empty
+        assert isinstance(wed.fleet, FleetSupply)
+
+    def test_provenance_carries_source(self, wed):
+        prov = wed.provenance
+        assert prov["source_repo"] == "vamseeachanta/worldenergydata"
+        assert prov["source_issue"] == "worldenergydata#638"
+        assert prov["feeds_issue"] == "digitalmodel#890"
+        assert prov["as_of"] == "2026-06-26"
+
+    def test_bands_are_banddemand(self, wed):
+        for b in wed.bands:
+            assert isinstance(b, BandDemand)
+
+
+class TestBandFiguresSurface:
+    def test_5000_10000_band_figures(self, wed):
+        b = wed.band("band_5000_10000")
+        assert b.subsea_wells == 270
+        assert b.interventions_per_well_floor == pytest.approx(6.434)
+        assert b.demand_rig_days_per_yr_central == pytest.approx(2227.5)
+        # binding GoM-resident utilization ratio ~4.4x -> the headline access risk
+        assert b.utilization_ratio_gom_resident_central == pytest.approx(4.359)
+        assert b.exposure_usd_per_yr_central == pytest.approx(1017967500)
+
+    def test_band_500_3000_demand(self, wed):
+        b = wed.band("band_500_3000")
+        assert b.subsea_wells == 114
+        assert b.interventions_per_yr_central == pytest.approx(17.1)
+
+    def test_unknown_band_raises(self, wed):
+        with pytest.raises(KeyError):
+            wed.band("band_does_not_exist")
+
+    def test_empirical_summary_carries_floor_note(self, wed):
+        summary = wed.empirical_demand_summary()
+        assert len(summary) == len(wed.bands)
+        row = next(r for r in summary if r["band"] == "band_5000_10000")
+        assert "lifetime UPPER proxy" in row["floor_note"]
+        assert row["confidence"] == "forward_looking_risk"
+
+
+class TestFleetSupply:
+    def test_global_vs_gom_resident(self, wed):
+        f = wed.fleet
+        assert f.global_eligible_fleet_count == 471
+        assert f.gom_resident_eligible_heavy_count == 2
+        assert "Helix Q4000" in f.gom_resident_eligible_heavy_units
+        # GEOGRAPHY (#628): ~0 resident dedicated LIGHT-intervention fleet
+        assert f.gom_resident_light_intervention_count == 0
+        # binding GoM-resident supply << global pool
+        assert (
+            f.rig_days_per_yr_gom_resident_central
+            < f.rig_days_per_yr_global_central
+        )
+
+    def test_supply_scope_selector(self, wed):
+        assert wed.heavy_pool_available_days_per_year("gom_resident") == pytest.approx(
+            511.0
+        )
+        assert wed.heavy_pool_available_days_per_year("global") == pytest.approx(
+            120340.5
+        )
+        with pytest.raises(ValueError):
+            wed.heavy_pool_available_days_per_year("mars")
+
+
+class TestCalibrationDerivations:
+    def test_calibrated_resource_pools_use_real_supply(self, wed):
+        pools = wed.calibrated_resource_pools(supply_scope="gom_resident")
+        assert len(pools) == 1
+        p = pools[0]
+        assert p["resource_class"] == "modu"
+        assert p["available_days_per_year"] == pytest.approx(511.0)
+        assert p["_wed_supply_scope"] == "gom_resident"
+
+    def test_access_multiplier_caps_when_demand_exceeds_supply(self, wed):
+        # band_5000_10000 ratio ~4.359 -> m_access ~ 1/4.359 ~ 0.229
+        m = wed.access_multiplier_from_supply_ratio("band_5000_10000")
+        assert m["m_access"] == pytest.approx(0.2294, abs=1e-3)
+        assert m["confidence"] == "forward_looking_risk"
+        assert "FORWARD-LOOKING" in m["caveat"]
+
+    def test_access_multiplier_unity_when_no_demand(self, wed):
+        # shelf band has zero subsea wells / zero utilization ratio -> no suppression
+        m = wed.access_multiplier_from_supply_ratio("shelf_lt_500")
+        assert m["m_access"] == pytest.approx(1.0)
+
+
+class TestCaveatsPreserved:
+    def test_caveats_carry_forward_looking_and_geography(self, wed):
+        joined = " ".join(wed.caveats)
+        assert "FORWARD-LOOKING" in joined
+        assert "FLOOR" in joined
+        assert "#628" in joined  # GoM resident light fleet geography
+        assert "PRESSURE CLASS" in joined
+
+    def test_dayrate_helix_not_public(self, wed):
+        helix = wed.dayrates["heavy_intervention_semi"]
+        assert helix["rate_disclosed"] is False
+        assert helix["median_usd_per_day"] is None
+
+
+class TestRouterIntegrationAdditive:
+    def test_router_wed_block_optional_and_off_by_default(self):
+        # Without a wed_calibration block, the payload must not gain the wed key.
+        from digitalmodel.well_access.router import router
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = {
+                "_config_dir_path": tmp,
+                "well_access": {
+                    "well_program": {
+                        "n_wells": 6,
+                        "field_life_years": 20,
+                        "access_class": "subsea_hub_spoke",
+                    },
+                    "calibration": {
+                        "base_rates": {
+                            "workover": {
+                                "duration_days": 45.0,
+                                "resource_class": "modu",
+                                "age_curve": [
+                                    {
+                                        "age_min_yr": 0,
+                                        "age_max_yr": 20,
+                                        "rate_per_well_year": 0.03,
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                    "access_multiplier": {"subsea_hub_spoke": {"workover": 0.6}},
+                    "outputs": {"directory": tmp},
+                },
+            }
+            out = router(cfg)["well_access"]
+            assert "wed_calibration" not in out
+
+    def test_router_wed_block_engages_when_requested(self):
+        from digitalmodel.well_access.router import router
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = {
+                "_config_dir_path": tmp,
+                "well_access": {
+                    "well_program": {
+                        "n_wells": 6,
+                        "field_life_years": 20,
+                        "access_class": "subsea_hub_spoke",
+                    },
+                    "calibration": {
+                        "base_rates": {
+                            "workover": {
+                                "duration_days": 45.0,
+                                "resource_class": "modu",
+                                "age_curve": [
+                                    {
+                                        "age_min_yr": 0,
+                                        "age_max_yr": 20,
+                                        "rate_per_well_year": 0.03,
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                    "access_multiplier": {"subsea_hub_spoke": {"workover": 0.6}},
+                    "wed_calibration": {
+                        "use_wed_supply": True,
+                        "supply_scope": "gom_resident",
+                    },
+                    "outputs": {"directory": tmp},
+                },
+            }
+            out = router(cfg)["well_access"]
+            assert "wed_calibration" in out
+            assert (
+                out["wed_calibration"]["provenance"]["source_issue"]
+                == "worldenergydata#638"
+            )
+            # supply-calibrated pool feeds the resource queue
+            modu = next(
+                r
+                for r in out["primary"]["resources"]
+                if r["resource_class"] == "modu"
+            )
+            assert modu["available_days"] == pytest.approx(511.0 * 20)


### PR DESCRIPTION
## What

Wires the **worldenergydata** BSEE intervention **access-gap** figures into the digitalmodel `well_access` (W7) model so intervention demand / fleet supply / cost can be calibrated to REAL figures instead of bare engineering assumptions.

digitalmodel cannot import the worldenergydata package, so the bridge is a **committed, dated snapshot**.

This **feeds #890** supply-demand gap; it provides the quantitative spine **#891 / #892** need.

## Changes

- **`base_configs/modules/well_access/wed_intervention_snapshot.yml`** — dated snapshot of the key figures: per water-depth band DEMAND/SUPPLY/GAP rig-days/yr, `$` exposure/yr, GoM-resident vs global fleet, empirical interventions/well (FLOOR), heavy-job dayrates. Full provenance (`source_repo`/`source_issue`/`source_commit`, `as_of: 2026-06-26`) and caveats inline.
- **`well_access/wed_calibration.py`** — `WedCalibration` adapter: loads the snapshot and exposes
  - empirical band demand (`BandDemand`),
  - fleet supply with the **GoM-resident binding constraint** (`FleetSupply`),
  - dayrate / cost,
  - derived `calibrated_resource_pools(...)` (heavy-pool available-days from REAL fleet supply) and `access_multiplier_from_supply_ratio(...)` (forward-looking, `m_access = min(1, supply/demand)`).
- **`well_access/router.py`** — OPTIONAL, additive hook: engages only when a `wed_calibration` block is present (default OFF). When `use_wed_supply` is set and no resources are supplied, the heavy pool's available-days come from the binding GoM-resident (or global) fleet supply; a provenance/empirical/caveats block is attached to the payload. **Existing behavior unchanged.**
- **`tests/well_access/test_wed_calibration.py`** — 16 tests (snapshot load, band/fleet/cost figures surface, caveats preserved, additive router integration on/off).

## Caveats honored (verbatim, from worldenergydata#638)

- **FORWARD-LOOKING ACCESS RISK**, not a measured crossover — `utilization_ratio > 1` is a risk *indicator*; derived multipliers carry `confidence='forward_looking_risk'`.
- **FLOOR (WAR ~6%)** — empirical interventions/well is a lifetime UPPER proxy on the ~6% depth-stamped WAR subset, NOT an annual lambda.
- **#628 GEOGRAPHY** — GoM has ~0 RESIDENT dedicated light-intervention fleet (geography + 6% WAR coverage), not avoidance; GoM-resident heavy fleet (~2 units) is the binding constraint.
- **Pressure class absent** — bands are water-depth only; HPHT / 20k-psi not resolved.
- Confidence labels preserved.

## Tests / lint

- `.venv/bin/python -m pytest tests/well_access/ -q -p no:randomly -p no:cov` → **27 passed** (16 new + 11 existing).
- `.venv/bin/ruff check` on changed Python files → **All checks passed**.
- `scripts/enforcement/check-no-abs-paths.sh` → no new violations from these files.

Source snapshot: `vamseeachanta/worldenergydata` issue #638 (epic #626), commit `adbd44c0` / PR #639.

Do not merge — review first.
