### PR TITLE
feat(reporting): mandatory-provenance / SSOT-view report block + pipeline report (#1019)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/spec_author.py
@@ -380,6 +380,68 @@ class AuthoredSpec:
         paths["intent"].write_text(self.intent.model_dump_json(indent=2))
         return paths
 
+    def report_html(
+        self,
+        output_path: str | Path | None = None,
+        *,
+        source_id: str = "authored-in-memory",
+        digest: str | None = None,
+    ) -> str | Path:
+        """Render the analysis SSOT as a provenance-gated HTML report (#1019).
+
+        The summary is a *view* over the spec (read from ``model_dump``, not
+        copied), provenance declares the spec as the data source (mandatory),
+        and the assumption ledger renders as the no-silent-assumptions block.
+        Returns the HTML string, or writes to ``output_path`` and returns it.
+        """
+        from html import escape
+
+        from digitalmodel.reporting import (
+            Provenance,
+            ReportSection,
+            SectionMode,
+            assemble_report,
+        )
+
+        spec_data = self.spec.model_dump(mode="json", exclude_none=True)
+        vessel_name = (spec_data.get("vessel") or {}).get("name") or "vessel"
+
+        def _summary(data: dict, **_: Any) -> str:
+            vessel = data.get("vessel") or {}
+            geometry = vessel.get("geometry") or {}
+            environment = data.get("environment") or {}
+            rows = [
+                ("Outcome", self.intent.outcome.value),
+                ("Vessel", vessel.get("name", "")),
+                ("Mesh", geometry.get("mesh_file", "")),
+                ("Water depth", environment.get("water_depth", "")),
+            ]
+            body = "".join(
+                f"<tr><td>{escape(str(k))}</td><td>{escape(str(v))}</td></tr>"
+                for k, v in rows
+            )
+            return (
+                '<div class="section" id="summary"><h2>Analysis summary</h2>'
+                f"<table><tbody>{body}</tbody></table></div>"
+            )
+
+        provenance = Provenance().add(
+            "spec",
+            source_id,
+            digest=digest,
+            description="Authored diffraction analysis SSOT (DiffractionSpec)",
+        )
+        return assemble_report(
+            title=f"Diffraction analysis - {vessel_name}",
+            provenance=provenance,
+            sections=[
+                ReportSection("summary", "Summary", SectionMode.ALWAYS, _summary)
+            ],
+            data=spec_data,
+            ledger=self.ledger,
+            output_path=output_path,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Top-level entry point

--- a/src/digitalmodel/reporting/__init__.py
+++ b/src/digitalmodel/reporting/__init__.py
@@ -17,17 +17,17 @@ Public API:
 
 from __future__ import annotations
 
-from digitalmodel.reporting._backbone import (
-    ReportBackbone,
-    ReportSection,
-    SectionMode,
-)
-from digitalmodel.reporting._base import (
-    ReportBlock,
-    ReportBlockFn,
-    ReportDataModel,
-)
+from digitalmodel.reporting._backbone import ReportBackbone, ReportSection, SectionMode
+from digitalmodel.reporting._base import ReportBlock, ReportBlockFn, ReportDataModel
 from digitalmodel.reporting._renderer import ReportRenderer
+from digitalmodel.reporting.provenance import (
+    DataSource,
+    Provenance,
+    ProvenanceError,
+    assemble_report,
+    assumption_ledger_block,
+    provenance_block,
+)
 
 __all__ = [
     "ReportDataModel",
@@ -37,4 +37,11 @@ __all__ = [
     "ReportSection",
     "ReportBackbone",
     "ReportRenderer",
+    # provenance / SSOT-view (#1019)
+    "ProvenanceError",
+    "DataSource",
+    "Provenance",
+    "provenance_block",
+    "assumption_ledger_block",
+    "assemble_report",
 ]

--- a/src/digitalmodel/reporting/provenance.py
+++ b/src/digitalmodel/reporting/provenance.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Reporting block library — provenance + SSOT-view enforcement (#1019).
+
+ABOUTME: Makes a report a *view* over a single source of truth, with
+**mandatory provenance**. A report assembled through :func:`assemble_report`
+must declare where its numbers came from (one or more :class:`DataSource`) or
+rendering fails closed -- killing the hand-pasted-results anti-pattern. The
+non-user-supplied :class:`~digitalmodel.common.assumption_ledger.AssumptionLedger`
+renders as a first-class provenance block (the #622 "no silent assumptions"
+surface), reusable by every reporter instead of being diffraction-only.
+"""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from pydantic import Field
+
+from digitalmodel.reporting._backbone import ReportBackbone, ReportSection
+from digitalmodel.reporting._base import ReportDataModel
+from digitalmodel.reporting._renderer import ReportRenderer
+
+if TYPE_CHECKING:  # avoid importing the ledger at module load
+    from digitalmodel.common.assumption_ledger import AssumptionLedger
+
+
+class ProvenanceError(RuntimeError):
+    """Raised when a report is assembled without declared provenance."""
+
+
+class DataSource(ReportDataModel):
+    """One declared origin of a report's data -- *where the numbers came from*.
+
+    ``retrieved_at`` is caller-supplied (kept out of the library so reports stay
+    deterministic and testable); pass an ISO timestamp when you have one.
+    """
+
+    kind: str = Field(
+        description="Source category, e.g. 'spec', 'solver_queue', "
+        "'analysis_store', 'file'."
+    )
+    identifier: str = Field(description="Path, run-id, or store key.")
+    digest: Optional[str] = Field(
+        default=None, description="Content hash, e.g. sha256."
+    )
+    retrieved_at: Optional[str] = None
+    description: Optional[str] = None
+
+
+class Provenance(ReportDataModel):
+    """The set of sources a report is a view over."""
+
+    sources: List[DataSource] = Field(default_factory=list)
+
+    def add(
+        self,
+        kind: str,
+        identifier: str,
+        *,
+        digest: Optional[str] = None,
+        retrieved_at: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> "Provenance":
+        """Append a source and return self (chainable)."""
+        self.sources.append(
+            DataSource(
+                kind=kind,
+                identifier=identifier,
+                digest=digest,
+                retrieved_at=retrieved_at,
+                description=description,
+            )
+        )
+        return self
+
+    def require(self) -> "Provenance":
+        """Enforce mandatory provenance; raise if no source is declared."""
+        if not self.sources:
+            raise ProvenanceError(
+                "Report has no declared data source -- provenance is mandatory "
+                "(#1019: a report is a view over a source, not a copy). Declare "
+                "at least one DataSource."
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Block builders (return complete ``<div class="section">`` fragments)
+# ---------------------------------------------------------------------------
+
+
+def provenance_block(provenance: Provenance, **_: Any) -> str:
+    """Render the data-source declaration table (id=``provenance``)."""
+    rows = []
+    for src in provenance.sources:
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(src.kind)}</td>"
+            f"<td>{html.escape(src.identifier)}</td>"
+            f"<td>{html.escape(src.digest or '')}</td>"
+            f"<td>{html.escape(src.retrieved_at or '')}</td>"
+            f"<td>{html.escape(src.description or '')}</td>"
+            "</tr>"
+        )
+    body = "".join(rows) or (
+        '<tr><td colspan="5"><em>No sources declared.</em></td></tr>'
+    )
+    return (
+        '<div class="section" id="provenance">'
+        "<h2>Data provenance</h2>"
+        "<p>This report is a <strong>view</strong> over the sources below; "
+        "values are read from them, not copied in.</p>"
+        "<table><thead><tr><th>Kind</th><th>Identifier</th><th>Digest</th>"
+        "<th>Retrieved</th><th>Description</th></tr></thead>"
+        f"<tbody>{body}</tbody></table>"
+        "</div>"
+    )
+
+
+def assumption_ledger_block(ledger: "AssumptionLedger", **_: Any) -> str:
+    """Render the non-user-supplied assumption ledger (id=``assumptions``).
+
+    Generalized from the diffraction reporter so any report can surface the
+    no-silent-assumptions ledger. An empty ledger renders an explicit
+    "every value was supplied" note rather than nothing.
+    """
+    if not ledger:
+        return (
+            '<div class="section" id="assumptions">'
+            "<h2>Assumptions</h2>"
+            "<p>No assumed values &mdash; every value was user-supplied.</p>"
+            "</div>"
+        )
+    rows = []
+    for record in ledger.rows():
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(record.field)}</td>"
+            f"<td>{html.escape(str(record.value))}</td>"
+            f"<td>{html.escape(record.source.value)}</td>"
+            f"<td>{html.escape(record.confidence.value)}</td>"
+            f"<td>{html.escape(record.basis)}</td>"
+            f"<td>{html.escape(str(record.reference or ''))}</td>"
+            "</tr>"
+        )
+    return (
+        '<div class="section" id="assumptions">'
+        "<h2>Assumptions</h2>"
+        "<p>Every value below was <strong>assumed</strong> by the resolver "
+        "(not supplied) and is surfaced for review.</p>"
+        "<table><thead><tr><th>Field</th><th>Value</th><th>Source</th>"
+        "<th>Confidence</th><th>Basis</th><th>Reference</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+        "</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembler — enforces mandatory provenance, appends provenance + ledger
+# ---------------------------------------------------------------------------
+
+
+def assemble_report(
+    title: str,
+    *,
+    provenance: Provenance,
+    sections: Optional[List[ReportSection]] = None,
+    data: Any = None,
+    ledger: Optional["AssumptionLedger"] = None,
+    mode: str = "full",
+    css: str = "",
+    output_path: Optional[Path | str] = None,
+    **builder_kwargs: Any,
+) -> str | Path:
+    """Assemble a provenance-gated report on the shared backbone.
+
+    Fails closed via :meth:`Provenance.require` if no source is declared. Body
+    ``sections`` (standard :class:`ReportSection` builders over ``data``) render
+    first, then the mandatory **provenance** block, then the **assumption
+    ledger** block (when a ledger is given). Returns the HTML string, or writes
+    to ``output_path`` and returns the :class:`Path`.
+    """
+    provenance.require()
+
+    body: List[str] = []
+    if sections:
+        backbone = ReportBackbone(title=title, sections=sections)
+        body.extend(backbone.render(data, mode=mode, **builder_kwargs))
+    body.append(provenance_block(provenance))
+    if ledger is not None:
+        body.append(assumption_ledger_block(ledger))
+
+    renderer = ReportRenderer()
+    html_doc = renderer.render_html(body, title=title, css=css)
+    if output_path is not None:
+        return renderer.write_html(html_doc, Path(output_path))
+    return html_doc
+
+
+__all__ = [
+    "ProvenanceError",
+    "DataSource",
+    "Provenance",
+    "provenance_block",
+    "assumption_ledger_block",
+    "assemble_report",
+]

--- a/tests/hydrodynamics/diffraction/test_spec_author.py
+++ b/tests/hydrodynamics/diffraction/test_spec_author.py
@@ -328,3 +328,27 @@ def test_author_spec_end_to_end_with_cli_runner(tmp_path: Path) -> None:
 
     result = author_spec(ProjectBundle(), "full QTF please", author=author)
     assert result.spec.solver_options.solve_type == "full_qtf"
+
+
+# --- AuthoredSpec.report_html (provenance-gated, #1019) --------------------
+
+
+def test_authored_spec_report_html_is_provenance_gated(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    result = author_spec(ProjectBundle(), "RAOs", author=StubAuthor(_full_intent(mesh)))
+    html = result.report_html(source_id="spec.yml", digest="deadbeef")
+    assert "<!DOCTYPE html>" in html
+    # mandatory provenance declares the spec as the source
+    assert 'id="provenance"' in html and "spec.yml" in html and "deadbeef" in html
+    # the no-silent-assumptions ledger is a first-class block
+    assert 'id="assumptions"' in html
+    # summary is a view over the spec (mesh path read from the SSOT)
+    assert str(mesh) in html
+
+
+def test_authored_spec_report_html_writes_file(tmp_path: Path) -> None:
+    mesh = _write_box_mesh(tmp_path / "box.gdf")
+    result = author_spec(ProjectBundle(), "RAOs", author=StubAuthor(_full_intent(mesh)))
+    out = tmp_path / "report.html"
+    written = result.report_html(out)
+    assert written == out and out.exists()

--- a/tests/reporting/test_provenance.py
+++ b/tests/reporting/test_provenance.py
@@ -1,0 +1,118 @@
+"""Tests for the reporting provenance / SSOT-view module (#1019)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.common.assumption_ledger import (
+    AssumptionLedger,
+    AssumptionSource,
+    Confidence,
+)
+from digitalmodel.reporting import (
+    DataSource,
+    Provenance,
+    ProvenanceError,
+    ReportSection,
+    SectionMode,
+    assemble_report,
+    assumption_ledger_block,
+    provenance_block,
+)
+
+
+def _ledger() -> AssumptionLedger:
+    led = AssumptionLedger()
+    led.record(
+        "environment.water_depth",
+        100.0,
+        AssumptionSource.ASSUMED_DEFAULT,
+        "Default screening depth",
+        Confidence.LOW,
+        reference="default",
+        impact=4,
+    )
+    return led
+
+
+# --- mandatory provenance ---------------------------------------------------
+
+
+def test_require_raises_without_sources() -> None:
+    with pytest.raises(ProvenanceError):
+        Provenance().require()
+
+
+def test_assemble_report_fails_closed_without_provenance() -> None:
+    with pytest.raises(ProvenanceError):
+        assemble_report("Untraceable", provenance=Provenance())
+
+
+def test_assemble_report_with_provenance_renders_document() -> None:
+    prov = Provenance().add("spec", "spec.yml", digest="abc123")
+    html = assemble_report("Test Report", provenance=prov, ledger=_ledger())
+    assert "<!DOCTYPE html>" in html
+    assert "Test Report" in html
+    # provenance section present and references the source
+    assert 'id="provenance"' in html
+    assert "spec.yml" in html and "abc123" in html
+    # ledger rendered as the assumptions block
+    assert 'id="assumptions"' in html
+    assert "environment.water_depth" in html
+
+
+def test_assemble_report_writes_file(tmp_path) -> None:
+    prov = Provenance().add("solver_queue", "completed/run_42")
+    out = tmp_path / "r.html"
+    result = assemble_report("R", provenance=prov, output_path=out)
+    assert result == out and out.exists()
+    assert "completed/run_42" in out.read_text()
+
+
+def test_body_sections_render_before_provenance() -> None:
+    prov = Provenance().add("file", "data.csv")
+
+    def _body(data, **_):
+        return '<div class="section" id="body">BODYMARK</div>'
+
+    html = assemble_report(
+        "R",
+        provenance=prov,
+        sections=[ReportSection("body", "Body", SectionMode.ALWAYS, _body)],
+        data={},
+    )
+    assert html.index("BODYMARK") < html.index('id="provenance"')
+
+
+# --- block builders ---------------------------------------------------------
+
+
+def test_provenance_block_lists_each_source() -> None:
+    prov = Provenance().add("spec", "a.yml").add("analysis_store", "store://x")
+    block = provenance_block(prov)
+    assert "a.yml" in block and "store://x" in block
+    assert "view" in block.lower()  # view-not-copy framing
+
+
+def test_assumption_ledger_block_empty_states_all_supplied() -> None:
+    block = assumption_ledger_block(AssumptionLedger())
+    assert "every value was user-supplied" in block
+
+
+def test_assumption_ledger_block_renders_rows() -> None:
+    block = assumption_ledger_block(_ledger())
+    assert "environment.water_depth" in block
+    assert "assumed_default" in block
+    assert "Default screening depth" in block
+
+
+def test_html_is_escaped_in_blocks() -> None:
+    prov = Provenance().add("file", "<script>x</script>")
+    block = provenance_block(prov)
+    assert "<script>x</script>" not in block
+    assert "&lt;script&gt;" in block
+
+
+def test_datasource_optional_fields() -> None:
+    ds = DataSource(kind="spec", identifier="s.yml")
+    assert ds.digest is None and ds.retrieved_at is None


### PR DESCRIPTION
The back-end "holy grail" of the model-generation pipeline: **a report is a view over a single source of truth, with mandatory provenance** (#1019 doctrine — "view, not a copy").

## `digitalmodel.reporting.provenance` (shared, on the #1018 backbone)
- `Provenance` / `DataSource` + `ProvenanceError`; `Provenance.require()` fails closed.
- `assemble_report(title, *, provenance, sections, data, ledger, output_path, ...)` — **enforces mandatory provenance** (raises if no `DataSource` declared), renders body sections, then the provenance declaration, then the assumption-ledger block.
- `provenance_block` (where the numbers came from) + `assumption_ledger_block` — the latter generalized from the diffraction reporter so the **#622 no-silent-assumptions ledger is now a shared, first-class block** reusable by all ~31 reporters, not diffraction-only. HTML-escaped throughout.
- Exported from `digitalmodel.reporting`.

## Pipeline wiring
`AuthoredSpec.report_html()` (diffraction) emits a standardized provenance-gated report — the summary is a **view over the spec** (`model_dump`), the spec is the declared data source, and the assumption ledger renders inline. This closes the loop: `project SSOT → LLM → analysis SSOT → validated, provenance-tracked report`.

## Verification
- +10 provenance tests + 2 `AuthoredSpec.report_html` tests.
- **54 passed** across reporting library + provenance + diffraction spec_author.
- black 25.9.0 / isort 5.13.2 / flake8 clean.

Advances **#1019**. Remaining reporting follow-ups: #1020 (tracer-bullet migrate a snowflake reporter onto the block), #1021 (skeleton-first CLI), #282 (per-OrcaWave-structure reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)