### PR TITLE
feat(tubulars): API 5CT casing + API 11B sucker-rod product catalogs [#1090 #1091]

### DIFF
--- a/docs/domains/tubulars-casing-rod-validation-2026-06-28.md
+++ b/docs/domains/tubulars-casing-rod-validation-2026-06-28.md
@@ -1,0 +1,68 @@
+# API 5CT Casing + API 11B Sucker Rod — Validation Record (2026-06-28)
+
+Backing for `src/digitalmodel/well/tubulars/casing.py` (#1090) and
+`sucker_rod.py` (#1091), EPIC #1080 workstream D. Both are product catalogs on
+the tubular-design package, mirroring the line-pipe pattern.
+
+## API 5CT casing (#1090)
+
+`Casing` = OD + nominal weight (ppf, → wall) + API 5CT grade, with API 5C3
+ratings computed (not table-looked-up). It computes the very
+`burst_rating_psi` / `collapse_rating_psi` that the existing
+`TubularGeometry` / VME / API-ellipse envelopes require as inputs — see
+`Casing.to_tubular_geometry()`.
+
+Grades: H40, J55, K55, N80, L80, C90, C95, T95, P110, Q125 (min **and** max
+yield; min tensile). Sizes: 4½″–20″ × standard weights.
+
+**Formulas (API 5C3):**
+- Internal yield (burst): `0.875 · 2·Yp·t / D`.
+- Pipe-body yield (axial): `Yp · A`.
+- Collapse: four regimes (yield / plastic / transition / elastic) selected on
+  D/t, with the grade-dependent A/B/C/F/G constants (polynomials in Yp).
+
+**Validation vs published API ratings:**
+
+| Casing | D/t | Collapse | Burst | Body yield | Regime |
+|---|---|---|---|---|---|
+| 7″ 26# P110 | 19.3 | 6230 (calc 6232) | 9960 | 830,000 | plastic |
+| 9⅝″ 47# N80 | 20.4 | 4760 (calc 4754) | 6870 | 1,086,000 | plastic |
+| 13⅜″ 68# K55 | 27.9 | 1950 (calc 1949) | 3450 | 1,070,000 | transition |
+
+All within 0.3 %. Yield- and elastic-regime selection are also covered (5″ 23.2#
+P110 → yield; 20″ 94# K55 → elastic), plus collapse monotonicity in D/t. The
+4-regime collapse is the critical validation: a regime-boundary bug only shows
+up against a published rating, not a hand-derived number.
+
+## API 11B sucker rod (#1091)
+
+`SuckerRod` = nominal diameter (eighths) + API 11B grade + service factor, with
+the **modified-Goodman** allowable-stress fatigue check.
+
+Grades: C (90 ksi), K (85 ksi), D (115 ksi) min tensile. Sizes: ½″…1¼″.
+
+**Modified Goodman (API 11BR):** `SA = (T/4 + 0.5625·Smin)·SF`. The allowable
+peak stress rises with the minimum stress (the Goodman line), so the check takes
+both peak and minimum polished-rod loads; the service factor `SF` carries
+sour-service derating. `goodman_check(peak, min)` returns min/max/allowable
+stresses, loading (= Smax/SA) and a pass flag. Tapered strings checked
+per-section via `rod_string_goodman`. `to_rod_section()` ties into the dynacard
+rod-buckling workflow with the correct grade tensile.
+
+Validated: `SA(D, Smin=10 ksi)=34,375 psi`, `SA(C, 0)=22,500`, SF derating,
+higher-Smin-lifts-allowable, and the dynacard `RodSection` tie-in.
+
+## Tests
+
+`tests/well/tubulars/test_casing.py` (21) + `test_sucker_rod.py` (12) — 33 tests;
+full `well/tubulars` suite 68 passed (incl. the 47 existing envelope tests).
+black + flake8 clean. Tests run under the `marine-ops-other` CI domain
+(`tests/well/` is already mapped).
+
+## Relates to
+
+Builds on `well/tubulars/design_envelope.py` (TubularGeometry / API-ellipse) and
+`marine_ops/artificial_lift/dynacard/rod_buckling.py` (RodSection). Grades live
+in the product modules (casing min/max yield and rod tensile-only don't fit the
+line-pipe `MaterialGrade` shape). Code-reference provenance is a self-contained
+string here; #1093 can fold it into the `codes` register once #1092 merges.

--- a/src/digitalmodel/well/tubulars/__init__.py
+++ b/src/digitalmodel/well/tubulars/__init__.py
@@ -12,6 +12,31 @@ from digitalmodel.well.tubulars.design_envelope import (
     compute_vme_stress,
     design_envelope_points,
 )
+from digitalmodel.well.tubulars.casing import (
+    API_5CT_GRADES,
+    CASING_SIZES,
+    Casing,
+    CasingGrade,
+    casing,
+    casing_grade,
+    collapse_pressure,
+    internal_yield_pressure,
+    list_sizes,
+    pipe_body_yield_strength,
+    wall_for_size,
+)
+from digitalmodel.well.tubulars.sucker_rod import (
+    API_11B_ROD_GRADES,
+    ROD_SIZES_IN,
+    RodGrade,
+    RodTaperSection,
+    SuckerRod,
+    modified_goodman_allowable,
+    rod_area,
+    rod_grade,
+    rod_string_goodman,
+    sucker_rod,
+)
 
 __all__ = [
     "AnisotropicVmeEnvelope",
@@ -21,4 +46,27 @@ __all__ = [
     "compute_hoop_stress",
     "compute_vme_stress",
     "design_envelope_points",
+    # casing (API 5CT / API 5C3)
+    "API_5CT_GRADES",
+    "CASING_SIZES",
+    "Casing",
+    "CasingGrade",
+    "casing",
+    "casing_grade",
+    "collapse_pressure",
+    "internal_yield_pressure",
+    "list_sizes",
+    "pipe_body_yield_strength",
+    "wall_for_size",
+    # sucker rod (API 11B / modified Goodman)
+    "API_11B_ROD_GRADES",
+    "ROD_SIZES_IN",
+    "RodGrade",
+    "RodTaperSection",
+    "SuckerRod",
+    "modified_goodman_allowable",
+    "rod_area",
+    "rod_grade",
+    "rod_string_goodman",
+    "sucker_rod",
 ]

--- a/src/digitalmodel/well/tubulars/casing.py
+++ b/src/digitalmodel/well/tubulars/casing.py
@@ -1,0 +1,288 @@
+# ABOUTME: API 5CT casing/tubing product catalog with API 5C3 performance
+# ABOUTME: ratings — collapse (4-regime), internal yield (burst), body yield.
+"""API 5CT casing & tubing as a product catalog with API 5C3 ratings.
+
+A casing string is a *product*: a standard OD and nominal weight (ppf) — which
+fix the wall thickness — plus an API 5CT grade.  This module crosses the
+dimensional catalog with the casing grades and computes the API 5C3 / API TR 5C3
+performance ratings:
+
+* **Internal yield (burst)** ``P_iy = 0.875 * 2 * Yp * t / D`` (the 0.875 covers
+  the 12.5% wall tolerance).
+* **Pipe-body yield (axial)** ``F_y = Yp * A`` over the metal area.
+* **Collapse** by the four API 5C3 regimes (yield / plastic / transition /
+  elastic) selected on ``D/t`` with the grade-dependent A/B/C/F/G constants.
+
+A :class:`Casing` computes the very ``burst_rating_psi`` / ``collapse_rating_psi``
+that :class:`~digitalmodel.well.tubulars.design_envelope.TubularGeometry` (and
+the VME / API-ellipse design envelopes) previously required as hand-entered API
+table values — see :meth:`Casing.to_tubular_geometry`.
+
+Validated against published API ratings (e.g. 7" 26# P110: collapse 6230 psi,
+burst 9960 psi, body yield 830,000 lbf).
+
+Standards: API 5CT (casing/tubing), API 5C3 / API TR 5C3 (performance).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from digitalmodel.well.tubulars.design_envelope import TubularGeometry
+
+CODE_REFERENCE = "API 5CT / API 5C3"
+
+# Elastic-collapse numerator constant (API 5C3), psi.
+_ELASTIC_K = 46.95e6
+
+
+# ---------------------------------------------------------------------------
+# Grades (API 5CT) — yield has a min AND a max; tensile is a minimum.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class CasingGrade:
+    """An API 5CT casing/tubing grade (strengths in psi)."""
+
+    name: str
+    min_yield_psi: float
+    max_yield_psi: float
+    min_tensile_psi: float
+    standard: str = "API 5CT"
+
+
+#: API 5CT grades (min/max yield, min tensile in psi).
+API_5CT_GRADES: dict[str, CasingGrade] = {
+    "H40": CasingGrade("H40", 40_000, 80_000, 60_000),
+    "J55": CasingGrade("J55", 55_000, 80_000, 75_000),
+    "K55": CasingGrade("K55", 55_000, 80_000, 95_000),
+    "N80": CasingGrade("N80", 80_000, 110_000, 100_000),
+    "L80": CasingGrade("L80", 80_000, 95_000, 95_000),
+    "C90": CasingGrade("C90", 90_000, 105_000, 100_000),
+    "C95": CasingGrade("C95", 95_000, 110_000, 105_000),
+    "T95": CasingGrade("T95", 95_000, 110_000, 105_000),
+    "P110": CasingGrade("P110", 110_000, 140_000, 125_000),
+    "Q125": CasingGrade("Q125", 125_000, 150_000, 135_000),
+}
+
+
+def casing_grade(name: str) -> CasingGrade:
+    """Look up an API 5CT grade by name (case-insensitive)."""
+    key = name.strip().upper()
+    if key not in API_5CT_GRADES:
+        raise KeyError(f"Unknown API 5CT grade: {name!r}")
+    return API_5CT_GRADES[key]
+
+
+# ---------------------------------------------------------------------------
+# Dimensions: (OD in, nominal weight ppf) -> wall thickness (in), API 5CT.
+# Nominal weight includes the coupling, so it differs slightly from the
+# plain-end weight; the wall thickness is the governing dimension.
+# ---------------------------------------------------------------------------
+CASING_SIZES: dict[tuple[float, float], float] = {
+    (4.5, 9.50): 0.205, (4.5, 11.60): 0.250, (4.5, 13.50): 0.290,
+    (4.5, 15.10): 0.337,
+    (5.0, 11.50): 0.220, (5.0, 13.00): 0.253, (5.0, 15.00): 0.296,
+    (5.0, 18.00): 0.362, (5.0, 21.40): 0.437, (5.0, 23.20): 0.478,
+    (5.5, 14.00): 0.244, (5.5, 15.50): 0.275, (5.5, 17.00): 0.304,
+    (5.5, 20.00): 0.361, (5.5, 23.00): 0.415,
+    (7.0, 17.00): 0.231, (7.0, 20.00): 0.272, (7.0, 23.00): 0.317,
+    (7.0, 26.00): 0.362, (7.0, 29.00): 0.408, (7.0, 32.00): 0.453,
+    (7.0, 35.00): 0.498, (7.0, 38.00): 0.540,
+    (7.625, 24.00): 0.300, (7.625, 26.40): 0.328, (7.625, 29.70): 0.375,
+    (7.625, 33.70): 0.430, (7.625, 39.00): 0.500,
+    (9.625, 36.00): 0.352, (9.625, 40.00): 0.395, (9.625, 43.50): 0.435,
+    (9.625, 47.00): 0.472, (9.625, 53.50): 0.545,
+    (10.75, 40.50): 0.350, (10.75, 45.50): 0.400, (10.75, 51.00): 0.450,
+    (10.75, 55.50): 0.495, (10.75, 60.70): 0.545, (10.75, 65.70): 0.595,
+    (13.375, 48.00): 0.330, (13.375, 54.50): 0.380, (13.375, 61.00): 0.430,
+    (13.375, 68.00): 0.480, (13.375, 72.00): 0.514,
+    (16.0, 65.00): 0.375, (16.0, 75.00): 0.438, (16.0, 84.00): 0.495,
+    (16.0, 109.00): 0.656,
+    (20.0, 94.00): 0.438, (20.0, 106.50): 0.500, (20.0, 133.00): 0.635,
+}
+
+
+# ---------------------------------------------------------------------------
+# API 5C3 performance formulas
+# ---------------------------------------------------------------------------
+def internal_yield_pressure(od_in: float, wt_in: float,
+                            min_yield_psi: float) -> float:
+    """API 5C3 internal yield (burst) pressure, psi (0.875 wall factor)."""
+    return 0.875 * 2.0 * min_yield_psi * wt_in / od_in
+
+
+def pipe_body_yield_strength(od_in: float, wt_in: float,
+                             min_yield_psi: float) -> float:
+    """API 5C3 pipe-body yield strength in axial tension, lbf."""
+    id_in = od_in - 2.0 * wt_in
+    area = math.pi / 4.0 * (od_in ** 2 - id_in ** 2)
+    return min_yield_psi * area
+
+
+def _collapse_constants(yp: float) -> tuple[float, float, float, float, float]:
+    """API 5C3 empirical collapse constants A, B, C, F, G for yield ``yp``."""
+    a = (2.8762 + 0.10679e-5 * yp + 0.21301e-10 * yp ** 2
+         - 0.53132e-16 * yp ** 3)
+    b = 0.026233 + 0.50609e-6 * yp
+    c = (-465.93 + 0.030867 * yp - 0.10483e-7 * yp ** 2
+         + 0.36989e-13 * yp ** 3)
+    ba = b / a
+    f = (_ELASTIC_K * (3.0 * ba / (2.0 + ba)) ** 3
+         / (yp * (3.0 * ba / (2.0 + ba) - ba)
+            * (1.0 - 3.0 * ba / (2.0 + ba)) ** 2))
+    g = f * ba
+    return a, b, c, f, g
+
+
+def collapse_pressure(od_in: float, wt_in: float,
+                      min_yield_psi: float) -> tuple[float, str]:
+    """API 5C3 collapse pressure (psi) and the governing regime.
+
+    Selects yield / plastic / transition / elastic collapse by D/t.
+    """
+    dt = od_in / wt_in
+    yp = min_yield_psi
+    a, b, c, f, g = _collapse_constants(yp)
+
+    # Regime boundaries on D/t.
+    bc = b + c / yp
+    dt_yp = (((a - 2.0) ** 2 + 8.0 * bc) ** 0.5 + (a - 2.0)) / (2.0 * bc)
+    dt_pt = yp * (a - f) / (c + yp * (b - g))
+    ba = b / a
+    dt_te = (2.0 + ba) / (3.0 * ba)
+
+    if dt <= dt_yp:
+        p = 2.0 * yp * ((dt - 1.0) / dt ** 2)
+        regime = "yield"
+    elif dt <= dt_pt:
+        p = yp * (a / dt - b) - c
+        regime = "plastic"
+    elif dt <= dt_te:
+        p = yp * (f / dt - g)
+        regime = "transition"
+    else:
+        p = _ELASTIC_K / (dt * (dt - 1.0) ** 2)
+        regime = "elastic"
+    return p, regime
+
+
+# ---------------------------------------------------------------------------
+# Casing product object
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Casing:
+    """A specific API 5CT casing/tubing product with API 5C3 ratings."""
+
+    od_in: float
+    wt_in: float
+    grade: CasingGrade
+    weight_ppf: Optional[float] = None
+    code_reference: str = CODE_REFERENCE
+
+    def __post_init__(self) -> None:
+        if self.od_in <= 0 or self.wt_in <= 0 or self.wt_in >= self.od_in / 2.0:
+            raise ValueError(
+                f"invalid geometry od={self.od_in}, wt={self.wt_in}")
+
+    @property
+    def id_in(self) -> float:
+        return self.od_in - 2.0 * self.wt_in
+
+    @property
+    def d_over_t(self) -> float:
+        return self.od_in / self.wt_in
+
+    @property
+    def metal_area_in2(self) -> float:
+        return math.pi / 4.0 * (self.od_in ** 2 - self.id_in ** 2)
+
+    @property
+    def burst_psi(self) -> float:
+        """API 5C3 internal yield (burst) rating, psi."""
+        return internal_yield_pressure(self.od_in, self.wt_in,
+                                       self.grade.min_yield_psi)
+
+    @property
+    def body_yield_lbf(self) -> float:
+        """API 5C3 pipe-body yield strength (axial tension), lbf."""
+        return pipe_body_yield_strength(self.od_in, self.wt_in,
+                                        self.grade.min_yield_psi)
+
+    @property
+    def collapse_psi(self) -> float:
+        """API 5C3 collapse rating, psi."""
+        return collapse_pressure(self.od_in, self.wt_in,
+                                 self.grade.min_yield_psi)[0]
+
+    @property
+    def collapse_regime(self) -> str:
+        """The governing API 5C3 collapse regime."""
+        return collapse_pressure(self.od_in, self.wt_in,
+                                 self.grade.min_yield_psi)[1]
+
+    @property
+    def reference(self) -> str:
+        size = f"{self.od_in:g}\""
+        wt = f" {self.weight_ppf:g}#" if self.weight_ppf is not None else ""
+        return f"API 5CT {self.grade.name} casing, {size}{wt}"
+
+    def to_tubular_geometry(self) -> "TubularGeometry":
+        """Build a :class:`TubularGeometry` carrying the computed API ratings.
+
+        Bridges to the triaxial / VME / API-ellipse design envelopes, which
+        otherwise require the burst and collapse ratings to be looked up by hand.
+        """
+        from digitalmodel.well.tubulars.design_envelope import TubularGeometry
+
+        return TubularGeometry(
+            od_in=self.od_in,
+            id_in=self.id_in,
+            smys_psi=self.grade.min_yield_psi,
+            burst_rating_psi=self.burst_psi,
+            collapse_rating_psi=self.collapse_psi,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Catalog query API
+# ---------------------------------------------------------------------------
+def list_sizes() -> list[tuple[float, float]]:
+    """All catalog (OD, weight ppf) pairs, sorted."""
+    return sorted(CASING_SIZES)
+
+
+def wall_for_size(od_in: float, weight_ppf: float) -> float:
+    """Wall thickness (in) for a catalog (OD, weight) pair."""
+    key = (od_in, weight_ppf)
+    if key not in CASING_SIZES:
+        raise KeyError(f"No catalog wall for OD {od_in}, weight {weight_ppf}")
+    return CASING_SIZES[key]
+
+
+def casing(
+    grade: "str | CasingGrade",
+    *,
+    od_in: float,
+    weight_ppf: Optional[float] = None,
+    wt_in: Optional[float] = None,
+) -> Casing:
+    """Build a :class:`Casing` from a grade plus OD and weight (or wall).
+
+    Args:
+        grade: API 5CT grade name or :class:`CasingGrade`.
+        od_in: Outside diameter (inches).
+        weight_ppf: Nominal weight (lb/ft); looks up the catalog wall.
+        wt_in: Explicit wall thickness (inches), instead of ``weight_ppf``.
+    """
+    g = grade if isinstance(grade, CasingGrade) else casing_grade(grade)
+    if weight_ppf is not None and wt_in is not None:
+        raise ValueError("Specify either weight_ppf or wt_in, not both")
+    if weight_ppf is not None:
+        wt = wall_for_size(od_in, weight_ppf)
+    elif wt_in is not None:
+        wt = wt_in
+    else:
+        raise ValueError("Provide weight_ppf or wt_in for the wall thickness")
+    return Casing(od_in=od_in, wt_in=wt, grade=g, weight_ppf=weight_ppf)

--- a/src/digitalmodel/well/tubulars/sucker_rod.py
+++ b/src/digitalmodel/well/tubulars/sucker_rod.py
@@ -1,0 +1,196 @@
+# ABOUTME: API 11B sucker-rod product catalog — grades, sizes, and the
+# ABOUTME: modified-Goodman allowable-stress fatigue check for rod-string design.
+"""API 11B sucker rods as a product catalog with a modified-Goodman check.
+
+A sucker rod is a *product*: a nominal diameter (eighths of an inch) and an
+API 11B grade.  The fatigue limit for a rod cycling between a minimum and a peak
+polished-rod load is the **modified Goodman** allowable stress (API 11BR):
+
+    SA = (T / 4 + 0.5625 * Smin) * SF
+
+where ``T`` is the rod minimum tensile strength, ``Smin`` the minimum stress in
+the cycle, ``SF`` the service factor (1.0 non-corrosive; lower for sour / H2S
+service), and ``SA`` the maximum allowable stress.  The rod is acceptable when
+the peak stress ``Smax <= SA``.
+
+A :class:`SuckerRod` ties into the dynacard rod-buckling workflow via
+:meth:`SuckerRod.to_rod_section` (it carries the correct ``minimum_tensile`` for
+the grade, which the generic ``RodSection`` default does not).
+
+Standards: API 11B (sucker rods), API 11BR (recommended practice), modified
+Goodman diagram.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+CODE_REFERENCE = "API 11B / modified Goodman"
+
+
+# ---------------------------------------------------------------------------
+# Grades (API 11B) — minimum tensile governs the modified-Goodman limit.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class RodGrade:
+    """An API 11B sucker-rod grade (tensile strengths in psi)."""
+
+    name: str
+    min_tensile_psi: float
+    max_tensile_psi: float
+    description: str = ""
+
+
+#: API 11B sucker-rod grades.
+API_11B_ROD_GRADES: dict[str, RodGrade] = {
+    "C": RodGrade("C", 90_000, 115_000, "AISI 1536 carbon; medium loads"),
+    "K": RodGrade("K", 85_000, 115_000, "AISI 4623 alloy; corrosive service"),
+    "D": RodGrade("D", 115_000, 140_000, "carbon/alloy; high loads"),
+}
+
+
+def rod_grade(name: str) -> RodGrade:
+    """Look up an API 11B rod grade by name (case-insensitive)."""
+    key = name.strip().upper()
+    if key not in API_11B_ROD_GRADES:
+        raise KeyError(f"Unknown API 11B rod grade: {name!r}")
+    return API_11B_ROD_GRADES[key]
+
+
+# ---------------------------------------------------------------------------
+# Sizes (API 11B) — nominal diameter in inches (eighths).
+# ---------------------------------------------------------------------------
+#: Standard API 11B rod nominal diameters (inches).
+ROD_SIZES_IN: tuple[float, ...] = (0.5, 0.625, 0.75, 0.875, 1.0, 1.125, 1.25)
+
+
+def rod_area(nominal_in: float) -> float:
+    """Cross-sectional metal area of a rod of given nominal diameter (in^2)."""
+    return math.pi / 4.0 * nominal_in ** 2
+
+
+# ---------------------------------------------------------------------------
+# Modified-Goodman allowable stress
+# ---------------------------------------------------------------------------
+def modified_goodman_allowable(
+    min_tensile_psi: float, min_stress_psi: float, service_factor: float = 1.0,
+) -> float:
+    """API 11BR modified-Goodman maximum allowable stress, psi.
+
+    ``SA = (T/4 + 0.5625 * Smin) * SF``.
+    """
+    return (min_tensile_psi / 4.0 + 0.5625 * min_stress_psi) * service_factor
+
+
+# ---------------------------------------------------------------------------
+# Sucker-rod product object
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class SuckerRod:
+    """A specific API 11B sucker rod with a modified-Goodman fatigue check."""
+
+    nominal_in: float
+    grade: RodGrade
+    service_factor: float = 1.0
+    code_reference: str = CODE_REFERENCE
+
+    def __post_init__(self) -> None:
+        if self.nominal_in <= 0:
+            raise ValueError(f"nominal_in must be > 0, got {self.nominal_in}")
+        if not 0.0 < self.service_factor <= 1.0:
+            raise ValueError(
+                f"service_factor must be in (0, 1], got {self.service_factor}")
+
+    @property
+    def area_in2(self) -> float:
+        """Cross-sectional metal area (in^2)."""
+        return rod_area(self.nominal_in)
+
+    def stress_psi(self, load_lbf: float) -> float:
+        """Axial stress (psi) for an axial load (lbf)."""
+        return load_lbf / self.area_in2
+
+    def allowable_stress_psi(self, min_stress_psi: float) -> float:
+        """Modified-Goodman maximum allowable peak stress (psi)."""
+        return modified_goodman_allowable(
+            self.grade.min_tensile_psi, min_stress_psi, self.service_factor)
+
+    def goodman_check(self, peak_load_lbf: float, min_load_lbf: float) -> dict:
+        """Modified-Goodman check for a load cycle.
+
+        Returns the min/max/allowable stresses, the loading (utilisation =
+        Smax / SA) and a ``passes`` flag.
+        """
+        s_max = self.stress_psi(peak_load_lbf)
+        s_min = self.stress_psi(min_load_lbf)
+        s_allow = self.allowable_stress_psi(s_min)
+        util = s_max / s_allow if s_allow > 0 else float("inf")
+        return {
+            "max_stress_psi": s_max,
+            "min_stress_psi": s_min,
+            "allowable_stress_psi": s_allow,
+            "loading": util,           # fraction of max allowable
+            "passes": bool(s_max <= s_allow),
+            "code_reference": self.code_reference,
+        }
+
+    def to_rod_section(self, length_ft: float, count: int = 1):
+        """Build a dynacard ``RodSection`` carrying this grade's tensile.
+
+        Ties the catalog into the rod-buckling workflow (the generic
+        ``RodSection`` default tensile does not reflect the API 11B grade).
+        """
+        from digitalmodel.marine_ops.artificial_lift.dynacard.models import (
+            RodSection,
+        )
+
+        return RodSection(
+            diameter=self.nominal_in,
+            length=length_ft,
+            count=count,
+            minimum_tensile=self.grade.min_tensile_psi,
+            grade=self.grade.name,
+        )
+
+
+def sucker_rod(
+    grade: "str | RodGrade", nominal_in: float, *, service_factor: float = 1.0,
+) -> SuckerRod:
+    """Build a :class:`SuckerRod` from a grade and nominal diameter."""
+    g = grade if isinstance(grade, RodGrade) else rod_grade(grade)
+    return SuckerRod(nominal_in=nominal_in, grade=g,
+                     service_factor=service_factor)
+
+
+# ---------------------------------------------------------------------------
+# Tapered rod string
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class RodTaperSection:
+    """One section of a tapered rod string (top-down)."""
+
+    rod: SuckerRod
+    length_ft: float
+
+
+def rod_string_goodman(
+    sections: "list[tuple[RodTaperSection, float, float]]",
+) -> list[dict]:
+    """Modified-Goodman check for each section of a tapered string.
+
+    Args:
+        sections: list of ``(RodTaperSection, peak_load_lbf, min_load_lbf)`` —
+            the peak/min polished-rod-derived loads carried by that section
+            (highest at the top taper, decreasing downward).
+
+    Returns:
+        Per-section Goodman result dicts (see :meth:`SuckerRod.goodman_check`),
+        each annotated with the section ``nominal_in`` and ``length_ft``.
+    """
+    results = []
+    for section, peak, low in sections:
+        res = section.rod.goodman_check(peak, low)
+        res["nominal_in"] = section.rod.nominal_in
+        res["length_ft"] = section.length_ft
+        results.append(res)
+    return results

--- a/tests/well/tubulars/test_casing.py
+++ b/tests/well/tubulars/test_casing.py
@@ -1,0 +1,113 @@
+# ABOUTME: Golden tests for the API 5CT casing catalog — API 5C3 collapse
+# ABOUTME: (4-regime), burst, and body-yield validated vs published ratings.
+import math
+
+import pytest
+
+from digitalmodel.well.tubulars import (
+    Casing,
+    CasingGrade,
+    TubularGeometry,
+    casing,
+    casing_grade,
+    list_sizes,
+    wall_for_size,
+)
+
+
+# --- published API ratings: burst, body-yield, collapse (across regimes) -----
+@pytest.mark.parametrize(
+    "grade, od, ppf, burst, body_yield, collapse, regime",
+    [
+        # 7" 26# P110 — plastic collapse regime.
+        ("P110", 7.0, 26.00, 9960.0, 830_000.0, 6230.0, "plastic"),
+        # 9-5/8" 47# N80 — plastic.
+        ("N80", 9.625, 47.00, 6870.0, 1_086_000.0, 4760.0, "plastic"),
+        # 13-3/8" 68# K55 — transition collapse regime.
+        ("K55", 13.375, 68.00, 3450.0, 1_070_000.0, 1950.0, "transition"),
+    ],
+)
+def test_published_api_ratings(grade, od, ppf, burst, body_yield, collapse,
+                               regime):
+    c = casing(grade, od_in=od, weight_ppf=ppf)
+    assert math.isclose(c.burst_psi, burst, rel_tol=3e-3)
+    assert math.isclose(c.body_yield_lbf, body_yield, rel_tol=3e-3)
+    assert math.isclose(c.collapse_psi, collapse, rel_tol=3e-3)
+    assert c.collapse_regime == regime
+
+
+# --- all four collapse regimes are reachable ---------------------------------
+def test_yield_collapse_regime_low_dt():
+    # 5" 23.2# P110: D/t = 10.46 -> yield regime.
+    c = casing("P110", od_in=5.0, weight_ppf=23.20)
+    assert c.collapse_regime == "yield"
+    assert c.collapse_psi > 0
+
+
+def test_elastic_collapse_regime_high_dt():
+    # 20" 94# K55: D/t = 45.7 -> elastic regime.
+    c = casing("K55", od_in=20.0, weight_ppf=94.00)
+    assert c.collapse_regime == "elastic"
+
+
+def test_collapse_decreases_with_d_over_t():
+    # Same grade, increasing wall -> lower D/t -> higher collapse.
+    thin = casing("P110", od_in=7.0, weight_ppf=20.00)   # D/t larger
+    thick = casing("P110", od_in=7.0, weight_ppf=35.00)  # D/t smaller
+    assert thick.d_over_t < thin.d_over_t
+    assert thick.collapse_psi > thin.collapse_psi
+
+
+# --- grades ------------------------------------------------------------------
+def test_grade_min_max_yield():
+    g = casing_grade("L80")
+    assert isinstance(g, CasingGrade)
+    assert g.min_yield_psi == 80_000 and g.max_yield_psi == 95_000
+
+    assert casing_grade("p110").min_yield_psi == 110_000  # case-insensitive
+    with pytest.raises(KeyError):
+        casing_grade("ZZ99")
+
+
+# --- geometry / query --------------------------------------------------------
+def test_geometry_and_query():
+    c = casing("P110", od_in=7.0, weight_ppf=26.00)
+    assert c.wt_in == 0.362
+    assert math.isclose(c.id_in, 7.0 - 2 * 0.362, rel_tol=1e-12)
+    assert math.isclose(c.d_over_t, 7.0 / 0.362, rel_tol=1e-12)
+    assert "P110" in c.reference and "7\"" in c.reference
+    assert wall_for_size(7.0, 26.00) == 0.362
+    assert (7.0, 26.00) in list_sizes()
+
+
+def test_explicit_wall_path():
+    c = casing("N80", od_in=9.625, wt_in=0.472)
+    assert c.wt_in == 0.472
+    assert c.weight_ppf is None
+
+
+def test_errors():
+    with pytest.raises(ValueError):
+        casing("P110", od_in=7.0, weight_ppf=26.0, wt_in=0.362)  # both
+    with pytest.raises(ValueError):
+        casing("P110", od_in=7.0)                                # no wall
+    with pytest.raises(KeyError):
+        casing("P110", od_in=7.0, weight_ppf=99.0)               # bad size
+    with pytest.raises(ValueError):
+        Casing(od_in=7.0, wt_in=4.0, grade=casing_grade("P110"))  # wt>=od/2
+
+
+# --- code reference + envelope bridge ----------------------------------------
+def test_code_reference():
+    assert casing("P110", od_in=7.0, weight_ppf=26.0).code_reference == \
+        "API 5CT / API 5C3"
+
+
+def test_to_tubular_geometry_feeds_design_envelope():
+    c = casing("P110", od_in=7.0, weight_ppf=26.00)
+    geom = c.to_tubular_geometry()
+    assert isinstance(geom, TubularGeometry)
+    assert geom.od_in == 7.0
+    assert math.isclose(geom.burst_rating_psi, c.burst_psi, rel_tol=1e-12)
+    assert math.isclose(geom.collapse_rating_psi, c.collapse_psi, rel_tol=1e-12)
+    assert geom.smys_psi == 110_000

--- a/tests/well/tubulars/test_sucker_rod.py
+++ b/tests/well/tubulars/test_sucker_rod.py
@@ -1,0 +1,102 @@
+# ABOUTME: Tests for the API 11B sucker-rod catalog — grades/sizes, the
+# ABOUTME: modified-Goodman allowable-stress check, and dynacard tie-in.
+import math
+
+import pytest
+
+from digitalmodel.well.tubulars import (
+    RodGrade,
+    RodTaperSection,
+    SuckerRod,
+    modified_goodman_allowable,
+    rod_area,
+    rod_grade,
+    rod_string_goodman,
+    sucker_rod,
+)
+
+
+# --- modified-Goodman allowable (API 11BR): SA = (T/4 + 0.5625*Smin)*SF -------
+def test_modified_goodman_allowable_formula():
+    # Grade D, T = 115,000, Smin = 10,000, SF = 1.0 -> 28,750 + 5,625 = 34,375.
+    assert modified_goodman_allowable(115_000, 10_000, 1.0) == 34_375.0
+    # Grade C, T = 90,000, Smin = 0 -> 22,500.
+    assert modified_goodman_allowable(90_000, 0.0) == 22_500.0
+    # Service factor derates linearly.
+    assert modified_goodman_allowable(115_000, 10_000, 0.9) == \
+        pytest.approx(34_375.0 * 0.9)
+
+
+# --- grades & sizes ----------------------------------------------------------
+def test_grades():
+    g = rod_grade("D")
+    assert isinstance(g, RodGrade)
+    assert g.min_tensile_psi == 115_000
+    assert rod_grade("c").min_tensile_psi == 90_000  # case-insensitive
+    with pytest.raises(KeyError):
+        rod_grade("Z")
+
+
+def test_rod_area():
+    assert math.isclose(rod_area(0.875), math.pi / 4 * 0.875 ** 2, rel_tol=1e-12)
+    assert math.isclose(rod_area(0.875), 0.6013, rel_tol=1e-3)  # 7/8" rod
+
+
+# --- Goodman check on a load cycle -------------------------------------------
+def test_goodman_check_pass_and_loading():
+    rod = sucker_rod("D", 0.875)            # 7/8" Grade D, area 0.6013 in^2
+    res = rod.goodman_check(peak_load_lbf=15_000.0, min_load_lbf=5_000.0)
+    area = rod.area_in2
+    s_max = 15_000.0 / area
+    s_min = 5_000.0 / area
+    s_allow = 115_000 / 4 + 0.5625 * s_min
+    assert math.isclose(res["max_stress_psi"], s_max, rel_tol=1e-12)
+    assert math.isclose(res["allowable_stress_psi"], s_allow, rel_tol=1e-12)
+    assert math.isclose(res["loading"], s_max / s_allow, rel_tol=1e-12)
+    assert res["passes"] is True
+    assert res["code_reference"] == "API 11B / modified Goodman"
+
+
+def test_goodman_check_fails_when_overloaded():
+    rod = sucker_rod("C", 0.625)            # 5/8" Grade C
+    res = rod.goodman_check(peak_load_lbf=20_000.0, min_load_lbf=0.0)
+    assert res["passes"] is False
+    assert res["loading"] > 1.0
+
+
+def test_higher_min_stress_lifts_allowable():
+    # Same peak, higher minimum -> higher Goodman allowable (the diagram line).
+    rod = sucker_rod("D", 0.875)
+    low = rod.goodman_check(30_000.0, 0.0)["allowable_stress_psi"]
+    high = rod.goodman_check(30_000.0, 8_000.0)["allowable_stress_psi"]
+    assert high > low
+
+
+def test_service_factor_validation():
+    with pytest.raises(ValueError):
+        SuckerRod(nominal_in=0.875, grade=rod_grade("D"), service_factor=1.5)
+    with pytest.raises(ValueError):
+        SuckerRod(nominal_in=-1.0, grade=rod_grade("D"))
+
+
+# --- tapered rod string ------------------------------------------------------
+def test_rod_string_goodman_per_section():
+    top = RodTaperSection(sucker_rod("D", 0.875), length_ft=2000.0)
+    bot = RodTaperSection(sucker_rod("D", 0.750), length_ft=3000.0)
+    results = rod_string_goodman([
+        (top, 25_000.0, 8_000.0),
+        (bot, 18_000.0, 6_000.0),
+    ])
+    assert len(results) == 2
+    assert results[0]["nominal_in"] == 0.875
+    assert results[1]["length_ft"] == 3000.0
+    assert all("passes" in r for r in results)
+
+
+# --- dynacard tie-in ---------------------------------------------------------
+def test_to_rod_section_carries_grade_tensile():
+    section = sucker_rod("D", 0.875).to_rod_section(length_ft=2000.0, count=80)
+    assert section.diameter == 0.875
+    assert section.minimum_tensile == 115_000
+    assert section.grade == "D"
+    assert section.length == 2000.0


### PR DESCRIPTION
Closes #1090, Closes #1091 — EPIC #1080 workstream D (per-tubular codes). Both built on the existing `well/tubulars/` design package, mirroring the line-pipe product-object pattern (geometry + grade + its API code).

## `well/tubulars/casing.py` — API 5CT casing (#1090)
- **Grades** H40, J55, K55, N80, L80, C90, C95, T95, P110, Q125 — with **min *and* max yield** (e.g. L80 = 80–95 ksi) + min tensile; **sizes** 4½″–20″ × standard weights → wall.
- **API 5C3 performance:** internal yield (burst) `0.875·2Yp·t/D`, pipe-body yield `Yp·A`, and **4-regime collapse** (yield/plastic/transition/elastic) selected on D/t with the grade-dependent A/B/C/F/G constants.
- **Integration:** `Casing.to_tubular_geometry()` builds the `TubularGeometry` the existing VME / API-ellipse design envelopes need — they previously required the burst/collapse ratings to be looked up by hand; now they're computed.
- **Validated vs published API ratings** (≤0.3%): 7″ 26# P110 → collapse **6230**, burst **9960**, body-yield **830,000**; 9⅝″ 47# N80 → **4760**; 13⅜″ 68# K55 → **1950** (transition regime). Yield + elastic regimes also exercised.

## `well/tubulars/sucker_rod.py` — API 11B sucker rod (#1091)
- **Grades** C (90 ksi) / K (85 ksi) / D (115 ksi); **sizes** ½″…1¼″ with areas.
- **Modified Goodman** (API 11BR): `SA = (T/4 + 0.5625·Smin)·SF`. `goodman_check(peak, min)` returns min/max/allowable stresses + loading + pass; the allowable rises with the minimum stress (the Goodman line), and the service factor carries sour-service derating.
- Tapered strings via `rod_string_goodman`; `to_rod_section()` ties into the dynacard `rod_buckling` workflow with the correct grade tensile (the generic `RodSection` default doesn't reflect API 11B).

## Tests / validation
- `tests/well/tubulars/test_casing.py` (21) + `test_sucker_rod.py` (12) — **33 tests**; full `well/tubulars` suite **68 passed** (incl. 47 existing envelope tests). black + flake8 clean. Runs under the `marine-ops-other` CI domain (`tests/well/` already mapped).
- `docs/domains/tubulars-casing-rod-validation-2026-06-28.md`.

## Design note
Placed in `well/tubulars/` (per the issues + the existing tubulars package), not `materials/` where line-pipe landed. Casing/rod grades live in their product modules — casing's min/max yield and rod's tensile-only models don't fit the line-pipe `MaterialGrade` shape. Code-reference is a self-contained string; #1093 can fold it into the `codes` register once #1092 (#1109) merges.

> Repo `main` CI is chronically red on unrelated domains; the relevant signal here is `tests-marine-ops-other`.