### PR TITLE
feat(installation_pamphlet): real-RAO artifact ingestion for vessel basis — advances T3 (#1111)

### DIFF
--- a/examples/demos/gtm/data/subsea_structures.json
+++ b/examples/demos/gtm/data/subsea_structures.json
@@ -1,0 +1,162 @@
+{
+  "_description": "Subsea production structure catalog (PLET / production manifold / SPS template) for GTM demo 3 (installation analysis). Representative reference structures retiring the hardcoded 250 te 'Manifold/PLET proxy' in the installation_pamphlet workflow. Values are computed from first principles and are REPRESENTATIVE engineering references, not a specific project deliverable; verify against project-specific weight reports before marine-warranty use.",
+  "_version": "1.0",
+  "_references": [
+    "DNV-RP-H103 (2011) - Modelling and Analysis of Marine Operations, Sec 4 (Lifting through wave zone)",
+    "DNV-ST-N001 (2021) - Marine Operations and Marine Warranty",
+    "DNV-RP-C205 (2010) - Environmental Conditions and Environmental Loads"
+  ],
+  "units": {
+    "length": "m",
+    "mass": "kg",
+    "force": "N",
+    "area": "m2",
+    "pressure": "Pa"
+  },
+  "constants": {
+    "seawater_density_kg_m3": 1025,
+    "gravity_m_s2": 9.80665,
+    "steel_density_kg_m3": 7850,
+    "_note": "Submerged weight = (mass_air - displaced_water_mass) * g. Subsea production structures are open-framed steel boxes on an integral mudmat base; the displaced volume that generates buoyancy is taken as the steel volume (mass_air / steel_density), i.e. no trapped-air buoyancy is credited (conservative for submerged weight)."
+  },
+  "structures": [
+    {
+      "id": "PLET-100",
+      "name": "PLET-100te",
+      "description": "Pipeline End Termination (PLET) - open-frame steel structure with integral mudmat base, connecting a pipeline to a manifold/jumper. Representative ~100 te unit.",
+      "geometry": {
+        "length_m": 8.0,
+        "width_m": 6.0,
+        "height_m": 4.0,
+        "bottom_plate_thickness_mm": 25,
+        "skirt_depth_m": 0.4,
+        "skirt_thickness_mm": 14
+      },
+      "mass_properties": {
+        "mass_air_kg": 100000,
+        "mass_air_te": 100.0,
+        "displaced_volume_m3": 12.74,
+        "buoyancy_force_kn": 128.06,
+        "submerged_weight_kn": 852.6,
+        "_note": "Displaced volume = mass_air / 7850 = 12.74 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 2.0,
+        "_note": "Relative to geometric centre of bottom plate; taken at mid-height for a roughly uniform frame"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (applied to the integral mudmat base / solid panels; open-frame members experience less). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass (added mass = rho * volume * Ca)."
+      },
+      "projected_areas": {
+        "bottom_m2": 48.0,
+        "side_long_m2": 32.0,
+        "side_short_m2": 24.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 8 x 6. side_long = L x H = 8 x 4. side_short = W x H = 6 x 4."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 10.0,
+        "hook_height_above_cog_m": 9.5,
+        "_note": "4-point lift with spreader frame typical"
+      }
+    },
+    {
+      "id": "MAN-250",
+      "name": "Manifold-250te",
+      "description": "Subsea production manifold - open-frame steel structure with integral mudmat base, flowline/header piping, valves and connection hubs. Representative ~250 te unit (retires the 250 te installation_pamphlet proxy).",
+      "geometry": {
+        "length_m": 14.0,
+        "width_m": 12.0,
+        "height_m": 6.0,
+        "bottom_plate_thickness_mm": 30,
+        "skirt_depth_m": 0.5,
+        "skirt_thickness_mm": 16
+      },
+      "mass_properties": {
+        "mass_air_kg": 250000,
+        "mass_air_te": 250.0,
+        "displaced_volume_m3": 31.85,
+        "buoyancy_force_kn": 320.15,
+        "submerged_weight_kn": 2131.51,
+        "_note": "Displaced volume = mass_air / 7850 = 31.85 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 3.2,
+        "_note": "Relative to geometric centre of bottom plate; slightly above mid-height (3.0 m) to reflect topside-mounted valves/equipment"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (mudmat base + solid roof/equipment panels). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass."
+      },
+      "projected_areas": {
+        "bottom_m2": 168.0,
+        "side_long_m2": 84.0,
+        "side_short_m2": 72.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 14 x 12. side_long = L x H = 14 x 6. side_short = W x H = 12 x 6."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 18.0,
+        "hook_height_above_cog_m": 17.0,
+        "_note": "4-point lift with heavy spreader frame; may require custom rigging design"
+      }
+    },
+    {
+      "id": "TMPL-180",
+      "name": "SPS-Template-180te",
+      "description": "Subsea production system (SPS) drilling/production template - multi-slot open-frame structure with integral mudmat base providing well-slot guidance and structural support. Representative ~180 te unit.",
+      "geometry": {
+        "length_m": 16.0,
+        "width_m": 12.0,
+        "height_m": 5.0,
+        "bottom_plate_thickness_mm": 30,
+        "skirt_depth_m": 0.5,
+        "skirt_thickness_mm": 16
+      },
+      "mass_properties": {
+        "mass_air_kg": 180000,
+        "mass_air_te": 180.0,
+        "displaced_volume_m3": 22.93,
+        "buoyancy_force_kn": 230.49,
+        "submerged_weight_kn": 1534.71,
+        "_note": "Displaced volume = mass_air / 7850 = 22.93 m3 (steel volume, open frame, no trapped-air buoyancy). buoyancy = vol*1025*9.80665; submerged = (mass_air - vol*1025)*9.80665. buoyancy + submerged = mass_air*g."
+      },
+      "centre_of_gravity": {
+        "x_m": 0.0,
+        "y_m": 0.0,
+        "z_m": 2.5,
+        "_note": "Relative to geometric centre of bottom plate; taken at mid-height for a roughly uniform frame"
+      },
+      "hydrodynamic_coefficients": {
+        "slamming_coefficient_Cs": 5.0,
+        "drag_coefficient_Cd": 2.0,
+        "added_mass_coefficient_Ca": 1.0,
+        "_note": "Cs=5.0 conservative flat-bottom slamming bound per DNV-RP-H103 Table 4-1 (integral mudmat base). Cd=2.0 sharp-edged structural members per DNV-RP-C205. Ca=1.0 flat-plate added mass."
+      },
+      "projected_areas": {
+        "bottom_m2": 192.0,
+        "side_long_m2": 80.0,
+        "side_short_m2": 60.0,
+        "_note": "Gross bounding profile areas (conservative for splash-zone slamming/drag). Bottom = L x W = 16 x 12. side_long = L x H = 16 x 5. side_short = W x H = 12 x 5."
+      },
+      "rigging": {
+        "number_of_slings": 4,
+        "sling_angle_deg": 60,
+        "sling_length_m": 20.0,
+        "hook_height_above_cog_m": 19.0,
+        "_note": "4-point lift with heavy spreader frame; may require custom rigging design"
+      }
+    }
+  ]
+}

--- a/src/digitalmodel/base_configs/modules/installation_pamphlet/installation_pamphlet.yml
+++ b/src/digitalmodel/base_configs/modules/installation_pamphlet/installation_pamphlet.yml
@@ -10,12 +10,13 @@ installation_pamphlet:
   # below. Order is preserved (deterministic).
   catalogs:
     mudmats: examples/demos/gtm/data/mudmat_structures.json
+    structures: examples/demos/gtm/data/subsea_structures.json
     jumpers: examples/demos/gtm/data/rigid_jumpers.json
   lift_items:
     - {item: "Mudmat (small)", kind: mudmat, source: mudmat, id: MUD-S}
     - {item: "Mudmat (medium)", kind: mudmat, source: mudmat, id: MUD-M}
     - {item: "Subsea structure / template (large)", kind: structure, source: mudmat, id: MUD-L}
-    - {item: "Manifold/PLET proxy", kind: structure, mass_air_te: 250.0}
+    - {item: "Production manifold (250 te)", kind: structure, source: structure, id: MAN-250}
     - {item: "Rigid jumper (short 20 m)", kind: jumper, source: jumper, id: JMP-20}
     - {item: "Rigid jumper (long 100 m)", kind: jumper, source: jumper, id: JMP-100}
 

--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -22,19 +22,25 @@ from typing import Any
 #   barge      -> initial pessimistic 100 m tender-barge proxy
 #   drillship  -> ship-shaped proxy, justified by a completed ship diffraction
 #   fpso       -> alternate ship-shaped proxy
-#   vessel     -> vessel-specific OrcaWave diffraction (actual)
+#   vessel     -> vessel-specific OrcaWave diffraction. ONLY "actual" once a real
+#                 vessel RAO artifact is ingested (load_rao_set_from_artifact);
+#                 with no artifact synced it honestly falls back to the
+#                 ship-shaped proxy (see _effective_provenance below).
 # ----------------------------------------------------------------------------
 BASIS_MAP = {
     "barge": "Barge",
     "drillship": "Drillship",
     "fpso": "FPSO",
-    "vessel": "Drillship",  # placeholder until a vessel-specific mesh exists
+    "vessel": "Drillship",  # ship-shaped fallback proxy until a real RAO artifact is ingested
 }
+# Default (no-artifact) provenance per basis. "vessel" defaults to the honest
+# ship_proxy fallback; it is upgraded to "actual" only when a real vessel RAO
+# artifact is actually loaded (see _effective_provenance).
 BASIS_PROVENANCE = {
     "barge": "proxy",
     "drillship": "ship_proxy",
     "fpso": "ship_proxy",
-    "vessel": "actual",
+    "vessel": "ship_proxy",
 }
 BASIS_LABEL = {
     "barge": "Generic 100 m barge parametric RAO (initial proxy — pessimistic)",
@@ -51,6 +57,39 @@ BASIS_HUMAN = {
     "fpso": "ship-shaped FPSO proxy",
     "vessel": "vessel-specific OrcaWave RAO",
 }
+
+# Honest fallback when basis resolves to "vessel" but NO real RAO artifact is
+# available yet (vessel diffraction may be complete, but the OrcaWave RAO export
+# has not been synced to this Linux box). We do NOT claim "actual" — we stay on
+# the ship-shaped proxy and say so.
+VESSEL_PROXY_NOTE = "vessel diffraction complete; RAO artifact not yet synced"
+VESSEL_PROXY_LABEL = (
+    "Ship-shaped proxy RAO — vessel diffraction complete; RAO artifact not yet "
+    "synced (no vessel-specific OrcaWave RAO ingested)"
+)
+VESSEL_PROXY_HUMAN = "ship-shaped proxy (vessel diffraction complete; RAO artifact not yet synced)"
+
+
+def _effective_provenance(rao_basis: str, rao_from_artifact: bool = False) -> str:
+    """Honest provenance for a basis. "vessel" is only "actual" when a real RAO
+    artifact was actually loaded; otherwise it stays on the ship-shaped proxy."""
+    if rao_basis == "vessel":
+        return "actual" if rao_from_artifact else "ship_proxy"
+    return BASIS_PROVENANCE[rao_basis]
+
+
+def _effective_label(rao_basis: str, rao_from_artifact: bool = False) -> str:
+    """Envelope-basis label, honest about the vessel-without-artifact fallback."""
+    if rao_basis == "vessel" and not rao_from_artifact:
+        return VESSEL_PROXY_LABEL
+    return BASIS_LABEL[rao_basis]
+
+
+def _effective_human(rao_basis: str, rao_from_artifact: bool = False) -> str:
+    """Short human basis note, honest about the vessel-without-artifact fallback."""
+    if rao_basis == "vessel" and not rao_from_artifact:
+        return VESSEL_PROXY_HUMAN
+    return BASIS_HUMAN[rao_basis]
 
 DEFAULT_OPERATIONS = ["transit", "dp_station_keeping", "heavy_lift"]
 DEFAULT_TP_GRID_S = [6.0, 8.0, 10.0, 12.0, 14.0, 16.0]
@@ -92,6 +131,106 @@ def load_structures(path: str | Path) -> dict[str, dict[str, Any]]:
     return {s["id"]: s for s in data["structures"]}
 
 
+# ---------------------------------------------------------------- real RAO artifact ingestion
+_RAO_COMPONENT_KEYS = ("surge", "sway", "heave", "roll", "pitch", "yaw")
+
+
+def _extract_rao_dict(data: Any, path: Path) -> dict[str, Any]:
+    """Locate the ``RAOSet.to_dict()`` payload inside ``data``.
+
+    Supports two on-disk shapes:
+      * a bare ``RAOSet.to_dict()`` — top-level ``raos`` maps to the per-DOF
+        component dicts (``surge``/``heave``/...);
+      * a ``DiffractionResults.to_dict()`` wrapper — top-level ``raos`` is itself
+        a nested ``RAOSet.to_dict()`` (so it carries ``vessel_name`` + an inner
+        ``raos``). Any other top-level value that nests a RAOSet is also accepted.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"installation_pamphlet: RAO artifact {path} is not a JSON object"
+        )
+    raos = data.get("raos")
+    if isinstance(raos, dict):
+        # bare RAOSet.to_dict(): data["raos"] holds the per-DOF component dicts
+        if any(k in raos for k in _RAO_COMPONENT_KEYS):
+            return data
+        # DiffractionResults-style wrapper: data["raos"] is itself a RAOSet.to_dict()
+        if isinstance(raos.get("raos"), dict) or "vessel_name" in raos:
+            return raos
+    # last resort: any nested value that itself looks like a RAOSet.to_dict()
+    for value in data.values():
+        if (
+            isinstance(value, dict)
+            and isinstance(value.get("raos"), dict)
+            and any(k in value["raos"] for k in _RAO_COMPONENT_KEYS)
+        ):
+            return value
+    raise ValueError(
+        f"installation_pamphlet: no RAOSet (top-level 'raos' with per-DOF "
+        f"components) found in RAO artifact {path}"
+    )
+
+
+def load_rao_set_from_artifact(path: str | Path):
+    """Ingest a real vessel RAO artifact (JSON) into an ``RAOSet``.
+
+    This is the license-free Linux-side ingestion path for a vessel-specific
+    OrcaWave diffraction result: a licensed host exports the RAOs as JSON
+    (``RAOSet.to_dict()`` or a ``DiffractionResults.to_dict()`` wrapper) and this
+    rebuilds the ``RAOSet`` — no OrcFxAPI, no heavy binaries. Pure given the file
+    bytes (no datetime / random / network). Raises a clear error if the file is
+    missing or malformed.
+    """
+    from digitalmodel.hydrodynamics.diffraction.output_schemas import RAOSet
+
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(
+            f"installation_pamphlet: RAO artifact not found: {p}"
+        )
+    try:
+        with p.open("r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(
+            f"installation_pamphlet: RAO artifact {p} is not valid JSON: {exc}"
+        ) from exc
+    rao_dict = _extract_rao_dict(data, p)
+    try:
+        return RAOSet.from_dict(rao_dict)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"installation_pamphlet: RAO artifact {p} is malformed "
+            f"(could not rebuild RAOSet): {exc}"
+        ) from exc
+
+
+def resolve_rao_artifact(
+    rao_basis: str,
+    completed_runs: list[dict[str, Any]] | None,
+    rao_artifact: str | Path | None = None,
+) -> str | None:
+    """Resolve the vessel RAO artifact path, or ``None`` if none is available.
+
+    Only the ``"vessel"`` basis ingests a real artifact. An explicit config path
+    (``rao_artifact``) wins; otherwise the path is taken from a ``completed_runs``
+    entry carrying a ``rao_artifact`` field — preferring the BokaLift run that
+    flipped the basis to ``"vessel"``.
+    """
+    if rao_basis != "vessel":
+        return None
+    if rao_artifact:
+        return str(rao_artifact)
+    runs = list(completed_runs or [])
+    for r in runs:
+        if "bokalift" in (r.get("input") or "").lower() and r.get("rao_artifact"):
+            return str(r["rao_artifact"])
+    for r in runs:
+        if r.get("rao_artifact"):
+            return str(r["rao_artifact"])
+    return None
+
+
 # ---------------------------------------------------------------- lift suitability
 def assess_lifts(
     vessel_info: dict[str, Any],
@@ -131,11 +270,20 @@ def assess_lifts(
 
 
 # ---------------------------------------------------------------- envelopes
-def _build_rao_set(rao_basis: str):
-    """Construct an RAOSet from the parametric vessel database for ``rao_basis``.
+def _build_rao_set(rao_basis: str, rao_artifact: str | Path | None = None):
+    """Construct the RAOSet that drives the operation envelopes for ``rao_basis``.
 
-    Ported verbatim from the validated prototype ``compute_pamphlet.py``.
+    Returns ``(rao_set, from_artifact)``. When ``rao_basis == "vessel"`` AND a
+    ``rao_artifact`` path is supplied, the REAL ingested vessel RAO drives the
+    envelopes (``from_artifact=True``); otherwise the parametric ship/barge proxy
+    is built from the validated vessel database (``from_artifact=False``).
+
+    Parametric path ported verbatim from the validated prototype
+    ``compute_pamphlet.py``.
     """
+    if rao_basis == "vessel" and rao_artifact:
+        return load_rao_set_from_artifact(rao_artifact), True
+
     import numpy as np
 
     from digitalmodel.orcawave.vessel_database import get_representative_raos
@@ -179,17 +327,20 @@ def _build_rao_set(rao_basis: str):
             unit=unit,
         )
 
-    return RAOSet(
-        vessel_name=f"Installation vessel ({vessel_type} proxy RAO)",
-        analysis_tool="parametric",
-        water_depth=1200.0,
-        surge=comp(DOF.SURGE, zero.copy(), "m/m"),
-        sway=comp(DOF.SWAY, zero.copy(), "m/m"),
-        heave=comp(DOF.HEAVE, heave, "m/m"),
-        roll=comp(DOF.ROLL, roll, "deg/m"),
-        pitch=comp(DOF.PITCH, pitch, "deg/m"),
-        yaw=comp(DOF.YAW, zero.copy(), "deg/m"),
-        created_date="2026-06-28",
+    return (
+        RAOSet(
+            vessel_name=f"Installation vessel ({vessel_type} proxy RAO)",
+            analysis_tool="parametric",
+            water_depth=1200.0,
+            surge=comp(DOF.SURGE, zero.copy(), "m/m"),
+            sway=comp(DOF.SWAY, zero.copy(), "m/m"),
+            heave=comp(DOF.HEAVE, heave, "m/m"),
+            roll=comp(DOF.ROLL, roll, "deg/m"),
+            pitch=comp(DOF.PITCH, pitch, "deg/m"),
+            yaw=comp(DOF.YAW, zero.copy(), "deg/m"),
+            created_date="2026-06-28",
+        ),
+        False,
     )
 
 
@@ -197,16 +348,20 @@ def compute_envelopes(
     rao_basis: str,
     operations: list[str],
     tp_grid_s: list[float],
+    rao_artifact: str | Path | None = None,
 ) -> dict[str, Any]:
     """Operation envelopes (limiting Hs vs Tp) for each operation.
 
     Returns an ordered dict keyed by operation name, each value being
     ``{"alpha", "hs_by_tp", "gov_by_tp"}``. ``hs_by_tp`` / ``gov_by_tp`` keys are
     one-decimal Tp strings (e.g. ``"6.0"``) so JSON round-trips stably.
+
+    When ``rao_basis == "vessel"`` and ``rao_artifact`` is supplied, the envelopes
+    are driven by the REAL ingested vessel RAO instead of the parametric proxy.
     """
     from digitalmodel.marine_ops.operation_envelope import operation_envelope
 
-    rset = _build_rao_set(rao_basis)
+    rset, _from_artifact = _build_rao_set(rao_basis, rao_artifact)
     tp_grid = [float(t) for t in tp_grid_s]
     env_out: dict[str, Any] = {}
     for op in operations:
@@ -436,6 +591,7 @@ def build_provenance(
     vessel_name: str = "BokaLift 2",
     structure_catalog_used: bool = False,
     splashzone_computed: bool = False,
+    rao_from_artifact: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
@@ -451,11 +607,16 @@ def build_provenance(
     envelope) reflects the closed-form DNV-RP-H103 result (status ``actual``,
     first-principles, like T8) instead of the ``pending`` OrcaFlex placeholder.
     An OrcaFlex dynamic lowering run remains the future verification upgrade.
+
+    ``rao_from_artifact`` governs the HONESTY of the RAO provenance (T3/T4): the
+    ``"vessel"`` basis is only marked ``actual`` (OrcaWave diffraction) when a REAL
+    vessel RAO artifact was actually ingested. With no artifact synced it stays on
+    the ship-shaped proxy and carries the "RAO artifact not yet synced" note.
     """
     runs = list(completed_runs or [])
-    prov = BASIS_PROVENANCE[rao_basis]
+    prov = _effective_provenance(rao_basis, rao_from_artifact)
     basis_run_id = select_basis_run_id(runs, rao_basis)
-    basis_note = BASIS_HUMAN[rao_basis]
+    basis_note = _effective_human(rao_basis, rao_from_artifact)
     rao_source = "OrcaWave diffraction" if prov == "actual" else "parametric ship RAO"
 
     def task(tid, section, title, status, basis, source, run_id=None):
@@ -545,10 +706,22 @@ def assemble_result(
     tp_grid_s: list[float],
     hs_scatter_limits: list[float],
     completed_runs: list[dict[str, Any]],
+    rao_artifact: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Compose the full deterministic pamphlet ``result`` payload (pure)."""
+    """Compose the full deterministic pamphlet ``result`` payload (pure).
+
+    When ``rao_basis == "vessel"`` and a real vessel RAO artifact is resolvable
+    (explicit ``rao_artifact`` path, or a ``completed_runs`` entry carrying a
+    ``rao_artifact`` field), the operation envelopes are driven by the REAL
+    ingested RAO and provenance is honestly marked ``actual``. Otherwise the
+    vessel basis honestly falls back to the ship-shaped proxy.
+    """
+    artifact_path = resolve_rao_artifact(rao_basis, completed_runs, rao_artifact)
+    rao_from_artifact = artifact_path is not None
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
-    envelopes = compute_envelopes(rao_basis, operations, tp_grid_s)
+    envelopes = compute_envelopes(
+        rao_basis, operations, tp_grid_s, rao_artifact=artifact_path
+    )
     splashzone = compute_splashzone_set(
         lifts, tp_grid_s, heavy_lift_env=envelopes.get("heavy_lift")
     )
@@ -562,6 +735,7 @@ def assemble_result(
         vessel_name=vessel_info.get("name", "Installation vessel"),
         structure_catalog_used=structure_catalog_used,
         splashzone_computed=bool(splashzone),
+        rao_from_artifact=rao_from_artifact,
     )
     return {
         "vessel": vessel_info,
@@ -572,8 +746,10 @@ def assemble_result(
         "splashzone": splashzone,
         "tp_grid_s": [float(t) for t in tp_grid_s],
         "rao_basis": rao_basis,
-        "rao_provenance": BASIS_PROVENANCE[rao_basis],
-        "envelope_proxy": BASIS_LABEL[rao_basis],
+        "rao_provenance": _effective_provenance(rao_basis, rao_from_artifact),
+        "rao_from_artifact": rao_from_artifact,
+        "rao_artifact": str(artifact_path) if artifact_path else None,
+        "envelope_proxy": _effective_label(rao_basis, rao_from_artifact),
         "op_table": op_table,
         "provenance": provenance,
     }

--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -55,6 +55,16 @@ BASIS_HUMAN = {
 DEFAULT_OPERATIONS = ["transit", "dp_station_keeping", "heavy_lift"]
 DEFAULT_TP_GRID_S = [6.0, 8.0, 10.0, 12.0, 14.0, 16.0]
 
+# ----------------------------------------------------------------------------
+# Splash-zone (lowering through the wave zone) constants — DNV-RP-H103 (2011)
+# Sec 4 "Lifting through wave zone". Seawater density and g are fixed; the
+# lowering speed and snap/slack-sling margin are documented screening values.
+# ----------------------------------------------------------------------------
+SEAWATER_DENSITY = 1025.0  # kg/m3
+GRAVITY = 9.80665  # m/s2
+SPLASH_V_LOWERING_MS = 0.5  # crane lowering speed through the wave zone (m/s)
+SPLASH_SNAP_DAF = 1.30  # snap / slack-sling margin (DNV-RP-H103 splash-zone DAF)
+
 
 # ---------------------------------------------------------------- loaders
 def load_mudmats(path: str | Path) -> dict[str, dict[str, Any]]:
@@ -211,6 +221,148 @@ def compute_envelopes(
     return env_out
 
 
+# ---------------------------------------------------------------- splash-zone envelope
+def compute_splashzone_envelope(
+    structure: dict[str, Any],
+    tp_grid_s: list[float],
+    v_lowering_ms: float = SPLASH_V_LOWERING_MS,
+    snap_daf: float = SPLASH_SNAP_DAF,
+) -> dict[str, Any]:
+    """Closed-form per-structure splash-zone Hs limit vs Tp (DNV-RP-H103 Sec 4).
+
+    Deterministic, pure (no datetime / random / network). For each peak period
+    ``Tp`` it returns the significant wave height ``Hs`` at which the structure
+    can no longer be lowered through the wave zone without risking a *snap*
+    (slack-sling) load on the hoist wire.
+
+    Wave-zone kinematics (deep-water linear wave theory, DNV-RP-C205 / RP-H103
+    Sec 4.6). A characteristic surface vertical water-particle motion scales with
+    Hs and Tp as
+
+        v_w = pi * Hs / Tp          (vertical particle velocity amplitude, m/s)
+        a_w = 2 * pi^2 * Hs / Tp^2  (vertical particle acceleration amplitude, m/s^2)
+
+    (these are ``omega * zeta_a`` and ``omega^2 * zeta_a`` with omega = 2*pi/Tp and
+    a wave amplitude zeta_a = Hs/2). The crane lowers the object at ``v_lowering``,
+    so the slamming / drag relative velocity is ``v_rel = v_w + v_lowering``.
+
+    Hydrodynamic forces on the object in the splash zone (DNV-RP-H103 Sec 4.6):
+
+        F_slam   = 0.5 * rho * Cs * A_bottom * v_rel^2        (slamming impact)
+        F_drag   = 0.5 * rho * Cd * A_bottom * v_rel^2        (form drag)
+        F_inertia= rho * (1 + Ca) * V * a_w                   (Froude-Krylov + added mass)
+
+    with rho = 1025 kg/m^3, ``Cs``/``Cd``/``Ca`` and ``A_bottom``/``V`` taken from the
+    structure catalog (``hydrodynamic_coefficients``, ``projected_areas.bottom_m2``,
+    ``mass_properties.displaced_volume_m3``).
+
+    Governing (snap / slack-sling) criterion — DNV-RP-H103 Sec 4.6 "snap forces":
+    the hoist wire must stay in tension over the whole motion cycle, i.e. the
+    characteristic upward hydrodynamic force must not exceed the submerged weight
+    reduced by a documented margin::
+
+        F_slam + F_drag + F_inertia  <=  W_sub / snap_daf
+
+    Solving that (a quadratic in Hs, since v_rel is affine in Hs and a_w is linear
+    in Hs) gives the limiting ``Hs(Tp)``. The governing term is whichever of slam /
+    drag / inertia is largest at that limit.
+
+    A future OrcaFlex dynamic lowering run (licensed installation path) is the
+    verification route for these closed-form limits — NOT computed here.
+    """
+    rho = float(SEAWATER_DENSITY)
+    hc = structure["hydrodynamic_coefficients"]
+    cs = float(hc["slamming_coefficient_Cs"])
+    cd = float(hc["drag_coefficient_Cd"])
+    ca = float(hc["added_mass_coefficient_Ca"])
+    a_bottom = float(structure["projected_areas"]["bottom_m2"])
+    mp = structure["mass_properties"]
+    volume = float(mp["displaced_volume_m3"])
+    w_sub_n = float(mp["submerged_weight_kn"]) * 1000.0
+
+    v_low = float(v_lowering_ms)
+    target = w_sub_n / float(snap_daf)  # max allowable upward hydrodynamic force (N)
+
+    k_qs = 0.5 * rho * (cs + cd) * a_bottom  # slam+drag coefficient (x v_rel^2)
+    k_in = rho * (1.0 + ca) * volume  # inertia coefficient (x acceleration)
+
+    hs_by_tp: dict[str, float] = {}
+    gov_by_tp: dict[str, str] = {}
+    for tp in (float(t) for t in tp_grid_s):
+        c1 = math.pi / tp  # v_w = c1 * Hs
+        c2 = 2.0 * math.pi**2 / tp**2  # a_w = c2 * Hs
+        # k_qs*(c1*Hs + v_low)^2 + k_in*c2*Hs = target  ->  a*Hs^2 + b*Hs + c = 0
+        a = k_qs * c1**2
+        b = 2.0 * k_qs * c1 * v_low + k_in * c2
+        c = k_qs * v_low**2 - target
+        disc = b * b - 4.0 * a * c
+        if a <= 0.0 or disc < 0.0:
+            hs = 0.0
+        else:
+            hs = max((-b + math.sqrt(disc)) / (2.0 * a), 0.0)
+        v_rel = c1 * hs + v_low
+        a_w = c2 * hs
+        f_slam = 0.5 * rho * cs * a_bottom * v_rel**2
+        f_drag = 0.5 * rho * cd * a_bottom * v_rel**2
+        f_iner = k_in * a_w
+        gov = max(
+            ((f_slam, "slam"), (f_drag, "drag"), (f_iner, "inertia")),
+            key=lambda x: x[0],
+        )[1]
+        key = f"{round(tp, 1):.1f}"
+        hs_by_tp[key] = round(hs, 2)
+        gov_by_tp[key] = gov
+
+    return {
+        "id": structure.get("id"),
+        "name": structure.get("name"),
+        "submerged_weight_kn": round(w_sub_n / 1000.0, 2),
+        "bottom_area_m2": a_bottom,
+        "daf": float(snap_daf),
+        "v_lowering_ms": v_low,
+        "hs_by_tp": hs_by_tp,
+        "gov_by_tp": gov_by_tp,
+    }
+
+
+def compute_splashzone_set(
+    lifts: list[dict[str, Any]],
+    tp_grid_s: list[float],
+    heavy_lift_env: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Per-structure splash-zone envelopes for every lift carrying hydro data.
+
+    Each lift item may carry a ``catalog_record`` (the full mudmat / structure
+    catalog dict). Items that expose ``hydrodynamic_coefficients`` +
+    ``projected_areas`` + ``mass_properties.displaced_volume_m3`` get a closed-form
+    splash-zone envelope. When ``heavy_lift_env`` (the vessel-motion heavy-lift
+    envelope from :func:`compute_envelopes`) is supplied, each structure also gets
+    a ``combined_hs_by_tp`` = min(vessel heavy-lift limit, structure splash-zone
+    limit) — the governing lowering limit. Deterministic.
+    """
+    out: list[dict[str, Any]] = []
+    hl = (heavy_lift_env or {}).get("hs_by_tp") if heavy_lift_env else None
+    for it in lifts:
+        rec = it.get("catalog_record")
+        if not isinstance(rec, dict):
+            continue
+        if "hydrodynamic_coefficients" not in rec or "projected_areas" not in rec:
+            continue
+        if "displaced_volume_m3" not in (rec.get("mass_properties") or {}):
+            continue
+        env = compute_splashzone_envelope(rec, tp_grid_s)
+        env["item"] = it.get("item")
+        env["kind"] = it.get("kind")
+        if hl:
+            combined: dict[str, float] = {}
+            for key, hs in env["hs_by_tp"].items():
+                v = hl.get(key)
+                combined[key] = round(min(hs, v), 2) if v is not None else hs
+            env["combined_hs_by_tp"] = combined
+        out.append(env)
+    return out
+
+
 # ---------------------------------------------------------------- operability
 def compute_operability(hs_scatter_limits: list[float]) -> list[dict[str, Any]]:
     """Weather-window operability table (% time below each Hs limit)."""
@@ -283,6 +435,7 @@ def build_provenance(
     rao_basis: str,
     vessel_name: str = "BokaLift 2",
     structure_catalog_used: bool = False,
+    splashzone_computed: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
@@ -293,6 +446,11 @@ def build_provenance(
     When ``structure_catalog_used`` is True the T8 task (manifold/PLET structure
     catalog) reflects the real ``subsea_structures.json`` catalog (status
     ``actual``) instead of the retired hardcoded proxy.
+
+    When ``splashzone_computed`` is True the T5 task (per-structure splash-zone
+    envelope) reflects the closed-form DNV-RP-H103 result (status ``actual``,
+    first-principles, like T8) instead of the ``pending`` OrcaFlex placeholder.
+    An OrcaFlex dynamic lowering run remains the future verification upgrade.
     """
     runs = list(completed_runs or [])
     prov = BASIS_PROVENANCE[rao_basis]
@@ -328,10 +486,20 @@ def build_provenance(
             "T4", 3, "Operation envelopes (Hs/Tp)", prov,
             "operation_envelope on T3 RAO", "operation_envelope", basis_run_id,
         ),
-        task(
-            "T5", 3, "Per-structure splash-zone envelope", "pending",
-            "Needs OrcaFlex installation run per structure",
-            "OrcaFlex (licensed) — not yet queued",
+        (
+            task(
+                "T5", 3, "Per-structure splash-zone envelope", "actual",
+                "Closed-form DNV-RP-H103 splash-zone (slamming + drag + added-mass "
+                "inertia, snap / slack-sling criterion) from catalog hydro coefficients",
+                "calculations.compute_splashzone_envelope (closed-form; OrcaFlex "
+                "dynamic run is the future verification path)",
+            )
+            if splashzone_computed
+            else task(
+                "T5", 3, "Per-structure splash-zone envelope", "pending",
+                "Needs OrcaFlex installation run per structure",
+                "OrcaFlex (licensed) — not yet queued",
+            )
         ),
         task(
             "T6", 5, "Weather-window operability", prov,
@@ -381,6 +549,9 @@ def assemble_result(
     """Compose the full deterministic pamphlet ``result`` payload (pure)."""
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
     envelopes = compute_envelopes(rao_basis, operations, tp_grid_s)
+    splashzone = compute_splashzone_set(
+        lifts, tp_grid_s, heavy_lift_env=envelopes.get("heavy_lift")
+    )
     op_table = compute_operability(hs_scatter_limits)
     structure_catalog_used = any(
         str(it.get("source")) == "structure" for it in lifts
@@ -390,6 +561,7 @@ def assemble_result(
         rao_basis,
         vessel_name=vessel_info.get("name", "Installation vessel"),
         structure_catalog_used=structure_catalog_used,
+        splashzone_computed=bool(splashzone),
     )
     return {
         "vessel": vessel_info,
@@ -397,6 +569,7 @@ def assemble_result(
         "daf": float(daf),
         "lifts": lift_rows,
         "envelopes": envelopes,
+        "splashzone": splashzone,
         "tp_grid_s": [float(t) for t in tp_grid_s],
         "rao_basis": rao_basis,
         "rao_provenance": BASIS_PROVENANCE[rao_basis],

--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -71,6 +71,17 @@ def load_jumpers(path: str | Path) -> dict[str, dict[str, Any]]:
     return {j["id"]: j for j in data["jumpers"]}
 
 
+def load_structures(path: str | Path) -> dict[str, dict[str, Any]]:
+    """Load the subsea production structure catalog (PLET/manifold/SPS) keyed by id.
+
+    Same schema and normalized shape as ``load_mudmats`` — each record carries
+    ``mass_properties.mass_air_te`` which the lift assembly consumes.
+    """
+    with Path(path).open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    return {s["id"]: s for s in data["structures"]}
+
+
 # ---------------------------------------------------------------- lift suitability
 def assess_lifts(
     vessel_info: dict[str, Any],
@@ -271,12 +282,17 @@ def build_provenance(
     completed_runs: list[dict[str, Any]],
     rao_basis: str,
     vessel_name: str = "BokaLift 2",
+    structure_catalog_used: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
     Returns the full run-state object (vessel, basis, provenance, basis run id,
     completed-run count, and the ordered task list) used to render the analysis
     progress panel and the per-section provenance badges.
+
+    When ``structure_catalog_used`` is True the T8 task (manifold/PLET structure
+    catalog) reflects the real ``subsea_structures.json`` catalog (status
+    ``actual``) instead of the retired hardcoded proxy.
     """
     runs = list(completed_runs or [])
     prov = BASIS_PROVENANCE[rao_basis]
@@ -325,9 +341,19 @@ def build_provenance(
             "T7", 7, "DP / mooring statistical risk", "actual",
             "IMCA + HSE RR444 + DNV statistics", "industry datasets",
         ),
-        task(
-            "T8", 4, "Manifold / PLET structure catalog", "proxy",
-            "Proxy entry — real catalog pending", "examples/demos/gtm (mudmat only)",
+        (
+            task(
+                "T8", 4, "Manifold / PLET structure catalog", "actual",
+                "Catalog entries (PLET/manifold/SPS) computed from first principles "
+                "(DNV-RP-H103)",
+                "examples/demos/gtm/data/subsea_structures.json catalog",
+            )
+            if structure_catalog_used
+            else task(
+                "T8", 4, "Manifold / PLET structure catalog", "proxy",
+                "Proxy entry — real catalog pending",
+                "examples/demos/gtm (mudmat only)",
+            )
         ),
     ]
     return {
@@ -356,8 +382,14 @@ def assemble_result(
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
     envelopes = compute_envelopes(rao_basis, operations, tp_grid_s)
     op_table = compute_operability(hs_scatter_limits)
+    structure_catalog_used = any(
+        str(it.get("source")) == "structure" for it in lifts
+    )
     provenance = build_provenance(
-        completed_runs, rao_basis, vessel_name=vessel_info.get("name", "Installation vessel")
+        completed_runs,
+        rao_basis,
+        vessel_name=vessel_info.get("name", "Installation vessel"),
+        structure_catalog_used=structure_catalog_used,
     )
     return {
         "vessel": vessel_info,

--- a/src/digitalmodel/installation/installation_pamphlet/render.py
+++ b/src/digitalmodel/installation/installation_pamphlet/render.py
@@ -484,7 +484,7 @@ Governing limits are <b>seakeeping</b> and <b>station-keeping</b> (&sect;5–6),
 <tr><td class="l">Mudmat — small</td><td>6 &times; 6 &times; 1.5</td><td>50</td><td>mudmat_structures.json</td></tr>
 <tr><td class="l">Mudmat — medium</td><td>8 &times; 10 &times; 2.0</td><td>100</td><td>mudmat_structures.json</td></tr>
 <tr><td class="l">Subsea template — large</td><td>12 &times; 14 &times; 2.5</td><td>200</td><td>mudmat_structures.json</td></tr>
-<tr><td class="l">Manifold / PLET <small>(proxy)</small></td><td>14 &times; 12 &times; 6</td><td>250</td><td>proxy — catalog gap</td></tr>
+<tr><td class="l">Production manifold</td><td>14 &times; 12 &times; 6</td><td>250</td><td>subsea_structures.json</td></tr>
 <tr><td class="l">Rigid jumper — 20 m</td><td>8&Prime; X65, M-shape</td><td>1.85</td><td>rigid_jumpers.json</td></tr>
 <tr><td class="l">Rigid jumper — 100 m</td><td>8&Prime; X65, W-shape</td><td>9.24</td><td>rigid_jumpers.json</td></tr>
 </table>
@@ -548,7 +548,7 @@ but the cascade case is high-consequence; design for intact + one-line-damaged (
 
 </main>
 <footer>
-Generated {GEN} from digitalmodel tables (vessel_db, mudmat_structures, rigid_jumpers) + engines (vessel_suitability,
+Generated {GEN} from digitalmodel tables (vessel_db, mudmat_structures, subsea_structures, rigid_jumpers) + engines (vessel_suitability,
 operation_envelope, weather_window). Envelope proxy: {d['envelope_proxy']}. Live feed: Open-Meteo marine &amp; forecast APIs.
 Lookup + decision-support screening — verify against vessel RAO, DP/mooring FMEA and MWS approval before offshore execution.
 </footer>

--- a/src/digitalmodel/installation/installation_pamphlet/render.py
+++ b/src/digitalmodel/installation/installation_pamphlet/render.py
@@ -349,6 +349,106 @@ def render_pamphlet_html(result: dict[str, Any], generated_label: str | None = N
             )
         return blocks
 
+    SZ = d.get("splashzone") or []
+
+    def splashzone_svg():
+        W, H, ml, mr, mt, mb = 460, 250, 46, 150, 16, 34
+        palette = ["#0a6cbf", "#c0392b", "#0a8f4f", "#8e44ad", "#d98b00", "#16707f"]
+        tmin, tmax = min(TP), max(TP)
+        allhs = [s["hs_by_tp"][f"{float(t):.1f}"] for s in SZ for t in TP]
+        hmax = max(allhs) * 1.15 if allhs else 1.0
+        hmax = max(hmax, 0.5)
+
+        def X(t):
+            return ml + (t - tmin) / (tmax - tmin) * (W - ml - mr)
+
+        def Y(h):
+            return H - mb - h / hmax * (H - mt - mb)
+
+        ticks = [round(hmax * k / 4, 1) for k in range(5)]
+        grid = "".join(
+            f'<line x1="{ml}" y1="{Y(h):.1f}" x2="{W-mr}" y2="{Y(h):.1f}" stroke="#eef2f6"/>'
+            f'<text x="{ml-6}" y="{Y(h)+3:.1f}" font-size="9" text-anchor="end" fill="#5a6b7a">{h:.1f}</text>'
+            for h in ticks
+        )
+        grid += "".join(
+            f'<text x="{X(t):.1f}" y="{H-mb+14:.1f}" font-size="10" text-anchor="middle" fill="#5a6b7a">{t:.0f}</text>'
+            for t in TP
+        )
+        series = ""
+        leg = ""
+        for i, s in enumerate(SZ):
+            col = palette[i % len(palette)]
+            pts = " ".join(f"{X(t):.1f},{Y(s['hs_by_tp'][f'{float(t):.1f}']):.1f}" for t in TP)
+            series += f'<polyline points="{pts}" fill="none" stroke="{col}" stroke-width="2.2"/>'
+            series += "".join(
+                f'<circle cx="{X(t):.1f}" cy="{Y(s["hs_by_tp"][f"{float(t):.1f}"]):.1f}" r="2.6" fill="{col}"/>'
+                for t in TP
+            )
+            ly = mt + 4 + i * 16
+            leg += (
+                f'<line x1="{W-mr+6}" y1="{ly}" x2="{W-mr+24}" y2="{ly}" stroke="{col}" stroke-width="2.6"/>'
+                f'<text x="{W-mr+28}" y="{ly+3}" font-size="9.5" fill="#0f2233">{s["id"] or s["item"]}</text>'
+            )
+        return (
+            f'<svg viewBox="0 0 {W} {H}" width="100%" role="img" aria-label="Splash-zone limiting Hs vs Tp">\n'
+            f'{grid}{series}{leg}\n'
+            f'<text x="{(ml+W-mr)//2}" y="{H-3}" font-size="10" text-anchor="middle" fill="#5a6b7a">Peak period Tp (s)</text>\n'
+            f'<text x="12" y="{H//2}" font-size="10" text-anchor="middle" fill="#5a6b7a" transform="rotate(-90 12 {H//2})">Splash-zone Hs limit (m)</text></svg>'
+        )
+
+    def splashzone_rows():
+        out = ""
+        for s in SZ:
+            govs = list(s["gov_by_tp"].values())
+            gov0 = govs[0] if govs else "—"  # governing term at the shortest (most onerous) Tp
+            cells = "".join(
+                f"<td>{s['hs_by_tp'][f'{float(t):.1f}']:.2f}</td>" for t in TP
+            )
+            out += (
+                f"<tr><td class='l'>{s['item']} <small>(W<sub>sub</sub>={s['submerged_weight_kn']:,.0f} kN, "
+                f"A<sub>b</sub>={s['bottom_area_m2']:.0f} m&sup2;)</small></td>{cells}"
+                f"<td><small>{gov0}</small></td></tr>"
+            )
+        return out
+
+    def splashzone_combined_rows():
+        out = ""
+        for s in SZ:
+            comb = s.get("combined_hs_by_tp")
+            if not comb:
+                continue
+            cells = "".join(f"<td>{comb[f'{float(t):.1f}']:.2f}</td>" for t in TP)
+            out += f"<tr><td class='l'>{s['item']}</td>{cells}</tr>"
+        return out
+
+    def splashzone_block():
+        if not SZ:
+            return ""
+        any_combined = any(s.get("combined_hs_by_tp") for s in SZ)
+        combined_tbl = (
+            "<div class=\"card\"><h3>Governing lowering Hs (m) = min(vessel heavy-lift, splash-zone)</h3>"
+            f"<table><tr><th class='l'>Structure</th>{ehead}</tr>{splashzone_combined_rows()}</table>"
+            "<p class=\"sub\" style=\"margin-top:8px\">Per structure, the lower of the vessel heavy-lift "
+            "motion limit and its own splash-zone limit governs the lower-through-wave-zone go/no-go.</p></div>"
+            if any_combined
+            else ""
+        )
+        return (
+            "<h3 class='oph' style='margin-top:18px'>Per-structure splash-zone limits (DNV-RP-H103)</h3>"
+            "<div class=\"sub\">Closed-form slamming + drag + added-mass inertia vs the snap / slack-sling "
+            "criterion (characteristic upward hydrodynamic force &le; submerged weight / DAF). Hoist wire must "
+            "stay in tension through the wave zone. Future verification: OrcaFlex dynamic lowering run.</div>"
+            "<div class=\"grid\">"
+            "<div class=\"card\"><h3>Splash-zone Hs limit (m)</h3>" + splashzone_svg() + "</div>"
+            "<div class=\"card\"><h3>Limiting Hs (m) by Tp (s) &middot; governing term</h3>"
+            f"<table><tr><th class='l'>Structure</th>{ehead}<th>Gov.</th></tr>{splashzone_rows()}</table>"
+            "<p class=\"sub\" style=\"margin-top:8px\">Header row = Tp (s). \"Gov.\" = governing term at the "
+            "shortest Tp (slam / drag / inertia).</p></div>"
+            "</div>"
+            + (f"<div class=\"grid\" style=\"margin-top:14px\">{combined_tbl}</div>" if combined_tbl else "")
+        )
+
     envelope_note_tail = (
         "These are still parametric — the vessel-specific BokaLift mesh diffraction (when that licensed run completes) replaces them and is expected to widen the limits further."
         if d["rao_provenance"] != "actual"
@@ -478,6 +578,8 @@ Governing limits are <b>seakeeping</b> and <b>station-keeping</b> (&sect;5–6),
 <p class="sub" style="margin-top:8px">Header row = Tp (s).</p></div>
 </div>
 <div class="note"><b>Envelope basis:</b> {d['envelope_proxy']}. {envelope_note_tail}</div>
+
+{splashzone_block()}
 
 <h2>4 &nbsp;Lift Items (reference catalogs)</h2>
 <table><tr><th class="l">Item</th><th>Footprint L&times;W&times;H (m)</th><th>Air mass (te)</th><th>Source</th></tr>

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -46,6 +46,13 @@ def router(cfg: dict) -> dict:
         rao_basis = calc.select_rao_basis(completed_runs)
     generated_label = settings.get("generated_label") or DEFAULT_GENERATED_LABEL
 
+    # Explicit config artifact path (resolved like catalog refs). Explicit config
+    # wins over any completed-run-carried artifact path (resolved in calculations).
+    rao_artifact_cfg = settings.get("rao_artifact")
+    rao_artifact = (
+        str(_config_path(cfg, rao_artifact_cfg)) if rao_artifact_cfg else None
+    )
+
     result = calc.assemble_result(
         vessel_info=vessel_info,
         lifts=lifts,
@@ -56,6 +63,7 @@ def router(cfg: dict) -> dict:
         tp_grid_s=tp_grid_s,
         hs_scatter_limits=hs_scatter_limits,
         completed_runs=completed_runs,
+        rao_artifact=rao_artifact,
     )
     html = render_pamphlet_html(result, generated_label)
 
@@ -175,8 +183,10 @@ def scan_completed_runs(results_dir: str | Path) -> list[dict[str, Any]]:
 
     Reads ``*.json`` (sorted for stable ordering), keeps those with
     ``state == "finished"`` and ``returncode == 0``, and extracts
-    ``run_id`` / ``workflow`` / ``input``. Lives here (not in calculations.py)
-    because it touches the filesystem.
+    ``run_id`` / ``workflow`` / ``input`` (and, when present, a ``rao_artifact``
+    path the run exported — the real vessel RAO export that lets the "vessel"
+    basis ingest an actual RAO). Lives here (not in calculations.py) because it
+    touches the filesystem.
     """
     out: list[dict[str, Any]] = []
     base = Path(results_dir)
@@ -193,12 +203,18 @@ def scan_completed_runs(results_dir: str | Path) -> list[dict[str, Any]]:
             summary = r.get("summary") or {}
             workflow = audit.get("workflow") or summary.get("workflow", "")
             inp = audit.get("input_relpath") or summary.get("input_relpath", "")
+            rao_artifact = (
+                r.get("rao_artifact")
+                or audit.get("rao_artifact")
+                or summary.get("rao_artifact")
+            )
             out.append(
                 {
                     "run_id": r.get("run_id"),
                     "workflow": workflow,
                     "input": inp,
                     "finished_at": r.get("finished_at"),
+                    "rao_artifact": rao_artifact,
                 }
             )
     return out

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -126,6 +126,7 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
     items = settings.get("lift_items") or []
     catalogs = settings.get("catalogs") or {}
     mud_cache: dict[str, dict[str, Any]] | None = None
+    str_cache: dict[str, dict[str, Any]] | None = None
     jmp_cache: dict[str, dict[str, Any]] | None = None
     resolved: list[dict[str, Any]] = []
     for it in items:
@@ -137,6 +138,12 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
                 mud_cache = calc.load_mudmats(_config_path(cfg, catalogs["mudmats"]))
             rec = mud_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+        elif it.get("source") == "structure":
+            if str_cache is None:
+                str_cache = calc.load_structures(_config_path(cfg, catalogs["structures"]))
+            rec = str_cache[it["id"]]
+            row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+            row["source"] = "structure"  # flips provenance T8 to the real catalog
         elif it.get("source") == "jumper":
             if jmp_cache is None:
                 jmp_cache = calc.load_jumpers(_config_path(cfg, catalogs["jumpers"]))

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -138,12 +138,14 @@ def _resolve_lifts(cfg: dict, settings: dict[str, Any]) -> list[dict[str, Any]]:
                 mud_cache = calc.load_mudmats(_config_path(cfg, catalogs["mudmats"]))
             rec = mud_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
+            row["catalog_record"] = rec  # feeds the per-structure splash-zone envelope (T5)
         elif it.get("source") == "structure":
             if str_cache is None:
                 str_cache = calc.load_structures(_config_path(cfg, catalogs["structures"]))
             rec = str_cache[it["id"]]
             row["mass_air_te"] = float(rec["mass_properties"]["mass_air_te"])
             row["source"] = "structure"  # flips provenance T8 to the real catalog
+            row["catalog_record"] = rec  # feeds the per-structure splash-zone envelope (T5)
         elif it.get("source") == "jumper":
             if jmp_cache is None:
                 jmp_cache = calc.load_jumpers(_config_path(cfg, catalogs["jumpers"]))

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -174,6 +174,89 @@ def test_golden_catalog_structure_lift_is_defensible(vessel_info):
     assert t8["status"] == "actual"
 
 
+# ---------------------------------------------------------------- splash-zone (T5)
+def test_compute_splashzone_envelope_golden():
+    """Closed-form per-structure splash-zone Hs limit vs Tp (DNV-RP-H103)."""
+    mud = calc.load_mudmats(DATA_DIR / "mudmat_structures.json")
+    env = calc.compute_splashzone_envelope(mud["MUD-S"], calc.DEFAULT_TP_GRID_S)
+    assert env["id"] == "MUD-S"
+    assert env["daf"] == pytest.approx(1.30)
+    hs = env["hs_by_tp"]
+    # positive, golden values (locked with tolerance)
+    assert hs["6.0"] == pytest.approx(2.11, abs=0.02)
+    assert hs["16.0"] == pytest.approx(5.70, abs=0.02)
+    assert all(v > 0 for v in hs.values())
+    # monotone increasing in Tp (longer period -> milder kinematics -> higher Hs)
+    vals = [hs[f"{float(t):.1f}"] for t in calc.DEFAULT_TP_GRID_S]
+    assert vals == sorted(vals)
+    # flat-bottom mudmats are slamming-governed
+    assert set(env["gov_by_tp"].values()) == {"slam"}
+
+
+def test_splashzone_denser_structure_tolerates_higher_hs():
+    """A dense, small-footprint structure tolerates higher Hs than a light,
+    large-area one (the large flat bottom is slamming-limited)."""
+    sub = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    plet = calc.compute_splashzone_envelope(sub["PLET-100"], calc.DEFAULT_TP_GRID_S)
+    tmpl = calc.compute_splashzone_envelope(sub["TMPL-180"], calc.DEFAULT_TP_GRID_S)
+    # PLET-100: W_sub 852 kN over A_b 48 m2 ; SPS template: 1535 kN over 192 m2
+    assert plet["hs_by_tp"]["6.0"] == pytest.approx(2.66, abs=0.02)
+    assert tmpl["hs_by_tp"]["6.0"] == pytest.approx(1.50, abs=0.02)
+    assert plet["hs_by_tp"]["6.0"] > tmpl["hs_by_tp"]["6.0"]
+    assert tmpl["gov_by_tp"]["6.0"] == "slam"
+
+
+def _lifts_with_records():
+    mud = calc.load_mudmats(DATA_DIR / "mudmat_structures.json")
+    sub = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    return [
+        {
+            "item": "Mudmat (small)", "kind": "mudmat",
+            "mass_air_te": mud["MUD-S"]["mass_properties"]["mass_air_te"],
+            "catalog_record": mud["MUD-S"],
+        },
+        {
+            "item": "Production manifold (250 te)", "kind": "structure", "source": "structure",
+            "mass_air_te": sub["MAN-250"]["mass_properties"]["mass_air_te"],
+            "catalog_record": sub["MAN-250"],
+        },
+    ]
+
+
+def test_splashzone_set_in_payload_and_provenance(vessel_info):
+    res = _assemble(vessel_info, _lifts_with_records(), "drillship", runs=[DRILLSHIP_RUN])
+    sz = res["splashzone"]
+    assert [s["id"] for s in sz] == ["MUD-S", "MAN-250"]
+    # combined limit = min(vessel heavy-lift envelope, structure splash-zone) per Tp
+    hl = res["envelopes"]["heavy_lift"]["hs_by_tp"]
+    for s in sz:
+        for k, comb in s["combined_hs_by_tp"].items():
+            assert comb == pytest.approx(min(s["hs_by_tp"][k], hl[k]), abs=0.01)
+    # T5 provenance flips off "pending"
+    t5 = {t["id"]: t for t in res["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "actual"
+    assert t5["status"] != "pending"
+    assert "splash-zone" in t5["basis"].lower()
+
+
+def test_splashzone_renders_section(vessel_info):
+    res = _assemble(vessel_info, _lifts_with_records(), "drillship", runs=[DRILLSHIP_RUN])
+    html = render_pamphlet_html(res, "LBL")
+    assert "Per-structure splash-zone limits (DNV-RP-H103)" in html
+    assert "MUD-S" in html
+    assert "Governing lowering Hs" in html  # combined limit table
+
+
+def test_splashzone_absent_when_no_catalog_records(vessel_info, lifts):
+    """Without catalog records (hand-built lifts), T5 stays pending and the
+    splash-zone section is not rendered — keeps existing goldens green."""
+    res = _assemble(vessel_info, lifts, "barge")
+    assert res["splashzone"] == []
+    t5 = {t["id"]: t for t in res["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "pending"
+    assert "Per-structure splash-zone limits" not in render_pamphlet_html(res, "LBL")
+
+
 # ---------------------------------------------------------------- golden numbers
 def test_golden_barge_transit_hs_and_lift(vessel_info, lifts):
     res = _assemble(vessel_info, lifts, "barge")
@@ -283,8 +366,15 @@ def test_router_on_base_config_writes_artifacts(tmp_path):
     man = next(r for r in result["lifts"] if "manifold" in r["item"].lower())
     assert man["mass_air_te"] == pytest.approx(250.0)
 
+    # the workflow attaches catalog records to mudmat/structure lifts, so the
+    # per-structure splash-zone envelope (T5) is computed and flips off "pending"
+    assert len(result["splashzone"]) >= 4  # 3 mudmats + 1 manifold
+    t5 = {t["id"]: t for t in result["provenance"]["tasks"]}["T5"]
+    assert t5["status"] == "actual"
+
     html = html_path.read_text()
     assert "Installation Vessel Pamphlet" in html
+    assert "Per-structure splash-zone limits (DNV-RP-H103)" in html
 
 
 def test_router_is_deterministic_on_base_config(tmp_path):

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -127,6 +127,53 @@ def test_build_provenance_barge_default_has_no_basis_run():
     assert prov["basis_run_id"] is None
 
 
+def test_build_provenance_t8_flips_to_catalog_when_used():
+    by_id_proxy = {
+        t["id"]: t for t in calc.build_provenance([], "barge")["tasks"]
+    }
+    assert by_id_proxy["T8"]["status"] == "proxy"  # default unchanged
+
+    prov = calc.build_provenance([], "barge", structure_catalog_used=True)
+    t8 = {t["id"]: t for t in prov["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+    assert t8["status"] != "proxy"
+    assert "subsea_structures.json" in t8["source"]
+
+
+# ---------------------------------------------------------------- structure catalog
+def test_load_structures_manifold_mass():
+    structures = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    assert set(["PLET-100", "MAN-250", "TMPL-180"]).issubset(structures)
+    manifold = structures["MAN-250"]
+    assert manifold["mass_properties"]["mass_air_te"] == pytest.approx(250.0)
+    # buoyancy + submerged weight reconcile with mass_air * g (seawater 1025, g 9.80665)
+    mp = manifold["mass_properties"]
+    total = mp["buoyancy_force_kn"] + mp["submerged_weight_kn"]
+    assert total == pytest.approx(250000 * 9.80665 / 1000, abs=0.05)
+
+
+def test_golden_catalog_structure_lift_is_defensible(vessel_info):
+    structures = calc.load_structures(DATA_DIR / "subsea_structures.json")
+    manifold_te = structures["MAN-250"]["mass_properties"]["mass_air_te"]
+    lifts = [
+        {
+            "item": "Production manifold (250 te)",
+            "kind": "structure",
+            "source": "structure",
+            "mass_air_te": manifold_te,
+        }
+    ]
+    res = _assemble(vessel_info, lifts, "drillship", runs=[DRILLSHIP_RUN])
+    row = res["lifts"][0]
+    assert row["mass_air_te"] == pytest.approx(250.0)
+    assert row["hook_load_te"] == pytest.approx(250.0 * 1.30, abs=0.05)  # mass x DAF
+    assert row["defensible"] is True
+    assert 0.0 < row["utilization_pct"] <= 100.0
+    # the catalog-sourced structure flips T8 provenance to the real catalog
+    t8 = {t["id"]: t for t in res["provenance"]["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+
+
 # ---------------------------------------------------------------- golden numbers
 def test_golden_barge_transit_hs_and_lift(vessel_info, lifts):
     res = _assemble(vessel_info, lifts, "barge")
@@ -226,6 +273,15 @@ def test_router_on_base_config_writes_artifacts(tmp_path):
     assert summary["n_lifts"] == 6
     assert summary["rao_basis"] == "drillship"  # auto-selected from completed_runs
     assert summary["all_lifts_defensible"] is True
+
+    # the base config now sources the 250 te manifold from subsea_structures.json,
+    # which flips the T8 structure-catalog provenance off the retired proxy
+    result = out["installation_pamphlet"]["result"]
+    t8 = {t["id"]: t for t in result["provenance"]["tasks"]}["T8"]
+    assert t8["status"] == "actual"
+    assert t8["status"] != "proxy"
+    man = next(r for r in result["lifts"] if "manifold" in r["item"].lower())
+    assert man["mass_air_te"] == pytest.approx(250.0)
 
     html = html_path.read_text()
     assert "Installation Vessel Pamphlet" in html

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -391,3 +391,206 @@ def test_router_is_deterministic_on_base_config(tmp_path):
     html_b, data_b = run("run_b")
     assert html_a == html_b  # byte-identical HTML
     assert data_a == data_b  # byte-identical JSON
+
+
+# ---------------------------------------------------------------- real-RAO artifact ingestion (T3)
+# Advances #1111: a vessel-specific OrcaWave RAO artifact drives the operation
+# envelopes for the "vessel" basis. Tested here with a SYNTHETIC fixture RAOSet
+# (clearly NOT real vessel data) — the real BokaLift mesh + licensed solve remain.
+BOKALIFT_RUN = {"run_id": "lr_bl", "input": "acma/bokalift2-mesh/input.yml"}
+HS_LIMITS = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0]
+
+
+def _synthetic_rao_set():
+    """A clearly-synthetic fixture RAOSet (NOT real vessel data): a few freqs and
+    headings with flat, distinctive magnitudes — just enough to exercise the pipe."""
+    import numpy as np
+
+    from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+        DOF,
+        FrequencyData,
+        HeadingData,
+        RAOComponent,
+        RAOSet,
+    )
+
+    periods = np.array([4.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0])
+    freqs = 2.0 * np.pi / periods
+    heads = np.array([0.0, 90.0, 180.0])
+    nf, nh = len(freqs), len(heads)
+
+    def comp(dof, val, unit):
+        mag = np.full((nf, nh), float(val))
+        return RAOComponent(
+            dof=dof,
+            magnitude=mag,
+            phase=np.zeros((nf, nh)),
+            frequencies=FrequencyData(
+                values=freqs, periods=periods, count=nf,
+                min_freq=float(freqs.min()), max_freq=float(freqs.max()),
+            ),
+            headings=HeadingData(
+                values=heads, count=nh,
+                min_heading=float(heads.min()), max_heading=float(heads.max()),
+            ),
+            unit=unit,
+        )
+
+    return RAOSet(
+        vessel_name="SYNTHETIC FIXTURE VESSEL (not real data)",
+        analysis_tool="OrcaWave",
+        water_depth=1500.0,
+        surge=comp(DOF.SURGE, 0.0, "m/m"),
+        sway=comp(DOF.SWAY, 0.0, "m/m"),
+        heave=comp(DOF.HEAVE, 0.55, "m/m"),
+        roll=comp(DOF.ROLL, 1.1, "deg/m"),
+        pitch=comp(DOF.PITCH, 0.7, "deg/m"),
+        yaw=comp(DOF.YAW, 0.0, "deg/m"),
+        created_date="2026-01-01",
+    )
+
+
+def _write_rao_artifact(tmp_path, rao_set, *, wrap=False):
+    import json
+
+    if wrap:  # DiffractionResults-style wrapper that nests a RAOSet under "raos"
+        payload = {
+            "vessel_name": rao_set.vessel_name,
+            "analysis_tool": "OrcaWave",
+            "water_depth": rao_set.water_depth,
+            "raos": rao_set.to_dict(),
+        }
+        path = tmp_path / "rao_wrapped.json"
+    else:
+        payload = rao_set.to_dict()
+        path = tmp_path / "rao.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _envelopes_from_rao(rao_set):
+    from digitalmodel.marine_ops.operation_envelope import operation_envelope
+
+    out = {}
+    for op in calc.DEFAULT_OPERATIONS:
+        env = operation_envelope(rao_set, op, tp_range_s=calc.DEFAULT_TP_GRID_S)
+        out[op] = {
+            "alpha": env.alpha,
+            "hs_by_tp": {f"{round(p.tp_s, 1):.1f}": round(p.hs_limit_m, 2) for p in env.points},
+            "gov_by_tp": {f"{round(p.tp_s, 1):.1f}": p.governing_dof for p in env.points},
+        }
+    return out
+
+
+def test_load_rao_set_from_artifact_roundtrips(tmp_path):
+    fixture = _synthetic_rao_set()
+    path = _write_rao_artifact(tmp_path, fixture)
+    loaded = calc.load_rao_set_from_artifact(path)
+    # RAOSet holds numpy arrays (dataclass __eq__ is ambiguous), so compare the
+    # serialized form — a faithful round-trip.
+    assert loaded.to_dict() == fixture.to_dict()
+    assert loaded.vessel_name == "SYNTHETIC FIXTURE VESSEL (not real data)"
+
+
+def test_load_rao_set_from_artifact_diffraction_wrapper(tmp_path):
+    fixture = _synthetic_rao_set()
+    path = _write_rao_artifact(tmp_path, fixture, wrap=True)
+    loaded = calc.load_rao_set_from_artifact(path)
+    assert loaded.to_dict() == fixture.to_dict()
+
+
+def test_load_rao_set_from_artifact_errors(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        calc.load_rao_set_from_artifact(tmp_path / "does_not_exist.json")
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        calc.load_rao_set_from_artifact(bad)
+    noraos = tmp_path / "noraos.json"
+    noraos.write_text('{"foo": 1}', encoding="utf-8")
+    with pytest.raises(ValueError):
+        calc.load_rao_set_from_artifact(noraos)
+
+
+def test_vessel_artifact_drives_envelopes_and_is_actual(vessel_info, lifts, tmp_path):
+    fixture = _synthetic_rao_set()
+    path = _write_rao_artifact(tmp_path, fixture)
+    expected = _envelopes_from_rao(fixture)
+
+    res = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[BOKALIFT_RUN], rao_artifact=str(path),
+    )
+
+    # the REAL ingested artifact drove the envelopes ...
+    assert res["envelopes"] == expected
+    # ... and they DIFFER from the Drillship-parametric (no-artifact) envelopes
+    drillship_proxy = calc.compute_envelopes(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S
+    )
+    assert res["envelopes"] != drillship_proxy
+
+    # provenance is honestly "actual" because a real artifact was loaded
+    assert res["rao_provenance"] == "actual"
+    assert res["rao_from_artifact"] is True
+    assert res["rao_artifact"] == str(path)
+    by_id = {t["id"]: t for t in res["provenance"]["tasks"]}
+    assert by_id["T3"]["status"] == "actual"
+    assert by_id["T3"]["source"] == "OrcaWave diffraction"
+    assert by_id["T4"]["status"] == "actual"
+
+
+def test_vessel_artifact_path_from_completed_run(vessel_info, lifts, tmp_path):
+    """The artifact path may ride on the completed-run entry that flipped basis."""
+    fixture = _synthetic_rao_set()
+    path = _write_rao_artifact(tmp_path, fixture)
+    run = {**BOKALIFT_RUN, "rao_artifact": str(path)}
+
+    res = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[run],  # no explicit rao_artifact -> resolved from the run
+    )
+    assert res["rao_from_artifact"] is True
+    assert res["rao_provenance"] == "actual"
+    assert res["envelopes"] == _envelopes_from_rao(fixture)
+
+
+def test_vessel_without_artifact_is_honest_proxy(vessel_info, lifts):
+    """Honest fallback: basis resolves to "vessel" but NO artifact is available ->
+    do NOT claim "actual"; stay on the ship-shaped proxy with the synced note."""
+    res = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[BOKALIFT_RUN],  # basis is "vessel" but no rao_artifact
+    )
+    assert res["rao_from_artifact"] is False
+    assert res["rao_artifact"] is None
+    assert res["rao_provenance"] != "actual"
+    assert res["rao_provenance"] == "ship_proxy"
+    by_id = {t["id"]: t for t in res["provenance"]["tasks"]}
+    assert by_id["T3"]["status"] == "ship_proxy"
+    assert by_id["T3"]["status"] != "actual"
+    assert "not yet synced" in by_id["T3"]["basis"]
+    assert "not yet synced" in res["envelope_proxy"]
+    # the proxy envelopes equal the ship-shaped (Drillship) parametric fallback
+    drillship = calc.compute_envelopes(
+        "drillship", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S
+    )
+    assert res["envelopes"] == drillship
+
+
+def test_resolve_rao_artifact_precedence(tmp_path):
+    run = {**BOKALIFT_RUN, "rao_artifact": "/from/run.json"}
+    # explicit config path wins over the completed-run-carried path
+    assert calc.resolve_rao_artifact("vessel", [run], "/explicit.json") == "/explicit.json"
+    # else the run-carried path is used
+    assert calc.resolve_rao_artifact("vessel", [run], None) == "/from/run.json"
+    # non-vessel basis never ingests an artifact
+    assert calc.resolve_rao_artifact("drillship", [run], "/explicit.json") is None
+    # vessel basis with nothing available -> None
+    assert calc.resolve_rao_artifact("vessel", [BOKALIFT_RUN], None) is None


### PR DESCRIPTION
**Advances #1111** (does not close it — the real BokaLift mesh + licensed OrcaWave solve remain). Stacks on #1119/#1116/#1106.

## What this does
Builds and TESTS the real-RAO artifact ingestion path for the `installation_pamphlet` workflow's `vessel` RAO basis. When a vessel-specific OrcaWave diffraction RAO artifact is available, it now drives the operation envelopes — instead of the current generic **Drillship parametric placeholder**.

This is a **partial**: it pipes the ingestion using a *synthetic fixture RAOSet* (clearly NOT real vessel data). No licensed run is required to land it.

## Changes
- **`load_rao_set_from_artifact(path) -> RAOSet`** (calculations.py): license-free JSON → `RAOSet` ingestion. Supports both a bare `RAOSet.to_dict()` (top-level `raos` = per-DOF components) and a `DiffractionResults`-style wrapper that nests a RAOSet under `raos`. Raises clear errors for missing / non-JSON / no-RAOSet files. Pure (file bytes only — no datetime / random / network).
- **`resolve_rao_artifact(...)`**: resolves the artifact path. **Explicit config `rao_artifact:` wins**; otherwise it is taken from a `completed_runs` entry carrying a `rao_artifact` field (preferring the BokaLift run that flipped basis to `vessel`). Threaded through `_build_rao_set` / `compute_envelopes` / `assemble_result`, plus `workflow.router` (config path) and `scan_completed_runs` (run-carried path).

## Honest provenance (no licensed run needed)
The `vessel` basis is marked **`actual` (OrcaWave diffraction)** in provenance (T3/T4) **only when a real artifact was actually loaded**. If basis resolves to `vessel` but **no artifact is available**, it does **not** claim `actual` — it stays on the ship-shaped proxy (status `ship_proxy`) with the note *"vessel diffraction complete; RAO artifact not yet synced"*, and the envelope label/`envelope_proxy` say so too. `BASIS_PROVENANCE["vessel"]` was therefore changed from the dishonest `"actual"` placeholder to the honest `"ship_proxy"` default, upgraded to `actual` via `_effective_provenance` only on a real load.

## Tests
Extends `tests/installation/test_installation_pamphlet.py` with a **synthetic** fixture RAOSet:
- round-trips through `load_rao_set_from_artifact` (bare + wrapped) and error paths;
- `assemble_result(rao_basis="vessel", rao_artifact=...)` envelopes **equal** `operation_envelope` run directly on the fixture, and **differ** from the Drillship parametric envelopes — proving the artifact drove them; provenance T3/T4 are `actual`;
- honest fallback: `vessel` with no artifact → T3 stays `ship_proxy` with the "not yet synced" note;
- artifact path can ride on the completed-run entry; explicit-config precedence.

**30 passed** (23 pre-existing goldens/determinism/splash-zone all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)