### PR TITLE
feat(diffraction): default spec-author to the `claude -p` CLI (no API key) (#1095)

### DIFF
--- a/examples/workflows/spec-authoring-llm/README.md
+++ b/examples/workflows/spec-authoring-llm/README.md
@@ -18,16 +18,31 @@ OrcaWave .yml / AQWA .dat   (licensed-program input)
 
 ## Run
 
-The LLM call uses the Anthropic SDK (`claude-opus-4-8`, structured outputs).
-It is an optional dependency, so run with `--with anthropic` and set a key:
+By default the LLM call goes through the **`claude -p` CLI** (Claude Code) —
+it uses your existing Claude Code auth, so **no `ANTHROPIC_API_KEY` and no extra
+dependency**:
+
+```bash
+uv run python -m digitalmodel.hydrodynamics.diffraction.spec_author \
+    examples/workflows/spec-authoring-llm/project_bundle.yml \
+    --request "Give me first-pass motion RAOs for a transit screening study" \
+    --out-dir /tmp/authored_spec
+```
+
+Alternative backend — the Anthropic SDK (needs `anthropic` + `ANTHROPIC_API_KEY`):
 
 ```bash
 export ANTHROPIC_API_KEY=...
 uv run --with anthropic python -m digitalmodel.hydrodynamics.diffraction.spec_author \
     examples/workflows/spec-authoring-llm/project_bundle.yml \
-    --request "Give me first-pass motion RAOs for a transit screening study" \
-    --out-dir /tmp/authored_spec
+    --request "..." --backend anthropic-sdk --out-dir /tmp/authored_spec
 ```
+
+> **Mesh note:** the resolver requires a hull mesh to complete the spec. This
+> example bundle deliberately omits one — the author step extracts the
+> particulars and **flags the missing mesh as an open question** (no silent
+> assumptions). For a full run, add `vessel_particulars.mesh_file: <path.gdf>`
+> to the bundle (or generate a parametric hull first).
 
 Outputs in `--out-dir`:
 

--- a/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
@@ -33,9 +33,10 @@ and is imported lazily -- ``anthropic`` is not a project dependency.
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Protocol
+from typing import Any, Callable, Optional, Protocol
 
 from pydantic import BaseModel, Field
 
@@ -266,6 +267,117 @@ class AnthropicIntentAuthor:
         return response.parsed_output
 
 
+def _extract_json_object(text: str) -> str:
+    """Pull the first top-level JSON object out of model text.
+
+    Tolerates ```json fences and surrounding prose by scanning for the first
+    balanced ``{...}`` (brace depth, string-aware).
+    """
+    start = text.find("{")
+    if start == -1:
+        raise ValueError(f"No JSON object in model output: {text[:200]!r}")
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise ValueError(f"Unbalanced JSON object in model output: {text[:200]!r}")
+
+
+# Runs the CLI: (argv, stdin) -> CompletedProcess. Injectable for tests.
+CliRunner = Callable[[list[str], str], "subprocess.CompletedProcess[str]"]
+
+
+def _default_cli_runner(
+    argv: list[str], stdin: str
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        argv, input=stdin, capture_output=True, text=True, timeout=300
+    )
+
+
+class ClaudeCliIntentAuthor:
+    """Intent author backed by the ``claude -p`` CLI (Claude Code).
+
+    Uses the local Claude Code install and its existing auth -- no
+    ``ANTHROPIC_API_KEY`` and no ``anthropic`` dependency. The CLI does not
+    expose typed structured outputs, so the schema is supplied in the system
+    prompt and the JSON object is parsed (and Pydantic-validated) from the
+    response. This is the default author.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        *,
+        cli: str = "claude",
+        extra_args: Optional[list[str]] = None,
+        runner: Optional[CliRunner] = None,
+    ) -> None:
+        self.model = model
+        self.cli = cli
+        self.extra_args = list(extra_args or [])
+        self._runner = runner or _default_cli_runner
+
+    def _system_prompt(self) -> str:
+        schema = json.dumps(AuthoredIntent.model_json_schema())
+        return (
+            SYSTEM_PROMPT
+            + "\n\nReturn ONLY a single JSON object conforming to this JSON "
+            "schema -- no prose, no markdown, no code fences:\n" + schema
+        )
+
+    def author(self, bundle: ProjectBundle, request: str) -> AuthoredIntent:
+        user_prompt = (
+            f"Analysis request:\n{request}\n\n"
+            f"Project data:\n{bundle.to_prompt_context()}"
+        )
+        argv = [
+            self.cli,
+            "-p",
+            "--output-format",
+            "json",
+            "--model",
+            self.model,
+            "--system-prompt",
+            self._system_prompt(),
+            *self.extra_args,
+        ]
+        proc = self._runner(argv, user_prompt)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"`{self.cli} -p` failed (rc={proc.returncode}): "
+                f"{(proc.stderr or proc.stdout or '').strip()[:500]}"
+            )
+        try:
+            envelope = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Could not parse `{self.cli} -p` JSON envelope: "
+                f"{proc.stdout[:500]!r}"
+            ) from exc
+        if envelope.get("is_error"):
+            raise RuntimeError(f"claude returned an error: {envelope.get('result')}")
+        result_text = envelope.get("result", "")
+        return AuthoredIntent.model_validate_json(_extract_json_object(result_text))
+
+
 # ---------------------------------------------------------------------------
 # Intent -> resolver inputs
 # ---------------------------------------------------------------------------
@@ -402,12 +514,14 @@ def author_spec(
         The natural-language analysis request.
     author:
         The :class:`IntentAuthor` that performs the LLM call. Defaults to
-        :class:`AnthropicIntentAuthor`. Inject a stub for offline tests.
+        :class:`ClaudeCliIntentAuthor` (the ``claude -p`` CLI, no API key).
+        Inject a stub for offline tests, or :class:`AnthropicIntentAuthor`
+        to use the Anthropic SDK directly.
     hull_lookup, config:
         Passed straight through to :func:`resolver.resolve`.
     """
     if author is None:
-        author = AnthropicIntentAuthor()
+        author = ClaudeCliIntentAuthor()
     intent = author.author(bundle, request)
     outcome, inputs = intent_to_resolver_inputs(intent)
     spec, ledger = resolve(outcome, inputs, hull_lookup=hull_lookup, config=config)
@@ -435,13 +549,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "-o", "--out-dir", default="authored_spec", help="Output directory."
     )
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="Anthropic model id.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model id.")
+    parser.add_argument(
+        "--backend",
+        choices=["claude-cli", "anthropic-sdk"],
+        default="claude-cli",
+        help="LLM backend: 'claude-cli' (claude -p, no key) or 'anthropic-sdk'.",
+    )
     args = parser.parse_args(argv)
 
+    if args.backend == "anthropic-sdk":
+        author: IntentAuthor = AnthropicIntentAuthor(model=args.model)
+    else:
+        author = ClaudeCliIntentAuthor(model=args.model)
+
     bundle = ProjectBundle.from_yaml(args.bundle)
-    result = author_spec(
-        bundle, args.request, author=AnthropicIntentAuthor(model=args.model)
-    )
+    result = author_spec(bundle, args.request, author=author)
     paths = result.write(args.out_dir)
     print(json.dumps({k: str(v) for k, v in paths.items()}, indent=2))
     return 0
@@ -456,6 +579,7 @@ __all__ = [
     "ProvenanceEntry",
     "AuthoredIntent",
     "IntentAuthor",
+    "ClaudeCliIntentAuthor",
     "AnthropicIntentAuthor",
     "AuthoredSpec",
     "author_spec",

--- a/tests/hydrodynamics/diffraction/test_spec_author.py
+++ b/tests/hydrodynamics/diffraction/test_spec_author.py
@@ -6,6 +6,7 @@ resolve -> analysis-SSOT pipeline without any network or API key.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -244,3 +245,86 @@ def test_system_prompt_lists_all_outcomes() -> None:
     prompt = build_system_prompt()
     for outcome in Outcome:
         assert outcome.value in prompt
+
+
+# --- ClaudeCliIntentAuthor (mocked runner, no real CLI) --------------------
+
+
+def _fake_completed(stdout: str, returncode: int = 0, stderr: str = ""):
+    import subprocess
+
+    return subprocess.CompletedProcess(
+        args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_claude_cli_author_parses_fenced_json(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.spec_author import ClaudeCliIntentAuthor
+
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    inner = (
+        '{"outcome": "ship_raos", "mesh_file": "%s", "water_depth": 100.0, '
+        '"provenance": [], "open_questions": [], "rationale": "ok"}' % mesh
+    )
+    # claude -p returns an envelope whose `result` may wrap JSON in fences.
+    envelope = json.dumps({"is_error": False, "result": "```json\n" + inner + "\n```"})
+
+    captured: dict = {}
+
+    def runner(argv, stdin):
+        captured["argv"] = argv
+        captured["stdin"] = stdin
+        return _fake_completed(envelope)
+
+    author = ClaudeCliIntentAuthor(runner=runner)
+    intent = author.author(ProjectBundle(notes="x"), "vessel RAOs")
+
+    assert intent.outcome == Outcome.SHIP_RAOS
+    assert intent.mesh_file == str(mesh)
+    # The CLI was invoked headlessly with the right flags + stdin prompt.
+    assert "-p" in captured["argv"]
+    assert "--output-format" in captured["argv"]
+    assert "vessel RAOs" in captured["stdin"]
+
+
+def test_claude_cli_author_raises_on_error_envelope() -> None:
+    from digitalmodel.hydrodynamics.diffraction.spec_author import ClaudeCliIntentAuthor
+
+    envelope = json.dumps({"is_error": True, "result": "boom"})
+    author = ClaudeCliIntentAuthor(runner=lambda argv, stdin: _fake_completed(envelope))
+    with pytest.raises(RuntimeError, match="boom"):
+        author.author(ProjectBundle(), "RAOs")
+
+
+def test_claude_cli_author_raises_on_nonzero_returncode() -> None:
+    from digitalmodel.hydrodynamics.diffraction.spec_author import ClaudeCliIntentAuthor
+
+    author = ClaudeCliIntentAuthor(
+        runner=lambda argv, stdin: _fake_completed("", returncode=1, stderr="no auth")
+    )
+    with pytest.raises(RuntimeError, match="no auth"):
+        author.author(ProjectBundle(), "RAOs")
+
+
+def test_extract_json_object_handles_prose_and_fences() -> None:
+    from digitalmodel.hydrodynamics.diffraction.spec_author import _extract_json_object
+
+    assert _extract_json_object('prefix ```json\n{"a": 1}\n``` suffix') == '{"a": 1}'
+    assert _extract_json_object('{"a": {"b": 2}} trailing') == '{"a": {"b": 2}}'
+    assert _extract_json_object('{"s": "}"}') == '{"s": "}"}'
+
+
+def test_author_spec_end_to_end_with_cli_runner(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.spec_author import ClaudeCliIntentAuthor
+
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    inner = (
+        '{"outcome": "full_qtf", "mesh_file": "%s", "loa": 120, "beam": 20, '
+        '"draft": 8, "displacement_t": 15000, "water_depth": 100, '
+        '"provenance": [], "open_questions": [], "rationale": "ok"}' % mesh
+    )
+    envelope = json.dumps({"is_error": False, "result": inner})
+    author = ClaudeCliIntentAuthor(runner=lambda argv, stdin: _fake_completed(envelope))
+
+    result = author_spec(ProjectBundle(), "full QTF please", author=author)
+    assert result.spec.solver_options.solve_type == "full_qtf"


### PR DESCRIPTION
Follow-up to #1097. Routes the LLM spec-authoring call through the **`claude -p` CLI** (Claude Code) by default, using existing Claude Code auth — **no `ANTHROPIC_API_KEY`, no `anthropic` dependency**.

## What
- New `ClaudeCliIntentAuthor` — shells out to `claude -p --output-format json --model <m> --system-prompt <…>`, prompt via stdin, parses the JSON envelope's `result`, then extracts + Pydantic-validates the `AuthoredIntent` (the CLI has no typed structured outputs, so the schema is supplied in the system prompt; `_extract_json_object` tolerates code fences/prose).
- It is now the **default** `IntentAuthor`. The Anthropic SDK path stays available via `--backend anthropic-sdk`.
- Subprocess is injectable (`CliRunner`) so tests stay offline.

## Verification
- +5 tests (mocked runner: fenced/prose JSON, error envelope, non-zero rc, `_extract_json_object`, e2e via runner). Full `test_spec_author.py` → 18 passed; lint clean.
- **Live**: `claude -p` authored a `full_qtf` intent from the example bundle, extracting LOA/beam/draft/displacement/water-depth with dual-source provenance (structured slot + data-sheet document) and flagging the missing mesh/mass/frequencies as open questions — the no-silent-assumptions discipline holding under a real model.

Part of #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)