### PR TITLE
feat(naval_architecture): hull-girder longitudinal strength (IACS UR S11/S11A) [#1082]

### DIFF
--- a/docs/domains/hull-girder-strength-validation-2026-06-28.md
+++ b/docs/domains/hull-girder-strength-validation-2026-06-28.md
@@ -1,0 +1,75 @@
+# Hull-Girder Longitudinal Strength — Validation Record (2026-06-28)
+
+Backing for `src/digitalmodel/naval_architecture/hull_girder_strength.py`
+(issue #1082, EPIC #1080 workstream A). Combines the still-water bending moment
+(from `loading_computer`) with the IACS UR S11 wave bending moment and checks the
+midship section against yield and a simplified hull-girder ultimate capacity.
+
+## What it computes
+
+| Function | Rule | Output |
+|---|---|---|
+| `wave_coefficient(L)` | IACS UR S11 wave coefficient C | dimensionless |
+| `wave_bending_moment(L, B, Cb)` | S11 hog `+0.19·C·L²·B·Cb`, sag `−0.11·C·L²·B·(Cb+0.7)` | kN·m |
+| `combined_bending_moment(M_sw, wave)` | still-water + wave per condition | kN·m envelope |
+| `section_modulus_check(M, Z, fy)` | yield: σ = M/Z ≤ 175/k | utilisation |
+| `hull_girder_ultimate_moment(Z, σ_U)` | simplified M_U = σ_U·Z | kN·m |
+| `ultimate_strength_check(M_sw, M_wv, M_U)` | S11A: γ_S·M_sw + γ_W·M_wv ≤ M_U/γ_R | utilisation |
+
+Material factor k: 1.00 (235) / 0.78 (315) / 0.72 (355) / 0.68 (390) / 0.62
+(460). S11A partial factors: γ_S = 1.0, γ_W = 1.2, γ_R = 1.1 (overridable).
+Units: moments kN·m (matching `loading_computer.max_bending_kn_m`), Z in m³,
+stress MPa.
+
+## Validation vs the IACS UR S11 rule formula
+
+Wave coefficient at the rule breakpoints: L=90 → 7.7068, L=200 → 9.75, L=300 →
+**10.75** (plateau start), L=350 → **10.75** (plateau end), L=400 → 10.5575.
+
+Worked example — L=200 m, B=32 m, Cb=0.8 (C=9.75, base = C·L²·B = 12,480,000):
+- M_wv,hog = 0.19 · 12,480,000 · 0.8 = **+1,896,960 kN·m**
+- M_wv,sag = −0.11 · 12,480,000 · 1.5 = **−2,059,200 kN·m**
+
+Yield: M = 2.0×10⁶ kN·m over Z = 50 m³ → σ = 40 MPa; AH36 permissible = 175/0.72
+= 243 MPa → utilisation 0.165. All reproduced by the tests.
+
+## Simplification level of the ultimate-strength method (required disclosure)
+
+`hull_girder_ultimate_moment` is a **single-step ("first-collapse")**
+estimate: `M_U = σ_U · Z_compression`, where σ_U is the buckling-reduced
+ultimate compressive stress of the compression flange and the tension flange is
+taken at yield. σ_U is **not** reimplemented here — it is taken from the
+validated DNV-RP-C201 stiffened-panel solver via
+`compression_flange_ultimate_stress(panel, material)` →
+`StiffenedPanelBucklingAnalyzer.check_panel(...).critical_stress`.
+
+This deliberately **omits** what the full IACS UR S11A / CSR **Smith
+incremental-iterative** method captures:
+- progressive collapse of individual stiffener-plate elements along their
+  load-shortening curves;
+- migration of the instantaneous neutral axis as the compression side softens;
+- post-buckling load redistribution to the still-effective elements.
+
+Consequently this M_U is a **preliminary-design figure**, generally a mild
+*over*-estimate of the true ultimate moment; it is not a CSR-compliant capacity.
+A full Smith march over a discretised cross-section is the follow-on (needs the
+section element list, not yet modelled).
+
+## Builds on (no physics reimplemented)
+
+- `naval_architecture/loading_computer.py` — still-water BM (`max_bending_kn_m`).
+- `naval_architecture/compliance.py` — ABS-SVR minimum section-modulus floor
+  (`check_section_modulus`), complementary to the stress-based yield check here.
+- `structural/structural_analysis/panel_buckling.py` — the compression-flange
+  σ_U (DNV-RP-C201, validated).
+- `structural/structural_analysis/models.py` — `MARINE_GRADES` (Grade A / AH36 /
+  EH40) for yields and the material factor.
+
+## Tests
+
+`tests/naval_architecture/test_hull_girder_strength.py` — 14 tests: the S11 wave
+coefficient breakpoints, the wave-BM golden, the combined envelope, material
+factor / permissible stress, yield check (pass + overstress), the simplified
+ultimate moment + S11A partial-factor check (incl. sagging magnitudes), the
+panel-solver integration, and an end-to-end worked example. black + flake8 clean;
+runs under the `naval-architecture` CI domain.

--- a/src/digitalmodel/naval_architecture/hull_girder_strength.py
+++ b/src/digitalmodel/naval_architecture/hull_girder_strength.py
@@ -1,0 +1,240 @@
+# ABOUTME: Hull-girder longitudinal strength — IACS UR S11 wave bending moment,
+# ABOUTME: combined envelope, section-modulus yield, and simplified ultimate (S11A).
+"""Hull-girder longitudinal strength (IACS UR S11 / S11A).
+
+Combines the still-water bending moment (from
+:mod:`digitalmodel.naval_architecture.loading_computer`) with the **wave** bending
+moment per IACS UR S11 and checks the midship section against:
+
+* **Yield** — section-modulus stress ``sigma = M / Z`` against the permissible
+  ``175 / k`` N/mm^2 (``k`` = material factor).
+* **Ultimate** — a *simplified* hull-girder ultimate capacity
+  ``M_U = sigma_U * Z_compression`` with the IACS UR S11A partial-factor format
+  ``gamma_S * M_sw + gamma_W * M_wv <= M_U / gamma_R``.
+
+The simplified ultimate is a single-step ("first collapse") estimate: the
+compression flange reaches its buckling-reduced ultimate stress ``sigma_U``
+(e.g. from the validated stiffened-panel solver,
+:meth:`...panel_buckling.StiffenedPanelBucklingAnalyzer.check_panel` ->
+``critical_stress``) while the tension flange is at yield.  It ignores the
+neutral-axis migration and post-buckling redistribution captured by the full
+Smith incremental-iterative method, so it is a preliminary-design figure, not a
+CSR-compliant M_U.
+
+Units: bending moments in **kN·m** (matching ``loading_computer`` and the S11
+rule), section modulus in **m^3**, stresses in **MPa**.
+
+References: IACS UR S11 (Longitudinal Strength Standard), UR S11A (Longitudinal
+Strength Standard for Container Ships / hull-girder ultimate), UR S34.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+CODE_REFERENCE = "IACS UR S11 / S11A"
+
+# Permissible hull-girder bending stress numerator (N/mm^2): sigma_perm = 175/k.
+_SIGMA_PERM_NUMERATOR = 175.0
+
+# IACS material factor k by specified minimum yield (N/mm^2).
+_MATERIAL_FACTOR_K = {
+    235: 1.00,   # mild steel / Grade A
+    315: 0.78,   # HT32
+    355: 0.72,   # HT36 / AH36
+    390: 0.68,   # HT40 / EH40
+    460: 0.62,   # HT47
+}
+
+# IACS UR S11A partial safety factors (hull-girder ultimate check).
+_GAMMA_S = 1.0   # still-water
+_GAMMA_W = 1.2   # wave
+_GAMMA_R = 1.1   # resistance (capacity)
+
+# kN·m per (MPa * m^3): sigma[MPa]=1e6 Pa; M[N·m]=sigma*Z; /1e3 -> kN·m.
+_KNM_PER_MPA_M3 = 1.0e3
+
+
+# ---------------------------------------------------------------------------
+# Wave bending moment — IACS UR S11
+# ---------------------------------------------------------------------------
+def wave_coefficient(length_m: float) -> float:
+    """IACS UR S11 wave coefficient C for rule length ``length_m`` (m)."""
+    L = length_m
+    if L < 90.0:
+        # Below the S11 range; extrapolate the 90-300 m branch (flagged in docs).
+        return 10.75 - ((300.0 - L) / 100.0) ** 1.5
+    if L <= 300.0:
+        return 10.75 - ((300.0 - L) / 100.0) ** 1.5
+    if L <= 350.0:
+        return 10.75
+    return 10.75 - ((L - 350.0) / 150.0) ** 1.5
+
+
+@dataclass(frozen=True)
+class WaveBendingMoment:
+    """IACS UR S11 vertical wave bending moment amidships (kN·m)."""
+
+    hogging_kn_m: float        # positive
+    sagging_kn_m: float        # negative
+    wave_coefficient: float
+    code_reference: str = CODE_REFERENCE
+
+
+def wave_bending_moment(length_m: float, beam_m: float,
+                        block_coefficient: float) -> WaveBendingMoment:
+    """IACS UR S11 vertical wave bending moment amidships.
+
+    ``M_hog = +0.19 * C * L^2 * B * Cb``;
+    ``M_sag = -0.11 * C * L^2 * B * (Cb + 0.7)`` (kN·m).
+    """
+    c = wave_coefficient(length_m)
+    base = c * length_m ** 2 * beam_m
+    hog = 0.19 * base * block_coefficient
+    sag = -0.11 * base * (block_coefficient + 0.7)
+    return WaveBendingMoment(hogging_kn_m=hog, sagging_kn_m=sag,
+                             wave_coefficient=c)
+
+
+# ---------------------------------------------------------------------------
+# Combined still-water + wave envelope
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class CombinedEnvelope:
+    """Combined still-water + wave bending-moment envelope (kN·m)."""
+
+    hogging_kn_m: float        # positive (M_sw,hog + M_wv,hog)
+    sagging_kn_m: float        # negative (M_sw,sag + M_wv,sag)
+
+
+def combined_bending_moment(
+    msw_hogging_kn_m: float, msw_sagging_kn_m: float, wave: WaveBendingMoment,
+) -> CombinedEnvelope:
+    """Combine still-water (signed) with the S11 wave moment, per condition.
+
+    Hogging adds positive still-water + positive wave; sagging adds the
+    (negative) still-water sag + the (negative) wave sag.
+    """
+    return CombinedEnvelope(
+        hogging_kn_m=msw_hogging_kn_m + wave.hogging_kn_m,
+        sagging_kn_m=msw_sagging_kn_m + wave.sagging_kn_m,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Material factor / permissible stress
+# ---------------------------------------------------------------------------
+def material_factor_k(yield_mpa: float) -> float:
+    """IACS material factor ``k`` for a specified minimum yield (MPa).
+
+    Exact for the tabulated yields (235/315/355/390/460); otherwise the
+    nearest tabulated grade is used.
+    """
+    yi = round(yield_mpa)
+    if yi in _MATERIAL_FACTOR_K:
+        return _MATERIAL_FACTOR_K[yi]
+    nearest = min(_MATERIAL_FACTOR_K, key=lambda y: abs(y - yield_mpa))
+    return _MATERIAL_FACTOR_K[nearest]
+
+
+def permissible_stress(yield_mpa: float) -> float:
+    """IACS permissible hull-girder bending stress ``175 / k`` (MPa)."""
+    return _SIGMA_PERM_NUMERATOR / material_factor_k(yield_mpa)
+
+
+# ---------------------------------------------------------------------------
+# Section-modulus (yield) check
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class SectionModulusCheck:
+    """Hull-girder bending-stress (yield) utilisation."""
+
+    stress_mpa: float
+    permissible_mpa: float
+    utilization: float
+    passes: bool
+    code_reference: str = CODE_REFERENCE
+
+
+def bending_stress_mpa(moment_kn_m: float, section_modulus_m3: float) -> float:
+    """Hull-girder bending stress (MPa) for a moment (kN·m) and Z (m^3)."""
+    return abs(moment_kn_m) / (section_modulus_m3 * _KNM_PER_MPA_M3)
+
+
+def section_modulus_check(
+    moment_kn_m: float, section_modulus_m3: float, yield_mpa: float,
+) -> SectionModulusCheck:
+    """Yield check: bending stress vs the permissible ``175/k``."""
+    sigma = bending_stress_mpa(moment_kn_m, section_modulus_m3)
+    perm = permissible_stress(yield_mpa)
+    return SectionModulusCheck(
+        stress_mpa=sigma, permissible_mpa=perm,
+        utilization=sigma / perm if perm > 0 else float("inf"),
+        passes=bool(sigma <= perm),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hull-girder ultimate strength (simplified) — IACS UR S11A format
+# ---------------------------------------------------------------------------
+def hull_girder_ultimate_moment(
+    section_modulus_m3: float, ultimate_stress_mpa: float,
+) -> float:
+    """Simplified hull-girder ultimate moment ``M_U = sigma_U * Z`` (kN·m).
+
+    ``ultimate_stress_mpa`` is the buckling-reduced ultimate stress of the
+    compression flange (e.g. the panel solver's ``critical_stress``).
+    """
+    return ultimate_stress_mpa * section_modulus_m3 * _KNM_PER_MPA_M3
+
+
+@dataclass(frozen=True)
+class UltimateStrengthCheck:
+    """IACS UR S11A hull-girder ultimate-strength utilisation."""
+
+    design_moment_kn_m: float       # gamma_S*M_sw + gamma_W*M_wv
+    ultimate_capacity_kn_m: float   # M_U
+    factored_capacity_kn_m: float   # M_U / gamma_R
+    utilization: float
+    passes: bool
+    gamma_s: float
+    gamma_w: float
+    gamma_r: float
+    code_reference: str = CODE_REFERENCE
+
+
+def ultimate_strength_check(
+    msw_kn_m: float, mwv_kn_m: float, ultimate_moment_kn_m: float,
+    *, gamma_s: float = _GAMMA_S, gamma_w: float = _GAMMA_W,
+    gamma_r: float = _GAMMA_R,
+) -> UltimateStrengthCheck:
+    """IACS UR S11A check: ``gamma_S*M_sw + gamma_W*M_wv <= M_U / gamma_R``.
+
+    Moments are magnitudes for the governing (hogging or sagging) condition.
+    """
+    design = gamma_s * abs(msw_kn_m) + gamma_w * abs(mwv_kn_m)
+    factored_cap = abs(ultimate_moment_kn_m) / gamma_r
+    return UltimateStrengthCheck(
+        design_moment_kn_m=design,
+        ultimate_capacity_kn_m=abs(ultimate_moment_kn_m),
+        factored_capacity_kn_m=factored_cap,
+        utilization=design / factored_cap if factored_cap > 0 else float("inf"),
+        passes=bool(design <= factored_cap),
+        gamma_s=gamma_s, gamma_w=gamma_w, gamma_r=gamma_r,
+    )
+
+
+def compression_flange_ultimate_stress(panel, material) -> float:
+    """Buckling-reduced ultimate compressive stress (MPa) of a hull flange.
+
+    Thin wrapper over the validated DNV-RP-C201 stiffened-panel solver: returns
+    the governing-mode ``critical_stress`` for use as ``sigma_U`` in
+    :func:`hull_girder_ultimate_moment`.
+    """
+    from digitalmodel.structural.structural_analysis.panel_buckling import (
+        StiffenedPanelBucklingAnalyzer,
+    )
+
+    analyzer = StiffenedPanelBucklingAnalyzer(material)
+    # Probe at the material yield; critical_stress is the capacity (probe-independent).
+    result = analyzer.check_panel(panel, sigma_x=material.yield_strength)
+    return result.critical_stress

--- a/tests/naval_architecture/test_hull_girder_strength.py
+++ b/tests/naval_architecture/test_hull_girder_strength.py
@@ -1,0 +1,138 @@
+# ABOUTME: Golden tests for hull-girder longitudinal strength — IACS UR S11
+# ABOUTME: wave bending, combined envelope, yield, and simplified ultimate (S11A).
+import math
+
+import pytest
+
+from digitalmodel.naval_architecture.hull_girder_strength import (
+    bending_stress_mpa,
+    combined_bending_moment,
+    compression_flange_ultimate_stress,
+    hull_girder_ultimate_moment,
+    material_factor_k,
+    permissible_stress,
+    section_modulus_check,
+    ultimate_strength_check,
+    wave_bending_moment,
+    wave_coefficient,
+)
+
+
+# --- IACS UR S11 wave coefficient C at rule breakpoints ----------------------
+@pytest.mark.parametrize(
+    "L, c",
+    [
+        (90.0, 10.75 - (210.0 / 100.0) ** 1.5),   # 7.7068
+        (200.0, 9.75),
+        (300.0, 10.75),                            # plateau start
+        (350.0, 10.75),                            # plateau end
+        (400.0, 10.75 - (50.0 / 150.0) ** 1.5),    # 10.5575
+    ],
+)
+def test_wave_coefficient(L, c):
+    assert math.isclose(wave_coefficient(L), c, rel_tol=1e-9)
+
+
+# --- IACS UR S11 wave bending moment -----------------------------------------
+def test_wave_bending_moment_golden():
+    w = wave_bending_moment(length_m=200.0, beam_m=32.0, block_coefficient=0.8)
+    # C=9.75; base=9.75*200^2*32=12,480,000.
+    assert math.isclose(w.wave_coefficient, 9.75, rel_tol=1e-9)
+    assert math.isclose(w.hogging_kn_m, 1_896_960.0, rel_tol=1e-9)
+    assert math.isclose(w.sagging_kn_m, -2_059_200.0, rel_tol=1e-9)
+    # Sagging magnitude exceeds hogging (the (Cb+0.7) factor).
+    assert abs(w.sagging_kn_m) > w.hogging_kn_m
+    assert w.code_reference == "IACS UR S11 / S11A"
+
+
+# --- combined still-water + wave envelope ------------------------------------
+def test_combined_envelope():
+    w = wave_bending_moment(200.0, 32.0, 0.8)
+    env = combined_bending_moment(
+        msw_hogging_kn_m=500_000.0, msw_sagging_kn_m=-400_000.0, wave=w)
+    assert math.isclose(env.hogging_kn_m, 500_000.0 + w.hogging_kn_m)
+    assert math.isclose(env.sagging_kn_m, -400_000.0 + w.sagging_kn_m)
+
+
+# --- material factor / permissible stress ------------------------------------
+def test_material_factor_and_permissible():
+    assert material_factor_k(235) == 1.00
+    assert material_factor_k(355) == 0.72        # AH36 / HT36
+    assert material_factor_k(390) == 0.68        # EH40 / HT40
+    assert material_factor_k(360) == 0.72        # nearest tabulated (355)
+    assert math.isclose(permissible_stress(235), 175.0, rel_tol=1e-9)
+    assert math.isclose(permissible_stress(355), 175.0 / 0.72, rel_tol=1e-9)
+
+
+# --- section-modulus (yield) check -------------------------------------------
+def test_bending_stress_and_yield_check():
+    # M = 2e6 kN·m, Z = 50 m^3 -> sigma = 40 MPa.
+    assert math.isclose(bending_stress_mpa(2.0e6, 50.0), 40.0, rel_tol=1e-9)
+
+    chk = section_modulus_check(2.0e6, 50.0, yield_mpa=355.0)
+    assert math.isclose(chk.stress_mpa, 40.0, rel_tol=1e-9)
+    assert math.isclose(chk.permissible_mpa, 175.0 / 0.72, rel_tol=1e-9)
+    assert math.isclose(chk.utilization, 40.0 / (175.0 / 0.72), rel_tol=1e-9)
+    assert chk.passes is True
+
+
+def test_yield_check_fails_when_overstressed():
+    chk = section_modulus_check(20.0e6, 50.0, yield_mpa=355.0)  # 400 MPa > 243
+    assert chk.passes is False
+    assert chk.utilization > 1.0
+
+
+# --- simplified hull-girder ultimate (S11A format) ---------------------------
+def test_ultimate_moment_and_check():
+    # sigma_U = 200 MPa, Z = 50 m^3 -> M_U = 200*50*1000 = 1e7 kN·m.
+    m_u = hull_girder_ultimate_moment(50.0, 200.0)
+    assert math.isclose(m_u, 1.0e7, rel_tol=1e-9)
+
+    chk = ultimate_strength_check(
+        msw_kn_m=1.0e6, mwv_kn_m=2.0e6, ultimate_moment_kn_m=m_u)
+    # design = 1.0*1e6 + 1.2*2e6 = 3.4e6; factored cap = 1e7/1.1 = 9.09e6.
+    assert math.isclose(chk.design_moment_kn_m, 3.4e6, rel_tol=1e-9)
+    assert math.isclose(chk.factored_capacity_kn_m, 1.0e7 / 1.1, rel_tol=1e-9)
+    assert math.isclose(chk.utilization, 3.4e6 / (1.0e7 / 1.1), rel_tol=1e-9)
+    assert chk.passes is True
+    assert chk.gamma_w == 1.2
+
+
+def test_ultimate_check_uses_magnitudes_for_sagging():
+    # Negative (sagging) moments enter as magnitudes.
+    chk = ultimate_strength_check(-1.0e6, -2.0e6, -1.0e7)
+    assert chk.design_moment_kn_m == pytest.approx(3.4e6)
+
+
+# --- integration: compression-flange ultimate stress via panel solver --------
+def test_compression_flange_ultimate_stress_from_panel():
+    from digitalmodel.structural.structural_analysis.models import STEEL_AH36
+    from digitalmodel.structural.structural_analysis.panel_buckling import (
+        StiffenedPanelGeometry,
+        StiffenerGeometry,
+    )
+
+    panel = StiffenedPanelGeometry(
+        plate_length=2400.0, plate_thickness=12.0,
+        stiffener=StiffenerGeometry(
+            web_height=250.0, web_thickness=10.0, flange_width=90.0,
+            flange_thickness=12.0, spacing=800.0, section_type="tee"),
+    )
+    sigma_u = compression_flange_ultimate_stress(panel, STEEL_AH36)
+    assert 0.0 < sigma_u <= STEEL_AH36.yield_strength  # buckling-reduced
+    # Feeds the ultimate moment directly.
+    assert hull_girder_ultimate_moment(40.0, sigma_u) > 0.0
+
+
+# --- end-to-end rule worked example ------------------------------------------
+def test_worked_example_chain():
+    # 200 m / 32 m / Cb 0.8 hull, AH36, Z = 18 m^3, M_sw,sag = -0.6e6 kN·m.
+    w = wave_bending_moment(200.0, 32.0, 0.8)
+    env = combined_bending_moment(0.5e6, -0.6e6, w)
+    # Sagging governs; check yield at the deck and the S11A ultimate.
+    yld = section_modulus_check(env.sagging_kn_m, 18.0, 355.0)
+    assert yld.stress_mpa > 0
+    m_u = hull_girder_ultimate_moment(18.0, 0.85 * 355.0)  # 85% knockdown
+    ult = ultimate_strength_check(0.6e6, abs(w.sagging_kn_m), m_u)
+    assert ult.ultimate_capacity_kn_m == pytest.approx(0.85 * 355.0 * 18.0 * 1e3)
+    assert isinstance(ult.passes, bool)


### PR DESCRIPTION
Closes #1082 — EPIC #1080 workstream A (the top structural item). Global longitudinal strength: combine the still-water bending moment with the IACS UR S11 wave bending moment and check the midship section against yield and a simplified hull-girder ultimate capacity.

## What it adds (`naval_architecture/hull_girder_strength.py`)
- **IACS UR S11 wave BM:** `wave_coefficient(L)` + `wave_bending_moment(L, B, Cb)` → hog `+0.19·C·L²·B·Cb`, sag `−0.11·C·L²·B·(Cb+0.7)` (kN·m).
- **Combined envelope:** `combined_bending_moment(M_sw, wave)` per condition (hog/sag).
- **Yield check:** `section_modulus_check(M, Z, fy)` → σ = M/Z vs permissible `175/k`, with the IACS material factor k (1.00/0.78/0.72/0.68/0.62 by yield band).
- **Simplified ultimate (S11A):** `hull_girder_ultimate_moment(Z, σ_U)` = `σ_U·Z_compression`; `ultimate_strength_check` applies the S11A format `γ_S·M_sw + γ_W·M_wv ≤ M_U/γ_R` (γ_S=1.0, γ_W=1.2, γ_R=1.1).

## Builds on validated modules — no physics reimplemented
- `loading_computer` → still-water BM (`max_bending_kn_m`); `compliance` → ABS min-Z floor; `MARINE_GRADES` → yields.
- **The one nonlinear input — σ_U — is delegated:** `compression_flange_ultimate_stress(panel, material)` is a thin wrapper over the validated DNV-RP-C201 `StiffenedPanelBucklingAnalyzer.check_panel(...).critical_stress`.

## Validation
- 14 tests vs the IACS rule formula: wave coefficient at all breakpoints (L=300/350 → 10.75 plateau), wave-BM golden (L=200/B=32/Cb=0.8 → hog **+1,896,960**, sag **−2,059,200** kN·m), yield + overstress, the ultimate moment + S11A check, the panel-solver integration, and an end-to-end worked example.
- `docs/domains/hull-girder-strength-validation-2026-06-28.md` — **explicitly documents the simplification level**: the single-step "first-collapse" M_U omits neutral-axis migration and post-buckling redistribution captured by the full Smith incremental-iterative method, so it's a preliminary-design figure (mild over-estimate), not a CSR-compliant capacity. A full Smith march (needs the discretised section element list) is the follow-on.

black + flake8 clean; runs under the `naval-architecture` CI domain.

> Repo `main` CI is chronically red on unrelated domains; the relevant signal here is `tests-naval-architecture`.