### PR TITLE
feat(orcaflex): LLM spec-authoring front-end (project SSOT → OrcaFlex model) (#1095)

### DIFF
--- a/examples/workflows/orcaflex-spec-authoring-llm/README.md
+++ b/examples/workflows/orcaflex-spec-authoring-llm/README.md
@@ -1,0 +1,87 @@
+# OrcaFlex LLM spec-authoring front-end
+
+Turn a **project single-source-of-truth** (heterogeneous project data) plus a
+natural-language request into an OrcaFlex **analysis SSOT**
+(`ProjectInputSpec` + assumption ledger), and optionally generate the OrcaFlex
+model YAML.
+
+```
+project_bundle.yml  +  "screen the mooring for storm strength"
+        |  LLM authors a structured intent (extracts only STATED facts)
+        v
+    OrcaFlexIntent  ->  inverse_resolver.resolve  (fills gaps, ledgers each)
+        v
+    ProjectInputSpec  +  AssumptionLedger   <-- analysis SSOT
+        |  (--generate-model)
+        v
+    OrcaFlex model YAML (master.yml + includes)
+```
+
+This mirrors the diffraction front-end
+(`digitalmodel.hydrodynamics.diffraction.spec_author`) and reuses the shared
+generic plumbing in `digitalmodel.common.spec_authoring`. Only **mooring**
+outcomes are in scope for now.
+
+## Responsibility split (why this is auditable)
+
+- The **LLM** only extracts mooring facts the project data actually states and
+  picks the matching outcome. Anything it cannot ground is left `null`, and it
+  records a `provenance` entry for every value it does set. It never invents
+  chain sizes, line counts, or water depths.
+- The **deterministic resolver** fills every remaining field from maintained
+  reference defaults and records each one in the `AssumptionLedger` -- the
+  "no silent assumptions" contract. Engineering assumptions live in auditable
+  code, not in the model output.
+
+## Run it (default: `claude -p`, no API key)
+
+The default backend shells out to the local Claude Code CLI (`claude -p`), so it
+uses your existing Claude Code auth -- **no `ANTHROPIC_API_KEY` and no
+`anthropic` dependency required**.
+
+```bash
+uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+    examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml \
+    -r "Screen the spread mooring for storm strength" \
+    -o authored_spec
+```
+
+This writes into `authored_spec/`:
+
+| File | What it is |
+|---|---|
+| `spec.yml` | The clean, reloadable analysis-SSOT `ProjectInputSpec`. |
+| `assumptions.md` | Human audit: extracted-from-data vs assumed-by-resolver. |
+| `assumption_ledger.json` | Machine-readable assumption ledger. |
+| `intent.json` | The structured intent the LLM authored. |
+
+## Also generate the OrcaFlex model
+
+Add `--generate-model` to emit the OrcaFlex model YAML (`master.yml` + includes)
+into `authored_spec/model/`:
+
+```bash
+uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+    examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml \
+    -r "Screen the spread mooring for storm strength" \
+    -o authored_spec \
+    --generate-model
+```
+
+## Use the Anthropic SDK instead
+
+To call the Anthropic API directly (structured outputs) instead of the CLI:
+
+```bash
+ANTHROPIC_API_KEY=sk-... uv run --with anthropic python -m \
+    digitalmodel.solvers.orcaflex.spec_author \
+    examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml \
+    -r "Screen the spread mooring for storm strength" \
+    --backend anthropic-sdk
+```
+
+## Offline / programmatic use
+
+The LLM call is injected via the `IntentAuthor` protocol, so the pipeline is
+fully testable without a network or API key -- pass a stub author that returns a
+fixed `OrcaFlexIntent`. See `tests/solvers/orcaflex/test_spec_author.py`.

--- a/examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml
+++ b/examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml
@@ -1,0 +1,36 @@
+# Project single-source-of-truth (project SSOT) for the OrcaFlex LLM
+# spec-authoring front-end.
+#
+# This is heterogeneous project data, NOT an analysis spec. The LLM reads it,
+# extracts only the mooring facts that are actually stated here, and leaves
+# everything else for the deterministic inverse resolver to fill (and ledger).
+#
+# Run:
+#   uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+#       examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml \
+#       -r "Screen the spread mooring for storm strength" \
+#       -o authored_spec
+
+project_name: West Horizon FPSO mooring screening
+
+vessel_particulars:
+  type: FPSO
+  loa_m: 285
+  beam_m: 63
+
+environment:
+  field: Deepwater GoM
+  water_depth_m: 1500
+
+notes: >
+  Permanent spread mooring, 12 lines. The chain segments are 130 mm R5 studless.
+  Client wants a first-pass storm strength screening (peak line tension vs MBL)
+  before the detailed metocean is finalised. No fairlead/anchor geometry has been
+  fixed yet, so leave the layout to the resolver defaults.
+
+documents:
+  - >
+    Mooring basis of design (excerpt): "The system comprises 12 mooring lines in
+    a symmetric spread. Top chain: 130 mm grade R5 studless. Water depth at the
+    site is 1500 m. Anchor radius and line length to be confirmed in detailed
+    design."

--- a/src/digitalmodel/common/spec_authoring.py
+++ b/src/digitalmodel/common/spec_authoring.py
@@ -1,0 +1,222 @@
+"""Generic, intent-type-agnostic plumbing for LLM spec-authoring front-ends.
+
+This module promotes the reusable pieces shared by the diffraction
+(``hydrodynamics.diffraction.spec_author``) and OrcaFlex
+(``solvers.orcaflex.spec_author``) authoring front-ends so they are not
+duplicated per domain:
+
+* :class:`ProjectBundle` -- the upstream project single-source-of-truth handed
+  to the LLM, rendered to text via :meth:`ProjectBundle.to_prompt_context`.
+* :class:`ProvenanceEntry` -- one value the LLM grounded, with its source.
+* :func:`_extract_json_object` -- pull the first balanced JSON object out of
+  model text (tolerates ```` ```json ```` fences and surrounding prose).
+* :data:`CliRunner` / :func:`_default_cli_runner` -- the injectable
+  ``claude -p`` subprocess hook (so the front-ends stay testable offline).
+* :func:`claude_cli_complete` -- a generic ``claude -p`` JSON caller that
+  returns the parsed inner JSON object.
+* :func:`build_outcome_menu` -- render an outcome-description map as a menu.
+
+It is intentionally dependency-light: only ``pydantic`` (and stdlib). The
+``anthropic`` SDK is *not* imported here -- domain front-ends import it lazily.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Project single-source-of-truth contract (LLM input context)
+# ---------------------------------------------------------------------------
+
+
+class ProjectBundle(BaseModel):
+    """The upstream project SSOT handed to the authoring LLM.
+
+    Intentionally loose: real project data is heterogeneous. Structured fields
+    are convenience slots; ``documents`` and ``notes`` carry whatever free text
+    the project has (data-sheet excerpts, emails, scope notes). The LLM reads
+    the whole thing rendered as text and extracts what it can ground.
+    """
+
+    project_name: Optional[str] = None
+    vessel_particulars: dict[str, Any] = Field(default_factory=dict)
+    environment: dict[str, Any] = Field(default_factory=dict)
+    documents: list[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "ProjectBundle":
+        import yaml
+
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        return cls.model_validate(data)
+
+    def to_prompt_context(self) -> str:
+        """Render the bundle as text for the LLM."""
+        lines: list[str] = []
+        if self.project_name:
+            lines.append(f"Project: {self.project_name}")
+        if self.vessel_particulars:
+            lines.append("\nVessel particulars (as provided):")
+            for key, value in self.vessel_particulars.items():
+                lines.append(f"  - {key}: {value}")
+        if self.environment:
+            lines.append("\nEnvironment / site (as provided):")
+            for key, value in self.environment.items():
+                lines.append(f"  - {key}: {value}")
+        if self.notes:
+            lines.append(f"\nNotes:\n{self.notes}")
+        for i, doc in enumerate(self.documents, 1):
+            lines.append(f"\n--- Document {i} ---\n{doc}")
+        return "\n".join(lines).strip() or "(no project data provided)"
+
+
+# ---------------------------------------------------------------------------
+# Shared structured-output fragment
+# ---------------------------------------------------------------------------
+
+
+class ProvenanceEntry(BaseModel):
+    """One value the LLM set, with where in the project data it came from."""
+
+    field: str
+    value: str
+    source: str = Field(description="Where in the project bundle this was found.")
+
+
+# ---------------------------------------------------------------------------
+# Outcome menu rendering
+# ---------------------------------------------------------------------------
+
+
+def build_outcome_menu(descriptions: dict[Any, str]) -> str:
+    """Render an ``{outcome: description}`` map as a bulleted menu.
+
+    Keys may be ``Enum`` members (their ``.value`` is used) or plain strings.
+    """
+    lines: list[str] = []
+    for outcome, desc in descriptions.items():
+        value = getattr(outcome, "value", outcome)
+        lines.append(f"  - {value}: {desc}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction from model text
+# ---------------------------------------------------------------------------
+
+
+def _extract_json_object(text: str) -> str:
+    """Pull the first top-level JSON object out of model text.
+
+    Tolerates ```` ```json ```` fences and surrounding prose by scanning for
+    the first balanced ``{...}`` (brace depth, string-aware).
+    """
+    start = text.find("{")
+    if start == -1:
+        raise ValueError(f"No JSON object in model output: {text[:200]!r}")
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise ValueError(f"Unbalanced JSON object in model output: {text[:200]!r}")
+
+
+# ---------------------------------------------------------------------------
+# claude -p CLI plumbing
+# ---------------------------------------------------------------------------
+
+# Runs the CLI: (argv, stdin) -> CompletedProcess. Injectable for tests.
+CliRunner = Callable[[list[str], str], "subprocess.CompletedProcess[str]"]
+
+
+def _default_cli_runner(
+    argv: list[str], stdin: str
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        argv, input=stdin, capture_output=True, text=True, timeout=300
+    )
+
+
+def claude_cli_complete(
+    system_prompt: str,
+    user_prompt: str,
+    *,
+    model: str,
+    cli: str = "claude",
+    extra_args: Optional[list[str]] = None,
+    runner: Optional[CliRunner] = None,
+) -> dict[str, Any]:
+    """Call the ``claude -p`` CLI and return the parsed inner JSON object.
+
+    Runs ``claude -p --output-format json --model <model> --system-prompt <s>``
+    with ``user_prompt`` on stdin, using the local Claude Code install and its
+    existing auth -- no ``ANTHROPIC_API_KEY`` and no ``anthropic`` dependency.
+
+    The CLI wraps the model's reply in an envelope (``{"is_error": ..., \
+"result": ...}``). This helper validates the envelope and returns the JSON
+    object found inside ``result`` (tolerating fences / prose).
+
+    Raises ``RuntimeError`` on a non-zero return code, an unparseable envelope,
+    or an error envelope (``is_error`` true).
+    """
+    runner = runner or _default_cli_runner
+    argv = [
+        cli,
+        "-p",
+        "--output-format",
+        "json",
+        "--model",
+        model,
+        "--system-prompt",
+        system_prompt,
+        *(extra_args or []),
+    ]
+    proc = runner(argv, user_prompt)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"`{cli} -p` failed (rc={proc.returncode}): "
+            f"{(proc.stderr or proc.stdout or '').strip()[:500]}"
+        )
+    try:
+        envelope = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Could not parse `{cli} -p` JSON envelope: {proc.stdout[:500]!r}"
+        ) from exc
+    if envelope.get("is_error"):
+        raise RuntimeError(f"claude returned an error: {envelope.get('result')}")
+    result_text = envelope.get("result", "")
+    return json.loads(_extract_json_object(result_text))
+
+
+__all__ = [
+    "ProjectBundle",
+    "ProvenanceEntry",
+    "build_outcome_menu",
+    "claude_cli_complete",
+    "CliRunner",
+]

--- a/src/digitalmodel/solvers/orcaflex/spec_author.py
+++ b/src/digitalmodel/solvers/orcaflex/spec_author.py
@@ -1,0 +1,477 @@
+"""LLM spec-authoring front-end for OrcaFlex (project SSOT -> analysis SSOT).
+
+The OrcaFlex counterpart of the diffraction ``spec_author`` (digitalmodel
+#1095). It is the **front-end** of the OrcaFlex model-generation pipeline:
+
+    project single-source-of-truth
+        |  LLM authors a structured intent (this module)
+        v
+    OrcaFlexIntent  (outcome + only the mooring facts stated in the project data)
+        |  deterministic inverse resolver (inverse_resolver.resolve, #1096)
+        v
+    ProjectInputSpec  +  AssumptionLedger   <-- the analysis single-source-of-truth
+        |  ModularModelGenerator
+        v
+    OrcaFlex model YAML (master.yml + includes)
+
+Responsibility split (deliberate, to keep the hallucination surface small):
+
+* The **LLM** only *extracts mooring facts that are stated* in the project
+  bundle and picks the matching outcome. It leaves anything it cannot ground as
+  ``None`` and records provenance for every value it sets. It never invents
+  chain sizes, line counts, or site depths.
+* The **deterministic resolver** fills every remaining field from maintained
+  reference defaults and records each filled value in the ``AssumptionLedger``
+  -- the #622 "no silent assumptions" contract.
+
+The LLM call is injected through the :class:`IntentAuthor` protocol so the core
+is fully unit-testable offline (pass a stub author). The default implementation,
+:class:`ClaudeCliIntentAuthor`, shells out to the ``claude -p`` CLI (no API key,
+no ``anthropic`` dependency). :class:`AnthropicIntentAuthor` uses the Anthropic
+SDK with structured outputs and is imported lazily.
+
+Only **mooring** outcomes are in scope for now (matching the resolver).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+import yaml
+from pydantic import BaseModel, Field
+
+from digitalmodel.common.assumption_ledger import AssumptionLedger
+from digitalmodel.common.spec_authoring import (
+    ProjectBundle,
+    ProvenanceEntry,
+    build_outcome_menu,
+    claude_cli_complete,
+)
+from digitalmodel.solvers.orcaflex import inverse_resolver
+from digitalmodel.solvers.orcaflex.inverse_resolver import (
+    OUTCOME_DESCRIPTIONS,
+    MooringResolverInputs,
+    Outcome,
+)
+from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+
+# Default model for the authoring call. Kept here (not hard-coded at the call
+# site) so it is easy to override and easy to find.
+DEFAULT_MODEL = "claude-opus-4-8"
+
+
+# ---------------------------------------------------------------------------
+# Structured LLM output: the authored intent
+# ---------------------------------------------------------------------------
+
+
+class OrcaFlexIntent(BaseModel):
+    """Structured output the LLM produces from a project bundle + request.
+
+    This is *not* the full spec -- only the sparse, grounded mooring facts the
+    resolver needs as a starting point, plus the chosen outcome. Every input
+    field is optional: the LLM leaves a field ``None`` when the project data
+    does not state it, and the deterministic resolver fills it (and ledgers it).
+
+    The input fields mirror :class:`inverse_resolver.MooringResolverInputs`.
+    """
+
+    outcome: Outcome = Field(
+        description="The analysis outcome that matches the request."
+    )
+    # Sparse mooring inputs -- only set when the project data states them.
+    name: Optional[str] = Field(default=None, description="Model / system name.")
+    water_depth: Optional[float] = Field(
+        default=None, description="Site water depth (m)."
+    )
+    num_lines: Optional[int] = Field(
+        default=None, description="Number of mooring lines."
+    )
+    chain_diameter: Optional[float] = Field(
+        default=None, description="Mooring chain diameter (m)."
+    )
+    chain_grade: Optional[str] = Field(
+        default=None, description="Mooring chain grade (e.g. R3, R4, R5)."
+    )
+    fairlead_radius: Optional[float] = Field(
+        default=None, description="Fairlead radius from origin (m)."
+    )
+    anchor_radius: Optional[float] = Field(
+        default=None, description="Anchor radius from origin (m)."
+    )
+    line_length: Optional[float] = Field(
+        default=None, description="Mooring line length (m)."
+    )
+    vessel_name: Optional[str] = Field(
+        default=None, description="Vessel the fairleads attach to."
+    )
+    pretension: Optional[float] = Field(
+        default=None, description="Target line pretension (kN)."
+    )
+    # Trace + handoff
+    provenance: list[ProvenanceEntry] = Field(
+        default_factory=list,
+        description="One entry per value set, citing the project-data source.",
+    )
+    open_questions: list[str] = Field(
+        default_factory=list,
+        description="Material facts the project data did not provide.",
+    )
+    rationale: str = Field(
+        default="",
+        description="One short paragraph on why this outcome and these inputs.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are a marine-mooring analysis spec author. Given an offshore project's data \
+and a natural-language request, you produce a structured authoring intent for an \
+OrcaFlex spread-mooring analysis.
+
+Choose the single `outcome` that best matches the request:
+{outcome_menu}
+
+Your job is fact extraction, not engineering invention:
+- Fill a field ONLY with a value the project data actually states. If the data \
+does not give a value, leave it null. Do NOT estimate, default, or invent water \
+depth, line count, chain diameter, chain grade, radii, line length, or any \
+physical quantity -- a downstream deterministic resolver fills every gap from \
+maintained reference data and records each assumption for review. Inventing \
+values defeats that audit trail.
+- For every value you DO set, add a `provenance` entry citing where in the \
+project data you found it.
+- List anything material but missing in `open_questions`.
+- Keep `rationale` to one short paragraph.
+"""
+
+
+def build_system_prompt() -> str:
+    """System prompt with the outcome menu rendered from the resolver."""
+    menu = build_outcome_menu(OUTCOME_DESCRIPTIONS)
+    return _SYSTEM_PROMPT_TEMPLATE.format(outcome_menu=menu)
+
+
+# Rendered once at import for convenience; ``build_system_prompt()`` stays the
+# source of truth if the outcome set changes at runtime.
+SYSTEM_PROMPT = build_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# Intent author protocol + implementations
+# ---------------------------------------------------------------------------
+
+
+class IntentAuthor(Protocol):
+    """Anything that turns (bundle, request) into an OrcaFlexIntent."""
+
+    def author(self, bundle: ProjectBundle, request: str) -> OrcaFlexIntent: ...
+
+
+def _user_prompt(bundle: ProjectBundle, request: str) -> str:
+    return (
+        f"Analysis request:\n{request}\n\n"
+        f"Project data:\n{bundle.to_prompt_context()}"
+    )
+
+
+class ClaudeCliIntentAuthor:
+    """Intent author backed by the ``claude -p`` CLI (Claude Code).
+
+    Uses the local Claude Code install and its existing auth -- no
+    ``ANTHROPIC_API_KEY`` and no ``anthropic`` dependency. The CLI does not
+    expose typed structured outputs, so the schema is supplied in the system
+    prompt and the JSON object is parsed (and Pydantic-validated) from the
+    response. This is the default author.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        *,
+        cli: str = "claude",
+        extra_args: Optional[list[str]] = None,
+        runner: Optional[Any] = None,
+    ) -> None:
+        self.model = model
+        self.cli = cli
+        self.extra_args = list(extra_args or [])
+        self._runner = runner
+
+    def _system_prompt(self) -> str:
+        schema = json.dumps(OrcaFlexIntent.model_json_schema())
+        return (
+            SYSTEM_PROMPT
+            + "\n\nReturn ONLY a single JSON object conforming to this JSON "
+            "schema -- no prose, no markdown, no code fences:\n" + schema
+        )
+
+    def author(self, bundle: ProjectBundle, request: str) -> OrcaFlexIntent:
+        data = claude_cli_complete(
+            self._system_prompt(),
+            _user_prompt(bundle, request),
+            model=self.model,
+            cli=self.cli,
+            extra_args=self.extra_args,
+            runner=self._runner,
+        )
+        return OrcaFlexIntent.model_validate(data)
+
+
+class AnthropicIntentAuthor:
+    """Real intent author backed by the Anthropic SDK (structured outputs).
+
+    ``anthropic`` is imported lazily so it stays an optional dependency. Install
+    with ``uv run --with anthropic`` (or add it to the environment) and set
+    ``ANTHROPIC_API_KEY``.
+    """
+
+    def __init__(self, model: str = DEFAULT_MODEL, client: Any = None) -> None:
+        self.model = model
+        self._client = client
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import anthropic
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise RuntimeError(
+                "AnthropicIntentAuthor needs the 'anthropic' package. Run with "
+                "`uv run --with anthropic ...` and set ANTHROPIC_API_KEY, or "
+                "inject a stub IntentAuthor for offline use."
+            ) from exc
+        self._client = anthropic.Anthropic()
+        return self._client
+
+    def author(self, bundle: ProjectBundle, request: str) -> OrcaFlexIntent:
+        client = self._get_client()
+        response = client.messages.parse(
+            model=self.model,
+            max_tokens=4000,
+            thinking={"type": "adaptive"},
+            output_config={"effort": "high"},
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": _user_prompt(bundle, request)}],
+            output_format=OrcaFlexIntent,
+        )
+        return response.parsed_output
+
+
+# ---------------------------------------------------------------------------
+# Intent -> resolver inputs
+# ---------------------------------------------------------------------------
+
+
+def intent_to_resolver_inputs(
+    intent: OrcaFlexIntent,
+) -> tuple[Outcome, MooringResolverInputs]:
+    """Map an OrcaFlexIntent to the inverse resolver's (outcome, inputs)."""
+    inputs = MooringResolverInputs(
+        name=intent.name,
+        water_depth=intent.water_depth,
+        num_lines=intent.num_lines,
+        chain_diameter=intent.chain_diameter,
+        chain_grade=intent.chain_grade,
+        fairlead_radius=intent.fairlead_radius,
+        anchor_radius=intent.anchor_radius,
+        line_length=intent.line_length,
+        vessel_name=intent.vessel_name,
+        pretension=intent.pretension,
+    )
+    return intent.outcome, inputs
+
+
+# ---------------------------------------------------------------------------
+# Authored spec result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuthoredSpec:
+    """Result of authoring: the analysis SSOT spec plus its audit trail."""
+
+    spec: ProjectInputSpec
+    ledger: AssumptionLedger
+    intent: OrcaFlexIntent
+
+    def to_spec_yaml(self, path: str | Path) -> Path:
+        """Write the clean, reloadable analysis-SSOT spec YAML."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = self.spec.model_dump(mode="json", exclude_none=True)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+        return path
+
+    def assumptions_markdown(self) -> str:
+        """Human-readable audit of what was extracted vs assumed."""
+        lines = ["# Authoring audit", ""]
+        lines.append(f"**Outcome:** {self.intent.outcome.value}")
+        if self.intent.rationale:
+            lines.append(f"\n{self.intent.rationale}")
+
+        lines.append("\n## Extracted from project data (LLM)")
+        if self.intent.provenance:
+            lines.append("\n| Field | Value | Source |")
+            lines.append("|---|---|---|")
+            for entry in self.intent.provenance:
+                lines.append(f"| {entry.field} | {entry.value} | {entry.source} |")
+        else:
+            lines.append("\n_(no values were grounded in the project data)_")
+
+        lines.append("\n## Assumed by the resolver (no silent assumptions)")
+        records = self.ledger.rows()
+        if records:
+            lines.append("\n| Field | Value | Source | Confidence | Basis |")
+            lines.append("|---|---|---|---|---|")
+            for rec in records:
+                lines.append(
+                    f"| {rec.field} | {rec.value} | {rec.source.value} | "
+                    f"{rec.confidence.value} | {rec.basis} |"
+                )
+        else:
+            lines.append("\n_(none -- every field was supplied)_")
+
+        if self.intent.open_questions:
+            lines.append("\n## Open questions")
+            for q in self.intent.open_questions:
+                lines.append(f"- {q}")
+        return "\n".join(lines) + "\n"
+
+    def write(self, out_dir: str | Path) -> dict[str, Path]:
+        """Write the full artifact set: spec, audit, ledger, intent.
+
+        Returns a mapping of artifact name -> path written.
+        """
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        paths = {
+            "spec": self.to_spec_yaml(out / "spec.yml"),
+            "assumptions": out / "assumptions.md",
+            "ledger": out / "assumption_ledger.json",
+            "intent": out / "intent.json",
+        }
+        paths["assumptions"].write_text(self.assumptions_markdown())
+        paths["ledger"].write_text(self.ledger.to_json())
+        paths["intent"].write_text(self.intent.model_dump_json(indent=2))
+        return paths
+
+    def generate_model(self, out_dir: str | Path) -> Path:
+        """Generate the OrcaFlex model YAML (master.yml + includes).
+
+        Returns the output directory containing ``master.yml``.
+        """
+        out = Path(out_dir)
+        ModularModelGenerator.from_spec(self.spec).generate(out)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def author_spec(
+    bundle: ProjectBundle,
+    request: str,
+    *,
+    author: IntentAuthor | None = None,
+) -> AuthoredSpec:
+    """Author an OrcaFlex analysis-SSOT spec from a project SSOT + a request.
+
+    Parameters
+    ----------
+    bundle:
+        The project single-source-of-truth (data + free text).
+    request:
+        The natural-language analysis request.
+    author:
+        The :class:`IntentAuthor` that performs the LLM call. Defaults to
+        :class:`ClaudeCliIntentAuthor` (the ``claude -p`` CLI, no API key).
+        Inject a stub for offline tests, or :class:`AnthropicIntentAuthor`
+        to use the Anthropic SDK directly.
+    """
+    if author is None:
+        author = ClaudeCliIntentAuthor()
+    intent = author.author(bundle, request)
+    outcome, inputs = intent_to_resolver_inputs(intent)
+    spec, ledger = inverse_resolver.resolve(outcome, inputs)
+    return AuthoredSpec(spec=spec, ledger=ledger, intent=intent)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Author an OrcaFlex mooring analysis spec (analysis SSOT) from a "
+            "project bundle (project SSOT) + a natural-language request, via an "
+            "LLM, then optionally generate the OrcaFlex model."
+        )
+    )
+    parser.add_argument("bundle", help="Path to the project bundle YAML.")
+    parser.add_argument(
+        "-r", "--request", required=True, help="Natural-language analysis request."
+    )
+    parser.add_argument(
+        "-o", "--out-dir", default="authored_spec", help="Output directory."
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model id.")
+    parser.add_argument(
+        "--backend",
+        choices=["claude-cli", "anthropic-sdk"],
+        default="claude-cli",
+        help="LLM backend: 'claude-cli' (claude -p, no key) or 'anthropic-sdk'.",
+    )
+    parser.add_argument(
+        "--generate-model",
+        action="store_true",
+        help="Also generate the OrcaFlex model YAML (into <out-dir>/model).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.backend == "anthropic-sdk":
+        author: IntentAuthor = AnthropicIntentAuthor(model=args.model)
+    else:
+        author = ClaudeCliIntentAuthor(model=args.model)
+
+    bundle = ProjectBundle.from_yaml(args.bundle)
+    result = author_spec(bundle, args.request, author=author)
+    paths = result.write(args.out_dir)
+    output = {k: str(v) for k, v in paths.items()}
+    if args.generate_model:
+        model_dir = result.generate_model(Path(args.out_dir) / "model")
+        output["model"] = str(model_dir / "master.yml")
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "OrcaFlexIntent",
+    "IntentAuthor",
+    "ClaudeCliIntentAuthor",
+    "AnthropicIntentAuthor",
+    "AuthoredSpec",
+    "author_spec",
+    "intent_to_resolver_inputs",
+    "build_system_prompt",
+    "DEFAULT_MODEL",
+]

--- a/tests/solvers/orcaflex/test_spec_author.py
+++ b/tests/solvers/orcaflex/test_spec_author.py
@@ -1,0 +1,241 @@
+"""Tests for the OrcaFlex LLM spec-authoring front-end (offline, stub author).
+
+The LLM call is injected, so these exercise the full project-SSOT -> intent ->
+resolve -> analysis-SSOT pipeline without any network or API key.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.common.spec_authoring import ProjectBundle, ProvenanceEntry
+from digitalmodel.solvers.orcaflex.inverse_resolver import (
+    MooringResolverInputs,
+    Outcome,
+)
+from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
+from digitalmodel.solvers.orcaflex.spec_author import (
+    AuthoredSpec,
+    ClaudeCliIntentAuthor,
+    OrcaFlexIntent,
+    author_spec,
+    build_system_prompt,
+    intent_to_resolver_inputs,
+)
+
+
+class StubAuthor:
+    """An IntentAuthor that returns a fixed intent (no LLM call)."""
+
+    def __init__(self, intent: OrcaFlexIntent) -> None:
+        self.intent = intent
+        self.calls: list[tuple[ProjectBundle, str]] = []
+
+    def author(self, bundle: ProjectBundle, request: str) -> OrcaFlexIntent:
+        self.calls.append((bundle, request))
+        return self.intent
+
+
+def _full_intent() -> OrcaFlexIntent:
+    return OrcaFlexIntent(
+        outcome=Outcome.MOORING_STRENGTH,
+        name="West Test mooring",
+        water_depth=1500.0,
+        num_lines=12,
+        chain_diameter=0.13,
+        chain_grade="R5",
+        pretension=1200.0,
+        provenance=[
+            ProvenanceEntry(field="water_depth", value="1500 m", source="data sheet"),
+            ProvenanceEntry(field="num_lines", value="12", source="mooring layout"),
+        ],
+        open_questions=["Storm metocean not specified"],
+        rationale="Request asks for a mooring strength check; sizing given.",
+    )
+
+
+# --- ProjectBundle ---------------------------------------------------------
+
+
+def test_bundle_from_yaml_and_prompt_context(tmp_path: Path) -> None:
+    bundle_yaml = tmp_path / "bundle.yml"
+    bundle_yaml.write_text(
+        "project_name: West Test\n"
+        "vessel_particulars:\n"
+        "  type: FPSO\n"
+        "environment:\n"
+        "  water_depth: 1500\n"
+        "notes: Spread-mooring strength screening.\n"
+    )
+    bundle = ProjectBundle.from_yaml(bundle_yaml)
+    assert bundle.project_name == "West Test"
+    context = bundle.to_prompt_context()
+    assert "West Test" in context
+    assert "water_depth: 1500" in context
+    assert "Spread-mooring strength" in context
+
+
+# --- intent_to_resolver_inputs ---------------------------------------------
+
+
+def test_intent_maps_to_resolver_inputs() -> None:
+    intent = _full_intent()
+    outcome, inputs = intent_to_resolver_inputs(intent)
+    assert outcome == Outcome.MOORING_STRENGTH
+    assert isinstance(inputs, MooringResolverInputs)
+    assert inputs.water_depth == 1500.0
+    assert inputs.num_lines == 12
+    assert inputs.chain_diameter == 0.13
+    assert inputs.chain_grade == "R5"
+    assert inputs.pretension == 1200.0
+
+
+def test_intent_leaves_unstated_fields_none() -> None:
+    intent = OrcaFlexIntent(outcome=Outcome.MOORING_PRETENSION)
+    _, inputs = intent_to_resolver_inputs(intent)
+    assert inputs.water_depth is None
+    assert inputs.num_lines is None
+    assert inputs.chain_diameter is None
+
+
+# --- author_spec end to end ------------------------------------------------
+
+
+def test_author_spec_produces_spec_and_ledger() -> None:
+    author = StubAuthor(_full_intent())
+    bundle = ProjectBundle(project_name="Test", notes="mooring strength please")
+
+    result = author_spec(bundle, "Check mooring strength", author=author)
+
+    assert isinstance(result, AuthoredSpec)
+    assert isinstance(result.spec, ProjectInputSpec)
+    assert result.spec.mooring is not None
+    assert len(result.spec.mooring.lines) == 12
+    assert result.spec.environment.water.depth == 1500.0
+    # The author was actually consulted with the request.
+    assert author.calls[0][1] == "Check mooring strength"
+
+
+def test_author_spec_ledgers_assumed_values() -> None:
+    # Intent supplies only the outcome; everything else must be assumed.
+    intent = OrcaFlexIntent(outcome=Outcome.MOORING_STRENGTH)
+    result = author_spec(ProjectBundle(), "mooring", author=StubAuthor(intent))
+    # No-silent-assumptions: derived values are recorded in the ledger.
+    fields = {rec.field for rec in result.ledger.rows()}
+    assert "environment.water.depth" in fields
+    assert "mooring.num_lines" in fields
+
+
+def test_supplied_values_not_ledgered() -> None:
+    result = author_spec(ProjectBundle(), "mooring", author=StubAuthor(_full_intent()))
+    fields = {rec.field for rec in result.ledger.rows()}
+    assert "environment.water.depth" not in fields
+    assert "mooring.num_lines" not in fields
+    assert "mooring.chain_diameter" not in fields
+
+
+def test_authored_spec_write_emits_all_artifacts(tmp_path: Path) -> None:
+    result = author_spec(ProjectBundle(), "mooring", author=StubAuthor(_full_intent()))
+    paths = result.write(tmp_path / "out")
+    for key in ("spec", "assumptions", "ledger", "intent"):
+        assert paths[key].exists(), key
+    # The spec round-trips as a clean analysis SSOT.
+    import yaml
+
+    with open(paths["spec"]) as f:
+        reloaded = ProjectInputSpec.model_validate(yaml.safe_load(f))
+    assert reloaded.mooring is not None
+    assert len(reloaded.mooring.lines) == 12
+    # Provenance and the chosen outcome appear in the human audit.
+    audit = paths["assumptions"].read_text()
+    assert "mooring_strength" in audit
+    assert "data sheet" in audit
+
+
+def test_assumptions_markdown_handles_empty_provenance() -> None:
+    intent = OrcaFlexIntent(outcome=Outcome.MOORING_STRENGTH)
+    result = author_spec(ProjectBundle(), "mooring", author=StubAuthor(intent))
+    md = result.assumptions_markdown()
+    assert "no values were grounded" in md
+
+
+def test_generate_model_via_modular_generator(tmp_path: Path) -> None:
+    result = author_spec(ProjectBundle(), "mooring", author=StubAuthor(_full_intent()))
+    out = result.generate_model(tmp_path / "model")
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
+
+
+def test_system_prompt_lists_all_outcomes() -> None:
+    prompt = build_system_prompt()
+    for outcome in Outcome:
+        assert outcome.value in prompt
+
+
+# --- ClaudeCliIntentAuthor (mocked runner, no real CLI) --------------------
+
+
+def _fake_completed(stdout: str, returncode: int = 0, stderr: str = ""):
+    import subprocess
+
+    return subprocess.CompletedProcess(
+        args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_claude_cli_author_parses_fenced_json() -> None:
+    inner = (
+        '{"outcome": "mooring_strength", "water_depth": 1500.0, "num_lines": 12, '
+        '"provenance": [], "open_questions": [], "rationale": "ok"}'
+    )
+    # claude -p returns an envelope whose `result` may wrap JSON in fences.
+    envelope = json.dumps({"is_error": False, "result": "```json\n" + inner + "\n```"})
+
+    captured: dict = {}
+
+    def runner(argv, stdin):
+        captured["argv"] = argv
+        captured["stdin"] = stdin
+        return _fake_completed(envelope)
+
+    author = ClaudeCliIntentAuthor(runner=runner)
+    intent = author.author(ProjectBundle(notes="x"), "mooring strength")
+
+    assert intent.outcome == Outcome.MOORING_STRENGTH
+    assert intent.water_depth == 1500.0
+    assert intent.num_lines == 12
+    # The CLI was invoked headlessly with the right flags + stdin prompt.
+    assert "-p" in captured["argv"]
+    assert "--output-format" in captured["argv"]
+    assert "mooring strength" in captured["stdin"]
+
+
+def test_claude_cli_author_raises_on_error_envelope() -> None:
+    envelope = json.dumps({"is_error": True, "result": "boom"})
+    author = ClaudeCliIntentAuthor(runner=lambda argv, stdin: _fake_completed(envelope))
+    with pytest.raises(RuntimeError, match="boom"):
+        author.author(ProjectBundle(), "mooring")
+
+
+def test_claude_cli_author_raises_on_nonzero_returncode() -> None:
+    author = ClaudeCliIntentAuthor(
+        runner=lambda argv, stdin: _fake_completed("", returncode=1, stderr="no auth")
+    )
+    with pytest.raises(RuntimeError, match="no auth"):
+        author.author(ProjectBundle(), "mooring")
+
+
+def test_author_spec_end_to_end_with_cli_runner(tmp_path: Path) -> None:
+    inner = (
+        '{"outcome": "mooring_pretension", "water_depth": 200, "num_lines": 6, '
+        '"provenance": [], "open_questions": [], "rationale": "ok"}'
+    )
+    envelope = json.dumps({"is_error": False, "result": inner})
+    author = ClaudeCliIntentAuthor(runner=lambda argv, stdin: _fake_completed(envelope))
+
+    result = author_spec(ProjectBundle(), "pretension check", author=author)
+    assert result.spec.simulation.stages == [10]
+    assert len(result.spec.mooring.lines) == 6


### PR DESCRIPTION
## Summary

Builds the **LLM spec-authoring front-end for OrcaFlex** (#1095), mirroring the
diffraction one. A project single-source-of-truth (heterogeneous project data)
plus a natural-language request produces an OrcaFlex `ProjectInputSpec`
(analysis SSOT) + `AssumptionLedger`, and optionally a generated OrcaFlex model.

```
project_bundle.yml + "screen the mooring for storm strength"
   -> LLM authors OrcaFlexIntent (extracts only STATED facts)
   -> inverse_resolver.resolve (fills gaps, ledgers each)  ==> ProjectInputSpec + AssumptionLedger
   -> ModularModelGenerator (--generate-model)             ==> OrcaFlex YAML
```

## What's in it

- **`common/spec_authoring.py`** — promotes the GENERIC, intent-type-agnostic
  plumbing so it isn't duplicated per domain: `ProjectBundle`,
  `ProvenanceEntry`, `_extract_json_object`, `CliRunner`/`_default_cli_runner`,
  a generic `claude_cli_complete()` JSON caller, and `build_outcome_menu()`.
  Dependency-light (pydantic only; **no `anthropic`**). The diffraction
  `spec_author` is intentionally **left untouched** — a later PR can dedupe it
  onto this shared module; minor duplication is acceptable now to keep
  diffraction's 18 tests green.
- **`solvers/orcaflex/spec_author.py`** — `OrcaFlexIntent` (LLM
  structured-output target mirroring `MooringResolverInputs`), `IntentAuthor`
  protocol, `ClaudeCliIntentAuthor` (**DEFAULT**, uses the shared
  `claude -p` helper — no API key), `AnthropicIntentAuthor` (lazy SDK,
  `claude-opus-4-8`, adaptive thinking + high effort),
  `intent_to_resolver_inputs`, `author_spec`, and an `AuthoredSpec` result
  (`write()` + `generate_model()`). CLI with `--backend {claude-cli,
  anthropic-sdk}` and `--generate-model`. **Mooring outcomes only** for now.
- **`tests/solvers/orcaflex/test_spec_author.py`** — fully offline (StubAuthor +
  mocked `CliRunner`): intent→inputs mapping, end-to-end `author_spec`, `write()`
  artifacts, model generation via `ModularModelGenerator`, and the claude-cli
  envelope paths (fenced JSON, error envelope, non-zero rc). 14 tests.
- **`examples/workflows/orcaflex-spec-authoring-llm/`** — `project_bundle.yml`
  (FPSO mooring screening) + `README.md` showing the default `claude -p` run
  (no API key) and the `--generate-model` flow.

## Design

Same responsibility split as diffraction to keep the hallucination surface
small: the **LLM** extracts only facts the project data states (everything else
left `null`, with provenance), and the **deterministic resolver** fills the rest
from reference defaults and ledgers each value (the "no silent assumptions"
contract). The LLM call is injected via the `IntentAuthor` protocol, so the
pipeline is testable with zero network/API key.

## Verification

- `tests/solvers/orcaflex/test_spec_author.py` — 14 passed.
- No regression: `tests/solvers/orcaflex/test_inverse_resolver.py` +
  `tests/hydrodynamics/diffraction/test_spec_author.py` — 29 passed.
- Lint clean: black 25.9.0, isort 5.13.2 (--profile black), flake8
  (--max-line-length=100 --extend-ignore=E203,W503).

Scope was limited to `common/spec_authoring.py`, `solvers/orcaflex/spec_author.py`,
the new test, and the example dir. `inverse_resolver.py` and its test were not
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
