### PR TITLE
feat(diffraction): live wiring — fill per-structure-type report from results (#282)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/report_catalog.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/report_catalog.py
@@ -21,9 +21,21 @@ report can be assembled from the same builders.
 from __future__ import annotations
 
 from enum import Enum
-from typing import List
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from digitalmodel.reporting.skeleton import BlockSpec, ReportSkeleton, SectionSpec
+from digitalmodel.reporting.provenance import Provenance
+from digitalmodel.reporting.skeleton import (
+    BlockSpec,
+    Completeness,
+    ReportSkeleton,
+    SectionSpec,
+)
+
+if TYPE_CHECKING:  # avoid importing the heavy reporter at module load
+    from digitalmodel.hydrodynamics.diffraction.report_data_models import (
+        DiffractionReportData,
+    )
 
 
 class StructureType(str, Enum):
@@ -184,9 +196,114 @@ def report_catalog() -> dict[str, ReportSkeleton]:
     return {s.value: diffraction_report_skeleton(s) for s in StructureType}
 
 
+# ---------------------------------------------------------------------------
+# Live wiring: fill skeleton slots from the existing diffraction builders (#282)
+# ---------------------------------------------------------------------------
+
+# Skeleton block key -> name of the existing report_generator section builder.
+# Builders return "" when their data is absent, so an unfilled slot stays empty
+# and completeness() flags it -- the acceptance gate is real, not cosmetic.
+_BLOCK_BUILDERS: Dict[str, str] = {
+    "executive_summary": "_sec_executive_summary",
+    "identification": "_sec_header",
+    "mesh_quality": "_sec_hull_description",
+    "stability": "_sec_stability",
+    "added_mass_diagonal": "_sec_added_mass",
+    "damping_diagonal": "_sec_damping",
+    "load_raos": "_sec_load_raos",
+    "natural_periods": "_sec_natural_periods",
+    "roll_damping": "_sec_roll_damping",
+    "validation_sanity": "_sec_validation",
+    "assumptions": "_sec_assumptions",
+}
+
+
+def build_diffraction_report_content(
+    report_data: "DiffractionReportData",
+    *,
+    assumption_ledger: Any = None,
+    validation_report: Optional[dict] = None,
+    include_plotlyjs: str = "cdn",
+    extra_blocks: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Map a ``DiffractionReportData`` to skeleton block content via the existing
+    diffraction section builders.
+
+    Only non-empty fragments are returned, so a slot whose data is missing stays
+    unfilled (and is reported by completeness). ``extra_blocks`` supplies content
+    the data-builders don't produce -- e.g. per-DOF RAO plots (``dof_sections``)
+    or a ``multibody_interaction`` note -- and also seeds from
+    ``report_data.benchmark_html_sections``.
+    """
+    from digitalmodel.hydrodynamics.diffraction import report_generator as rg
+
+    content: Dict[str, str] = {}
+    for block_key, builder_name in _BLOCK_BUILDERS.items():
+        builder = getattr(rg, builder_name, None)
+        if builder is None:  # pragma: no cover - guards builder renames
+            continue
+        try:
+            fragment = builder(
+                report_data,
+                include_plotlyjs=include_plotlyjs,
+                validation_report=validation_report,
+                assumption_ledger=assumption_ledger,
+            )
+        except Exception:  # pragma: no cover - a bad block must not kill report
+            fragment = ""
+        if fragment:
+            content[block_key] = fragment
+
+    # Per-DOF RAOs and any other benchmark-only fragments come from the data's
+    # benchmark sections (e.g. ``dof_sections``); explicit extra_blocks win.
+    for key, frag in (report_data.benchmark_html_sections or {}).items():
+        if frag and key not in content:
+            content[key] = frag
+    for key, frag in (extra_blocks or {}).items():
+        if frag:
+            content[key] = frag
+    return content
+
+
+def render_structured_report(
+    structure_type: StructureType | str,
+    report_data: "DiffractionReportData",
+    *,
+    provenance: Provenance,
+    assumption_ledger: Any = None,
+    validation_report: Optional[dict] = None,
+    include_plotlyjs: str = "cdn",
+    extra_blocks: Optional[Dict[str, str]] = None,
+    output_path: Optional[str | Path] = None,
+    css: str = "",
+) -> Tuple[str | Path, Completeness]:
+    """Render a standardized per-structure-type diffraction report from results.
+
+    Fills the structure-type skeleton from the existing diffraction builders and
+    ``report_data``, enforces mandatory provenance, and returns
+    ``(html_or_path, completeness)`` so the caller can gate on acceptance (all
+    required slots filled for that hull form). Provenance is required (#1019).
+    """
+    skeleton = diffraction_report_skeleton(structure_type)
+    content = build_diffraction_report_content(
+        report_data,
+        assumption_ledger=assumption_ledger,
+        validation_report=validation_report,
+        include_plotlyjs=include_plotlyjs,
+        extra_blocks=extra_blocks,
+    )
+    status = skeleton.completeness(content, provenance=provenance)
+    out = skeleton.build_html(
+        content, provenance=provenance, output_path=output_path, css=css
+    )
+    return out, status
+
+
 __all__ = [
     "StructureType",
     "list_structure_types",
     "diffraction_report_skeleton",
     "report_catalog",
+    "build_diffraction_report_content",
+    "render_structured_report",
 ]

--- a/tests/hydrodynamics/diffraction/test_report_catalog.py
+++ b/tests/hydrodynamics/diffraction/test_report_catalog.py
@@ -81,3 +81,67 @@ def test_filled_skeleton_with_provenance_is_complete() -> None:
 def test_unknown_structure_type_rejected() -> None:
     with pytest.raises(ValueError):
         diffraction_report_skeleton("submarine")
+
+
+# --- live wiring: fill slots from DiffractionReportData (#282) -------------
+
+
+def _report_data():
+    from digitalmodel.hydrodynamics.diffraction.report_data_models import (
+        DiffractionReportData,
+    )
+
+    return DiffractionReportData(
+        vessel_name="Test FPSO",
+        hull_type="fpso",
+        executive_warnings=["check roll"],
+        benchmark_html_sections={"dof_sections": "<div>RAO plots</div>"},
+    )
+
+
+def test_build_content_invokes_existing_builders():
+    from digitalmodel.hydrodynamics.diffraction.report_catalog import (
+        build_diffraction_report_content,
+    )
+
+    content = build_diffraction_report_content(_report_data())
+    # builders that always render from minimal data
+    assert "executive_summary" in content and "identification" in content
+    # benchmark fragment is picked up
+    assert content["dof_sections"] == "<div>RAO plots</div>"
+    # a slot whose data is absent stays unfilled
+    assert "roll_damping" not in content
+
+
+def test_render_structured_report_gates_on_completeness():
+    from digitalmodel.hydrodynamics.diffraction.report_catalog import (
+        render_structured_report,
+    )
+
+    out, status = render_structured_report(
+        "fpso", _report_data(), provenance=Provenance().add("solver_queue", "run9")
+    )
+    assert "<!DOCTYPE html>" in out and "run9" in out and "RAO plots" in out
+    # FPSO is ship-shaped -> roll_damping required and unfilled -> incomplete
+    assert not status.complete
+    assert "roll_damping" in status.missing_blocks
+
+
+def test_render_structured_report_complete_when_all_slots_filled(tmp_path):
+    from digitalmodel.hydrodynamics.diffraction.report_catalog import (
+        diffraction_report_skeleton,
+        render_structured_report,
+    )
+
+    sk = diffraction_report_skeleton("ship")
+    extra = {k: f"<p>{k}</p>" for k in sk.required_block_keys()}
+    out_path = tmp_path / "ship_report.html"
+    out, status = render_structured_report(
+        "ship",
+        _report_data(),
+        provenance=Provenance().add("spec", "s.yml"),
+        extra_blocks=extra,
+        output_path=out_path,
+    )
+    assert out == out_path and out_path.exists()
+    assert status.complete and status.missing_blocks == []


### PR DESCRIPTION
Closes #282. Completes the standardized per-structure-type reporting: a structure type + `DiffractionReportData` → a complete, provenance-gated report, filling the per-hull-type skeleton (#1123) slots from the **existing** diffraction section builders (no plotting rebuilt).

## What
- **`build_diffraction_report_content(report_data, ...)`** — maps each skeleton block key to its `report_generator` section builder (executive_summary, identification, mesh_quality, stability, added_mass/damping, load_raos, natural_periods, roll_damping, validation, assumptions). Builders return `""` when data is absent, so an unfilled slot stays empty and `completeness()` flags it — **the acceptance gate is real**. Per-DOF RAOs and other benchmark-only fragments are seeded from `report_data.benchmark_html_sections`; explicit `extra_blocks` win.
- **`render_structured_report(structure_type, report_data, *, provenance, ...) → (html_or_path, Completeness)`** — fills + renders + returns the acceptance verdict (all required slots filled for that hull form). Mandatory provenance (#1019).

## Verification
- +3 tests (builders invoked from minimal data; ship-shaped FPSO is incomplete with `roll_damping` missing; complete path when all slots filled + written to disk) → **17 tests** in the catalog suite.
- Live smoke: minimal FPSO data → 4/11 slots filled, correct missing list, doc carries provenance + DOF plots.
- black 25.9.0 / isort 5.13.2 / flake8 clean.

This closes the reporting backbone: #1018 ✓ #1019 ✓ #1020 ✓ #1021 ✓ #282 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)