### PR TITLE
feat(naval_architecture): class-rule scantling checks (min thickness, section modulus) [#1084]

### DIFF
--- a/docs/domains/scantlings-validation-2026-06-28.md
+++ b/docs/domains/scantlings-validation-2026-06-28.md
@@ -1,0 +1,60 @@
+# Class-Rule Scantling Checks — Validation Record (2026-06-28)
+
+Backing for `src/digitalmodel/naval_architecture/scantlings.py` (issue #1084,
+EPIC #1080 workstream A). Prescriptive class-rule minimums — the counterpart to
+the buckling utilisation (`structural_analysis.panel_buckling`): "is it thick
+enough / strong enough", not "does it buckle".
+
+Each `check_*` returns the same dict shape as
+`naval_architecture/compliance.py` (`name / code / pass / value / required /
+unit`), so the scantling checks aggregate with the other compliance checks.
+
+## Checks & formulas
+
+| Check | Formula | Units |
+|---|---|---|
+| Min plate thickness (by location) | `t_min = (a + b·L)·√(235/ReH)` | mm |
+| Plate thickness (lateral pressure) | `t = 15.8·k_a·s·√p/√σ + t_k` | mm |
+| Min stiffener section modulus | `Z = 1000·p·s·l²/(m·σ)` | cm³ |
+
+with `k_a = (1.1 − 0.25·s/l)² ≤ 1.0` (aspect factor), `s` = spacing (m), `l` =
+span (m), `p` = lateral pressure (kN/m²), `σ` = permissible bending stress
+(N/mm²), `m` = 12 (clamped) / 8 (simply supported), `t_k` = corrosion addition.
+
+## Validation (hand-computed against the rule formulas)
+
+- **Aspect factor:** square plate (s=l) → `k_a = (1.1−0.25)² = 0.7225`;
+  s=2/l=2.5 → `(1.1−0.2)² = 0.81`; s=0.8/l=2.5 → 1.0404 → **capped at 1.0**.
+- **Plate (pressure):** s=0.8, l=2.5 (k_a=1.0), p=100, σ=160 →
+  `t = 15.8·0.8·√100/√160 = 9.99 mm`.
+- **Section modulus:** same inputs, m=12 →
+  `Z = 1000·100·0.8·2.5²/(12·160) = 260.4 cm³`; m=8 (simply supported) is 1.5×
+  larger.
+- **Min thickness:** L=150, bottom (5.0 + 0.04·L) → 11.0 mm; AH36 (355 MPa) →
+  `11.0·√(235/355) = 8.95 mm`.
+
+## Simplification / scope disclosure
+
+The **lateral-pressure plate thickness and stiffener section modulus** are the
+rigorous, formula-validated core (the DNV/IACS forms). The **location minimum
+thickness** uses representative DNV-RU-SHIP general coefficients (keel/bottom/
+side/deck/tank-top/bulkhead); the exact rule table (edition- and ship-type-
+specific, e.g. IACS CSR bulk carriers vs tankers) should be consulted for a class
+submission, and the coefficients are overridable. The permissible stress `σ` is a
+caller input (it depends on location and load case), not hard-coded.
+
+## Builds on
+
+Generalises the single ABS hull-girder section-modulus check in
+`naval_architecture/compliance.py` (`check_section_modulus`) to local
+plate/stiffener scantlings, in the same dict-check style. Complements the
+buckling utilisation from `structural_analysis.panel_buckling` and the
+hull-girder longitudinal-strength checks (#1082).
+
+## Tests
+
+`tests/naval_architecture/test_scantlings.py` — 9 tests: aspect factor (incl.
+cap), plate thickness for pressure (+ corrosion addition), section modulus
+(clamped vs simply supported), location minimum thickness (+ material scaling),
+material factor, and the compliance-style pass/fail dicts. black + flake8 clean;
+runs under the `naval-architecture` CI domain.

--- a/src/digitalmodel/naval_architecture/scantlings.py
+++ b/src/digitalmodel/naval_architecture/scantlings.py
@@ -1,0 +1,148 @@
+# ABOUTME: Class-rule scantling minimums — minimum plate thickness, plate
+# ABOUTME: thickness for lateral pressure, and minimum stiffener section modulus.
+"""Prescriptive class-rule scantling checks (DNV-RU-SHIP / IACS CSR style).
+
+These are the *prescriptive* minimums — distinct from, and complementary to, the
+buckling utilisation (`structural_analysis.panel_buckling`). They answer "is the
+plate thick enough / the stiffener strong enough" per the rule formulas, not "does
+it buckle".
+
+Checks (each returns the same dict shape as
+:mod:`digitalmodel.naval_architecture.compliance` — ``name / code / pass /
+value / required / unit`` — so they aggregate with the other compliance checks):
+
+* **Minimum plate thickness** by location (keel / bottom / side / deck / …):
+  ``t_min = (a + b*L) * sqrt(235/ReH)`` (mm).
+* **Plate thickness for lateral pressure** (DNV):
+  ``t = 15.8 * k_a * s * sqrt(p) / sqrt(sigma) + t_k`` (mm), with the aspect
+  factor ``k_a = (1.1 - 0.25 s/l)^2 <= 1.0``.
+* **Minimum stiffener section modulus** by span & lateral pressure:
+  ``Z = 1000 * p * s * l^2 / (m * sigma)`` (cm^3), bending factor ``m`` (12
+  clamped / 8 simply supported).
+
+``s`` = stiffener spacing (m), ``l`` = stiffener span (m), ``p`` = design lateral
+pressure (kN/m^2), ``sigma`` = permissible bending stress (N/mm^2).
+
+References: DNV-RU-SHIP Pt.3, ABS Rules for Steel Vessels, IACS CSR.
+"""
+from __future__ import annotations
+
+import math
+
+CODE_REFERENCE = "DNV-RU-SHIP / IACS CSR"
+
+# Representative DNV-RU-SHIP general minimum-thickness coefficients (a, b) for
+# t_min = (a + b*L) * sqrt(235/ReH) (mm).  Location-specific; the exact rule
+# table should be consulted for a class submission.
+_MIN_THICKNESS_COEFF: dict[str, tuple[float, float]] = {
+    "keel": (7.0, 0.05),
+    "bottom": (5.0, 0.04),
+    "side": (5.0, 0.04),
+    "deck": (5.5, 0.02),
+    "tank_top": (5.5, 0.04),
+    "bulkhead": (5.0, 0.04),
+}
+
+# Default bending-moment factor m for the stiffener section modulus.
+_M_CLAMPED = 12.0
+_M_SIMPLY_SUPPORTED = 8.0
+
+
+def material_factor_f1(yield_mpa: float) -> float:
+    """DNV material factor ``f1 = ReH / 235`` (>= 1 for higher-strength steel)."""
+    return yield_mpa / 235.0
+
+
+# ---------------------------------------------------------------------------
+# Required-value formulas
+# ---------------------------------------------------------------------------
+def minimum_plate_thickness(length_m: float, location: str,
+                            yield_mpa: float = 235.0) -> float:
+    """DNV general minimum plate thickness for a location (mm).
+
+    ``t_min = (a + b*L) * sqrt(235/ReH)``.  Higher-strength steel reduces the
+    minimum via the ``sqrt(235/ReH)`` factor.
+
+    Raises:
+        KeyError: if ``location`` is not one of the tabulated locations.
+    """
+    key = location.strip().lower()
+    if key not in _MIN_THICKNESS_COEFF:
+        raise KeyError(
+            f"Unknown location {location!r}; choose from "
+            f"{sorted(_MIN_THICKNESS_COEFF)}")
+    a, b = _MIN_THICKNESS_COEFF[key]
+    return (a + b * length_m) * math.sqrt(235.0 / yield_mpa)
+
+
+def plate_aspect_factor(spacing_m: float, span_m: float) -> float:
+    """DNV plate aspect factor ``k_a = (1.1 - 0.25 s/l)^2``, capped at 1.0."""
+    return min(1.0, (1.1 - 0.25 * spacing_m / span_m) ** 2)
+
+
+def plate_thickness_for_pressure(
+    spacing_m: float, span_m: float, pressure_kn_m2: float,
+    permissible_mpa: float, *, corrosion_mm: float = 0.0,
+) -> float:
+    """DNV plate thickness for lateral pressure (mm).
+
+    ``t = 15.8 * k_a * s * sqrt(p) / sqrt(sigma) + t_k``.
+    """
+    ka = plate_aspect_factor(spacing_m, span_m)
+    return (15.8 * ka * spacing_m * math.sqrt(pressure_kn_m2)
+            / math.sqrt(permissible_mpa) + corrosion_mm)
+
+
+def required_section_modulus(
+    spacing_m: float, span_m: float, pressure_kn_m2: float,
+    permissible_mpa: float, *, m_factor: float = _M_CLAMPED,
+) -> float:
+    """Minimum stiffener section modulus for lateral pressure (cm^3).
+
+    ``Z = 1000 * p * s * l^2 / (m * sigma)`` (m = 12 clamped / 8 simply
+    supported).
+    """
+    return (1000.0 * pressure_kn_m2 * spacing_m * span_m ** 2
+            / (m_factor * permissible_mpa))
+
+
+# ---------------------------------------------------------------------------
+# Pass/fail checks (compliance-style dicts)
+# ---------------------------------------------------------------------------
+def check_minimum_plate_thickness(
+    actual_t_mm: float, length_m: float, location: str,
+    yield_mpa: float = 235.0,
+) -> dict:
+    """Check actual plate thickness against the location minimum."""
+    req = minimum_plate_thickness(length_m, location, yield_mpa)
+    return {"name": f"Minimum plate thickness ({location})",
+            "code": CODE_REFERENCE, "pass": bool(actual_t_mm >= req),
+            "value": round(actual_t_mm, 2), "required": round(req, 2),
+            "unit": "mm"}
+
+
+def check_plate_thickness_pressure(
+    actual_t_mm: float, spacing_m: float, span_m: float, pressure_kn_m2: float,
+    permissible_mpa: float, *, corrosion_mm: float = 0.0,
+) -> dict:
+    """Check actual plate thickness against the lateral-pressure requirement."""
+    req = plate_thickness_for_pressure(
+        spacing_m, span_m, pressure_kn_m2, permissible_mpa,
+        corrosion_mm=corrosion_mm)
+    return {"name": "Plate thickness (lateral pressure)",
+            "code": CODE_REFERENCE, "pass": bool(actual_t_mm >= req),
+            "value": round(actual_t_mm, 2), "required": round(req, 2),
+            "unit": "mm"}
+
+
+def check_stiffener_section_modulus(
+    actual_z_cm3: float, spacing_m: float, span_m: float, pressure_kn_m2: float,
+    permissible_mpa: float, *, m_factor: float = _M_CLAMPED,
+) -> dict:
+    """Check actual stiffener section modulus against the rule minimum."""
+    req = required_section_modulus(
+        spacing_m, span_m, pressure_kn_m2, permissible_mpa, m_factor=m_factor)
+    return {"name": "Stiffener section modulus", "code": CODE_REFERENCE,
+            "pass": bool(actual_z_cm3 >= req),
+            "value": round(actual_z_cm3, 1), "required": round(req, 1),
+            "unit": "cm³"}

--- a/tests/naval_architecture/test_scantlings.py
+++ b/tests/naval_architecture/test_scantlings.py
@@ -1,0 +1,93 @@
+# ABOUTME: Golden tests for class-rule scantling checks — minimum plate
+# ABOUTME: thickness, plate thickness for pressure, stiffener section modulus.
+import math
+
+import pytest
+
+from digitalmodel.naval_architecture.scantlings import (
+    check_minimum_plate_thickness,
+    check_plate_thickness_pressure,
+    check_stiffener_section_modulus,
+    material_factor_f1,
+    minimum_plate_thickness,
+    plate_aspect_factor,
+    plate_thickness_for_pressure,
+    required_section_modulus,
+)
+
+
+# --- aspect factor ka = (1.1 - 0.25 s/l)^2, capped at 1.0 --------------------
+def test_plate_aspect_factor():
+    assert math.isclose(plate_aspect_factor(1.0, 1.0), 0.7225, rel_tol=1e-9)
+    assert math.isclose(plate_aspect_factor(2.0, 2.5), 0.81, rel_tol=1e-9)
+    assert plate_aspect_factor(0.8, 2.5) == 1.0  # (1.02)^2 -> capped
+
+
+# --- plate thickness for lateral pressure -----------------------------------
+def test_plate_thickness_for_pressure():
+    # s=0.8, l=2.5 (ka=1.0), p=100 kN/m^2, sigma=160 -> 9.992 mm.
+    t = plate_thickness_for_pressure(0.8, 2.5, 100.0, 160.0)
+    assert math.isclose(t, 15.8 * 0.8 * 10.0 / math.sqrt(160.0), rel_tol=1e-9)
+    assert math.isclose(t, 9.9926, rel_tol=1e-4)
+
+
+def test_plate_thickness_adds_corrosion():
+    base = plate_thickness_for_pressure(0.8, 2.5, 100.0, 160.0)
+    with_corr = plate_thickness_for_pressure(0.8, 2.5, 100.0, 160.0,
+                                             corrosion_mm=1.5)
+    assert math.isclose(with_corr - base, 1.5, rel_tol=1e-9)
+
+
+# --- required stiffener section modulus -------------------------------------
+def test_required_section_modulus():
+    # s=0.8, l=2.5, p=100, sigma=160, m=12 -> 260.42 cm^3.
+    z = required_section_modulus(0.8, 2.5, 100.0, 160.0)
+    assert math.isclose(z, 1000 * 100 * 0.8 * 2.5 ** 2 / (12 * 160), rel_tol=1e-9)
+    assert math.isclose(z, 260.4167, rel_tol=1e-4)
+
+
+def test_section_modulus_simply_supported_is_larger():
+    clamped = required_section_modulus(0.8, 2.5, 100.0, 160.0, m_factor=12.0)
+    ss = required_section_modulus(0.8, 2.5, 100.0, 160.0, m_factor=8.0)
+    assert ss > clamped
+    assert math.isclose(ss / clamped, 12.0 / 8.0, rel_tol=1e-9)
+
+
+# --- minimum plate thickness by location ------------------------------------
+def test_minimum_plate_thickness():
+    # L=150, bottom (5.0 + 0.04L), mild steel -> 11.0 mm.
+    assert math.isclose(minimum_plate_thickness(150.0, "bottom"), 11.0,
+                        rel_tol=1e-9)
+    # Higher-strength steel reduces it by sqrt(235/ReH).
+    ah36 = minimum_plate_thickness(150.0, "bottom", yield_mpa=355.0)
+    assert math.isclose(ah36, 11.0 * math.sqrt(235.0 / 355.0), rel_tol=1e-9)
+    assert ah36 < 11.0
+    with pytest.raises(KeyError):
+        minimum_plate_thickness(150.0, "funnel")
+
+
+def test_material_factor_f1():
+    assert material_factor_f1(235.0) == 1.0
+    assert math.isclose(material_factor_f1(355.0), 355.0 / 235.0, rel_tol=1e-9)
+
+
+# --- compliance-style pass/fail checks --------------------------------------
+def test_check_dicts_shape_and_pass():
+    chk = check_plate_thickness_pressure(12.0, 0.8, 2.5, 100.0, 160.0)
+    assert set(chk) == {"name", "code", "pass", "value", "required", "unit"}
+    assert chk["code"] == "DNV-RU-SHIP / IACS CSR"
+    assert chk["pass"] is True            # 12 >= 9.99
+    assert chk["unit"] == "mm"
+
+    fail = check_plate_thickness_pressure(8.0, 0.8, 2.5, 100.0, 160.0)
+    assert fail["pass"] is False          # 8 < 9.99
+
+
+def test_check_section_modulus_and_min_thickness():
+    z = check_stiffener_section_modulus(300.0, 0.8, 2.5, 100.0, 160.0)
+    assert z["pass"] is True              # 300 >= 260.4
+    assert z["unit"] == "cm³"
+
+    t = check_minimum_plate_thickness(10.0, 150.0, "bottom")
+    assert t["pass"] is False             # 10 < 11.0
+    assert t["required"] == 11.0


### PR DESCRIPTION
Closes #1084 — EPIC #1080 workstream A. Prescriptive class-rule scantling minimums — the **counterpart to** the buckling utilisation (`panel_buckling`): "is it thick/strong enough", not "does it buckle".

## What it adds (`naval_architecture/scantlings.py`)
Same dict-check style as `compliance.py` (`name/code/pass/value/required/unit`), so the scantling checks aggregate with the other compliance checks:
- **Min plate thickness by location** — `t_min = (a + b·L)·√(235/ReH)` (keel/bottom/side/deck/tank-top/bulkhead).
- **Plate thickness for lateral pressure** — DNV `t = 15.8·k_a·s·√p/√σ + t_k`, with `k_a = (1.1 − 0.25·s/l)² ≤ 1.0`.
- **Min stiffener section modulus** — `Z = 1000·p·s·l²/(m·σ)` cm³ (m = 12 clamped / 8 simply supported).
- `check_*` pass/fail wrappers vs the actual scantling.

## Validation (hand-computed vs the rule formulas)
- Aspect factor: square plate → 0.7225; capped at 1.0 for long panels.
- Plate (pressure): s=0.8/l=2.5/p=100/σ=160 → **9.99 mm**.
- Section modulus: same → **260.4 cm³** (simply-supported 1.5× larger).
- Min thickness: L=150 bottom → 11.0 mm; AH36 → `11.0·√(235/355)` = 8.95 mm.

9 tests, black + flake8 clean; runs under the `naval-architecture` CI domain.

## Scope disclosure (in the validation doc)
The lateral-pressure plate-thickness and section-modulus formulas are the **rigorous, formula-validated core**. The **location minimum-thickness** uses representative DNV-RU-SHIP general coefficients (edition-/ship-type-specific exact tables — IACS CSR bulk vs tanker — should be consulted for a class submission, and the coefficients are overridable). Permissible σ is a caller input (depends on location/load case), not hard-coded. Generalises the single ABS hull-girder `compliance.check_section_modulus` to local scantlings; complements #1082 (hull-girder strength).

> Repo `main` CI is chronically red on unrelated domains; the relevant signal here is `tests-naval-architecture`.