### PR TITLE
feat(structural): grillage / cross-stiffened panel buckling (DNV-RP-C201) [#1081]

### DIFF
--- a/docs/domains/grillage-buckling-validation-2026-06-28.md
+++ b/docs/domains/grillage-buckling-validation-2026-06-28.md
@@ -1,0 +1,171 @@
+# Grillage / Cross-Stiffened Panel Buckling — Validation
+
+**Module:** `src/digitalmodel/structural/structural_analysis/grillage_buckling.py`
+**Tests:** `tests/structural/structural_analysis/test_grillage_buckling.py`
+**Code basis:** DNV-RP-C201 *Buckling Strength of Plated Structures*, Sec. 7.3–7.4
+**Issue:** digitalmodel #1081 (EPIC #1080, Workstream A, Phase 1)
+**Date:** 2026-06-28
+
+## 1. Scope
+
+A **grillage** is a plate field stiffened by *both* longitudinal stiffeners
+and transverse frames (the real hull-plating layout). The pre-existing
+`StiffenedPanelBucklingAnalyzer` only models a single longitudinal stiffener +
+attached plate. This module adds the cross-stiffener (orthogonally stiffened)
+interaction and reports the governing mode among four:
+
+| Mode | Solver | Length scale |
+|------|--------|--------------|
+| `plate_field` | `PlateBucklingAnalyzer` (reused) | bay `s_T × s_L` |
+| `longitudinal_stiffener` | `StiffenedPanelBucklingAnalyzer.check_panel` (reused, unchanged) | column `L_eff = s_T` |
+| `transverse_frame` | `column_buckling` (+ in-domain `torsional_buckling`, reused) | column `L_eff = width_y` |
+| `overall_grillage` | **new** orthotropic-plate mode | gross `a = length_x`, `b = width_y` |
+
+Only the **overall orthotropic mode + the governing-mode aggregation** are new
+physics. Everything else delegates to the validated single-stiffener solvers
+(`effective_section`, `plate_induced` via `check_panel`, `torsional_buckling`,
+`column_buckling`, `johnson_ostenfeld`).
+
+## 2. Two length scales (kept distinct)
+
+- **Longitudinal-stiffener column** spans *between transverse frames*:
+  `L_eff = s_T` (the transverse spacing).
+- **Overall grillage** spans the *gross* length: `a = length_x = L_g`.
+
+Conflating these is the classic grillage error; the geometry object stores
+`length_x` separately from `transverse.spacing`.
+
+## 3. Overall orthotropic mode (the new physics)
+
+For a simply supported orthotropic plate `a × b` under uniaxial compression
+`σ_x`, the critical axial force per unit width is
+
+```
+N_x(m, n) = π² [ Dx (m/a)² + 2 H (n/b)² + Dy (n/b)⁴ (a/m)² ]
+```
+
+minimised over integer half-wave counts `m ≥ 1` (along `x`) and `n ≥ 1`
+(along `y`; `n = 1` governs for pure `σ_x`). Smeared flexural rigidities:
+
+```
+Dx = E · I_L / s_L         longitudinal stiffener + full-spacing attached plate
+Dy = E · I_T / s_T         transverse frame + C_xs effective-width attached plate
+H  = √(Dx · Dy)            equivalent-isotropic torsional rigidity
+```
+
+`I_L`, `I_T` come from the validated `effective_section`. The critical stress
+is `σ_e = N_x,cr / t_x` with smeared axial thickness `t_x = t_p + A_L / s_L`
+(A_L = longitudinal stiffener area). The inelastic **Johnson-Ostenfeld**
+correction (reused) yields the characteristic capacity `σ_cr`.
+
+`H = √(Dx·Dy)` is the standard simplification: it makes an equally-stiffened
+panel collapse to the isotropic plate result and vanishes correctly as either
+stiffener direction softens (so the limit behaviour below is exact).
+
+### Effective width (risk guard)
+The transverse spacing `s_T` is wide, so the full-spacing attached plate would
+overstate `I_T`. `Dy` therefore uses the DNV-RP-C201 `C_xs` effective-width
+reduction:
+
+```
+λ_p  = 0.525 (s_T / t_p) √(f_y / E)
+C_xs = 1.0                       if λ_p ≤ 0.673
+C_xs = (λ_p − 0.22) / λ_p²       otherwise
+b_eff,T = C_xs · s_T
+```
+
+### Multi-bay guard (risk guard)
+`Dy = E·I_T/s_T → 0` as `s_T → ∞`, which would let the overall mode spuriously
+dominate a single-bay panel. The overall mode is therefore **suppressed**
+(`overall_mode_applicable = False`, utilisation 0) unless the gross length spans
+**≥ 2 frame bays** (`num_frame_bays = round(length_x / s_T) ≥ 2`). For a single
+bay the longitudinal-stiffener column is the correct governing mode.
+
+## 4. Golden values
+
+### G1 — Isotropic collapse to DNV `k = 4` (independent closed form)
+With `Dx = Dy = H = Dp = E t³ / [12(1−ν²)]`, a long panel (`a = 3b`) gives
+`N_x,cr = 4π²·Dp/b²`, so `σ_e = 4π²·Dp/(b²·t)`.
+
+For `t = 12 mm, b = 700 mm, E = 210000 MPa, ν = 0.3`:
+`Dp = 210000·12³/(12·0.91) = 3.3231×10⁷ N·mm`
+`σ_e = 4π²·3.3231e7 / (700²·12) = 223.11 MPa`
+
+This equals the DNV plate-buckling stress `σ = k·π²E/[12(1−ν²)]·(t/b)²` with
+`k = 4` exactly. **→ `test_orthotropic_collapses_to_isotropic_k4_plate`** (and
+a direct equality to the `k=4` formula at `rel=1e-9`).
+
+### G2 — Euler limit (independent closed form)
+With `Dy = H = 0` the formula reduces to `N_x,cr = π²·Dx·m²/a²`, minimised at
+`m = 1` → `N_x,cr = π²·Dx/a²` (Euler buckling of the longitudinal direction
+over the gross length). **→ `test_orthotropic_euler_limit_single_longitudinal`**.
+
+### G3 — Defined grillage, overall mode
+AH36 (`E = 206000, f_y = 355, ν = 0.3`), plate `t = 10`, longitudinal flat-bar
+`150×10 @ s_L = 600`, transverse flat-bar `250×12 @ s_T = 2400`,
+`length_x = 9600` (4 bays), `width_y = 3600`:
+
+| Quantity | Value |
+|----------|-------|
+| `I_L` (full-width attached plate) | 1.054×10⁷ mm⁴ |
+| `C_xs` (transverse) | 0.183 |
+| `I_T` (effective-width attached plate) | 4.580×10⁷ mm⁴ |
+| `Dx` | 3.620×10⁹ N·mm |
+| `Dy` | 3.931×10⁹ N·mm |
+| `H = √(Dx·Dy)` | 3.772×10⁹ N·mm |
+| `t_x` | 12.5 mm |
+| min at | `m = 3, n = 1` |
+| `σ_e` (elastic) | **927.9 MPa** |
+| `σ_cr` (Johnson-Ostenfeld, < f_y) | **321.0 MPa** |
+
+**→ `test_overall_mode_golden_values`**. (σ_e well above f_y confirms that for
+a normally-stiffened grillage the overall mode rarely governs — it is the
+lightly-stiffened, wide-bay panels where it bites; see §5.)
+
+### G4 — Closer transverse frames raise the overall capacity (monotone)
+Same grillage, `s_T ∈ {4800, 3200, 2400, 1600, 1200}` → `σ_e =
+{664, 820, 928, 1122, 1299}` MPa: strictly increasing as `s_T` decreases.
+**→ `test_closer_transverse_frames_raise_overall_capacity`**.
+
+### G5 — Reduces to the single stiffener (acceptance criterion)
+One-bay grillage (`s_T = length_x = 9600`): overall mode suppressed, and the
+grillage `longitudinal_utilization` equals the standalone
+`StiffenedPanelBucklingAnalyzer.check_panel` result to `rel=1e-12`; governing
+mode = `longitudinal_stiffener`.
+**→ `test_single_bay_reduces_to_single_stiffener`**.
+
+### G6 — Governing-mode selection switches correctly
+`length_x = 14400`, `σ_x = 150`: at `s_T = 4800` slender longitudinal columns
+govern (util > 1); at `s_T = 1800` the plate field governs. Under biaxial load
+(`σ_x = σ_y = 120`) the transverse frame governs.
+**→ `test_governing_mode_switches_with_layout`,
+`test_transverse_frame_can_govern_under_biaxial_load`**.
+
+## 5. Simplification level vs a full FE grillage analysis
+
+This is a **screening** model, not an FE plate/beam grillage. Relative to FE:
+
+- **Smeared orthotropic idealisation** — discrete stiffener positions, local
+  stiffener flexibility and the true coupled mode shapes are homogenised into
+  `Dx, Dy, H`; `H = √(Dx·Dy)` neglects the stiffeners' own (small, open-section)
+  St-Venant torsional contribution.
+- **Boundary / loading** — simply supported on all four edges; no rotational
+  edge restraint, no lateral pressure / continuous-beam bending, no residual
+  stresses. Only the leading buckle mode (integer `m, n` sweep), not the full
+  eigenvalue spectrum.
+- **Transverse-frame mode** — its tripping (torsional) check is only evaluated
+  inside the panel solver's validated domain (`spacing ≤ span`, non-zero axial);
+  a widely spaced frame uses column buckling only.
+
+Use it to **rank modes and flag a grillage for detailed FE**, not as a final
+capacity statement for a critical structure.
+
+## 6. What is reused vs new
+
+| Reused (validated, unchanged) | New |
+|-------------------------------|-----|
+| `PlateBucklingAnalyzer.check_plate_buckling`, `johnson_ostenfeld` | `orthotropic_critical_force` (m,n sweep) |
+| `StiffenedPanelBucklingAnalyzer.effective_section` | `flexural_rigidities` (Dx, Dy, H, t_x) |
+| `.check_panel`, `.column_buckling`, `.torsional_buckling` | `overall_buckling` (σ_e, J-O, multi-bay guard) |
+| `MaterialProperties`, `MARINE_GRADES`, `StiffenerGeometry` | `GrillageGeometry`, `GrillageBucklingAnalyzer`, `check_grillage` |
+| | `C_xs` effective-width for the transverse plate |

--- a/src/digitalmodel/structural/structural_analysis/grillage_buckling.py
+++ b/src/digitalmodel/structural/structural_analysis/grillage_buckling.py
@@ -1,0 +1,454 @@
+# ABOUTME: Cross-stiffened (orthogonally stiffened) grillage buckling solver per
+# ABOUTME: DNV-RP-C201 Sec. 7.3-7.4: overall orthotropic mode + governing-mode pick.
+"""
+Grillage / Cross-Stiffened Panel Buckling
+=========================================
+
+A closed-form buckling check for a **grillage**: a plate field stiffened by
+*both* longitudinal stiffeners and transverse frames (the real hull-plating
+layout), following DNV-RP-C201 ("Buckling Strength of Plated Structures"),
+Sec. 7.3-7.4.
+
+Four failure modes are screened and the governing (most-utilised) one is
+reported:
+
+1. ``plate_field`` -- buckling of the unstiffened plate panel bounded by two
+   longitudinal stiffeners (width = longitudinal spacing ``s_L``) and two
+   transverse frames (length = transverse spacing ``s_T``). Delegated to the
+   validated :class:`PlateBucklingAnalyzer`.
+2. ``longitudinal_stiffener`` -- column + lateral-torsional (tripping) buckling
+   of a longitudinal stiffener spanning between transverse frames
+   (``L_eff = s_T``). Delegated *unchanged* to the validated
+   :class:`StiffenedPanelBucklingAnalyzer`.
+3. ``transverse_frame`` -- column + tripping buckling of a transverse frame
+   spanning the panel width (``L_eff = width_y``), carrying the transverse
+   stress ``sigma_y``. Also delegated to :class:`StiffenedPanelBucklingAnalyzer`.
+4. ``overall_grillage`` -- **the new physics**: buckling of the whole stiffened
+   panel as an equivalent orthotropic plate (smeared stiffener rigidities),
+   minimised over the integer buckle-mode numbers ``m`` (along ``x``) and ``n``
+   (along ``y``). This is the cross-stiffener interaction that the
+   single-stiffener panel solver cannot capture.
+
+Orthotropic overall mode (DNV-RP-C201 Sec. 7.3-7.4)
+---------------------------------------------------
+For a simply supported orthotropic plate ``a x b`` (``a`` = gross length in the
+compression direction ``x``, ``b`` = gross width) the critical axial force per
+unit width under uniaxial compression ``N_x`` solves::
+
+    N_x(m, n) = pi^2 [ Dx (m/a)^2
+                       + 2 H (n/b)^2
+                       + Dy (n/b)^4 (a/m)^2 ]
+
+minimised over integer half-wave counts ``m >= 1`` (and ``n >= 1``; ``n = 1``
+governs for pure ``sigma_x``). The smeared flexural rigidities are::
+
+    Dx = E I_L / s_L      (longitudinal stiffener + effective plating)
+    Dy = E I_T / s_T      (transverse frame + effective plating)
+    H  = sqrt(Dx Dy)      (equivalent-isotropic torsional rigidity -- the
+                           standard simplification; it makes the panel collapse
+                           to the isotropic DNV k = 4 plate result and vanishes
+                           correctly as a stiffener direction softens)
+
+The critical *stress* is ``sigma_e = N_x,cr / t_x`` with the smeared axial
+thickness ``t_x = t_p + A_L / s_L``; the inelastic Johnson-Ostenfeld correction
+(reused from :class:`PlateBucklingAnalyzer`) gives the characteristic capacity.
+
+Limit behaviour (validated)
+---------------------------
+- **Isotropic collapse**: with ``Dx = Dy = H = E t^3 / (12 (1 - nu^2))`` the
+  long-panel discrete minimum is ``4 pi^2 sqrt(Dx Dy) / b^2``, i.e. exactly the
+  DNV plate-buckling stress with ``k = 4`` (golden: 223.11 MPa for
+  ``t = 12, b = 700, E = 210000, nu = 0.3``).
+- **Reduces to the single stiffener**: for a one-bay grillage
+  (``length_x ~ s_T``) the overall orthotropic mode is *suppressed* (it is only
+  meaningful for a multi-bay field; ``Dy -> 0`` as ``s_T -> inf`` would
+  otherwise spuriously dominate) and the governing utilisation equals the
+  standalone :class:`StiffenedPanelBucklingAnalyzer` result for the longitudinal
+  stiffener.
+- **Closer transverse frames raise capacity**: shrinking ``s_T`` raises ``Dy``
+  and the overall elastic buckling stress (monotone).
+
+Simplification level vs a full FE grillage analysis
+---------------------------------------------------
+This is a *screening* model, not a finite-element grillage solution. Compared
+to an FE plate/beam grillage:
+
+- Smeared-orthotropic-plate idealisation: discrete stiffener positions, local
+  stiffener flexibility, and the true coupled mode shapes are homogenised into
+  equivalent rigidities; ``H = sqrt(Dx Dy)`` neglects the stiffeners' own
+  (usually small, open-section) St-Venant torsional contribution.
+- Simply supported boundary on all four edges; no rotational edge restraint,
+  no lateral pressure / continuous-beam bending, no residual stresses, and only
+  the leading buckle mode is taken (integer ``m, n`` sweep, not a full
+  eigenvalue spectrum).
+- Effective plate width for the (wide) transverse-frame flange uses the
+  DNV-RP-C201 ``C_xs`` reduction; the longitudinal mode keeps the validated
+  panel solver's full-spacing assumption.
+
+Use it to rank modes and flag a grillage for detailed FE, not as a final
+capacity statement for a critical structure.
+
+Units: stresses in MPa, lengths in mm, ``E`` in MPa, areas in mm^2, second
+moments in mm^4 (consistent with the rest of ``structural_analysis``).
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict
+
+import numpy as np
+
+from .models import MaterialProperties, PlateGeometry
+from .buckling import PlateBucklingAnalyzer
+from .panel_buckling import (
+    StiffenerGeometry,
+    StiffenedPanelGeometry,
+    StiffenedPanelBucklingAnalyzer,
+)
+
+# Self-contained code reference (do not import from digitalmodel.codes).
+GRILLAGE_CODE_REFERENCE = "DNV-RP-C201"
+
+# This solver is a validated screening model (see module docstring). The overall
+# orthotropic mode is new; modes 1-3 reuse already-validated solvers.
+PRELIMINARY = False
+
+
+@dataclass
+class GrillageGeometry:
+    """A cross-stiffened (orthogonally stiffened) grillage.
+
+    All dimensions in mm. The compression of interest acts along ``x`` (the
+    longitudinal-stiffener direction).
+
+    ``longitudinal.spacing`` is ``s_L`` (transverse pitch of longitudinal
+    stiffeners); ``transverse.spacing`` is ``s_T`` (longitudinal pitch of the
+    transverse frames). ``length_x`` is the gross grillage length ``L_g`` (the
+    overall span used for the overall-grillage mode); the longitudinal-stiffener
+    column span is ``s_T`` (between transverse frames), so the two length scales
+    are kept distinct.
+    """
+
+    length_x: float  # L_g, gross length in compression direction (mm)
+    width_y: float  # B, gross width (mm)
+    plate_thickness: float  # t_p (mm)
+    longitudinal: StiffenerGeometry  # spacing = s_L
+    transverse: StiffenerGeometry  # spacing = s_T
+
+    def num_frame_bays(self) -> int:
+        """Number of plate bays along ``x`` (= number of transverse-frame
+        spaces in the gross length). 1 means a single bay (frames only at the
+        two ends)."""
+        return max(1, int(round(self.length_x / self.transverse.spacing)))
+
+
+@dataclass
+class GrillageBucklingResult:
+    """Result of a grillage buckling check (governing among four modes)."""
+
+    governing_mode: str
+    utilization: float
+    plate_utilization: float
+    longitudinal_utilization: float
+    transverse_utilization: float
+    overall_utilization: float
+    critical_stress: float  # MPa, governing mode
+    overall_elastic_stress: float  # MPa, orthotropic sigma_e (pre Johnson-Ostenfeld)
+    overall_critical_stress: float  # MPa, after Johnson-Ostenfeld
+    overall_half_waves: int  # m (x-direction) at the overall minimum
+    overall_mode_applicable: bool  # False for a single-bay grillage
+    passes: bool
+    details: Dict = field(default_factory=dict)
+    code_reference: str = GRILLAGE_CODE_REFERENCE
+
+
+class GrillageBucklingAnalyzer:
+    """Cross-stiffened grillage buckling analyzer per DNV-RP-C201 Sec. 7.3-7.4.
+
+    Reuses the validated single-stiffener panel solver for the plate-field,
+    longitudinal-stiffener and transverse-frame modes; adds the overall
+    orthotropic-plate (grillage) mode and the governing-mode aggregation.
+    """
+
+    def __init__(self, material: MaterialProperties):
+        self.material = material
+        self.panel_analyzer = StiffenedPanelBucklingAnalyzer(material)
+        self.plate_analyzer = PlateBucklingAnalyzer(material)
+
+    # ------------------------------------------------------------------
+    # Sub-panel geometries delegated to the validated solver
+    # ------------------------------------------------------------------
+    def longitudinal_panel(self, g: GrillageGeometry) -> StiffenedPanelGeometry:
+        """Longitudinal stiffener + attached plate, spanning between transverse
+        frames (column span ``L_eff = s_T``)."""
+        return StiffenedPanelGeometry(
+            plate_length=g.transverse.spacing,  # span between transverse frames
+            plate_thickness=g.plate_thickness,
+            stiffener=g.longitudinal,  # spacing = s_L
+        )
+
+    def transverse_panel(self, g: GrillageGeometry) -> StiffenedPanelGeometry:
+        """Transverse frame + attached plate, spanning the panel width
+        (column span ``L_eff = width_y``)."""
+        return StiffenedPanelGeometry(
+            plate_length=g.width_y,  # span across the grillage width
+            plate_thickness=g.plate_thickness,
+            stiffener=g.transverse,  # spacing = s_T
+        )
+
+    # ------------------------------------------------------------------
+    # Effective plate width (DNV-RP-C201 C_xs) -- used for the smeared rigidity
+    # of the (wide) transverse-frame attached plate.
+    # ------------------------------------------------------------------
+    def effective_width_factor(self, spacing: float, t: float) -> float:
+        """DNV-RP-C201 effective-width factor ``C_xs`` for an attached plate
+        flange (1.0 for stocky plates, reduced for slender wide plates)."""
+        E = self.material.youngs_modulus
+        fy = self.material.yield_strength
+        lam_p = 0.525 * (spacing / t) * math.sqrt(fy / E)
+        if lam_p <= 0.673:
+            return 1.0
+        return (lam_p - 0.22) / lam_p**2
+
+    # ------------------------------------------------------------------
+    # Smeared orthotropic flexural rigidities
+    # ------------------------------------------------------------------
+    def flexural_rigidities(self, g: GrillageGeometry) -> Dict:
+        """Smeared orthotropic plate rigidities ``Dx, Dy, H`` (N*mm).
+
+        ``Dx`` uses the longitudinal stiffener with its full-spacing attached
+        plate (validated panel-solver convention); ``Dy`` uses the transverse
+        frame with a DNV ``C_xs`` effective-width-reduced attached plate, since
+        the transverse spacing is wide and the full width overstates ``I_T``.
+        """
+        E = self.material.youngs_modulus
+
+        # Longitudinal: I_L over full spacing s_L (validated convention).
+        long_panel = self.longitudinal_panel(g)
+        long_sec = self.panel_analyzer.effective_section(long_panel)
+        I_L = long_sec["I"]
+        s_L = g.longitudinal.spacing
+        A_L = long_sec["area_web"] + long_sec["area_flange"]  # stiffener only
+
+        # Transverse: I_T with effective-width-reduced attached plate.
+        c_xs = self.effective_width_factor(g.transverse.spacing, g.plate_thickness)
+        b_eff_T = c_xs * g.transverse.spacing
+        trans_eff = StiffenerGeometry(
+            web_height=g.transverse.web_height,
+            web_thickness=g.transverse.web_thickness,
+            flange_width=g.transverse.flange_width,
+            flange_thickness=g.transverse.flange_thickness,
+            spacing=b_eff_T,
+            section_type=g.transverse.section_type,
+        )
+        trans_eff_panel = StiffenedPanelGeometry(
+            plate_length=g.width_y,
+            plate_thickness=g.plate_thickness,
+            stiffener=trans_eff,
+        )
+        I_T = self.panel_analyzer.effective_section(trans_eff_panel)["I"]
+        s_T = g.transverse.spacing
+
+        Dx = E * I_L / s_L
+        Dy = E * I_T / s_T
+        H = math.sqrt(Dx * Dy)  # equivalent-isotropic torsional rigidity
+
+        # Smeared axial thickness in the x (compression) direction.
+        t_x = g.plate_thickness + A_L / s_L
+
+        return {
+            "Dx": Dx,
+            "Dy": Dy,
+            "H": H,
+            "I_L": I_L,
+            "I_T": I_T,
+            "t_x": t_x,
+            "Cxs_transverse": c_xs,
+            "effective_width_transverse": b_eff_T,
+        }
+
+    # ------------------------------------------------------------------
+    # Orthotropic critical force per unit width (the new physics)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def orthotropic_critical_force(
+        Dx: float,
+        Dy: float,
+        H: float,
+        a: float,
+        b: float,
+        m_max: int = 40,
+        n_max: int = 4,
+    ) -> Dict:
+        """Minimum critical axial force per unit width ``N_x,cr`` (N/mm) for a
+        simply supported orthotropic plate ``a x b`` under uniaxial ``sigma_x``.
+
+        ``N_x(m, n) = pi^2 [ Dx (m/a)^2 + 2 H (n/b)^2 + Dy (n/b)^4 (a/m)^2 ]``,
+        minimised over integer ``m`` in ``1..m_max`` and ``n`` in ``1..n_max``.
+        """
+        m = np.arange(1, m_max + 1, dtype=float)[:, None]  # x half-waves
+        n = np.arange(1, n_max + 1, dtype=float)[None, :]  # y half-waves
+        nx = (math.pi**2) * (
+            Dx * (m / a) ** 2
+            + 2.0 * H * (n / b) ** 2
+            + Dy * (n / b) ** 4 * (a / m) ** 2
+        )
+        idx = np.unravel_index(int(np.argmin(nx)), nx.shape)
+        return {
+            "Nx_cr": float(nx[idx]),
+            "m": int(m[idx[0], 0]),
+            "n": int(n[0, idx[1]]),
+        }
+
+    def overall_buckling(
+        self,
+        g: GrillageGeometry,
+        sigma_x: float,
+        gamma_m: float = 1.15,
+    ) -> Dict:
+        """Overall orthotropic (grillage) buckling check.
+
+        Suppressed (``applicable = False``) for a single-bay grillage, where the
+        smeared idealisation is not meaningful and the longitudinal-stiffener
+        column mode governs instead.
+        """
+        rig = self.flexural_rigidities(g)
+        applicable = g.num_frame_bays() >= 2
+
+        ortho = self.orthotropic_critical_force(
+            rig["Dx"], rig["Dy"], rig["H"], g.length_x, g.width_y
+        )
+        sigma_e = ortho["Nx_cr"] / rig["t_x"]
+        sigma_cr = self.plate_analyzer.johnson_ostenfeld(sigma_e)
+
+        if applicable and sigma_cr > 0:
+            util = sigma_x / (sigma_cr / gamma_m)
+        else:
+            util = 0.0
+
+        return {
+            "applicable": bool(applicable),
+            "sigma_e": sigma_e,
+            "sigma_cr": sigma_cr,
+            "utilization": max(0.0, util),
+            "m": ortho["m"],
+            "n": ortho["n"],
+            "num_frame_bays": g.num_frame_bays(),
+            **rig,
+        }
+
+    # ------------------------------------------------------------------
+    # Plate-field buckling (panel bounded by both stiffener families)
+    # ------------------------------------------------------------------
+    def plate_field(
+        self,
+        g: GrillageGeometry,
+        sigma_x: float,
+        sigma_y: float = 0.0,
+        tau: float = 0.0,
+        gamma_m: float = 1.15,
+    ):
+        """Unstiffened plate panel bounded by longitudinals (width ``s_L``) and
+        transverse frames (length ``s_T``)."""
+        plate = PlateGeometry(
+            length=g.transverse.spacing,  # bay length between frames
+            width=g.longitudinal.spacing,  # spacing between longitudinals
+            thickness=g.plate_thickness,
+        )
+        return self.plate_analyzer.check_plate_buckling(
+            plate, sigma_x, sigma_y=sigma_y, tau=tau, gamma_m=gamma_m
+        )
+
+    # ------------------------------------------------------------------
+    # Top-level grillage check
+    # ------------------------------------------------------------------
+    def check_grillage(
+        self,
+        g: GrillageGeometry,
+        sigma_x: float,
+        sigma_y: float = 0.0,
+        tau: float = 0.0,
+        gamma_m: float = 1.15,
+    ) -> GrillageBucklingResult:
+        """Run all four modes and report the governing (most-utilised) one."""
+        # Mode 1: plate field (between both stiffener families).
+        plate_res = self.plate_field(
+            g, sigma_x, sigma_y=sigma_y, tau=tau, gamma_m=gamma_m
+        )
+        plate_util = plate_res.utilization
+
+        # Mode 2: longitudinal stiffener (delegated, unchanged).
+        long_res = self.panel_analyzer.check_panel(
+            self.longitudinal_panel(g),
+            sigma_x,
+            sigma_y=sigma_y,
+            tau=tau,
+            gamma_m=gamma_m,
+        )
+        long_col = long_res.details["column_result"].utilization
+        long_tors = long_res.details["torsional"]["utilization"]
+        long_util = max(long_col, long_tors)
+
+        # Mode 3: transverse frame -- carries the transverse stress sigma_y as
+        # its axial load. Built from the same validated panel methods (column +
+        # tripping). The tripping (torsional) check is only evaluated inside the
+        # panel solver's validated domain (stiffener spacing <= span and a
+        # non-zero axial stress); a widely spaced transverse frame
+        # (s_T > 2*width_y) falls outside it, so only column buckling is used
+        # there (documented simplification).
+        trans_panel = self.transverse_panel(g)
+        trans_col_res = self.panel_analyzer.column_buckling(
+            trans_panel, sigma_y, gamma_m=gamma_m
+        )
+        trans_col = trans_col_res.utilization
+        trans_tors = 0.0
+        tors_in_domain = (
+            sigma_y > 0.0 and trans_panel.stiffener.spacing <= trans_panel.plate_length
+        )
+        if tors_in_domain:
+            trans_tors = self.panel_analyzer.torsional_buckling(
+                trans_panel, sigma_y, tau=tau, gamma_m=gamma_m
+            )["utilization"]
+        trans_util = max(trans_col, trans_tors)
+
+        # Mode 4: overall orthotropic grillage (the new physics).
+        overall = self.overall_buckling(g, sigma_x, gamma_m=gamma_m)
+        overall_util = overall["utilization"]
+
+        modes = {
+            "plate_field": (plate_util, plate_res.critical_stress),
+            "longitudinal_stiffener": (long_util, long_res.critical_stress),
+            "transverse_frame": (trans_util, trans_col_res.critical_stress),
+            "overall_grillage": (overall_util, overall["sigma_cr"]),
+        }
+        governing_mode = max(modes, key=lambda k: modes[k][0])
+        governing_util, governing_stress = modes[governing_mode]
+
+        details = {
+            "plate_result": plate_res,
+            "longitudinal_result": long_res,
+            "transverse_column_result": trans_col_res,
+            "transverse_tripping_in_domain": bool(tors_in_domain),
+            "overall": overall,
+            "modes_utilization": {k: v[0] for k, v in modes.items()},
+            "preliminary": PRELIMINARY,
+            "standard": GRILLAGE_CODE_REFERENCE,
+            "section_long": "x=longitudinal (compression); column L_eff=s_T",
+        }
+
+        return GrillageBucklingResult(
+            governing_mode=governing_mode,
+            utilization=governing_util,
+            plate_utilization=plate_util,
+            longitudinal_utilization=long_util,
+            transverse_utilization=trans_util,
+            overall_utilization=overall_util,
+            critical_stress=governing_stress,
+            overall_elastic_stress=overall["sigma_e"],
+            overall_critical_stress=overall["sigma_cr"],
+            overall_half_waves=int(overall["m"]),
+            overall_mode_applicable=bool(overall["applicable"]),
+            passes=bool(governing_util <= 1.0),
+            details=details,
+            code_reference=GRILLAGE_CODE_REFERENCE,
+        )

--- a/tests/structural/structural_analysis/test_grillage_buckling.py
+++ b/tests/structural/structural_analysis/test_grillage_buckling.py
@@ -1,0 +1,238 @@
+# ABOUTME: Golden + property tests for the cross-stiffened grillage buckling
+# ABOUTME: solver (DNV-RP-C201 Sec. 7.3-7.4): orthotropic mode + governing pick.
+"""Tests for ``grillage_buckling``.
+
+Golden values (derivations in
+``docs/domains/grillage-buckling-validation-2026-06-28.md``):
+
+* Isotropic collapse: an orthotropic plate with ``Dx = Dy = H = E t^3 /
+  (12 (1 - nu^2))`` reproduces the DNV plate-buckling stress with ``k = 4``
+  (223.11 MPa for ``t = 12, b = 700, E = 210000, nu = 0.3``).
+* Reduces to the single stiffener: a one-bay grillage suppresses the overall
+  mode and its longitudinal utilisation equals the standalone
+  ``StiffenedPanelBucklingAnalyzer`` result exactly.
+* Closer transverse frames raise the overall capacity (monotone) and the
+  governing mode switches as the layout changes.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.structural.structural_analysis.models import (
+    STEEL_AH36,
+    MaterialProperties,
+)
+from digitalmodel.structural.structural_analysis.panel_buckling import (
+    StiffenerGeometry,
+)
+from digitalmodel.structural.structural_analysis.grillage_buckling import (
+    GRILLAGE_CODE_REFERENCE,
+    GrillageGeometry,
+    GrillageBucklingAnalyzer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+def _longitudinal():
+    return StiffenerGeometry(
+        web_height=150,
+        web_thickness=10,
+        flange_width=0,
+        flange_thickness=0,
+        spacing=600,
+        section_type="flatbar",
+    )
+
+
+def _transverse(spacing=2400):
+    return StiffenerGeometry(
+        web_height=250,
+        web_thickness=12,
+        flange_width=0,
+        flange_thickness=0,
+        spacing=spacing,
+        section_type="flatbar",
+    )
+
+
+def _canonical_grillage(s_T=2400, length_x=9600):
+    """Light, wide AH36 grillage where the orthotropic mode is meaningful."""
+    return GrillageGeometry(
+        length_x=length_x,
+        width_y=3600,
+        plate_thickness=10,
+        longitudinal=_longitudinal(),
+        transverse=_transverse(s_T),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden 1: isotropic collapse to the DNV k = 4 plate-buckling stress
+# ---------------------------------------------------------------------------
+def test_orthotropic_collapses_to_isotropic_k4_plate():
+    """With Dx = Dy = H = plate rigidity Dp, the long-panel orthotropic minimum
+    equals the DNV plate-buckling force 4*pi^2*Dp/b^2, i.e. k = 4."""
+    E, nu, t, b = 210000.0, 0.3, 12.0, 700.0
+    Dp = E * t**3 / (12.0 * (1.0 - nu**2))
+
+    # Long panel (a = 3b) so the integer minimum reaches the continuous k = 4.
+    res = GrillageBucklingAnalyzer.orthotropic_critical_force(
+        Dp, Dp, Dp, a=3.0 * b, b=b
+    )
+    sigma_e = res["Nx_cr"] / t
+
+    k4_plate = 4.0 * math.pi**2 * E / (12.0 * (1.0 - nu**2)) * (t / b) ** 2
+    assert sigma_e == pytest.approx(223.11, abs=0.05)
+    assert sigma_e == pytest.approx(k4_plate, rel=1e-9)
+
+
+def test_orthotropic_euler_limit_single_longitudinal():
+    """Dy = H = 0 (no transverse stiffness) -> N_x,cr = pi^2 Dx / a^2 at m = 1,
+    i.e. Euler buckling of the longitudinal direction over the full length."""
+    Dx, a, b = 5.0e10, 9600.0, 3600.0
+    res = GrillageBucklingAnalyzer.orthotropic_critical_force(Dx, 0.0, 0.0, a, b)
+    assert res["m"] == 1
+    assert res["n"] == 1
+    assert res["Nx_cr"] == pytest.approx(math.pi**2 * Dx / a**2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Golden 2: overall orthotropic mode for a defined grillage
+# ---------------------------------------------------------------------------
+def test_overall_mode_golden_values():
+    """Defined AH36 grillage -> hand-checked overall elastic/critical stress."""
+    g = _canonical_grillage()
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    ob = A.overall_buckling(g, sigma_x=150.0)
+
+    assert ob["applicable"] is True
+    assert ob["num_frame_bays"] == 4
+    assert ob["m"] == 3
+    assert ob["n"] == 1
+    # Orthotropic elastic buckling stress (pre Johnson-Ostenfeld).
+    assert ob["sigma_e"] == pytest.approx(927.9, abs=1.0)
+    # Inelastic (Johnson-Ostenfeld) characteristic capacity, capped near fy.
+    assert ob["sigma_cr"] == pytest.approx(321.0, abs=1.0)
+    assert ob["sigma_cr"] < STEEL_AH36.yield_strength
+    # Effective-width reduction was applied to the wide transverse plate.
+    assert 0.0 < ob["Cxs_transverse"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Golden 3 / monotonicity: closer transverse frames raise the overall capacity
+# ---------------------------------------------------------------------------
+def test_closer_transverse_frames_raise_overall_capacity():
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    spacings = [4800, 3200, 2400, 1600, 1200]
+    sigma_e = []
+    for s_T in spacings:
+        ob = A.overall_buckling(_canonical_grillage(s_T=s_T), sigma_x=150.0)
+        sigma_e.append(ob["sigma_e"])
+    # Strictly increasing as transverse spacing decreases.
+    assert all(b > a for a, b in zip(sigma_e, sigma_e[1:]))
+
+
+# ---------------------------------------------------------------------------
+# Reduces to the single stiffener (acceptance criterion)
+# ---------------------------------------------------------------------------
+def test_single_bay_reduces_to_single_stiffener():
+    """One-bay grillage: overall mode is suppressed and the longitudinal
+    utilisation equals the standalone single-stiffener panel result."""
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    g = _canonical_grillage(s_T=9600, length_x=9600)  # frames only at the ends
+    assert g.num_frame_bays() == 1
+
+    r = A.check_grillage(g, sigma_x=80.0)
+    assert r.overall_mode_applicable is False
+    assert r.overall_utilization == 0.0
+
+    # Standalone validated single-stiffener panel over the same span.
+    panel = A.longitudinal_panel(g)
+    standalone = A.panel_analyzer.check_panel(panel, 80.0)
+    standalone_util = max(
+        standalone.details["column_result"].utilization,
+        standalone.details["torsional"]["utilization"],
+    )
+    assert r.longitudinal_utilization == pytest.approx(standalone_util, rel=1e-12)
+    assert r.governing_mode == "longitudinal_stiffener"
+
+
+# ---------------------------------------------------------------------------
+# Governing-mode selection switches correctly
+# ---------------------------------------------------------------------------
+def test_governing_mode_switches_with_layout():
+    """Widely spaced frames -> long, slender longitudinal columns govern;
+    closely spaced frames -> the plate field governs."""
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+
+    wide = A.check_grillage(_canonical_grillage(s_T=4800, length_x=14400), 150.0)
+    assert wide.governing_mode == "longitudinal_stiffener"
+    assert wide.utilization > 1.0  # slender columns -> fails
+
+    tight = A.check_grillage(_canonical_grillage(s_T=1800, length_x=14400), 150.0)
+    assert tight.governing_mode == "plate_field"
+    assert tight.governing_mode != wide.governing_mode
+
+
+def test_transverse_frame_can_govern_under_biaxial_load():
+    """Transverse compression sigma_y loads the transverse frame, which can then
+    become the governing mode."""
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    g = _canonical_grillage(s_T=1800, length_x=14400)
+    r = A.check_grillage(g, sigma_x=120.0, sigma_y=120.0)
+    assert r.governing_mode == "transverse_frame"
+    assert r.transverse_utilization > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Plumbing / contract
+# ---------------------------------------------------------------------------
+def test_result_contract_and_code_reference():
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    r = A.check_grillage(_canonical_grillage(), sigma_x=150.0)
+    assert r.code_reference == GRILLAGE_CODE_REFERENCE == "DNV-RP-C201"
+    # Governing utilisation is the max across the four modes.
+    assert r.utilization == pytest.approx(
+        max(
+            r.plate_utilization,
+            r.longitudinal_utilization,
+            r.transverse_utilization,
+            r.overall_utilization,
+        )
+    )
+    assert isinstance(r.passes, bool)
+    assert isinstance(r.overall_half_waves, int)
+    assert isinstance(r.overall_mode_applicable, bool)
+
+
+def test_passes_flag_consistent_with_utilization():
+    A = GrillageBucklingAnalyzer(STEEL_AH36)
+    # Low stress -> passes.
+    r_low = A.check_grillage(_canonical_grillage(), sigma_x=40.0)
+    assert r_low.passes == (r_low.utilization <= 1.0)
+    assert r_low.passes is True
+    # High stress -> fails.
+    r_high = A.check_grillage(_canonical_grillage(), sigma_x=400.0)
+    assert r_high.passes is False
+
+
+def test_custom_material_runs():
+    mat = MaterialProperties(
+        yield_strength=355,
+        ultimate_strength=490,
+        youngs_modulus=210000,
+        poissons_ratio=0.3,
+        density=7850,
+        name="S355",
+    )
+    A = GrillageBucklingAnalyzer(mat)
+    r = A.check_grillage(_canonical_grillage(), sigma_x=150.0)
+    assert r.governing_mode in (
+        "plate_field",
+        "longitudinal_stiffener",
+        "transverse_frame",
+        "overall_grillage",
+    )


### PR DESCRIPTION
## Summary
Adds **grillage (cross-stiffened panel) buckling** per DNV-RP-C201 Sec. 7.3–7.4 — a plate field stiffened by *both* longitudinal stiffeners and transverse frames. Extends the existing single-stiffener `StiffenedPanelBucklingAnalyzer` to the real hull-plating layout and reports the governing mode among four.

`src/digitalmodel/structural/structural_analysis/grillage_buckling.py`
- `GrillageGeometry` + `GrillageBucklingAnalyzer.check_grillage(...)` → `GrillageBucklingResult` (governing mode + utilisation).
- Modes: `plate_field`, `longitudinal_stiffener`, `transverse_frame`, `overall_grillage`.

## New physics (only this is new)
- **Overall orthotropic-plate mode**: smeared rigidities `Dx = E·I_L/s_L`, `Dy = E·I_T/s_T`, `H = √(Dx·Dy)`; critical force `N_x(m,n) = π²[Dx(m/a)² + 2H(n/b)² + Dy(n/b)⁴(a/m)²]` minimised over integer `m,n`; `σ_e = N_x,cr/t_x` then Johnson-Ostenfeld.
- **Governing-mode aggregation** across the four modes.

Everything else **delegates unchanged** to the validated solvers (`effective_section`, `check_panel`, `column_buckling`, `torsional_buckling`, `johnson_ostenfeld`). `code_reference` is a self-contained `"DNV-RP-C201"` string — `src/digitalmodel/codes.py` is untouched.

## Risk guards
- **Multi-bay suppression** — overall mode is disabled for a single-bay panel (`Dy→0` as `s_T→∞` would otherwise spuriously dominate).
- **Two distinct length scales** — longitudinal column `L_eff = s_T`; overall `a = length_x`.
- **C_xs effective-width** for the wide transverse attached plate (full width overstates `I_T`).
- `m` **and** `n` minimisation.

## Validation (10 golden + property tests)
- Isotropic collapse to DNV `k = 4` plate stress = **223.11 MPa** (independent closed form).
- Euler limit (`Dy=H=0` → `π²Dx/a²`, m=1).
- Defined AH36 grillage overall stress `σ_e ≈ 927.9`, `σ_cr ≈ 321.0` MPa (m=3, n=1).
- Closer transverse frames raise overall capacity (monotone).
- **Reduces to the single stiffener** for a one-bay grillage (`rel=1e-12` vs standalone `check_panel`).
- Governing-mode switching (longitudinal ↔ plate; transverse under biaxial load).

Derivations + simplification-level discussion (vs full FE grillage): `docs/domains/grillage-buckling-validation-2026-06-28.md`.

Local run: `10 passed`. Lint clean (black, flake8 E9/F-codes). Relevant CI signal: `tests-structural` (main is chronically red on unrelated domains).

Closes #1081