### PR TITLE
feat(diffraction): standardized per-structure-type report catalog (#282)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/report_catalog.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_catalog.py
@@ -1,0 +1,192 @@
+"""Standardized per-structure-type diffraction report templates (#282).
+
+The diffraction report *content* (per-DOF RAOs, added mass/damping, hydrostatics,
+roll damping, mesh quality) is already rendered by
+``report_generator.generate_diffraction_report``. What #282 asks for is the
+**standardization layer**: a consistent, acceptance-gated report template per
+hull category (barge / ship / FPSO / LNGC / spar / semi-submersible / TLP).
+
+This module supplies that as a catalog of skeleton-first report templates
+(:class:`~digitalmodel.reporting.skeleton.ReportSkeleton`, #1021): each structure
+type yields the same standard sections, with required vs optional slots tuned to
+what matters for that hull form -- ship-shaped hulls require roll critical
+damping; column-stabilized hulls (spar/semi/TLP) require heave/pitch natural
+periods instead. Analysis fills the slots; completeness is acceptance-gated and
+provenance is mandatory (#1019).
+
+Block keys align with the existing diffraction report section keys so a filled
+report can be assembled from the same builders.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+from digitalmodel.reporting.skeleton import BlockSpec, ReportSkeleton, SectionSpec
+
+
+class StructureType(str, Enum):
+    """Supported OrcaWave hull categories for standardized reporting."""
+
+    BARGE = "barge"
+    SHIP = "ship"
+    FPSO = "fpso"
+    LNGC = "lngc"
+    SPAR = "spar"
+    SEMISUBMERSIBLE = "semisubmersible"
+    TLP = "tlp"
+
+
+# Ship-shaped hulls: roll critical damping governs; column-stabilized hulls:
+# heave/pitch natural periods govern (resonance avoidance).
+_SHIP_SHAPED = frozenset(
+    {StructureType.BARGE, StructureType.SHIP, StructureType.FPSO, StructureType.LNGC}
+)
+_COLUMN_STABILIZED = frozenset(
+    {StructureType.SPAR, StructureType.SEMISUBMERSIBLE, StructureType.TLP}
+)
+
+# Multibody shielding/interaction is a standard consideration for FPSO/LNGC
+# (side-by-side offloading) reports.
+_MULTIBODY_RELEVANT = frozenset({StructureType.FPSO, StructureType.LNGC})
+
+
+def list_structure_types() -> List[str]:
+    """All supported structure-type values."""
+    return [s.value for s in StructureType]
+
+
+def diffraction_report_skeleton(
+    structure_type: StructureType | str,
+) -> ReportSkeleton:
+    """Standardized diffraction report skeleton for a hull category (#282).
+
+    The same sections appear for every type; required vs optional slots are
+    tuned per hull form. Render/check with the skeleton CLI or
+    ``ReportSkeleton.build_html`` / ``.completeness``.
+    """
+    st = StructureType(structure_type)
+    ship_shaped = st in _SHIP_SHAPED
+    column = st in _COLUMN_STABILIZED
+
+    sections = [
+        SectionSpec(
+            key="summary",
+            label="Summary & Identification",
+            blocks=[
+                BlockSpec(
+                    key="executive_summary",
+                    label="Executive summary",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="identification",
+                    label="Vessel & analysis identification",
+                    required=True,
+                ),
+            ],
+        ),
+        SectionSpec(
+            key="geometry",
+            label="Geometry, Mesh & Hydrostatics",
+            blocks=[
+                BlockSpec(
+                    key="mesh_quality",
+                    label="Hull description & mesh quality",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="stability",
+                    label="Hydrostatic properties & stability",
+                    required=True,
+                ),
+            ],
+        ),
+        SectionSpec(
+            key="hydrodynamics",
+            label="Hydrodynamic Results",
+            blocks=[
+                BlockSpec(
+                    key="added_mass_diagonal",
+                    label="Added mass (diagonal)",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="damping_diagonal",
+                    label="Radiation damping (diagonal)",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="load_raos",
+                    label="Wave excitation forces (load RAOs)",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="dof_sections",
+                    label="Displacement RAOs (per DOF)",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="natural_periods",
+                    label="Heave/pitch natural periods",
+                    required=column,
+                    description=(
+                        "Resonance avoidance governs column-stabilized hulls."
+                    ),
+                ),
+                BlockSpec(
+                    key="roll_damping",
+                    label="Roll critical damping analysis",
+                    required=ship_shaped,
+                    description="Governs ship-shaped hulls.",
+                ),
+                BlockSpec(
+                    key="multibody_interaction",
+                    label="Multibody shielding / interaction",
+                    required=False,
+                    description=(
+                        "Side-by-side offloading interaction (FPSO/LNGC)."
+                        if st in _MULTIBODY_RELEVANT
+                        else "Optional for single-body analyses."
+                    ),
+                ),
+            ],
+        ),
+        SectionSpec(
+            key="quality",
+            label="Validation & Assumptions",
+            blocks=[
+                BlockSpec(
+                    key="validation_sanity",
+                    label="Validation sanity check",
+                    required=True,
+                ),
+                BlockSpec(
+                    key="assumptions",
+                    label="Assumption ledger",
+                    required=True,
+                ),
+            ],
+        ),
+    ]
+
+    return ReportSkeleton(
+        title=f"Diffraction analysis report - {st.value}",
+        sections=sections,
+        require_provenance=True,
+    )
+
+
+# Pre-built catalog: structure-type value -> skeleton factory result.
+def report_catalog() -> dict[str, ReportSkeleton]:
+    """All standardized per-structure-type diffraction report skeletons."""
+    return {s.value: diffraction_report_skeleton(s) for s in StructureType}
+
+
+__all__ = [
+    "StructureType",
+    "list_structure_types",
+    "diffraction_report_skeleton",
+    "report_catalog",
+]

--- a/tests/hydrodynamics/diffraction/test_report_catalog.py
+++ b/tests/hydrodynamics/diffraction/test_report_catalog.py
@@ -1,0 +1,83 @@
+"""Tests for the standardized per-structure-type diffraction report catalog (#282)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.report_catalog import (
+    StructureType,
+    diffraction_report_skeleton,
+    list_structure_types,
+    report_catalog,
+)
+from digitalmodel.reporting import Provenance, ReportSkeleton
+
+_CORE_REQUIRED = {
+    "executive_summary",
+    "identification",
+    "mesh_quality",
+    "stability",
+    "added_mass_diagonal",
+    "damping_diagonal",
+    "load_raos",
+    "dof_sections",
+    "validation_sanity",
+    "assumptions",
+}
+
+
+@pytest.mark.parametrize("st", list(StructureType))
+def test_every_structure_type_yields_valid_skeleton(st: StructureType) -> None:
+    sk = diffraction_report_skeleton(st)
+    assert isinstance(sk, ReportSkeleton)
+    assert st.value in sk.title
+    assert sk.require_provenance is True
+    # the standard core required slots are present for every hull type
+    required = set(sk.required_block_keys())
+    assert _CORE_REQUIRED <= required
+
+
+def test_string_structure_type_accepted() -> None:
+    sk = diffraction_report_skeleton("fpso")
+    assert "fpso" in sk.title
+
+
+def test_ship_shaped_requires_roll_damping_not_natural_periods() -> None:
+    for name in ("barge", "ship", "fpso", "lngc"):
+        req = set(diffraction_report_skeleton(name).required_block_keys())
+        assert "roll_damping" in req
+        assert "natural_periods" not in req
+
+
+def test_column_stabilized_requires_natural_periods_not_roll_damping() -> None:
+    for name in ("spar", "semisubmersible", "tlp"):
+        req = set(diffraction_report_skeleton(name).required_block_keys())
+        assert "natural_periods" in req
+        assert "roll_damping" not in req
+
+
+def test_catalog_covers_all_types() -> None:
+    cat = report_catalog()
+    assert set(cat) == set(list_structure_types())
+    assert len(cat) == len(StructureType)
+
+
+def test_skeleton_is_provenance_gated_and_renders_pending() -> None:
+    sk = diffraction_report_skeleton(StructureType.SPAR)
+    # incomplete until required slots filled + provenance declared
+    assert not sk.completeness().complete
+    html = sk.build_html()
+    assert "slot pending (required)" in html
+    assert 'id="natural_periods"' in html  # spar requires it
+
+
+def test_filled_skeleton_with_provenance_is_complete() -> None:
+    sk = diffraction_report_skeleton(StructureType.SHIP)
+    content = {k: f"<p>{k}</p>" for k in sk.required_block_keys()}
+    status = sk.completeness(content, provenance=Provenance().add("spec", "s.yml"))
+    assert status.complete and status.missing_blocks == []
+
+
+def test_unknown_structure_type_rejected() -> None:
+    with pytest.raises(ValueError):
+        diffraction_report_skeleton("submarine")


### PR DESCRIPTION
Advances #282. The diffraction report *content* is already rendered by `generate_diffraction_report` (per-DOF RAOs, added mass/damping, hydrostatics, roll damping, mesh quality); the remaining gap is the **standardization layer** — a consistent, acceptance-gated report template per hull category. Built on the skeleton-first machinery (#1021).

## What
`report_catalog.py`:
- **`StructureType`**: barge / ship / fpso / lngc / spar / semisubmersible / tlp.
- **`diffraction_report_skeleton(structure_type) → ReportSkeleton`** — the same standard sections for every type, with required vs optional slots tuned to the hull form:
  - **ship-shaped** (barge/ship/fpso/lngc) → **roll critical damping required**;
  - **column-stabilized** (spar/semi/TLP) → **heave/pitch natural periods required** (roll optional);
  - FPSO/LNGC → multibody shielding/interaction slot.
  - Block keys align with the existing report section keys, so a filled report assembles from the same builders. **Provenance mandatory** (#1019); **completeness acceptance-gated** (#1021).
- `report_catalog()` / `list_structure_types()`.

## Verification
- +14 tests (every type valid + core required slots present, ship-shaped vs column-stabilized slot rules, catalog coverage, provenance-gating, completeness path).
- black/isort/flake8 clean.

This delivers #282's per-hull-type standardized templates; live per-type plot-filling reuses the existing diffraction builders (follow-up wiring). Leaving #282 open for that wiring unless you'd prefer to close it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)