### PR TITLE
feat(structural): girder & web-frame buckling (DNV-RP-C201) [#1083]

### DIFF
--- a/docs/domains/girder-web-frame-validation-2026-06-28.md
+++ b/docs/domains/girder-web-frame-validation-2026-06-28.md
@@ -1,0 +1,61 @@
+# Girder & Web-Frame Buckling — Validation Record (2026-06-28)
+
+Backing for
+`src/digitalmodel/structural/structural_analysis/girder_web_frame.py`
+(issue #1083, EPIC #1080 workstream A). Primary supporting members — girders and
+transverse web frames — built on the validated plate / stiffened-panel solvers
+(no buckling physics reimplemented).
+
+## Web-panel shear buckling (transverse frames)
+
+`tau_cr = JO(k_tau · π²E / (12(1−ν²)) · (t_w/d)²)`, with the classical shear
+coefficient:
+- `a/d ≥ 1` (long panel): `k_tau = 5.34 + 4·(d/a)²`
+- `a/d < 1` (short panel): `k_tau = 4.0 + 5.34·(d/a)²`
+
+and **the same Johnson-Ostenfeld inelastic knockdown** as the plate solver
+(`PlateBucklingAnalyzer.johnson_ostenfeld`, reused directly).
+
+Validation:
+- k_tau: a/d=2 → **6.34**; a/d=0.5 → **25.36**; square → **9.34**.
+- Web 1000×12 mm, panel 2000 mm, AH36 → `tau_e` < 0.5·f_y → `tau_cr = tau_e`
+  (elastic, no knockdown).
+- Web 1000×**25** mm → `tau_e` > 0.5·f_y → `tau_cr < tau_e` (Johnson-Ostenfeld
+  applied) and `< f_y`.
+
+## Girder tripping — bracket-spacing effect
+
+Reuses the validated DNV-RP-C201 Sec. 7.5.2 tripping solver
+(`StiffenedPanelBucklingAnalyzer.torsional_buckling`, validated against the
+0119-015 worked example: fET=441.66, λ_T=0.729, fT=215.61 MPa) with the
+**tripping-bracket spacing** set as the torsional restraint length `L_T`.
+
+Validation: for a tee girder, the tripping capacity `fT` at `L_T = 800 mm` is
+**greater** than at `L_T = 2400 mm` — i.e. closer brackets raise the capacity, as
+expected.
+
+## Builds on (no physics reimplemented)
+
+- `structural_analysis/buckling.py` — `PlateBucklingAnalyzer.johnson_ostenfeld`
+  (the inelastic shear knockdown); the elastic shear form mirrors the in-package
+  `k_tau·π²E/(12(1−ν²))·(t/b)²` used in `check_plate_buckling`.
+- `structural_analysis/panel_buckling.py` — the DNV-RP-C201 tripping solver and
+  `StiffenedPanelGeometry` (`torsional_restraint_spacing`).
+- `structural_analysis/models.py` — `MaterialProperties` / `MARINE_GRADES`.
+
+Complements the stiffened-panel buckling (single longitudinal stiffener) and the
+hull-girder longitudinal strength (#1082), where girders and web frames are the
+primary supporting members.
+
+## Tests
+
+`tests/structural/structural_analysis/test_girder_web_frame.py` — 7 tests: the
+k_tau branches, the web shear stress (elastic + inelastic-knockdown cases), the
+web-frame shear check (pass + overload), the bracket-spacing effect on tripping,
+the girder-tripping check, and input validation. black + flake8 clean; runs under
+the `structural` CI domain.
+
+## Deferred
+
+Web-frame combined shear+bending interaction and the full grillage (orthogonally
+stiffened, longitudinal × transverse) buckling are #1081.

--- a/src/digitalmodel/structural/structural_analysis/girder_web_frame.py
+++ b/src/digitalmodel/structural/structural_analysis/girder_web_frame.py
@@ -1,0 +1,164 @@
+# ABOUTME: Girder & web-frame buckling — web-panel shear buckling (k_tau) for
+# ABOUTME: transverse frames and girder tripping with bracket-spacing effect.
+"""Primary supporting member buckling — girders and web frames (DNV-RP-C201).
+
+Two checks for primary members, both built on the validated plate / stiffened-
+panel solvers (no buckling physics reimplemented):
+
+* **Web-panel shear buckling** (transverse web frames under shear): the web
+  panel between stiffeners/brackets buckles in shear at
+  ``tau_cr = JO(k_tau * pi^2 E / (12(1-nu^2)) * (t_w/d)^2)`` with the classical
+  shear coefficient ``k_tau`` (a/d branches) and the **same** Johnson-Ostenfeld
+  inelastic knockdown as the plate solver
+  (:meth:`...buckling.PlateBucklingAnalyzer.johnson_ostenfeld`).
+
+* **Girder tripping** (lateral-torsional buckling of a deep girder): reuses the
+  validated DNV-RP-C201 Sec. 7.5.2 tripping solver
+  (:meth:`...panel_buckling.StiffenedPanelBucklingAnalyzer.torsional_buckling`)
+  with the **tripping-bracket spacing** as the torsional restraint length
+  ``L_T`` — closer brackets raise the tripping capacity.
+
+Units: mm (lengths), MPa (stresses), matching the structural-analysis package.
+
+References: DNV-RP-C201 (Buckling Strength of Plated Structures) Sec. 7;
+DNV CN 30.1 (buckling strength of bars and frames).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Optional
+
+from .buckling import PlateBucklingAnalyzer
+from .models import MaterialProperties
+from .panel_buckling import (
+    StiffenedPanelBucklingAnalyzer,
+    StiffenedPanelGeometry,
+)
+
+CODE_REFERENCE = "DNV-RP-C201 / DNV CN 30.1"
+
+
+# ---------------------------------------------------------------------------
+# Web-panel shear buckling (transverse web frames)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class WebPanel:
+    """A web panel of a girder / transverse frame (mm)."""
+
+    depth_mm: float          # web depth d (short transverse dimension)
+    thickness_mm: float      # web thickness t_w
+    panel_length_mm: float   # a, between stiffeners / tripping brackets
+
+    def __post_init__(self) -> None:
+        if min(self.depth_mm, self.thickness_mm, self.panel_length_mm) <= 0:
+            raise ValueError("web panel dimensions must be > 0")
+
+
+def web_shear_buckling_coefficient(depth_mm: float, length_mm: float) -> float:
+    """Classical plate shear-buckling coefficient ``k_tau``.
+
+    ``k_tau = 5.34 + 4*(d/a)^2`` for ``a/d >= 1`` (long panel),
+    ``k_tau = 4.0 + 5.34*(d/a)^2`` for ``a/d < 1`` (short panel),
+    with ``d`` the shorter (depth) and ``a`` the panel length.
+    """
+    d, a = depth_mm, length_mm
+    if a / d >= 1.0:
+        return 5.34 + 4.0 * (d / a) ** 2
+    return 4.0 + 5.34 * (d / a) ** 2
+
+
+def web_shear_buckling_stress(web: WebPanel,
+                              material: MaterialProperties) -> float:
+    """Critical shear-buckling stress of a web panel (MPa).
+
+    ``tau_e = k_tau * pi^2 E / (12(1-nu^2)) * (t_w/d)^2``; the inelastic value is
+    the plate solver's Johnson-Ostenfeld knockdown of ``tau_e``.
+    """
+    e = material.youngs_modulus
+    nu = material.poissons_ratio
+    k_tau = web_shear_buckling_coefficient(web.depth_mm, web.panel_length_mm)
+    tau_e = (k_tau * math.pi ** 2 * e / (12.0 * (1.0 - nu ** 2))
+             * (web.thickness_mm / web.depth_mm) ** 2)
+    # Reuse the validated inelastic (Johnson-Ostenfeld) correction.
+    return PlateBucklingAnalyzer(material).johnson_ostenfeld(tau_e)
+
+
+@dataclass(frozen=True)
+class WebShearResult:
+    """Web-panel shear-buckling check result."""
+
+    critical_shear_stress_mpa: float
+    applied_shear_stress_mpa: float
+    k_tau: float
+    utilization: float
+    passes: bool
+    code_reference: str = CODE_REFERENCE
+
+
+def check_web_frame_shear(
+    web: WebPanel, material: MaterialProperties, applied_shear_mpa: float,
+    *, gamma_m: float = 1.15,
+) -> WebShearResult:
+    """Check a transverse-frame web panel against shear buckling."""
+    tau_cr = web_shear_buckling_stress(web, material)
+    design_cap = tau_cr / gamma_m
+    util = applied_shear_mpa / design_cap if design_cap > 0 else float("inf")
+    return WebShearResult(
+        critical_shear_stress_mpa=tau_cr,
+        applied_shear_stress_mpa=applied_shear_mpa,
+        k_tau=web_shear_buckling_coefficient(web.depth_mm, web.panel_length_mm),
+        utilization=util,
+        passes=bool(applied_shear_mpa <= design_cap),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Girder tripping — bracket-spacing effect (reuses the validated tripping solver)
+# ---------------------------------------------------------------------------
+def girder_tripping_capacity(
+    girder: StiffenedPanelGeometry, material: MaterialProperties,
+    sigma_x: float, *, bracket_spacing_mm: Optional[float] = None,
+) -> float:
+    """Characteristic tripping (lateral-torsional) capacity ``fT`` (MPa).
+
+    When ``bracket_spacing_mm`` is given it sets the torsional restraint length
+    ``L_T`` — closer tripping brackets raise ``fT``.
+    """
+    if bracket_spacing_mm is not None:
+        girder = replace(girder, torsional_restraint_spacing=bracket_spacing_mm)
+    analyzer = StiffenedPanelBucklingAnalyzer(material)
+    return analyzer.torsional_buckling(girder, sigma_x)["fT"]
+
+
+@dataclass(frozen=True)
+class GirderTrippingResult:
+    """Girder tripping check result at a given bracket spacing."""
+
+    tripping_capacity_mpa: float
+    applied_stress_mpa: float
+    bracket_spacing_mm: float
+    utilization: float
+    passes: bool
+    code_reference: str = CODE_REFERENCE
+
+
+def check_girder_tripping(
+    girder: StiffenedPanelGeometry, material: MaterialProperties,
+    sigma_x: float, *, bracket_spacing_mm: Optional[float] = None,
+    gamma_m: float = 1.15,
+) -> GirderTrippingResult:
+    """Check girder tripping at a bracket spacing (DNV-RP-C201 Sec. 7.5.2)."""
+    l_t = (bracket_spacing_mm if bracket_spacing_mm is not None
+           else (girder.torsional_restraint_spacing or girder.plate_length))
+    f_t = girder_tripping_capacity(girder, material, sigma_x,
+                                   bracket_spacing_mm=bracket_spacing_mm)
+    design_cap = f_t / gamma_m
+    util = sigma_x / design_cap if design_cap > 0 else float("inf")
+    return GirderTrippingResult(
+        tripping_capacity_mpa=f_t,
+        applied_stress_mpa=sigma_x,
+        bracket_spacing_mm=l_t,
+        utilization=util,
+        passes=bool(sigma_x <= design_cap),
+    )

--- a/tests/structural/structural_analysis/test_girder_web_frame.py
+++ b/tests/structural/structural_analysis/test_girder_web_frame.py
@@ -1,0 +1,109 @@
+# ABOUTME: Tests for girder & web-frame buckling — web-panel shear buckling
+# ABOUTME: (k_tau + Johnson-Ostenfeld) and girder tripping bracket-spacing effect.
+import math
+
+import pytest
+
+from digitalmodel.structural.structural_analysis.girder_web_frame import (
+    WebPanel,
+    check_girder_tripping,
+    check_web_frame_shear,
+    girder_tripping_capacity,
+    web_shear_buckling_coefficient,
+    web_shear_buckling_stress,
+)
+from digitalmodel.structural.structural_analysis.models import STEEL_AH36
+from digitalmodel.structural.structural_analysis.panel_buckling import (
+    StiffenedPanelGeometry,
+    StiffenerGeometry,
+)
+
+
+def _girder():
+    return StiffenedPanelGeometry(
+        plate_length=2400.0, plate_thickness=12.0,
+        stiffener=StiffenerGeometry(
+            web_height=250.0, web_thickness=10.0, flange_width=90.0,
+            flange_thickness=12.0, spacing=800.0, section_type="tee"),
+    )
+
+
+# --- shear buckling coefficient k_tau (two branches) -------------------------
+def test_k_tau_branches():
+    # a/d = 2 (long): 5.34 + 4*(0.5)^2 = 6.34
+    assert math.isclose(web_shear_buckling_coefficient(1000.0, 2000.0), 6.34,
+                        rel_tol=1e-9)
+    # a/d = 0.5 (short): 4 + 5.34*(2)^2 = 25.36
+    assert math.isclose(web_shear_buckling_coefficient(1000.0, 500.0), 25.36,
+                        rel_tol=1e-9)
+    # square a/d = 1: 5.34 + 4 = 9.34
+    assert math.isclose(web_shear_buckling_coefficient(1000.0, 1000.0), 9.34,
+                        rel_tol=1e-9)
+
+
+# --- web shear buckling stress (formula + JO reuse) --------------------------
+def test_web_shear_buckling_stress_elastic():
+    web = WebPanel(depth_mm=1000.0, thickness_mm=12.0, panel_length_mm=2000.0)
+    tau_cr = web_shear_buckling_stress(web, STEEL_AH36)
+    # Recompute tau_e (k_tau=6.34) and confirm it is the elastic value (<0.5 fy).
+    k = 6.34
+    tau_e = (k * math.pi ** 2 * 206000.0 / (12.0 * (1 - 0.3 ** 2))
+             * (12.0 / 1000.0) ** 2)
+    assert tau_e <= 0.5 * STEEL_AH36.yield_strength
+    assert math.isclose(tau_cr, tau_e, rel_tol=1e-9)   # elastic: no knockdown
+
+
+def test_web_shear_buckling_stress_inelastic_knockdown():
+    # Thick web -> tau_e > 0.5 fy -> Johnson-Ostenfeld reduces it below tau_e.
+    web = WebPanel(depth_mm=1000.0, thickness_mm=25.0, panel_length_mm=2000.0)
+    tau_cr = web_shear_buckling_stress(web, STEEL_AH36)
+    k = 6.34
+    tau_e = (k * math.pi ** 2 * 206000.0 / (12.0 * (1 - 0.3 ** 2))
+             * (25.0 / 1000.0) ** 2)
+    assert tau_e > 0.5 * STEEL_AH36.yield_strength
+    assert tau_cr < tau_e                               # knocked down
+    assert tau_cr < STEEL_AH36.yield_strength
+
+
+# --- web frame shear check ---------------------------------------------------
+def test_check_web_frame_shear():
+    web = WebPanel(1000.0, 12.0, 2000.0)
+    res = check_web_frame_shear(web, STEEL_AH36, applied_shear_mpa=50.0)
+    assert math.isclose(res.k_tau, 6.34, rel_tol=1e-9)
+    assert res.passes is True
+    assert math.isclose(
+        res.utilization, 50.0 / (res.critical_shear_stress_mpa / 1.15),
+        rel_tol=1e-9)
+    assert res.code_reference == "DNV-RP-C201 / DNV CN 30.1"
+
+    overloaded = check_web_frame_shear(web, STEEL_AH36, applied_shear_mpa=300.0)
+    assert overloaded.passes is False
+
+
+# --- girder tripping: bracket-spacing effect ---------------------------------
+def test_closer_brackets_raise_tripping_capacity():
+    girder = _girder()
+    sigma = 150.0
+    wide = girder_tripping_capacity(girder, STEEL_AH36, sigma,
+                                    bracket_spacing_mm=2400.0)
+    tight = girder_tripping_capacity(girder, STEEL_AH36, sigma,
+                                     bracket_spacing_mm=800.0)
+    assert tight > wide                                 # closer brackets help
+    assert wide > 0
+
+
+def test_check_girder_tripping():
+    girder = _girder()
+    res = check_girder_tripping(girder, STEEL_AH36, sigma_x=150.0,
+                                bracket_spacing_mm=1200.0)
+    assert res.bracket_spacing_mm == 1200.0
+    assert res.tripping_capacity_mpa > 0
+    assert isinstance(res.passes, bool)
+    assert math.isclose(
+        res.utilization, 150.0 / (res.tripping_capacity_mpa / 1.15),
+        rel_tol=1e-9)
+
+
+def test_web_panel_validation():
+    with pytest.raises(ValueError):
+        WebPanel(depth_mm=-1.0, thickness_mm=12.0, panel_length_mm=2000.0)


### PR DESCRIPTION
Closes #1083 — EPIC #1080 workstream A. Primary supporting members (girders, transverse web frames), built **on** the validated plate / stiffened-panel solvers — no buckling physics reimplemented.

## What it adds (`structural_analysis/girder_web_frame.py`)
- **Web-panel shear buckling** (transverse frames): `tau_cr = JO(k_tau·π²E/(12(1−ν²))·(t_w/d)²)` with the two-branch shear coefficient `k_tau` (`5.34+4(d/a)²` for a/d≥1; `4+5.34(d/a)²` for a/d<1), reusing `PlateBucklingAnalyzer.johnson_ostenfeld` for the inelastic knockdown.
- **Girder tripping with bracket-spacing effect**: reuses the validated DNV-RP-C201 `torsional_buckling` solver with the tripping-bracket spacing as the torsional restraint length `L_T` — closer brackets raise the tripping capacity `fT`.
- `WebShearResult` / `GirderTrippingResult` + `check_*` wrappers.

## Validation
- k_tau branches: a/d=2 → **6.34**, a/d=0.5 → **25.36**, square → **9.34**.
- Web shear: 1000×12 mm panel → elastic (`tau_cr = tau_e`); 1000×**25** mm → `tau_e > 0.5 f_y` → Johnson-Ostenfeld knocks it down below `tau_e` and `f_y`.
- Tripping: `fT(L_T=800) > fT(L_T=2400)` — closer brackets help, as expected.

7 tests, black + flake8 clean; runs under the `structural` CI domain.

## Builds on
`buckling.py` (`johnson_ostenfeld`, shear form), `panel_buckling.py` (DNV-RP-C201 tripping solver — validated against the 0119-015 worked example, fT=215.61 MPa), `models.py` (`MARINE_GRADES`). Complements the single-stiffener panel buckling and the hull-girder longitudinal strength (#1082). The full grillage (orthogonally stiffened) is #1081.

> Repo `main` CI is chronically red on unrelated domains; the relevant signal here is `tests-structural`.