### PR TITLE
feat(orcaflex): wire riser + pipeline outcomes through the LLM spec-author front-end (#1095)

### DIFF
--- a/examples/workflows/orcaflex-spec-authoring-llm/README.md
+++ b/examples/workflows/orcaflex-spec-authoring-llm/README.md
@@ -19,8 +19,17 @@ project_bundle.yml  +  "screen the mooring for storm strength"
 
 This mirrors the diffraction front-end
 (`digitalmodel.hydrodynamics.diffraction.spec_author`) and reuses the shared
-generic plumbing in `digitalmodel.common.spec_authoring`. Only **mooring**
-outcomes are in scope for now.
+generic plumbing in `digitalmodel.common.spec_authoring`. Three license-free
+model families are supported, dispatched by the chosen outcome's family:
+
+| Family | Outcomes | Example bundle |
+|---|---|---|
+| Mooring | `mooring_strength`, `mooring_pretension` | `project_bundle.yml` |
+| Riser | `riser_static`, `riser_dynamic` | `project_bundle_riser.yml` |
+| Pipeline | `pipeline_onbottom`, `pipeline_lay` | `project_bundle_pipeline.yml` |
+
+The LLM sets only the input fields that apply to the chosen family (e.g.
+`riser_outer_diameter` for a riser outcome) and leaves the rest `null`.
 
 ## Responsibility split (why this is auditable)
 
@@ -44,6 +53,20 @@ uv run python -m digitalmodel.solvers.orcaflex.spec_author \
     examples/workflows/orcaflex-spec-authoring-llm/project_bundle.yml \
     -r "Screen the spread mooring for storm strength" \
     -o authored_spec
+```
+
+Riser and pipeline requests use the same command with their bundles:
+
+```bash
+uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+    examples/workflows/orcaflex-spec-authoring-llm/project_bundle_riser.yml \
+    -r "Check the steel catenary riser wave dynamics" \
+    -o authored_spec_riser
+
+uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+    examples/workflows/orcaflex-spec-authoring-llm/project_bundle_pipeline.yml \
+    -r "Screen the pipeline installation lay" \
+    -o authored_spec_pipeline
 ```
 
 This writes into `authored_spec/`:

--- a/examples/workflows/orcaflex-spec-authoring-llm/project_bundle_pipeline.yml
+++ b/examples/workflows/orcaflex-spec-authoring-llm/project_bundle_pipeline.yml
@@ -1,0 +1,30 @@
+# Project single-source-of-truth (project SSOT) for the OrcaFlex LLM
+# spec-authoring front-end -- PIPELINE example.
+#
+# This is heterogeneous project data, NOT an analysis spec. The LLM reads it,
+# extracts only the pipeline facts that are actually stated here, and leaves
+# everything else for the deterministic inverse resolver to fill (and ledger).
+#
+# Run:
+#   uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+#       examples/workflows/orcaflex-spec-authoring-llm/project_bundle_pipeline.yml \
+#       -r "Screen the pipeline installation lay" \
+#       -o authored_spec_pipeline
+
+project_name: West Horizon trunkline installation screening
+
+environment:
+  field: Deepwater GoM
+  water_depth_m: 300
+
+notes: >
+  24 in export trunkline, X70 line pipe, 0.6 m OD with a 30 mm wall, ~5 km long.
+  Client wants a first-pass installation lay check (sag-bend / over-bend response
+  during laydown) before the lay vessel and stinger are selected. Lay geometry
+  not fixed yet, so leave it to the resolver defaults.
+
+documents:
+  - >
+    Pipeline basis of design (excerpt): "Export trunkline, API 5L X70. Outer
+    diameter 0.60 m, wall thickness 30 mm. Total length ~5000 m. Water depth at
+    the site is 300 m. FBE corrosion coating. Lay vessel to be confirmed."

--- a/examples/workflows/orcaflex-spec-authoring-llm/project_bundle_riser.yml
+++ b/examples/workflows/orcaflex-spec-authoring-llm/project_bundle_riser.yml
@@ -1,0 +1,36 @@
+# Project single-source-of-truth (project SSOT) for the OrcaFlex LLM
+# spec-authoring front-end -- RISER example.
+#
+# This is heterogeneous project data, NOT an analysis spec. The LLM reads it,
+# extracts only the riser facts that are actually stated here, and leaves
+# everything else for the deterministic inverse resolver to fill (and ledger).
+#
+# Run:
+#   uv run python -m digitalmodel.solvers.orcaflex.spec_author \
+#       examples/workflows/orcaflex-spec-authoring-llm/project_bundle_riser.yml \
+#       -r "Check the steel catenary riser wave dynamics" \
+#       -o authored_spec_riser
+
+project_name: West Horizon FPSO export riser screening
+
+vessel_particulars:
+  type: FPSO
+  loa_m: 285
+
+environment:
+  field: Deepwater GoM
+  water_depth_m: 1200
+
+notes: >
+  16 in steel catenary export riser hung off the FPSO. Pipe is 0.4 m OD with a
+  30 mm wall. Client wants a first-pass wave dynamic check (dynamic tension and
+  bending at the hang-off and touchdown) before the detailed metocean is final.
+  Hang-off and touchdown geometry not fixed yet, so leave the layout to the
+  resolver defaults.
+
+documents:
+  - >
+    Riser basis of design (excerpt): "Single steel catenary riser, lazy-wave
+    configuration. Outer diameter 0.40 m, wall thickness 30 mm. Water depth at
+    the hang-off is 1200 m. Arc length ~2000 m. Touchdown layback to be confirmed
+    in detailed design."

--- a/src/digitalmodel/solvers/orcaflex/spec_author.py
+++ b/src/digitalmodel/solvers/orcaflex/spec_author.py
@@ -30,7 +30,10 @@ is fully unit-testable offline (pass a stub author). The default implementation,
 no ``anthropic`` dependency). :class:`AnthropicIntentAuthor` uses the Anthropic
 SDK with structured outputs and is imported lazily.
 
-Only **mooring** outcomes are in scope for now (matching the resolver).
+It covers the resolver's three license-free model families -- **mooring**
+(spread-mooring strength / pretension), **riser** (static configuration / wave
+dynamic), and **pipeline** (on-bottom stability / installation lay) -- each
+dispatched by the chosen outcome's family.
 """
 
 from __future__ import annotations
@@ -53,8 +56,13 @@ from digitalmodel.common.spec_authoring import (
 from digitalmodel.solvers.orcaflex import inverse_resolver
 from digitalmodel.solvers.orcaflex.inverse_resolver import (
     OUTCOME_DESCRIPTIONS,
+    PIPELINE_OUTCOMES,
+    RISER_OUTCOMES,
     MooringResolverInputs,
     Outcome,
+    PipelineResolverInputs,
+    ResolverInputs,
+    RiserResolverInputs,
 )
 from digitalmodel.solvers.orcaflex.modular_generator import ModularModelGenerator
 from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
@@ -72,45 +80,90 @@ DEFAULT_MODEL = "claude-opus-4-8"
 class OrcaFlexIntent(BaseModel):
     """Structured output the LLM produces from a project bundle + request.
 
-    This is *not* the full spec -- only the sparse, grounded mooring facts the
-    resolver needs as a starting point, plus the chosen outcome. Every input
-    field is optional: the LLM leaves a field ``None`` when the project data
-    does not state it, and the deterministic resolver fills it (and ledgers it).
+    This is *not* the full spec -- only the sparse, grounded facts the resolver
+    needs as a starting point, plus the chosen outcome. Every input field is
+    optional: the LLM leaves a field ``None`` when the project data does not
+    state it, and the deterministic resolver fills it (and ledgers it).
 
-    The input fields mirror :class:`inverse_resolver.MooringResolverInputs`.
+    The fields are grouped by model family and mirror the resolver input models
+    (:class:`inverse_resolver.MooringResolverInputs`,
+    :class:`~inverse_resolver.RiserResolverInputs`,
+    :class:`~inverse_resolver.PipelineResolverInputs`). Set only the fields that
+    apply to the chosen outcome's family; leave the others ``None``.
     """
 
     outcome: Outcome = Field(
         description="The analysis outcome that matches the request."
     )
-    # Sparse mooring inputs -- only set when the project data states them.
+    # Common across families -- only set when the project data states them.
     name: Optional[str] = Field(default=None, description="Model / system name.")
     water_depth: Optional[float] = Field(
         default=None, description="Site water depth (m)."
     )
+    vessel_name: Optional[str] = Field(
+        default=None,
+        description="Vessel the system attaches to (mooring fairleads / riser "
+        "hang-off).",
+    )
+    # --- Mooring fields (outcomes: mooring_strength, mooring_pretension) ---
     num_lines: Optional[int] = Field(
-        default=None, description="Number of mooring lines."
+        default=None, description="[mooring] Number of mooring lines."
     )
     chain_diameter: Optional[float] = Field(
-        default=None, description="Mooring chain diameter (m)."
+        default=None, description="[mooring] Mooring chain diameter (m)."
     )
     chain_grade: Optional[str] = Field(
-        default=None, description="Mooring chain grade (e.g. R3, R4, R5)."
+        default=None, description="[mooring] Mooring chain grade (e.g. R3, R4, R5)."
     )
     fairlead_radius: Optional[float] = Field(
-        default=None, description="Fairlead radius from origin (m)."
+        default=None, description="[mooring] Fairlead radius from origin (m)."
     )
     anchor_radius: Optional[float] = Field(
-        default=None, description="Anchor radius from origin (m)."
+        default=None, description="[mooring] Anchor radius from origin (m)."
     )
     line_length: Optional[float] = Field(
-        default=None, description="Mooring line length (m)."
-    )
-    vessel_name: Optional[str] = Field(
-        default=None, description="Vessel the fairleads attach to."
+        default=None, description="[mooring] Mooring line length (m)."
     )
     pretension: Optional[float] = Field(
-        default=None, description="Target line pretension (kN)."
+        default=None, description="[mooring] Target line pretension (kN)."
+    )
+    # --- Riser fields (outcomes: riser_static, riser_dynamic) ---
+    riser_outer_diameter: Optional[float] = Field(
+        default=None, description="[riser] Riser pipe outer diameter (m)."
+    )
+    riser_wall_thickness: Optional[float] = Field(
+        default=None, description="[riser] Riser pipe wall thickness (m)."
+    )
+    riser_length: Optional[float] = Field(
+        default=None, description="[riser] Riser arc length (m)."
+    )
+    riser_configuration: Optional[str] = Field(
+        default=None,
+        description="[riser] Configuration (e.g. catenary, lazy_wave).",
+    )
+    riser_top_position: Optional[list[float]] = Field(
+        default=None,
+        description="[riser] Hang-off [x, y, z] in m (z below free surface).",
+    )
+    riser_bottom_position: Optional[list[float]] = Field(
+        default=None,
+        description="[riser] Touchdown / anchor [x, y, z] in m.",
+    )
+    # --- Pipeline fields (outcomes: pipeline_onbottom, pipeline_lay) ---
+    pipeline_outer_diameter: Optional[float] = Field(
+        default=None, description="[pipeline] Pipe outer diameter (m)."
+    )
+    pipeline_wall_thickness: Optional[float] = Field(
+        default=None, description="[pipeline] Pipe wall thickness (m)."
+    )
+    pipeline_length: Optional[float] = Field(
+        default=None, description="[pipeline] Pipeline length (m)."
+    )
+    pipeline_material: Optional[str] = Field(
+        default=None, description="[pipeline] Line-pipe steel grade (e.g. X65)."
+    )
+    pipeline_segment_length: Optional[float] = Field(
+        default=None, description="[pipeline] FE mesh segment length (m)."
     )
     # Trace + handoff
     provenance: list[ProvenanceEntry] = Field(
@@ -133,17 +186,31 @@ class OrcaFlexIntent(BaseModel):
 
 
 _SYSTEM_PROMPT_TEMPLATE = """\
-You are a marine-mooring analysis spec author. Given an offshore project's data \
-and a natural-language request, you produce a structured authoring intent for an \
-OrcaFlex spread-mooring analysis.
+You are an offshore marine-analysis spec author. Given an offshore project's \
+data and a natural-language request, you produce a structured authoring intent \
+for an OrcaFlex analysis. Three license-free model families are supported -- \
+mooring (spread mooring), riser (steel catenary / wave dynamic), and pipeline \
+(on-bottom stability / installation lay).
 
 Choose the single `outcome` that best matches the request:
 {outcome_menu}
 
+The outcome's prefix names its family and which input fields apply:
+- `mooring_*` -> use the mooring fields: num_lines, chain_diameter, \
+chain_grade, fairlead_radius, anchor_radius, line_length, pretension (plus the \
+common name, water_depth, vessel_name).
+- `riser_*` -> use the riser fields: riser_outer_diameter, \
+riser_wall_thickness, riser_length, riser_configuration, riser_top_position, \
+riser_bottom_position (plus name, water_depth, vessel_name).
+- `pipeline_*` -> use the pipeline fields: pipeline_outer_diameter, \
+pipeline_wall_thickness, pipeline_length, pipeline_material, \
+pipeline_segment_length (plus name, water_depth).
+Leave the fields of the other families null.
+
 Your job is fact extraction, not engineering invention:
 - Fill a field ONLY with a value the project data actually states. If the data \
 does not give a value, leave it null. Do NOT estimate, default, or invent water \
-depth, line count, chain diameter, chain grade, radii, line length, or any \
+depth, diameters, wall thickness, line counts, grades, radii, lengths, or any \
 physical quantity -- a downstream deterministic resolver fills every gap from \
 maintained reference data and records each assumption for review. Inventing \
 values defeats that audit trail.
@@ -273,21 +340,51 @@ class AnthropicIntentAuthor:
 
 def intent_to_resolver_inputs(
     intent: OrcaFlexIntent,
-) -> tuple[Outcome, MooringResolverInputs]:
-    """Map an OrcaFlexIntent to the inverse resolver's (outcome, inputs)."""
-    inputs = MooringResolverInputs(
-        name=intent.name,
-        water_depth=intent.water_depth,
-        num_lines=intent.num_lines,
-        chain_diameter=intent.chain_diameter,
-        chain_grade=intent.chain_grade,
-        fairlead_radius=intent.fairlead_radius,
-        anchor_radius=intent.anchor_radius,
-        line_length=intent.line_length,
-        vessel_name=intent.vessel_name,
-        pretension=intent.pretension,
-    )
-    return intent.outcome, inputs
+) -> tuple[Outcome, ResolverInputs]:
+    """Map an OrcaFlexIntent to the inverse resolver's (outcome, inputs).
+
+    Dispatches on the outcome's model family and builds the matching
+    resolver-inputs object (mooring / riser / pipeline), copying only the
+    fields that family accepts.
+    """
+    outcome = intent.outcome
+    inputs: ResolverInputs
+    if outcome in RISER_OUTCOMES:
+        inputs = RiserResolverInputs(
+            name=intent.name,
+            water_depth=intent.water_depth,
+            outer_diameter=intent.riser_outer_diameter,
+            wall_thickness=intent.riser_wall_thickness,
+            length=intent.riser_length,
+            configuration=intent.riser_configuration,
+            vessel_name=intent.vessel_name,
+            top_position=intent.riser_top_position,
+            bottom_position=intent.riser_bottom_position,
+        )
+    elif outcome in PIPELINE_OUTCOMES:
+        inputs = PipelineResolverInputs(
+            name=intent.name,
+            water_depth=intent.water_depth,
+            outer_diameter=intent.pipeline_outer_diameter,
+            wall_thickness=intent.pipeline_wall_thickness,
+            length=intent.pipeline_length,
+            material=intent.pipeline_material,
+            segment_length=intent.pipeline_segment_length,
+        )
+    else:  # mooring family (default)
+        inputs = MooringResolverInputs(
+            name=intent.name,
+            water_depth=intent.water_depth,
+            num_lines=intent.num_lines,
+            chain_diameter=intent.chain_diameter,
+            chain_grade=intent.chain_grade,
+            fairlead_radius=intent.fairlead_radius,
+            anchor_radius=intent.anchor_radius,
+            line_length=intent.line_length,
+            vessel_name=intent.vessel_name,
+            pretension=intent.pretension,
+        )
+    return outcome, inputs
 
 
 # ---------------------------------------------------------------------------
@@ -418,9 +515,10 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(
         description=(
-            "Author an OrcaFlex mooring analysis spec (analysis SSOT) from a "
-            "project bundle (project SSOT) + a natural-language request, via an "
-            "LLM, then optionally generate the OrcaFlex model."
+            "Author an OrcaFlex analysis spec (analysis SSOT) for a mooring, "
+            "riser, or pipeline outcome from a project bundle (project SSOT) + "
+            "a natural-language request, via an LLM, then optionally generate "
+            "the OrcaFlex model."
         )
     )
     parser.add_argument("bundle", help="Path to the project bundle YAML.")

--- a/tests/solvers/orcaflex/test_spec_author.py
+++ b/tests/solvers/orcaflex/test_spec_author.py
@@ -15,6 +15,8 @@ from digitalmodel.common.spec_authoring import ProjectBundle, ProvenanceEntry
 from digitalmodel.solvers.orcaflex.inverse_resolver import (
     MooringResolverInputs,
     Outcome,
+    PipelineResolverInputs,
+    RiserResolverInputs,
 )
 from digitalmodel.solvers.orcaflex.modular_generator.schema import ProjectInputSpec
 from digitalmodel.solvers.orcaflex.spec_author import (
@@ -239,3 +241,138 @@ def test_author_spec_end_to_end_with_cli_runner(tmp_path: Path) -> None:
     result = author_spec(ProjectBundle(), "pretension check", author=author)
     assert result.spec.simulation.stages == [10]
     assert len(result.spec.mooring.lines) == 6
+
+
+# --- Riser outcomes --------------------------------------------------------
+
+
+def _riser_intent() -> OrcaFlexIntent:
+    return OrcaFlexIntent(
+        outcome=Outcome.RISER_DYNAMIC,
+        name="West Test SCR",
+        water_depth=1200.0,
+        vessel_name="FPSO_A",
+        riser_outer_diameter=0.4,
+        riser_wall_thickness=0.03,
+        riser_length=2000.0,
+        riser_configuration="lazy_wave",
+        provenance=[
+            ProvenanceEntry(field="water_depth", value="1200 m", source="data sheet"),
+            ProvenanceEntry(field="riser_outer_diameter", value="16 in", source="BOD"),
+        ],
+        open_questions=["Wave spectrum not specified"],
+        rationale="Request asks for a riser wave dynamic check; geometry given.",
+    )
+
+
+def test_riser_intent_maps_to_riser_resolver_inputs() -> None:
+    outcome, inputs = intent_to_resolver_inputs(_riser_intent())
+    assert outcome == Outcome.RISER_DYNAMIC
+    assert isinstance(inputs, RiserResolverInputs)
+    assert inputs.water_depth == 1200.0
+    assert inputs.outer_diameter == 0.4
+    assert inputs.wall_thickness == 0.03
+    assert inputs.length == 2000.0
+    assert inputs.configuration == "lazy_wave"
+    assert inputs.vessel_name == "FPSO_A"
+
+
+def test_author_spec_produces_riser_spec() -> None:
+    author = StubAuthor(_riser_intent())
+    result = author_spec(ProjectBundle(notes="riser"), "riser dynamic", author=author)
+    assert isinstance(result.spec, ProjectInputSpec)
+    # Right model family is set; other families are absent.
+    assert result.spec.riser is not None
+    assert result.spec.mooring is None and result.spec.pipeline is None
+    assert result.spec.metadata.structure == "riser"
+    # Correct outcome -> simulation stages (static + wave dynamic).
+    assert result.spec.simulation.stages == [8, 16]
+    lt = result.spec.riser.line_types[0]
+    assert lt.outer_diameter == 0.4
+    assert lt.inner_diameter == 0.34  # 0.4 - 2*0.03
+    assert result.spec.riser.vessel.name == "FPSO_A"
+
+
+def test_riser_static_outcome_drives_single_stage() -> None:
+    intent = OrcaFlexIntent(outcome=Outcome.RISER_STATIC)
+    result = author_spec(ProjectBundle(), "riser config", author=StubAuthor(intent))
+    assert result.spec.riser is not None
+    assert result.spec.simulation.stages == [10]
+
+
+def test_generate_riser_model_via_modular_generator(tmp_path: Path) -> None:
+    result = author_spec(ProjectBundle(), "riser", author=StubAuthor(_riser_intent()))
+    out = result.generate_model(tmp_path / "riser_model")
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
+
+
+# --- Pipeline outcomes -----------------------------------------------------
+
+
+def _pipeline_intent() -> OrcaFlexIntent:
+    return OrcaFlexIntent(
+        outcome=Outcome.PIPELINE_LAY,
+        name="Trunkline",
+        water_depth=300.0,
+        pipeline_outer_diameter=0.6,
+        pipeline_wall_thickness=0.03,
+        pipeline_length=5000.0,
+        pipeline_material="X70",
+        provenance=[
+            ProvenanceEntry(field="pipeline_material", value="X70", source="BOD"),
+        ],
+        open_questions=["Lay vessel not specified"],
+        rationale="Request asks for an installation lay check; geometry given.",
+    )
+
+
+def test_pipeline_intent_maps_to_pipeline_resolver_inputs() -> None:
+    outcome, inputs = intent_to_resolver_inputs(_pipeline_intent())
+    assert outcome == Outcome.PIPELINE_LAY
+    assert isinstance(inputs, PipelineResolverInputs)
+    assert inputs.water_depth == 300.0
+    assert inputs.outer_diameter == 0.6
+    assert inputs.wall_thickness == 0.03
+    assert inputs.length == 5000.0
+    assert inputs.material == "X70"
+
+
+def test_author_spec_produces_pipeline_spec() -> None:
+    author = StubAuthor(_pipeline_intent())
+    result = author_spec(ProjectBundle(notes="pipe"), "pipeline lay", author=author)
+    assert isinstance(result.spec, ProjectInputSpec)
+    assert result.spec.pipeline is not None
+    assert result.spec.mooring is None and result.spec.riser is None
+    assert result.spec.metadata.structure == "pipeline"
+    # Correct outcome -> simulation stages (static + lay dynamic).
+    assert result.spec.simulation.stages == [8, 16]
+    assert result.spec.pipeline.dimensions.outer_diameter == 0.6
+    assert result.spec.pipeline.dimensions.wall_thickness == 0.03
+    assert result.spec.pipeline.material == "X70"
+
+
+def test_pipeline_onbottom_outcome_drives_single_stage() -> None:
+    intent = OrcaFlexIntent(outcome=Outcome.PIPELINE_ONBOTTOM)
+    result = author_spec(ProjectBundle(), "stability", author=StubAuthor(intent))
+    assert result.spec.pipeline is not None
+    assert result.spec.simulation.stages == [10]
+
+
+def test_generate_pipeline_model_via_modular_generator(tmp_path: Path) -> None:
+    result = author_spec(
+        ProjectBundle(), "pipeline", author=StubAuthor(_pipeline_intent())
+    )
+    out = result.generate_model(tmp_path / "pipeline_model")
+    assert (out / "master.yml").exists()
+    assert any(out.rglob("*.yml"))
+
+
+def test_riser_intent_leaves_pipeline_fields_unmapped() -> None:
+    # A riser intent must not leak into pipeline resolver inputs (family-scoped).
+    intent = OrcaFlexIntent(
+        outcome=Outcome.RISER_STATIC, riser_outer_diameter=0.3, water_depth=500.0
+    )
+    _, inputs = intent_to_resolver_inputs(intent)
+    assert isinstance(inputs, RiserResolverInputs)
+    assert inputs.outer_diameter == 0.3


### PR DESCRIPTION
Generalizes the OrcaFlex LLM spec-author front-end from mooring-only to the inverse resolver's three license-free families (mooring / riser / pipeline).

- `OrcaFlexIntent` now carries sparse Optional riser and pipeline fields (mirroring `RiserResolverInputs` / `PipelineResolverInputs`) alongside mooring.
- `intent_to_resolver_inputs` dispatches on the outcome's family (`RISER_OUTCOMES` / `PIPELINE_OUTCOMES` / mooring-default) to build the matching resolver-inputs object; mooring behavior unchanged.
- System prompt tells the LLM which input fields apply to each outcome family.
- Offline `StubAuthor` tests + riser/pipeline example bundles cover both families end-to-end (riser/pipeline `ProjectInputSpec` → `ModularModelGenerator` generates YAML).

Verified: `uv run python -m pytest tests/solvers/orcaflex/test_spec_author.py tests/solvers/orcaflex/test_inverse_resolver.py -q` → **48 passed**; black 25.9.0 / isort 5.13.2 / flake8 clean.

Part of #1095. Supersedes #1107 (that branch accidentally bundled an unrelated concurrent session's installation-pamphlet commits; this is the clean single-commit version — only the 5 spec-author files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)