### PR TITLE
feat(structural): connection & bracket SCF (DNV-RP-C203) [#1086]

### DIFF
--- a/docs/domains/connection-scf-validation-2026-06-28.md
+++ b/docs/domains/connection-scf-validation-2026-06-28.md
@@ -1,0 +1,92 @@
+# Connection & Bracket Stress-Concentration Validation (DNV-RP-C203)
+
+Issue: digitalmodel #1086 (Ship-struct A6, EPIC #1080, Workstream A, Phase 3).
+Module: `src/digitalmodel/structural/structural_analysis/connection_scf.py`
+Tests:  `tests/structural/structural_analysis/test_connection_scf.py` (14 tests)
+Code basis: **DNV-RP-C203** (Fatigue design of offshore steel structures, 2021).
+
+## Scope
+
+Local detail checks at loaded ship/offshore connections:
+
+- **Frame-to-girder / girder-to-shell junctions** — plate butt / cruciform
+  junctions with a fit-up eccentricity that bends an axially-loaded plate
+  (axial-misalignment SCF).
+- **Soft-toe brackets** — bracket toes welded to plating; a ground/tapered
+  ("soft") toe lowers the weld-toe SCF vs a square ("hard") toe.
+- **Attachment lugs / tubular brace stubs** — loaded tubular attachment on a
+  chord, governed by the Efthymiou parametric chord-saddle SCF.
+
+## What is reused (no physics reimplemented)
+
+This module is a thin **ship-detail orchestration** layer over the existing
+fatigue library:
+
+| Reused from | Function | Used for |
+|---|---|---|
+| `fatigue/scf_library.py` | `scf_butt_weld_misalignment` (1 + 3 e/t) | pinned junction misalignment |
+| `fatigue/scf_library.py` | `scf_cruciform_joint` (km = 1 + 6 e/t) | restrained junction misalignment |
+| `fatigue/scf_library.py` | `scf_fillet_weld_toe` | bracket-toe (soft/hard) SCF |
+| `fatigue/hotspot_stress.py` | `extrapolate_hotspot_linear` (1.67/−0.67) | weld-toe hot-spot extrapolation |
+| `fatigue/weld_classification.py` | `classify_weld_detail` | DNV S-N detail class (E/F/F1/W3...) |
+
+The only new closed-form physics added is the **published Efthymiou
+chord-saddle** equation (see reconciliation note below).
+
+## Approach: detail class AND SCF
+
+DNV-RP-C203 handles welded ship attachments/brackets mainly by **S-N detail
+classification** (E / F / F1 / F3 by attachment length & load path), *not* by a
+single multiplicative SCF. `assess_connection()` therefore returns **both**:
+
+1. the DNV S-N detail class (from the weld classifier), and
+2. the discontinuity SCF (misalignment / bracket toe / tubular), used to form
+   the weld-toe hot-spot stress `sigma_hs = SCF * sigma_nominal`
+   (DNV-RP-C203 Sec. 2.3).
+
+The misalignment restraint condition is an **explicit argument**
+(`restrained=False` → pinned 3 e/t; `restrained=True` → restrained 6 e/t).
+
+The plate **thickness-effect (size) correction** is deliberately kept OUT of the
+SCF — per DNV-RP-C203 it belongs in the S-N (fatigue-strength) layer, not the
+stress side.
+
+## Golden values (independently reproduced)
+
+| Quantity | Inputs | Formula | Expected | Source |
+|---|---|---|---|---|
+| Axial misalignment SCF (pinned) | e=3 mm, t=20 mm | 1 + 3 e/t | **1.45** | DNV-RP-C203 App. D (single-sided / pinned plate) |
+| Axial misalignment SCF (restrained) | e=3 mm, t=20 mm | 1 + 6 e/t | **1.90** | DNV-RP-C203 (restrained / cruciform / fixed ends) |
+| Hot-spot stress (linear extrap.) | σ(0.4t)=200, σ(1.0t)=150 MPa | 1.67·σ₀.₄ₜ − 0.67·σ₁.₀ₜ | **233.5 MPa** | DNV-RP-C203 Eq. 4.1 |
+| Efthymiou chord-saddle SCF (axial T) | β=0.5, γ=12, τ=0.5, θ=90° | γ·τ^1.1·(1.11 − 3(β−0.52)²)·sin θ^1.6 | **6.21** | DNV-RP-C203 App. B / Efthymiou (1988) |
+| Hot-spot stress = SCF·nominal | SCF=1.45, σ=100 MPa | SCF·σ | **145.0 MPa** | DNV-RP-C203 Sec. 2.3 |
+
+Efthymiou hand check (full precision):
+`12 · 0.5^1.1 · (1.11 − 3·(0.5−0.52)²) · sin(90°)^1.6`
+`= 12 · 0.466516 · 1.1088 · 1 = 6.2072` → rounds to **6.21**.
+
+## Reconciliation note — existing library τ^1.0 vs published τ^1.1
+
+The repository's `scf_library.efthymiou_ty_axial` chord-saddle term uses
+`tau^1.0`, so for the same geometry (β=0.5, γ=12, τ=0.5, θ=90°) it returns
+**6.65** — about **7% higher** than the published **6.21** (`tau^1.1`). This
+module's `efthymiou_chord_saddle_axial_scf` reproduces the **published τ^1.1**
+form (DNV-RP-C203 App. B / Efthymiou 1988). The discrepancy in the existing
+library is documented here and intentionally **not** silently inherited; a
+follow-up could correct `scf_library.efthymiou_ty_axial` to `tau^1.1`.
+
+## Simplification level / caveats
+
+- **Misalignment SCF** is the standard membrane-bending amplification (3 e/t
+  pinned, 6 e/t restrained); the thickness-step term is available via `t2_mm`
+  for the pinned case.
+- **Bracket-toe SCF** uses representative soft/hard toe geometry presets
+  (soft: flank 20°, r=4 mm; hard: flank 45°, r=1 mm) fed to the validated
+  IIW/DNV fillet-toe SCF. Presets are overridable; for detailed design, replace
+  with measured toe geometry or an FE hot-spot SCF. The model guarantees
+  soft-toe SCF < hard-toe SCF.
+- **Efthymiou** here covers the axial chord-saddle hot spot only (the governing
+  term for a loaded brace stub); IPB/OPB/brace-side terms remain available in
+  `scf_library` (with the τ^1.0 caveat above).
+- This is a screening / detail-design-input layer; it does not perform the S-N
+  damage summation (that is the `fatigue/` damage layer).

--- a/src/digitalmodel/structural/structural_analysis/connection_scf.py
+++ b/src/digitalmodel/structural/structural_analysis/connection_scf.py
@@ -1,0 +1,313 @@
+# ABOUTME: Connection & bracket stress-concentration (DNV-RP-C203) — local
+# ABOUTME: detail SCFs + weld-toe hot-spot stress at loaded ship connections.
+"""Connection & bracket stress-concentration factors (DNV-RP-C203).
+
+Local fatigue-detail checks at the loaded connections of a ship/offshore hull:
+
+* **Frame-to-girder / girder-to-shell junctions** — plate butt/cruciform
+  junctions where a thickness step or fit-up eccentricity raises the stress
+  (axial-misalignment SCF).
+* **Soft-toe brackets** — bracket toes welded to plating; the ground/tapered
+  ("soft") toe lowers the weld-toe SCF relative to a square ("hard") toe.
+* **Attachment lugs / tubular brace stubs** — a loaded tubular attachment on a
+  chord, governed by the Efthymiou parametric SCF (chord-saddle hot spot).
+
+Design philosophy — this module is a thin *ship-detail orchestration* layer; it
+reimplements **no** SCF physics. It reuses the validated fatigue library:
+
+* :mod:`digitalmodel.fatigue.scf_library` — misalignment / cruciform / fillet-toe
+  SCF formulae and the Efthymiou tubular set.
+* :mod:`digitalmodel.fatigue.hotspot_stress` — DNV-RP-C203 surface-stress
+  extrapolation to the weld toe.
+* :mod:`digitalmodel.fatigue.weld_classification` — DNV-RP-C203 Tables 2-1..2-8
+  S-N detail class for the connection.
+
+DNV-RP-C203 handles welded ship attachments/brackets mainly by **S-N detail
+classification** (E / F / F1 / F3 ...), *not* by one multiplicative SCF. So a
+connection assessment here returns **both** a detail class (from the weld
+classifier) **and** the discontinuity SCF (misalignment / toe / tubular) where
+applicable. The plate thickness-effect (size) correction is deliberately kept
+OUT of the SCF — it belongs in the S-N (fatigue-strength) layer.
+
+Units: mm (lengths), MPa (stresses).
+
+References
+----------
+- DNV-RP-C203 (2021), Sec. 2.3 (hot-spot stress = SCF x nominal), Sec. 4.3
+  (extrapolation), App. B (Efthymiou tubular), App. C/D (plate SCFs).
+- Efthymiou, M. (1988), "Development of SCF formulae...", OTC, Surrey.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from digitalmodel.fatigue.hotspot_stress import extrapolate_hotspot_linear
+from digitalmodel.fatigue.scf_library import (
+    scf_butt_weld_misalignment,
+    scf_cruciform_joint,
+    scf_fillet_weld_toe,
+)
+from digitalmodel.fatigue.weld_classification import (
+    WeldDetail,
+    classify_weld_detail,
+)
+
+CODE_REFERENCE = "DNV-RP-C203"
+
+
+# ---------------------------------------------------------------------------
+# Hot-spot stress = SCF x nominal  (DNV-RP-C203 Sec. 2.3)
+# ---------------------------------------------------------------------------
+def hot_spot_stress(scf: float, nominal_stress_mpa: float) -> float:
+    """Weld-toe hot-spot stress from a stress-concentration factor.
+
+    DNV-RP-C203 Sec. 2.3: ``sigma_hotspot = SCF * sigma_nominal``.
+
+    Parameters
+    ----------
+    scf : float
+        Stress-concentration factor (>= 1.0).
+    nominal_stress_mpa : float
+        Nominal (far-field) stress at the connection (MPa).
+    """
+    if scf < 1.0:
+        raise ValueError("SCF must be >= 1.0")
+    return scf * nominal_stress_mpa
+
+
+# ---------------------------------------------------------------------------
+# Frame-to-girder / girder-to-shell junction — axial-misalignment SCF
+# ---------------------------------------------------------------------------
+def misalignment_scf(
+    thickness_mm: float,
+    eccentricity_mm: float,
+    *,
+    restrained: bool = False,
+    t2_mm: float | None = None,
+) -> float:
+    """SCF from fit-up eccentricity at a plate junction (DNV-RP-C203 App. D/C).
+
+    The restraint condition sets the bending amplification of an axial
+    misalignment ``e`` over thickness ``t``:
+
+    * ``restrained=False`` — a **pinned** / single-sided butt junction (free to
+      rotate): ``SCF = 1 + 3 e/t`` (reuses
+      :func:`...scf_library.scf_butt_weld_misalignment`).
+    * ``restrained=True`` — a **restrained** junction held straight by adjoining
+      structure (e.g. cruciform / fixed-ends, as at a girder-to-shell tee):
+      ``SCF = 1 + 6 e/t`` (reuses the ``km`` term of
+      :func:`...scf_library.scf_cruciform_joint`).
+
+    Parameters
+    ----------
+    thickness_mm : float
+        Plate thickness ``t`` (mm).
+    eccentricity_mm : float
+        Linear (axial) misalignment ``e`` (mm).
+    restrained : bool
+        Restraint condition (see above). Default ``False`` (pinned).
+    t2_mm : float, optional
+        Thickness of the second plate (mm) for the pinned case, to include the
+        thickness-step term. Defaults to ``thickness_mm`` (pure misalignment).
+    """
+    if restrained:
+        # a_weld >= t -> the cruciform weld-geometry factor kw collapses to 1.0,
+        # leaving the restrained misalignment km = 1 + 6 e/t.
+        return scf_cruciform_joint(thickness_mm, thickness_mm, eccentricity_mm)
+    t2 = thickness_mm if t2_mm is None else t2_mm
+    return scf_butt_weld_misalignment(thickness_mm, t2, eccentricity_mm)
+
+
+# ---------------------------------------------------------------------------
+# Soft-toe vs hard-toe bracket — weld-toe SCF
+# ---------------------------------------------------------------------------
+# Representative weld-toe geometry for ship bracket toes. A ground/tapered
+# "soft" toe presents a shallow flank angle and a generous effective radius; a
+# square "hard" toe is a steep, near-sharp toe. Values feed the validated
+# IIW/DNV fillet-toe SCF (scf_library.scf_fillet_weld_toe).
+_HARD_TOE_ANGLE_DEG = 45.0
+_HARD_TOE_RADIUS_MM = 1.0
+_SOFT_TOE_ANGLE_DEG = 20.0
+_SOFT_TOE_RADIUS_MM = 4.0
+
+
+def bracket_toe_scf(
+    thickness_mm: float,
+    *,
+    soft_toe: bool = False,
+    toe_angle_deg: float | None = None,
+    toe_radius_mm: float | None = None,
+) -> float:
+    """Weld-toe SCF at a bracket toe (DNV-RP-C203 App. C; IIW-2259-15).
+
+    Reuses :func:`...scf_library.scf_fillet_weld_toe`. A soft (ground/tapered)
+    toe has a shallower flank angle and larger effective radius than a hard
+    (square) toe, so ``bracket_toe_scf(..., soft_toe=True) <
+    bracket_toe_scf(..., soft_toe=False)`` for the same plate.
+
+    Parameters
+    ----------
+    thickness_mm : float
+        Attached-plate thickness ``t`` (mm).
+    soft_toe : bool
+        Select the soft-toe geometry preset. Default ``False`` (hard toe).
+    toe_angle_deg, toe_radius_mm : float, optional
+        Override the preset weld-toe flank angle / radius (mm).
+    """
+    angle = toe_angle_deg
+    radius = toe_radius_mm
+    if angle is None:
+        angle = _SOFT_TOE_ANGLE_DEG if soft_toe else _HARD_TOE_ANGLE_DEG
+    if radius is None:
+        radius = _SOFT_TOE_RADIUS_MM if soft_toe else _HARD_TOE_RADIUS_MM
+    return scf_fillet_weld_toe(thickness_mm, angle, radius)
+
+
+# ---------------------------------------------------------------------------
+# Attachment lug / tubular brace stub — Efthymiou chord-saddle SCF
+# ---------------------------------------------------------------------------
+def efthymiou_chord_saddle_axial_scf(
+    beta: float,
+    gamma: float,
+    tau: float,
+    theta_deg: float = 90.0,
+) -> float:
+    """Chord-saddle SCF of an axially-loaded tubular T/Y joint (Efthymiou).
+
+    DNV-RP-C203 App. B / Efthymiou (1988), chord-saddle term::
+
+        SCF = gamma * tau^1.1 * (1.11 - 3(beta - 0.52)^2) * sin(theta)^1.6
+
+    with non-dimensional geometry ``beta = d/D``, ``gamma = D/(2T)``,
+    ``tau = t/T``. This is the **published tau^1.1** form. Note that the
+    repository's :func:`...scf_library.efthymiou_ty_axial` uses ``tau^1.0`` and
+    therefore returns a value ~7% higher; this function reproduces the
+    published value for a loaded attachment lug / brace stub.
+
+    Parameters
+    ----------
+    beta : float
+        Brace/chord diameter ratio ``d/D`` (0.2..1.0).
+    gamma : float
+        Chord radius/thickness ratio ``D/(2T)`` (typ. 8..32).
+    tau : float
+        Brace/chord thickness ratio ``t/T`` (0.2..1.0).
+    theta_deg : float
+        Brace-to-chord angle (degrees). Default 90.
+    """
+    if beta <= 0 or gamma <= 0 or tau <= 0:
+        raise ValueError("beta, gamma, tau must be > 0")
+    sin_th = math.sin(math.radians(theta_deg))
+    scf = gamma * tau**1.1 * (1.11 - 3.0 * (beta - 0.52) ** 2) * sin_th**1.6
+    return max(scf, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Hot-spot stress at a connection by surface-stress extrapolation
+# ---------------------------------------------------------------------------
+def junction_hotspot_stress(
+    plate_thickness_mm: float,
+    stress_at_04t_mpa: float,
+    stress_at_10t_mpa: float,
+) -> float:
+    """Weld-toe hot-spot stress by 2-point linear extrapolation.
+
+    DNV-RP-C203 Eq. 4.1, reused from
+    :func:`...hotspot_stress.extrapolate_hotspot_linear`::
+
+        sigma_hs = 1.67 sigma(0.4t) - 0.67 sigma(1.0t)
+    """
+    return extrapolate_hotspot_linear(
+        plate_thickness_mm, stress_at_04t_mpa, stress_at_10t_mpa
+    ).hotspot_stress
+
+
+# ---------------------------------------------------------------------------
+# Connection assessment — detail class + SCF + hot-spot stress
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ConnectionSCFResult:
+    """Local stress-concentration assessment of a loaded connection.
+
+    Attributes
+    ----------
+    detail : str
+        Free-text description of the connection detail.
+    scf : float
+        Governing discontinuity SCF applied to the nominal stress.
+    nominal_stress_mpa : float
+        Nominal (far-field) stress at the connection (MPa).
+    hot_spot_stress_mpa : float
+        Weld-toe hot-spot stress = ``scf * nominal_stress_mpa`` (MPa).
+    sn_class : str
+        DNV-RP-C203 S-N detail class (Tables 2-1..2-8) for the connection.
+    sn_table : str
+        DNV-RP-C203 table the class was taken from.
+    notes : str
+        Classifier notes / caveats.
+    code_reference : str
+        Governing code — ``"DNV-RP-C203"``.
+    """
+
+    detail: str
+    scf: float
+    nominal_stress_mpa: float
+    hot_spot_stress_mpa: float
+    sn_class: str
+    sn_table: str = ""
+    notes: str = ""
+    code_reference: str = CODE_REFERENCE
+
+
+def assess_connection(
+    detail: str,
+    nominal_stress_mpa: float,
+    scf: float,
+    *,
+    joint_type: str = "",
+    transverse_load: bool = True,
+    full_penetration: bool = True,
+    ground_flush: bool = False,
+    inspected: bool = False,
+) -> ConnectionSCFResult:
+    """Assess a loaded connection: S-N detail class + SCF + hot-spot stress.
+
+    Combines the DNV-RP-C203 detail classification (S-N layer, from the weld
+    classifier) with a supplied discontinuity ``scf`` (this module's
+    misalignment / bracket-toe / tubular helpers) to produce the weld-toe
+    hot-spot stress.
+
+    Parameters
+    ----------
+    detail : str
+        Description of the connection (e.g. ``"bracket toe attachment"``).
+    nominal_stress_mpa : float
+        Nominal stress at the connection (MPa).
+    scf : float
+        Discontinuity SCF (>= 1.0) from a helper in this module.
+    joint_type : str
+        Optional joint-type hint for the classifier (``"attachment"``,
+        ``"cruciform"``, ``"butt"``, ``"fillet"``, ``"tubular"``...).
+    transverse_load, full_penetration, ground_flush, inspected : bool
+        Weld attributes forwarded to the classifier.
+    """
+    classification = classify_weld_detail(
+        WeldDetail(
+            description=detail,
+            joint_type=joint_type,
+            transverse_load=transverse_load,
+            full_penetration=full_penetration,
+            ground_flush=ground_flush,
+            inspected=inspected,
+        )
+    )
+    return ConnectionSCFResult(
+        detail=detail,
+        scf=scf,
+        nominal_stress_mpa=nominal_stress_mpa,
+        hot_spot_stress_mpa=hot_spot_stress(scf, nominal_stress_mpa),
+        sn_class=classification.dnv_class,
+        sn_table=classification.dnv_table,
+        notes=classification.notes,
+    )

--- a/tests/structural/structural_analysis/test_connection_scf.py
+++ b/tests/structural/structural_analysis/test_connection_scf.py
@@ -1,0 +1,127 @@
+# ABOUTME: Golden tests for connection & bracket SCF (DNV-RP-C203) vs published
+# ABOUTME: misalignment, hot-spot extrapolation, and Efthymiou chord-saddle values.
+import math
+
+import pytest
+
+from digitalmodel.structural.structural_analysis.connection_scf import (
+    CODE_REFERENCE,
+    ConnectionSCFResult,
+    assess_connection,
+    bracket_toe_scf,
+    efthymiou_chord_saddle_axial_scf,
+    hot_spot_stress,
+    junction_hotspot_stress,
+    misalignment_scf,
+)
+
+
+# --- hot-spot stress = SCF x nominal (DNV-RP-C203 Sec. 2.3) -------------------
+def test_hot_spot_stress_is_scf_times_nominal():
+    assert hot_spot_stress(1.45, 100.0) == pytest.approx(145.0)
+
+
+def test_hot_spot_stress_rejects_scf_below_one():
+    with pytest.raises(ValueError):
+        hot_spot_stress(0.9, 100.0)
+
+
+# --- GOLDEN: axial misalignment SCF (frame-to-girder / girder-to-shell) -------
+def test_golden_misalignment_pinned():
+    # DNV-RP-C203 App. D: pinned/single butt SCF = 1 + 3 e/t.
+    # e=3 mm, t=20 mm -> 1 + 3*3/20 = 1.45 (independently reproduced).
+    assert misalignment_scf(20.0, 3.0, restrained=False) == pytest.approx(
+        1.45, rel=1e-9
+    )
+
+
+def test_golden_misalignment_restrained():
+    # DNV-RP-C203: restrained (cruciform/fixed-ends) SCF = 1 + 6 e/t.
+    # e=3 mm, t=20 mm -> 1 + 6*3/20 = 1.90 (independently reproduced).
+    assert misalignment_scf(20.0, 3.0, restrained=True) == pytest.approx(1.90, rel=1e-9)
+
+
+def test_restrained_misalignment_exceeds_pinned():
+    pinned = misalignment_scf(20.0, 2.0, restrained=False)
+    restrained = misalignment_scf(20.0, 2.0, restrained=True)
+    assert bool(restrained > pinned)
+
+
+# --- GOLDEN: hot-spot stress by linear extrapolation (DNV Eq. 4.1) -----------
+def test_golden_hotspot_linear_extrapolation():
+    # sigma_hs = 1.67*200 - 0.67*150 = 334 - 100.5 = 233.5 MPa.
+    assert junction_hotspot_stress(20.0, 200.0, 150.0) == pytest.approx(233.5)
+
+
+# --- GOLDEN: Efthymiou chord-saddle SCF, axial T-joint (published tau^1.1) ----
+def test_golden_efthymiou_chord_saddle_axial():
+    # gamma*tau^1.1*(1.11-3(beta-0.52)^2)*sin(theta)^1.6
+    # beta=0.5, gamma=12, tau=0.5, theta=90 ->
+    #   12 * 0.5^1.1 * (1.11 - 3*(-0.02)^2) * 1 = 6.207 (~6.21 published).
+    scf = efthymiou_chord_saddle_axial_scf(0.5, 12.0, 0.5, 90.0)
+    assert scf == pytest.approx(6.21, abs=0.01)
+    # hand value to full precision
+    expected = 12.0 * 0.5**1.1 * (1.11 - 3.0 * (0.5 - 0.52) ** 2)
+    assert scf == pytest.approx(expected, rel=1e-12)
+
+
+def test_efthymiou_angle_reduces_saddle_scf():
+    # Saddle SCF scales with sin(theta)^1.6 -> a Y-joint (theta<90) is lower.
+    s90 = efthymiou_chord_saddle_axial_scf(0.5, 12.0, 0.5, 90.0)
+    s45 = efthymiou_chord_saddle_axial_scf(0.5, 12.0, 0.5, 45.0)
+    assert bool(s45 < s90)
+
+
+def test_efthymiou_rejects_nonpositive():
+    with pytest.raises(ValueError):
+        efthymiou_chord_saddle_axial_scf(0.0, 12.0, 0.5)
+
+
+# --- soft-toe vs hard-toe bracket --------------------------------------------
+def test_soft_toe_lowers_scf_versus_hard_toe():
+    hard = bracket_toe_scf(20.0, soft_toe=False)
+    soft = bracket_toe_scf(20.0, soft_toe=True)
+    assert bool(soft < hard)
+    assert bool(hard > 1.0) and bool(soft >= 1.0)
+
+
+def test_bracket_toe_matches_fillet_toe_formula():
+    # hard toe: angle=45 deg, r=1 mm, t=20 mm
+    #   1 + 0.27*(pi/4)^0.37*(20/1)^0.25
+    th = math.radians(45.0)
+    expected = 1.0 + 0.27 * (th**0.37) * (20.0 / 1.0) ** 0.25
+    assert bracket_toe_scf(20.0, soft_toe=False) == pytest.approx(
+        round(expected, 4), rel=1e-9
+    )
+
+
+# --- connection assessment: detail class + SCF + hot-spot --------------------
+def test_assess_connection_returns_class_and_hotspot():
+    scf = misalignment_scf(20.0, 3.0, restrained=False)  # 1.45
+    res = assess_connection(
+        "load-carrying attachment fillet weld at bracket toe",
+        nominal_stress_mpa=120.0,
+        scf=scf,
+        joint_type="attachment",
+        transverse_load=True,
+    )
+    assert isinstance(res, ConnectionSCFResult)
+    assert res.code_reference == CODE_REFERENCE
+    # load-carrying transverse attachment -> DNV class F1 (Table 2-5)
+    assert res.sn_class == "F1"
+    assert res.hot_spot_stress_mpa == pytest.approx(1.45 * 120.0)
+
+
+def test_assess_connection_non_load_carrying_attachment_class_e():
+    res = assess_connection(
+        "non-load carrying bracket attachment",
+        nominal_stress_mpa=100.0,
+        scf=1.3,
+        joint_type="attachment",
+        transverse_load=False,
+    )
+    assert res.sn_class == "E"
+
+
+def test_code_reference_constant():
+    assert CODE_REFERENCE == "DNV-RP-C203"


### PR DESCRIPTION
## #1086 — Connection & bracket stress-concentration (DNV-RP-C203)

Part of EPIC #1080, Workstream A, Phase 3. Local detail checks at loaded ship/offshore connections: frame-to-girder / girder-to-shell junctions, soft-toe brackets, and attachment lugs — stress-concentration factors (SCFs) and weld-toe hot-spot stress.

### Module
`src/digitalmodel/structural/structural_analysis/connection_scf.py`

A thin **ship-detail orchestration** layer — reimplements **no** SCF physics. Reuses the existing fatigue library:
- `fatigue/scf_library.py` — misalignment (1+3e/t), cruciform (km=1+6e/t), fillet-toe SCFs
- `fatigue/hotspot_stress.py` — `extrapolate_hotspot_linear` (DNV Eq. 4.1)
- `fatigue/weld_classification.py` — `classify_weld_detail` for the DNV S-N detail class

DNV-RP-C203 handles ship attachments/brackets mainly by **S-N detail classification** (E/F/F1/F3...), not one multiplicative SCF — so `assess_connection()` returns **both** a detail class and the discontinuity SCF. The misalignment restraint case is an explicit argument (pinned `3e/t` vs restrained `6e/t`). The thickness-effect (size) correction is kept OUT of the SCF (it belongs in the S-N layer). `code_reference="DNV-RP-C203"` carried on results.

### Golden values (validated vs published)
| Quantity | Inputs | Expected | Source |
|---|---|---|---|
| Misalignment SCF, pinned | e=3, t=20 | 1.45 (1+3e/t) | DNV-RP-C203 App. D |
| Misalignment SCF, restrained | e=3, t=20 | 1.90 (1+6e/t) | DNV-RP-C203 |
| Hot-spot linear extrap. | σ₀.₄ₜ=200, σ₁.₀ₜ=150 | 233.5 MPa | DNV-RP-C203 Eq. 4.1 |
| Efthymiou chord-saddle (axial T) | β=0.5,γ=12,τ=0.5,θ=90° | 6.21 (τ^1.1) | DNV-RP-C203 App. B / Efthymiou 1988 |

**Reconciliation:** the existing `scf_library.efthymiou_ty_axial` uses `τ^1.0` → 6.65 (~7% high) vs the published `τ^1.1` → 6.21. This PR's `efthymiou_chord_saddle_axial_scf` uses the published form and the discrepancy is documented (not silently inherited).

### Tests & validation
- `tests/structural/structural_analysis/test_connection_scf.py` — **14 tests, all green**
- Validation doc: `docs/domains/connection-scf-validation-2026-06-28.md`
- black clean; flake8 (E9,F63,F7,F82,F401,F811,F841) clean

### CI note
digitalmodel `main` CI is chronically red on unrelated domains; the relevant signal here is **tests-structural**.

Closes #1086