### PR TITLE
refactor(spec-authoring): dedupe diffraction onto common + harden ProjectBundle contract (#1095)

### DIFF
--- a/src/digitalmodel/common/spec_authoring.py
+++ b/src/digitalmodel/common/spec_authoring.py
@@ -27,7 +27,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Project single-source-of-truth contract (LLM input context)
@@ -37,17 +37,52 @@ from pydantic import BaseModel, Field
 class ProjectBundle(BaseModel):
     """The upstream project SSOT handed to the authoring LLM.
 
-    Intentionally loose: real project data is heterogeneous. Structured fields
-    are convenience slots; ``documents`` and ``notes`` carry whatever free text
-    the project has (data-sheet excerpts, emails, scope notes). The LLM reads
-    the whole thing rendered as text and extracts what it can ground.
+    Deliberately loose *inside* the data slots (``vessel_particulars`` /
+    ``environment`` are open dicts; ``documents`` / ``notes`` carry free text) so
+    heterogeneous real project data fits. The *contract* around them is hardened:
+
+    * unknown TOP-LEVEL keys are rejected (``extra="forbid"``) -- a misspelled
+      ``vessel_particular`` is an error, not a silently-dropped field;
+    * ``units`` declares the unit system explicitly (silent unit assumptions are
+      a classic engineering footgun) and :meth:`contract_warnings` flags it when
+      missing alongside numeric data;
+    * ``codes`` / ``references`` carry design standards and citations, surfaced
+      to the LLM so it can ground against them.
+
+    The LLM reads :meth:`to_prompt_context` and extracts only what it can ground;
+    the deterministic resolver fills and ledgers the rest.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     project_name: Optional[str] = None
+    units: Optional[str] = Field(
+        default=None,
+        description="Declared unit system for numeric data, e.g. 'SI' or 'metric'.",
+    )
     vessel_particulars: dict[str, Any] = Field(default_factory=dict)
     environment: dict[str, Any] = Field(default_factory=dict)
+    codes: list[str] = Field(
+        default_factory=list, description="Design codes / standards in scope."
+    )
+    references: list[str] = Field(
+        default_factory=list, description="Citations / source links."
+    )
     documents: list[str] = Field(default_factory=list)
     notes: Optional[str] = None
+
+    @field_validator("project_name", "units", "notes")
+    @classmethod
+    def _blank_to_none(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        v = v.strip()
+        return v or None
+
+    @field_validator("documents", "codes", "references")
+    @classmethod
+    def _drop_empty_strings(cls, v: list[str]) -> list[str]:
+        return [s for s in (item.strip() for item in v) if s]
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "ProjectBundle":
@@ -57,11 +92,50 @@ class ProjectBundle(BaseModel):
             data = yaml.safe_load(f) or {}
         return cls.model_validate(data)
 
+    @classmethod
+    def to_json_schema(cls) -> dict[str, Any]:
+        """JSON Schema for the project-SSOT contract (for docs / validation)."""
+        return cls.model_json_schema()
+
+    def is_empty(self) -> bool:
+        """True when the bundle carries no project data at all."""
+        return not any(
+            (
+                self.project_name,
+                self.vessel_particulars,
+                self.environment,
+                self.codes,
+                self.references,
+                self.documents,
+                self.notes,
+            )
+        )
+
+    def contract_warnings(self) -> list[str]:
+        """Non-fatal gaps worth surfacing before authoring (advisory, not fatal).
+
+        Empty list means the bundle is well-formed. The resolver still ledgers
+        every assumed value downstream regardless.
+        """
+        warnings: list[str] = []
+        if self.is_empty():
+            warnings.append("Project bundle is empty -- nothing to ground against.")
+        if (self.vessel_particulars or self.environment) and self.units is None:
+            warnings.append(
+                "No 'units' declared while numeric particulars are present -- "
+                "unit interpretation is ambiguous; declare e.g. units: SI."
+            )
+        return warnings
+
     def to_prompt_context(self) -> str:
         """Render the bundle as text for the LLM."""
         lines: list[str] = []
         if self.project_name:
             lines.append(f"Project: {self.project_name}")
+        if self.units:
+            lines.append(f"Units: {self.units}")
+        if self.codes:
+            lines.append("Design codes / standards: " + ", ".join(self.codes))
         if self.vessel_particulars:
             lines.append("\nVessel particulars (as provided):")
             for key, value in self.vessel_particulars.items():
@@ -72,6 +146,10 @@ class ProjectBundle(BaseModel):
                 lines.append(f"  - {key}: {value}")
         if self.notes:
             lines.append(f"\nNotes:\n{self.notes}")
+        if self.references:
+            lines.append("\nReferences:")
+            for ref in self.references:
+                lines.append(f"  - {ref}")
         for i, doc in enumerate(self.documents, 1):
             lines.append(f"\n--- Document {i} ---\n{doc}")
         return "\n".join(lines).strip() or "(no project data provided)"

--- a/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
@@ -33,13 +33,19 @@ and is imported lazily -- ``anthropic`` is not a project dependency.
 from __future__ import annotations
 
 import json
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, Protocol
+from typing import Any, Optional, Protocol
 
 from pydantic import BaseModel, Field
 
+from digitalmodel.common.spec_authoring import (
+    CliRunner,
+    ProjectBundle,
+    ProvenanceEntry,
+    build_outcome_menu,
+    claude_cli_complete,
+)
 from digitalmodel.hydrodynamics.diffraction.assumption_ledger import AssumptionLedger
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.resolver import (
@@ -57,64 +63,13 @@ DEFAULT_MODEL = "claude-opus-4-8"
 
 
 # ---------------------------------------------------------------------------
-# Project single-source-of-truth contract (LLM input context)
-# ---------------------------------------------------------------------------
-
-
-class ProjectBundle(BaseModel):
-    """The upstream project SSOT handed to the authoring LLM.
-
-    Intentionally loose: real project data is heterogeneous. Structured fields
-    are convenience slots; ``documents`` and ``notes`` carry whatever free text
-    the project has (data-sheet excerpts, emails, scope notes). The LLM reads
-    the whole thing rendered as text and extracts what it can ground.
-    """
-
-    project_name: Optional[str] = None
-    vessel_particulars: dict[str, Any] = Field(default_factory=dict)
-    environment: dict[str, Any] = Field(default_factory=dict)
-    documents: list[str] = Field(default_factory=list)
-    notes: Optional[str] = None
-
-    @classmethod
-    def from_yaml(cls, path: str | Path) -> "ProjectBundle":
-        import yaml
-
-        with open(path) as f:
-            data = yaml.safe_load(f) or {}
-        return cls.model_validate(data)
-
-    def to_prompt_context(self) -> str:
-        """Render the bundle as text for the LLM."""
-        lines: list[str] = []
-        if self.project_name:
-            lines.append(f"Project: {self.project_name}")
-        if self.vessel_particulars:
-            lines.append("\nVessel particulars (as provided):")
-            for key, value in self.vessel_particulars.items():
-                lines.append(f"  - {key}: {value}")
-        if self.environment:
-            lines.append("\nEnvironment / site (as provided):")
-            for key, value in self.environment.items():
-                lines.append(f"  - {key}: {value}")
-        if self.notes:
-            lines.append(f"\nNotes:\n{self.notes}")
-        for i, doc in enumerate(self.documents, 1):
-            lines.append(f"\n--- Document {i} ---\n{doc}")
-        return "\n".join(lines).strip() or "(no project data provided)"
-
-
-# ---------------------------------------------------------------------------
 # Structured LLM output: the authored intent
 # ---------------------------------------------------------------------------
-
-
-class ProvenanceEntry(BaseModel):
-    """One value the LLM set, with where in the project data it came from."""
-
-    field: str
-    value: str
-    source: str = Field(description="Where in the project bundle this was found.")
+#
+# ``ProjectBundle`` and ``ProvenanceEntry`` are the generic project-SSOT contract
+# and provenance fragment, shared with the OrcaFlex front-end via
+# ``digitalmodel.common.spec_authoring`` (imported above and re-exported here for
+# back-compat).
 
 
 class AuthoredIntent(BaseModel):
@@ -212,10 +167,9 @@ water; otherwise give `water_depth` if stated, else leave both unset.
 
 def build_system_prompt() -> str:
     """System prompt with the outcome menu rendered from the resolver."""
-    menu = "\n".join(
-        f"  - {outcome.value}: {desc}" for outcome, desc in OUTCOME_DESCRIPTIONS.items()
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        outcome_menu=build_outcome_menu(OUTCOME_DESCRIPTIONS)
     )
-    return _SYSTEM_PROMPT_TEMPLATE.format(outcome_menu=menu)
 
 
 # Rendered once at import for convenience; ``build_system_prompt()`` stays the
@@ -267,51 +221,6 @@ class AnthropicIntentAuthor:
         return response.parsed_output
 
 
-def _extract_json_object(text: str) -> str:
-    """Pull the first top-level JSON object out of model text.
-
-    Tolerates ```json fences and surrounding prose by scanning for the first
-    balanced ``{...}`` (brace depth, string-aware).
-    """
-    start = text.find("{")
-    if start == -1:
-        raise ValueError(f"No JSON object in model output: {text[:200]!r}")
-    depth = 0
-    in_string = False
-    escaped = False
-    for i in range(start, len(text)):
-        ch = text[i]
-        if in_string:
-            if escaped:
-                escaped = False
-            elif ch == "\\":
-                escaped = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-        elif ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0:
-                return text[start : i + 1]
-    raise ValueError(f"Unbalanced JSON object in model output: {text[:200]!r}")
-
-
-# Runs the CLI: (argv, stdin) -> CompletedProcess. Injectable for tests.
-CliRunner = Callable[[list[str], str], "subprocess.CompletedProcess[str]"]
-
-
-def _default_cli_runner(
-    argv: list[str], stdin: str
-) -> "subprocess.CompletedProcess[str]":
-    return subprocess.run(
-        argv, input=stdin, capture_output=True, text=True, timeout=300
-    )
-
-
 class ClaudeCliIntentAuthor:
     """Intent author backed by the ``claude -p`` CLI (Claude Code).
 
@@ -319,7 +228,7 @@ class ClaudeCliIntentAuthor:
     ``ANTHROPIC_API_KEY`` and no ``anthropic`` dependency. The CLI does not
     expose typed structured outputs, so the schema is supplied in the system
     prompt and the JSON object is parsed (and Pydantic-validated) from the
-    response. This is the default author.
+    response via the shared ``claude_cli_complete`` helper. Default author.
     """
 
     def __init__(
@@ -333,7 +242,7 @@ class ClaudeCliIntentAuthor:
         self.model = model
         self.cli = cli
         self.extra_args = list(extra_args or [])
-        self._runner = runner or _default_cli_runner
+        self._runner = runner
 
     def _system_prompt(self) -> str:
         schema = json.dumps(AuthoredIntent.model_json_schema())
@@ -348,34 +257,15 @@ class ClaudeCliIntentAuthor:
             f"Analysis request:\n{request}\n\n"
             f"Project data:\n{bundle.to_prompt_context()}"
         )
-        argv = [
-            self.cli,
-            "-p",
-            "--output-format",
-            "json",
-            "--model",
-            self.model,
-            "--system-prompt",
+        data = claude_cli_complete(
             self._system_prompt(),
-            *self.extra_args,
-        ]
-        proc = self._runner(argv, user_prompt)
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"`{self.cli} -p` failed (rc={proc.returncode}): "
-                f"{(proc.stderr or proc.stdout or '').strip()[:500]}"
-            )
-        try:
-            envelope = json.loads(proc.stdout)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(
-                f"Could not parse `{self.cli} -p` JSON envelope: "
-                f"{proc.stdout[:500]!r}"
-            ) from exc
-        if envelope.get("is_error"):
-            raise RuntimeError(f"claude returned an error: {envelope.get('result')}")
-        result_text = envelope.get("result", "")
-        return AuthoredIntent.model_validate_json(_extract_json_object(result_text))
+            user_prompt,
+            model=self.model,
+            cli=self.cli,
+            extra_args=self.extra_args,
+            runner=self._runner,
+        )
+        return AuthoredIntent.model_validate(data)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/common/test_spec_authoring.py
+++ b/tests/common/test_spec_authoring.py
@@ -1,0 +1,147 @@
+"""Tests for the shared spec-authoring plumbing + hardened ProjectBundle contract."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from pydantic import ValidationError
+
+from digitalmodel.common.spec_authoring import (
+    ProjectBundle,
+    ProvenanceEntry,
+    _extract_json_object,
+    build_outcome_menu,
+    claude_cli_complete,
+)
+
+# --- ProjectBundle contract (hardening) ------------------------------------
+
+
+def test_unknown_top_level_key_is_rejected() -> None:
+    # A misspelled field is an error, not a silently-dropped value.
+    with pytest.raises(ValidationError):
+        ProjectBundle(vessel_particular={"loa": 100})  # missing trailing 's'
+
+
+def test_units_codes_references_render_in_context() -> None:
+    bundle = ProjectBundle(
+        project_name="P",
+        units="SI",
+        codes=["DNV-OS-E301"],
+        references=["doc://datasheet-revB"],
+        vessel_particulars={"loa": 245},
+    )
+    ctx = bundle.to_prompt_context()
+    assert "Units: SI" in ctx
+    assert "DNV-OS-E301" in ctx
+    assert "doc://datasheet-revB" in ctx
+    assert "loa: 245" in ctx
+
+
+def test_contract_warnings_flags_missing_units_with_numeric_data() -> None:
+    warned = ProjectBundle(vessel_particulars={"loa": 245})
+    assert any("units" in w.lower() for w in warned.contract_warnings())
+    # Declaring units clears the warning.
+    ok = ProjectBundle(units="SI", vessel_particulars={"loa": 245})
+    assert ok.contract_warnings() == []
+
+
+def test_contract_warnings_flags_empty_bundle() -> None:
+    b = ProjectBundle()
+    assert b.is_empty()
+    assert any("empty" in w.lower() for w in b.contract_warnings())
+
+
+def test_blank_strings_normalize_to_none_and_empty_docs_dropped() -> None:
+    b = ProjectBundle(
+        project_name="   ",
+        notes="",
+        documents=["  ", "real doc", ""],
+        codes=["", " DNV "],
+    )
+    assert b.project_name is None
+    assert b.notes is None
+    assert b.documents == ["real doc"]
+    assert b.codes == ["DNV"]
+
+
+def test_to_json_schema_describes_the_contract() -> None:
+    schema = ProjectBundle.to_json_schema()
+    assert schema["type"] == "object"
+    for key in ("project_name", "units", "vessel_particulars", "codes"):
+        assert key in schema["properties"]
+
+
+def test_from_yaml_roundtrip(tmp_path) -> None:
+    p = tmp_path / "bundle.yml"
+    p.write_text("project_name: P\nunits: SI\nvessel_particulars:\n  loa: 100\n")
+    b = ProjectBundle.from_yaml(p)
+    assert b.project_name == "P" and b.units == "SI"
+    assert b.vessel_particulars["loa"] == 100
+
+
+# --- shared helpers --------------------------------------------------------
+
+
+def test_build_outcome_menu_handles_enum_and_str_keys() -> None:
+    import enum
+
+    class Outcome(str, enum.Enum):
+        A = "alpha"
+
+    menu = build_outcome_menu({Outcome.A: "first", "beta": "second"})
+    assert "- alpha: first" in menu
+    assert "- beta: second" in menu
+
+
+def test_extract_json_object_tolerates_fences_and_prose() -> None:
+    assert _extract_json_object('x ```json\n{"a": 1}\n``` y') == '{"a": 1}'
+    assert _extract_json_object('{"s": "}"}') == '{"s": "}"}'
+    with pytest.raises(ValueError):
+        _extract_json_object("no json here")
+
+
+def _completed(stdout: str, rc: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(["claude"], rc, stdout=stdout, stderr=stderr)
+
+
+def test_claude_cli_complete_parses_envelope_and_passes_flags() -> None:
+    import json
+
+    captured = {}
+
+    def runner(argv, stdin):
+        captured["argv"] = argv
+        captured["stdin"] = stdin
+        return _completed(json.dumps({"is_error": False, "result": '{"ok": true}'}))
+
+    out = claude_cli_complete("sys", "usr", model="claude-opus-4-8", runner=runner)
+    assert out == {"ok": True}
+    assert "-p" in captured["argv"] and "--output-format" in captured["argv"]
+    assert "claude-opus-4-8" in captured["argv"]
+    assert captured["stdin"] == "usr"
+
+
+def test_claude_cli_complete_raises_on_error_envelope_and_rc() -> None:
+    import json
+
+    err_env = claude_cli_complete
+    with pytest.raises(RuntimeError, match="boom"):
+        err_env(
+            "s",
+            "u",
+            model="m",
+            runner=lambda a, s: _completed(
+                json.dumps({"is_error": True, "result": "boom"})
+            ),
+        )
+    with pytest.raises(RuntimeError, match="no auth"):
+        claude_cli_complete(
+            "s", "u", model="m", runner=lambda a, s: _completed("", 1, "no auth")
+        )
+
+
+def test_provenance_entry_shape() -> None:
+    e = ProvenanceEntry(field="loa", value="245 m", source="data sheet")
+    assert e.field == "loa" and e.source == "data sheet"

--- a/tests/hydrodynamics/diffraction/test_spec_author.py
+++ b/tests/hydrodynamics/diffraction/test_spec_author.py
@@ -307,7 +307,7 @@ def test_claude_cli_author_raises_on_nonzero_returncode() -> None:
 
 
 def test_extract_json_object_handles_prose_and_fences() -> None:
-    from digitalmodel.hydrodynamics.diffraction.spec_author import _extract_json_object
+    from digitalmodel.common.spec_authoring import _extract_json_object
 
     assert _extract_json_object('prefix ```json\n{"a": 1}\n``` suffix') == '{"a": 1}'
     assert _extract_json_object('{"a": {"b": 2}} trailing') == '{"a": {"b": 2}}'


### PR DESCRIPTION
The two follow-ups to the LLM spec-authoring work.

## 1. Dedupe diffraction onto `common`
`hydrodynamics/diffraction/spec_author.py` no longer carries its own copies of `ProjectBundle`, `ProvenanceEntry`, `_extract_json_object`, `CliRunner`/`_default_cli_runner` — it imports the generic plumbing from `digitalmodel.common.spec_authoring`. `ClaudeCliIntentAuthor.author` delegates to the shared `claude_cli_complete`; `build_system_prompt` uses `build_outcome_menu`. Public API preserved (re-exports). OrcaFlex already used `common`, so both front-ends now share one implementation.

## 2. Harden the project-SSOT contract (`common.ProjectBundle`)
Benefits both solvers:
- **`extra="forbid"`** — a misspelled top-level key is an error, not a silently-dropped field (the `vessel_particulars`/`environment` data slots stay open dicts).
- **`units`** declaration + **`contract_warnings()`** that flags missing units alongside numeric data (silent unit assumptions are an engineering footgun) and an empty bundle.
- **`codes`** / **`references`** fields, surfaced in `to_prompt_context` for grounding.
- blank→None / empty-string-drop validators; `is_empty()`; `to_json_schema()`.

## Verification
- +12 contract tests (`tests/common/test_spec_authoring.py`).
- Full suite green: common + diffraction spec_author + orcaflex spec_author + inverse_resolver = **78 passed**.
- All shipped example bundles load clean under the hardened contract.
- black 25.9.0 / isort 5.13.2 / flake8 clean.

Part of #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)