### PR TITLE
feat(asset_integrity): original B31G allowable-length chart + validate vs ASME table

### DIFF
--- a/docs/domains/asset-integrity/b31g-validation-2026-06-27.md
+++ b/docs/domains/asset-integrity/b31g-validation-2026-06-27.md
@@ -1,0 +1,50 @@
+# Corroded-Pipe Remaining Strength — Validation Record
+
+**Date:** 2026-06-27
+**Module:** `digitalmodel.asset_integrity.corroded_pipe`
+**Standards:** ASME B31G-2012 (original & Modified B31G), RSTRENG effective-area
+**Issues:** #1060 (implementation), #1061 (validation), epic #1057
+
+## Methods implemented
+`b31g_original`, `modified_b31g`, `rstreng_effective_area`, `allowable_flaw_length`
+(pressure-based, Modified B31G), and `b31g_original_allowable_length` (the
+canonical geometric B31G acceptance chart).
+
+## Validation 1 — failure pressure (hand calculation)
+Reference defect: 30 in OD × 0.375 in WT, d = 0.15 in (40 % WT), L = 8 in, X52
+(SMYS = 52 000 psi).
+
+| Method | Folias M | A/A0 | Failure pressure | Source |
+|---|---|---|---|---|
+| Modified B31G | 2.112 | 0.340 | **1219 psi** | hand calc |
+| Original B31G | 2.356 | 0.267 | **1183 psi** | hand calc |
+
+Original is more conservative, as expected. Limit cases verified: zero defect →
+intact pressure; `L²/(Dt) > 20` → original infinite-length regime.
+
+## Validation 2 — ASME B31G-2012 allowable-defect-length table (page 26)
+Source table located at
+`/mnt/ace/aceengineercode/data_manager/data/codes/asmeb31g/asme31gfile_pg_26.csv`
+(rows = depth d, columns = wall thickness t, values = max allowable longitudinal
+length, **OD = 20 in**, reverse-derived and confirmed). The table is reproduced
+by `b31g_original_allowable_length` via `L = 1.12·B·√(Dt)`,
+`B = min(4.0, √((d/t / (1.1·d/t − 0.15))² − 1))`:
+
+| d (in) | t (in) | ASME table L (in) | Computed L (in) | Δ |
+|---|---|---|---|---|
+| 0.10 | 0.500 | 9.48 | 9.48 | 0.0 |
+| 0.15 | 0.500 | 4.72 | 4.72 | 0.0 |
+| 0.25 | 0.625 | 3.76 | 3.76 | 0.0 |
+| 0.10 | 0.219 | 1.93 | 1.93 | 0.0 |
+| 0.05 | 0.500 | 14.17 | 14.17 | 0.0 (B capped at 4) |
+| 0.04 | 0.344 | 11.75 | 11.75 | 0.0 (B capped at 4) |
+| 0.50 | 0.625 | 1.78 | 1.78 | 0.0 (d/t = 0.80 boundary) |
+
+Defects deeper than 80 % of the wall return 0 (reject), matching the table's
+zero entries. Golden tests: `test_b31g_allowable_length_matches_asme_table`.
+
+## Note
+The ASME table is an **output** of the public B31G formula, so the formula (not
+the lost CSV) is the source of truth; the table merely confirms the
+implementation. The CSV lives outside this repo (`aceengineercode`) and is not
+required at runtime or in tests.

--- a/src/digitalmodel/asset_integrity/corroded_pipe.py
+++ b/src/digitalmodel/asset_integrity/corroded_pipe.py
@@ -237,6 +237,35 @@ def allowable_flaw_length(
     return lo
 
 
+def b31g_original_allowable_length(D: float, t: float, d: float) -> float:
+    """Original ASME B31G maximum allowable longitudinal defect length (in).
+
+    The canonical B31G acceptance chart (e.g. ASME B31G-2012 page 26):
+
+        L_allow = 1.12 * B * sqrt(D * t)
+        B = sqrt( (dt / (1.1*dt - 0.15))^2 - 1 ),  capped at 4.0,
+
+    where ``dt = d/t``. ``B`` is taken as 4.0 for shallow defects (where the
+    bracket is <= 0 or would exceed 4.0). Defects deeper than 80 % of the wall
+    are not acceptable (returns 0.0 — repair/replace).
+
+    Unlike :func:`allowable_flaw_length` (a pressure-based Modified-B31G
+    inversion), this is the pressure-independent geometric B31G chart and
+    reproduces the published ASME table for a given diameter.
+    """
+    _validate(D, t, d, 0.0)
+    dt = d / t
+    if dt > 0.80:
+        return 0.0
+    denom = 1.1 * dt - 0.15
+    if denom <= 0.0:
+        B = 4.0
+    else:
+        bracket = (dt / denom) ** 2 - 1.0
+        B = 4.0 if bracket < 0.0 else min(4.0, math.sqrt(bracket))
+    return 1.12 * B * math.sqrt(D * t)
+
+
 # ---------------------------------------------------------------------------
 def _validate_geometry(D: float, t: float) -> None:
     if D <= 0 or t <= 0 or t >= D:

--- a/tests/asset_integrity/test_corroded_pipe.py
+++ b/tests/asset_integrity/test_corroded_pipe.py
@@ -11,6 +11,7 @@ from digitalmodel.asset_integrity.corroded_pipe import (
     CorrodedPipeResult,
     allowable_flaw_length,
     b31g_original,
+    b31g_original_allowable_length,
     folias_modified,
     folias_original,
     modified_b31g,
@@ -151,3 +152,34 @@ def test_geometry_validation():
         modified_b31g(0.0, T, DEPTH, LEN, SMYS)
     with pytest.raises(ValueError):
         modified_b31g(D, T, T + 0.1, LEN, SMYS)   # depth exceeds wall
+
+
+# --- Original B31G allowable length vs the published ASME table -------------
+# Golden values from ASME B31G-2012 page-26 allowable-defect-length table,
+# OD = 20 in (d in., t in. -> allowable longitudinal length in.).
+ASME_OD = 20.0
+
+
+@pytest.mark.parametrize("d, t, expected_L", [
+    (0.10, 0.500, 9.48),   # B-parameter regime
+    (0.15, 0.500, 4.72),
+    (0.25, 0.625, 3.76),
+    (0.10, 0.219, 1.93),
+    (0.05, 0.500, 14.17),  # shallow -> B capped at 4.0
+    (0.04, 0.344, 11.75),  # shallow -> B capped at 4.0
+    (0.50, 0.625, 1.78),   # d/t = 0.80 boundary (still acceptable)
+])
+def test_b31g_allowable_length_matches_asme_table(d, t, expected_L):
+    L = b31g_original_allowable_length(ASME_OD, t, d)
+    assert L == pytest.approx(expected_L, abs=0.02)
+
+
+def test_b31g_allowable_length_rejects_above_80pct():
+    # d/t = 0.18/0.219 = 0.822 > 0.80 -> not acceptable (table shows 0).
+    assert b31g_original_allowable_length(ASME_OD, 0.219, 0.18) == 0.0
+
+
+def test_b31g_allowable_length_decreases_with_depth():
+    shallow = b31g_original_allowable_length(ASME_OD, 0.5, 0.10)
+    deep = b31g_original_allowable_length(ASME_OD, 0.5, 0.30)
+    assert deep < shallow


### PR DESCRIPTION
Follow-up to #1060; seeds validation #1061.

## What
Adds `b31g_original_allowable_length()` — the canonical ASME B31G acceptance chart `L = 1.12·B·√(D·t)`, `B = min(4.0, √((d/t/(1.1·d/t−0.15))²−1))`, reject for d/t > 0.80. This is the **pressure-independent geometric** B31G method (distinct from the pressure-based `allowable_flaw_length`).

## Validation against the real ASME table
The disk scan located the ASME B31G-2012 page-26 allowable-defect-length table (OD 20") at `aceengineercode/.../asme31gfile_pg_26.csv`. The new function reproduces it exactly — 7 hand-verified cells to ≤0.02":

| d (in) | t (in) | ASME | Computed |
|---|---|---|---|
| 0.10 | 0.500 | 9.48 | 9.48 |
| 0.15 | 0.500 | 4.72 | 4.72 |
| 0.05 | 0.500 | 14.17 | 14.17 (B cap) |
| 0.50 | 0.625 | 1.78 | 1.78 (d/t=0.80) |

plus the d/t>0.8 reject (table shows 0). The table is an **output** of the public formula, so the CSV isn't a runtime/test dependency. Record: `docs/domains/asset-integrity/b31g-validation-2026-06-27.md`.

## Tests
27 corroded-pipe tests pass (9 new for the allowable-length chart + ASME-table golden values).