### PR TITLE
docs(codes): consolidated codes register + provenance citations [#1093]

### DIFF
--- a/docs/domains/codes-register.md
+++ b/docs/domains/codes-register.md
@@ -1,0 +1,67 @@
+# Engineering Codes Register
+
+The single index of every engineering standard implemented in digitalmodel:
+standard → edition → module(s) → tests. The reference strings are defined once in
+`src/digitalmodel/codes.py` (`CodeReference` constants + `REGISTER`), which the
+strength/FFS results carry as `code_reference` (issue #1092). This register is
+kept in sync with `codes.REGISTER` by
+`tests/asset_integrity/test_codes_register.py`.
+
+> Kept current: when you add a `CodeReference` to `codes.py`, add its row here —
+> the consistency test fails otherwise.
+
+## Remaining-strength / fitness-for-service
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| ASME B31G | 2012 | `asset_integrity/corroded_pipe.py` | `test_corroded_pipe`, `test_code_provenance` |
+| DNV-RP-F101 | 2021 | `asset_integrity/dnv_rp_f101.py` | `test_dnv_rp_f101` |
+| API 579-1/ASME FFS-1 | 2021 | `asset_integrity/assessment/*`, `structural_analysis/plate_metal_loss_ffs.py` | `test_ffs_*`, `test_code_provenance` |
+| BS 7910 | 2019 | `asset_integrity/common/fad.py` | `test_ffs_assessment` |
+
+## Buckling / plated structures
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| DNV-RP-C201 | 2010 | `structural_analysis/buckling.py`, `panel_buckling.py`, `girder_web_frame.py`, `plate_metal_loss_ffs.py` | `test_panel_buckling_parametric`, `test_girder_web_frame`, `test_code_provenance` |
+| EN 1993-1-1 (Eurocode 3) | 2005 | `structural_analysis/capacity.py`, `buckling.py` (column) | `test_code_provenance` |
+| DNV CN 30.1 | — | `structural_analysis/girder_web_frame.py` | `test_girder_web_frame` |
+
+## Pipe / riser wall thickness & pressure containment
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| API RP 1111 | 2015 | `structural/analysis/wall_thickness_codes/api_rp_1111.py` | `test_wall_thickness_codes` |
+| API RP 2RD | 2013 | `.../wall_thickness_codes/api_rp_2rd.py` | `test_wall_thickness_codes` |
+| API STD 2RD | 2013 | `.../wall_thickness_codes/api_std_2rd.py` | `test_wall_thickness_codes` |
+| DNV-ST-F201 | 2021 | `.../wall_thickness_codes/dnv_st_f201.py` | `test_wall_thickness_codes` |
+| DNV-ST-F101 | 2021 | `.../wall_thickness_codes/dnv_st_f101.py`, `subsea/pipeline/pipeline_pressure.py` | `test_wall_thickness_codes`, `test_wall_thickness_collapse_solver` |
+| PD 8010-2 | 2015 | `.../wall_thickness_codes/pd_8010_2.py` | `test_wall_thickness_codes` |
+| ISO 13623 | 2017 | `.../wall_thickness_codes/iso_13623.py` | `test_wall_thickness_codes` |
+| ASME B31.4 | 2019 | `.../wall_thickness_codes/asme_b31_4.py` | `test_wall_thickness_codes` |
+| ASME B31.8 | 2020 | `.../wall_thickness_codes/asme_b31_8.py` | `test_wall_thickness_codes` |
+
+## Tubular products
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| API 5L / ISO 3183 | 2018 | `materials/grades.py`, `materials/line_pipe.py` | `test_grade_matrix`, `test_line_pipe` |
+| API 5CT | 2018 | `well/tubulars/casing.py` | `test_casing` |
+| API 5C3 / API TR 5C3 | 2018 | `well/tubulars/casing.py`, `asset_integrity/custom/PipeCapacity.py` | `test_casing` |
+| API 11B | 2018 | `well/tubulars/sucker_rod.py` | `test_sucker_rod` |
+
+## Materials (structural / marine)
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| IACS UR W11 | — | `materials/grades.py`, `structural_analysis/models.py` | `test_grade_matrix` |
+| EN 10025-2 | 2019 | `materials/grades.py`, `structural_analysis/models.py` | `test_grade_matrix` |
+
+## Ship longitudinal strength & scantlings
+
+| Standard | Edition | Module(s) | Tests |
+|---|---|---|---|
+| IACS UR S11 | 2020 | `naval_architecture/hull_girder_strength.py` | `test_hull_girder_strength` |
+| IACS UR S11A | 2021 | `naval_architecture/hull_girder_strength.py` | `test_hull_girder_strength` |
+| DNV-RU-SHIP | 2021 | `naval_architecture/scantlings.py`, `compliance.py` | `test_scantlings` |
+| IACS CSR | 2022 | `naval_architecture/scantlings.py` | `test_scantlings` |

--- a/src/digitalmodel/asset_integrity/common/fad.py
+++ b/src/digitalmodel/asset_integrity/common/fad.py
@@ -1,4 +1,8 @@
-"""Failure Assessment Diagram (FAD) construction and evaluation."""
+"""Failure Assessment Diagram (FAD) construction and evaluation.
+
+Per BS 7910 (Guide to methods for assessing the acceptability of flaws in
+metallic structures) — the Level 2/3 FAD failure-assessment curve.
+"""
 
 class FAD():
     def __init__(self, cfg):

--- a/src/digitalmodel/asset_integrity/custom/PipeCapacity.py
+++ b/src/digitalmodel/asset_integrity/custom/PipeCapacity.py
@@ -1,4 +1,8 @@
-"""Custom pipe capacity methods for asset integrity assessments."""
+"""Custom pipe capacity methods for asset integrity assessments.
+
+Collapse pressure per API TR 5C3 (performance properties of pipe used as casing
+or tubing); burst per Barlow / thick-wall.
+"""
 
 import logging
 import math

--- a/src/digitalmodel/codes.py
+++ b/src/digitalmodel/codes.py
@@ -90,6 +90,27 @@ IACS_W11 = CodeReference(
     "IACS UR W11", "", "Normal & Higher Strength Hull Structural Steels")
 EN_10025_2 = CodeReference("EN 10025-2", "2019", "Hot rolled structural steel")
 
+# ---------------------------------------------------------------------------
+# Tubular products (casing / tubing / sucker rod)
+# ---------------------------------------------------------------------------
+API_5CT = CodeReference("API 5CT", "2018", "Casing and Tubing")
+API_5C3 = CodeReference(
+    "API 5C3 / API TR 5C3", "2018",
+    "Calculating Performance Properties of Pipe Used as Casing or Tubing")
+API_11B = CodeReference("API 11B", "2018", "Sucker Rods")
+
+# ---------------------------------------------------------------------------
+# Ship longitudinal strength & scantlings
+# ---------------------------------------------------------------------------
+IACS_S11 = CodeReference(
+    "IACS UR S11", "2020", "Longitudinal Strength Standard")
+IACS_S11A = CodeReference(
+    "IACS UR S11A", "2021",
+    "Longitudinal Strength Standard for Container Ships")
+DNV_RU_SHIP = CodeReference(
+    "DNV-RU-SHIP", "2021", "Rules for Classification: Ships")
+IACS_CSR = CodeReference("IACS CSR", "2022", "Common Structural Rules")
+
 #: All references, keyed by attribute name — used by the codes register (#1093).
 REGISTER: dict[str, CodeReference] = {
     name: value

--- a/src/digitalmodel/structural/structural_analysis/models.py
+++ b/src/digitalmodel/structural/structural_analysis/models.py
@@ -3,6 +3,9 @@ Data Models for Structural Analysis
 
 Defines data structures for stress states, material properties,
 geometry, and analysis results.
+
+Material grades follow IACS UR W11 (marine hull steels: Grade A / AH36 / EH40)
+and EN 10025-2 (structural steels: S275 / S355 / S420).
 """
 
 from dataclasses import dataclass

--- a/tests/asset_integrity/test_codes_register.py
+++ b/tests/asset_integrity/test_codes_register.py
@@ -1,0 +1,36 @@
+# ABOUTME: Keeps docs/domains/codes-register.md in sync with codes.REGISTER —
+# ABOUTME: every registered CodeReference standard must be documented.
+from pathlib import Path
+
+from digitalmodel import codes
+
+_REGISTER_DOC = (
+    Path(__file__).resolve().parents[2] / "docs" / "domains" / "codes-register.md"
+)
+
+
+def test_register_doc_exists():
+    assert _REGISTER_DOC.is_file(), f"missing {_REGISTER_DOC}"
+
+
+def test_every_registered_code_is_documented():
+    text = _REGISTER_DOC.read_text(encoding="utf-8")
+    missing = [
+        ref.standard
+        for ref in codes.REGISTER.values()
+        if ref.standard not in text
+    ]
+    assert not missing, f"codes missing from codes-register.md: {missing}"
+
+
+def test_register_is_nonempty_and_well_formed():
+    assert codes.REGISTER
+    assert all(isinstance(r, codes.CodeReference) for r in codes.REGISTER.values())
+    assert all(r.standard for r in codes.REGISTER.values())
+
+
+def test_session_codes_present():
+    # The tubular-product and ship-structural codes added with the register.
+    for name in ("API_5CT", "API_5C3", "API_11B", "IACS_S11", "IACS_S11A",
+                 "DNV_RU_SHIP", "IACS_CSR"):
+        assert name in codes.REGISTER, f"{name} not registered"


### PR DESCRIPTION
Closes #1093 — EPIC #1080 workstream C, the consolidation of the provenance work (reuses `codes.REGISTER` from #1092, now merged).

## What it adds
- **`codes.py`**: registers this session's standards — API 5CT, API 5C3 / API TR 5C3, API 11B, IACS UR S11, IACS UR S11A, DNV-RU-SHIP, IACS CSR — auto-collected into `REGISTER`.
- **`docs/domains/codes-register.md`**: the single index of every implemented standard → edition → module(s) → tests, grouped by domain (FFS, buckling, wall-thickness, tubulars, materials, ship strength/scantlings).
- **Docstring citations** for the modules flagged in the #1094 audit that lacked an explicit code reference: `structural_analysis/models.py` (IACS UR W11 + EN 10025-2), `asset_integrity/common/fad.py` (BS 7910), `asset_integrity/custom/PipeCapacity.py` (API TR 5C3). (The wall-thickness-code strategies already name their codes.)

## Kept-current guard
`tests/asset_integrity/test_codes_register.py` (4 tests) asserts **every `codes.REGISTER` entry's standard appears in `codes-register.md`** — so adding a `CodeReference` without documenting it fails CI. Also checks the 7 new codes are registered and the register is well-formed.

15 tests pass (11 provenance + 4 register); black clean (the one pre-existing `PipeCapacity.py:832` F401 is unrelated to the line-1 docstring edit).

> Repo `main` CI is chronically red on unrelated domains; the relevant signal here is `tests-asset-integrity` + `docs`.