### PR TITLE
feat(orcaflex): riser + pipeline outcomes in the inverse resolver (#1095)

### DIFF
--- a/src/digitalmodel/solvers/orcaflex/inverse_resolver.py
+++ b/src/digitalmodel/solvers/orcaflex/inverse_resolver.py
@@ -6,11 +6,13 @@ The OrcaFlex counterpart of the diffraction ``resolver.resolve`` (digitalmodel
 *assumed* (rather than received) in an :class:`AssumptionLedger` -- the
 "no silent assumptions" contract.
 
-This first increment covers the **mooring** model type (the best-supported,
-license-free path). The ``Outcome`` enum and dispatch are structured so riser /
-pipeline / installation outcomes can be added the same way later.
+It covers three license-free model families, each dispatched by outcome:
 
-    Outcome.MOORING_STRENGTH + sparse inputs
+* **mooring** -- spread-mooring strength / pretension.
+* **riser** -- static configuration / wave dynamic (#1095).
+* **pipeline** -- on-bottom stability / installation lay (#1095).
+
+    Outcome.RISER_STATIC + sparse inputs
         |  resolve()  (fills gaps from reference defaults, ledgers each)
         v
     ProjectInputSpec  +  AssumptionLedger
@@ -23,7 +25,7 @@ from __future__ import annotations
 
 import math
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -40,18 +42,32 @@ class Outcome(str, Enum):
 
     MOORING_STRENGTH = "mooring_strength"
     MOORING_PRETENSION = "mooring_pretension"
+    RISER_STATIC = "riser_static"
+    RISER_DYNAMIC = "riser_dynamic"
+    PIPELINE_ONBOTTOM = "pipeline_onbottom"
+    PIPELINE_LAY = "pipeline_lay"
 
 
 # Per-outcome simulation profile (stages = list of stage durations in seconds).
-# Strength wants a build-up + storm dynamic stage; pretension/equilibrium is a
-# static-only check.
+# Static / equilibrium checks are static-only ([single stage]); dynamic checks
+# add a build-up stage ahead of the main wave/lay dynamic stage.
 _OUTCOME_SIMULATION: dict[Outcome, dict[str, Any]] = {
     Outcome.MOORING_STRENGTH: {"stages": [8, 16]},
     Outcome.MOORING_PRETENSION: {"stages": [10]},
+    Outcome.RISER_STATIC: {"stages": [10]},
+    Outcome.RISER_DYNAMIC: {"stages": [8, 16]},
+    Outcome.PIPELINE_ONBOTTOM: {"stages": [10]},
+    Outcome.PIPELINE_LAY: {"stages": [8, 16]},
 }
 
 MOORING_OUTCOMES: frozenset[Outcome] = frozenset(
     {Outcome.MOORING_STRENGTH, Outcome.MOORING_PRETENSION}
+)
+RISER_OUTCOMES: frozenset[Outcome] = frozenset(
+    {Outcome.RISER_STATIC, Outcome.RISER_DYNAMIC}
+)
+PIPELINE_OUTCOMES: frozenset[Outcome] = frozenset(
+    {Outcome.PIPELINE_ONBOTTOM, Outcome.PIPELINE_LAY}
 )
 
 OUTCOME_DESCRIPTIONS: dict[Outcome, str] = {
@@ -62,10 +78,37 @@ OUTCOME_DESCRIPTIONS: dict[Outcome, str] = {
     Outcome.MOORING_PRETENSION: (
         "Mooring pretension / static equilibrium check (static stage only)."
     ),
+    Outcome.RISER_STATIC: (
+        "Riser static configuration check (static stage only) -- effective "
+        "tension and curvature along the catenary."
+    ),
+    Outcome.RISER_DYNAMIC: (
+        "Riser wave dynamic check (static + wave dynamic stage) -- dynamic "
+        "tension and bending at the hang-off and touchdown."
+    ),
+    Outcome.PIPELINE_ONBOTTOM: (
+        "Pipeline on-bottom stability check (static stage only) -- seabed "
+        "contact and lateral stability."
+    ),
+    Outcome.PIPELINE_LAY: (
+        "Pipeline installation lay check (static + lay dynamic stage) -- "
+        "sag-bend / over-bend response during laydown."
+    ),
 }
 
+# Per-family (structure label, default model name).
+_FAMILY_DEFAULTS: dict[str, tuple[str, str]] = {
+    "mooring": ("mooring", "mooring_system"),
+    "riser": ("riser", "riser_system"),
+    "pipeline": ("pipeline", "pipeline_system"),
+}
+
+# ---------------------------------------------------------------------------
 # Reference defaults used when a value is not supplied (each is ledgered).
+# ---------------------------------------------------------------------------
 DEFAULT_WATER_DEPTH = 100.0  # m
+
+# Mooring
 DEFAULT_NUM_LINES = 8
 DEFAULT_CHAIN_DIAMETER = 0.095  # m (95 mm studless)
 DEFAULT_CHAIN_GRADE = "R4"
@@ -76,6 +119,31 @@ DEFAULT_VESSEL_NAME = "vessel_1"
 ANCHOR_RADIUS_DEPTH_FACTOR = 8.0
 # Line length as a multiple of the straight anchor-to-fairlead distance.
 LINE_LENGTH_SLACK_FACTOR = 1.15
+
+# Steel reference properties used to estimate riser line-type stiffness/mass.
+STEEL_DENSITY = 7.85  # te/m3
+STEEL_YOUNGS_MODULUS = 2.1e8  # kN/m2 (210 GPa)
+
+# Riser
+DEFAULT_RISER_OUTER_DIAMETER = 0.30  # m (~12 in SCR)
+DEFAULT_RISER_WALL_THICKNESS = 0.025  # m
+DEFAULT_RISER_SEGMENT_LENGTH = 10.0  # m (FE target, <= 50)
+DEFAULT_RISER_CONFIGURATION = "catenary"
+DEFAULT_RISER_HANGOFF_RADIUS = 25.0  # m horizontal offset of the hang-off
+DEFAULT_RISER_HANGOFF_Z = -10.0  # m below the free surface
+# Horizontal touchdown layback as a multiple of water depth (catenary scope).
+RISER_LAYBACK_DEPTH_FACTOR = 1.0
+# Arc length as a multiple of the straight hang-off-to-touchdown distance.
+RISER_LENGTH_SLACK_FACTOR = 1.2
+
+# Pipeline
+DEFAULT_PIPELINE_OUTER_DIAMETER = 0.508  # m (20 in)
+DEFAULT_PIPELINE_WALL_THICKNESS = 0.0254  # m (1 in)
+DEFAULT_PIPELINE_MATERIAL = "X65"
+DEFAULT_PIPELINE_LENGTH = 2000.0  # m
+DEFAULT_PIPELINE_SEGMENT_LENGTH = 10.0  # m (mesh target, <= 100)
+DEFAULT_PIPELINE_CORROSION_THICKNESS = 0.003  # m (FBE)
+DEFAULT_PIPELINE_CORROSION_DENSITY = 1.3  # te/m3
 
 
 class MooringResolverInputs(BaseModel):
@@ -96,26 +164,95 @@ class MooringResolverInputs(BaseModel):
     partial_spec: Optional[dict[str, Any]] = None
 
 
+class RiserResolverInputs(BaseModel):
+    """Sparse inputs accepted by the riser inverse resolver."""
+
+    name: Optional[str] = None
+    water_depth: Optional[float] = Field(default=None, gt=0)
+    outer_diameter: Optional[float] = Field(default=None, gt=0)
+    wall_thickness: Optional[float] = Field(default=None, gt=0)
+    length: Optional[float] = Field(default=None, gt=0)
+    configuration: Optional[str] = None
+    vessel_name: Optional[str] = None
+    top_position: Optional[list[float]] = Field(
+        default=None, min_length=3, max_length=3
+    )
+    bottom_position: Optional[list[float]] = Field(
+        default=None, min_length=3, max_length=3
+    )
+    # Escape hatch: a fully/partly specified ProjectInputSpec dict to merge.
+    partial_spec: Optional[dict[str, Any]] = None
+
+
+class PipelineResolverInputs(BaseModel):
+    """Sparse inputs accepted by the pipeline inverse resolver."""
+
+    name: Optional[str] = None
+    water_depth: Optional[float] = Field(default=None, gt=0)
+    outer_diameter: Optional[float] = Field(default=None, gt=0)
+    wall_thickness: Optional[float] = Field(default=None, gt=0)
+    length: Optional[float] = Field(default=None, gt=0)
+    material: Optional[str] = None
+    segment_length: Optional[float] = Field(default=None, gt=0)
+    # Escape hatch: a fully/partly specified ProjectInputSpec dict to merge.
+    partial_spec: Optional[dict[str, Any]] = None
+
+
+ResolverInputs = Union[
+    MooringResolverInputs, RiserResolverInputs, PipelineResolverInputs
+]
+
+_FAMILY_INPUT_MODELS: dict[str, type[BaseModel]] = {
+    "mooring": MooringResolverInputs,
+    "riser": RiserResolverInputs,
+    "pipeline": PipelineResolverInputs,
+}
+
+
+def _family_of(outcome: Outcome) -> str:
+    """Return the model family ('mooring' / 'riser' / 'pipeline') for an outcome."""
+    if outcome in MOORING_OUTCOMES:
+        return "mooring"
+    if outcome in RISER_OUTCOMES:
+        return "riser"
+    if outcome in PIPELINE_OUTCOMES:
+        return "pipeline"
+    raise ValueError(f"Unsupported outcome: {outcome}")  # pragma: no cover
+
+
 def resolve(
     outcome: Outcome | str,
-    inputs: MooringResolverInputs | dict[str, Any] | None = None,
+    inputs: ResolverInputs | dict[str, Any] | None = None,
 ) -> tuple[ProjectInputSpec, AssumptionLedger]:
     """Resolve an outcome + sparse inputs into a complete ProjectInputSpec."""
     outcome = Outcome(outcome)
-    if outcome not in MOORING_OUTCOMES:  # pragma: no cover - guard for future
-        raise ValueError(f"Unsupported outcome: {outcome}")
+    family = _family_of(outcome)
+    inputs_cls = _FAMILY_INPUT_MODELS[family]
 
-    resolver_inputs = (
-        inputs
-        if isinstance(inputs, MooringResolverInputs)
-        else MooringResolverInputs.model_validate(inputs or {})
-    )
+    if isinstance(inputs, inputs_cls):
+        resolver_inputs = inputs
+    elif isinstance(
+        inputs,
+        (MooringResolverInputs, RiserResolverInputs, PipelineResolverInputs),
+    ):
+        raise ValueError(
+            f"Inputs of type {type(inputs).__name__} do not match outcome "
+            f"family '{family}' (expected {inputs_cls.__name__})"
+        )
+    else:
+        resolver_inputs = inputs_cls.model_validate(inputs or {})
+
     ledger = AssumptionLedger()
     data: dict[str, Any] = _deep_copy(resolver_inputs.partial_spec or {})
 
-    _resolve_metadata(data, resolver_inputs, outcome, ledger)
+    _resolve_metadata(data, resolver_inputs, outcome, family, ledger)
     _resolve_environment(data, resolver_inputs, ledger)
-    _resolve_mooring(data, resolver_inputs, ledger)
+    if family == "mooring":
+        _resolve_mooring(data, resolver_inputs, ledger)
+    elif family == "riser":
+        _resolve_riser(data, resolver_inputs, ledger)
+    else:
+        _resolve_pipeline(data, resolver_inputs, ledger)
     _resolve_simulation(data, outcome, ledger)
 
     spec = ProjectInputSpec.model_validate(data)
@@ -129,13 +266,15 @@ def resolve(
 
 def _resolve_metadata(
     data: dict[str, Any],
-    inputs: MooringResolverInputs,
+    inputs: ResolverInputs,
     outcome: Outcome,
+    family: str,
     ledger: AssumptionLedger,
 ) -> None:
+    structure, default_name = _FAMILY_DEFAULTS[family]
     meta = _nested(data, "metadata")
     if "name" not in meta:
-        meta["name"] = inputs.name or "mooring_system"
+        meta["name"] = inputs.name or default_name
         if inputs.name is None:
             ledger.record(
                 "metadata.name",
@@ -148,7 +287,7 @@ def _resolve_metadata(
             )
     for field, value, basis in (
         ("description", f"{outcome.value} model", "Derived from outcome"),
-        ("structure", "mooring", "Mooring model type"),
+        ("structure", structure, f"{family.capitalize()} model type"),
         ("operation", outcome.value, "Derived from outcome"),
     ):
         if field not in meta:
@@ -166,7 +305,7 @@ def _resolve_metadata(
 
 def _resolve_environment(
     data: dict[str, Any],
-    inputs: MooringResolverInputs,
+    inputs: ResolverInputs,
     ledger: AssumptionLedger,
 ) -> None:
     env = _nested(data, "environment")
@@ -333,6 +472,304 @@ def _resolve_mooring(
     data["mooring"] = {"lines": lines}
 
 
+def _resolve_riser(
+    data: dict[str, Any],
+    inputs: RiserResolverInputs,
+    ledger: AssumptionLedger,
+) -> None:
+    if "riser" in data and data["riser"]:
+        return  # fully user-specified riser -> leave as is (not ledgered)
+
+    water_depth = _nested(data, "environment", "water")["depth"]
+
+    outer_diameter = inputs.outer_diameter or DEFAULT_RISER_OUTER_DIAMETER
+    if inputs.outer_diameter is None:
+        ledger.record(
+            "riser.outer_diameter",
+            outer_diameter,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default steel-catenary-riser outer diameter",
+            Confidence.LOW,
+            reference="default",
+            impact=5,
+        )
+
+    wall_thickness = inputs.wall_thickness or DEFAULT_RISER_WALL_THICKNESS
+    if inputs.wall_thickness is None:
+        ledger.record(
+            "riser.wall_thickness",
+            wall_thickness,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default riser wall thickness",
+            Confidence.LOW,
+            reference="default",
+            impact=4,
+        )
+
+    inner_diameter = round(outer_diameter - 2.0 * wall_thickness, 6)
+    if inner_diameter <= 0:
+        raise ValueError(
+            f"wall_thickness ({wall_thickness}) too large for outer_diameter "
+            f"({outer_diameter}); inner diameter would be {inner_diameter}"
+        )
+
+    # Section properties estimated from a steel pipe of the resolved geometry.
+    area = math.pi / 4.0 * (outer_diameter**2 - inner_diameter**2)
+    second_moment = math.pi / 64.0 * (outer_diameter**4 - inner_diameter**4)
+    mass_per_length = round(STEEL_DENSITY * area, 6)
+    bending_stiffness = round(STEEL_YOUNGS_MODULUS * second_moment, 3)
+    axial_stiffness = round(STEEL_YOUNGS_MODULUS * area, 3)
+    for field, value, basis in (
+        ("riser.mass_per_length", mass_per_length, "Steel pipe mass from geometry"),
+        ("riser.bending_stiffness", bending_stiffness, "E*I from steel geometry"),
+        ("riser.axial_stiffness", axial_stiffness, "E*A from steel geometry"),
+    ):
+        ledger.record(
+            field,
+            value,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            basis,
+            Confidence.MEDIUM,
+            reference="steel pipe: rho=7.85 te/m3, E=210 GPa",
+            impact=4,
+        )
+
+    configuration = inputs.configuration or DEFAULT_RISER_CONFIGURATION
+    if inputs.configuration is None:
+        ledger.record(
+            "riser.configuration",
+            configuration,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default riser configuration",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    vessel = inputs.vessel_name or DEFAULT_VESSEL_NAME
+    if inputs.vessel_name is None:
+        ledger.record(
+            "riser.vessel_name",
+            vessel,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default vessel name for hang-off",
+            Confidence.LOW,
+            reference="default",
+            impact=2,
+        )
+
+    if inputs.top_position is not None:
+        top_position = [float(v) for v in inputs.top_position]
+    else:
+        top_position = [DEFAULT_RISER_HANGOFF_RADIUS, 0.0, DEFAULT_RISER_HANGOFF_Z]
+        ledger.record(
+            "riser.top_position",
+            top_position,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default hang-off position below the vessel",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    if inputs.bottom_position is not None:
+        bottom_position = [float(v) for v in inputs.bottom_position]
+    else:
+        layback = top_position[0] + RISER_LAYBACK_DEPTH_FACTOR * water_depth
+        bottom_position = [round(layback, 3), 0.0, -water_depth]
+        ledger.record(
+            "riser.bottom_position",
+            bottom_position,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            f"Touchdown {RISER_LAYBACK_DEPTH_FACTOR}x water depth downrange",
+            Confidence.MEDIUM,
+            reference="bottom_x=top_x+factor*depth",
+            impact=4,
+        )
+
+    straight = math.hypot(
+        bottom_position[0] - top_position[0],
+        bottom_position[2] - top_position[2],
+    )
+    length = inputs.length or RISER_LENGTH_SLACK_FACTOR * straight
+    if inputs.length is None:
+        length = round(length, 3)
+        ledger.record(
+            "riser.length",
+            length,
+            AssumptionSource.ESTIMATED_FROM_DATA,
+            f"{RISER_LENGTH_SLACK_FACTOR}x straight hang-off-touchdown distance",
+            Confidence.MEDIUM,
+            reference="length=slack*straight",
+            impact=4,
+        )
+
+    segment_length = DEFAULT_RISER_SEGMENT_LENGTH
+    ledger.record(
+        "riser.segment_length",
+        segment_length,
+        AssumptionSource.ASSUMED_DEFAULT,
+        "Default FE segment length",
+        Confidence.LOW,
+        reference="default",
+        impact=2,
+    )
+
+    line_type_name = "riser_pipe"
+    data["riser"] = {
+        "vessel": {"name": vessel},
+        "line_types": [
+            {
+                "name": line_type_name,
+                "outer_diameter": outer_diameter,
+                "inner_diameter": inner_diameter,
+                "mass_per_length": mass_per_length,
+                "bending_stiffness": bending_stiffness,
+                "axial_stiffness": axial_stiffness,
+            }
+        ],
+        "lines": [
+            {
+                "name": "riser_1",
+                "configuration": configuration,
+                "end_a": {
+                    "type": "vessel",
+                    "name": vessel,
+                    "position": top_position,
+                },
+                "end_b": {
+                    "type": "anchor",
+                    "position": bottom_position,
+                },
+                "sections": [
+                    {
+                        "line_type": line_type_name,
+                        "length": length,
+                        "segment_length": segment_length,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _resolve_pipeline(
+    data: dict[str, Any],
+    inputs: PipelineResolverInputs,
+    ledger: AssumptionLedger,
+) -> None:
+    if "pipeline" in data and data["pipeline"]:
+        return  # fully user-specified pipeline -> leave as is (not ledgered)
+
+    pipeline_name = inputs.name or "pipeline_1"
+    if inputs.name is None:
+        ledger.record(
+            "pipeline.name",
+            pipeline_name,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default pipeline name",
+            Confidence.LOW,
+            reference="default",
+            impact=1,
+        )
+
+    material = inputs.material or DEFAULT_PIPELINE_MATERIAL
+    if inputs.material is None:
+        ledger.record(
+            "pipeline.material",
+            material,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default line-pipe steel grade",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    outer_diameter = inputs.outer_diameter or DEFAULT_PIPELINE_OUTER_DIAMETER
+    if inputs.outer_diameter is None:
+        ledger.record(
+            "pipeline.outer_diameter",
+            outer_diameter,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default pipeline outer diameter",
+            Confidence.LOW,
+            reference="default",
+            impact=5,
+        )
+
+    wall_thickness = inputs.wall_thickness or DEFAULT_PIPELINE_WALL_THICKNESS
+    if inputs.wall_thickness is None:
+        ledger.record(
+            "pipeline.wall_thickness",
+            wall_thickness,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default pipeline wall thickness",
+            Confidence.LOW,
+            reference="default",
+            impact=5,
+        )
+    if wall_thickness >= outer_diameter / 2.0:
+        raise ValueError(
+            f"wall_thickness ({wall_thickness}) must be < half outer_diameter "
+            f"({outer_diameter / 2.0})"
+        )
+
+    length = inputs.length or DEFAULT_PIPELINE_LENGTH
+    if inputs.length is None:
+        ledger.record(
+            "pipeline.length",
+            length,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default screening pipeline length",
+            Confidence.LOW,
+            reference="default",
+            impact=3,
+        )
+
+    segment_length = inputs.segment_length or DEFAULT_PIPELINE_SEGMENT_LENGTH
+    if inputs.segment_length is None:
+        ledger.record(
+            "pipeline.segment_length",
+            segment_length,
+            AssumptionSource.ASSUMED_DEFAULT,
+            "Default mesh segment length",
+            Confidence.LOW,
+            reference="default",
+            impact=2,
+        )
+
+    corrosion = {
+        "thickness": DEFAULT_PIPELINE_CORROSION_THICKNESS,
+        "density": DEFAULT_PIPELINE_CORROSION_DENSITY,
+    }
+    ledger.record(
+        "pipeline.coatings.corrosion",
+        corrosion,
+        AssumptionSource.ASSUMED_DEFAULT,
+        "Default FBE corrosion coating",
+        Confidence.LOW,
+        reference="default",
+        impact=2,
+    )
+
+    data["pipeline"] = {
+        "name": pipeline_name,
+        "material": material,
+        "dimensions": {
+            "outer_diameter": outer_diameter,
+            "wall_thickness": wall_thickness,
+        },
+        "coatings": {"corrosion": corrosion},
+        "segments": [
+            {
+                "type": "pipe_main",
+                "length": length,
+                "segment_length": segment_length,
+            }
+        ],
+    }
+
+
 def _resolve_simulation(
     data: dict[str, Any],
     outcome: Outcome,
@@ -379,6 +816,10 @@ __all__ = [
     "Outcome",
     "OUTCOME_DESCRIPTIONS",
     "MOORING_OUTCOMES",
+    "RISER_OUTCOMES",
+    "PIPELINE_OUTCOMES",
     "MooringResolverInputs",
+    "RiserResolverInputs",
+    "PipelineResolverInputs",
     "resolve",
 ]

--- a/tests/solvers/orcaflex/test_inverse_resolver.py
+++ b/tests/solvers/orcaflex/test_inverse_resolver.py
@@ -13,8 +13,12 @@ import pytest
 from digitalmodel.solvers.orcaflex.inverse_resolver import (
     MOORING_OUTCOMES,
     OUTCOME_DESCRIPTIONS,
+    PIPELINE_OUTCOMES,
+    RISER_OUTCOMES,
     MooringResolverInputs,
     Outcome,
+    PipelineResolverInputs,
+    RiserResolverInputs,
     resolve,
 )
 from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
@@ -121,11 +125,209 @@ def test_every_outcome_has_a_description() -> None:
     for outcome in Outcome:
         assert outcome in OUTCOME_DESCRIPTIONS, outcome
     assert MOORING_OUTCOMES.issubset(set(Outcome))
+    assert RISER_OUTCOMES.issubset(set(Outcome))
+    assert PIPELINE_OUTCOMES.issubset(set(Outcome))
+    # Families partition the outcome set without overlap.
+    assert MOORING_OUTCOMES | RISER_OUTCOMES | PIPELINE_OUTCOMES == set(Outcome)
+    assert not (MOORING_OUTCOMES & RISER_OUTCOMES)
+    assert not (RISER_OUTCOMES & PIPELINE_OUTCOMES)
 
 
 def test_unsupported_outcome_raises() -> None:
     with pytest.raises(ValueError):
-        resolve("riser_static")  # not yet implemented
+        resolve("buckling_check")  # not a defined Outcome
+
+
+def test_inputs_must_match_outcome_family() -> None:
+    # A riser outcome cannot be resolved with mooring inputs.
+    with pytest.raises(ValueError):
+        resolve(Outcome.RISER_STATIC, MooringResolverInputs(water_depth=500))
+
+
+# ---------------------------------------------------------------------------
+# Riser outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_barebones_riser_resolves_to_valid_spec() -> None:
+    spec, ledger = resolve(Outcome.RISER_STATIC)
+    assert isinstance(spec, ProjectInputSpec)
+    assert spec.riser is not None
+    assert spec.mooring is None and spec.pipeline is None and spec.generic is None
+    assert spec.metadata.structure == "riser"
+    assert len(spec.riser.lines) == 1
+    assert len(spec.riser.line_types) == 1
+    fields = {r.field for r in ledger.rows()}
+    assert "riser.outer_diameter" in fields
+    assert "riser.bottom_position" in fields
+    assert "environment.water.depth" in fields
+
+
+def test_string_riser_outcome_accepted() -> None:
+    spec, _ = resolve("riser_static")
+    assert spec.riser is not None
+
+
+def test_riser_supplied_inputs_honored_and_not_ledgered() -> None:
+    spec, ledger = resolve(
+        Outcome.RISER_DYNAMIC,
+        RiserResolverInputs(
+            water_depth=1200.0,
+            outer_diameter=0.4,
+            wall_thickness=0.03,
+            length=2000.0,
+            vessel_name="FPSO_A",
+            configuration="lazy_wave",
+        ),
+    )
+    assert spec.environment.water.depth == 1200.0
+    lt = spec.riser.line_types[0]
+    assert lt.outer_diameter == 0.4
+    assert lt.inner_diameter == 0.34  # 0.4 - 2*0.03
+    line = spec.riser.lines[0]
+    assert line.get_total_length() == 2000.0
+    assert spec.riser.vessel.name == "FPSO_A"
+    assert line.configuration.value == "lazy_wave"
+    fields = {r.field for r in ledger.rows()}
+    assert "riser.outer_diameter" not in fields
+    assert "riser.wall_thickness" not in fields
+    assert "riser.length" not in fields
+    assert "riser.vessel_name" not in fields
+    # Stiffness/mass are always derived (never user-supplied) -> still ledgered.
+    assert "riser.axial_stiffness" in fields
+
+
+def test_riser_outcome_drives_simulation_stages() -> None:
+    static, _ = resolve(Outcome.RISER_STATIC)
+    dynamic, _ = resolve(Outcome.RISER_DYNAMIC)
+    assert static.simulation.stages == [10]
+    assert dynamic.simulation.stages == [8, 16]
+
+
+def test_riser_bottom_position_scales_with_water_depth() -> None:
+    shallow, _ = resolve(Outcome.RISER_STATIC, RiserResolverInputs(water_depth=200))
+    deep, _ = resolve(Outcome.RISER_STATIC, RiserResolverInputs(water_depth=1500))
+    shallow_x = shallow.riser.lines[0].end_b.position[0]
+    deep_x = deep.riser.lines[0].end_b.position[0]
+    assert deep_x > shallow_x
+
+
+def test_partial_spec_riser_is_used_verbatim() -> None:
+    partial = {
+        "riser": {
+            "vessel": {"name": "v"},
+            "line_types": [
+                {
+                    "name": "lt",
+                    "outer_diameter": 0.3,
+                    "inner_diameter": 0.25,
+                    "mass_per_length": 0.15,
+                    "bending_stiffness": 20000.0,
+                    "axial_stiffness": 2.0e6,
+                }
+            ],
+            "lines": [
+                {
+                    "name": "R1",
+                    "end_a": {"type": "vessel", "name": "v", "position": [40, 0, -10]},
+                    "end_b": {"type": "anchor", "position": [800, 0, -1000]},
+                    "sections": [
+                        {"line_type": "lt", "length": 1400, "segment_length": 10}
+                    ],
+                }
+            ],
+        }
+    }
+    spec, ledger = resolve(
+        Outcome.RISER_STATIC, RiserResolverInputs(partial_spec=partial)
+    )
+    assert len(spec.riser.lines) == 1
+    assert spec.riser.lines[0].name == "R1"
+    assert not any(r.field.startswith("riser.") for r in ledger.rows())
+
+
+def test_generates_riser_model_yaml(tmp_path: Path) -> None:
+    spec, _ = resolve(Outcome.RISER_DYNAMIC)
+    out = tmp_path / "riser_model"
+    ModularModelGenerator.from_spec(spec).generate(out)
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
+
+
+# ---------------------------------------------------------------------------
+# Pipeline outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_barebones_pipeline_resolves_to_valid_spec() -> None:
+    spec, ledger = resolve(Outcome.PIPELINE_ONBOTTOM)
+    assert isinstance(spec, ProjectInputSpec)
+    assert spec.pipeline is not None
+    assert spec.mooring is None and spec.riser is None and spec.generic is None
+    assert spec.metadata.structure == "pipeline"
+    assert len(spec.pipeline.segments) == 1
+    fields = {r.field for r in ledger.rows()}
+    assert "pipeline.outer_diameter" in fields
+    assert "pipeline.wall_thickness" in fields
+    assert "pipeline.coatings.corrosion" in fields
+
+
+def test_string_pipeline_outcome_accepted() -> None:
+    spec, _ = resolve("pipeline_lay")
+    assert spec.pipeline is not None
+
+
+def test_pipeline_supplied_inputs_honored_and_not_ledgered() -> None:
+    spec, ledger = resolve(
+        Outcome.PIPELINE_LAY,
+        PipelineResolverInputs(
+            outer_diameter=0.6,
+            wall_thickness=0.03,
+            length=5000.0,
+            material="X70",
+        ),
+    )
+    assert spec.pipeline.dimensions.outer_diameter == 0.6
+    assert spec.pipeline.dimensions.wall_thickness == 0.03
+    assert spec.pipeline.material == "X70"
+    assert sum(s.length for s in spec.pipeline.segments) == 5000.0
+    fields = {r.field for r in ledger.rows()}
+    assert "pipeline.outer_diameter" not in fields
+    assert "pipeline.wall_thickness" not in fields
+    assert "pipeline.length" not in fields
+    assert "pipeline.material" not in fields
+
+
+def test_pipeline_outcome_drives_simulation_stages() -> None:
+    onbottom, _ = resolve(Outcome.PIPELINE_ONBOTTOM)
+    lay, _ = resolve(Outcome.PIPELINE_LAY)
+    assert onbottom.simulation.stages == [10]
+    assert lay.simulation.stages == [8, 16]
+
+
+def test_partial_spec_pipeline_is_used_verbatim() -> None:
+    partial = {
+        "pipeline": {
+            "name": "Trunkline",
+            "material": "X65",
+            "dimensions": {"outer_diameter": 0.5, "wall_thickness": 0.025},
+            "coatings": {"corrosion": {"thickness": 0.004, "density": 1.3}},
+            "segments": [{"type": "main", "length": 3000, "segment_length": 12}],
+        }
+    }
+    spec, ledger = resolve(
+        Outcome.PIPELINE_ONBOTTOM, PipelineResolverInputs(partial_spec=partial)
+    )
+    assert spec.pipeline.name == "Trunkline"
+    assert not any(r.field.startswith("pipeline.") for r in ledger.rows())
+
+
+def test_generates_pipeline_model_yaml(tmp_path: Path) -> None:
+    spec, _ = resolve(Outcome.PIPELINE_ONBOTTOM)
+    out = tmp_path / "pipeline_model"
+    ModularModelGenerator.from_spec(spec).generate(out)
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
 
 
 def test_ledger_comes_from_shared_common_module() -> None:


### PR DESCRIPTION
## Summary
Broadens the OrcaFlex inverse resolver (`src/digitalmodel/solvers/orcaflex/inverse_resolver.py`) beyond mooring to cover the **riser** and **pipeline** model families, mirroring the established mooring pattern and the no-silent-assumptions `AssumptionLedger`.

## New outcomes
| Outcome | Resolves | Simulation stages |
|---|---|---|
| `RISER_STATIC` | Riser static configuration / effective tension | `[10]` (static only) |
| `RISER_DYNAMIC` | Riser wave dynamic response | `[8, 16]` (build-up + wave dynamic) |
| `PIPELINE_ONBOTTOM` | Pipeline on-bottom stability | `[10]` (static only) |
| `PIPELINE_LAY` | Pipeline installation lay | `[8, 16]` (build-up + lay dynamic) |

(`INSTALLATION_LOWERING` was intentionally **not** added — installation-dynamic intent is already covered by `PIPELINE_LAY`, and there is no distinct model type it would map to cleanly.)

## What each resolves
- **Riser**: a single-line steel catenary riser — one `RiserLineType` whose mass/EI/EA are estimated from a steel pipe (`rho=7.85 te/m3`, `E=210 GPa`) of the resolved OD/wall-thickness geometry (ledgered `ESTIMATED_FROM_DATA`); hang-off (`end_a`=vessel) and touchdown (`end_b`=anchor) positions scaled from water depth; arc length from straight hang-off-to-touchdown distance.
- **Pipeline**: a single-segment line pipe — OD/wall-thickness, X65 grade, FBE corrosion coating, and screening length, all from reference defaults and ledgered.

Adds `RiserResolverInputs` / `PipelineResolverInputs` (sparse, all-Optional), per-family frozensets (`RISER_OUTCOMES`, `PIPELINE_OUTCOMES`), family-dispatched `resolve()` with a family/inputs-mismatch guard, and updated `__all__`. The mooring path is unchanged (its tests still pass).

## Generatability (honest status)
Both new model types are **schema-valid AND generatable** — `ModularModelGenerator.from_spec(spec).generate()` writes YAML for each (dedicated riser/pipeline builders already exist and are registered). No model type is schema-valid-but-not-generatable.

## Tests & checks
- 14 new license-free tests added; full file = **25 passed** (11 original mooring + 14 new).
- Each new outcome covered: barebones resolve -> valid `ProjectInputSpec` with the right model type set (others `None`), non-empty ledger, supplied-inputs-honored-and-not-ledgered, outcome->stages, water-depth scaling, `partial_spec` verbatim (no `<type>.*` assumptions), and `generate()` writes YAML.
- Lint clean: `black==25.9.0`, `isort==5.13.2 --profile black`, `flake8 --max-line-length=100 --extend-ignore=E203,W503`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)