### PR TITLE
test(asset_integrity): published-example golden tests for FFS strength methods [#1094]

### DIFF
--- a/docs/domains/ffs-published-examples-2026-06-28.md
+++ b/docs/domains/ffs-published-examples-2026-06-28.md
@@ -1,0 +1,62 @@
+# FFS strength methods — published-example validation (2026-06-28)
+
+Validation-only companion to issue **#1094** (deferred published-example golden
+tests). No source behaviour was changed; this adds
+`tests/asset_integrity/test_ffs_published_examples.py`, which encodes the exact
+**inputs** of recognised published worked examples and asserts our code
+reproduces the published **outputs** within a stated tolerance.
+
+Modules under test:
+- `src/digitalmodel/asset_integrity/corroded_pipe.py` — `b31g_original`,
+  `modified_b31g`, `rstreng_effective_area`.
+- `src/digitalmodel/asset_integrity/dnv_rp_f101.py` — `dnv_f101_single_defect`.
+
+## Status legend
+- **PUBLISHED-VALIDATED** — asserted number is from a published worked example
+  (standard appendix example or published reference implementation) *and*
+  independently hand-verified here.
+- **REGRESSION-ANCHOR** — no external published numeric output could be sourced
+  for these exact inputs; we pin our own current output to catch drift. Not a
+  claim of agreement with an external authority.
+
+## Cases
+
+| # | Method | Source | Inputs | Published output | Our output | Status |
+|---|--------|--------|--------|------------------|-----------|--------|
+| A1 | ASME B31G original (safe pressure) | ASME B31G-1991 App. A Example #1 (Kiefner & Vieth CRVL.BAS; pipenostics `b31crvl`) | D=30 in, t=0.438 in, X52 SMYS=52,000 psi, d=0.100 in, L=7.5 in, F=0.72, MAOP=910 psi | Design = Safe pressure = **1093 psi**; intermediate factor A=1.847 | 1093.25 psi; A=1.847 | **PUBLISHED-VALIDATED** |
+| A2 | ASME B31G original (corroded P_f) | same example | as A1, at the published max allowed depth d=0.2490 in | max allowed depth **0.2490 in** ⇔ MAOP **910 psi** (P_f·F = MAOP) | 910.9 psi (0.1 % high) | **PUBLISHED-VALIDATED** |
+| B1 | DNV-RP-F101 single defect | DNV-RP-F101 (Oct 2010) §8.2 Example 1 (pipenostics `dnvpf`) | D=812.8 mm, t=19.1 mm, d=13.4 mm, L=203.2 mm, f_u(SMTS)=530.9 MPa | **15.86626 MPa** | 15.866256 MPa | **PUBLISHED-VALIDATED** |
+| B2 | DNV-RP-F101 single defect | DNV-RP-F101 (Oct 2010) §8.2 Example 2 (pipenostics `dnvpf`) | D=219.0 mm, t=14.5 mm, d=9.0 mm, L=200.0 mm, f_u(SMTS)=455.1 MPa | **34.01183 MPa** | 34.011827 MPa | **PUBLISHED-VALIDATED** |
+| C1 | Modified B31G (0.85 dL) | (geometry of Example #1) | D=30 in, t=0.438 in, X52, d=0.100 in, L=7.5 in | — none sourced — | 1624.68 psi | REGRESSION-ANCHOR |
+| C2 | RSTRENG effective area | (geometry of Example #1, uniform profile) | D=30 in, t=0.438 in, X52, d=0.100 in, L=7.5 in | — none sourced — | 1587.44 psi | REGRESSION-ANCHOR |
+
+## Notes on method and units
+- **Case A1** reproduces the CRVL "safe pressure": the B31G estimated failure
+  pressure factored by the design factor `F`, capped at the intact design
+  pressure `2·SMYS·t/D·F`. For this shallow defect the cap governs (so the
+  published number is the intact design pressure, 1093 psi). Case A2 is the
+  stronger check because the corroded failure-pressure formula governs.
+- **Cases B1/B2** are run in SI (mm, MPa). The capacity equation is
+  unit-consistent, so the `capacity_pressure_psi`-named field carries **MPa**
+  for these two SI cases; the test docstrings call this out.
+- The DNV cases match the published values to ~5 significant figures (rel error
+  < 1e-5), confirming our `dnv_f101_single_defect` uses the standard's mean
+  capacity equation `P = (2 t f_u/(D−t))(1−d/t)/(1−(d/t)/Q)` with
+  `Q = sqrt(1 + 0.31 (L/√(D t))²)` exactly.
+
+## Discrepancies found
+None beyond the documented method scope. The #1094 review already noted these
+methods use the standard simplified Folias factors (parabolic B31G; two-part
+Modified B31G; DNV `Q`); the validated cases above agree with the published
+examples within tight tolerance, so no simplification surfaced a real
+disagreement. The two regression-anchored cases are flagged honestly: they are
+*not* externally validated — only no published number was found for those exact
+inputs.
+
+## Sources
+- ASME B31G-1991, Nonmandatory Appendix A (worked Example #1), via the Kiefner &
+  Vieth `CRVL.BAS` program and the CRAN `pipenostics` package
+  (`b31crvl` reference example).
+- DNV-RP-F101, *Corroded Pipelines* (October 2010), Section 8.2 single-defect
+  capacity equation; worked examples via `pipenostics` `dnvpf` (examples 1 & 2),
+  each hand-verified against the closed-form capacity equation.

--- a/tests/asset_integrity/test_ffs_published_examples.py
+++ b/tests/asset_integrity/test_ffs_published_examples.py
@@ -1,0 +1,144 @@
+# ABOUTME: Published-example golden tests for the FFS corroded-pipe strength
+# ABOUTME: methods (ASME B31G / Kiefner-Vieth and DNV-RP-F101), issue #1094.
+"""Golden tests against PUBLISHED worked examples (validation-only, #1094).
+
+Each test encodes the exact published INPUTS of a recognised worked example and
+asserts our implementation reproduces the published OUTPUT within a stated
+tolerance.  Tests are explicitly labelled:
+
+* PUBLISHED-VALIDATED  -- the asserted number is sourced from a published
+  worked example (the standard's own appendix example or a published reference
+  implementation) AND independently hand-verified here.
+* REGRESSION-ANCHOR    -- no external published numeric output could be sourced
+  for these exact inputs, so we anchor our own current output to catch silent
+  drift.  These are NOT claims of agreement with an external authority.
+
+Sources
+-------
+* ASME B31G-1991 Nonmandatory Appendix A, worked Example #1, as reproduced by
+  the Kiefner & Vieth ``CRVL.BAS`` program and the CRAN ``pipenostics`` package
+  (``b31crvl`` reference example).
+* DNV-RP-F101 (Oct 2010) Section 8.2 single-defect capacity equation, worked
+  examples as reproduced by ``pipenostics`` (``dnvpf`` reference examples 1 & 2),
+  each also hand-verified against the closed-form capacity equation.
+
+See docs/domains/ffs-published-examples-2026-06-28.md for the source register
+and the validated-vs-regression status of every case below.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.asset_integrity.corroded_pipe import (
+    b31g_original,
+    modified_b31g,
+    rstreng_effective_area,
+)
+from digitalmodel.asset_integrity.dnv_rp_f101 import dnv_f101_single_defect
+
+# ---------------------------------------------------------------------------
+# Example A -- ASME B31G-1991 Appendix A / CRVL.BAS Example #1 (Original B31G)
+#
+#   D = 30 in, t = 0.438 in, SMYS = 52,000 psi (API 5L X52),
+#   defect depth d = 0.100 in, axial length L = 7.5 in,
+#   design factor F = 0.72, MAOP = 910 psi.
+#
+# Published output (CRVL.BAS / pipenostics b31crvl):
+#   Design pressure = 910-psi-safe; "Design pressure = Safe pressure = 1093 PSI";
+#   "maximum allowed corrosion depth = 0.2490 inch" at the 910 psi MAOP.
+# ---------------------------------------------------------------------------
+B31G_D, B31G_T, B31G_SMYS = 30.0, 0.438, 52_000.0
+B31G_L, B31G_F, B31G_MAOP = 7.5, 0.72, 910.0
+
+
+def test_b31g_original_crvl_example1_design_safe_pressure_published():
+    """PUBLISHED-VALIDATED: CRVL.BAS Example #1 design/safe pressure = 1093 psi.
+
+    CRVL reports the safe operating pressure as the B31G estimated failure
+    pressure factored by the design factor F, capped at the intact design
+    pressure ``2*SMYS*t/D*F``.  For this shallow defect the cap governs, so the
+    published "Design pressure = Safe pressure = 1093 PSI".
+    """
+    r = b31g_original(B31G_D, B31G_T, 0.100, B31G_L, B31G_SMYS)
+    intact_design = 2.0 * B31G_SMYS * B31G_T / B31G_D * B31G_F
+    safe_crvl = min(r.failure_pressure_psi * B31G_F, intact_design)
+    # Published value rounded to 1093 psi; we reproduce 1093.25 psi.
+    assert safe_crvl == pytest.approx(1093.0, abs=1.0)
+    # The B31G intermediate factor A = 0.893*L/sqrt(D*t) = 1.847 (published).
+    A = 0.893 * B31G_L / math.sqrt(B31G_D * B31G_T)
+    assert A == pytest.approx(1.847, abs=0.005)
+
+
+def test_b31g_original_crvl_example1_allowed_depth_published():
+    """PUBLISHED-VALIDATED: CRVL Example #1 max allowed depth 0.2490 in @ 910 psi.
+
+    At the published maximum allowable corrosion depth (0.2490 in) the B31G
+    failure pressure factored by F must equal the MAOP (910 psi).  This exercises
+    the corroded failure-pressure formula at a non-trivial (deeper) defect.
+    """
+    r = b31g_original(B31G_D, B31G_T, 0.2490, B31G_L, B31G_SMYS)
+    safe_at_allowed_depth = r.failure_pressure_psi * B31G_F
+    # We reproduce 910.9 psi vs the published 910 psi MAOP (0.1 % high; the
+    # published depth is itself rounded to 4 dp).
+    assert safe_at_allowed_depth == pytest.approx(B31G_MAOP, abs=3.0)
+
+
+# ---------------------------------------------------------------------------
+# Example B -- DNV-RP-F101 (Oct 2010) Section 8.2 single-defect capacity.
+#
+# The capacity equation is unit-consistent, so these SI examples are run in
+# mm / N-per-mm^2 (MPa); the returned ``capacity_pressure_psi`` field then
+# carries MPa for these two cases (documented below).
+#
+# Source: DNV-RP-F101 Sec 8.2 worked examples, reproduced by pipenostics dnvpf;
+# both also hand-verified here against P = (2 t f_u/(D-t))(1-d/t)/(1-(d/t)/Q),
+# Q = sqrt(1 + 0.31 (L/sqrt(D t))^2).
+# ---------------------------------------------------------------------------
+def test_dnv_f101_single_defect_example1_published_mpa():
+    """PUBLISHED-VALIDATED: DNV-RP-F101 Sec 8.2 Example 1 -> 15.86626 MPa.
+
+    D=812.8 mm, t=19.1 mm, d=13.4 mm, L=203.2 mm, f_u(SMTS)=530.9 MPa.
+    NOTE: inputs/outputs are in mm / MPa for this SI example; the
+    ``*_psi``-named fields therefore carry MPa here (formula is unit-agnostic).
+    """
+    res = dnv_f101_single_defect(812.8, 19.1, 13.4, 203.2, 530.9)
+    assert res.capacity_pressure_psi == pytest.approx(15.86626, rel=1e-5)
+
+
+def test_dnv_f101_single_defect_example2_published_mpa():
+    """PUBLISHED-VALIDATED: DNV-RP-F101 Sec 8.2 Example 2 -> 34.01183 MPa.
+
+    D=219.0 mm, t=14.5 mm, d=9.0 mm, L=200.0 mm, f_u(SMTS)=455.1 MPa.
+    Inputs/outputs in mm / MPa (see Example 1 note).
+    """
+    res = dnv_f101_single_defect(219.0, 14.5, 9.0, 200.0, 455.1)
+    assert res.capacity_pressure_psi == pytest.approx(34.01183, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Regression anchors -- same published geometry, methods for which no external
+# published numeric output for these exact inputs could be sourced.  These pin
+# our CURRENT output so a behaviour change is caught; they are NOT external
+# validations.
+# ---------------------------------------------------------------------------
+def test_modified_b31g_crvl_geometry_regression_anchor():
+    """REGRESSION-ANCHOR: Modified B31G on the CRVL Example #1 geometry.
+
+    No external published Modified-B31G (0.85 dL) output was sourced for these
+    exact inputs; value is our own current output (hand-traceable: flow=62 ksi,
+    A/A0=0.85 d/t, two-part Folias).
+    """
+    r = modified_b31g(B31G_D, B31G_T, 0.100, B31G_L, B31G_SMYS)
+    assert r.failure_pressure_psi == pytest.approx(1624.68, rel=1e-4)
+
+
+def test_rstreng_uniform_profile_regression_anchor():
+    """REGRESSION-ANCHOR: RSTRENG, uniform-depth profile, CRVL Example #1 geom.
+
+    A uniform (rectangular) metal-loss profile gives effective A/A0 = d/t; no
+    external published RSTRENG output was sourced for these exact inputs.
+    """
+    r = rstreng_effective_area(B31G_D, B31G_T, [0.0, B31G_L], [0.100, 0.100], B31G_SMYS)
+    assert r.area_ratio == pytest.approx(0.100 / B31G_T, rel=1e-9)
+    assert r.failure_pressure_psi == pytest.approx(1587.44, rel=1e-4)


### PR DESCRIPTION
## Summary

Validation-only (#1094 deferred): **no source behaviour was changed.** Adds
`tests/asset_integrity/test_ffs_published_examples.py` (6 tests) that encode the
exact **inputs** of recognised published worked examples and assert our code
reproduces the published **outputs** within stated tolerances, plus a source
register `docs/domains/ffs-published-examples-2026-06-28.md`.

## Cases

| Method | Source | Published output | Our output | Status |
|--------|--------|------------------|-----------|--------|
| ASME B31G original — safe pressure | ASME B31G-1991 App. A / CRVL.BAS Example #1 (X52, D=30 in, t=0.438 in, d=0.1 in, L=7.5 in, F=0.72) | 1093 psi; A=1.847 | 1093.25 psi | **PUBLISHED-VALIDATED** |
| ASME B31G original — corroded P_f | same example, at published max allowed depth | 0.2490 in ⇔ 910 psi MAOP | 910.9 psi | **PUBLISHED-VALIDATED** |
| DNV-RP-F101 single defect (ex.1) | DNV-RP-F101 (Oct 2010) §8.2, via pipenostics `dnvpf` | 15.86626 MPa | 15.866256 MPa | **PUBLISHED-VALIDATED** |
| DNV-RP-F101 single defect (ex.2) | DNV-RP-F101 (Oct 2010) §8.2 | 34.01183 MPa | 34.011827 MPa | **PUBLISHED-VALIDATED** |
| Modified B31G | (geometry of Example #1) | none sourced | 1624.68 psi | REGRESSION-ANCHOR |
| RSTRENG (uniform profile) | (geometry of Example #1) | none sourced | 1587.44 psi | REGRESSION-ANCHOR |

## Honesty notes
- The four PUBLISHED-VALIDATED cases are sourced from standard/appendix worked
  examples (and a published reference implementation, CRAN `pipenostics`) **and**
  independently hand-verified against the closed-form equations.
- The two REGRESSION-ANCHOR cases are clearly labelled: no external published
  number was found for those exact inputs, so they only pin our current output
  to catch drift — they are **not** claims of external agreement.
- DNV cases run in SI (mm/MPa); the `*_psi`-named field carries MPa for those
  two (formula is unit-consistent), documented in the test docstrings.

## Discrepancy found
None. All four validated cases agree with the published values within tight
tolerance (DNV to <1e-5), so the documented simplifications (parabolic B31G,
two-part Modified-B31G Folias, DNV `Q`) did not surface any real disagreement.

## Test / lint
- `pytest tests/asset_integrity/test_ffs_published_examples.py` → **6 passed**.
- `black --check` clean; `flake8 --select=E9,F63,F7,F82,F401,F811,F841` clean.