### PR TITLE
feat(provenance): carry governing code_reference in every strength result [#1092]

### DIFF
--- a/docs/domains/codes-provenance-2026-06-28.md
+++ b/docs/domains/codes-provenance-2026-06-28.md
@@ -1,0 +1,60 @@
+# Code-Reference Provenance — Validation Record (2026-06-28)
+
+Backing for issue #1092 (EPIC #1080 workstream C). Every strength / capacity /
+FFS result now carries a `code_reference` string stating its governing code and
+edition in the returned object — not only in the docstring.
+
+## Single source of truth
+
+`src/digitalmodel/codes.py` defines `CodeReference(standard, edition, title)`
+with a uniform `label` (e.g. `"ASME B31G (2012)"`) and named constants. The
+`REGISTER` dict enumerates them for the codes register (#1093), so the
+documentation cannot drift from what the code stamps on results.
+
+## Result class → governing code
+
+| Result dataclass | Module | `code_reference` |
+|---|---|---|
+| `CorrodedPipeResult` | `asset_integrity/corroded_pipe.py` | ASME B31G (2012) |
+| `DNVF101Result` | `asset_integrity/dnv_rp_f101.py` | DNV-RP-F101 (2021) |
+| `BucklingResult` (plate) | `structural_analysis/buckling.py` | DNV-RP-C201 (2010) |
+| `BucklingResult` (column) | `structural_analysis/buckling.py` | EN 1993-1-1 (2005) |
+| `PanelBucklingResult` | `structural_analysis/panel_buckling.py` | DNV-RP-C201 (2010) |
+| `CapacityResult` | `structural_analysis/capacity.py` | EN 1993-1-1 (2005) |
+| `MetalLossFFSResult` | `structural_analysis/plate_metal_loss_ffs.py` | API 579-1/ASME FFS-1 (2021); DNV-RP-C201 (2010) (capacity basis) |
+| `FFSAssessmentResult` | `assessment/ffs_coordinator.py` | API 579-1/ASME FFS-1 (2021) |
+| `WallThicknessResult` | `analysis/wall_thickness.py` | governing `DesignCode` (e.g. DNV-ST-F101 (2021)) |
+
+`BucklingResult` is set per construction site because the module hosts two codes
+(plate buckling per DNV-RP-C201, column buckling per Eurocode 3). The others use
+a single governing code (field default or a single `_finalise` choke point).
+`WallThicknessResult` maps its selected `DesignCode` enum to the reference.
+
+## Surfaced in lookup / dashboards
+
+The FFS lookup record (`ffs_results.json`, consumed by the field dashboard /
+Deckhand API) now carries `code_reference`:
+- `ffs_lookup._record(...)` adds it as a first-class field.
+- `evaluate_pipe_corroded`, `evaluate_plate_metal_loss`, and
+  `record_from_assessment` thread the result's `code_reference` through.
+- `FFSAssessmentResult.to_dict()` includes it.
+
+(The published dashboard HTML regenerates from this data; rendering the field
+visually is a publish-step follow-up.)
+
+## Tests
+
+`tests/asset_integrity/test_code_provenance.py` — 11 tests asserting each result
+type's `code_reference` (presence + exact value vs the `codes` constants), the
+two BucklingResult codes, the metal-loss combined reference, the
+`FFSAssessmentResult.to_dict()` key, and the lookup-record surfacing. All
+passing; the broader asset-integrity + structural + materials suites stay green
+(2365 passed; the 16 `test_structural_analysis_cli` failures are a pre-existing
+environment artifact — they subprocess an installed `structural-analysis`
+console script absent under a PYTHONPATH-only run).
+
+## Relates to
+
+Per-strategy / module-level docstring citations and the consolidated
+`docs/domains/codes-register.md` are tracked by the sibling issue #1093, which
+reuses the `codes.REGISTER` defined here.

--- a/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
@@ -31,6 +31,7 @@ from typing import Any, Optional, Union
 import numpy as np
 import pandas as pd
 
+from digitalmodel.codes import API_579
 from .ffs_decision import FFSDecision
 from .ffs_router import FFSRouter
 from .grid_parser import GridParser
@@ -81,6 +82,7 @@ class FFSAssessmentResult:
     level2: dict = field(default_factory=dict)
     decision: dict = field(default_factory=dict)
     details: dict = field(default_factory=dict)
+    code_reference: str = API_579.label  # governing FFS code
 
     @property
     def passes(self) -> bool:
@@ -106,6 +108,7 @@ class FFSAssessmentResult:
             "rerated_pressure_psi": self.rerated_pressure_psi,
             "sufficiency_status": self.sufficiency_status,
             "passes": self.passes,
+            "code_reference": self.code_reference,
         }
 
 

--- a/src/digitalmodel/asset_integrity/corroded_pipe.py
+++ b/src/digitalmodel/asset_integrity/corroded_pipe.py
@@ -35,6 +35,8 @@ from typing import Optional, Sequence
 
 import numpy as np
 
+from digitalmodel.codes import ASME_B31G
+
 # Flow-stress adder for Modified B31G / RSTRENG: SMYS + 10 ksi (= 68.95 MPa).
 _FLOW_ADDER_PSI = 10_000.0
 # Default safety factor applied to predicted failure pressure (B31G practice).
@@ -65,6 +67,7 @@ class CorrodedPipeResult:
     safe_pressure_psi: float     # failure_pressure / safety_factor
     acceptable: Optional[bool] = None   # safe_pressure >= MAOP (if given)
     details: dict = field(default_factory=dict)
+    code_reference: str = ""            # governing code, e.g. "ASME B31G (2012)"
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +115,7 @@ def _finalise(method, pf, intact, flow, M, ar, *, maop_psi, safety_factor, detai
         safe_pressure_psi=safe,
         acceptable=(None if maop_psi is None else bool(safe >= maop_psi)),
         details=details,
+        code_reference=ASME_B31G.label,
     )
 
 

--- a/src/digitalmodel/asset_integrity/dnv_rp_f101.py
+++ b/src/digitalmodel/asset_integrity/dnv_rp_f101.py
@@ -48,6 +48,8 @@ from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 
+from digitalmodel.codes import DNV_RP_F101
+
 # ---------------------------------------------------------------------------
 # Material — API 5L specified minimum TENSILE strength (SMTS), psi.
 # DNV-RP-F101 capacity uses f_u = SMTS (not SMYS).  Values are the API 5L /
@@ -104,6 +106,7 @@ class DNVF101Result:
     intact_pressure_psi: float        # 2 t f_u / (D - t) (defect-free)
     acceptable: Optional[bool] = None  # allowable >= MAOP (if maop_psi given)
     details: dict = field(default_factory=dict)
+    code_reference: str = DNV_RP_F101.label  # governing code (all formats)
 
 
 # ---------------------------------------------------------------------------

--- a/src/digitalmodel/asset_integrity/ffs_lookup.py
+++ b/src/digitalmodel/asset_integrity/ffs_lookup.py
@@ -70,7 +70,8 @@ def signature(domain: str, inputs: dict) -> str:
     return domain + "|" + "|".join(f"{_num(inputs[f])}" for f in fields)
 
 
-def _record(domain, inputs, metric, metric_name, acceptable, governing, extra=None):
+def _record(domain, inputs, metric, metric_name, acceptable, governing,
+            extra=None, code_reference=""):
     inputs = {k: _num(v) for k, v in inputs.items()}
     rec = {
         "domain": domain,
@@ -83,6 +84,7 @@ def _record(domain, inputs, metric, metric_name, acceptable, governing, extra=No
             else ("ACCEPTABLE" if acceptable else "UNACCEPTABLE")
         ),
         "governing": governing,
+        "code_reference": code_reference,
         "key": signature(domain, inputs),
     }
     if extra:
@@ -134,6 +136,7 @@ def evaluate_pipe_corroded(
          "d_in": d_in, "L_in": L_in},
         metric, mname, accept, governing=m,
         extra={"maop_psi": round(float(maop_psi), 2)},
+        code_reference=r.code_reference,
     )
 
 
@@ -156,6 +159,7 @@ def evaluate_plate_metal_loss(
         r.utilization, "utilization", bool(r.passes), governing="plate_buckling",
         extra={"capacity_retained_frac": round(r.capacity_retained_frac, 4),
                "remaining_thickness_mm": round(r.remaining_thickness_mm, 3)},
+        code_reference=r.code_reference,
     )
 
 
@@ -185,6 +189,7 @@ def record_from_assessment(result) -> dict:
         "acceptable": bool(result.passes),
         "verdict": result.verdict,
         "governing": result.assessment_type,
+        "code_reference": result.code_reference,
         "key": f"component|{result.component_id}",
         "sufficiency_status": result.sufficiency_status,
         "remaining_life_yr": result.remaining_life_yr,

--- a/src/digitalmodel/codes.py
+++ b/src/digitalmodel/codes.py
@@ -1,0 +1,98 @@
+# ABOUTME: Engineering code references (standard + edition) carried in strength
+# ABOUTME: results so every capacity / FFS verdict states its governing code.
+"""Governing-code references for strength and fitness-for-service methods.
+
+Each strength/capacity result carries a ``code_reference`` string (the
+:attr:`CodeReference.label`) so the user or inspector sees the governing code and
+edition in the returned object — not only in the docstring.  This module is the
+single source of truth for those references; the codes register (issue #1093)
+enumerates the same objects so the documentation cannot drift from what the code
+actually stamps on results.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CodeReference:
+    """A governing engineering standard and edition.
+
+    Attributes:
+        standard: Standard designation (e.g. ``"ASME B31G"``).
+        edition: Edition / year (e.g. ``"2012"``); may be empty.
+        title: Optional short title of the standard.
+    """
+
+    standard: str
+    edition: str = ""
+    title: str = ""
+
+    @property
+    def label(self) -> str:
+        """Human-readable reference, e.g. ``"ASME B31G (2012)"``."""
+        return f"{self.standard} ({self.edition})" if self.edition else self.standard
+
+    def __str__(self) -> str:
+        return self.label
+
+
+# ---------------------------------------------------------------------------
+# Remaining-strength / corroded pipe
+# ---------------------------------------------------------------------------
+ASME_B31G = CodeReference(
+    "ASME B31G", "2012",
+    "Manual for Determining the Remaining Strength of Corroded Pipelines")
+DNV_RP_F101 = CodeReference(
+    "DNV-RP-F101", "2021", "Corroded Pipelines")
+
+# ---------------------------------------------------------------------------
+# Fitness-for-service
+# ---------------------------------------------------------------------------
+API_579 = CodeReference(
+    "API 579-1/ASME FFS-1", "2021", "Fitness-For-Service")
+BS_7910 = CodeReference(
+    "BS 7910", "2019",
+    "Guide to methods for assessing the acceptability of flaws in "
+    "metallic structures")
+
+# ---------------------------------------------------------------------------
+# Buckling / plated structures
+# ---------------------------------------------------------------------------
+DNV_RP_C201 = CodeReference(
+    "DNV-RP-C201", "2010", "Buckling Strength of Plated Structures")
+EUROCODE_3 = CodeReference(
+    "EN 1993-1-1", "2005", "Eurocode 3: Design of steel structures")
+
+# ---------------------------------------------------------------------------
+# Pipe / riser wall thickness & pressure containment
+# ---------------------------------------------------------------------------
+API_RP_1111 = CodeReference(
+    "API RP 1111", "2015",
+    "Design, Construction, Operation and Maintenance of Offshore Hydrocarbon "
+    "Pipelines (Limit State Design)")
+API_RP_2RD = CodeReference("API RP 2RD", "2013", "Dynamic Risers for FPS")
+API_STD_2RD = CodeReference("API STD 2RD", "2013", "Dynamic Risers for FPS")
+DNV_ST_F201 = CodeReference("DNV-ST-F201", "2021", "Dynamic Risers")
+DNV_ST_F101 = CodeReference("DNV-ST-F101", "2021", "Submarine Pipeline Systems")
+PD_8010_2 = CodeReference(
+    "PD 8010-2", "2015", "Pipeline systems - Subsea pipelines")
+ISO_13623 = CodeReference("ISO 13623", "2017", "Pipeline transportation systems")
+ASME_B31_4 = CodeReference(
+    "ASME B31.4", "2019", "Pipeline Transportation Systems for Liquids")
+ASME_B31_8 = CodeReference("ASME B31.8", "2020", "Gas Transmission Piping")
+
+# ---------------------------------------------------------------------------
+# Material standards
+# ---------------------------------------------------------------------------
+API_5L = CodeReference("API 5L / ISO 3183", "2018", "Line Pipe")
+IACS_W11 = CodeReference(
+    "IACS UR W11", "", "Normal & Higher Strength Hull Structural Steels")
+EN_10025_2 = CodeReference("EN 10025-2", "2019", "Hot rolled structural steel")
+
+#: All references, keyed by attribute name — used by the codes register (#1093).
+REGISTER: dict[str, CodeReference] = {
+    name: value
+    for name, value in list(globals().items())
+    if isinstance(value, CodeReference)
+}

--- a/src/digitalmodel/structural/analysis/wall_thickness.py
+++ b/src/digitalmodel/structural/analysis/wall_thickness.py
@@ -23,6 +23,8 @@ from typing import Dict, Optional
 import math
 import logging
 
+from digitalmodel import codes as _codes
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,6 +42,20 @@ class DesignCode(Enum):
     ASME_B31_8 = "ASME-B31.8"
     ISO_13623 = "ISO-13623"
     ASME_B31_4 = "ASME-B31.4"
+
+
+#: Governing code reference for each design code (used by WallThicknessResult).
+_CODE_REFERENCES = {
+    DesignCode.DNV_ST_F101: _codes.DNV_ST_F101,
+    DesignCode.DNV_ST_F201: _codes.DNV_ST_F201,
+    DesignCode.API_RP_1111: _codes.API_RP_1111,
+    DesignCode.API_RP_2RD: _codes.API_RP_2RD,
+    DesignCode.API_STD_2RD: _codes.API_STD_2RD,
+    DesignCode.PD_8010_2: _codes.PD_8010_2,
+    DesignCode.ASME_B31_8: _codes.ASME_B31_8,
+    DesignCode.ISO_13623: _codes.ISO_13623,
+    DesignCode.ASME_B31_4: _codes.ASME_B31_4,
+}
 
 
 @dataclass(frozen=True)
@@ -193,6 +209,7 @@ class WallThicknessResult:
     governing_check: Optional[str] = None
     max_utilisation: float = 0.0
     details: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    code_reference: str = ""   # governing design code, e.g. "DNV-ST-F101 (2021)"
 
 
 # ---------------------------------------------------------------------------
@@ -644,12 +661,14 @@ class WallThicknessAnalyzer:
         max_util = max(checks.values()) if checks else 0.0
         governing = max(checks, key=checks.get) if checks else None
 
+        _ref = _CODE_REFERENCES.get(self.code)
         result = WallThicknessResult(
             checks=checks,
             is_safe=max_util <= 1.0,
             governing_check=governing,
             max_utilisation=max_util,
             details=details,
+            code_reference=_ref.label if _ref else self.code.value,
         )
 
         logger.info(

--- a/src/digitalmodel/structural/structural_analysis/buckling.py
+++ b/src/digitalmodel/structural/structural_analysis/buckling.py
@@ -9,6 +9,7 @@ Implements:
 
 import numpy as np
 from .models import MaterialProperties, PlateGeometry, BucklingResult
+from digitalmodel.codes import DNV_RP_C201, EUROCODE_3
 
 
 class PlateBucklingAnalyzer:
@@ -135,7 +136,8 @@ class PlateBucklingAnalyzer:
             utilization=total_util,
             safety_factor=1 / total_util if total_util > 0 else float('inf'),
             mode="plate_buckling",
-            passes=total_util <= 1.0
+            passes=total_util <= 1.0,
+            code_reference=DNV_RP_C201.label,
         )
 
 
@@ -262,5 +264,6 @@ class ColumnBucklingAnalyzer:
             utilization=util,
             safety_factor=1 / util if util > 0 else float('inf'),
             mode="column_buckling",
-            passes=util <= 1.0
+            passes=util <= 1.0,
+            code_reference=EUROCODE_3.label,
         )

--- a/src/digitalmodel/structural/structural_analysis/capacity.py
+++ b/src/digitalmodel/structural/structural_analysis/capacity.py
@@ -11,6 +11,7 @@ from typing import Dict
 from .models import MaterialProperties, CapacityResult
 from .stress_calculator import StressCalculator
 from .buckling import PlateBucklingAnalyzer, ColumnBucklingAnalyzer
+from digitalmodel.codes import EUROCODE_3
 
 
 class MemberCapacityChecker:
@@ -63,7 +64,8 @@ class MemberCapacityChecker:
             utilization=util,
             governing_mode=governing,
             passes=util <= 1.0,
-            details={'N_pl': N_pl, 'N_u': N_u}
+            details={'N_pl': N_pl, 'N_u': N_u},
+            code_reference=EUROCODE_3.label,
         )
 
     def check_combined_loading(
@@ -126,5 +128,6 @@ class MemberCapacityChecker:
                 'util_My': util_My,
                 'util_Mz': util_Mz,
                 'chi': chi
-            }
+            },
+            code_reference=EUROCODE_3.label,
         )

--- a/src/digitalmodel/structural/structural_analysis/models.py
+++ b/src/digitalmodel/structural/structural_analysis/models.py
@@ -155,6 +155,7 @@ class BucklingResult:
     safety_factor: float
     mode: str
     passes: bool
+    code_reference: str = ""   # governing code (set per buckling mode)
 
 
 @dataclass
@@ -166,3 +167,4 @@ class CapacityResult:
     governing_mode: str
     passes: bool
     details: Dict
+    code_reference: str = ""   # governing code, e.g. "EN 1993-1-1 (2005)"

--- a/src/digitalmodel/structural/structural_analysis/panel_buckling.py
+++ b/src/digitalmodel/structural/structural_analysis/panel_buckling.py
@@ -62,6 +62,7 @@ from typing import Dict, Optional
 
 from .models import MaterialProperties, PlateGeometry
 from .buckling import PlateBucklingAnalyzer, ColumnBucklingAnalyzer
+from digitalmodel.codes import DNV_RP_C201
 
 
 # This stiffened-panel solver is validated (see module docstring) -> production.
@@ -134,6 +135,7 @@ class PanelBucklingResult:
     critical_stress: float   # MPa (governing mode)
     passes: bool
     details: Dict = field(default_factory=dict)
+    code_reference: str = ""   # governing code, e.g. "DNV-RP-C201 (2010)"
 
 
 class StiffenedPanelBucklingAnalyzer:
@@ -432,4 +434,5 @@ class StiffenedPanelBucklingAnalyzer:
             critical_stress=critical_stress,
             passes=governing_util <= 1.0,
             details=details,
+            code_reference=DNV_RP_C201.label,
         )

--- a/src/digitalmodel/structural/structural_analysis/plate_metal_loss_ffs.py
+++ b/src/digitalmodel/structural/structural_analysis/plate_metal_loss_ffs.py
@@ -50,11 +50,15 @@ from .panel_buckling import (
     StiffenedPanelGeometry,
     StiffenerGeometry,
 )
+from digitalmodel.codes import API_579, DNV_RP_C201
 
 
 # This layer only orchestrates the validated buckling solvers; it adds no new
 # (unvalidated) closed-form physics of its own.
 PRELIMINARY = False
+
+# FFS framing (API 579-style screening) over the validated DNV-RP-C201 capacity.
+_METAL_LOSS_FFS_CODE = f"{API_579.label}; {DNV_RP_C201.label} (capacity basis)"
 
 
 @dataclass
@@ -76,6 +80,7 @@ class MetalLossFFSResult:
     governing_mode: Optional[str] = None    # panel governing mode
     max_acceptable_loss_mm: Optional[float] = None
     details: Dict = field(default_factory=dict)
+    code_reference: str = _METAL_LOSS_FFS_CODE  # FFS framing + capacity basis
 
 
 # ---------------------------------------------------------------------------

--- a/tests/asset_integrity/test_code_provenance.py
+++ b/tests/asset_integrity/test_code_provenance.py
@@ -1,0 +1,155 @@
+# ABOUTME: Verifies every strength/capacity result carries its governing
+# ABOUTME: code_reference (issue #1092) and that it surfaces in the lookup JSON.
+import pandas as pd
+
+from digitalmodel import codes
+from digitalmodel.asset_integrity.corroded_pipe import (
+    b31g_original,
+    modified_b31g,
+    rstreng_effective_area,
+)
+from digitalmodel.asset_integrity.dnv_rp_f101 import dnv_f101_single_defect
+from digitalmodel.asset_integrity.ffs_lookup import (
+    evaluate_pipe_corroded,
+    evaluate_plate_metal_loss,
+    record_from_assessment,
+)
+from digitalmodel.asset_integrity.assessment.ffs_coordinator import (
+    FFSComponent,
+    assess_component,
+)
+from digitalmodel.structural.structural_analysis.buckling import (
+    ColumnBucklingAnalyzer,
+    PlateBucklingAnalyzer,
+)
+from digitalmodel.structural.structural_analysis.capacity import (
+    MemberCapacityChecker,
+)
+from digitalmodel.structural.structural_analysis.models import (
+    PlateGeometry,
+    STEEL_AH36,
+    STEEL_S355,
+)
+from digitalmodel.structural.structural_analysis.panel_buckling import (
+    StiffenedPanelBucklingAnalyzer,
+    StiffenedPanelGeometry,
+    StiffenerGeometry,
+)
+from digitalmodel.structural.structural_analysis.plate_metal_loss_ffs import (
+    assess_plate_uniform_loss,
+)
+from digitalmodel.structural.analysis.wall_thickness import (
+    DesignCode,
+    DesignFactors,
+    DesignLoads,
+    PipeGeometry,
+    PipeMaterial,
+    WallThicknessAnalyzer,
+)
+
+
+# --- codes module ------------------------------------------------------------
+def test_code_reference_label_format():
+    assert codes.ASME_B31G.label == "ASME B31G (2012)"
+    assert codes.CodeReference("X", "").label == "X"  # no edition
+    assert codes.REGISTER  # non-empty register for #1093
+
+
+# --- corroded pipe (ASME B31G) ----------------------------------------------
+def test_corroded_pipe_code_reference():
+    for r in (
+        b31g_original(20.0, 0.5, 0.2, 4.0, 52_000.0),
+        modified_b31g(20.0, 0.5, 0.2, 4.0, 52_000.0),
+        rstreng_effective_area(20.0, 0.5, [0.0, 4.0], [0.2, 0.2], 52_000.0),
+    ):
+        assert r.code_reference == codes.ASME_B31G.label
+
+
+# --- DNV-RP-F101 -------------------------------------------------------------
+def test_dnv_f101_code_reference():
+    r = dnv_f101_single_defect(20.0, 0.5, 0.2, 4.0, 66_700.0)
+    assert r.code_reference == codes.DNV_RP_F101.label
+
+
+# --- buckling: plate = DNV-RP-C201, column = Eurocode 3 ----------------------
+def test_plate_buckling_code_reference():
+    r = PlateBucklingAnalyzer(STEEL_S355).check_plate_buckling(
+        PlateGeometry(800.0, 800.0, 12.0), sigma_x=100.0)
+    assert r.code_reference == codes.DNV_RP_C201.label
+
+
+def test_column_buckling_code_reference():
+    r = ColumnBucklingAnalyzer(STEEL_S355).check_column_buckling(
+        axial_force=1.0e5, area=5000.0, I_min=1.0e7, L_eff=3000.0)
+    assert r.code_reference == codes.EUROCODE_3.label
+
+
+# --- panel buckling (DNV-RP-C201) -------------------------------------------
+def test_panel_buckling_code_reference():
+    panel = StiffenedPanelGeometry(
+        plate_length=2400.0, plate_thickness=12.0,
+        stiffener=StiffenerGeometry(
+            web_height=250.0, web_thickness=10.0, flange_width=90.0,
+            flange_thickness=12.0, spacing=800.0, section_type="tee"),
+    )
+    r = StiffenedPanelBucklingAnalyzer(STEEL_AH36).check_panel(panel, sigma_x=120.0)
+    assert r.code_reference == codes.DNV_RP_C201.label
+
+
+# --- member capacity (Eurocode 3) -------------------------------------------
+def test_capacity_code_reference():
+    r = MemberCapacityChecker(STEEL_S355).check_tension_member(
+        axial_force=1.0e5, area_gross=5000.0, area_net=4500.0)
+    assert r.code_reference == codes.EUROCODE_3.label
+
+
+# --- metal-loss FFS (API 579 framing over DNV-RP-C201 capacity) -------------
+def test_metal_loss_ffs_code_reference():
+    r = assess_plate_uniform_loss(
+        PlateGeometry(800.0, 800.0, 12.0), STEEL_AH36, 2.0, sigma_x=120.0)
+    assert "API 579" in r.code_reference
+    assert "DNV-RP-C201" in r.code_reference
+
+
+# --- FFS coordinator (API 579) ----------------------------------------------
+def _component():
+    return FFSComponent(
+        component_id="LINE-001", design_code="B31.8", nominal_od_in=12.75,
+        nominal_wt_in=0.500, design_pressure_psi=1000.0, smys_psi=52_000.0,
+        corrosion_rate_in_per_yr=0.005, rsf_a=0.90)
+
+
+def test_ffs_coordinator_code_reference_and_to_dict():
+    grid = pd.DataFrame([[0.47] * 5 for _ in range(5)])
+    result = assess_component(_component(), grid)
+    assert result.code_reference == codes.API_579.label
+    assert result.to_dict()["code_reference"] == codes.API_579.label
+
+
+# --- wall thickness (governing design code) ---------------------------------
+def test_wall_thickness_code_reference():
+    result = WallThicknessAnalyzer(
+        PipeGeometry(outer_diameter=0.3239, wall_thickness=0.0127,
+                     corrosion_allowance=0.003),
+        PipeMaterial(grade="X65", smys=448e6, smts=531e6),
+        DesignLoads(internal_pressure=0.0, external_pressure=15.08e6),
+        DesignFactors(), DesignCode.DNV_ST_F101,
+    ).perform_analysis()
+    assert result.code_reference == codes.DNV_ST_F101.label
+
+
+# --- lookup / dashboard serialization ---------------------------------------
+def test_lookup_records_carry_code_reference():
+    rec = evaluate_pipe_corroded(
+        method="modified_b31g", grade="X52", D_in=20.0, t_in=0.5,
+        d_in=0.2, L_in=4.0)
+    assert rec["code_reference"] == codes.ASME_B31G.label
+
+    rec2 = evaluate_plate_metal_loss(
+        grade="AH36", length_mm=800.0, width_mm=800.0, thickness_mm=12.0,
+        sigma_x_mpa=120.0, metal_loss_mm=2.0)
+    assert "DNV-RP-C201" in rec2["code_reference"]
+
+    grid = pd.DataFrame([[0.47] * 5 for _ in range(5)])
+    rec3 = record_from_assessment(assess_component(_component(), grid))
+    assert rec3["code_reference"] == codes.API_579.label


### PR DESCRIPTION
Closes #1092 — EPIC #1080 workstream C (Phase 1). "Add the code along with the method": every strength / capacity / FFS result now states its governing code **and edition** in the returned object, so a user or inspector sees e.g. *"Modified B31G per ASME B31G (2012)"* without reading the source.

## Single source of truth
New `src/digitalmodel/codes.py` — `CodeReference(standard, edition, title)` with a uniform `label` (`"ASME B31G (2012)"`) + named constants + a `REGISTER` dict. The codes register (#1093) reuses these objects, so the docs can't drift from what the code stamps on results.

## `code_reference` added to 8 result dataclasses
| Result | Governing code |
|---|---|
| `CorrodedPipeResult` | ASME B31G (2012) — via the `_finalise` choke point |
| `DNVF101Result` | DNV-RP-F101 (2021) — all formats |
| `BucklingResult` | **per site**: plate → DNV-RP-C201, column → EN 1993-1-1 |
| `PanelBucklingResult` | DNV-RP-C201 (2010) |
| `CapacityResult` | EN 1993-1-1 (2005) |
| `MetalLossFFSResult` | API 579-1/ASME FFS-1 (2021); DNV-RP-C201 (capacity basis) |
| `FFSAssessmentResult` | API 579-1/ASME FFS-1 (2021) — + `to_dict()` |
| `WallThicknessResult` | governing `DesignCode` → reference map |

`BucklingResult` is set per construction site because that module hosts two codes (DNV-RP-C201 plate vs Eurocode 3 column). All new fields are appended with defaults — no positional-construction or behavior changes.

## Surfaced in the lookup JSON (`ffs_results.json` / dashboards / Deckhand API)
`ffs_lookup._record` carries `code_reference` as a first-class field; `evaluate_pipe_corroded`, `evaluate_plate_metal_loss`, and `record_from_assessment` thread the result's value through; `FFSAssessmentResult.to_dict()` includes it. (The published dashboard HTML regenerates from this data; visual rendering is a publish-step follow-up.)

## Tests / validation
- `tests/asset_integrity/test_code_provenance.py` — **11 tests**: each result type's `code_reference` (exact value vs the `codes` constants), the two BucklingResult codes, the metal-loss combined reference, the `to_dict()` key, and the lookup-record surfacing.
- Broader suites green: **2365 passed** across asset-integrity + structural + materials. (The 16 `test_structural_analysis_cli` failures are a pre-existing environment artifact — they `subprocess.run(["structural-analysis", …])` an installed console script that's absent under a PYTHONPATH-only run; CI installs it via `--with-editable .`.)
- `docs/domains/codes-provenance-2026-06-28.md`.

## Not in scope (→ #1093)
Per-strategy / module-level docstring citations and the consolidated `docs/domains/codes-register.md` — #1093 reuses `codes.REGISTER` from here. Also addresses the #1094 "DNV usage-factor mislabeled" class by making the governing code explicit on every result.