### PR TITLE
feat(asset_integrity): canonical FFS coordinator + unified data model

### DIFF
--- a/docs/domains/asset-integrity/ffs-architecture.md
+++ b/docs/domains/asset-integrity/ffs-architecture.md
@@ -1,0 +1,51 @@
+# FFS Architecture — Canonical Path and Data Model
+
+**Date:** 2026-06-27 · **Issue:** #1058 (FFS epic #1057)
+
+## Decision
+The modular **Phase-1 assessment pipeline** (`asset_integrity/assessment/`) is
+the **canonical** Fitness-For-Service path. New code builds on it through the
+single coordinator `assess_component()`. The legacy
+`asset_integrity/common/API579_components.py` (driven by the `API579` engine
+basename) is retained for backward compatibility but is **not** extended.
+
+## The two paths
+
+| | Canonical (Phase 1) | Legacy |
+|---|---|---|
+| Location | `assessment/` (`grid_parser`, `ffs_router`, `level1_screener`, `level2_engine`, `ffs_decision`, `measurement_sufficiency`, `ffs_coordinator`) | `common/API579_components.py` |
+| Style | small, single-responsibility, unit-tested modules | one ~1000-line class, config/YAML-driven |
+| Entry | `assess_component(component, grid)` → `FFSAssessmentResult` | `engine` basename `API579` → GML/LML methods |
+| Tests | ~100 focused tests | legacy integration tests |
+| Status | **canonical — build here** | frozen; do not extend |
+
+## Canonical data model
+`FFSComponent` (input) and `FFSAssessmentResult` (output) in
+`assessment/ffs_coordinator.py`. `assess_component()` chains, in order:
+
+```
+GridParser -> FFSRouter -> Level1Screener -> Level2Engine
+            -> FFSDecision -> MeasurementSufficiency
+```
+
+and returns one `FFSAssessmentResult` with: assessment_type (GML/LML),
+level_reached, nominal/min/measured thickness, FCA, RSF/RSFa, Folias factor,
+remaining life, verdict (ACCEPT/MONITOR/RE_RATE/REPAIR/REPLACE), a screening
+re-rated pressure, the measurement-sufficiency status, and the raw stage dicts.
+`FFSComponent`/`FFSAssessmentResult` are the single record shape that all
+downstream consumers (reports, the design showcase, parametric acceptance
+curves #1065, the indexed lookup / Deckhand API #1066, the field dashboard
+#1067) share — no consumer re-wires the six modules or re-invents field names.
+
+**No physics here.** The coordinator orchestrates and normalises only; every
+value originates in a module with golden tests. Pipeline/structural method
+modules (`corroded_pipe`, `dnv_rp_f101`, `plate_metal_loss_ffs`,
+`assessment/level3_escalation`) are independent calculators consumed alongside
+this model.
+
+## Why additive, not a rewrite
+Consolidation here is **adding** the coordinator + data model on top of the
+validated modules — the existing ~100 Phase-1 tests and the legacy path are
+untouched, so there is zero behaviour-change risk. Migrating the `API579`
+engine basename onto the Phase-1 path (or deleting the legacy class) is a
+separate, optional follow-up that would need its own characterization tests.

--- a/src/digitalmodel/asset_integrity/assessment/__init__.py
+++ b/src/digitalmodel/asset_integrity/assessment/__init__.py
@@ -21,6 +21,11 @@ from .measurement_sufficiency import (
     SufficiencyAction,
     SufficiencyResult,
 )
+from .ffs_coordinator import (
+    FFSComponent,
+    FFSAssessmentResult,
+    assess_component,
+)
 
 __all__ = [
     "GridParser",
@@ -31,5 +36,8 @@ __all__ = [
     "MeasurementSufficiency",
     "SufficiencyAction",
     "SufficiencyResult",
+    "FFSComponent",
+    "FFSAssessmentResult",
+    "assess_component",
     "FFSReport",
 ]

--- a/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
@@ -1,0 +1,211 @@
+# ABOUTME: Canonical FFS coordinator — one data model + one orchestration call
+# ABOUTME: chaining the validated Phase-1 assessment modules end to end.
+"""Canonical Fitness-For-Service coordinator (Phase-1 path).
+
+This is the single entry point and unified data model for an FFS metal-loss
+assessment. It chains the validated Phase-1 modules in one call:
+
+    GridParser -> FFSRouter -> Level1Screener -> Level2Engine
+                -> FFSDecision -> MeasurementSufficiency
+
+so callers (engine, reports, dashboards, the Deckhand API) get one
+`FFSAssessmentResult` instead of having to wire six modules and remember each
+field name. No assessment physics is implemented here — every number comes from
+the modules that already have golden tests; this layer only orchestrates and
+normalises the result.
+
+The legacy `asset_integrity/common/API579_components.py` (GML/LML via the
+`API579` engine basename) remains for backward compatibility but is **not** the
+path new code should build on — see
+`docs/domains/asset-integrity/ffs-architecture.md`.
+
+Units: inches and psi (consistent with the Phase-1 modules).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .ffs_decision import FFSDecision
+from .ffs_router import FFSRouter
+from .grid_parser import GridParser
+from .level1_screener import Level1Screener
+from .level2_engine import Level2Engine
+from .measurement_sufficiency import MeasurementSufficiency
+
+GridLike = Union[pd.DataFrame, np.ndarray, str, Path]
+
+
+@dataclass
+class FFSComponent:
+    """The component under assessment (geometry, code, material, condition)."""
+
+    component_id: str
+    design_code: str               # e.g. "B31.8", "B31.4", "ASME_VIII_DIV1"
+    nominal_od_in: float
+    nominal_wt_in: float
+    design_pressure_psi: float
+    smys_psi: Optional[float] = None
+    corrosion_rate_in_per_yr: float = 0.0
+    fca_in: float = 0.0            # future corrosion allowance
+    rsf_a: float = 0.90            # allowable remaining strength factor
+    component_type: str = "pipe"
+
+
+@dataclass
+class FFSAssessmentResult:
+    """Unified FFS result — the canonical record for downstream consumers."""
+
+    component_id: str
+    assessment_type: str           # "GML" | "LML"
+    level_reached: int             # 1 (screening sufficed) or 2 (RSF needed)
+    t_nominal_in: float
+    t_min_in: float
+    t_measured_min_in: float
+    t_measured_avg_in: float
+    fca_in: float
+    rsf: float
+    rsf_a: float
+    folias_factor: float
+    remaining_life_yr: float
+    verdict: str                   # ACCEPT/MONITOR/RE_RATE/REPAIR/REPLACE
+    rerated_pressure_psi: float    # screening re-rate = P_design * min(1, rsf/rsf_a)
+    sufficiency_status: str        # SUFFICIENT/TAKE_MORE/ESCALATE
+    sufficiency: Any = None        # SufficiencyResult
+    level1: dict = field(default_factory=dict)
+    level2: dict = field(default_factory=dict)
+    decision: dict = field(default_factory=dict)
+    details: dict = field(default_factory=dict)
+
+    @property
+    def passes(self) -> bool:
+        """True when the component is fit-for-service without re-rating."""
+        return self.verdict in ("ACCEPT", "MONITOR")
+
+    def to_dict(self) -> dict:
+        """JSON-serialisable summary (for lookup tables / the Deckhand API)."""
+        return {
+            "component_id": self.component_id,
+            "assessment_type": self.assessment_type,
+            "level_reached": self.level_reached,
+            "t_nominal_in": self.t_nominal_in,
+            "t_min_in": self.t_min_in,
+            "t_measured_min_in": self.t_measured_min_in,
+            "t_measured_avg_in": self.t_measured_avg_in,
+            "fca_in": self.fca_in,
+            "rsf": self.rsf,
+            "rsf_a": self.rsf_a,
+            "folias_factor": self.folias_factor,
+            "remaining_life_yr": self.remaining_life_yr,
+            "verdict": self.verdict,
+            "rerated_pressure_psi": self.rerated_pressure_psi,
+            "sufficiency_status": self.sufficiency_status,
+            "passes": self.passes,
+        }
+
+
+def assess_component(
+    component: FFSComponent,
+    grid: GridLike,
+    *,
+    input_units: str = "in",
+    force_type: Optional[str] = None,
+) -> FFSAssessmentResult:
+    """Run the full Phase-1 FFS chain and return one unified result.
+
+    Args:
+        component: the :class:`FFSComponent` being assessed.
+        grid: wall-thickness measurement grid — a pandas DataFrame, a 2-D numpy
+            array, or a path to a CSV.
+        input_units: ``"in"`` (default) or ``"mm"`` — passed to GridParser.
+        force_type: override the GML/LML auto-classification ("GML"/"LML").
+    """
+    df = _to_grid_df(grid, input_units)
+
+    route = FFSRouter.classify(
+        df, component.nominal_od_in, component.nominal_wt_in, force_type=force_type
+    )
+    atype = route["assessment_type"]
+
+    screener = Level1Screener(
+        design_code=component.design_code,
+        nominal_od_in=component.nominal_od_in,
+        design_pressure_psi=component.design_pressure_psi,
+        smys_psi=component.smys_psi,
+    )
+    t_min = screener.t_min()
+    t_mm = GridParser.min_thickness(df)
+    t_am = GridParser.mean_thickness(df)
+    l1 = screener.evaluate(t_mm)
+
+    l2 = Level2Engine(
+        assessment_type=atype,
+        nominal_od_in=component.nominal_od_in,
+        nominal_wt_in=component.nominal_wt_in,
+        t_min_in=t_min,
+        rsf_a=component.rsf_a,
+    ).evaluate(df)
+
+    decision = FFSDecision.decide(
+        level1_verdict=l1["verdict"],
+        level2_verdict=l2["verdict"],
+        rsf=l2["rsf"],
+        rsf_a=component.rsf_a,
+        t_mm_in=t_mm,
+        t_min_in=t_min,
+        corrosion_rate_in_per_yr=component.corrosion_rate_in_per_yr,
+    )
+
+    sufficiency = MeasurementSufficiency().evaluate(
+        df,
+        nominal_wt_in=component.nominal_wt_in,
+        assessment_type=atype,
+        level1_result=l1,
+        level2_result=l2,
+    )
+
+    rsf = float(l2["rsf"])
+    rerated = component.design_pressure_psi * min(1.0, rsf / component.rsf_a) \
+        if component.rsf_a > 0 else float("nan")
+    level_reached = 1 if l1["verdict"] == "ACCEPT" else 2
+
+    return FFSAssessmentResult(
+        component_id=component.component_id,
+        assessment_type=atype,
+        level_reached=level_reached,
+        t_nominal_in=component.nominal_wt_in,
+        t_min_in=float(t_min),
+        t_measured_min_in=float(t_mm),
+        t_measured_avg_in=float(t_am),
+        fca_in=component.fca_in,
+        rsf=rsf,
+        rsf_a=component.rsf_a,
+        folias_factor=float(l2.get("folias_factor", 1.0)),
+        remaining_life_yr=float(decision.get("remaining_life_yr", float("nan"))),
+        verdict=str(decision.get("verdict", "UNKNOWN")),
+        rerated_pressure_psi=float(rerated),
+        sufficiency_status=str(sufficiency.status),
+        sufficiency=sufficiency,
+        level1=l1,
+        level2=l2,
+        decision=decision,
+        details={"router": route, "design_code": component.design_code},
+    )
+
+
+def _to_grid_df(grid: GridLike, input_units: str) -> pd.DataFrame:
+    """Normalise any supported grid input to a thickness DataFrame (inches)."""
+    if isinstance(grid, pd.DataFrame):
+        return GridParser.from_dataframe(grid, input_units=input_units)
+    if isinstance(grid, np.ndarray):
+        return GridParser.from_numpy(grid, input_units=input_units)
+    if isinstance(grid, (str, Path)):
+        return GridParser.from_csv(str(grid), input_units=input_units)
+    raise TypeError(
+        f"grid must be a DataFrame, numpy array, or CSV path; got {type(grid)!r}."
+    )

--- a/tests/asset_integrity/test_ffs_coordinator.py
+++ b/tests/asset_integrity/test_ffs_coordinator.py
@@ -1,0 +1,114 @@
+# ABOUTME: Tests for the canonical FFS coordinator (ffs_coordinator.py) — the
+# ABOUTME: end-to-end chain and unified FFSAssessmentResult data model.
+"""Tests for digitalmodel.asset_integrity.assessment.ffs_coordinator."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from digitalmodel.asset_integrity.assessment import (
+    FFSComponent,
+    FFSAssessmentResult,
+    assess_component,
+)
+
+
+def _pipe():
+    return FFSComponent(
+        component_id="LINE-001",
+        design_code="B31.8",
+        nominal_od_in=12.75,
+        nominal_wt_in=0.500,
+        design_pressure_psi=1000.0,
+        smys_psi=52_000.0,
+        corrosion_rate_in_per_yr=0.005,
+        rsf_a=0.90,
+    )
+
+
+def _healthy_grid():
+    # 6x6, all near nominal -> general, healthy.
+    return pd.DataFrame([[0.48] * 6 for _ in range(6)])
+
+
+def _local_thin_grid():
+    g = np.full((6, 6), 0.50)
+    g[2, 3] = 0.30
+    g[3, 3] = 0.32
+    return g
+
+
+# --- end-to-end chain ------------------------------------------------------
+def test_assess_returns_unified_result():
+    res = assess_component(_pipe(), _healthy_grid())
+    assert isinstance(res, FFSAssessmentResult)
+    assert res.component_id == "LINE-001"
+    assert res.assessment_type in ("GML", "LML")
+    assert res.t_nominal_in == 0.500
+    assert res.t_min_in > 0
+    assert res.t_measured_min_in <= res.t_measured_avg_in
+    assert 0.0 < res.rsf <= 1.0001
+    assert res.verdict in ("ACCEPT", "MONITOR", "RE_RATE", "REPAIR", "REPLACE")
+    assert res.sufficiency_status in ("SUFFICIENT", "TAKE_MORE", "ESCALATE")
+    # all six stages echoed
+    assert res.level1 and res.level2 and res.decision
+    assert res.details["router"]["assessment_type"] == res.assessment_type
+
+
+def test_healthy_component_passes():
+    res = assess_component(_pipe(), _healthy_grid())
+    assert res.passes is True
+    assert res.rsf >= res.rsf_a
+
+
+def test_local_thin_spot_routes_lml_and_flags_sufficiency():
+    # A 2-cell deep spot -> LML, and the sufficiency engine flags under-sampling.
+    res = assess_component(_pipe(), _local_thin_grid())
+    assert res.assessment_type == "LML"
+    assert res.sufficiency_status in ("TAKE_MORE", "ESCALATE")
+    assert res.folias_factor >= 1.0
+
+
+def test_accepts_numpy_dataframe_and_csv(tmp_path):
+    arr = np.full((5, 5), 0.47)
+    res_np = assess_component(_pipe(), arr)
+    res_df = assess_component(_pipe(), pd.DataFrame(arr))
+    assert res_np.t_measured_min_in == pytest.approx(res_df.t_measured_min_in)
+    # CSV path
+    csv = tmp_path / "grid.csv"
+    pd.DataFrame(arr).to_csv(csv, index=False, header=False)
+    res_csv = assess_component(_pipe(), str(csv))
+    assert res_csv.t_measured_min_in == pytest.approx(res_np.t_measured_min_in, rel=1e-6)
+
+
+def test_mm_units_converted():
+    # 12 mm uniform (~0.472 in) should give the same as the inch equivalent.
+    mm = pd.DataFrame([[12.0] * 5 for _ in range(5)])
+    res = assess_component(_pipe(), mm, input_units="mm")
+    assert res.t_measured_min_in == pytest.approx(12.0 / 25.4, rel=1e-3)
+
+
+def test_force_type_override():
+    res = assess_component(_pipe(), _healthy_grid(), force_type="LML")
+    assert res.assessment_type == "LML"
+
+
+def test_rerated_pressure_bounded():
+    res = assess_component(_pipe(), _healthy_grid())
+    # Healthy -> rsf>=rsf_a -> rerate clamps to design pressure.
+    assert res.rerated_pressure_psi == pytest.approx(1000.0, rel=1e-6)
+
+
+def test_to_dict_is_json_friendly():
+    import json
+    res = assess_component(_pipe(), _healthy_grid())
+    d = res.to_dict()
+    json.dumps(d)  # must not raise
+    assert d["component_id"] == "LINE-001"
+    assert d["passes"] is True
+    assert isinstance(d["rsf"], float)
+
+
+def test_invalid_grid_type_raises():
+    with pytest.raises(TypeError):
+        assess_component(_pipe(), 42)


### PR DESCRIPTION
Closes #1058. FFS epic #1057 (Phase 1 foundation).

The single canonical entry point + data model for metal-loss FFS:
- `FFSComponent` (input) + `FFSAssessmentResult` (unified output, `.to_dict()`/`.passes`).
- `assess_component(component, grid)` chains the validated Phase-1 modules end to end: GridParser → FFSRouter → Level1Screener → Level2Engine → FFSDecision → MeasurementSufficiency → one normalised result. Accepts DataFrame / numpy array / CSV path; in or mm; GML/LML override.

**Additive, zero behaviour-change**: no physics here — orchestration + normalisation only, every value from a golden-tested module. Legacy `common/API579_components.py` documented as frozen-legacy (`docs/domains/asset-integrity/ffs-architecture.md`); existing ~100 Phase-1 tests untouched.

This is the single record shape the remaining Phase-3 consumers (#1065 curves, #1066 Deckhand lookup, #1067 dashboard) will share. 9 coordinator tests; **94 assessment tests green, no regression.**