### PR TITLE
feat(installation_pamphlet): per-structure splash-zone Hs/Tp envelope (DNV-RP-H103) — T5

### DIFF
--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -55,6 +55,16 @@ BASIS_HUMAN = {
 DEFAULT_OPERATIONS = ["transit", "dp_station_keeping", "heavy_lift"]
 DEFAULT_TP_GRID_S = [6.0, 8.0, 10.0, 12.0, 14.0, 16.0]
 
+# ----------------------------------------------------------------------------
+# Splash-zone (lowering through the wave zone) constants — DNV-RP-H103 (2011)
+# Sec 4 "Lifting through wave zone". Seawater density and g are fixed; the
+# lowering speed and snap/slack-sling margin are documented screening values.
+# ----------------------------------------------------------------------------
+SEAWATER_DENSITY = 1025.0  # kg/m3
+GRAVITY = 9.80665  # m/s2
+SPLASH_V_LOWERING_MS = 0.5  # crane lowering speed through the wave zone (m/s)
+SPLASH_SNAP_DAF = 1.30  # snap / slack-sling margin (DNV-RP-H103 splash-zone DAF)
+
 
 # ---------------------------------------------------------------- loaders
 def load_mudmats(path: str | Path) -> dict[str, dict[str, Any]]:
@@ -211,6 +221,148 @@ def compute_envelopes(
     return env_out
 
 
+# ---------------------------------------------------------------- splash-zone envelope
+def compute_splashzone_envelope(
+    structure: dict[str, Any],
+    tp_grid_s: list[float],
+    v_lowering_ms: float = SPLASH_V_LOWERING_MS,
+    snap_daf: float = SPLASH_SNAP_DAF,
+) -> dict[str, Any]:
+    """Closed-form per-structure splash-zone Hs limit vs Tp (DNV-RP-H103 Sec 4).
+
+    Deterministic, pure (no datetime / random / network). For each peak period
+    ``Tp`` it returns the significant wave height ``Hs`` at which the structure
+    can no longer be lowered through the wave zone without risking a *snap*
+    (slack-sling) load on the hoist wire.
+
+    Wave-zone kinematics (deep-water linear wave theory, DNV-RP-C205 / RP-H103
+    Sec 4.6). A characteristic surface vertical water-particle motion scales with
+    Hs and Tp as
+
+        v_w = pi * Hs / Tp          (vertical particle velocity amplitude, m/s)
+        a_w = 2 * pi^2 * Hs / Tp^2  (vertical particle acceleration amplitude, m/s^2)
+
+    (these are ``omega * zeta_a`` and ``omega^2 * zeta_a`` with omega = 2*pi/Tp and
+    a wave amplitude zeta_a = Hs/2). The crane lowers the object at ``v_lowering``,
+    so the slamming / drag relative velocity is ``v_rel = v_w + v_lowering``.
+
+    Hydrodynamic forces on the object in the splash zone (DNV-RP-H103 Sec 4.6):
+
+        F_slam   = 0.5 * rho * Cs * A_bottom * v_rel^2        (slamming impact)
+        F_drag   = 0.5 * rho * Cd * A_bottom * v_rel^2        (form drag)
+        F_inertia= rho * (1 + Ca) * V * a_w                   (Froude-Krylov + added mass)
+
+    with rho = 1025 kg/m^3, ``Cs``/``Cd``/``Ca`` and ``A_bottom``/``V`` taken from the
+    structure catalog (``hydrodynamic_coefficients``, ``projected_areas.bottom_m2``,
+    ``mass_properties.displaced_volume_m3``).
+
+    Governing (snap / slack-sling) criterion — DNV-RP-H103 Sec 4.6 "snap forces":
+    the hoist wire must stay in tension over the whole motion cycle, i.e. the
+    characteristic upward hydrodynamic force must not exceed the submerged weight
+    reduced by a documented margin::
+
+        F_slam + F_drag + F_inertia  <=  W_sub / snap_daf
+
+    Solving that (a quadratic in Hs, since v_rel is affine in Hs and a_w is linear
+    in Hs) gives the limiting ``Hs(Tp)``. The governing term is whichever of slam /
+    drag / inertia is largest at that limit.
+
+    A future OrcaFlex dynamic lowering run (licensed installation path) is the
+    verification route for these closed-form limits — NOT computed here.
+    """
+    rho = float(SEAWATER_DENSITY)
+    hc = structure["hydrodynamic_coefficients"]
+    cs = float(hc["slamming_coefficient_Cs"])
+    cd = float(hc["drag_coefficient_Cd"])
+    ca = float(hc["added_mass_coefficient_Ca"])
+    a_bottom = float(structure["projected_areas"]["bottom_m2"])
+    mp = structure["mass_properties"]
+    volume = float(mp["displaced_volume_m3"])
+    w_sub_n = float(mp["submerged_weight_kn"]) * 1000.0
+
+    v_low = float(v_lowering_ms)
+    target = w_sub_n / float(snap_daf)  # max allowable upward hydrodynamic force (N)
+
+    k_qs = 0.5 * rho * (cs + cd) * a_bottom  # slam+drag coefficient (x v_rel^2)
+    k_in = rho * (1.0 + ca) * volume  # inertia coefficient (x acceleration)
+
+    hs_by_tp: dict[str, float] = {}
+    gov_by_tp: dict[str, str] = {}
+    for tp in (float(t) for t in tp_grid_s):
+        c1 = math.pi / tp  # v_w = c1 * Hs
+        c2 = 2.0 * math.pi**2 / tp**2  # a_w = c2 * Hs
+        # k_qs*(c1*Hs + v_low)^2 + k_in*c2*Hs = target  ->  a*Hs^2 + b*Hs + c = 0
+        a = k_qs * c1**2
+        b = 2.0 * k_qs * c1 * v_low + k_in * c2
+        c = k_qs * v_low**2 - target
+        disc = b * b - 4.0 * a * c
+        if a <= 0.0 or disc < 0.0:
+            hs = 0.0
+        else:
+            hs = max((-b + math.sqrt(disc)) / (2.0 * a), 0.0)
+        v_rel = c1 * hs + v_low
+        a_w = c2 * hs
+        f_slam = 0.5 * rho * cs * a_bottom * v_rel**2
+        f_drag = 0.5 * rho * cd * a_bottom * v_rel**2
+        f_iner = k_in * a_w
+        gov = max(
+            ((f_slam, "slam"), (f_drag, "drag"), (f_iner, "inertia")),
+            key=lambda x: x[0],
+        )[1]
+        key = f"{round(tp, 1):.1f}"
+        hs_by_tp[key] = round(hs, 2)
+        gov_by_tp[key] = gov
+
+    return {
+        "id": structure.get("id"),
+        "name": structure.get("name"),
+        "submerged_weight_kn": round(w_sub_n / 1000.0, 2),
+        "bottom_area_m2": a_bottom,
+        "daf": float(snap_daf),
+        "v_lowering_ms": v_low,
+        "hs_by_tp": hs_by_tp,
+        "gov_by_tp": gov_by_tp,
+    }
+
+
+def compute_splashzone_set(
+    lifts: list[dict[str, Any]],
+    tp_grid_s: list[float],
+    heavy_lift_env: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Per-structure splash-zone envelopes for every lift carrying hydro data.
+
+    Each lift item may carry a ``catalog_record`` (the full mudmat / structure
+    catalog dict). Items that expose ``hydrodynamic_coefficients`` +
+    ``projected_areas`` + ``mass_properties.displaced_volume_m3`` get a closed-form
+    splash-zone envelope. When ``heavy_lift_env`` (the vessel-motion heavy-lift
+    envelope from :func:`compute_envelopes`) is supplied, each structure also gets
+    a ``combined_hs_by_tp`` = min(vessel heavy-lift limit, structure splash-zone
+    limit) — the governing lowering limit. Deterministic.
+    """
+    out: list[dict[str, Any]] = []
+    hl = (heavy_lift_env or {}).get("hs_by_tp") if heavy_lift_env else None
+    for it in lifts:
+        rec = it.get("catalog_record")
+        if not isinstance(rec, dict):
+            continue
+        if "hydrodynamic_coefficients" not in rec or "projected_areas" not in rec:
+            continue
+        if "displaced_volume_m3" not in (rec.get("mass_properties") or {}):
+            continue
+        env = compute_splashzone_envelope(rec, tp_grid_s)
+        env["item"] = it.get("item")
+        env["kind"] = it.get("kind")
+        if hl:
+            combined: dict[str, float] = {}
+            for key, hs in env["hs_by_tp"].items():
+                v = hl.get(key)
+                combined[key] = round(min(hs, v), 2) if v is not None else hs
+            env["combined_hs_by_tp"] = combined
+        out.append(env)
+    return out
+
+
 # ---------------------------------------------------------------- operability
 def compute_operability(hs_scatter_limits: list[float]) -> list[dict[str, Any]]:
     """Weather-window operability table (% time below each Hs limit)."""
@@ -283,6 +435,7 @@ def build_provenance(
     rao_basis: str,
     vessel_name: str = "BokaLift 2",
     structure_catalog_used: bool = False,
+    splashzone_computed: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
@@ -293,6 +446,11 @@ def build_provenance(
     When ``structure_catalog_used`` is True the T8 task (manifold/PLET structure
     catalog) reflects the real ``subsea_structures.json`` catalog (status
     ``actual``) instead of the retired hardcoded proxy.
+
+    When ``splashzone_computed`` is True the T5 task (per-structure splash-zone
+    envelope) reflects the closed-form DNV-RP-H103 result (status ``actual``,
+    first-principles, like T8) instead of the ``pending`` OrcaFlex placeholder.
+    An OrcaFlex dynamic lowering run remains the future verification upgrade.
     """
     runs = list(completed_runs or [])
     prov = BASIS_PROVENANCE[rao_basis]
@@ -328,10 +486,20 @@ def build_provenance(
             "T4", 3, "Operation envelopes (Hs/Tp)", prov,
             "operation_envelope on T3 RAO", "operation_envelope", basis_run_id,
         ),
-        task(
-            "T5", 3, "Per-structure splash-zone envelope", "pending",
-            "Needs OrcaFlex installation run per structure",
-            "OrcaFlex (licensed) — not yet queued",
+        (
+            task(
+                "T5", 3, "Per-structure splash-zone envelope", "actual",
+                "Closed-form DNV-RP-H103 splash-zone (slamming + drag + added-mass "
+                "inertia, snap / slack-sling criterion) from catalog hydro coefficients",
+                "calculations.compute_splashzone_envelope (closed-form; OrcaFlex "
+                "dynamic run is the future verification path)",
+            )
+            if splashzone_computed
+            else task(
+                "T5", 3, "Per-structure splash-zone envelope", "pending",
+                "Needs OrcaFlex installation run per structure",
+                "OrcaFlex (licensed) — not yet queued",
+            )
         ),
         task(
             "T6", 5, "Weather-window operability", prov,
@@ -381,6 +549,9 @@ def assemble_result(
     """Compose the full deterministic pamphlet ``result`` payload (pure)."""
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
     envelopes = compute_envelopes(rao_basis, operations, tp_grid_s)
+    splashzone = compute_splashzone_set(
+        lifts, tp_grid_s, heavy_lift_env=envelopes.get("heavy_lift")
+    )
     op_table = compute_operability(hs_scatter_limits)
     structure_catalog_used = any(
         str(it.get("source")) == "structure" for it in lifts
@@ -390,6 +561,7 @@ def assemble_result(
         rao_basis,
         vessel_name=vessel_info.get("name", "Installation vessel"),
         structure_catalog_used=structure_catalog_used,
+        splashzone_computed=bool(splashzone),
     )
     return {
         "vessel": vessel_info,
@@ -397,6 +569,7 @@ def assemble_result(
         "daf": float(daf),
         "lifts": lift_rows,
         "envelopes": envelopes,
+        "splashzone": splashzone,
         "tp_grid_s": [float(t) for t in tp_grid_s],
         "rao_basis": rao_basis,
         "rao_provenance": BASIS_PROVENANCE[rao_basis],

--- a/src/digitalmodel/installation/installation_pamphlet/render.py
+++ b/src/digitalmodel/installation/installation_pamphlet/render.py
@@ -349,6 +349,106 @@ def render_pamphlet_html(result: dict[str, Any], generated_label: str | None = N
             )
         return blocks
 
+    SZ = d.get("splashzone") or []
+
+    def splashzone_svg():
+        W, H, ml, mr, mt, mb = 460, 250, 46, 150, 16, 34
+        palette = ["#0a6cbf", "#c0392b", "#0a8f4f", "#8e44ad", "#d98b00", "#16707f"]
+        tmin, tmax = min(TP), max(TP)
+        allhs = [s["hs_by_tp"][f"{float(t):.1f}"] for s in SZ for t in TP]
+        hmax = max(allhs) * 1.15 if allhs else 1.0
+        hmax = max(hmax, 0.5)
+
+        def X(t):
+            return ml + (t - tmin) / (tmax - tmin) * (W - ml - mr)
+
+        def Y(h):
+            return H - mb - h / hmax * (H - mt - mb)
+
+        ticks = [round(hmax * k / 4, 1) for k in range(5)]
+        grid = "".join(
+            f'<line x1="{ml}" y1="{Y(h):.1f}" x2="{W-mr}" y2="{Y(h):.1f}" stroke="#eef2f6"/>'
+            f'<text x="{ml-6}" y="{Y(h)+3:.1f}" font-size="9" text-anchor="end" fill="#5a6b7a">{h:.1f}</text>'
+            for h in ticks
+        )
+        grid += "".join(
+            f'<text x="{X(t):.1f}" y="{H-mb+14:.1f}" font-size="10" text-anchor="middle" fill="#5a6b7a">{t:.0f}</text>'
+            for t in TP
+        )
+        series = ""
+        leg = ""
+        for i, s in enumerate(SZ):
+            col = palette[i % len(palette)]
+            pts = " ".join(f"{X(t):.1f},{Y(s['hs_by_tp'][f'{float(t):.1f}']):.1f}" for t in TP)
+            series += f'<polyline points="{pts}" fill="none" stroke="{col}" stroke-width="2.2"/>'
+            series += "".join(
+                f'<circle cx="{X(t):.1f}" cy="{Y(s["hs_by_tp"][f"{float(t):.1f}"]):.1f}" r="2.6" fill="{col}"/>'
+                for t in TP
+            )
+            ly = mt + 4 + i * 16
+            leg += (
+                f'<line x1="{W-mr+6}" y1="{ly}" x2="{W-mr+24}" y2="{ly}" stroke="{col}" stroke-width="2.6"/>'
+                f'<text x="{W-mr+28}" y="{ly+3}" font-size="9.5" fill="#0f2233">{s["id"] or s["item"]}</text>'
+            )
+        return (
+            f'<svg viewBox="0 0 {W} {H}" width="100%" role="img" aria-label="Splash-zone limiting Hs vs Tp">\n'
+            f'{grid}{series}{leg}\n'
+            f'<text x="{(ml+W-mr)//2}" y="{H-3}" font-size="10" text-anchor="middle" fill="#5a6b7a">Peak period Tp (s)</text>\n'
+            f'<text x="12" y="{H//2}" font-size="10" text-anchor="middle" fill="#5a6b7a" transform="rotate(-90 12 {H//2})">Splash-zone Hs limit (m)</text></svg>'
+        )
+
+    def splashzone_rows():
+        out = ""
+        for s in SZ:
+            govs = list(s["gov_by_tp"].values())
+            gov0 = govs[0] if govs else "—"  # governing term at the shortest (most onerous) Tp
+            cells = "".join(
+                f"<td>{s['hs_by_tp'][f'{float(t):.1f}']:.2f}</td>" for t in TP
+            )
+            out += (
+                f"<tr><td class='l'>{s['item']} <small>(W<sub>sub</sub>={s['submerged_weight_kn']:,.0f} kN, "
+                f"A<sub>b</sub>={s['bottom_area_m2']:.0f} m&sup2;)</small></td>{cells}"
+                f"<td><small>{gov0}</small></td></tr>"
+            )
+        return out
+
+    def splashzone_combined_rows():
+        out = ""
+        for s in SZ:
+            comb = s.get("combined_hs_by_tp")
+            if not comb:
+                continue
+            cells = "".join(f"<td>{comb[f'{float(t):.1f}']:.2f}</td>" for t in TP)
+            out += f"<tr><td class='l'>{s['item']}</td>{cells}</tr>"
+        return out
+
+    def splashzone_block():
+        if not SZ:
+            return ""
+        any_combined = any(s.get("combined_hs_by_tp") for s in SZ)
+        combined_tbl = (
+            "<div class=\"card\"><h3>Governing lowering Hs (m) = min(vessel heavy-lift, splash-zone)</h3>"
+            f"<table><tr><th class='l'>Structure</th>{ehead}</tr>{splashzone_combined_rows()}</table>"
+            "<p class=\"sub\" style=\"margin-top:8px\">Per structure, the lower of the vessel heavy-lift "
+            "motion limit and its own splash-zone limit governs the lower-through-wave-zone go/no-go.</p></div>"
+            if any_combined
+            else ""
+        )
+        return (
+            "<h3 class='oph' style='margin-top:18px'>Per-structure splash-zone limits (DNV-RP-H103)</h3>"
+            "<div class=\"sub\">Closed-form slamming + drag + added-mass inertia vs the snap / slack-sling "
+            "criterion (characteristic upward hydrodynamic force &le; submerged weight / DAF). Hoist wire must "
+            "stay in tension through the wave zone. Future verification: OrcaFlex dynamic lowering run.</div>"
+            "<div class=\"grid\">"
+            "<div class=\"card\"><h3>Splash-zone Hs limit (m)</h3>" + splashzone_svg() + "</div>"
+            "<div class=\"card\"><h3>Limiting Hs (m) by Tp (s) &middot; governing term</h3>"
+            f"<table><tr><th class='l'>Structure</th>{ehead}<th>Gov.</th></tr>{splashzone_rows()}</table>"
+            "<p class=\"sub\" style=\"margin-top:8px\">Header row = Tp (s). \"Gov.\" = governing term at the "
+            "shortest Tp (slam / drag / inertia).</p></div>"
+            "</div>"
+            + (f"<div class=\"grid\" style=\"margin-top:14px\">{combined_tbl}</div>" if combined_tbl else "")
+        )
+
     envelope_note_tail = (
         "These are still parametric — the vessel-specific BokaLift mesh diffraction (when that licensed run completes) replaces them and is expected to widen the limits further."
         if d["rao_provenance"] != "actual"
@@ -478,6 +578,8 @@ Governing limits are <b>seakeeping</b> and <b>station-keeping</b> (&sect;5–6),
 <p class="sub" style="margin-top:8px">Header row = Tp (s).</p></div>
 </div>
 <div class="note"><b>Envelope basis:</b> {d['envelope_proxy']}. {envelope_note_tail}</div>
+
+{splashzone_block()}
 
 <h2>4 &nbsp;Lift Items (reference catalogs)</h2>
 <table><tr><th class="l">Item</th><th>Footprint L&times;W&times;H (m)</th><th>Air mass (te)</th><th>Source</th></tr>

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -138,12 +138,14 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
                 mud_cache = calc.load_mudmats(_config_path(cfg, catalogs["mudmats"]))
             rec = mud_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+            row["catalog_record"] = rec  # feeds the per-structure splash-zone envelope (T5)
         elif it.get("source") == "structure":
             if str_cache is None:
                 str_cache = calc.load_structures(_config_path(cfg, catalogs["structures"]))
             rec = str_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
             row["source"] = "structure"  # flips provenance T8 to the real catalog
+            row["catalog_record"] = rec  # feeds the per-structure splash-zone envelope (T5)
         elif it.get("source") == "jumper":
             if jmp_cache is None:
                 jmp_cache = calc.load_jumpers(_config_path(cfg, catalogs["jumpers"]))

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -174,6 +174,89 @@ def test_golden_catalog_structure_lift_is_defensible(vessel_info):
     assert t8["status"] == "actual"
 
 
+# ---------------------------------------------------------------- splash-zone (T5)
+def test_compute_splashzone_envelope_golden():
+    """Closed-form per-structure splash-zone Hs limit vs Tp (DNV-RP-H103)."""
+    mud = calc.load_mudmats(DATA_DIR / "mudmat_structures.json")
+    env = calc.compute_splashzone_envelope(mud["MUD-S"], calc.DEFAULT_TP_GRID_S)
+    assert env["id"] == "MUD-S"
+    assert env["daf"] == pytest.approx(1.30)
+    hs = env["hs_by_tp"]
+    # positive, golden values (locked with tolerance)
+    assert hs["6.0"] == pytest.approx(2.11, abs=0.02)
+    assert hs["16.0"] == pytest.approx(5.70, abs=0.02)
+    assert all(v > 0 for v in hs.values())
+    # monotone increasing in Tp (longer period -> milder kinematics -> higher Hs)
+    vals = [hs[f"{float(t):.1f}"] for t in calc.DEFAULT_TP_GRID_S]
+    assert vals == sorted(vals)
+    # flat-bottom mudmats are slamming-governed
+    assert set(env["gov_by_tp"].values()) == {"slam"}
+
+
+def test_splashzone_denser_structure_tolerates_higher_hs():
+    """A dense, small-footprint structure tolerates higher Hs than a light,
+    large-area one (the large flat bottom is slamming-limited)."""
+    sub = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    plet = calc.compute_splashzone_envelope(sub["PLET-100"], calc.DEFAULT_TP_GRID_S)
+    tmpl = calc.compute_splashzone_envelope(sub["TMPL-180"], calc.DEFAULT_TP_GRID_S)
+    # PLET-100: W_sub 852 kN over A_b 48 m2 ; SPS template: 1535 kN over 192 m2
+    assert plet["hs_by_tp"]["6.0"] == pytest.approx(2.66, abs=0.02)
+    assert tmpl["hs_by_tp"]["6.0"] == pytest.approx(1.50, abs=0.02)
+    assert plet["hs_by_tp"]["6.0"] > tmpl["hs_by_tp"]["6.0"]
+    assert tmpl["gov_by_tp"]["6.0"] == "slam"
+
+
+def _lifts_with_records():
+    mud = calc.load_mudmats(DATA_DIR / "mudmat_structures.json")
+    sub = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    return [
+        {
+            "item": "Mudmat (small)", "kind": "mudmat",
+            "mass_air_te": mud["MUD-S"]["mass_properties"]["mass_air_te"],
+            "catalog_record": mud["MUD-S"],
+        },
+        {
+            "item": "Production manifold (250 te)", "kind": "structure", "source": "structure",
+            "mass_air_te": sub["MAN-250"]["mass_properties"]["mass_air_te"],
+            "catalog_record": sub["MAN-250"],
+        },
+    ]
+
+
+def test_splashzone_set_in_payload_and_provenance(vessel_info):
+    res = _assemble(vessel_info, _lifts_with_records(), "drillship", runs=[DRILLSHIP_RUN])
+    sz = res["splashzone"]
+    assert [s["id"] for s in sz] == ["MUD-S", "MAN-250"]
+    # combined limit = min(vessel heavy-lift envelope, structure splash-zone) per Tp
+    hl = res["envelopes"]["heavy_lift"]["hs_by_tp"]
+    for s in sz:
+        for k, comb in s["combined_hs_by_tp"].items():
+            assert comb == pytest.approx(min(s["hs_by_tp"][k], hl[k]), abs=0.01)
+    # T5 provenance flips off "pending"
+    t5 = {t["id"]: t for t in res["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "actual"
+    assert t5["status"] != "pending"
+    assert "splash-zone" in t5["basis"].lower()
+
+
+def test_splashzone_renders_section(vessel_info):
+    res = _assemble(vessel_info, _lifts_with_records(), "drillship", runs=[DRILLSHIP_RUN])
+    html = render_pamphlet_html(res, "LBL")
+    assert "Per-structure splash-zone limits (DNV-RP-H103)" in html
+    assert "MUD-S" in html
+    assert "Governing lowering Hs" in html  # combined limit table
+
+
+def test_splashzone_absent_when_no_catalog_records(vessel_info, lifts):
+    """Without catalog records (hand-built lifts), T5 stays pending and the
+    splash-zone section is not rendered — keeps existing goldens green."""
+    res = _assemble(vessel_info, lifts, "barge")
+    assert res["splashzone"] == []
+    t5 = {t["id"]: t for t in res["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "pending"
+    assert "Per-structure splash-zone limits" not in render_pamphlet_html(res, "LBL")
+
+
 # ---------------------------------------------------------------- golden numbers
 def test_golden_barge_transit_hs_and_lift(vessel_info, lifts):
     res = _assemble(vessel_info, lifts, "barge")
@@ -283,8 +366,15 @@ def test_router_on_base_config_writes_artifacts(tmp_path):
     man = next(r for r in result["lifts"] if "manifold" in r["item"].lower())
     assert man["mass_air_te"] == pytest.approx(250.0)
 
+    # the workflow attaches catalog records to mudmat/structure lifts, so the
+    # per-structure splash-zone envelope (T5) is computed and flips off "pending"
+    assert len(result["splashzone"]) >= 4  # 3 mudmats + 1 manifold
+    t5 = {t["id"]: t for t in result["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "actual"
+
     html = html_path.read_text()
     assert "Installation Vessel Pamphlet" in html
+    assert "Per-structure splash-zone limits (DNV-RP-H103)" in html
 
 
 def test_router_is_deterministic_on_base_config(tmp_path):


### PR DESCRIPTION
Closes #1112

Adds a deterministic, closed-form **per-structure splash-zone Hs/Tp envelope** to the `installation_pamphlet` §3, augmenting (not replacing) the vessel-motion-only operation envelopes with a structure-aware lowering-through-wave-zone limit.

## What
- `compute_splashzone_envelope(structure, tp_grid_s)` (pure, in `calculations.py`): per Tp, deep-water linear wave kinematics `v_w = pi*Hs/Tp`, `a_w = 2*pi^2*Hs/Tp^2`; forces `F_slam = 0.5*rho*Cs*A_b*v_rel^2`, `F_drag = 0.5*rho*Cd*A_b*v_rel^2`, `F_inertia = rho*(1+Ca)*V*a_w` (rho=1025, g=9.80665, `v_rel = v_w + 0.5 m/s` lowering). Governing **snap / slack-sling** criterion (DNV-RP-H103 Sec 4.6): `F_slam+F_drag+F_inertia <= W_sub/DAF` (DAF=1.30) — hoist wire must stay in tension. Closed-form quadratic solve for the limiting `Hs(Tp)` + governing term.
- `compute_splashzone_set` computes one envelope per lifted mudmat/structure and a **combined limit = min(vessel heavy-lift envelope, structure splash-zone)** per Tp.
- `workflow.py` attaches the catalog record to mudmat/structure lift items.
- `render.py` adds a §3 sub-block "Per-structure splash-zone limits (DNV-RP-H103)" — SVG + table + combined-limit table (deterministic, generated_label injected).
- Provenance **T5 flips `pending → actual`** (closed-form, first-principles like T8). An OrcaFlex dynamic lowering run remains the documented future verification path.

## Golden values (locked, abs tol 0.02)
- MUD-S: Hs@Tp6 = 2.11 m, Hs@Tp16 = 5.70 m (monotone increasing, slamming-governed)
- PLET-100 (dense/small) Hs@Tp6 = 2.66 m **>** TMPL-180 (light/large-area) 1.50 m — slam-limited ordering

## Tests
5 new tests + extended router integration; **42/42 installation tests pass**; determinism (byte-identical HTML+JSON) preserved.

## Stacking
Stacks on `feat/installation-pamphlet-t8-catalog` (PR #1116), which stacks on #1106. Merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)