### PR TITLE
feat(asset_integrity): FFS Level 3 escalation interface + handoff

### DIFF
--- a/src/digitalmodel/asset_integrity/assessment/level3_escalation.py
+++ b/src/digitalmodel/asset_integrity/assessment/level3_escalation.py
@@ -1,0 +1,299 @@
+# ABOUTME: FFS Level 3 escalation interface — decides WHEN to escalate beyond
+# ABOUTME: L1/L2 screening and builds a structured handoff package for the office.
+"""Level 3 (advanced assessment) escalation interface for FFS.
+
+The Phase-1 FFS pipeline gives a fast field/desk answer:
+
+* :mod:`...assessment.level1_screener` — minimum-thickness screening,
+* :mod:`...assessment.level2_engine` — closed-form RSF (returns ``rsf``,
+  ``rsf_a``, ``t_mm_in``, ``assessment_type``, ``folias_factor``),
+* :mod:`...assessment.ffs_decision` — a verdict (ACCEPT / MONITOR / RE_RATE /
+  REPAIR / REPLACE),
+* :mod:`...assessment.measurement_sufficiency` — is the field data adequate.
+
+Those Level 1/2 methods are *closed-form metal-loss* assessments (API 579-1 /
+ASME FFS-1 Parts 4 & 5). They deliberately do **not** cover crack-like (planar)
+flaws, strongly interacting defect colonies, or geometry that the closed-form
+Folias/RSF treatment cannot represent. For those, API 579-1 / ASME FFS-1
+directs the assessor to a **Level 3** advanced assessment: numerical (FEA)
+stress analysis and, for crack-like flaws, a BS 7910 Failure Assessment Diagram
+(FAD) / fracture-mechanics evaluation.
+
+This module is the *escalation interface* between quick screening and that
+advanced work. It does **two** things and no more:
+
+1. :func:`should_escalate_to_level3` — the decision logic for *when* a case
+   must leave the L1/L2 screening track.
+2. :func:`escalate_to_level3` — assembles a complete, structured
+   :class:`Level3Handoff` package (geometry, full measurement summary, loads,
+   material, and the L1/L2 results) plus the recommended analyses and the
+   specific open questions the specialist must close out.
+
+**Honesty note.** Level 3 *here* is an INTERFACE and a DATA CONTRACT, not the
+advanced computation itself. This module does not run FEA and does not solve a
+FAD; it decides escalation and produces the handoff so that fast L1/L2
+screening never silently substitutes for the detailed analysis a flaw needs.
+The actual fracture path is implemented elsewhere
+(:func:`digitalmodel.asset_integrity.fracture_mechanics.fracture_mechanics`,
+a BS 7910 FAD router).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# RSF at/below which the Level-2 closed-form re-rating is no longer applicable;
+# the component is in repair/replace territory and needs a Level-3 / engineering
+# assessment regardless of further screening. Mirrors the severe-loss floor used
+# by the measurement-sufficiency engine.
+_DEFAULT_RSF_FLOOR = 0.50
+
+
+@dataclass
+class Level3Handoff:
+    """A complete, structured handoff to a Level 3 specialist / the office.
+
+    Attributes:
+        triggered: Whether escalation to Level 3 is required.
+        triggers: Human-readable reasons escalation was (or was not) triggered.
+        recommended_analysis: Advanced analyses to perform, e.g.
+            ``"nonlinear FEA"``, ``"BS7910 FAD fracture"``,
+            ``"interacting-defect FEA"``.
+        data_package: Echo of every input so the specialist has a complete
+            record — ``geometry``, ``grid_summary``, ``loads``, ``material``,
+            ``level1_result`` and ``level2_result``.
+        open_questions: Specific questions the specialist must resolve.
+        notes: Free-text framing / caveats for the handoff.
+    """
+
+    triggered: bool
+    triggers: list = field(default_factory=list)
+    recommended_analysis: list = field(default_factory=list)
+    data_package: dict = field(default_factory=dict)
+    open_questions: list = field(default_factory=list)
+    notes: str = ""
+
+
+def should_escalate_to_level3(
+    level1_result: dict,
+    level2_result: dict,
+    *,
+    has_crack_like_flaw: bool = False,
+    interacting_defects: bool = False,
+    complex_geometry: bool = False,
+    rsf_floor: float = _DEFAULT_RSF_FLOOR,
+) -> tuple[bool, list]:
+    """Decide whether a case must escalate from L1/L2 screening to Level 3.
+
+    Escalation is triggered when **any** of the following hold:
+
+    * **Severe metal loss** — the remaining-strength factor is below the
+      Level-2 applicability / re-rating floor (``rsf < rsf_floor``); the
+      closed-form re-rating no longer applies.
+    * **Crack-like (planar) flaw** — outside the metal-loss L1/L2 scope; this is
+      BS 7910 / fracture-mechanics territory.
+    * **Interacting defects** — a colony the closed-form single-flaw RSF cannot
+      represent.
+    * **Complex geometry** — discontinuities/shapes the closed-form Folias/RSF
+      treatment cannot represent.
+    * **Level 2 fails** — ``rsf < rsf_a`` with no viable re-rate (the Level-2
+      assessment itself does not pass).
+
+    Args:
+        level1_result: dict from the Level 1 screener (uses ``verdict`` if
+            present, informational only here).
+        level2_result: dict from the Level 2 engine; needs ``rsf`` and
+            ``rsf_a``.
+        has_crack_like_flaw: Flaw is crack-like / planar rather than volumetric
+            metal loss.
+        interacting_defects: Multiple flaws interact (a colony).
+        complex_geometry: Geometry the closed-form method cannot represent.
+        rsf_floor: RSF below which Level-2 re-rating is inapplicable.
+
+    Returns:
+        ``(triggered, reasons)`` where ``triggered`` is a Python ``bool`` and
+        ``reasons`` is a list of human-readable trigger strings (empty when not
+        triggered).
+    """
+    rsf = float(level2_result.get("rsf", 0.0))
+    rsf_a = float(level2_result.get("rsf_a", 0.0))
+
+    reasons: list = []
+
+    if rsf < float(rsf_floor):
+        reasons.append(
+            f"RSF={rsf:.3f} is below the Level-2 re-rating floor of "
+            f"{float(rsf_floor):.2f} — the closed-form re-rating no longer "
+            "applies; severe metal loss requires a Level 3 / detailed "
+            "assessment."
+        )
+
+    if has_crack_like_flaw:
+        reasons.append(
+            "A crack-like (planar) flaw is present — this is outside the "
+            "metal-loss scope of Level 1/2 and requires a BS 7910 "
+            "fracture-mechanics (FAD) assessment."
+        )
+
+    if interacting_defects:
+        reasons.append(
+            "Interacting defects (a flaw colony) are present — the closed-form "
+            "single-flaw RSF cannot represent their interaction; a numerical "
+            "(FEA) assessment is required."
+        )
+
+    if complex_geometry:
+        reasons.append(
+            "Complex geometry / structural discontinuity is present that the "
+            "closed-form Folias/RSF treatment cannot represent; a numerical "
+            "(FEA) assessment is required."
+        )
+
+    # Level 2 itself fails with no viable re-rate. Only meaningful when an RSFa
+    # is supplied (rsf_a > 0); guard against a still-passing case that already
+    # tripped the floor above.
+    if rsf_a > 0.0 and rsf < rsf_a:
+        reasons.append(
+            f"Level 2 fails: RSF={rsf:.3f} is below RSFa={rsf_a:.2f} with no "
+            "viable re-rate — a Level 3 assessment is required to qualify "
+            "continued service."
+        )
+
+    return bool(len(reasons) > 0), reasons
+
+
+def escalate_to_level3(
+    geometry: dict,
+    loads: dict,
+    material: dict,
+    level1_result: dict,
+    level2_result: dict,
+    *,
+    grid_summary: dict | None = None,
+    has_crack_like_flaw: bool = False,
+    interacting_defects: bool = False,
+    complex_geometry: bool = False,
+    rsf_floor: float = _DEFAULT_RSF_FLOOR,
+) -> Level3Handoff:
+    """Build a complete Level 3 handoff package from the screening inputs.
+
+    This assembles the data contract a Level 3 specialist needs. It does not
+    perform the advanced analysis; it records the case, decides escalation via
+    :func:`should_escalate_to_level3`, selects the recommended analyses from the
+    triggers, and lists the specific open questions to close out.
+
+    Args:
+        geometry: Component geometry (OD, wall thickness, flaw dims, ...).
+        loads: Applied loads (pressure, temperature, axial/bending, ...).
+        material: Material data (grade, SMYS/SMTS, toughness if available, ...).
+        level1_result: dict from the Level 1 screener.
+        level2_result: dict from the Level 2 engine (``rsf``, ``rsf_a``, ...).
+        grid_summary: Optional summary of the full measurement grid (counts,
+            min thickness, scatter, ...). Echoed into the data package.
+        has_crack_like_flaw: See :func:`should_escalate_to_level3`.
+        interacting_defects: See :func:`should_escalate_to_level3`.
+        complex_geometry: See :func:`should_escalate_to_level3`.
+        rsf_floor: RSF below which Level-2 re-rating is inapplicable.
+
+    Returns:
+        A fully-populated :class:`Level3Handoff`.
+    """
+    rsf = float(level2_result.get("rsf", 0.0))
+    rsf_a = float(level2_result.get("rsf_a", 0.0))
+
+    triggered, triggers = should_escalate_to_level3(
+        level1_result,
+        level2_result,
+        has_crack_like_flaw=has_crack_like_flaw,
+        interacting_defects=interacting_defects,
+        complex_geometry=complex_geometry,
+        rsf_floor=rsf_floor,
+    )
+
+    severe_metal_loss = (rsf < float(rsf_floor)) or (rsf_a > 0.0 and rsf < rsf_a)
+
+    # --- Recommended analyses, selected from the active triggers -------------
+    recommended_analysis: list = []
+    if has_crack_like_flaw:
+        # Crack-like flaw -> BS 7910 FAD via the fracture-mechanics router.
+        recommended_analysis.append(
+            "BS7910 FAD fracture assessment (crack-like flaw) — via "
+            "digitalmodel.asset_integrity.fracture_mechanics.fracture_mechanics"
+        )
+    if interacting_defects:
+        recommended_analysis.append(
+            "interacting-defect FEA (flaw-colony stress interaction)"
+        )
+    if complex_geometry:
+        recommended_analysis.append(
+            "numerical FEA stress analysis for complex geometry / discontinuity"
+        )
+    if severe_metal_loss:
+        recommended_analysis.append(
+            "nonlinear FEA / detailed RSF (elastic-plastic) for severe metal loss"
+        )
+
+    # --- Specific open questions for the specialist --------------------------
+    open_questions: list = []
+    if has_crack_like_flaw:
+        open_questions.append(
+            "Confirm the flaw is planar (crack-like) vs volumetric metal loss."
+        )
+        open_questions.append(
+            "Provide CVN / fracture toughness (Kmat or J) for the FAD assessment."
+        )
+        open_questions.append(
+            "Characterise flaw type (surface vs embedded) and depth/length (a, 2c)."
+        )
+    if interacting_defects:
+        open_questions.append(
+            "Provide a full 3D scan of the interacting flaw colony with "
+            "ligament spacings to confirm/deny interaction."
+        )
+    if complex_geometry:
+        open_questions.append(
+            "Provide as-built geometry / discontinuity detail and the local "
+            "stress state (SCF or measured strains) at the feature."
+        )
+    if severe_metal_loss:
+        open_questions.append(
+            "Confirm the operating/design loads and temperature for an "
+            "elastic-plastic (nonlinear) RSF assessment."
+        )
+        open_questions.append(
+            "Confirm the future corrosion allowance / remaining-life basis for "
+            "re-rate vs repair vs replace."
+        )
+
+    # --- Complete record: echo every input so the specialist has it all ------
+    data_package = {
+        "geometry": geometry,
+        "grid_summary": grid_summary if grid_summary is not None else {},
+        "loads": loads,
+        "material": material,
+        "level1_result": level1_result,
+        "level2_result": level2_result,
+    }
+
+    if triggered:
+        notes = (
+            "Level 3 escalation REQUIRED. This package is an interface and data "
+            "contract for an advanced (FEA / BS 7910 FAD) assessment — the "
+            "computation is not performed here. Quick L1/L2 screening does not "
+            "eliminate the need for the detailed analysis listed above."
+        )
+    else:
+        notes = (
+            "Level 3 escalation NOT required by the screening triggers; the "
+            "Level 1/2 closed-form result stands. This package is retained as a "
+            "complete record of the assessed case."
+        )
+
+    return Level3Handoff(
+        triggered=bool(triggered),
+        triggers=triggers,
+        recommended_analysis=recommended_analysis,
+        data_package=data_package,
+        open_questions=open_questions,
+        notes=notes,
+    )

--- a/tests/asset_integrity/test_level3_escalation.py
+++ b/tests/asset_integrity/test_level3_escalation.py
@@ -1,0 +1,160 @@
+# ABOUTME: Tests for the FFS Level 3 escalation interface — when to escalate
+# ABOUTME: beyond L1/L2 screening and the structured specialist handoff package.
+"""Tests for digitalmodel.asset_integrity.assessment.level3_escalation."""
+
+from digitalmodel.asset_integrity.assessment.level3_escalation import (
+    Level3Handoff,
+    escalate_to_level3,
+    should_escalate_to_level3,
+)
+
+
+# --- helpers ---------------------------------------------------------------
+def l1(verdict="ACCEPT", t_min=0.30, margin=0.16):
+    return {"verdict": verdict, "t_min_in": t_min, "margin_in": margin}
+
+
+def l2(rsf=0.95, rsf_a=0.90, t_mm=0.46, atype="GML"):
+    return {
+        "rsf": rsf,
+        "rsf_a": rsf_a,
+        "t_mm_in": t_mm,
+        "assessment_type": atype,
+        "folias_factor": 1.2,
+    }
+
+
+def geom():
+    return {"od_in": 12.75, "wt_in": 0.50, "flaw_length_in": 6.0, "flaw_depth_in": 0.2}
+
+
+def loads():
+    return {"design_pressure_psi": 1000, "temperature_f": 150, "axial_lbf": 0.0}
+
+
+def material():
+    return {"grade": "API 5L X52", "smys_psi": 52000, "smts_psi": 66000}
+
+
+# --- should_escalate_to_level3: each trigger -------------------------------
+def test_escalate_low_rsf_below_floor():
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(rsf=0.40, rsf_a=0.90), rsf_floor=0.50
+    )
+    assert triggered is True
+    assert any("floor" in r.lower() for r in reasons)
+
+
+def test_escalate_crack_like_flaw():
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(), has_crack_like_flaw=True
+    )
+    assert triggered is True
+    assert any("crack" in r.lower() for r in reasons)
+
+
+def test_escalate_interacting_defects():
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(), interacting_defects=True
+    )
+    assert triggered is True
+    assert any("interact" in r.lower() for r in reasons)
+
+
+def test_escalate_complex_geometry():
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(), complex_geometry=True
+    )
+    assert triggered is True
+    assert any("geometry" in r.lower() for r in reasons)
+
+
+def test_escalate_level2_fail_rsf_below_rsfa():
+    # rsf above the floor but below RSFa -> Level 2 fails, no viable re-rate.
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(rsf=0.70, rsf_a=0.90), rsf_floor=0.50
+    )
+    assert triggered is True
+    assert any("rsfa" in r.lower() for r in reasons)
+
+
+def test_no_escalation_comfortable_case():
+    # RSF well above RSFa, no flags -> no escalation.
+    triggered, reasons = should_escalate_to_level3(
+        l1(), l2(rsf=0.95, rsf_a=0.90)
+    )
+    assert triggered is False
+    assert reasons == []
+
+
+def test_returns_python_bool():
+    triggered, _ = should_escalate_to_level3(l1(), l2(rsf=0.40))
+    assert isinstance(triggered, bool)
+
+
+# --- escalate_to_level3: handoff package -----------------------------------
+def test_handoff_is_dataclass_with_echoed_inputs():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(rsf=0.40, rsf_a=0.90)
+    )
+    assert isinstance(handoff, Level3Handoff)
+    dp = handoff.data_package
+    assert dp["geometry"] == geom()
+    assert dp["loads"] == loads()
+    assert dp["material"] == material()
+    assert dp["level1_result"] == l1()
+    assert dp["level2_result"] == l2(rsf=0.40, rsf_a=0.90)
+
+
+def test_handoff_package_completeness_all_five_inputs():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(), has_crack_like_flaw=True
+    )
+    for key in ("geometry", "loads", "material", "level1_result", "level2_result"):
+        assert key in handoff.data_package
+
+
+def test_handoff_grid_summary_echoed():
+    grid = {"n_readings": 25, "min_thickness_in": 0.30, "cov": 0.04}
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(), grid_summary=grid,
+        interacting_defects=True,
+    )
+    assert handoff.data_package["grid_summary"] == grid
+
+
+def test_handoff_triggered_has_analysis_and_questions():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(rsf=0.40, rsf_a=0.90)
+    )
+    assert handoff.triggered is True
+    assert handoff.recommended_analysis  # non-empty
+    assert handoff.open_questions        # non-empty
+
+
+def test_handoff_crack_recommends_bs7910_fad():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(), has_crack_like_flaw=True
+    )
+    blob = " ".join(handoff.recommended_analysis).lower()
+    assert "bs7910" in blob or "fad" in blob or "fracture" in blob
+
+
+def test_handoff_crack_questions_ask_for_toughness():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(), has_crack_like_flaw=True
+    )
+    blob = " ".join(handoff.open_questions).lower()
+    assert "toughness" in blob or "cvn" in blob or "fad" in blob
+
+
+def test_handoff_not_triggered_empty_analysis_but_complete_record():
+    handoff = escalate_to_level3(
+        geom(), loads(), material(), l1(), l2(rsf=0.95, rsf_a=0.90)
+    )
+    assert handoff.triggered is False
+    assert handoff.recommended_analysis == []
+    assert handoff.open_questions == []
+    # Even when not triggered, the package is a complete record.
+    for key in ("geometry", "loads", "material", "level1_result", "level2_result"):
+        assert key in handoff.data_package


### PR DESCRIPTION
Closes #1064. FFS epic #1057 (Phase 2). Completes L1/L2/L3 tiering with a structured Level-3 escalation interface: `should_escalate_to_level3` (triggers: RSF below re-rate floor, crack-like flaw, interacting defects, complex geometry, L2 failure) and `escalate_to_level3` → `Level3Handoff` (recommended_analysis, open_questions, complete data_package echoing geometry/loads/material/L1/L2/grid). Interface + data contract only — not the FEA/fracture computation; makes explicit that L1/L2 screening doesn't replace detailed analysis. 14 tests pass.