### PR TITLE
ci: add uv caching to 4 setup-uv domain workflows (workspace-hub#3291)

### DIFF
--- a/.github/workflows/aqwa-tests.yml
+++ b/.github/workflows/aqwa-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'src/digitalmodel/modules/aqwa/**'
       - 'tests/domains/aqwa/**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -31,7 +32,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |
@@ -72,7 +76,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |

--- a/.github/workflows/diffraction-tests.yml
+++ b/.github/workflows/diffraction-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'src/digitalmodel/modules/diffraction/**'
       - 'tests/domains/diffraction/**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -31,7 +32,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |
@@ -68,7 +72,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |

--- a/.github/workflows/mooring-analysis-tests.yml
+++ b/.github/workflows/mooring-analysis-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'src/digitalmodel/modules/mooring_analysis/**'
       - 'tests/domains/mooring_analysis/**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -31,7 +32,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |
@@ -72,7 +76,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |

--- a/.github/workflows/structural-analysis-tests.yml
+++ b/.github/workflows/structural-analysis-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'src/digitalmodel/modules/structural_analysis/**'
       - 'tests/domains/structural_analysis/**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -31,7 +32,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |
@@ -72,7 +76,10 @@ jobs:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Create virtual environment
       run: |


### PR DESCRIPTION
Implements workspace-hub#3291.

Adds uv dependency caching to the four uv-based per-domain test workflows (`aqwa`, `diffraction`, `mooring-analysis`, `structural-analysis`): bumps `astral-sh/setup-uv` `@v3` -> `@v7` at both sites (test + lint) in each file and adds `enable-cache: true` + `cache-dependency-glob: "uv.lock"`, copying the worldenergydata `ci.yml` reference pattern. Also adds a `workflow_dispatch:` trigger to each `on:` block.

**Why workflow_dispatch:** each file's `pull_request` `paths:` filter covers only `src/.../<m>/**` and `tests/domains/<m>/**` (NOT the workflow YAML), and `push` is branch-filtered to main/develop — so a YAML-only PR fires neither trigger. `workflow_dispatch` gives a manual run handle (`gh workflow run <file>`) for cache-hit verification.

**Scope (owner decision D2):** the 5 plain-pip workflows keep `cache: 'pip'` (no pip->uv swap); `quality-gates*.yml` descoped.

**Verification:** YAML parses for all 4; each file has exactly 2 cache blocks, 2 `@v7` pins, 0 `@v3`, and a `workflow_dispatch:` trigger; `git diff --stat` confirms only these 4 files changed. End-to-end cache-hit verification is via `gh workflow run` post-merge (GitHub only accepts `workflow_dispatch` once the trigger is on the default branch) — NOT triggered from this PR.