### PR TITLE
ci: route push touched-domain-only in quality-gates-by-domain (workspace-hub#3292)

### DIFF
--- a/.github/workflows/quality-gates-by-domain.yml
+++ b/.github/workflows/quality-gates-by-domain.yml
@@ -36,6 +36,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.event.after }}
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
             matrix=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
@@ -44,7 +46,20 @@ jobs:
               --head "$PR_HEAD_SHA" \
               --domains-file tests/DOMAINS.md \
               --output-format json-matrix)
+          elif [ "$EVENT_NAME" = "push" ]; then
+            # Route push like PR: touched-domain-only. github.event.before is the
+            # all-zero SHA on branch-create and may be pruned after a force-push;
+            # --on-missing-base full makes the detector fail SAFE to the full sweep
+            # rather than silently skipping every leg.
+            matrix=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
+              --mode touched \
+              --base "$PUSH_BEFORE_SHA" \
+              --head "$PUSH_AFTER_SHA" \
+              --on-missing-base full \
+              --domains-file tests/DOMAINS.md \
+              --output-format json-matrix)
           else
+            # schedule (nightly cron) + workflow_dispatch run the full sweep.
             matrix=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
               --mode full \
               --domains-file tests/DOMAINS.md \

--- a/scripts/ci/detect_touched_domains.py
+++ b/scripts/ci/detect_touched_domains.py
@@ -262,6 +262,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--output-format", choices=("json-matrix", "list"), default="json-matrix"
     )
+    parser.add_argument(
+        "--on-missing-base",
+        choices=("error", "full"),
+        default="error",
+        help=(
+            "Behavior when the base SHA is unreachable (zero-SHA new branch or "
+            "force-push pruned history). 'error' (default) hard-fails with exit 2; "
+            "'full' fails SAFE to the full matrix."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.mode == "touched" and (not args.base or not args.head):
         parser.error("--mode touched requires --base and --head")
@@ -272,16 +282,26 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
         domains = parse_domains(args.domains_file)
-        selected = (
-            domains
-            if args.mode == "full"
-            else touched_domains(
-                git_changed_files(args.base, args.head),
-                domains,
-                args.base,
-                args.head,
-            )
-        )
+        if args.mode == "full":
+            selected = domains
+        else:
+            try:
+                changed = git_changed_files(args.base, args.head)
+            except subprocess.CalledProcessError:
+                # Base SHA unreachable: zero-SHA new branch or force-push pruned
+                # history. Fail SAFE to the full matrix when asked; otherwise let
+                # the catch-all below preserve the historical exit-2 behavior.
+                if args.on_missing_base == "full":
+                    selected = domains
+                else:
+                    raise
+            else:
+                selected = touched_domains(
+                    changed,
+                    domains,
+                    args.base,
+                    args.head,
+                )
     except Exception as exc:
         print(f"detect_touched_domains.py: {exc}", file=sys.stderr)
         return 2

--- a/tests/scripts/test_detect_touched_domains.py
+++ b/tests/scripts/test_detect_touched_domains.py
@@ -577,3 +577,163 @@ def test_quality_gate_workflows_parse() -> None:
         Path(".github/workflows/quality-gates-by-domain.yml"),
     ):
         assert yaml.safe_load(workflow.read_text())
+
+
+BOGUS_SHA = "0123456789abcdef0123456789abcdef01234567"
+ZERO_SHA = "0000000000000000000000000000000000000000"
+
+
+def _repo_with_single_domain_change(tmp_path: Path) -> tuple[Path, str, str]:
+    domains_file = tmp_path / "DOMAINS.md"
+    write_domains(domains_file)
+    init_repo(tmp_path)
+    test_file = tmp_path / "tests" / "citations" / "test_registry.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_old():\n    assert True\n")
+    base = commit_all(tmp_path, "base")
+    test_file.write_text("def test_new():\n    assert True\n")
+    head = commit_all(tmp_path, "head")
+    return domains_file, base, head
+
+
+def test_touched_mode_unreachable_base_errors_by_default(tmp_path: Path) -> None:
+    """Without --on-missing-base, an unreachable base is still a hard error (exit 2)."""
+    domains_file, _base, head = _repo_with_single_domain_change(tmp_path)
+
+    result = run_detector(
+        tmp_path,
+        domains_file,
+        "--mode",
+        "touched",
+        "--base",
+        BOGUS_SHA,
+        "--head",
+        head,
+        "--output-format",
+        "json-matrix",
+    )
+
+    assert result.returncode == 2, result.stdout
+    assert "detect_touched_domains.py" in result.stderr
+
+
+def test_touched_mode_unreachable_base_falls_back_to_full(tmp_path: Path) -> None:
+    """--on-missing-base full makes an unreachable base fail SAFE to the full matrix."""
+    domains_file, _base, head = _repo_with_single_domain_change(tmp_path)
+
+    result = run_detector(
+        tmp_path,
+        domains_file,
+        "--mode",
+        "touched",
+        "--base",
+        BOGUS_SHA,
+        "--head",
+        head,
+        "--on-missing-base",
+        "full",
+        "--output-format",
+        "json-matrix",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert [item["domain"] for item in json.loads(result.stdout)["include"]] == [
+        "asset-integrity",
+        "citations",
+        "structural",
+        "workflows",
+    ]
+
+
+def test_zero_sha_base_falls_back_to_full(tmp_path: Path) -> None:
+    """New-branch zero-SHA base fails SAFE to the full matrix under the flag."""
+    domains_file, _base, head = _repo_with_single_domain_change(tmp_path)
+
+    result = run_detector(
+        tmp_path,
+        domains_file,
+        "--mode",
+        "touched",
+        "--base",
+        ZERO_SHA,
+        "--head",
+        head,
+        "--on-missing-base",
+        "full",
+        "--output-format",
+        "json-matrix",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert [item["domain"] for item in json.loads(result.stdout)["include"]] == [
+        "asset-integrity",
+        "citations",
+        "structural",
+        "workflows",
+    ]
+
+
+def test_on_missing_base_full_does_not_alter_happy_path(tmp_path: Path) -> None:
+    """The flag is inert when the base is reachable: still scopes to the touched domain."""
+    domains_file, base, head = _repo_with_single_domain_change(tmp_path)
+
+    result = run_detector(
+        tmp_path,
+        domains_file,
+        "--mode",
+        "touched",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--on-missing-base",
+        "full",
+        "--output-format",
+        "list",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["citations"]
+
+
+def test_push_like_pr_scopes_single_domain(tmp_path: Path) -> None:
+    """A single-domain push diff routes to one leg, mirroring the PR touched path."""
+    domains_file, base, head = _repo_with_single_domain_change(tmp_path)
+
+    result = run_detector(
+        tmp_path,
+        domains_file,
+        "--mode",
+        "touched",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--output-format",
+        "list",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["citations"]
+
+
+def test_workflow_routes_push_to_touched_mode() -> None:
+    """Structural guard: the workflow routes push -> touched (--on-missing-base full),
+    and --mode full is reachable only from the schedule/dispatch (else) arm."""
+    workflow_text = Path(
+        ".github/workflows/quality-gates-by-domain.yml"
+    ).read_text()
+
+    # push routes to touched mode with the fail-safe flag
+    assert 'EVENT_NAME" = "push"' in workflow_text
+    assert "--on-missing-base full" in workflow_text
+
+    # before/after SHAs are wired into the detect step env
+    assert "github.event.before" in workflow_text
+    assert "github.event.after" in workflow_text
+
+    # the --mode full arm must not be reached from the push branch: it lives in the
+    # final else (schedule + workflow_dispatch). Assert the push arm precedes full.
+    push_idx = workflow_text.index('EVENT_NAME" = "push"')
+    full_idx = workflow_text.index("--mode full")
+    assert push_idx < full_idx, "push arm must precede the --mode full (else) arm"


### PR DESCRIPTION
Implements workspace-hub#3292 (deliverable #1 — routing only).

**Workflow** (`quality-gates-by-domain.yml`): replaces the 2-arm `if pull_request / else full` with explicit 3-way routing. `push` now runs the touched-domain matrix scoped to `github.event.before..github.event.after` with `--on-missing-base full` as a fail-safe; `--mode full` runs only on `schedule` (nightly cron) and `workflow_dispatch`. Adds `PUSH_BEFORE_SHA`/`PUSH_AFTER_SHA` to the detect-step env (`fetch-depth: 0` already set).

**Detector** (`detect_touched_domains.py`): adds `--on-missing-base {error,full}` (default `error`). A `CalledProcessError` from `git_changed_files` on an unreachable base (zero-SHA branch-create or force-push pruned history) fails SAFE to the full matrix when `full`, else re-raises into the existing catch-all (byte-identical exit-2 for PR/schedule/dispatch callers, which never pass the flag).

**Tests** (TDD, 6 new): unreachable-base default-error (exit 2), fallback-full, zero-SHA fallback, inert-on-happy-path, push-scopes-single-domain, and a structural workflow-routing guard.

**Scope:** issue deliverable #1 (routing) only. Baseline-red triage + license/solver quarantine (deliverable #2 / issue Acceptance bullet #2) is **explicitly out of scope**, owned by digitalmodel #700/#949/#706 and #705/#714. No caching / package-manager change (D2/#3291 boundary).

**Verification:** `uv run python -m pytest tests/scripts/test_detect_touched_domains.py` → 20 passed (14 existing + 6 new); workflow YAML parses; `git diff` shows no `cache:` key and no pip/uv swap. The end-to-end push routing fires only on main/develop, so it is observable post-merge (recorded as a follow-up observation, not a pre-merge gate).