### PR TITLE
feat(catalog): subsea PLET/manifold/SPS structure catalog — retire pamphlet proxy (T8)

### DIFF
--- a/examples/demos/gtm/data/subsea_structures.json
+++ b/examples/demos/gtm/data/subsea_structures.json
@@ -1,0 +1,162 @@
+{
+  "_description": "Subsea production structure catalog (PLET / production manifold / SPS template) for GTM demo 3 (installation analysis). Representative reference structures retiring the hardcoded 250 te 'Manifold/PLET proxy' in the installation_pamphlet workflow. Values are computed from first principles and are REPRESENTATIVE engineering references, not a specific project deliverable; verify against project-specific weight reports before marine-warranty use.",
+  "_version": "1.0",
+  "_references": [
+    "DNV-RP-H103 (2011) - Modelling and Analysis of Marine Operations, Sec 4 (Lifting through wave zone)",
+    "DNV-ST-N001 (2021) - Marine Operations and Marine Warranty",
+    "DNV-RP-C205 (2010) - Environmental Conditions and Environmental Loads"
+  ],
+  "units": {
+    "length": "m",
+    "mass": "kg",
+    "force": "N",
+    "area": "m2",
+    "pressure": "Pa"
+  },
+  "constants": {
+    "seawater_density_kg_m3": 1025,
+    "gravity_m_s2": 9.80665,
+    "steel_density_kg_m3": 7850,
+    "_note": "Submerged weight = (mass_air - displaced_water_mass) * g. Subsea production structures are open-framed steel boxes on an integral mudmat base; the displaced volume that generates buoyancy is taken as the steel volume (mass_air / steel_density), i.e. no trapped-air buoyancy is credited (conservative for submerged weight)."
+  },
+  "structures": [
+    {
+      "id": "PLET-100",
+      "name": "PLET-100te",
+      "description": "Pipeline End Termination (PLET) - open-frame steel structure with integral mudmat base, connecting a pipeline to a manifold/jumper. Representative ~100 te unit.",
+      "geometry": {
+        "length_m": 8.0,
+        "width_m": 6.0,
+        "height_m": 4.0,
+        "bottom_plate_thickness_mm": 25,
+        "skirt_depth_m": 0.4,
+        "skirt_thickness_mm": 14
+      },
+      "mass_properties": {
+        "mass_air_kg": 100000,
+        "mass_air_te": 100.0,
+        "displaced_volume_m3": 12.74,
+        "buoyancy_force_kn": 128.06,
+        "submerged_weight_kn": 852.6,
+        "_note": "Displaced volume = mass_air / 7850 = 12.74 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 2.0,
+        "_note": "Relative to geometric centre of bottom plate; taken at mid-height for a roughly uniform frame"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (applied to the integral mudmat base / solid panels; open-frame members experience less). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass (added mass = rho * volume * Ca)."
+      },
+      "projected_areas": {
+        "bottom_m2": 48.0,
+        "side_long_m2": 32.0,
+        "side_short_m2": 24.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 8 x 6. side_long = L x H = 8 x 4. side_short = W x H = 6 x 4."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 10.0,
+        "hook_height_above_cog_m": 9.5,
+        "_note": "4-point lift with spreader frame typical"
+      }
+    },
+    {
+      "id": "MAN-250",
+      "name": "Manifold-250te",
+      "description": "Subsea production manifold - open-frame steel structure with integral mudmat base, flowline/header piping, valves and connection hubs. Representative ~250 te unit (retires the 250 te installation_pamphlet proxy).",
+      "geometry": {
+        "length_m": 14.0,
+        "width_m": 12.0,
+        "height_m": 6.0,
+        "bottom_plate_thickness_mm": 30,
+        "skirt_depth_m": 0.5,
+        "skirt_thickness_mm": 16
+      },
+      "mass_properties": {
+        "mass_air_kg": 250000,
+        "mass_air_te": 250.0,
+        "displaced_volume_m3": 31.85,
+        "buoyancy_force_kn": 320.15,
+        "submerged_weight_kn": 2131.51,
+        "_note": "Displaced volume = mass_air / 7850 = 31.85 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 3.2,
+        "_note": "Relative to geometric centre of bottom plate; slightly above mid-height (3.0 m) to reflect topside-mounted valves/equipment"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (mudmat base + solid roof/equipment panels). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass."
+      },
+      "projected_areas": {
+        "bottom_m2": 168.0,
+        "side_long_m2": 84.0,
+        "side_short_m2": 72.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 14 x 12. side_long = L x H = 14 x 6. side_short = W x H = 12 x 6."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 18.0,
+        "hook_height_above_cog_m": 17.0,
+        "_note": "4-point lift with heavy spreader frame; may require custom rigging design"
+      }
+    },
+    {
+      "id": "TMPL-180",
+      "name": "SPS-Template-180te",
+      "description": "Subsea production system (SPS) drilling/production template - multi-slot open-frame structure with integral mudmat base providing well-slot guidance and structural support. Representative ~180 te unit.",
+      "geometry": {
+        "length_m": 16.0,
+        "width_m": 12.0,
+        "height_m": 5.0,
+        "bottom_plate_thickness_mm": 30,
+        "skirt_depth_m": 0.5,
+        "skirt_thickness_mm": 16
+      },
+      "mass_properties": {
+        "mass_air_kg": 180000,
+        "mass_air_te": 180.0,
+        "displaced_volume_m3": 22.93,
+        "buoyancy_force_kn": 230.49,
+        "submerged_weight_kn": 1534.71,
+        "_note": "Displaced volume = mass_air / 7850 = 22.93 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 2.5,
+        "_note": "Relative to geometric centre of bottom plate; taken at mid-height for a roughly uniform frame"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (integral mudmat base). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass."
+      },
+      "projected_areas": {
+        "bottom_m2": 192.0,
+        "side_long_m2": 80.0,
+        "side_short_m2": 60.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 16 x 12. side_long = L x H = 16 x 5. side_short = W x H = 12 x 5."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 20.0,
+        "hook_height_above_cog_m": 19.0,
+        "_note": "4-point lift with heavy spreader frame; may require custom rigging design"
+      }
+    }
+  ]
+}

--- a/src/digitalmodel/base_configs/modules/installation_pamphlet/installation_pamphlet.yml
+++ b/src/digitalmodel/base_configs/modules/installation_pamphlet/installation_pamphlet.yml
@@ -10,12 +10,13 @@ installation_pamphlet:
   # below. Order is preserved (deterministic).
   catalogs:
     mudmats: examples/demos/gtm/data/mudmat_structures.json
+    structures: examples/demos/gtm/data/subsea_structures.json
     jumpers: examples/demos/gtm/data/rigid_jumpers.json
   lift_items:
     - {item: "Mudmat (small)", kind: mudmat, source: mudmat, id: MUD-S}
     - {item: "Mudmat (medium)", kind: mudmat, source: mudmat, id: MUD-M}
     - {item: "Subsea structure / template (large)", kind: structure, source: mudmat, id: MUD-L}
-    - {item: "Manifold/PLET proxy", kind: structure, mass_air_te: 250.0}
+    - {item: "Production manifold (250 te)", kind: structure, source: structure, id: MAN-250}
     - {item: "Rigid jumper (short 20 m)", kind: jumper, source: jumper, id: JMP-20}
     - {item: "Rigid jumper (long 100 m)", kind: jumper, source: jumper, id: JMP-100}
 

--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -71,6 +71,17 @@ def load_jumpers(path: str | Path) -> dict[str, dict[str, Any]]:
     return {j["id"]: j for j in data["jumpers"]}
 
 
+def load_structures(path: str | Path) -> dict[str, dict[str, Any]]:
+    """Load the subsea production structure catalog (PLET/manifold/SPS) keyed by id.
+
+    Same schema and normalized shape as ``load_mudmats`` — each record carries
+    ``mass_properties.mass_air_te`` which the lift assembly consumes.
+    """
+    with Path(path).open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    return {s["id"]: s for s in data["structures"]}
+
+
 # ---------------------------------------------------------------- lift suitability
 def assess_lifts(
     vessel_info: dict[str, Any],
@@ -271,12 +282,17 @@ def build_provenance(
     completed_runs: list[dict[str, Any]],
     rao_basis: str,
     vessel_name: str = "BokaLift 2",
+    structure_catalog_used: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
     Returns the full run-state object (vessel, basis, provenance, basis run id,
     completed-run count, and the ordered task list) used to render the analysis
     progress panel and the per-section provenance badges.
+
+    When ``structure_catalog_used`` is True the T8 task (manifold/PLET structure
+    catalog) reflects the real ``subsea_structures.json`` catalog (status
+    ``actual``) instead of the retired hardcoded proxy.
     """
     runs = list(completed_runs or [])
     prov = BASIS_PROVENANCE[rao_basis]
@@ -325,9 +341,19 @@ def build_provenance(
             "T7", 7, "DP / mooring statistical risk", "actual",
             "IMCA + HSE RR444 + DNV statistics", "industry datasets",
         ),
-        task(
-            "T8", 4, "Manifold / PLET structure catalog", "proxy",
-            "Proxy entry — real catalog pending", "examples/demos/gtm (mudmat only)",
+        (
+            task(
+                "T8", 4, "Manifold / PLET structure catalog", "actual",
+                "Catalog entries (PLET/manifold/SPS) computed from first principles "
+                "(DNV-RP-H103)",
+                "examples/demos/gtm/data/subsea_structures.json catalog",
+            )
+            if structure_catalog_used
+            else task(
+                "T8", 4, "Manifold / PLET structure catalog", "proxy",
+                "Proxy entry — real catalog pending",
+                "examples/demos/gtm (mudmat only)",
+            )
         ),
     ]
     return {
@@ -356,8 +382,14 @@ def assemble_result(
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
     envelopes = compute_envelopes(rao_basis, operations, tp_grid_s)
     op_table = compute_operability(hs_scatter_limits)
+    structure_catalog_used = any(
+        str(it.get("source")) == "structure" for it in lifts
+    )
     provenance = build_provenance(
-        completed_runs, rao_basis, vessel_name=vessel_info.get("name", "Installation vessel")
+        completed_runs,
+        rao_basis,
+        vessel_name=vessel_info.get("name", "Installation vessel"),
+        structure_catalog_used=structure_catalog_used,
     )
     return {
         "vessel": vessel_info,

--- a/src/digitalmodel/installation/installation_pamphlet/render.py
+++ b/src/digitalmodel/installation/installation_pamphlet/render.py
@@ -484,7 +484,7 @@ Governing limits are <b>seakeeping</b> and <b>station-keeping</b> (&sect;5–6),
 <tr><td class="l">Mudmat — small</td><td>6 &times; 6 &times; 1.5</td><td>50</td><td>mudmat_structures.json</td></tr>
 <tr><td class="l">Mudmat — medium</td><td>8 &times; 10 &times; 2.0</td><td>100</td><td>mudmat_structures.json</td></tr>
 <tr><td class="l">Subsea template — large</td><td>12 &times; 14 &times; 2.5</td><td>200</td><td>mudmat_structures.json</td></tr>
-<tr><td class="l">Manifold / PLET <small>(proxy)</small></td><td>14 &times; 12 &times; 6</td><td>250</td><td>proxy — catalog gap</td></tr>
+<tr><td class="l">Production manifold</td><td>14 &times; 12 &times; 6</td><td>250</td><td>subsea_structures.json</td></tr>
 <tr><td class="l">Rigid jumper — 20 m</td><td>8&Prime; X65, M-shape</td><td>1.85</td><td>rigid_jumpers.json</td></tr>
 <tr><td class="l">Rigid jumper — 100 m</td><td>8&Prime; X65, W-shape</td><td>9.24</td><td>rigid_jumpers.json</td></tr>
 </table>
@@ -548,7 +548,7 @@ but the cascade case is high-consequence; design for intact + one-line-damaged (
 
 </main>
 <footer>
-Generated {GEN} from digitalmodel tables (vessel_db, mudmat_structures, rigid_jumpers) + engines (vessel_suitability,
+Generated {GEN} from digitalmodel tables (vessel_db, mudmat_structures, subsea_structures, rigid_jumpers) + engines (vessel_suitability,
 operation_envelope, weather_window). Envelope proxy: {d['envelope_proxy']}. Live feed: Open-Meteo marine &amp; forecast APIs.
 Lookup + decision-support screening — verify against vessel RAO, DP/mooring FMEA and MWS approval before offshore execution.
 </footer>

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -126,6 +126,7 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
     items = settings.get("lift_items") or []
     catalogs = settings.get("catalogs") or {}
     mud_cache: dict[str, dict[str, Any]] | None = None
+    str_cache: dict[str, dict[str, Any]] | None = None
     jmp_cache: dict[str, dict[str, Any]] | None = None
     resolved: list[dict[str, Any]] = []
     for it in items:
@@ -137,6 +138,12 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
                 mud_cache = calc.load_mudmats(_config_path(cfg, catalogs["mudmats"]))
             rec = mud_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+        elif it.get("source") == "structure":
+            if str_cache is None:
+                str_cache = calc.load_structures(_config_path(cfg, catalogs["structures"]))
+            rec = str_cache[it["id"]]
+            row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+            row["source"] = "structure"  # flips provenance T8 to the real catalog
         elif it.get("source") == "jumper":
             if jmp_cache is None:
                 jmp_cache = calc.load_jumpers(_config_path(cfg, catalogs["jumpers"]))

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -127,6 +127,53 @@ def test_build_provenance_barge_default_has_no_basis_run():
     assert prov["basis_run_id"] is None
 
 
+def test_build_provenance_t8_flips_to_catalog_when_used():
+    by_id_proxy = {
+        t["id"]: t for t in calc.build_provenance([], "barge")["tasks"]
+    }
+    assert by_id_proxy["T8"]["status"] == "proxy"  # default unchanged
+
+    prov = calc.build_provenance([], "barge", structure_catalog_used=True)
+    t8 = {t["id"]: t for t in prov["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+    assert t8["status"] != "proxy"
+    assert "subsea_structures.json" in t8["source"]
+
+
+# ---------------------------------------------------------------- structure catalog
+def test_load_structures_manifold_mass():
+    structures = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    assert set(["PLET-100", "MAN-250", "TMPL-180"]).issubset(structures)
+    manifold = structures["MAN-250"]
+    assert manifold["mass_properties"]["mass_air_te"] == pytest.approx(250.0)
+    # buoyancy + submerged weight reconcile with mass_air * g (seawater 1025, g 9.80665)
+    mp = manifold["mass_properties"]
+    total = mp["buoyancy_force_kn"] + mp["submerged_weight_kn"]
+    assert total == pytest.approx(250000 * 9.80665 / 1000, abs=0.05)
+
+
+def test_golden_catalog_structure_lift_is_defensible(vessel_info):
+    structures = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    manifold_te = structures["MAN-250"]["mass_properties"]["mass_air_te"]
+    lifts = [
+        {
+            "item": "Production manifold (250 te)",
+            "kind": "structure",
+            "source": "structure",
+            "mass_air_te": manifold_te,
+        }
+    ]
+    res = _assemble(vessel_info, lifts, "drillship", runs=[DRILLSHIP_RUN])
+    row = res["lifts"][0]
+    assert row["mass_air_te"] == pytest.approx(250.0)
+    assert row["hook_load_te"] == pytest.approx(250.0 * 1.30, abs=0.05)  # mass x DAF
+    assert row["defensible"] is True
+    assert 0.0 < row["utilization_pct"] <= 100.0
+    # the catalog-sourced structure flips T8 provenance to the real catalog
+    t8 = {t["id"]: t for t in res["provenance"]["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+
+
 # ---------------------------------------------------------------- golden numbers
 def test_golden_barge_transit_hs_and_lift(vessel_info, lifts):
     res = _assemble(vessel_info, lifts, "barge")
@@ -226,6 +273,15 @@ def test_router_on_base_config_writes_artifacts(tmp_path):
     assert summary["n_lifts"] == 6
     assert summary["rao_basis"] == "drillship"  # auto-selected from completed_runs
     assert summary["all_lifts_defensible"] is True
+
+    # the base config now sources the 250 te manifold from subsea_structures.json,
+    # which flips the T8 structure-catalog provenance off the retired proxy
+    result = out["installation_pamphlet"]["result"]
+    t8 = {t["id"]: t for t in result["provenance"]["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+    assert t8["status"] != "proxy"
+    man = next(r for r in result["lifts"] if "manifold" in r["item"].lower())
+    assert man["mass_air_te"] == pytest.approx(250.0)
 
     html = html_path.read_text()
     assert "Installation Vessel Pamphlet" in html


### PR DESCRIPTION
## What
Adds a structured **subsea structure catalog** and wires it into the `installation_pamphlet` workflow, retiring the hardcoded 250 te "Manifold/PLET proxy" (provenance task **T8**).

Closes #1113. **Stacks on #1106** (base = `feat/installation-pamphlet-workflow`); review/merge #1106 first.

## Changes
- **New** `examples/demos/gtm/data/subsea_structures.json` — mirrors `mudmat_structures.json` schema (geometry, mass_properties, DNV-RP-H103 hydrodynamic coefficients Cs/Cd/Ca, projected_areas, rigging; documented references). Three representative entries:
  - `PLET-100te` — pipeline end termination
  - `Manifold-250te` — production manifold (replaces the proxy)
  - `SPS-Template-180te` — subsea production system template
- **Loader** `load_structures()` in `calculations.py` (mirrors `load_mudmats`).
- **Config** `installation_pamphlet.yml` sources the manifold from the catalog instead of the hardcoded 250 te proxy.
- **Provenance**: T8 flips `proxy → actual` when the catalog is used (`structure_catalog_used`); render/workflow updated.

## Determinism
Preserved — no `datetime.now`/random/network in the generation path; same cfg → byte-identical HTML + JSON (existing determinism test still green).

## Tests — 18 passing
`tests/installation/test_installation_pamphlet.py` (+3 new): `load_structures` loads the manifold with expected mass; a catalog-sourced structure is defensible with hook = mass × DAF; T8 provenance no longer `proxy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
