### PR TITLE
fix(asset_integrity): FFS strength-method #1094 quick wins

### DIFF
--- a/src/digitalmodel/asset_integrity/assessment/level2_engine.py
+++ b/src/digitalmodel/asset_integrity/assessment/level2_engine.py
@@ -19,11 +19,15 @@ LML (Local Metal Loss, Part 5):
         Mt  = Folias (bulging) factor (Eq. 4.20 / Table 4.4)
         L_a = longitudinal flaw length (derived from flaw bounding box)
 
-The Folias factor M_t for a cylindrical shell (API 579 Eq. 4.20):
+The Folias factor M_t for a cylindrical shell.  This uses the *simplified*
+Table 4.4 closed form, sqrt(1 + 0.48*lambda^2); the API 579-1 2021 main
+relation (Eq. 4.20) is a higher-order polynomial in lambda — the simplified
+form is a conservative approximation valid over the tabulated range:
   For lambda <= 0.354:   M_t = 1.0
   For lambda in (0.354, 20]:
-      M_t = sqrt(1 + 0.48 * lambda^2)   [Table 4.4 simplified column]
-  For lambda > 20:        M_t = 1.0 / Rt  (very long flaw → Rt floor = 0.9 RSF)
+      M_t = sqrt(1 + 0.48 * lambda^2)
+  For lambda > 20:        M_t = sqrt(1 + 0.48 * 20^2)   (frozen at the
+      lambda = 20 table limit; the simplified form is not extrapolated)
 
   lambda = 1.285 * L_a / sqrt(D * t_c)
   where D = nominal inside diameter = OD - 2*t_c (approximately OD - 2*t_min)
@@ -115,7 +119,9 @@ class Level2Engine:
 
         RSF = t_am / t_c  (t_c = t_min for current assessment)
         """
-        t_am = float(grid_df.mean(skipna=True).mean())
+        # True area-average over all valid cells.  ``df.mean().mean()`` averages
+        # the column means and is biased when columns hold unequal NaN counts.
+        t_am = float(np.nanmean(grid_df.to_numpy(dtype=float)))
         t_mm = float(grid_df.min(skipna=True).min())
         t_c = self._t_min  # conservative: use t_min as the reference
 
@@ -147,7 +153,8 @@ class Level2Engine:
         4. Compute RSF = Rt / (1 - (1 - Rt) / M_t).
         """
         t_mm = float(grid_df.min(skipna=True).min())
-        t_am = float(grid_df.mean(skipna=True).mean())
+        # True area-average over all valid cells (unbiased vs df.mean().mean()).
+        t_am = float(np.nanmean(grid_df.to_numpy(dtype=float)))
 
         # t_c: future thickness outside the flaw = t_min (conservative)
         t_c = self._t_min
@@ -206,7 +213,9 @@ class Level2Engine:
 
         For lambda <= 0.354:          M_t = 1.0
         For lambda in (0.354, 20]:    M_t = sqrt(1 + 0.48 * lambda**2)
-        For lambda > 20:              M_t → large (cap at formula limit)
+        For lambda > 20:              M_t = sqrt(1 + 0.48 * 20**2)
+                                      (frozen at the lambda = 20 table limit;
+                                      the simplified form is not extrapolated)
 
         Args:
             l_a: Flaw longitudinal extent (inches).

--- a/src/digitalmodel/asset_integrity/corroded_pipe.py
+++ b/src/digitalmodel/asset_integrity/corroded_pipe.py
@@ -39,6 +39,10 @@ import numpy as np
 _FLOW_ADDER_PSI = 10_000.0
 # Default safety factor applied to predicted failure pressure (B31G practice).
 _DEFAULT_SAFETY_FACTOR = 1.39
+# ASME B31G / Modified B31G validity limit on relative defect depth.  The
+# methods are calibrated for d/t up to 0.80; deeper defects fall outside the
+# qualified range and should be assessed by repair/replace criteria.
+_B31G_MAX_DT = 0.80
 
 # API 5L specified minimum yield strength (psi) — grade number is SMYS in ksi.
 SMYS_PSI = {
@@ -86,8 +90,17 @@ def _failure_pressure(flow: float, t: float, D: float, ar: float, M: float) -> f
     return (2.0 * flow * t / D) * (1.0 - ar) / (1.0 - ar / M)
 
 
-def _finalise(method, pf, intact, flow, M, ar, *, maop_psi, safety_factor, details):
+def _finalise(method, pf, intact, flow, M, ar, *, maop_psi, safety_factor, details,
+              d_over_t=None):
     safe = pf / safety_factor
+    if d_over_t is not None:
+        within = d_over_t <= _B31G_MAX_DT
+        details = {**details,
+                   "within_applicability": bool(within),
+                   "applicability_note": (
+                       None if within else
+                       f"d/t={d_over_t:.3f} exceeds B31G validity limit "
+                       f"{_B31G_MAX_DT:.2f}; assess by repair/replace criteria")}
     return CorrodedPipeResult(
         method=method,
         failure_pressure_psi=pf,
@@ -135,6 +148,7 @@ def b31g_original(
         "B31G", pf, intact, flow, M_report, ar,
         maop_psi=maop_psi, safety_factor=safety_factor,
         details={"z": z, "regime": regime, "d_over_t": d / t},
+        d_over_t=d / t,
     )
 
 
@@ -154,6 +168,7 @@ def modified_b31g(
         "Modified_B31G", pf, intact, flow, M, ar,
         maop_psi=maop_psi, safety_factor=safety_factor,
         details={"z": z, "d_over_t": d / t},
+        d_over_t=d / t,
     )
 
 
@@ -203,11 +218,14 @@ def rstreng_effective_area(
                 worst_pf = pf
                 worst = {"L": float(L), "ar": float(ar), "M": float(M),
                          "i": i, "j": j}
+    max_dt = float(np.max(d)) / t
     return _finalise(
         "RSTRENG", worst_pf, intact, flow, worst["M"], worst["ar"],
         maop_psi=maop_psi, safety_factor=safety_factor,
         details={"critical_length_in": worst["L"],
-                 "critical_segment": (worst["i"], worst["j"])},
+                 "critical_segment": (worst["i"], worst["j"]),
+                 "d_over_t": max_dt},
+        d_over_t=max_dt,
     )
 
 

--- a/src/digitalmodel/asset_integrity/dnv_rp_f101.py
+++ b/src/digitalmodel/asset_integrity/dnv_rp_f101.py
@@ -51,13 +51,13 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Material — API 5L specified minimum TENSILE strength (SMTS), psi.
 # DNV-RP-F101 capacity uses f_u = SMTS (not SMYS).  Values are the API 5L /
-# ISO 3183 PSL2 minimum UTS for each grade (rounded from MPa): X52 = 455 MPa,
+# ISO 3183 PSL2 minimum UTS for each grade (rounded from MPa): X52 = 460 MPa,
 # X60 = 520 MPa, X65 = 535 MPa, X70 = 570 MPa, X80 = 625 MPa.
 # ---------------------------------------------------------------------------
 SMTS_PSI = {
     "X42": 60_200.0,   # 415 MPa
     "X46": 63_100.0,   # 435 MPa
-    "X52": 66_700.0,   # 455 MPa
+    "X52": 66_700.0,   # 460 MPa
     "X56": 71_100.0,   # 490 MPa
     "X60": 75_400.0,   # 520 MPa
     "X65": 77_600.0,   # 535 MPa
@@ -85,6 +85,11 @@ _DEFAULT_GAMMA_M = 0.77
 _DEFAULT_GAMMA_D = 1.0
 _DEFAULT_EPSILON_D = 1.0
 _DEFAULT_STD_REL_DEPTH = 0.08
+
+# DNV-RP-F101 validity limit on relative defect depth.  The capacity equation is
+# calibrated for d/t up to 0.85; deeper defects are outside the qualified range
+# and should be assessed by repair/replace criteria rather than extrapolated.
+_DNV_F101_MAX_DT = 0.85
 
 
 @dataclass
@@ -147,6 +152,7 @@ def dnv_f101_single_defect(
     Q = length_correction_factor(D, t, L)
     p_cap = _capacity(t, f_u, D, dt, Q)
     p_allow = usage_factor * p_cap
+    within = dt <= _DNV_F101_MAX_DT
     return DNVF101Result(
         method="DNV-F101-AS",
         capacity_pressure_psi=p_cap,
@@ -156,7 +162,12 @@ def dnv_f101_single_defect(
         intact_pressure_psi=_intact_pressure(t, f_u, D),
         acceptable=(None if maop_psi is None else bool(p_allow >= maop_psi)),
         details={"usage_factor": usage_factor, "L_in": L,
-                 "smts_psi": f_u, "format": "allowable_stress"},
+                 "smts_psi": f_u, "format": "allowable_stress",
+                 "within_applicability": bool(within),
+                 "applicability_note": (
+                     None if within else
+                     f"d/t={dt:.3f} exceeds DNV-RP-F101 validity limit "
+                     f"{_DNV_F101_MAX_DT:.2f}; assess by repair/replace criteria")},
     )
 
 

--- a/tests/asset_integrity/test_ffs_1094_quickwins.py
+++ b/tests/asset_integrity/test_ffs_1094_quickwins.py
@@ -1,0 +1,77 @@
+# ABOUTME: Regression tests for the #1094 FFS strength-method quick-win fixes:
+# ABOUTME: unbiased area-average t_am, d/t applicability flags, frozen Folias cap.
+import math
+
+import numpy as np
+import pandas as pd
+
+from digitalmodel.asset_integrity import corroded_pipe as cp
+from digitalmodel.asset_integrity import dnv_rp_f101 as dnv
+from digitalmodel.asset_integrity.assessment.level2_engine import (
+    Level2Engine,
+    _LAMBDA_UPPER,
+)
+
+
+# --- #8: t_am is the true area-average, unbiased under unequal NaN counts -----
+def test_gml_t_am_is_area_average_not_mean_of_column_means():
+    # Column 1 has a missing cell, so the old df.mean().mean() (mean of the
+    # per-column means) would give 0.525; the true area-average is 0.500.
+    grid = pd.DataFrame({"c0": [0.40, 0.50], "c1": [0.60, np.nan]})
+    engine = Level2Engine("GML", nominal_od_in=20.0, nominal_wt_in=0.5,
+                          t_min_in=0.45)
+    result = engine.evaluate(grid)
+
+    valid = grid.to_numpy(dtype=float)
+    expected = float(np.nanmean(valid))  # = 1.5 / 3 = 0.5
+    assert math.isclose(result["t_am_in"], expected, rel_tol=1e-12)
+    assert math.isclose(result["t_am_in"], 0.5, rel_tol=1e-12)
+    # The biased mean-of-column-means would have been 0.525.
+    assert not math.isclose(result["t_am_in"], 0.525, rel_tol=1e-6)
+
+
+# --- #2: B31G / Modified / RSTRENG applicability flag (d/t <= 0.80) -----------
+def test_b31g_flags_defect_beyond_applicability():
+    deep = cp.b31g_original(D=20.0, t=0.5, d=0.45, L=4.0, smys_psi=52_000.0)
+    assert deep.details["within_applicability"] is False
+    assert deep.details["applicability_note"] is not None
+
+    shallow = cp.b31g_original(D=20.0, t=0.5, d=0.20, L=4.0, smys_psi=52_000.0)
+    assert shallow.details["within_applicability"] is True
+    assert shallow.details["applicability_note"] is None
+
+
+def test_modified_b31g_flags_defect_beyond_applicability():
+    deep = cp.modified_b31g(D=20.0, t=0.5, d=0.45, L=4.0, smys_psi=52_000.0)
+    assert deep.details["within_applicability"] is False
+
+
+def test_rstreng_flags_profile_beyond_applicability():
+    # Deepest profile point is 0.45 in of a 0.5 in wall -> d/t = 0.9 > 0.80.
+    res = cp.rstreng_effective_area(
+        D=20.0, t=0.5, positions_in=[0.0, 2.0, 4.0],
+        depths_in=[0.10, 0.45, 0.10], smys_psi=52_000.0)
+    assert res.details["within_applicability"] is False
+    assert math.isclose(res.details["d_over_t"], 0.9, rel_tol=1e-9)
+
+
+# --- #3: DNV-RP-F101 single-defect applicability flag (d/t <= 0.85) -----------
+def test_dnv_f101_single_defect_flags_beyond_applicability():
+    deep = dnv.dnv_f101_single_defect(D=20.0, t=0.5, d=0.45, L=4.0,
+                                      smts_psi=66_700.0)
+    assert deep.details["within_applicability"] is False
+    assert deep.details["applicability_note"] is not None
+
+    ok = dnv.dnv_f101_single_defect(D=20.0, t=0.5, d=0.40, L=4.0,
+                                    smts_psi=66_700.0)
+    assert ok.details["within_applicability"] is True
+    assert ok.details["applicability_note"] is None
+
+
+# --- #11: Folias factor is frozen at the lambda = 20 value beyond the range ---
+def test_folias_factor_frozen_above_lambda_20():
+    # Long flaw -> lambda >> 20; M_t must equal the lambda = 20 table value,
+    # not extrapolate the simplified closed form.
+    mt = Level2Engine._folias_factor(l_a=100.0, nominal_id=20.0, t_c=0.5)
+    expected = math.sqrt(1.0 + 0.48 * _LAMBDA_UPPER ** 2)
+    assert math.isclose(mt, expected, rel_tol=1e-12)


### PR DESCRIPTION
Implements the **safe-now quick wins** from the #1094 adversarial review of the merged FFS strength methods. **No core failure-pressure formula or constant changed** — every golden value is preserved (verified: full `asset_integrity` suite 452 passed / 8 skipped). The findings addressed are applicability/labeling/defaults, not physics.

## Findings fixed
| # | Where | Fix | Sev |
|---|---|---|---|
| 2 | `corroded_pipe` B31G/Mod/RSTRENG | Surface a `d/t <= 0.80` applicability flag (`within_applicability` + `applicability_note`) through the shared `_finalise`; RSTRENG reports governing `d/t` = max profile depth | Med |
| 3 | `dnv_rp_f101` single-defect | Surface a `d/t <= 0.85` applicability flag | Med |
| 5,11 | `level2_engine._folias_factor` | Docstrings now match the code: `lambda>20` freezes `M_t` at the `lambda=20` simplified-table value (not `1/Rt`); clarify simplified vs API 579-1 polynomial form | Med/Low |
| 8 | `level2_engine` t_am | True area-average via `np.nanmean` over valid cells — unbiased vs the prior mean-of-column-means under unequal NaN counts | Low |
| 10 | `dnv_rp_f101` SMTS comment | X52 `455 MPa` -> `460 MPa` (value `66,700 psi` already correct; comment-only) | Low |

The flags are **non-breaking**: numeric results are unchanged; out-of-range defects now carry a visible warning instead of silently returning an extrapolated number.

## Tests
New `tests/asset_integrity/test_ffs_1094_quickwins.py` (6 regression tests): unbiased `t_am`, the three applicability flags, and the frozen Folias cap.

## Deferred (fold into epic #1080 / FFS-hardening)
Larger #1094 items remain open: DNV interacting-defect area-averaging (finding 1), DNV vs ASME usage-factor semantics (4), full DNV Part-A PSF tables + validity layer (6), and the published-example golden tests (API 579 E4.1/E5.1, DNV-RP-F101 appendix, RSTRENG burst DB).

Refs #1094