### PR TITLE
feat(orcaflex): inverse resolver + assumption ledger (outcome → ProjectInputSpec) (#1096)

### DIFF
--- a/src/digitalmodel/common/__init__.py
+++ b/src/digitalmodel/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared, domain-neutral utilities for digitalmodel."""

--- a/src/digitalmodel/common/assumption_ledger.py
+++ b/src/digitalmodel/common/assumption_ledger.py
@@ -1,0 +1,135 @@
+"""Assumption provenance ledger for inverse spec resolution.
+
+Domain-neutral: shared by the diffraction resolver (OrcaWave/AQWA) and the
+OrcaFlex inverse resolver. Records every value an inverse resolver *assumed*
+(rather than received) so it can be surfaced for review -- the "no silent
+assumptions" contract (digitalmodel#622).
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Iterator, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AssumptionSource(str, Enum):
+    """Source category for a resolved input value."""
+
+    USER_SUPPLIED = "user_supplied"
+    ASSUMED_DEFAULT = "assumed_default"
+    ESTIMATED_FROM_DATA = "estimated_from_data"
+    DATABASE_LOOKUP = "database_lookup"
+
+
+class Confidence(str, Enum):
+    """Confidence in an assumed value."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class AssumptionRecord(BaseModel):
+    """One non-user-supplied value used to complete a spec."""
+
+    field: str
+    value: Any
+    source: AssumptionSource
+    basis: str
+    reference: Optional[str] = None
+    confidence: Confidence
+    impact: int = Field(default=0)
+
+
+class AssumptionLedger:
+    """Collection of non-user-supplied assumption records.
+
+    User-supplied values are intentionally not stored. A fully detailed
+    resolver run therefore produces a literally empty ledger.
+    """
+
+    def __init__(self, records: list[AssumptionRecord] | None = None) -> None:
+        self._records = list(records or [])
+
+    def record(
+        self,
+        field: str,
+        value: Any,
+        source: AssumptionSource,
+        basis: str,
+        confidence: Confidence,
+        *,
+        reference: str | None = None,
+        impact: int = 0,
+    ) -> None:
+        """Store a non-user-supplied assumption record."""
+        if source == AssumptionSource.USER_SUPPLIED:
+            return
+        self._records.append(
+            AssumptionRecord(
+                field=field,
+                value=value,
+                source=source,
+                basis=basis,
+                reference=reference,
+                confidence=confidence,
+                impact=impact,
+            )
+        )
+
+    @property
+    def records(self) -> list[AssumptionRecord]:
+        """Return records in insertion order."""
+        return list(self._records)
+
+    def rows(self) -> list[AssumptionRecord]:
+        """Return records sorted for human review by impact then confidence."""
+        confidence_rank = {
+            Confidence.LOW: 0,
+            Confidence.MEDIUM: 1,
+            Confidence.HIGH: 2,
+        }
+        return sorted(
+            self._records,
+            key=lambda r: (-r.impact, confidence_rank[r.confidence], r.field),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a machine-readable dictionary."""
+        return {"records": [record.model_dump(mode="json") for record in self._records]}
+
+    def to_json(self) -> str:
+        """Serialise to JSON."""
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AssumptionLedger":
+        """Rebuild a ledger from ``to_dict`` output."""
+        return cls(
+            [AssumptionRecord.model_validate(item) for item in data.get("records", [])]
+        )
+
+    @classmethod
+    def from_json(cls, data: str) -> "AssumptionLedger":
+        """Rebuild a ledger from ``to_json`` output."""
+        return cls.from_dict(json.loads(data))
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    def __bool__(self) -> bool:
+        return bool(self._records)
+
+    def __iter__(self) -> Iterator[AssumptionRecord]:
+        return iter(self._records)
+
+
+__all__ = [
+    "AssumptionLedger",
+    "AssumptionRecord",
+    "AssumptionSource",
+    "Confidence",
+]

--- a/src/digitalmodel/hydrodynamics/diffraction/assumption_ledger.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/assumption_ledger.py
@@ -1,132 +1,19 @@
-"""Assumption provenance ledger for diffraction input resolution."""
+"""Assumption provenance ledger (back-compat re-export).
+
+The ledger was promoted to the domain-neutral
+:mod:`digitalmodel.common.assumption_ledger` so the OrcaFlex inverse resolver
+can share it without depending on the diffraction package. This module re-exports
+it to preserve the original import path.
+"""
 
 from __future__ import annotations
 
-import json
-from enum import Enum
-from typing import Any, Iterator, Optional
-
-from pydantic import BaseModel, Field
-
-
-class AssumptionSource(str, Enum):
-    """Source category for a resolved diffraction input value."""
-
-    USER_SUPPLIED = "user_supplied"
-    ASSUMED_DEFAULT = "assumed_default"
-    ESTIMATED_FROM_DATA = "estimated_from_data"
-    DATABASE_LOOKUP = "database_lookup"
-
-
-class Confidence(str, Enum):
-    """Confidence in an assumed value."""
-
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-
-
-class AssumptionRecord(BaseModel):
-    """One non-user-supplied value used to complete a diffraction spec."""
-
-    field: str
-    value: Any
-    source: AssumptionSource
-    basis: str
-    reference: Optional[str] = None
-    confidence: Confidence
-    impact: int = Field(default=0)
-
-
-class AssumptionLedger:
-    """Collection of non-user-supplied assumption records.
-
-    User-supplied values are intentionally not stored. A fully detailed
-    resolver run therefore produces a literally empty ledger.
-    """
-
-    def __init__(self, records: list[AssumptionRecord] | None = None) -> None:
-        self._records = list(records or [])
-
-    def record(
-        self,
-        field: str,
-        value: Any,
-        source: AssumptionSource,
-        basis: str,
-        confidence: Confidence,
-        *,
-        reference: str | None = None,
-        impact: int = 0,
-    ) -> None:
-        """Store a non-user-supplied assumption record."""
-        if source == AssumptionSource.USER_SUPPLIED:
-            return
-        self._records.append(
-            AssumptionRecord(
-                field=field,
-                value=value,
-                source=source,
-                basis=basis,
-                reference=reference,
-                confidence=confidence,
-                impact=impact,
-            )
-        )
-
-    @property
-    def records(self) -> list[AssumptionRecord]:
-        """Return records in insertion order."""
-        return list(self._records)
-
-    def rows(self) -> list[AssumptionRecord]:
-        """Return records sorted for human review by impact then confidence."""
-        confidence_rank = {
-            Confidence.LOW: 0,
-            Confidence.MEDIUM: 1,
-            Confidence.HIGH: 2,
-        }
-        return sorted(
-            self._records,
-            key=lambda r: (-r.impact, confidence_rank[r.confidence], r.field),
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        """Serialise to a machine-readable dictionary."""
-        return {
-            "records": [
-                record.model_dump(mode="json") for record in self._records
-            ]
-        }
-
-    def to_json(self) -> str:
-        """Serialise to JSON."""
-        return json.dumps(self.to_dict(), sort_keys=True)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "AssumptionLedger":
-        """Rebuild a ledger from ``to_dict`` output."""
-        return cls(
-            [
-                AssumptionRecord.model_validate(item)
-                for item in data.get("records", [])
-            ]
-        )
-
-    @classmethod
-    def from_json(cls, data: str) -> "AssumptionLedger":
-        """Rebuild a ledger from ``to_json`` output."""
-        return cls.from_dict(json.loads(data))
-
-    def __len__(self) -> int:
-        return len(self._records)
-
-    def __bool__(self) -> bool:
-        return bool(self._records)
-
-    def __iter__(self) -> Iterator[AssumptionRecord]:
-        return iter(self._records)
-
+from digitalmodel.common.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionRecord,
+    AssumptionSource,
+    Confidence,
+)
 
 __all__ = [
     "AssumptionLedger",

--- a/src/digitalmodel/solvers/orcaflex/inverse_resolver.py
+++ b/src/digitalmodel/solvers/orcaflex/inverse_resolver.py
@@ -1,0 +1,384 @@
+"""Inverse resolver for OrcaFlex ``ProjectInputSpec`` (outcome -> complete spec).
+
+The OrcaFlex counterpart of the diffraction ``resolver.resolve`` (digitalmodel
+#622 / #1096). Given an analysis *outcome* and sparse inputs, it fills a complete,
+``ModularModelGenerator``-ready ``ProjectInputSpec`` and records every value it
+*assumed* (rather than received) in an :class:`AssumptionLedger` -- the
+"no silent assumptions" contract.
+
+This first increment covers the **mooring** model type (the best-supported,
+license-free path). The ``Outcome`` enum and dispatch are structured so riser /
+pipeline / installation outcomes can be added the same way later.
+
+    Outcome.MOORING_STRENGTH + sparse inputs
+        |  resolve()  (fills gaps from reference defaults, ledgers each)
+        v
+    ProjectInputSpec  +  AssumptionLedger
+        |  ModularModelGenerator
+        v
+    OrcaFlex model YAML
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from digitalmodel.common.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+
+class Outcome(str, Enum):
+    """Supported OrcaFlex analysis outcomes for inverse resolution."""
+
+    MOORING_STRENGTH = "mooring_strength"
+    MOORING_PRETENSION = "mooring_pretension"
+
+
+# Per-outcome simulation profile (stages = list of stage durations in seconds).
+# Strength wants a build-up + storm dynamic stage; pretension/equilibrium is a
+# static-only check.
+_OUTCOME_SIMULATION: dict[Outcome, dict[str, Any]] = {
+    Outcome.MOORING_STRENGTH: {"stages": [8, 16]},
+    Outcome.MOORING_PRETENSION: {"stages": [10]},
+}
+
+MOORING_OUTCOMES: frozenset[Outcome] = frozenset(
+    {Outcome.MOORING_STRENGTH, Outcome.MOORING_PRETENSION}
+)
+
+OUTCOME_DESCRIPTIONS: dict[Outcome, str] = {
+    Outcome.MOORING_STRENGTH: (
+        "Spread-mooring strength check (static + storm dynamic stage) -- peak "
+        "line tensions vs MBL."
+    ),
+    Outcome.MOORING_PRETENSION: (
+        "Mooring pretension / static equilibrium check (static stage only)."
+    ),
+}
+
+# Reference defaults used when a value is not supplied (each is ledgered).
+DEFAULT_WATER_DEPTH = 100.0  # m
+DEFAULT_NUM_LINES = 8
+DEFAULT_CHAIN_DIAMETER = 0.095  # m (95 mm studless)
+DEFAULT_CHAIN_GRADE = "R4"
+DEFAULT_FAIRLEAD_RADIUS = 40.0  # m from origin
+DEFAULT_FAIRLEAD_Z = 0.0  # m relative to free surface
+DEFAULT_VESSEL_NAME = "vessel_1"
+# Anchor radius as a multiple of water depth (typical spread-mooring scope).
+ANCHOR_RADIUS_DEPTH_FACTOR = 8.0
+# Line length as a multiple of the straight anchor-to-fairlead distance.
+LINE_LENGTH_SLACK_FACTOR = 1.15
+
+
+class MooringResolverInputs(BaseModel):
+    """Sparse inputs accepted by the mooring inverse resolver."""
+
+    name: Optional[str] = None
+    water_depth: Optional[float] = Field(default=None, gt=0)
+    num_lines: Optional[int] = Field(default=None, gt=0)
+    chain_diameter: Optional[float] = Field(default=None, gt=0)
+    chain_grade: Optional[str] = None
+    fairlead_radius: Optional[float] = Field(default=None, gt=0)
+    anchor_radius: Optional[float] = Field(default=None, gt=0)
+    line_length: Optional[float] = Field(default=None, gt=0)
+    vessel_name: Optional[str] = None
+    pretension: Optional[float] = Field(default=None, gt=0)
+    # Escape hatch: a fully/partly specified ProjectInputSpec dict to merge.
+    # Anything provided here is treated as user-supplied (not ledgered).
+    partial_spec: Optional[dict[str, Any]] = None
+
+
+def resolve(
+    outcome: Outcome | str,
+    inputs: MooringResolverInputs | dict[str, Any] | None = None,
+) -> tuple[ProjectInputSpec, AssumptionLedger]:
+    """Resolve an outcome + sparse inputs into a complete ProjectInputSpec."""
+    outcome = Outcome(outcome)
+    if outcome not in MOORING_OUTCOMES:  # pragma: no cover - guard for future
+        raise ValueError(f"Unsupported outcome: {outcome}")
+
+    resolver_inputs = (
+        inputs
+        if isinstance(inputs, MooringResolverInputs)
+        else MooringResolverInputs.model_validate(inputs or {})
+    )
+    ledger = AssumptionLedger()
+    data: dict[str, Any] = _deep_copy(resolver_inputs.partial_spec or {})
+
+    _resolve_metadata(data, resolver_inputs, outcome, ledger)
+    _resolve_environment(data, resolver_inputs, ledger)
+    _resolve_mooring(data, resolver_inputs, ledger)
+    _resolve_simulation(data, outcome, ledger)
+
+    spec = ProjectInputSpec.model_validate(data)
+    return spec, ledger
+
+
+# ---------------------------------------------------------------------------
+# Section resolvers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_metadata(
+    data: dict[str, Any],
+    inputs: MooringResolverInputs,
+    outcome: Outcome,
+    ledger: AssumptionLedger,
+) -> None:
+    meta = _nested(data, "metadata")
+    if "name" not in meta:
+        meta["name"] = inputs.name or "mooring_system"
+        if inputs.name is None:
+            ledger.record(
+                "metadata.name",
+                meta["name"],
+                AssumptionSource.ASSUMED_DEFAULT,
+                "Default model name",
+                Confidence.LOW,
+                reference="default",
+                impact=1,
+            )
+    for field, value, basis in (
+        ("description", f"{outcome.value} model", "Derived from outcome"),
+        ("structure", "mooring", "Mooring model type"),
+        ("operation", outcome.value, "Derived from outcome"),
+    ):
+        if field not in meta:
+            meta[field] = value
+            ledger.record(
+                f"metadata.{field}",
+                value,
+                AssumptionSource.ASSUMED_DEFAULT,
+                basis,
+                Confidence.LOW,
+                reference=f"outcome:{outcome.value}",
+                impact=1,
+            )
+
+
+def _resolve_environment(
+    data: dict[str, Any],
+    inputs: MooringResolverInputs,
+    ledger: AssumptionLedger,
+) -> None:
+    env = _nested(data, "environment")
+    water = _nested(env, "water")
+    if "depth" not in water:
+        depth = inputs.water_depth or DEFAULT_WATER_DEPTH
+        water["depth"] = depth
+        if inputs.water_depth is None:
+            ledger.record(
+                "environment.water.depth",
+                depth,
+                AssumptionSource.ASSUMED_DEFAULT,
+                "Default screening water depth",
+                Confidence.LOW,
+                reference="default",
+                impact=4,
+            )
+    # Seabed is required; an unspecified stiffness defaults to rigid (0 -> rigid
+    # in OrcaFlex), which is the conservative screening default.
+    seabed = _nested(env, "seabed")
+    if "stiffness" not in seabed:
+        seabed["stiffness"] = {}
+        ledger.record(
+            "environment.seabed.stiffness",
+            {},
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default seabed stiffness (rigid)",
+            Confidence.LOW,
+            reference="default",
+            impact=2,
+        )
+
+
+def _resolve_mooring(
+    data: dict[str, Any],
+    inputs: MooringResolverInputs,
+    ledger: AssumptionLedger,
+) -> None:
+    if "mooring" in data and data["mooring"]:
+        return  # fully user-specified mooring -> leave as is (not ledgered)
+
+    water_depth = _nested(data, "environment", "water")["depth"]
+
+    num_lines = inputs.num_lines or DEFAULT_NUM_LINES
+    if inputs.num_lines is None:
+        ledger.record(
+            "mooring.num_lines",
+            num_lines,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default spread-mooring line count",
+            Confidence.LOW,
+            reference="default",
+            impact=4,
+        )
+
+    diameter = inputs.chain_diameter or DEFAULT_CHAIN_DIAMETER
+    if inputs.chain_diameter is None:
+        ledger.record(
+            "mooring.chain_diameter",
+            diameter,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default studless chain diameter",
+            Confidence.LOW,
+            reference="default",
+            impact=5,
+        )
+
+    grade = inputs.chain_grade or DEFAULT_CHAIN_GRADE
+    if inputs.chain_grade is None:
+        ledger.record(
+            "mooring.chain_grade",
+            grade,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default chain grade",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    fairlead_radius = inputs.fairlead_radius or DEFAULT_FAIRLEAD_RADIUS
+    if inputs.fairlead_radius is None:
+        ledger.record(
+            "mooring.fairlead_radius",
+            fairlead_radius,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default fairlead radius from origin",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    anchor_radius = inputs.anchor_radius or ANCHOR_RADIUS_DEPTH_FACTOR * water_depth
+    if inputs.anchor_radius is None:
+        ledger.record(
+            "mooring.anchor_radius",
+            anchor_radius,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            f"{ANCHOR_RADIUS_DEPTH_FACTOR}x water depth (typical scope)",
+            Confidence.MEDIUM,
+            reference="anchor_radius=factor*depth",
+            impact=4,
+        )
+
+    straight = math.hypot(anchor_radius - fairlead_radius, water_depth)
+    line_length = inputs.line_length or LINE_LENGTH_SLACK_FACTOR * straight
+    if inputs.line_length is None:
+        ledger.record(
+            "mooring.line_length",
+            round(line_length, 2),
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            f"{LINE_LENGTH_SLACK_FACTOR}x straight anchor-fairlead distance",
+            Confidence.MEDIUM,
+            reference="line_length=slack*straight",
+            impact=4,
+        )
+
+    vessel = inputs.vessel_name or DEFAULT_VESSEL_NAME
+    if inputs.vessel_name is None:
+        ledger.record(
+            "mooring.vessel_name",
+            vessel,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default vessel name for fairleads",
+            Confidence.LOW,
+            reference="default",
+            impact=2,
+        )
+
+    lines = []
+    for i in range(num_lines):
+        azimuth = math.radians(i * 360.0 / num_lines)
+        cos_a, sin_a = math.cos(azimuth), math.sin(azimuth)
+        segment: dict[str, Any] = {
+            "type": "chain",
+            "diameter": diameter,
+            "length": round(line_length, 3),
+            "grade": grade,
+        }
+        line: dict[str, Any] = {
+            "name": f"line_{i + 1}",
+            "segments": [segment],
+            "anchor": {
+                "type": "anchor",
+                "position": [
+                    round(anchor_radius * cos_a, 3),
+                    round(anchor_radius * sin_a, 3),
+                    -water_depth,
+                ],
+            },
+            "fairlead": {
+                "type": "fairlead",
+                "position": [
+                    round(fairlead_radius * cos_a, 3),
+                    round(fairlead_radius * sin_a, 3),
+                    DEFAULT_FAIRLEAD_Z,
+                ],
+                "vessel": vessel,
+            },
+        }
+        if inputs.pretension is not None:
+            line["pretension"] = inputs.pretension
+        lines.append(line)
+
+    data["mooring"] = {"lines": lines}
+
+
+def _resolve_simulation(
+    data: dict[str, Any],
+    outcome: Outcome,
+    ledger: AssumptionLedger,
+) -> None:
+    sim = _nested(data, "simulation")
+    if "stages" not in sim:
+        stages = list(_OUTCOME_SIMULATION[outcome]["stages"])
+        sim["stages"] = stages
+        ledger.record(
+            "simulation.stages",
+            stages,
+            AssumptionSource.ASSUMED_DEFAULT,
+            f"Default simulation stages for {outcome.value}",
+            Confidence.LOW,
+            reference=f"outcome:{outcome.value}",
+            impact=3,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _nested(data: dict[str, Any], *keys: str) -> dict[str, Any]:
+    node = data
+    for key in keys:
+        child = node.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            node[key] = child
+        node = child
+    return node
+
+
+def _deep_copy(data: dict[str, Any]) -> dict[str, Any]:
+    import copy
+
+    return copy.deepcopy(data)
+
+
+__all__ = [
+    "Outcome",
+    "OUTCOME_DESCRIPTIONS",
+    "MOORING_OUTCOMES",
+    "MooringResolverInputs",
+    "resolve",
+]

--- a/tests/solvers/orcaflex/test_inverse_resolver.py
+++ b/tests/solvers/orcaflex/test_inverse_resolver.py
@@ -1,0 +1,136 @@
+"""Tests for the OrcaFlex inverse resolver (license-free, offline).
+
+Mirrors the diffraction resolver tests: outcome + sparse inputs -> complete
+ProjectInputSpec + AssumptionLedger, generatable by ModularModelGenerator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.solvers.orcaflex.inverse_resolver import (
+    MOORING_OUTCOMES,
+    OUTCOME_DESCRIPTIONS,
+    MooringResolverInputs,
+    Outcome,
+    resolve,
+)
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+
+def test_barebones_outcome_resolves_to_valid_mooring_spec() -> None:
+    spec, ledger = resolve(Outcome.MOORING_STRENGTH)
+    assert isinstance(spec, ProjectInputSpec)
+    assert spec.mooring is not None
+    assert spec.pipeline is None and spec.riser is None and spec.generic is None
+    assert len(spec.mooring.lines) == 8
+    # Barebones -> everything assumed -> non-empty ledger (no silent assumptions).
+    fields = {r.field for r in ledger.rows()}
+    assert "environment.water.depth" in fields
+    assert "mooring.num_lines" in fields
+
+
+def test_string_outcome_accepted() -> None:
+    spec, _ = resolve("mooring_strength")
+    assert spec.metadata.structure == "mooring"
+
+
+def test_supplied_inputs_are_honored_and_not_ledgered() -> None:
+    spec, ledger = resolve(
+        Outcome.MOORING_STRENGTH,
+        MooringResolverInputs(
+            water_depth=1500.0, num_lines=12, chain_diameter=0.13, chain_grade="R5"
+        ),
+    )
+    assert spec.environment.water.depth == 1500.0
+    assert len(spec.mooring.lines) == 12
+    seg = spec.mooring.lines[0].segments[0]
+    assert seg.diameter == 0.13
+    assert seg.grade.value == "R5"
+    fields = {r.field for r in ledger.rows()}
+    # User-supplied values are not recorded as assumptions.
+    assert "environment.water.depth" not in fields
+    assert "mooring.num_lines" not in fields
+    assert "mooring.chain_diameter" not in fields
+
+
+def test_outcome_drives_simulation_stages() -> None:
+    strength, _ = resolve(Outcome.MOORING_STRENGTH)
+    pretension, _ = resolve(Outcome.MOORING_PRETENSION)
+    assert strength.simulation.stages == [8, 16]
+    assert pretension.simulation.stages == [10]
+
+
+def test_anchor_radius_scales_with_water_depth() -> None:
+    shallow, _ = resolve(
+        Outcome.MOORING_STRENGTH, MooringResolverInputs(water_depth=100)
+    )
+    deep, _ = resolve(Outcome.MOORING_STRENGTH, MooringResolverInputs(water_depth=1000))
+    shallow_r = shallow.mooring.lines[0].anchor.position[0]
+    deep_r = deep.mooring.lines[0].anchor.position[0]
+    assert deep_r > shallow_r
+
+
+def test_pretension_applied_when_supplied() -> None:
+    spec, _ = resolve(
+        Outcome.MOORING_STRENGTH, MooringResolverInputs(pretension=1200.0)
+    )
+    assert all(line.pretension == 1200.0 for line in spec.mooring.lines)
+
+
+def test_partial_spec_mooring_is_used_verbatim() -> None:
+    partial = {
+        "mooring": {
+            "lines": [
+                {
+                    "name": "L1",
+                    "segments": [
+                        {"type": "chain", "diameter": 0.1, "length": 500, "grade": "R3"}
+                    ],
+                    "anchor": {"type": "anchor", "position": [800, 0, -200]},
+                    "fairlead": {
+                        "type": "fairlead",
+                        "position": [40, 0, 0],
+                        "vessel": "v",
+                    },
+                }
+            ]
+        }
+    }
+    spec, ledger = resolve(
+        Outcome.MOORING_STRENGTH, MooringResolverInputs(partial_spec=partial)
+    )
+    assert len(spec.mooring.lines) == 1
+    assert spec.mooring.lines[0].name == "L1"
+    # The user-supplied mooring is not re-derived, so no mooring.* assumptions.
+    assert not any(r.field.startswith("mooring.") for r in ledger.rows())
+
+
+def test_generates_orcaflex_model_yaml(tmp_path: Path) -> None:
+    spec, _ = resolve(Outcome.MOORING_STRENGTH)
+    out = tmp_path / "model"
+    ModularModelGenerator.from_spec(spec).generate(out)
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
+
+
+def test_every_outcome_has_a_description() -> None:
+    for outcome in Outcome:
+        assert outcome in OUTCOME_DESCRIPTIONS, outcome
+    assert MOORING_OUTCOMES.issubset(set(Outcome))
+
+
+def test_unsupported_outcome_raises() -> None:
+    with pytest.raises(ValueError):
+        resolve("riser_static")  # not yet implemented
+
+
+def test_ledger_comes_from_shared_common_module() -> None:
+    # The promoted ledger is importable from the neutral location and used here.
+    from digitalmodel.common.assumption_ledger import AssumptionLedger
+
+    _, ledger = resolve(Outcome.MOORING_STRENGTH)
+    assert isinstance(ledger, AssumptionLedger)


### PR DESCRIPTION
Closes #1096. The OrcaFlex counterpart of the diffraction `resolver.resolve` (#622) — the symmetric gap from the 2026-06-28 review. Given an analysis **outcome** + sparse inputs, it fills a complete, `ModularModelGenerator`-ready `ProjectInputSpec` and **ledgers every assumed value** (no-silent-assumptions). Deterministic, license-free, fully unit-tested on Linux.

## Scope (mooring pilot)
- `Outcome.MOORING_STRENGTH` (static + storm dynamic stages) and `Outcome.MOORING_PRETENSION` (static equilibrium) — the outcome drives `simulation.stages`.
- `MooringResolverInputs`: sparse inputs (`water_depth`, `num_lines`, chain `diameter`/`grade`, fairlead/anchor radius, line length, vessel, pretension). Anchor radius scales with water depth; line length derives from anchor↔fairlead geometry; lines placed symmetrically.
- `partial_spec` escape hatch: a user-supplied mooring is used verbatim and **not** re-derived (detailed run → no `mooring.*` assumptions), matching the diffraction "detailed run → empty ledger" contract.
- `Outcome` enum + section-dispatch are structured so riser / pipeline / installation outcomes drop in the same way (future increments).

## Shared ledger
Promotes `AssumptionLedger` to a domain-neutral home — **`digitalmodel.common.assumption_ledger`** — so OrcaFlex shares it without depending on the diffraction package. The old `hydrodynamics.diffraction.assumption_ledger` path now **re-exports** it (back-compat; all 6 existing importers unaffected, diffraction suite green).

## Verification
- Barebones outcome → valid 8-line mooring `ProjectInputSpec` → `ModularModelGenerator.from_spec(spec).generate()` writes OrcaFlex YAML.
- **+11 resolver tests** (barebones, supplied-inputs-not-ledgered, outcome→stages, depth-scaled geometry, pretension, partial_spec verbatim, generation, unsupported-outcome guard, shared-ledger).
- Diffraction `test_resolver` + `test_spec_author` green after the ledger move; black/isort/flake8 clean.

Part of #1095. Next: generalize the LLM `spec_author` front-end (#1095) over this resolver so the project-SSOT→analysis-SSOT pipeline works for OrcaFlex too; add riser/pipeline outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)