### PR TITLE
feat(asset_integrity): FFS measurement-sufficiency engine (field decision layer)

### DIFF
--- a/src/digitalmodel/asset_integrity/assessment/__init__.py
+++ b/src/digitalmodel/asset_integrity/assessment/__init__.py
@@ -6,6 +6,7 @@ Provides:
   Level1Screener   — compare t_mm to code-required t_min
   Level2Engine     — RSF/Folias-factor detailed assessment
   FFSDecision      — accept/reject/monitor/repair/replace verdict
+  MeasurementSufficiency — field guidance: sufficient / take more / escalate
   FFSReport        — self-contained HTML report generator
 """
 
@@ -15,6 +16,11 @@ from .ffs_router import FFSRouter
 from .grid_parser import GridParser
 from .level1_screener import Level1Screener
 from .level2_engine import Level2Engine
+from .measurement_sufficiency import (
+    MeasurementSufficiency,
+    SufficiencyAction,
+    SufficiencyResult,
+)
 
 __all__ = [
     "GridParser",
@@ -22,5 +28,8 @@ __all__ = [
     "Level1Screener",
     "Level2Engine",
     "FFSDecision",
+    "MeasurementSufficiency",
+    "SufficiencyAction",
+    "SufficiencyResult",
     "FFSReport",
 ]

--- a/src/digitalmodel/asset_integrity/assessment/ffs_report.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_report.py
@@ -77,6 +77,7 @@ class FFSReport:
         smys_psi: Optional[float] = None,
         corrosion_rate_in_per_yr: Optional[float] = None,
         plotly_heatmap_json: Optional[str] = None,
+        sufficiency: Optional[object] = None,
     ) -> str:
         """Render the full FFS assessment as a self-contained HTML string.
 
@@ -134,12 +135,66 @@ class FFSReport:
             FFSReport._html_foot(),
         ]
 
+        if sufficiency is not None:
+            # Field measurement-sufficiency guidance, prominent near the top.
+            sections.insert(2, FFSReport._section_sufficiency(sufficiency))
+
         if plotly_heatmap_json:
             # Insert after executive summary
             heatmap_section = FFSReport._section_heatmap(plotly_heatmap_json)
             sections.insert(2, heatmap_section)
 
         return "\n".join(sections)
+
+    @staticmethod
+    def _section_sufficiency(result: object) -> str:
+        """Render the field measurement-sufficiency guidance section.
+
+        Accepts any object exposing ``status``, ``confidence``, ``reasons``
+        (list[str]) and ``actions`` (list with ``action``/``location``/
+        ``rationale``/``count`` attributes) — i.e. a ``SufficiencyResult``.
+        """
+        status = html.escape(str(getattr(result, "status", "UNKNOWN")))
+        confidence = html.escape(str(getattr(result, "confidence", "")))
+        colors = {
+            "SUFFICIENT": "#38a169", "TAKE_MORE": "#dd6b20", "ESCALATE": "#e53e3e",
+        }
+        color = colors.get(status, _DEFAULT_COLOR)
+        reasons = getattr(result, "reasons", []) or []
+        actions = getattr(result, "actions", []) or []
+
+        reason_items = "".join(
+            f"<li>{html.escape(str(r))}</li>" for r in reasons
+        )
+        action_rows = ""
+        for a in actions:
+            act = html.escape(str(getattr(a, "action", "")))
+            loc = html.escape(str(getattr(a, "location", "")))
+            why = html.escape(str(getattr(a, "rationale", "")))
+            cnt = getattr(a, "count", None)
+            cnt_str = "" if cnt is None else f" (x{int(cnt)})"
+            action_rows += (
+                f"<tr><td><strong>{act}{cnt_str}</strong></td>"
+                f"<td>{loc}</td><td>{why}</td></tr>"
+            )
+        action_table = (
+            "<table><thead><tr><th>Action</th><th>Where</th><th>Why</th></tr>"
+            f"</thead><tbody>{action_rows}</tbody></table>"
+            if action_rows else "<p>No further field action required.</p>"
+        )
+
+        return (
+            "<div class='section'>\n"
+            "<h2>Field Measurement Sufficiency</h2>\n"
+            f"<p><span style='display:inline-block;padding:4px 12px;border-radius:6px;"
+            f"color:#fff;font-weight:700;background:{color}'>{status}</span>"
+            f" &nbsp; confidence: {confidence}</p>\n"
+            f"<ul>{reason_items}</ul>\n"
+            f"{action_table}\n"
+            "<p><em>Field screening only — does not replace a detailed Level 2/3 "
+            "assessment.</em></p>\n"
+            "</div>"
+        )
 
     # ------------------------------------------------------------------
     # Section builders

--- a/src/digitalmodel/asset_integrity/assessment/measurement_sufficiency.py
+++ b/src/digitalmodel/asset_integrity/assessment/measurement_sufficiency.py
@@ -1,0 +1,321 @@
+# ABOUTME: Field measurement-sufficiency engine for FFS — tells an inspector
+# ABOUTME: whether thickness data is adequate (sufficient / take more / escalate).
+"""Measurement-sufficiency engine (FFS Phase 1).
+
+The FFS assessment modules return a *verdict* (ACCEPT / RE_RATE / ...), but a
+field inspector also needs to know whether the wall-thickness measurements they
+took are **adequate to trust that verdict** — and, if not, exactly what else to
+capture *before leaving the site*. This module answers that question so that
+re-measurement does not become a new work order / re-mobilisation.
+
+It consumes the outputs of the existing Phase-1 pipeline
+(:class:`~...assessment.grid_parser.GridParser`,
+:class:`~...assessment.ffs_router.FFSRouter`,
+:class:`~...assessment.level1_screener.Level1Screener`,
+:class:`~...assessment.level2_engine.Level2Engine`) and returns one of three
+field actions:
+
+* ``SUFFICIENT`` — data is adequate and Level 1 passes with margin; the
+  inspector can demobilise.
+* ``TAKE_MORE`` — capture specific additional readings now (with counts and
+  locations) before leaving.
+* ``ESCALATE`` — data is adequate but the result needs a higher-level (office
+  Level 2 / Level 3) assessment; do not re-measure in the field, hand to
+  engineering.
+
+This screening **does not replace** a detailed Level 2/3 assessment; it guides
+the field decision.
+
+Thresholds are engineering defaults informed by API 579-1/ASME FFS-1 Part 4
+(point-thickness averaging is justified when the coefficient of variation is
+small) and common UT practice; they are configurable, not code mandates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+# RSF below which the component is in repair/replace territory — more field
+# readings will not change the need for an engineering (Level 3) assessment.
+_SEVERE_RSF_FLOOR = 0.50
+
+
+@dataclass
+class SufficiencyAction:
+    """A concrete recommended field action."""
+
+    action: str          # e.g. add_readings | densify_readings | extend_coverage
+                         #      | remeasure_min_cell | escalate_level_2 | escalate_level_3
+    location: str        # where to act (human-readable)
+    rationale: str       # why
+    count: Optional[int] = None   # recommended number of additional readings
+
+
+@dataclass
+class SufficiencyResult:
+    """Outcome of a measurement-sufficiency evaluation."""
+
+    status: str          # SUFFICIENT | TAKE_MORE | ESCALATE
+    confidence: str      # high | medium | low
+    reasons: list = field(default_factory=list)
+    actions: list = field(default_factory=list)  # list[SufficiencyAction]
+    metrics: dict = field(default_factory=dict)
+
+
+class MeasurementSufficiency:
+    """Assess whether a thickness-measurement grid is adequate for an FFS verdict.
+
+    Parameters
+    ----------
+    min_readings:
+        Minimum number of valid thickness readings before area-averaging /
+        screening is considered statistically supported (Part 4 favours a
+        reasonable sample; 15 is a common practice default).
+    max_cov_gml:
+        Maximum coefficient of variation (std/mean) for which uniform
+        (general metal loss) area-averaging is trustworthy. Above this the
+        loss is non-uniform and a local thin spot may be masked.
+    ut_tolerance_in:
+        Ultrasonic thickness measurement tolerance (inches). If the pass
+        margin is smaller than this, the verdict is within measurement error.
+    min_lml_profile_cells:
+        Minimum number of grid cells that must resolve a local flaw for the
+        river-bottom (critical thickness) profile to be considered sampled.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_readings: int = 15,
+        max_cov_gml: float = 0.10,
+        ut_tolerance_in: float = 0.020,
+        min_lml_profile_cells: int = 5,
+    ) -> None:
+        self.min_readings = min_readings
+        self.max_cov_gml = max_cov_gml
+        self.ut_tolerance_in = ut_tolerance_in
+        self.min_lml_profile_cells = min_lml_profile_cells
+
+    # ------------------------------------------------------------------
+    def evaluate(
+        self,
+        grid_df: pd.DataFrame,
+        *,
+        nominal_wt_in: float,
+        assessment_type: str,
+        level1_result: dict,
+        level2_result: dict,
+    ) -> SufficiencyResult:
+        """Return a :class:`SufficiencyResult` for the given grid and results.
+
+        Args:
+            grid_df: Normalised wall-thickness grid (inches), rows x cols.
+            nominal_wt_in: Nominal wall thickness (inches).
+            assessment_type: ``'GML'`` or ``'LML'`` (from FFSRouter).
+            level1_result: dict from ``Level1Screener.evaluate`` (needs
+                ``verdict``, ``t_min_in``, ``margin_in``).
+            level2_result: dict from ``Level2Engine.evaluate`` (needs ``rsf``,
+                ``rsf_a``, ``t_mm_in``).
+        """
+        atype = assessment_type.upper().strip()
+        metrics = self._metrics(grid_df, nominal_wt_in, level1_result, level2_result)
+
+        rsf = float(level2_result["rsf"])
+        rsf_a = float(level2_result["rsf_a"])
+        l1_pass = level1_result.get("verdict") == "ACCEPT"
+
+        reasons: list = []
+        actions: list = []
+
+        # --- Precedence 1: severe loss → escalate (data won't change need) ---
+        if rsf < _SEVERE_RSF_FLOOR:
+            reasons.append(
+                f"RSF={rsf:.3f} is below the {_SEVERE_RSF_FLOOR:.2f} floor — the "
+                "component is in repair/replace territory; a Level 3 / engineering "
+                "assessment is required regardless of additional field readings."
+            )
+            actions.append(SufficiencyAction(
+                action="escalate_level_3",
+                location="office / engineering review",
+                rationale="RSF below safe re-rating floor",
+            ))
+            # Still useful to map the full extent for repair scoping.
+            if metrics["min_on_edge"] and metrics["min_degraded"]:
+                actions.append(SufficiencyAction(
+                    action="extend_coverage",
+                    location=f"beyond grid edge near min cell {metrics['min_location']}",
+                    rationale="bound the full extent of loss for repair scoping",
+                ))
+            return SufficiencyResult(
+                status="ESCALATE", confidence="high",
+                reasons=reasons, actions=actions, metrics=metrics,
+            )
+
+        # --- Precedence 2: data-adequacy gaps → take more readings now ---
+        if metrics["n_readings"] < self.min_readings:
+            reasons.append(
+                f"Only {metrics['n_readings']} valid readings; at least "
+                f"{self.min_readings} are recommended before averaging/screening "
+                "is statistically supported."
+            )
+            actions.append(SufficiencyAction(
+                action="add_readings",
+                count=self.min_readings - metrics["n_readings"],
+                location="distributed across the component / CML grid",
+                rationale="insufficient reading count",
+            ))
+
+        if atype == "GML" and metrics["cov"] is not None and metrics["cov"] > self.max_cov_gml:
+            reasons.append(
+                f"Thickness scatter COV={metrics['cov']:.2f} exceeds {self.max_cov_gml:.2f}; "
+                "loss is non-uniform, so general (area-averaged) assessment may mask a "
+                "local thin spot."
+            )
+            actions.append(SufficiencyAction(
+                action="densify_readings",
+                location=f"around the minimum-thickness cell {metrics['min_location']}",
+                rationale="high scatter — possible localised metal loss",
+            ))
+
+        if atype == "LML" and metrics["profile_cells"] < self.min_lml_profile_cells:
+            reasons.append(
+                f"Local flaw is resolved by only {metrics['profile_cells']} grid cells; "
+                "the critical (river-bottom) thickness profile is under-sampled."
+            )
+            actions.append(SufficiencyAction(
+                action="densify_readings",
+                count=self.min_lml_profile_cells - metrics["profile_cells"],
+                location="across and immediately around the flaw",
+                rationale="under-resolved local thickness profile",
+            ))
+
+        if metrics["min_on_edge"] and metrics["min_degraded"]:
+            reasons.append(
+                "The minimum thickness lies on the grid boundary; the thinned region "
+                "may continue beyond the measured area."
+            )
+            actions.append(SufficiencyAction(
+                action="extend_coverage",
+                location=f"beyond the grid edge near min cell {metrics['min_location']}",
+                rationale="boundary minimum — coverage may be incomplete",
+            ))
+
+        if (metrics["t_margin_in"] is not None
+                and 0.0 <= metrics["t_margin_in"] < self.ut_tolerance_in):
+            reasons.append(
+                f"Minimum thickness exceeds t_min by only {metrics['t_margin_in']:.3f} in, "
+                f"within the UT tolerance of {self.ut_tolerance_in:.3f} in — the pass is "
+                "within measurement error."
+            )
+            actions.append(SufficiencyAction(
+                action="remeasure_min_cell",
+                count=3,
+                location=f"at/around the minimum-thickness cell {metrics['min_location']}",
+                rationale="verdict is sensitive to measurement error",
+            ))
+
+        if actions:
+            confidence = "low" if metrics["n_readings"] < self.min_readings else "medium"
+            return SufficiencyResult(
+                status="TAKE_MORE", confidence=confidence,
+                reasons=reasons, actions=actions, metrics=metrics,
+            )
+
+        # --- Precedence 3: data adequate → sufficient or escalate by verdict ---
+        if l1_pass and rsf >= rsf_a:
+            comfortable = (metrics["t_margin_in"] is None
+                           or metrics["t_margin_in"] >= 2.0 * self.ut_tolerance_in)
+            reasons.append(
+                "Grid coverage and scatter are adequate and Level 1 passes with margin "
+                "— the field measurements are sufficient to support the verdict."
+            )
+            return SufficiencyResult(
+                status="SUFFICIENT",
+                confidence="high" if comfortable else "medium",
+                reasons=reasons, actions=actions, metrics=metrics,
+            )
+
+        # Data adequate but Level 1 fails or Level 2 below RSFa → office escalation.
+        if not l1_pass and rsf >= rsf_a:
+            reasons.append(
+                "Level 1 fails (t_mm < t_min) but Level 2 RSF passes — a formal "
+                "Level 2 re-rating in the office is warranted; field data is adequate."
+            )
+            actions.append(SufficiencyAction(
+                action="escalate_level_2",
+                location="office Level 2 re-rating",
+                rationale="Level 1 screening fail with passing Level 2 RSF",
+            ))
+        else:  # rsf in [floor, rsf_a)
+            reasons.append(
+                f"RSF={rsf:.3f} is between the {_SEVERE_RSF_FLOOR:.2f} floor and "
+                f"RSFa={rsf_a:.2f} — re-rating / Level 2 evaluation in the office; "
+                "field data is adequate."
+            )
+            actions.append(SufficiencyAction(
+                action="escalate_level_2",
+                location="office Level 2 re-rating",
+                rationale="RSF below RSFa but above the replace floor",
+            ))
+        return SufficiencyResult(
+            status="ESCALATE", confidence="high",
+            reasons=reasons, actions=actions, metrics=metrics,
+        )
+
+    # ------------------------------------------------------------------
+    def _metrics(
+        self,
+        grid_df: pd.DataFrame,
+        nominal_wt_in: float,
+        level1_result: dict,
+        level2_result: dict,
+    ) -> dict:
+        """Compute grid-adequacy and margin metrics."""
+        arr = grid_df.to_numpy(dtype=float)
+        n = int(np.count_nonzero(~np.isnan(arr)))
+        mean = float(np.nanmean(arr)) if n else 0.0
+        std = float(np.nanstd(arr)) if n else 0.0  # population std (ddof=0)
+        cov = (std / mean) if (n > 1 and mean > 0) else (0.0 if n else None)
+
+        # Cells that participate in a local flaw (>10% loss from nominal).
+        # NaN comparisons evaluate False, so NaN cells are not counted.
+        degraded_threshold = nominal_wt_in * 0.90
+        profile_cells = int((arr < degraded_threshold).sum()) if n else 0
+
+        # Location of the minimum thickness and whether it sits on a boundary.
+        if n:
+            r, c = np.unravel_index(np.nanargmin(arr), arr.shape)
+            min_thickness = float(arr[r, c])
+            on_edge = bool(
+                r == 0 or r == arr.shape[0] - 1
+                or c == 0 or c == arr.shape[1] - 1
+            )
+            min_location = (int(r), int(c))   # (row, col) positional indices
+            min_degraded = bool(min_thickness < degraded_threshold)
+        else:
+            min_thickness = None
+            on_edge = False
+            min_location = None
+            min_degraded = False
+
+        # Pass margin in thickness terms (Level 1).
+        t_margin_in = level1_result.get("margin_in")
+        if t_margin_in is not None:
+            t_margin_in = float(t_margin_in)
+
+        return {
+            "n_readings": n,
+            "cov": cov,
+            "min_thickness_in": min_thickness,
+            "min_location": min_location,
+            "min_on_edge": on_edge,
+            "min_degraded": min_degraded,
+            "profile_cells": profile_cells,
+            "t_margin_in": t_margin_in,
+            "rsf": float(level2_result.get("rsf", 0.0)),
+            "rsf_a": float(level2_result.get("rsf_a", 0.0)),
+        }

--- a/tests/asset_integrity/test_measurement_sufficiency.py
+++ b/tests/asset_integrity/test_measurement_sufficiency.py
@@ -1,0 +1,239 @@
+# ABOUTME: Tests for the FFS measurement-sufficiency engine (sufficient / take
+# ABOUTME: more / escalate) — one test per decision branch + metrics.
+"""Tests for digitalmodel.asset_integrity.assessment.measurement_sufficiency."""
+
+import pandas as pd
+import pytest
+
+from digitalmodel.asset_integrity.assessment.measurement_sufficiency import (
+    MeasurementSufficiency,
+    SufficiencyAction,
+    SufficiencyResult,
+)
+
+NOMINAL = 0.50  # inches
+
+
+# --- helpers ---------------------------------------------------------------
+def adequate_grid():
+    """5x5 grid, interior minimum, not degraded, low scatter (>=15 readings)."""
+    df = pd.DataFrame([[0.47] * 5 for _ in range(5)])
+    df.iat[2, 2] = 0.46          # interior unique minimum, > 0.45 (not degraded)
+    return df
+
+
+def l1(verdict="ACCEPT", t_min=0.30, margin=0.16):
+    return {"verdict": verdict, "t_min_in": t_min, "margin_in": margin}
+
+
+def l2(rsf=0.95, rsf_a=0.90, t_mm=0.46):
+    return {"rsf": rsf, "rsf_a": rsf_a, "t_mm_in": t_mm}
+
+
+@pytest.fixture
+def engine():
+    return MeasurementSufficiency()
+
+
+def _actions(result):
+    return {a.action for a in result.actions}
+
+
+# --- SUFFICIENT ------------------------------------------------------------
+def test_sufficient_when_adequate_and_passing(engine):
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert isinstance(res, SufficiencyResult)
+    assert res.status == "SUFFICIENT"
+    assert res.confidence == "high"
+    assert res.actions == []
+
+
+def test_sufficient_medium_confidence_thin_margin(engine):
+    # Margin above UT tolerance (no take-more) but below 2x tolerance -> medium.
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(margin=0.03), level2_result=l2(),
+    )
+    assert res.status == "SUFFICIENT"
+    assert res.confidence == "medium"
+
+
+# --- TAKE_MORE -------------------------------------------------------------
+def test_take_more_too_few_readings(engine):
+    small = pd.DataFrame([[0.47] * 3 for _ in range(3)])  # 9 < 15
+    res = engine.evaluate(
+        small, nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.status == "TAKE_MORE"
+    assert res.confidence == "low"
+    assert "add_readings" in _actions(res)
+    add = next(a for a in res.actions if a.action == "add_readings")
+    assert add.count == 15 - 9
+
+
+def test_take_more_high_cov_gml(engine):
+    # Interior low-thickness cluster -> high COV, non-uniform GML.
+    df = pd.DataFrame([[0.50] * 4 for _ in range(4)])
+    for r, c in [(1, 1), (1, 2), (2, 1), (2, 2)]:
+        df.iat[r, c] = 0.30
+    res = engine.evaluate(
+        df, nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.status == "TAKE_MORE"
+    assert "densify_readings" in _actions(res)
+    assert res.metrics["cov"] > 0.10
+
+
+def test_take_more_lml_underresolved(engine):
+    # LML with only 2 degraded cells -> profile under-sampled.
+    df = pd.DataFrame([[0.48] * 4 for _ in range(4)])
+    df.iat[1, 1] = 0.40
+    df.iat[2, 2] = 0.40
+    res = engine.evaluate(
+        df, nominal_wt_in=NOMINAL, assessment_type="LML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.status == "TAKE_MORE"
+    assert "densify_readings" in _actions(res)
+    assert res.metrics["profile_cells"] == 2
+
+
+def test_take_more_minimum_on_edge(engine):
+    # Degraded minimum on the grid boundary -> extend coverage.
+    df = pd.DataFrame([[0.48] * 4 for _ in range(4)])
+    df.iat[0, 0] = 0.40   # boundary, degraded (< 0.45)
+    res = engine.evaluate(
+        df, nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.status == "TAKE_MORE"
+    assert "extend_coverage" in _actions(res)
+    assert res.metrics["min_on_edge"] is True
+    assert res.metrics["min_degraded"] is True
+
+
+def test_take_more_verdict_within_ut_tolerance(engine):
+    # Pass margin smaller than UT tolerance -> remeasure the min cell.
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(margin=0.01), level2_result=l2(),
+    )
+    assert res.status == "TAKE_MORE"
+    assert "remeasure_min_cell" in _actions(res)
+    rm = next(a for a in res.actions if a.action == "remeasure_min_cell")
+    assert rm.count == 3
+
+
+def test_uniform_grid_does_not_false_flag_edge(engine):
+    # A truly uniform, healthy grid: min is the first (edge) cell but NOT
+    # degraded -> must not trigger an extend_coverage take-more.
+    df = pd.DataFrame([[0.47] * 5 for _ in range(5)])  # all equal
+    res = engine.evaluate(
+        df, nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.status == "SUFFICIENT"
+    assert "extend_coverage" not in _actions(res)
+
+
+# --- ESCALATE --------------------------------------------------------------
+def test_escalate_severe_rsf(engine):
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="LML",
+        level1_result=l1(verdict="FAIL_LEVEL_1", margin=-0.05),
+        level2_result=l2(rsf=0.40),
+    )
+    assert res.status == "ESCALATE"
+    assert res.confidence == "high"
+    assert "escalate_level_3" in _actions(res)
+
+
+def test_escalate_level1_fail_level2_pass(engine):
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(verdict="FAIL_LEVEL_1", margin=-0.01),
+        level2_result=l2(rsf=0.92, rsf_a=0.90),
+    )
+    assert res.status == "ESCALATE"
+    assert "escalate_level_2" in _actions(res)
+
+
+def test_escalate_rsf_below_rsfa(engine):
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(rsf=0.70, rsf_a=0.90),
+    )
+    assert res.status == "ESCALATE"
+    assert "escalate_level_2" in _actions(res)
+
+
+# --- metrics + action structure -------------------------------------------
+def test_metrics_reported(engine):
+    res = engine.evaluate(
+        adequate_grid(), nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    m = res.metrics
+    assert m["n_readings"] == 25
+    assert m["min_location"] == (2, 2)
+    assert m["min_on_edge"] is False
+    assert m["cov"] is not None and m["cov"] >= 0.0
+
+
+def test_actions_have_location_and_rationale(engine):
+    res = engine.evaluate(
+        pd.DataFrame([[0.47] * 3 for _ in range(3)]),
+        nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    assert res.actions
+    for a in res.actions:
+        assert isinstance(a, SufficiencyAction)
+        assert a.location and a.rationale
+
+
+# --- FFS report integration ------------------------------------------------
+def test_ffs_report_includes_sufficiency_section(engine):
+    from digitalmodel.asset_integrity.assessment import FFSDecision, FFSReport
+
+    grid = pd.DataFrame([[0.47] * 3 for _ in range(3)])  # sparse -> TAKE_MORE
+    suf = engine.evaluate(
+        grid, nominal_wt_in=NOMINAL, assessment_type="GML",
+        level1_result=l1(), level2_result=l2(),
+    )
+    decision = FFSDecision.decide(
+        level1_verdict="ACCEPT", level2_verdict="ACCEPT",
+        rsf=0.95, rsf_a=0.90, t_mm_in=0.46, t_min_in=0.30,
+        corrosion_rate_in_per_yr=0.005,
+    )
+    html_out = FFSReport.generate_html(
+        grid_df=grid, decision=decision, component_id="TEST-001",
+        nominal_od_in=12.75, nominal_wt_in=0.50, t_min_in=0.30,
+        design_code="B31.8", design_pressure_psi=1000,
+        sufficiency=suf,
+    )
+    assert "Field Measurement Sufficiency" in html_out
+    assert "TAKE_MORE" in html_out
+    assert "add_readings" in html_out
+
+
+def test_ffs_report_omits_sufficiency_when_absent():
+    from digitalmodel.asset_integrity.assessment import FFSDecision, FFSReport
+
+    grid = pd.DataFrame([[0.47] * 3 for _ in range(3)])
+    decision = FFSDecision.decide(
+        level1_verdict="ACCEPT", level2_verdict="ACCEPT",
+        rsf=0.95, rsf_a=0.90, t_mm_in=0.46, t_min_in=0.30,
+        corrosion_rate_in_per_yr=0.005,
+    )
+    html_out = FFSReport.generate_html(
+        grid_df=grid, decision=decision, component_id="TEST-001",
+        nominal_od_in=12.75, nominal_wt_in=0.50, t_min_in=0.30,
+        design_code="B31.8", design_pressure_psi=1000,
+    )
+    assert "Field Measurement Sufficiency" not in html_out


### PR DESCRIPTION
Closes #1059. First build of FFS epic #1057.

## What
`MeasurementSufficiency` tells a field inspector whether their wall-thickness measurements are adequate to trust the FFS verdict — and, if not, exactly what else to capture **before demobilising**. Three outcomes:
- **SUFFICIENT** — data adequate + Level 1 passes with margin → demobilise.
- **TAKE_MORE** — capture specific extra readings now (with count + location): too few readings, high COV (non-uniform GML can mask a local thin spot), under-resolved LML river-bottom profile, a degraded minimum on the grid boundary, or a pass within UT tolerance.
- **ESCALATE** — data adequate but the result needs office Level 2/3 (don't re-measure).

This screening **does not replace** detailed Level 2/3 analysis — it mitigates iterations on work orders for re-measurement.

## How
Consumes the existing Phase-1 outputs (`GridParser` / `FFSRouter` / `Level1Screener` / `Level2Engine`) — no physics reimplemented. Wired into `FFSReport` via an optional `sufficiency` section (backward compatible). Thresholds are API-579-informed engineering defaults (reading count, COV ≤ 0.10, UT tolerance), all configurable — not code mandates.

## Why it matters (end-to-end demo)
A 2-cell localized thin spot returns **Level 1 + Level 2 ACCEPT (RSF=1.000)** — the calculators say fit-for-service — but the engine returns **TAKE_MORE: densify 3 readings around the flaw**, because a local flaw resolved by 2 cells is an under-sampled profile. It catches an under-measured ACCEPT before the inspector leaves the field.

## Tests
15 new tests (every branch + report integration + metrics); **85 asset_integrity tests green**, no regression.