### PR TITLE
feat(structural): corrugated bulkhead buckling (DNV-RP-C201 / IACS CSR) [#1085]

### DIFF
--- a/docs/domains/corrugated-bulkhead-validation-2026-06-28.md
+++ b/docs/domains/corrugated-bulkhead-validation-2026-06-28.md
@@ -1,0 +1,123 @@
+# Corrugated bulkhead buckling — validation (2026-06-28)
+
+Issue: digitalmodel #1085 (EPIC #1080, Workstream A, Phase 3).
+Module: `src/digitalmodel/structural/structural_analysis/corrugated_bulkhead.py`
+Tests: `tests/structural/structural_analysis/test_corrugated_bulkhead.py` (11 tests).
+Code reference carried on results: `DNV-RP-C201 / IACS CSR`.
+
+## What this models
+
+A corrugated bulkhead is a folded plate forming a trapezoidal wave. The fold
+geometry gives a large bending stiffness in the corrugation direction (it acts
+as a deep beam) with failure modes distinct from a flat or stiffened panel. We
+provide:
+
+1. **Trapezoidal-corrugation section properties** (rigorously validated closed
+   forms — the core deliverable).
+2. **Buckling screens** for the governing failure mode: local flange plate
+   buckling, local web plate buckling, overall column buckling, web shear
+   buckling. These **reuse** the validated DNV-RP-C201 solvers — no plate or
+   column physics is reimplemented.
+
+## Geometry of the repeating half-pitch unit
+
+Corrugation angle `phi` is measured from the bulkhead plane. Inputs are the
+flange (face) width `a`, the web **slant** width `c`, plate thickness `t`
+(separate `t_f`/`t_w` supported), and `phi`. Derived:
+
+- corrugation depth `d = c·sin(phi)`  (perpendicular distance between flanges)
+- web horizontal projection `c·cos(phi)`
+- half pitch `s = a + c·cos(phi)`  (one flange + one web)
+- full pitch `2s` (two flanges + two webs)
+
+Important: `c` is the **slant** web width, so web material area is `t_w·c`. The
+horizontal projection `c·cos(phi)` is used only for the pitch `s`, never for the
+web area. Depth is derived from `c` and `phi` so the inputs cannot be made
+mutually inconsistent.
+
+## Section-property derivation (per half-pitch / per corrugation)
+
+Neutral axis lies at mid-depth `d/2`. (Full-pitch centroid:
+`[a·t_f·d + a·t_f·0 + 2·c·t_w·(d/2)] / [2(a·t_f + c·t_w)] = d/2` when both
+flanges share thickness `t_f`.)
+
+- **Area**: `A = a·t_f + c·t_w`
+- **Moment of inertia** about the NA:
+  - flange at `|z| = d/2`: `a·t_f·(d/2)²`
+  - inclined web spanning `z = 0…d` (centroid at NA, own second moment of a
+    uniform strip `= A_web·d²/12`): `c·t_w·d²/12`
+  - `I = a·t_f·(d/2)² + c·t_w·d²/12`
+- **Section modulus** (extreme fibre = flange at `d/2`):
+  `Z = I/(d/2) = d·(3·a·t_f + c·t_w)/6`  ← the IACS CSR corrugated-bulkhead form.
+
+With equal thickness `t` these collapse to the clean closed forms:
+
+- `I = t·d²·(3a + c)/12`
+- `Z = t·d·(3a + c)/6`
+- `A = t·(a + c)`
+
+Per-unit-width values divide by the half pitch `s`.
+
+## Golden values (hand-derived)
+
+### Golden 1 — equal thickness: a=300, c=200, t=10 mm, phi=30°
+`d = 200·sin30 = 100 mm` (exact), `s = 300 + 200·cos30 = 473.2050808 mm`.
+
+| Quantity | Formula | Value |
+|----------|---------|-------|
+| A (half-pitch) | `t(a+c) = 10·500` | 5 000 mm² |
+| I (half-pitch) | `t·d²(3a+c)/12 = 10·10⁴·1100/12` | 9 166 666.67 mm⁴ |
+| Z (half-pitch) | `t·d(3a+c)/6 = 10·100·1100/6` | 183 333.33 mm³ |
+| Z per unit width | `Z/s` | 387.43 mm³/mm |
+| I per unit width | `I/s` | 19 371.6 mm⁴/mm |
+
+### Golden 2 — unequal thickness (general IACS form): t_f=12, t_w=8, a=300, c=200, phi=30°
+`d = 100 mm`.
+
+| Quantity | Formula | Value |
+|----------|---------|-------|
+| Z (half-pitch) | `d(3·a·t_f + c·t_w)/6 = 100·(10800+1600)/6` | 206 666.67 mm³ |
+| I (half-pitch) | `a·t_f·(d/2)² + c·t_w·d²/12 = 9e6 + 1.333e6` | 10 333 333.33 mm⁴ |
+
+This case validates the general (unequal-thickness) form and the NA at `d/2`.
+
+### Golden 3 — symmetric 45° corrugation (independent cross-check): a=c=800, t=15 mm, phi=45°
+`d = 800·sin45 = 565.685 mm`, `d² = 320000`.
+
+| Quantity | Formula | Value |
+|----------|---------|-------|
+| A (half-pitch) | `t(a+c) = 15·1600` | 24 000 mm² |
+| I (half-pitch) | `t·d²(3a+c)/12 = 15·320000·3200/12` | 1.280×10⁹ mm⁴ |
+| Z (half-pitch) | `t·d(3a+c)/6` | 4.525×10⁶ mm³ |
+| flange elastic plate buckling | `σ_E = 4π²E/[12(1−ν²)]·(t/a)²`, E=206000, ν=0.3 | 261.82 MPa |
+
+## Buckling screens (what is reused, simplification level)
+
+- **Local flange plate buckling** — `PlateBucklingAnalyzer.check_plate_buckling`
+  on a plate element of width = flange width `a` (short edge), length = bulkhead
+  span, thickness `t_f`. Test `test_flange_buckling_matches_plate_solver`
+  confirms the returned utilisation equals a direct plate-solver call.
+- **Local web plate buckling** — same solver on a plate element of width =
+  web slant width `c`, carrying axial + shear.
+- **Overall column buckling** — `ColumnBucklingAnalyzer.check_column_buckling`
+  with the half-pitch `A` and `I`, effective length = span. The partial factor
+  `gamma_m` is passed **explicitly and consistently** (same value as the plate
+  checks; default 1.15) rather than relying on the column solver's `1.0`
+  default.
+- **Web shear buckling** — classical `k_tau` coefficient with the **same**
+  Johnson-Ostenfeld inelastic knockdown as the plate solver.
+
+`check_corrugated_bulkhead` returns the governing (highest-utilisation) mode.
+
+## Simplification level — PRELIMINARY
+
+`PRELIMINARY = True` (carried on `CorrugatedBulkheadResult.preliminary`).
+
+The **section properties (Z, I, A)** are rigorously validated closed forms
+(three golden cases, two thickness regimes, NA verified, IACS CSR section
+modulus reproduced). The **buckling screens** reuse the validated DNV-RP-C201
+plate/column solvers, but no in-repo CSR worked example anchors the combined
+overall-buckling path, so the combined check is flagged preliminary. It is a
+screening tool: section-property accuracy is production-grade; the
+mode-governing utilisation is a conservative screen pending a CSR worked-example
+anchor.

--- a/src/digitalmodel/structural/structural_analysis/corrugated_bulkhead.py
+++ b/src/digitalmodel/structural/structural_analysis/corrugated_bulkhead.py
@@ -1,0 +1,280 @@
+# ABOUTME: Corrugated-bulkhead strength/buckling — trapezoidal-corrugation section
+# ABOUTME: properties + local/column/shear buckling (DNV-RP-C201 plate elements / IACS CSR).
+"""Corrugated bulkhead strength and buckling (DNV-RP-C201 / IACS CSR).
+
+A corrugated bulkhead is a folded plate forming a trapezoidal wave. The fold
+geometry gives the panel a large bending stiffness in the corrugation direction
+(it behaves as a deep beam) with failure modes that are distinct from a flat or
+stiffened panel:
+
+* **Section properties** of one trapezoidal corrugation are derived in closed
+  form below (the same per-corrugation section modulus used by the IACS Common
+  Structural Rules for corrugated bulkheads).
+* **Local plate buckling** of the *flange* and *web* plate elements reuses the
+  validated DNV-RP-C201 plate solver
+  (:class:`...buckling.PlateBucklingAnalyzer`) — no plate physics reimplemented.
+* **Overall column buckling** of the corrugation over the bulkhead span reuses
+  the validated column solver (:class:`...buckling.ColumnBucklingAnalyzer`).
+* **Web shear buckling** uses the classical shear coefficient ``k_tau`` with the
+  same Johnson-Ostenfeld inelastic knockdown as the plate solver.
+
+Geometry of the repeating *half-pitch* unit (one flange + one web), trapezoidal
+corrugation with corrugation angle ``phi`` measured from the bulkhead plane::
+
+        |<-- a -->|
+        __________                       a  = flange width
+       /          \\                      c  = web (slant) width
+      / phi         \\                    d  = corrugation depth = c*sin(phi)
+     /__web__________\\__________         s  = half pitch = a + c*cos(phi)
+        |<- c*cos(phi) ->|                t  = plate thickness
+
+The neutral axis of the repeating corrugation lies at mid-depth ``d/2`` (the
+full-pitch centroid is ``d/2`` when the two flanges share the same thickness).
+
+Closed-form per-half-pitch section properties (one flange + one web):
+
+* Area              ``A = a*t_f + c*t_w``
+* Moment of inertia ``I = a*t_f*(d/2)^2 + c*t_w*d^2/12``
+* Section modulus    ``Z = I/(d/2) = d*(3*a*t_f + c*t_w)/6``
+
+With equal thickness ``t`` these collapse to ``I = t*d^2*(3a+c)/12`` and
+``Z = t*d*(3a+c)/6`` (the IACS CSR corrugated-bulkhead section modulus).
+
+Units: mm (lengths), MPa (stresses), matching the structural-analysis package.
+
+References: DNV-RP-C201 (Buckling Strength of Plated Structures);
+IACS Common Structural Rules — corrugated bulkhead section modulus / strength.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .buckling import ColumnBucklingAnalyzer, PlateBucklingAnalyzer
+from .models import MaterialProperties, PlateGeometry
+
+CODE_REFERENCE = "DNV-RP-C201 / IACS CSR"
+
+# The per-corrugation section properties (Z, I) are rigorously validated closed
+# forms (IACS CSR Pt 1 Ch 3). The buckling *screens* reuse the validated
+# DNV-RP-C201 plate/column solvers, but no in-repo CSR worked example anchors the
+# overall-buckling path, so the combined check is flagged PRELIMINARY.
+PRELIMINARY = True
+
+
+# ---------------------------------------------------------------------------
+# Geometry + section properties
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class CorrugatedBulkheadGeometry:
+    """One trapezoidal corrugation of a bulkhead (mm, degrees).
+
+    The corrugation depth is *derived* from the web slant width and the
+    corrugation angle (``depth = web_width * sin(angle)``) so the inputs cannot
+    be mutually inconsistent.  ``web_thickness_mm`` defaults to the flange
+    thickness (a constant-thickness corrugation).
+    """
+
+    flange_width_mm: float  # a — flat flange (face) breadth
+    web_width_mm: float  # c — slant length of the inclined web
+    thickness_mm: float  # t_f — flange (and default web) thickness
+    corrugation_angle_deg: float  # phi — web inclination from bulkhead plane
+    span_mm: float  # bulkhead span / height (column + plate len)
+    web_thickness_mm: float = 0.0  # t_w — defaults to flange thickness if <= 0
+
+    def __post_init__(self) -> None:
+        if (
+            min(
+                self.flange_width_mm, self.web_width_mm, self.thickness_mm, self.span_mm
+            )
+            <= 0
+        ):
+            raise ValueError("corrugation dimensions must be > 0")
+        if not 0.0 < self.corrugation_angle_deg < 90.0:
+            raise ValueError("corrugation angle must be in (0, 90) degrees")
+
+    # -- derived geometry ---------------------------------------------------
+    @property
+    def t_f(self) -> float:
+        return self.thickness_mm
+
+    @property
+    def t_w(self) -> float:
+        return self.web_thickness_mm if self.web_thickness_mm > 0 else self.thickness_mm
+
+    @property
+    def corrugation_depth_mm(self) -> float:
+        """Perpendicular depth between the two flange planes, ``c*sin(phi)``."""
+        return self.web_width_mm * math.sin(math.radians(self.corrugation_angle_deg))
+
+    @property
+    def half_pitch_mm(self) -> float:
+        """Repeating unit width ``s = a + c*cos(phi)`` (one flange + one web).
+
+        ``c*cos(phi)`` is the *horizontal projection* of the slant web — not the
+        slant width ``c`` itself (web material area stays ``t_w*c``).
+        """
+        return self.flange_width_mm + self.web_width_mm * math.cos(
+            math.radians(self.corrugation_angle_deg)
+        )
+
+    @property
+    def full_pitch_mm(self) -> float:
+        """Full corrugation period ``2*s`` (two flanges + two webs)."""
+        return 2.0 * self.half_pitch_mm
+
+    @property
+    def neutral_axis_mm(self) -> float:
+        """Distance of the neutral axis from a flange plane, ``d/2``."""
+        return self.corrugation_depth_mm / 2.0
+
+    # -- per-half-pitch (per-corrugation) section properties ---------------
+    @property
+    def area_mm2(self) -> float:
+        """Cross-sectional area of one half-pitch, ``a*t_f + c*t_w``."""
+        return self.flange_width_mm * self.t_f + self.web_width_mm * self.t_w
+
+    @property
+    def moment_of_inertia_mm4(self) -> float:
+        """Second moment of area of one half-pitch about the neutral axis."""
+        d = self.corrugation_depth_mm
+        flange = self.flange_width_mm * self.t_f * (d / 2.0) ** 2
+        web = self.web_width_mm * self.t_w * d**2 / 12.0
+        return flange + web
+
+    @property
+    def section_modulus_mm3(self) -> float:
+        """Section modulus of one half-pitch, ``I/(d/2) = d(3 a t_f + c t_w)/6``."""
+        return self.moment_of_inertia_mm4 / self.neutral_axis_mm
+
+    # -- per-unit-width section properties (divide by half pitch) ----------
+    @property
+    def area_per_unit_width_mm(self) -> float:
+        return self.area_mm2 / self.half_pitch_mm
+
+    @property
+    def moment_of_inertia_per_unit_width_mm3(self) -> float:
+        return self.moment_of_inertia_mm4 / self.half_pitch_mm
+
+    @property
+    def section_modulus_per_unit_width_mm2(self) -> float:
+        return self.section_modulus_mm3 / self.half_pitch_mm
+
+
+# ---------------------------------------------------------------------------
+# Buckling check
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class CorrugatedBulkheadResult:
+    """Governing buckling check of a corrugated bulkhead."""
+
+    governing_mode: str
+    utilization: float
+    passes: bool
+    flange_buckling_util: float
+    web_buckling_util: float
+    column_buckling_util: float
+    shear_buckling_util: float
+    section_modulus_mm3: float
+    moment_of_inertia_mm4: float
+    code_reference: str = CODE_REFERENCE
+    preliminary: bool = PRELIMINARY
+
+
+def _web_shear_buckling_stress(
+    geom: CorrugatedBulkheadGeometry, material: MaterialProperties
+) -> float:
+    """Critical shear-buckling stress of the inclined web plate (MPa).
+
+    ``tau_e = k_tau * pi^2 E / (12(1-nu^2)) * (t_w/c)^2`` with the classical
+    coefficient ``k_tau`` (``c`` the web slant width as the short edge, ``span``
+    the long edge), reduced by the plate solver's Johnson-Ostenfeld knockdown.
+    """
+    c = geom.web_width_mm
+    a = geom.span_mm
+    if a / c >= 1.0:
+        k_tau = 5.34 + 4.0 * (c / a) ** 2
+    else:
+        k_tau = 4.0 + 5.34 * (c / a) ** 2
+    e = material.youngs_modulus
+    nu = material.poissons_ratio
+    tau_e = k_tau * math.pi**2 * e / (12.0 * (1.0 - nu**2)) * (geom.t_w / c) ** 2
+    return PlateBucklingAnalyzer(material).johnson_ostenfeld(tau_e)
+
+
+def check_corrugated_bulkhead(
+    geom: CorrugatedBulkheadGeometry,
+    material: MaterialProperties,
+    *,
+    axial_stress_mpa: float,
+    shear_stress_mpa: float = 0.0,
+    gamma_m: float = 1.15,
+) -> CorrugatedBulkheadResult:
+    """Check a corrugated bulkhead against its buckling failure modes.
+
+    Args:
+        geom: corrugation geometry.
+        material: plate material.
+        axial_stress_mpa: in-plane compressive stress along the corrugation
+            (positive = compression) carried by the flange/web plate elements.
+        shear_stress_mpa: in-plane shear carried by the web.
+        gamma_m: material resistance factor.
+
+    Returns the governing (highest-utilisation) mode among local flange plate
+    buckling, local web plate buckling, overall column buckling and web shear
+    buckling.
+    """
+    plate = PlateBucklingAnalyzer(material)
+    column = ColumnBucklingAnalyzer(material)
+
+    # --- local flange plate buckling (flange width = short edge) ----------
+    flange = PlateGeometry(
+        length=geom.span_mm, width=geom.flange_width_mm, thickness=geom.t_f
+    )
+    flange_res = plate.check_plate_buckling(
+        flange, sigma_x=axial_stress_mpa, gamma_m=gamma_m
+    )
+
+    # --- local web plate buckling (web slant width = short edge) ----------
+    web = PlateGeometry(
+        length=geom.span_mm, width=geom.web_width_mm, thickness=geom.t_w
+    )
+    web_res = plate.check_plate_buckling(
+        web, sigma_x=axial_stress_mpa, tau=shear_stress_mpa, gamma_m=gamma_m
+    )
+
+    # --- overall column buckling of the corrugation over the span ---------
+    axial_force = axial_stress_mpa * geom.area_mm2
+    col_res = column.check_column_buckling(
+        axial_force=max(axial_force, 0.0),
+        area=geom.area_mm2,
+        I_min=geom.moment_of_inertia_mm4,
+        L_eff=geom.span_mm,
+        gamma_m=gamma_m,
+    )
+
+    # --- web shear buckling -----------------------------------------------
+    tau_cr = _web_shear_buckling_stress(geom, material)
+    tau_cap = tau_cr / gamma_m
+    shear_util = shear_stress_mpa / tau_cap if tau_cap > 0 else float("inf")
+
+    modes = {
+        "flange_plate_buckling": float(flange_res.utilization),
+        "web_plate_buckling": float(web_res.utilization),
+        "column_buckling": float(col_res.utilization),
+        "web_shear_buckling": float(shear_util),
+    }
+    governing_mode = max(modes, key=modes.get)
+    governing_util = modes[governing_mode]
+
+    return CorrugatedBulkheadResult(
+        governing_mode=governing_mode,
+        utilization=governing_util,
+        passes=bool(governing_util <= 1.0),
+        flange_buckling_util=modes["flange_plate_buckling"],
+        web_buckling_util=modes["web_plate_buckling"],
+        column_buckling_util=modes["column_buckling"],
+        shear_buckling_util=modes["web_shear_buckling"],
+        section_modulus_mm3=geom.section_modulus_mm3,
+        moment_of_inertia_mm4=geom.moment_of_inertia_mm4,
+    )

--- a/tests/structural/structural_analysis/test_corrugated_bulkhead.py
+++ b/tests/structural/structural_analysis/test_corrugated_bulkhead.py
@@ -1,0 +1,188 @@
+# ABOUTME: Tests for corrugated-bulkhead buckling — hand-derived trapezoidal
+# ABOUTME: section properties (Z, I per corrugation & per unit width) + mode checks.
+import math
+
+import pytest
+
+from digitalmodel.structural.structural_analysis.buckling import (
+    PlateBucklingAnalyzer,
+)
+from digitalmodel.structural.structural_analysis.corrugated_bulkhead import (
+    CODE_REFERENCE,
+    CorrugatedBulkheadGeometry,
+    check_corrugated_bulkhead,
+)
+from digitalmodel.structural.structural_analysis.models import (
+    STEEL_AH36,
+    PlateGeometry,
+)
+
+
+# A clean trapezoidal corrugation used for the golden hand calcs:
+#   a (flange) = 300 mm, c (web slant) = 200 mm, t = 10 mm, phi = 30 deg
+#   => d = c*sin(30) = 200*0.5 = 100 mm (exact)
+#      s = a + c*cos(30) = 300 + 200*0.8660254038 = 473.2050808 mm
+def _geom(**kw):
+    base = dict(
+        flange_width_mm=300.0,
+        web_width_mm=200.0,
+        thickness_mm=10.0,
+        corrugation_angle_deg=30.0,
+        span_mm=3000.0,
+    )
+    base.update(kw)
+    return CorrugatedBulkheadGeometry(**base)
+
+
+# --- derived geometry --------------------------------------------------------
+def test_derived_depth_and_pitch():
+    g = _geom()
+    assert math.isclose(g.corrugation_depth_mm, 100.0, rel_tol=1e-12)
+    assert math.isclose(
+        g.half_pitch_mm, 300.0 + 200.0 * math.cos(math.radians(30)), rel_tol=1e-12
+    )
+    assert math.isclose(g.neutral_axis_mm, 50.0, rel_tol=1e-12)
+
+
+# --- GOLDEN 1: equal-thickness section properties ----------------------------
+# By hand (a=300, c=200, t=10, d=100):
+#   A = t*(a+c)            = 10*500            = 5000      mm^2
+#   I = t*d^2*(3a+c)/12    = 10*1e4*1100/12    = 9,166,666.6667 mm^4
+#   Z = t*d*(3a+c)/6       = 10*100*1100/6     = 183,333.3333   mm^3
+#   per unit width (/s, s = 473.2050808 mm):
+#     Z/s = 387.4327 mm^2 (=mm^3/mm) ,  I/s = 19,371.6 mm^3 (=mm^4/mm)
+def test_golden_section_properties_equal_thickness():
+    g = _geom()
+    assert math.isclose(g.area_mm2, 5000.0, rel_tol=1e-12)
+    assert math.isclose(g.moment_of_inertia_mm4, 9_166_666.66667, rel_tol=1e-9)
+    assert math.isclose(g.section_modulus_mm3, 183_333.33333, rel_tol=1e-9)
+
+    # consistency: Z = I / (d/2)
+    assert math.isclose(
+        g.section_modulus_mm3,
+        g.moment_of_inertia_mm4 / g.neutral_axis_mm,
+        rel_tol=1e-12,
+    )
+
+    # per-unit-width golden values
+    s = g.half_pitch_mm
+    assert math.isclose(
+        g.section_modulus_per_unit_width_mm2, 183_333.33333 / s, rel_tol=1e-9
+    )
+    assert math.isclose(g.section_modulus_per_unit_width_mm2, 387.4327, rel_tol=1e-4)
+    assert math.isclose(
+        g.moment_of_inertia_per_unit_width_mm3, 9_166_666.66667 / s, rel_tol=1e-9
+    )
+    assert math.isclose(g.moment_of_inertia_per_unit_width_mm3, 19_371.64, rel_tol=1e-4)
+
+
+# --- GOLDEN 2: unequal flange/web thickness (general IACS form) --------------
+# t_f=12, t_w=8, a=300, c=200, d=100:
+#   Z = d*(3 a t_f + c t_w)/6 = 100*(10800+1600)/6 = 206,666.6667 mm^3
+#   I = a t_f (d/2)^2 + c t_w d^2/12 = 9,000,000 + 1,333,333.33 = 10,333,333.33 mm^4
+def test_golden_section_properties_unequal_thickness():
+    g = _geom(thickness_mm=12.0, web_thickness_mm=8.0)
+    assert math.isclose(g.section_modulus_mm3, 206_666.66667, rel_tol=1e-9)
+    assert math.isclose(g.moment_of_inertia_mm4, 10_333_333.33333, rel_tol=1e-9)
+    assert math.isclose(g.area_mm2, 300.0 * 12.0 + 200.0 * 8.0, rel_tol=1e-12)
+
+
+# --- GOLDEN 3: symmetric 45-deg corrugation (independent cross-check) --------
+# a = c = 800 mm, phi = 45 deg, t = 15 mm:
+#   d = c*sin(45) = 800*0.7071068 = 565.685 mm ; d^2 = 320000
+#   A = t*(a+c)            = 15*1600              = 24000     mm^2
+#   I = t*d^2*(3a+c)/12    = 15*320000*3200/12    = 1.280e9   mm^4
+#   Z = t*d*(3a+c)/6       = 15*565.685*3200/6    = 4.525e6   mm^3
+#   flange elastic plate buckling: sigma_E = 4 pi^2 E/[12(1-nu^2)] (t/a)^2
+#     = 4 pi^2 * 206000 / (12*0.91) * (15/800)^2 = 261.82 MPa
+def test_golden_symmetric_45deg():
+    g = CorrugatedBulkheadGeometry(
+        flange_width_mm=800.0,
+        web_width_mm=800.0,
+        thickness_mm=15.0,
+        corrugation_angle_deg=45.0,
+        span_mm=4000.0,
+    )
+    assert math.isclose(
+        g.corrugation_depth_mm, 800.0 * math.sin(math.radians(45)), rel_tol=1e-12
+    )
+    assert math.isclose(g.area_mm2, 24000.0, rel_tol=1e-12)
+    assert math.isclose(g.moment_of_inertia_mm4, 1.280e9, rel_tol=1e-3)
+    assert math.isclose(g.section_modulus_mm3, 4.525e6, rel_tol=1e-3)
+
+    # full pitch is exactly twice the half-pitch unit
+    assert math.isclose(g.full_pitch_mm, 2.0 * g.half_pitch_mm, rel_tol=1e-12)
+
+    # flange elastic plate-buckling stress (reused DNV-RP-C201 plate solver)
+    plate = PlateBucklingAnalyzer(STEEL_AH36)
+    flange = PlateGeometry(length=g.span_mm, width=g.flange_width_mm, thickness=g.t_f)
+    assert math.isclose(plate.elastic_buckling_stress(flange), 261.82, rel_tol=1e-3)
+
+
+def test_result_is_flagged_preliminary():
+    res = check_corrugated_bulkhead(_geom(), STEEL_AH36, axial_stress_mpa=60.0)
+    assert res.preliminary is True
+
+
+# --- buckling: flange local mode reuses the validated plate solver ----------
+def test_flange_buckling_matches_plate_solver():
+    g = _geom()
+    sigma = 120.0
+    res = check_corrugated_bulkhead(g, STEEL_AH36, axial_stress_mpa=sigma)
+
+    # Independent re-computation with the plate solver for the flange element.
+    plate = PlateBucklingAnalyzer(STEEL_AH36)
+    flange = PlateGeometry(length=g.span_mm, width=g.flange_width_mm, thickness=g.t_f)
+    direct = plate.check_plate_buckling(flange, sigma_x=sigma, gamma_m=1.15)
+    assert math.isclose(res.flange_buckling_util, direct.utilization, rel_tol=1e-12)
+    assert res.code_reference == CODE_REFERENCE
+
+
+# --- buckling: wider (more slender) flange raises local utilisation ---------
+def test_wider_flange_more_slender():
+    narrow = check_corrugated_bulkhead(
+        _geom(flange_width_mm=200.0), STEEL_AH36, axial_stress_mpa=120.0
+    )
+    wide = check_corrugated_bulkhead(
+        _geom(flange_width_mm=500.0), STEEL_AH36, axial_stress_mpa=120.0
+    )
+    assert wide.flange_buckling_util > narrow.flange_buckling_util
+
+
+# --- buckling: governing-mode selection -------------------------------------
+def test_slender_flange_governs_and_fails():
+    # Wide, thin flange under high axial -> local flange buckling governs & fails.
+    g = _geom(flange_width_mm=900.0, thickness_mm=8.0)
+    res = check_corrugated_bulkhead(g, STEEL_AH36, axial_stress_mpa=260.0)
+    assert res.governing_mode == "flange_plate_buckling"
+    assert res.passes is False
+    assert res.utilization > 1.0
+
+
+def test_high_shear_governs():
+    g = _geom()
+    res = check_corrugated_bulkhead(
+        g, STEEL_AH36, axial_stress_mpa=30.0, shear_stress_mpa=140.0
+    )
+    assert res.governing_mode == "web_shear_buckling"
+    assert res.shear_buckling_util > res.flange_buckling_util
+
+
+def test_robust_corrugation_passes():
+    # Compact corrugation, modest load -> all modes well within capacity.
+    g = _geom(flange_width_mm=250.0, thickness_mm=14.0)
+    res = check_corrugated_bulkhead(
+        g, STEEL_AH36, axial_stress_mpa=60.0, shear_stress_mpa=20.0
+    )
+    assert res.passes is True
+    assert res.utilization < 1.0
+
+
+# --- validation --------------------------------------------------------------
+def test_geometry_validation():
+    with pytest.raises(ValueError):
+        _geom(flange_width_mm=-1.0)
+    with pytest.raises(ValueError):
+        _geom(corrugation_angle_deg=0.0)
+    with pytest.raises(ValueError):
+        _geom(corrugation_angle_deg=90.0)


### PR DESCRIPTION
## What

Corrugated-bulkhead strength/buckling (EPIC #1080, Workstream A, Phase 3). New module `src/digitalmodel/structural/structural_analysis/corrugated_bulkhead.py`.

### Section properties (rigorously validated)
Trapezoidal-corrugation closed forms, per half-pitch unit (one flange + one web) and per unit width:
- Area `A = a·t_f + c·t_w`
- Neutral axis at mid-depth `d/2` (derived), depth `d = c·sin φ`
- `I = a·t_f·(d/2)² + c·t_w·d²/12`
- `Z = I/(d/2) = d·(3·a·t_f + c·t_w)/6` — the IACS CSR corrugated-bulkhead section modulus

`c` is the web **slant** width (web area `t_w·c`); depth is derived from `c` and `φ` so inputs can't be inconsistent.

### Buckling screens (reuse validated solvers — no plate/column physics reimplemented)
- Local **flange** + **web** plate buckling → `PlateBucklingAnalyzer` (DNV-RP-C201)
- Overall **column** buckling → `ColumnBucklingAnalyzer` (`gamma_m` passed explicitly/consistently)
- **Web shear** buckling → classical `k_tau` + Johnson-Ostenfeld
- `check_corrugated_bulkhead` returns the governing mode + utilisation

Flagged `PRELIMINARY` for the combined buckling path (section properties are production-grade; no in-repo CSR worked example anchors overall buckling). Results carry `code_reference = "DNV-RP-C201 / IACS CSR"` (self-contained; `codes.py` untouched).

## Validation — 3 hand-derived golden cases (11 tests)
- **G1** a=300,c=200,t=10,φ=30° → A=5000, I=9.167e6 mm⁴, Z=183 333 mm³ (+ per-unit-width)
- **G2** unequal t_f=12/t_w=8 → Z=206 667 mm³, I=1.0333e7 mm⁴ (general IACS form + NA check)
- **G3** symmetric a=c=800,t=15,φ=45° → A=24000, I=1.280e9 mm⁴, Z=4.525e6 mm³; flange σ_E=261.82 MPa
- Mode checks: flange util matches direct plate-solver call; slender flange / high-shear governing-mode selection; robust case passes.

Run: `PYTHONPATH=src .venv/bin/python -m pytest tests/structural/structural_analysis/test_corrugated_bulkhead.py` → 11 passed. Lint clean (black, flake8). Relevant CI signal: `tests-structural`.

Docs: `docs/domains/corrugated-bulkhead-validation-2026-06-28.md`.

Closes #1085