### PR TITLE
feat(asset_integrity): corroded-pipe remaining strength — B31G / Modified B31G / RSTRENG

### DIFF
--- a/src/digitalmodel/asset_integrity/corroded_pipe.py
+++ b/src/digitalmodel/asset_integrity/corroded_pipe.py
@@ -1,0 +1,251 @@
+# ABOUTME: Corroded-pipe remaining-strength — ASME B31G, Modified B31G (0.85dL)
+# ABOUTME: and RSTRENG effective-area failure-pressure methods (FFS Level 1/2).
+"""Corroded-pipeline remaining-strength assessment.
+
+Implements the three classic remaining-strength methods for a blunt metal-loss
+defect in a pressurised pipe, all of the common form
+
+    P_f = (2 * S_flow * t / D) * (1 - A/A0) / (1 - (A/A0) / M)
+
+where ``S_flow`` is the flow stress, ``A/A0`` the fractional metal-loss area in
+the longitudinal plane and ``M`` the Folias (bulging) factor:
+
+* **Original B31G** — parabolic area ``A/A0 = (2/3)(d/t)``,
+  ``S_flow = 1.1*SMYS``, ``M = sqrt(1 + 0.8 z)`` for ``z = L^2/(D t) <= 20``;
+  for longer flaws the defect is treated as infinitely long
+  (``P_f = 2 S_flow t/D * (1 - d/t)``).
+* **Modified B31G (0.85 dL)** — ``A/A0 = 0.85(d/t)``,
+  ``S_flow = SMYS + 10 ksi``, two-part ``M``
+  (``sqrt(1 + 0.6275 z - 0.003375 z^2)`` for ``z <= 50`` else ``0.032 z + 3.3``).
+* **RSTRENG effective-area** — same flow stress and ``M`` as Modified B31G but
+  ``A`` is the *measured* metal-loss area from a river-bottom thickness profile;
+  the governing (lowest failure pressure) sub-segment of the profile is
+  searched and returned.
+
+Formula constants confirmed against ASME B31G-2012 / the ``pipenostics``
+reference. Units are US customary: lengths in inches, pressures and stresses in
+psi.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+import numpy as np
+
+# Flow-stress adder for Modified B31G / RSTRENG: SMYS + 10 ksi (= 68.95 MPa).
+_FLOW_ADDER_PSI = 10_000.0
+# Default safety factor applied to predicted failure pressure (B31G practice).
+_DEFAULT_SAFETY_FACTOR = 1.39
+
+# API 5L specified minimum yield strength (psi) — grade number is SMYS in ksi.
+SMYS_PSI = {
+    "X42": 42_000.0, "X46": 46_000.0, "X52": 52_000.0, "X56": 56_000.0,
+    "X60": 60_000.0, "X65": 65_000.0, "X70": 70_000.0, "X80": 80_000.0,
+}
+
+
+@dataclass
+class CorrodedPipeResult:
+    """Remaining-strength result for a corroded pipe defect."""
+
+    method: str                  # B31G | Modified_B31G | RSTRENG
+    failure_pressure_psi: float  # predicted burst pressure of the defect
+    intact_pressure_psi: float   # flow-stress pressure of the undamaged pipe
+    flow_stress_psi: float
+    folias_factor: float
+    area_ratio: float            # A/A0 (fraction of wall area lost)
+    rsf: float                   # failure_pressure / intact_pressure
+    safe_pressure_psi: float     # failure_pressure / safety_factor
+    acceptable: Optional[bool] = None   # safe_pressure >= MAOP (if given)
+    details: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Folias bulging factors
+# ---------------------------------------------------------------------------
+def folias_original(z: float) -> Optional[float]:
+    """Original B31G Folias factor; ``None`` signals the infinite-length regime."""
+    if z <= 20.0:
+        return math.sqrt(1.0 + 0.8 * z)
+    return None
+
+
+def folias_modified(z: float) -> float:
+    """Modified B31G / RSTRENG two-part Folias factor."""
+    if z <= 50.0:
+        return math.sqrt(1.0 + 0.6275 * z - 0.003375 * z * z)
+    return 0.032 * z + 3.3
+
+
+def _failure_pressure(flow: float, t: float, D: float, ar: float, M: float) -> float:
+    """Common B31G failure-pressure form (guards full-penetration A/A0 -> 1)."""
+    ar = min(ar, 0.999)
+    return (2.0 * flow * t / D) * (1.0 - ar) / (1.0 - ar / M)
+
+
+def _finalise(method, pf, intact, flow, M, ar, *, maop_psi, safety_factor, details):
+    safe = pf / safety_factor
+    return CorrodedPipeResult(
+        method=method,
+        failure_pressure_psi=pf,
+        intact_pressure_psi=intact,
+        flow_stress_psi=flow,
+        folias_factor=M,
+        area_ratio=ar,
+        rsf=(pf / intact) if intact > 0 else float("nan"),
+        safe_pressure_psi=safe,
+        acceptable=(None if maop_psi is None else bool(safe >= maop_psi)),
+        details=details,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Methods
+# ---------------------------------------------------------------------------
+def b31g_original(
+    D: float, t: float, d: float, L: float, smys_psi: float,
+    *, maop_psi: Optional[float] = None, safety_factor: float = _DEFAULT_SAFETY_FACTOR,
+) -> CorrodedPipeResult:
+    """Original ASME B31G remaining-strength failure pressure.
+
+    Args:
+        D: Pipe outside diameter (in). t: nominal wall thickness (in).
+        d: maximum defect depth (in). L: axial defect length (in).
+        smys_psi: specified minimum yield strength (psi).
+        maop_psi: maximum allowable operating pressure for an accept/reject flag.
+        safety_factor: applied to failure pressure for the safe pressure.
+    """
+    _validate(D, t, d, L)
+    flow = 1.1 * smys_psi
+    intact = 2.0 * flow * t / D
+    z = L * L / (D * t)
+    M = folias_original(z)
+    if M is None:  # infinitely long flaw
+        ar = d / t
+        pf = 2.0 * flow * t / D * (1.0 - ar)
+        M_report, regime = float("inf"), "infinite_length"
+    else:
+        ar = (2.0 / 3.0) * (d / t)
+        pf = _failure_pressure(flow, t, D, ar, M)
+        M_report, regime = M, "parabolic"
+    return _finalise(
+        "B31G", pf, intact, flow, M_report, ar,
+        maop_psi=maop_psi, safety_factor=safety_factor,
+        details={"z": z, "regime": regime, "d_over_t": d / t},
+    )
+
+
+def modified_b31g(
+    D: float, t: float, d: float, L: float, smys_psi: float,
+    *, maop_psi: Optional[float] = None, safety_factor: float = _DEFAULT_SAFETY_FACTOR,
+) -> CorrodedPipeResult:
+    """Modified B31G (0.85 dL) remaining-strength failure pressure."""
+    _validate(D, t, d, L)
+    flow = smys_psi + _FLOW_ADDER_PSI
+    intact = 2.0 * flow * t / D
+    z = L * L / (D * t)
+    M = folias_modified(z)
+    ar = 0.85 * (d / t)
+    pf = _failure_pressure(flow, t, D, ar, M)
+    return _finalise(
+        "Modified_B31G", pf, intact, flow, M, ar,
+        maop_psi=maop_psi, safety_factor=safety_factor,
+        details={"z": z, "d_over_t": d / t},
+    )
+
+
+def rstreng_effective_area(
+    D: float, t: float, positions_in: Sequence[float], depths_in: Sequence[float],
+    smys_psi: float, *, maop_psi: Optional[float] = None,
+    safety_factor: float = _DEFAULT_SAFETY_FACTOR,
+) -> CorrodedPipeResult:
+    """RSTRENG effective-area method from a river-bottom metal-loss profile.
+
+    Args:
+        positions_in: axial positions of the profile points (in), increasing.
+        depths_in: metal-loss DEPTH at each position (in); 0 = full wall.
+    The governing sub-segment (lowest predicted failure pressure) is returned.
+    """
+    _validate_geometry(D, t)
+    x = np.asarray(positions_in, dtype=float)
+    d = np.asarray(depths_in, dtype=float)
+    if x.shape != d.shape or x.size < 2:
+        raise ValueError("positions_in and depths_in must be equal-length (>=2).")
+    if np.any(np.diff(x) <= 0):
+        raise ValueError("positions_in must be strictly increasing.")
+    if np.any(d < 0) or np.any(d > t):
+        raise ValueError("depths must be within [0, t].")
+
+    flow = smys_psi + _FLOW_ADDER_PSI
+    intact = 2.0 * flow * t / D
+    # Prefix trapezoidal integral of metal-loss depth for O(1) sub-segment area.
+    seg = np.diff(x) * 0.5 * (d[:-1] + d[1:])           # area of each interval
+    cum = np.concatenate(([0.0], np.cumsum(seg)))        # cum[k] = area up to x[k]
+
+    n = x.size
+    worst_pf = math.inf
+    worst = None
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            L = x[j] - x[i]
+            if L <= 0:
+                continue
+            A = cum[j] - cum[i]            # effective metal-loss area
+            A0 = t * L
+            ar = A / A0 if A0 > 0 else 0.0
+            z = L * L / (D * t)
+            M = folias_modified(z)
+            pf = _failure_pressure(flow, t, D, ar, M)
+            if pf < worst_pf:
+                worst_pf = pf
+                worst = {"L": float(L), "ar": float(ar), "M": float(M),
+                         "i": i, "j": j}
+    return _finalise(
+        "RSTRENG", worst_pf, intact, flow, worst["M"], worst["ar"],
+        maop_psi=maop_psi, safety_factor=safety_factor,
+        details={"critical_length_in": worst["L"],
+                 "critical_segment": (worst["i"], worst["j"])},
+    )
+
+
+def allowable_flaw_length(
+    D: float, t: float, d: float, smys_psi: float, design_pressure_psi: float,
+    *, method: str = "modified", safety_factor: float = _DEFAULT_SAFETY_FACTOR,
+    max_length_in: float = 1000.0,
+) -> float:
+    """Maximum axial flaw length (in) acceptable at the design pressure.
+
+    Reconstructs the ASME B31G "allowable defect length" relationship by
+    bisecting the failure-pressure curve for the chosen method.
+    """
+    fn = modified_b31g if method.lower().startswith("mod") else b31g_original
+    # Acceptable at L=0; find the length where safe pressure drops to design.
+    lo, hi = 1.0e-6, max_length_in
+    if fn(D, t, d, hi, smys_psi, safety_factor=safety_factor).safe_pressure_psi \
+            >= design_pressure_psi:
+        return max_length_in
+    for _ in range(80):
+        mid = 0.5 * (lo + hi)
+        safe = fn(D, t, d, mid, smys_psi, safety_factor=safety_factor).safe_pressure_psi
+        if safe >= design_pressure_psi:
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
+# ---------------------------------------------------------------------------
+def _validate_geometry(D: float, t: float) -> None:
+    if D <= 0 or t <= 0 or t >= D:
+        raise ValueError(f"Invalid geometry: D={D}, t={t}.")
+
+
+def _validate(D: float, t: float, d: float, L: float) -> None:
+    _validate_geometry(D, t)
+    if not (0.0 <= d <= t):
+        raise ValueError(f"defect depth d={d} must be in [0, t={t}].")
+    if L < 0:
+        raise ValueError(f"defect length L={L} must be >= 0.")

--- a/tests/asset_integrity/test_corroded_pipe.py
+++ b/tests/asset_integrity/test_corroded_pipe.py
@@ -1,0 +1,153 @@
+# ABOUTME: Tests for corroded-pipe remaining strength (B31G / Modified B31G /
+# ABOUTME: RSTRENG) — golden hand-calcs, regimes, monotonicity, validation.
+"""Tests for digitalmodel.asset_integrity.corroded_pipe."""
+
+import math
+
+import pytest
+
+from digitalmodel.asset_integrity.corroded_pipe import (
+    SMYS_PSI,
+    CorrodedPipeResult,
+    allowable_flaw_length,
+    b31g_original,
+    folias_modified,
+    folias_original,
+    modified_b31g,
+    rstreng_effective_area,
+)
+
+# Reference defect: 30 in OD x 0.375 in WT, d=0.15 in (40% WT), L=8 in, X52.
+D, T, DEPTH, LEN, SMYS = 30.0, 0.375, 0.15, 8.0, 52_000.0
+
+
+# --- Folias factors --------------------------------------------------------
+def test_folias_original_parabolic():
+    # z = 8^2 / (30*0.375) = 5.6889 -> sqrt(1+0.8z) = 2.356
+    assert folias_original(5.68889) == pytest.approx(2.3561, rel=1e-3)
+
+
+def test_folias_original_infinite_regime_returns_none():
+    assert folias_original(25.0) is None
+
+
+def test_folias_modified_two_part():
+    assert folias_modified(5.68889) == pytest.approx(2.1120, rel=1e-3)
+    # z > 50 uses the linear branch
+    assert folias_modified(60.0) == pytest.approx(0.032 * 60 + 3.3, rel=1e-6)
+
+
+# --- Golden hand calculations ----------------------------------------------
+def test_modified_b31g_golden():
+    r = modified_b31g(D, T, DEPTH, LEN, SMYS)
+    assert isinstance(r, CorrodedPipeResult)
+    assert r.flow_stress_psi == pytest.approx(62_000.0)
+    assert r.intact_pressure_psi == pytest.approx(1550.0, rel=1e-4)
+    assert r.area_ratio == pytest.approx(0.34, rel=1e-6)
+    assert r.failure_pressure_psi == pytest.approx(1219.3, rel=2e-3)
+    assert r.rsf == pytest.approx(0.7866, rel=2e-3)
+
+
+def test_original_b31g_golden():
+    r = b31g_original(D, T, DEPTH, LEN, SMYS)
+    assert r.flow_stress_psi == pytest.approx(57_200.0)
+    assert r.intact_pressure_psi == pytest.approx(1430.0, rel=1e-4)
+    assert r.failure_pressure_psi == pytest.approx(1182.6, rel=2e-3)
+    assert r.details["regime"] == "parabolic"
+
+
+def test_original_more_conservative_than_modified():
+    orig = b31g_original(D, T, DEPTH, LEN, SMYS).failure_pressure_psi
+    mod = modified_b31g(D, T, DEPTH, LEN, SMYS).failure_pressure_psi
+    assert orig < mod
+
+
+# --- Regimes & limits ------------------------------------------------------
+def test_original_infinite_length_regime():
+    r = b31g_original(D, T, DEPTH, 40.0, SMYS)   # z ~ 142 > 20
+    assert r.details["regime"] == "infinite_length"
+    assert math.isinf(r.folias_factor)
+    # P_f = 2*flow*t/D*(1 - d/t) = 1430 * 0.6
+    assert r.failure_pressure_psi == pytest.approx(1430.0 * 0.6, rel=1e-3)
+
+
+def test_zero_defect_recovers_intact_pressure():
+    r = modified_b31g(D, T, 0.0, LEN, SMYS)
+    assert r.area_ratio == pytest.approx(0.0)
+    assert r.failure_pressure_psi == pytest.approx(r.intact_pressure_psi, rel=1e-6)
+    assert r.rsf == pytest.approx(1.0, rel=1e-6)
+
+
+def test_deeper_defect_lowers_failure_pressure():
+    shallow = modified_b31g(D, T, 0.075, LEN, SMYS).failure_pressure_psi
+    deep = modified_b31g(D, T, 0.30, LEN, SMYS).failure_pressure_psi
+    assert deep < shallow
+
+
+def test_longer_defect_lowers_failure_pressure():
+    short = modified_b31g(D, T, DEPTH, 3.0, SMYS).failure_pressure_psi
+    long = modified_b31g(D, T, DEPTH, 16.0, SMYS).failure_pressure_psi
+    assert long < short
+
+
+# --- RSTRENG effective area ------------------------------------------------
+def test_rstreng_rectangular_more_conservative_than_modified():
+    # Uniform-depth profile -> effective A/A0 = d/t (0.40) > 0.85*d/t (0.34),
+    # so RSTRENG predicts a lower failure pressure than Modified B31G.
+    r = rstreng_effective_area(D, T, [0.0, LEN], [DEPTH, DEPTH], SMYS)
+    mod = modified_b31g(D, T, DEPTH, LEN, SMYS)
+    assert r.area_ratio == pytest.approx(0.40, rel=1e-6)
+    assert r.failure_pressure_psi < mod.failure_pressure_psi
+
+
+def test_rstreng_reports_critical_segment():
+    # A deep notch in the middle of an otherwise shallow profile.
+    xs = [0.0, 2.0, 4.0, 6.0, 8.0]
+    ds = [0.02, 0.05, 0.25, 0.05, 0.02]
+    r = rstreng_effective_area(D, T, xs, ds, SMYS)
+    assert r.method == "RSTRENG"
+    assert r.failure_pressure_psi > 0
+    assert "critical_length_in" in r.details
+
+
+def test_rstreng_validates_inputs():
+    with pytest.raises(ValueError):
+        rstreng_effective_area(D, T, [0.0, 1.0], [0.1], SMYS)        # mismatched
+    with pytest.raises(ValueError):
+        rstreng_effective_area(D, T, [1.0, 0.0], [0.1, 0.1], SMYS)   # not increasing
+    with pytest.raises(ValueError):
+        rstreng_effective_area(D, T, [0.0, 1.0], [0.1, 0.5], SMYS)   # depth > t
+
+
+# --- acceptance vs MAOP ----------------------------------------------------
+def test_acceptable_flag_vs_maop():
+    r_lo = modified_b31g(D, T, DEPTH, LEN, SMYS, maop_psi=500.0)
+    r_hi = modified_b31g(D, T, DEPTH, LEN, SMYS, maop_psi=1200.0)
+    assert r_lo.acceptable is True       # safe ~877 psi >= 500
+    assert r_hi.acceptable is False      # safe ~877 psi <  1200
+
+
+# --- allowable flaw length (regenerated B31G table) ------------------------
+def test_allowable_length_decreases_with_depth():
+    shallow = allowable_flaw_length(D, T, 0.075, SMYS, 800.0)
+    deep = allowable_flaw_length(D, T, 0.20, SMYS, 800.0)
+    assert deep < shallow
+
+
+def test_allowable_length_meets_design_pressure():
+    L = allowable_flaw_length(D, T, DEPTH, SMYS, 900.0)
+    safe = modified_b31g(D, T, DEPTH, L, SMYS).safe_pressure_psi
+    assert safe == pytest.approx(900.0, rel=5e-3)
+
+
+# --- material table & validation ------------------------------------------
+def test_smys_table_grades():
+    assert SMYS_PSI["X52"] == 52_000.0
+    assert SMYS_PSI["X65"] == 65_000.0
+
+
+def test_geometry_validation():
+    with pytest.raises(ValueError):
+        modified_b31g(0.0, T, DEPTH, LEN, SMYS)
+    with pytest.raises(ValueError):
+        modified_b31g(D, T, T + 0.1, LEN, SMYS)   # depth exceeds wall


### PR DESCRIPTION
Closes #1060. FFS epic #1057 (Phase 1).

## What
Replaces the `b31g()` plotting stub with the three classic corroded-pipeline remaining-strength methods, all of the form `P_f = (2·S_flow·t/D)·(1 − A/A0)/(1 − (A/A0)/M)`:
- **`b31g_original`** — parabolic `A/A0 = (2/3)(d/t)`, `S_flow = 1.1·SMYS`, `M = √(1+0.8z)` for `z≤20` else infinite-length.
- **`modified_b31g`** — `A/A0 = 0.85(d/t)`, `S_flow = SMYS + 10 ksi`, two-part Folias `M`.
- **`rstreng_effective_area`** — effective metal-loss area from a measured river-bottom thickness profile; searches the governing (lowest-pressure) sub-segment.
- **`allowable_flaw_length`** — regenerates the ASME B31G "allowable defect length" table from the formula.

Returns `CorrodedPipeResult` (failure / intact / safe pressure, flow stress, Folias, A/A0, RSF, accept-vs-MAOP) + `SMYS_PSI` API 5L grade table. US units (in, psi).

## On "the B31G tables"
The repo references a lost `asme31gfile_pg_26.csv` (ASME B31G-2012 allowable-defect-length). That table is an **output** of the failure-pressure formula, not a needed input — `allowable_flaw_length` regenerates it for any geometry. Formula constants confirmed against ASME B31G-2012 / the `pipenostics` reference.

## Validation
Golden hand-calcs: 30"×0.375", d=0.15", L=8", X52 → **Modified B31G 1219 psi, Original 1183 psi** (original more conservative). Limit cases (zero defect → intact, infinite-length regime), monotonicity, RSTRENG-vs-Modified ordering, allowable-length round-trip. **18 tests pass.**