### PR TITLE
feat(materials): unified material grade matrix (API 5L + IACS + EN) [#1088]

### DIFF
--- a/docs/domains/materials/grade-matrix-validation-2026-06-28.md
+++ b/docs/domains/materials/grade-matrix-validation-2026-06-28.md
@@ -1,0 +1,77 @@
+# Material Grade Matrix — Validation Record (2026-06-28)
+
+Backing for `src/digitalmodel/materials/` (issue #1088, EPIC #1080 workstream B).
+The matrix is the single source of truth that the line-pipe (#1087), casing
+(#1090), rod (#1091) and structural modules consume, replacing 8+ scattered
+strength dicts that disagreed on values and units.
+
+## Scope
+
+| Standard | Grades | Count |
+|---|---|---|
+| API 5L / ISO 3183 | A25, A, B, X42, X46, X52, X56, X60, X65, X70, X80, X90, X100, X120 | 14 |
+| IACS UR W11 (hull) | Grade A/B/D/E (235) + {A,D,E,F}H 32 (315) / 36 (355) / 40 (390) | 16 |
+| EN 10025-2 | S275, S355, S420 | 3 |
+
+Stored in **MPa** (SI); psi properties and back-compat adapters provided.
+
+## Reconciliation of the prior disagreement
+
+The scattered tables disagreed on X52 in two distinct ways, both now resolved
+and documented per record:
+
+1. **SMYS 358 / 359 / 360 MPa** — 358–359 are the US-customary `52 ksi`
+   conversion (52,000 psi = 358.5 MPa); 360 MPa is the ISO 3183 metric grade
+   `L360`. The matrix stores the ISO metric value (`smys_mpa`) and preserves the
+   US designation via `grade_ksi` for psi back-compat.
+2. **SMTS 455 vs 460 MPa** — this is the **PSL1 vs PSL2** split, *not* an error.
+   PSL1 X52 minimum tensile = 455 MPa; PSL2 = 460 MPa. The matrix stores PSL2 in
+   `smts_mpa` and PSL1 in `smts_psl1_mpa`; `smts_mpa(name, psl=...)` selects.
+
+The same PSL1/PSL2 pattern explains the X60 (517/520), X65 (530/535), X70
+(565/570) and X80 (620/625) differences seen across the legacy dicts.
+
+## Golden values (published references)
+
+Spot-checked against API 5L (46th ed.) / ISO 3183, IACS UR W11, EN 10025-2:
+
+| Grade | SMYS (MPa) | SMTS (MPa) | Note |
+|---|---|---|---|
+| X52 | 360 | 460 (PSL2) / 455 (PSL1) | ISO L360 |
+| X65 | 450 | 535 (PSL2) / 530 (PSL1) | ISO L450 |
+| X80 | 555 | 625 (PSL2) / 620 (PSL1) | ISO L555 |
+| X120 | 830 | 915 | PSL2 only |
+| Grade A (hull) | 235 | 400 | NS, Charpy +20 C |
+| AH36 / EH36 / FH36 | 355 | 490 | letter = toughness only |
+| EH40 | 390 | 510 | HS-40 |
+| S355 | 355 | 510 | EN, t ≤ 16 mm |
+
+Young's modulus by family: line pipe 207 GPa, hull 206 GPa, EN structural
+210 GPa; ν = 0.30, ρ = 7850 kg/m³.
+
+## Back-compat verification
+
+The legacy FFS dicts are **regenerated from the matrix** (not copied) and the
+test-suite asserts equality against the live imports, which both documents the
+convention and guards against drift:
+
+* `legacy_smys_psi_dict()` == `asset_integrity.corroded_pipe.SMYS_PSI`
+  — convention: SMYS psi = grade number (ksi) × 1000 (X52 → 52,000 psi).
+* `legacy_smts_psi_dict()` == `asset_integrity.dnv_rp_f101.SMTS_PSI`
+  — convention: PSL2 SMTS (MPa) × 145.0377, rounded to nearest 100 psi
+  (460 MPa → 66,700 psi).
+
+## Tests
+
+`tests/materials/test_grade_matrix.py` — 29 tests: published-value golden
+parametrizations (API 5L / IACS / EN), the legacy back-compat equalities, the
+toughness-letter invariance, ISO-alias and name-collision lookup behavior
+(API `A` vs hull `Grade A`), psi conversions, and registry completeness (33
+grades). All passing.
+
+## Deferred
+
+Migrating the remaining scattered consumers (`pipe_db_client`, `riser_config`,
+`pipeline_pressure`, `wall_thickness_parametric`, structural `models.py`, …)
+onto this matrix is tracked by issue #1089. Some of those carry US-customary or
+PSL1 roundings; #1089 will surface and resolve each value delta on migration.

--- a/src/digitalmodel/materials/__init__.py
+++ b/src/digitalmodel/materials/__init__.py
@@ -1,0 +1,45 @@
+# ABOUTME: Canonical material-grade matrix — single source of truth for steel
+# ABOUTME: grade strengths (API 5L / ISO 3183, IACS UR W11, EN 10025-2).
+"""Canonical material-grade matrix for digitalmodel.
+
+One reconciled record per grade (see :class:`MaterialGrade`) replaces the eight-
+plus scattered strength dicts that previously disagreed on X52 SMYS (358 / 359 /
+360 MPa) and mixed psi / MPa / Pa units.  Strengths are stored in **MPa**; psi
+helpers and back-compat adapters are provided for existing consumers.
+
+Standards covered:
+  * API 5L / ISO 3183 line pipe — A25..X120 (PSL1 and PSL2).
+  * IACS UR W11 hull structural steel — A/B/D/E, AH/DH/EH/FH 32/36/40.
+  * EN 10025-2 structural steel — S275/S355/S420.
+"""
+from .grades import (
+    MaterialGrade,
+    GRADES,
+    get,
+    all_grades,
+    by_standard,
+    smys_mpa,
+    smts_mpa,
+    smys_psi,
+    smts_psi,
+    legacy_smys_psi_dict,
+    legacy_smts_psi_dict,
+    MPA_PER_PSI,
+    PSI_PER_MPA,
+)
+
+__all__ = [
+    "MaterialGrade",
+    "GRADES",
+    "get",
+    "all_grades",
+    "by_standard",
+    "smys_mpa",
+    "smts_mpa",
+    "smys_psi",
+    "smts_psi",
+    "legacy_smys_psi_dict",
+    "legacy_smts_psi_dict",
+    "MPA_PER_PSI",
+    "PSI_PER_MPA",
+]

--- a/src/digitalmodel/materials/grades.py
+++ b/src/digitalmodel/materials/grades.py
@@ -1,0 +1,260 @@
+# ABOUTME: MaterialGrade record + reconciled registry of steel grade strengths
+# ABOUTME: with sourced values and derivable back-compat adapters for legacy dicts.
+"""Canonical material-grade matrix.
+
+Strengths are stored in **MPa** (SI).  For API 5L the stored ``smts_mpa`` is the
+PSL2 minimum tensile strength; ``smts_psl1_mpa`` carries the (slightly lower)
+PSL1 / US-customary minimum where it differs — this is the origin of the legacy
+"X52 = 455 vs 460 MPa" disagreement (PSL1 vs PSL2).
+
+Sources:
+  * API 5L (46th ed.) / ISO 3183 — line-pipe grade strengths (Tables 4/5).
+  * IACS UR W11 (Rev.) — Normal & Higher-Strength Hull Structural Steels.
+  * EN 10025-2 — hot-rolled structural steel (t <= 16 mm class).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+# Unit conversion (exact-enough engineering constant).
+PSI_PER_MPA = 145.0377
+MPA_PER_PSI = 1.0 / PSI_PER_MPA
+
+# Per-standard elastic defaults (MPa), Poisson ratio, density (kg/m^3).
+_E_LINE_PIPE = 207_000.0   # API 5L line pipe (207 GPa)
+_E_MARINE = 206_000.0      # IACS hull steel (206 GPa)
+_E_STRUCTURAL = 210_000.0  # EN 10025 structural (210 GPa)
+_NU = 0.30
+_RHO = 7850.0
+
+
+@dataclass(frozen=True)
+class MaterialGrade:
+    """One reconciled material grade.
+
+    Attributes:
+        name: Canonical registry key (e.g. ``"X52"``, ``"AH36"``, ``"S355"``).
+        standard: Governing standard (``"API 5L"`` / ``"IACS UR W11"`` /
+            ``"EN 10025-2"``).
+        smys_mpa: Specified minimum yield strength (MPa).
+        smts_mpa: Specified minimum tensile strength (MPa); PSL2 for API 5L.
+        E_mpa: Young's modulus (MPa).
+        nu: Poisson's ratio.
+        rho_kg_m3: Density (kg/m^3).
+        designation: Equivalent designation (ISO 3183 L-grade or alias).
+        grade_ksi: SMYS in ksi for API 5L (the X-number); ``None`` otherwise.
+        toughness_grade: Charpy test-temperature class for hull steel
+            (``A`` 20C / ``B`` 0C / ``D`` -20C / ``E`` -40C / ``F`` -60C).
+        smts_psl1_mpa: API 5L PSL1 minimum tensile strength (MPa) where it
+            differs from PSL2; ``None`` for non-API or PSL2-only grades.
+        source: Citation for the strength values.
+        notes: Free-form reconciliation notes.
+    """
+
+    name: str
+    standard: str
+    smys_mpa: float
+    smts_mpa: float
+    E_mpa: float = _E_LINE_PIPE
+    nu: float = _NU
+    rho_kg_m3: float = _RHO
+    designation: Optional[str] = None
+    grade_ksi: Optional[float] = None
+    toughness_grade: Optional[str] = None
+    smts_psl1_mpa: Optional[float] = None
+    source: str = ""
+    notes: str = ""
+
+    @property
+    def smys_psi(self) -> float:
+        """Yield strength in psi (MPa -> psi)."""
+        return self.smys_mpa * PSI_PER_MPA
+
+    @property
+    def smts_psi(self) -> float:
+        """Tensile strength in psi (MPa -> psi)."""
+        return self.smts_mpa * PSI_PER_MPA
+
+
+# ---------------------------------------------------------------------------
+# Registry construction
+# ---------------------------------------------------------------------------
+_API_5L_SRC = "API 5L (46th ed.) / ISO 3183, line-pipe grade strengths"
+_IACS_SRC = "IACS UR W11, Normal & Higher-Strength Hull Structural Steels"
+_EN_SRC = "EN 10025-2, structural steel (t <= 16 mm)"
+
+
+def _api5l(name, ksi, smys, smts2, smts1, iso, *, note=""):
+    return MaterialGrade(
+        name=name, standard="API 5L", smys_mpa=smys, smts_mpa=smts2,
+        E_mpa=_E_LINE_PIPE, designation=iso, grade_ksi=ksi,
+        smts_psl1_mpa=smts1, source=_API_5L_SRC, notes=note)
+
+
+def _hull(name, smys, smts, tough, *, note=""):
+    return MaterialGrade(
+        name=name, standard="IACS UR W11", smys_mpa=smys, smts_mpa=smts,
+        E_mpa=_E_MARINE, toughness_grade=tough, source=_IACS_SRC, notes=note)
+
+
+def _en(name, smys, smts):
+    return MaterialGrade(
+        name=name, standard="EN 10025-2", smys_mpa=smys, smts_mpa=smts,
+        E_mpa=_E_STRUCTURAL, source=_EN_SRC)
+
+
+# API 5L / ISO 3183 — SMYS = ISO L-grade (MPa); SMTS = PSL2 min, PSL1 in 5th col.
+# US-customary (ksi) SMYS values differ by ~1-2% on the low grades; the grade
+# number (grade_ksi) preserves that designation for psi back-compat.
+_API_5L = [
+    _api5l("A25", 25, 175.0, 310.0, 310.0, "L175",
+           note="PSL1 only; D <= 141.3 mm. US 25 ksi = 172 MPa."),
+    _api5l("A", 30, 210.0, 335.0, 335.0, "L210", note="US 30 ksi = 207 MPa."),
+    _api5l("B", 35, 245.0, 415.0, 415.0, "L245", note="US 35 ksi = 241 MPa."),
+    _api5l("X42", 42, 290.0, 415.0, 414.0, "L290"),
+    _api5l("X46", 46, 320.0, 435.0, 434.0, "L320"),
+    _api5l("X52", 52, 360.0, 460.0, 455.0, "L360",
+           note="Legacy 358/359 MPa = US 52 ksi; PSL1 SMTS 455, PSL2 460."),
+    _api5l("X56", 56, 390.0, 490.0, 489.0, "L390"),
+    _api5l("X60", 60, 415.0, 520.0, 517.0, "L415"),
+    _api5l("X65", 65, 450.0, 535.0, 530.0, "L450"),
+    _api5l("X70", 70, 485.0, 570.0, 565.0, "L485"),
+    _api5l("X80", 80, 555.0, 625.0, 620.0, "L555"),
+    _api5l("X90", 90, 625.0, 695.0, None, "L625", note="PSL2 only."),
+    _api5l("X100", 100, 690.0, 760.0, None, "L690", note="PSL2 only."),
+    _api5l("X120", 120, 830.0, 915.0, None, "L830", note="PSL2 only."),
+]
+
+# IACS UR W11 — normal strength (235 MPa yield, Rm 400-520, min 400).
+_HULL_NS = [
+    _hull("Grade A", 235.0, 400.0, "A", note="Charpy at +20 C."),
+    _hull("Grade B", 235.0, 400.0, "B", note="Charpy at 0 C."),
+    _hull("Grade D", 235.0, 400.0, "D", note="Charpy at -20 C."),
+    _hull("Grade E", 235.0, 400.0, "E", note="Charpy at -40 C."),
+]
+
+# IACS UR W11 — higher strength: 32 -> 315, 36 -> 355, 40 -> 390 MPa yield.
+# Tensile minima: 32 -> 440, 36 -> 490, 40 -> 510 MPa.  The leading letter is
+# the toughness (test-temperature) class and does not change the strength.
+_HULL_HS_LEVELS = [(32, 315.0, 440.0), (36, 355.0, 490.0), (40, 390.0, 510.0)]
+_HULL_TOUGHNESS = [("A", "A", "+0 C"), ("D", "D", "-20 C"),
+                   ("E", "E", "-40 C"), ("F", "F", "-60 C")]
+_HULL_HS = [
+    _hull(f"{tletter}H{lvl}", smys, smts, tclass,
+          note=f"Higher-strength {lvl}; Charpy at {ttemp}.")
+    for (lvl, smys, smts) in _HULL_HS_LEVELS
+    for (tletter, tclass, ttemp) in _HULL_TOUGHNESS
+]
+
+# EN 10025-2 structural steel (t <= 16 mm class).
+_EN_GRADES = [
+    _en("S275", 275.0, 430.0),
+    _en("S355", 355.0, 510.0),
+    _en("S420", 420.0, 520.0),
+]
+
+#: The canonical registry, keyed by :attr:`MaterialGrade.name`.
+GRADES: dict[str, MaterialGrade] = {
+    g.name: g for g in (_API_5L + _HULL_NS + _HULL_HS + _EN_GRADES)
+}
+
+# Alias map (ISO L-grade -> canonical name) for forgiving lookup.
+_ALIASES: dict[str, str] = {
+    g.designation.upper(): g.name
+    for g in GRADES.values() if g.designation
+}
+
+
+# ---------------------------------------------------------------------------
+# Query API
+# ---------------------------------------------------------------------------
+def get(name: str) -> MaterialGrade:
+    """Look up a grade by canonical name, ISO designation, or alias.
+
+    Case-insensitive; tolerates the ``"Grade "`` prefix for hull steel.
+
+    Raises:
+        KeyError: if the grade is unknown.
+    """
+    if name in GRADES:
+        return GRADES[name]
+    key = name.strip()
+    # Direct, then case-normalised, then alias.
+    for candidate in (key, key.upper(), f"Grade {key.upper()[-1]}"):
+        if candidate in GRADES:
+            return GRADES[candidate]
+    upper = key.upper()
+    if upper in _ALIASES:
+        return GRADES[_ALIASES[upper]]
+    # Case-insensitive name match.
+    for canonical, grade in GRADES.items():
+        if canonical.upper() == upper:
+            return grade
+    raise KeyError(f"Unknown material grade: {name!r}")
+
+
+def all_grades() -> list[MaterialGrade]:
+    """All registered grades, in registry (standard) order."""
+    return list(GRADES.values())
+
+
+def by_standard(standard: str) -> list[MaterialGrade]:
+    """All grades belonging to a standard (case-insensitive substring match)."""
+    s = standard.strip().lower()
+    return [g for g in GRADES.values() if s in g.standard.lower()]
+
+
+def smys_mpa(name: str) -> float:
+    """Specified minimum yield strength (MPa)."""
+    return get(name).smys_mpa
+
+
+def smts_mpa(name: str, *, psl: str = "PSL2") -> float:
+    """Specified minimum tensile strength (MPa).
+
+    For API 5L, ``psl="PSL1"`` returns the PSL1 minimum where it differs.
+    """
+    g = get(name)
+    if psl.upper() == "PSL1" and g.smts_psl1_mpa is not None:
+        return g.smts_psl1_mpa
+    return g.smts_mpa
+
+
+def smys_psi(name: str) -> float:
+    """Specified minimum yield strength (psi)."""
+    return get(name).smys_psi
+
+
+def smts_psi(name: str, *, psl: str = "PSL2") -> float:
+    """Specified minimum tensile strength (psi)."""
+    return smts_mpa(name, psl=psl) * PSI_PER_MPA
+
+
+# ---------------------------------------------------------------------------
+# Back-compat adapters — regenerate the legacy FFS dicts from the matrix.
+# These are checked against the live legacy dicts by the test-suite, both to
+# document the convention and to guard against future drift.  Migration of the
+# scattered consumers onto these is tracked separately (issue #1089).
+# ---------------------------------------------------------------------------
+#: API 5L grades that the legacy asset_integrity dicts covered.
+_LEGACY_API_5L = ["X42", "X46", "X52", "X56", "X60", "X65", "X70", "X80"]
+
+
+def legacy_smys_psi_dict() -> dict[str, float]:
+    """Reproduce ``asset_integrity.corroded_pipe.SMYS_PSI``.
+
+    Convention: SMYS in psi = grade number (ksi) x 1000 (X52 -> 52,000 psi).
+    """
+    return {name: get(name).grade_ksi * 1000.0 for name in _LEGACY_API_5L}
+
+
+def legacy_smts_psi_dict() -> dict[str, float]:
+    """Reproduce ``asset_integrity.dnv_rp_f101.SMTS_PSI``.
+
+    Convention: PSL2 SMTS (MPa) -> psi, rounded to the nearest 100 psi.
+    """
+    return {
+        name: float(round(get(name).smts_mpa * PSI_PER_MPA, -2))
+        for name in _LEGACY_API_5L
+    }

--- a/tests/materials/test_grade_matrix.py
+++ b/tests/materials/test_grade_matrix.py
@@ -1,0 +1,146 @@
+# ABOUTME: Golden tests for the canonical material-grade matrix — published
+# ABOUTME: reference strengths, legacy back-compat adapters, and lookup behavior.
+import math
+
+import pytest
+
+from digitalmodel.materials import (
+    GRADES,
+    MaterialGrade,
+    all_grades,
+    by_standard,
+    get,
+    legacy_smts_psi_dict,
+    legacy_smys_psi_dict,
+    smts_mpa,
+    PSI_PER_MPA,
+)
+
+
+# --- Golden: API 5L / ISO 3183 (SMYS = ISO L-grade; SMTS = PSL2 min) ----------
+@pytest.mark.parametrize(
+    "name, smys, smts_psl2, smts_psl1",
+    [
+        ("A25", 175.0, 310.0, 310.0),
+        ("X42", 290.0, 415.0, 414.0),
+        ("X52", 360.0, 460.0, 455.0),   # PSL1 455 vs PSL2 460 -> legacy split
+        ("X65", 450.0, 535.0, 530.0),
+        ("X70", 485.0, 570.0, 565.0),
+        ("X80", 555.0, 625.0, 620.0),
+        ("X90", 625.0, 695.0, None),    # PSL2 only
+        ("X100", 690.0, 760.0, None),
+        ("X120", 830.0, 915.0, None),
+    ],
+)
+def test_api_5l_published_values(name, smys, smts_psl2, smts_psl1):
+    g = get(name)
+    assert g.standard == "API 5L"
+    assert g.smys_mpa == smys
+    assert g.smts_mpa == smts_psl2
+    assert g.smts_psl1_mpa == smts_psl1
+    assert g.E_mpa == 207_000.0
+    # PSL helper returns PSL1 value where it differs, else PSL2.
+    if smts_psl1 is not None:
+        assert smts_mpa(name, psl="PSL1") == smts_psl1
+    assert smts_mpa(name, psl="PSL2") == smts_psl2
+
+
+# --- Golden: IACS UR W11 hull steel -------------------------------------------
+@pytest.mark.parametrize(
+    "name, smys, smts, tough",
+    [
+        ("Grade A", 235.0, 400.0, "A"),
+        ("Grade E", 235.0, 400.0, "E"),
+        ("AH32", 315.0, 440.0, "A"),
+        ("AH36", 355.0, 490.0, "A"),
+        ("EH36", 355.0, 490.0, "E"),
+        ("FH36", 355.0, 490.0, "F"),
+        ("EH40", 390.0, 510.0, "E"),
+    ],
+)
+def test_iacs_w11_published_values(name, smys, smts, tough):
+    g = get(name)
+    assert g.standard == "IACS UR W11"
+    assert g.smys_mpa == smys
+    assert g.smts_mpa == smts
+    assert g.toughness_grade == tough
+    assert g.E_mpa == 206_000.0
+
+
+def test_hull_toughness_letter_does_not_change_strength():
+    # The leading letter is the Charpy test-temperature class only.
+    for level in (32, 36, 40):
+        strengths = {
+            (get(f"{t}H{level}").smys_mpa, get(f"{t}H{level}").smts_mpa)
+            for t in ("A", "D", "E", "F")
+        }
+        assert len(strengths) == 1
+
+
+# --- Golden: EN 10025-2 structural --------------------------------------------
+@pytest.mark.parametrize(
+    "name, smys, smts",
+    [("S275", 275.0, 430.0), ("S355", 355.0, 510.0), ("S420", 420.0, 520.0)],
+)
+def test_en_10025_published_values(name, smys, smts):
+    g = get(name)
+    assert g.standard == "EN 10025-2"
+    assert g.smys_mpa == smys
+    assert g.smts_mpa == smts
+    assert g.E_mpa == 210_000.0
+
+
+# --- Back-compat: adapters reproduce the live legacy FFS dicts exactly ---------
+def test_legacy_smys_psi_matches_corroded_pipe():
+    from digitalmodel.asset_integrity.corroded_pipe import SMYS_PSI
+
+    assert legacy_smys_psi_dict() == SMYS_PSI
+
+
+def test_legacy_smts_psi_matches_dnv_rp_f101():
+    from digitalmodel.asset_integrity.dnv_rp_f101 import SMTS_PSI
+
+    assert legacy_smts_psi_dict() == SMTS_PSI
+
+
+# --- Lookup behavior ----------------------------------------------------------
+def test_iso_designation_alias_resolves():
+    assert get("L360").name == "X52"
+    assert get("l485").name == "X70"
+
+
+def test_api_a_and_hull_grade_a_do_not_collide():
+    assert get("A").standard == "API 5L"          # API 5L Grade A (210 MPa)
+    assert get("Grade A").standard == "IACS UR W11"  # hull NS A (235 MPa)
+    assert get("A").smys_mpa != get("Grade A").smys_mpa
+
+
+def test_get_is_case_insensitive():
+    assert get("x52") is get("X52")
+    assert get("ah36") is get("AH36")
+
+
+def test_get_unknown_raises():
+    with pytest.raises(KeyError):
+        get("ZZ999")
+
+
+# --- psi conversions ----------------------------------------------------------
+def test_psi_properties():
+    g = get("X52")
+    assert math.isclose(g.smys_psi, 360.0 * PSI_PER_MPA, rel_tol=1e-9)
+    assert math.isclose(g.smts_psi, 460.0 * PSI_PER_MPA, rel_tol=1e-9)
+
+
+# --- Registry integrity -------------------------------------------------------
+def test_registry_completeness():
+    # 14 API 5L + 4 hull NS + 12 hull HS + 3 EN = 33 grades.
+    assert len(GRADES) == 33
+    assert len(by_standard("API 5L")) == 14
+    assert len(by_standard("IACS")) == 16
+    assert len(by_standard("EN 10025")) == 3
+    assert all(isinstance(g, MaterialGrade) for g in all_grades())
+
+
+def test_every_record_has_a_source():
+    assert all(g.source for g in all_grades())


### PR DESCRIPTION
Closes #1088 — EPIC #1080 workstream B backbone (Phase 1).

## What
One canonical, sourced material-grade matrix (`src/digitalmodel/materials/`) replacing the **8+ scattered strength dicts** that disagreed on values and units (the inventory actually found 14 tables across `asset_integrity`, `subsea`, `structural`, `orcaflex`, `data_systems`). This is the single source of truth the line-pipe (#1087), casing (#1090), rod (#1091) and structural modules consume.

- **`MaterialGrade`** (frozen dataclass) + a registry of **33 grades**:
  - **API 5L / ISO 3183:** A25, A, B, X42, X46, X52, X56, X60, X65, X70, X80, X90, X100, X120 — SMYS + PSL2 tensile, with the PSL1 tensile preserved.
  - **IACS UR W11 hull:** Grade A/B/D/E (235) + {A,D,E,F}H 32 (315) / 36 (355) / 40 (390), with the Charpy toughness class.
  - **EN 10025-2:** S275/S355/S420.
  - Strengths in **MPa**; E/ν/ρ per family (line pipe 207, hull 206, EN 210 GPa); psi helpers; ISO-alias + name-collision-safe lookup (`get("L360")` → X52; API `A` vs hull `Grade A`).

## Reconciliation (the point of the issue)
The legacy X52 disagreement is now resolved and documented per record:
- **SMYS 358 / 359 / 360 MPa** → 358–359 are the US-customary `52 ksi` conversion; **360** is the ISO metric `L360` (stored canonical; `grade_ksi` preserves the US designation).
- **SMTS 455 vs 460 MPa** → this is the **PSL1 vs PSL2** split, *not* an error. Both stored (`smts_mpa` = PSL2, `smts_psl1_mpa` = PSL1; `smts_mpa(name, psl=...)` selects). Same pattern for X60/X65/X70/X80.

## Back-compat (risk-free #1089 migration)
The legacy FFS dicts are **regenerated from the matrix** (not copied), and the tests assert equality against the *live* imports — documenting the convention and guarding against drift:
- `legacy_smys_psi_dict()` == `corroded_pipe.SMYS_PSI` (psi = grade-ksi × 1000).
- `legacy_smts_psi_dict()` == `dnv_rp_f101.SMTS_PSI` (PSL2 MPa × 145.0377, round to nearest 100 psi → 460 MPa = 66,700 psi).

## Tests / validation
- `tests/materials/test_grade_matrix.py` — **29 golden tests** vs published API 5L / IACS / EN values, the two back-compat equalities, toughness-letter invariance, lookup behavior, psi conversions, registry completeness. All passing (black + flake8 clean).
- Validation record: `docs/domains/materials/grade-matrix-validation-2026-06-28.md`.

## Not in scope (tracked by #1089)
Migrating the scattered consumers onto this matrix — some carry US-customary/PSL1 roundings; #1089 surfaces and resolves each delta on migration. No existing module is modified here, so no behavior changes.

> Note: this repo's `main` CI baseline is chronically red on unrelated domains (orcaflex-solver/subsea/infrastructure/misc) and a pre-existing abs-path Quality-Gate violation in `marine_ops/vessel_db/wed_adapter.py`. The relevant signal here is the new `tests-materials` / touched domain.