### PR TITLE
wf-api(digitalmodel): adopt ResultEnvelope — ffs/buckling/mooring_mbl routes + runner + goldens (workspace-hub#3285)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -709,6 +709,8 @@ workflows:
       - examples/workflows/wall-thickness-quickcheck/results/wall_thickness_quickcheck.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[wall-thickness-quickcheck]
     runtime: offline
+    result:                             # workflow-API result descriptor (#3282 shape; #3295-reserved slot)
+      kind: files                       # extract_result globs the injected embed root; EXCLUDES the save_cfg dump
   - id: api579-pipe-ffs-b314
     basename: API579
     title: API 579 FFS for a 12.75 inch B31.4 oil pipe
@@ -1171,3 +1173,41 @@ workflows:
       - examples/workflows/weather-window-atlas-query/results/input_result.yml
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[weather-window-atlas-query]
     runtime: offline
+  # ---- workflow-API adoption rows (workspace-hub#3285) ---------------------
+  # FULL durable workflows (input/outputs/test/runtime + the #3282 result: slot):
+  # tests/workflows/test_durable_workflows.py parametrizes over EVERY row and reads
+  # input/outputs, so these are real CLI-exercised workflows, not descriptor-only.
+  - id: ffs-metal-loss                  # NEW basename `ffs` -- legacy api579-* rows untouched
+    basename: ffs
+    title: API 579 L1/L2 metal-loss FFS coordinator (measurement-sufficiency aware, #1066)
+    input: examples/workflows/ffs-metal-loss/input.yml
+    outputs:
+      - examples/workflows/ffs-metal-loss/results/input.yml   # save_cfg dump carrying cfg["ffs"] = to_dict()
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[ffs-metal-loss]
+    runtime: offline
+    result:
+      kind: in_memory
+      key: ffs                          # cfg["ffs"] = FFSAssessmentResult.to_dict() (16-key indexed shape)
+  - id: buckling-parametric             # #3285-OWNED; bare in-repo id; #3283 references golden illustratively
+    basename: buckling_parametric
+    title: DNV-RP-C201 plate-buckling parametric sweep (results.json + O(1) index)
+    input: examples/workflows/buckling-parametric/input.yml
+    outputs:
+      - examples/workflows/buckling-parametric/results/input.yml     # save_cfg dump
+      - examples/workflows/buckling-parametric/results/results.json  # write_outputs (meta.generated_at omitted -> byte-stable)
+      - examples/workflows/buckling-parametric/results/cases.csv     # write_outputs cases table
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[buckling-parametric]
+    runtime: offline
+    result:
+      kind: files                       # results.json {meta,lookup,index,index_status,curves} + cases.csv
+  - id: mooring-design-mbl              # NEW basename `mooring_mbl` -- reserved `mooring` arm untouched
+    basename: mooring_mbl
+    title: DNV-OS-E301 mooring MBL safety-factor check (calc-citation pilot #2685)
+    input: examples/workflows/mooring-design-mbl/input.yml
+    outputs:
+      - examples/workflows/mooring-design-mbl/results/input.yml      # save_cfg dump carrying cfg["mooring_mbl"]
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[mooring-design-mbl]
+    runtime: offline
+    result:
+      kind: in_memory
+      key: mooring_mbl

--- a/examples/workflows/buckling-parametric/input.yml
+++ b/examples/workflows/buckling-parametric/input.yml
@@ -1,5 +1,11 @@
 basename: buckling_parametric
 
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
 # DNV-RP-C201 parametric plate-buckling sweep. A SMALL explicit sweep (not the
 # 972-case default) keeps results.json compact + byte-stable for the reference
 # golden. write_outputs runs with timestamp=None so meta.generated_at is omitted.

--- a/examples/workflows/buckling-parametric/input.yml
+++ b/examples/workflows/buckling-parametric/input.yml
@@ -1,0 +1,15 @@
+basename: buckling_parametric
+
+# DNV-RP-C201 parametric plate-buckling sweep. A SMALL explicit sweep (not the
+# 972-case default) keeps results.json compact + byte-stable for the reference
+# golden. write_outputs runs with timestamp=None so meta.generated_at is omitted.
+buckling_parametric:
+  sweep:
+    grades: [Grade A, AH36]
+    thicknesses: [12.0, 16.0]
+    widths: [800.0]
+    plate_lengths: [2400.0]
+    load_cases:
+      - [150.0, 0.0, 0.0]
+      - [120.0, 60.0, 0.0]
+    gamma_m: 1.15

--- a/examples/workflows/ffs-metal-loss/input.yml
+++ b/examples/workflows/ffs-metal-loss/input.yml
@@ -1,5 +1,11 @@
 basename: ffs
 
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
 # Phase-1 FFS metal-loss coordinator (assess_component). The grid is a 6x6
 # measurement lattice with a 2-cell deep local thin spot -> routes LML and the
 # measurement-sufficiency engine flags it under-sampled (TAKE_MORE) -- the #1066

--- a/examples/workflows/ffs-metal-loss/input.yml
+++ b/examples/workflows/ffs-metal-loss/input.yml
@@ -1,0 +1,24 @@
+basename: ffs
+
+# Phase-1 FFS metal-loss coordinator (assess_component). The grid is a 6x6
+# measurement lattice with a 2-cell deep local thin spot -> routes LML and the
+# measurement-sufficiency engine flags it under-sampled (TAKE_MORE) -- the #1066
+# "catch the under-measured ACCEPT" case.
+ffs_assessment:
+  input_units: in
+  component:
+    component_id: LINE-001
+    design_code: B31.8
+    nominal_od_in: 12.75
+    nominal_wt_in: 0.500
+    design_pressure_psi: 1000.0
+    smys_psi: 52000.0
+    corrosion_rate_in_per_yr: 0.005
+    rsf_a: 0.90
+  grid:
+    - [0.50, 0.50, 0.50, 0.50, 0.50, 0.50]
+    - [0.50, 0.50, 0.50, 0.50, 0.50, 0.50]
+    - [0.50, 0.50, 0.50, 0.30, 0.50, 0.50]
+    - [0.50, 0.50, 0.50, 0.32, 0.50, 0.50]
+    - [0.50, 0.50, 0.50, 0.50, 0.50, 0.50]
+    - [0.50, 0.50, 0.50, 0.50, 0.50, 0.50]

--- a/examples/workflows/mooring-design-mbl/input.yml
+++ b/examples/workflows/mooring-design-mbl/input.yml
@@ -1,0 +1,18 @@
+basename: mooring_mbl
+
+# DNV-OS-E301 mooring MBL safety-factor pilot (#2685). check_mbl_with_safety_factor
+# applies the intact-condition SF (1.67) to each segment's utilisation and emits a
+# DNV-OS-E301 citation sidecar. Standalone (no knowledge/wikis tree) degrades to an
+# empty citations list with a one-shot RuntimeWarning; with a wiki base resolvable
+# the citation populates provenance.standard_revisions.
+mooring_mbl_design:
+  condition: intact
+  max_tension_kn: 3000.0
+  design:
+    water_depth: 1500.0
+    fairlead_depth: 10.0
+    target_pretension: 1500.0
+    segments:
+      - {material_key: R4_84mm_chain, length: 150.0}
+      - {material_key: "160mm_polyester", length: 1800.0}
+      - {material_key: R4_84mm_chain, length: 300.0}

--- a/examples/workflows/mooring-design-mbl/input.yml
+++ b/examples/workflows/mooring-design-mbl/input.yml
@@ -1,5 +1,11 @@
 basename: mooring_mbl
 
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
 # DNV-OS-E301 mooring MBL safety-factor pilot (#2685). check_mbl_with_safety_factor
 # applies the intact-condition SF (1.67) to each segment's utilisation and emits a
 # DNV-OS-E301 citation sidecar. Standalone (no knowledge/wikis tree) degrades to an
@@ -8,6 +14,11 @@ basename: mooring_mbl
 mooring_mbl_design:
   condition: intact
   max_tension_kn: 3000.0
+  # Wiki base (dir containing knowledge/wikis/) for DNV-OS-E301 citation resolution.
+  # Relative -> resolved against the digitalmodel repo root (portable + embed-safe).
+  # The committed fixture wiki tree is the only DNV-OS-E301 page in this public repo;
+  # production runs set LLM_WIKI_PATH to a private llm-wiki clone instead.
+  repo_root: tests/citations/fixtures
   design:
     water_depth: 1500.0
     fairlead_depth: 10.0

--- a/src/digitalmodel/asset_integrity/assessment/ffs_workflow.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_workflow.py
@@ -1,0 +1,65 @@
+# ABOUTME: Thin engine router exposing the Phase-1 FFS coordinator (assess_component)
+# ABOUTME: under the engine basename "ffs" (workspace-hub#3285). kind: in_memory.
+"""Engine route for the canonical FFS metal-loss coordinator.
+
+This adapter gives ``asset_integrity/assessment/ffs_coordinator.assess_component``
+an engine basename (``ffs``) so it is callable both from the durable CLI path
+(``uv run python -m digitalmodel <input.yml>``) and from the deterministic
+``digitalmodel.workflow_api.run_workflow("ffs-metal-loss", ...)`` entrypoint.
+
+No assessment physics lives here -- every number comes from the validated
+Phase-1 chain. The router only normalises the cfg inputs into a
+:class:`FFSComponent` + grid, runs ``assess_component``, and parks the indexed
+16-key ``FFSAssessmentResult.to_dict()`` (the #1066 Deckhand-API surface) on
+``cfg["ffs"]`` so the registry ``result: {kind: in_memory, key: ffs}`` descriptor
+can locate it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from digitalmodel.asset_integrity.assessment import (
+    FFSComponent,
+    assess_component,
+)
+
+
+class FFSWorkflow:
+    """Engine adapter for the Phase-1 FFS coordinator (basename ``ffs``)."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        ffs_cfg = cfg.get("ffs_assessment")
+        if not ffs_cfg:
+            raise KeyError(
+                "ffs workflow requires an 'ffs_assessment' block with "
+                "'component' and 'grid' keys"
+            )
+
+        component = FFSComponent(**ffs_cfg["component"])
+        grid = _to_grid(ffs_cfg["grid"])
+        result = assess_component(
+            component,
+            grid,
+            input_units=ffs_cfg.get("input_units", "in"),
+            force_type=ffs_cfg.get("force_type"),
+        )
+
+        # in-memory locator target: cfg[basename] == cfg["ffs"] (the 16-key
+        # indexed FFSAssessmentResult.to_dict() Deckhand-API shape, #1066).
+        cfg[cfg["basename"]] = result.to_dict()
+        return cfg
+
+
+def _to_grid(grid: Any):
+    """Normalise the cfg-supplied grid to a form ``assess_component`` accepts.
+
+    A YAML fixture supplies the measurement lattice as a list-of-lists; convert
+    that to a 2-D float ``np.ndarray``. A string is treated as a CSV path and
+    passed through unchanged (``assess_component`` handles DataFrame/ndarray/CSV).
+    """
+    if isinstance(grid, (list, tuple)):
+        return np.asarray(grid, dtype=float)
+    return grid

--- a/src/digitalmodel/base_configs/modules/buckling_parametric/buckling_parametric.yml
+++ b/src/digitalmodel/base_configs/modules/buckling_parametric/buckling_parametric.yml
@@ -1,0 +1,10 @@
+# Packaged base config for the `buckling_parametric` engine basename (workspace-hub#3285).
+# Minimal skeleton -- omitting a `buckling_parametric.sweep` falls back to the
+# DEFAULT_SHIP_PLATE_SWEEP (972 cases); the durable fixture supplies a small sweep.
+basename: buckling_parametric
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/ffs/ffs.yml
+++ b/src/digitalmodel/base_configs/modules/ffs/ffs.yml
@@ -1,0 +1,11 @@
+# Packaged base config for the `ffs` engine basename (workspace-hub#3285).
+# Minimal skeleton -- the durable example fixture (examples/workflows/ffs-metal-loss/
+# input.yml) supplies the `ffs_assessment` component + grid, which deep-merge over
+# this base (custom wins).
+basename: ffs
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/base_configs/modules/mooring_mbl/mooring_mbl.yml
+++ b/src/digitalmodel/base_configs/modules/mooring_mbl/mooring_mbl.yml
@@ -1,0 +1,10 @@
+# Packaged base config for the `mooring_mbl` engine basename (workspace-hub#3285).
+# Minimal skeleton -- the durable fixture supplies `mooring_mbl_design` (design,
+# max_tension_kn, condition, repo_root for DNV-OS-E301 citation resolution).
+basename: mooring_mbl
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -653,6 +653,26 @@ def engine(
 
         production = ProductionEngineeringWorkflow()
         cfg_base = production.router(cfg_base)
+    elif basename == "ffs":
+        # workspace-hub#3285: Phase-1 FFS coordinator (assess_component) engine route.
+        # NEW basename -- legacy "API579" arm (a different engine) is untouched.
+        from digitalmodel.asset_integrity.assessment.ffs_workflow import FFSWorkflow
+
+        cfg_base = FFSWorkflow().router(cfg_base)
+    elif basename == "buckling_parametric":
+        # workspace-hub#3285-OWNED: DNV-RP-C201 parametric plate-buckling sweep.
+        # NEW basename -- legacy "plate_buckling" arm (PlateBuckling class) untouched.
+        from digitalmodel.structural.buckling_workflow import (
+            BucklingParametricWorkflow,
+        )
+
+        cfg_base = BucklingParametricWorkflow().router(cfg_base)
+    elif basename == "mooring_mbl":
+        # workspace-hub#3285: DNV-OS-E301 mooring MBL pilot (#2685). NEW basename --
+        # the reserved "mooring" arm (subsea/mooring_analysis/ redirect) is untouched.
+        from digitalmodel.orcaflex.mooring_workflow import MooringMBLWorkflow
+
+        cfg_base = MooringMBLWorkflow().router(cfg_base)
     else:
         raise (Exception(f"Analysis for basename: {basename} not found. ... FAIL"))
 

--- a/src/digitalmodel/orcaflex/mooring_workflow.py
+++ b/src/digitalmodel/orcaflex/mooring_workflow.py
@@ -36,11 +36,10 @@ class MooringMBLWorkflow:
             )
 
         design = MooringLineDesign(**mbl_cfg.get("design", {}))
-        repo_root = mbl_cfg.get("repo_root")
         out = design.check_mbl_with_safety_factor(
             float(mbl_cfg["max_tension_kn"]),
             condition=mbl_cfg.get("condition", "intact"),
-            repo_root=Path(repo_root) if repo_root else None,
+            repo_root=_resolve_repo_root(mbl_cfg.get("repo_root")),
         )
 
         # Serialise Citation sidecars to plain dicts -> JSON-clean in_memory payload.
@@ -49,6 +48,28 @@ class MooringMBLWorkflow:
 
         cfg[cfg["basename"]] = out
         return cfg
+
+
+def _digitalmodel_repo_root() -> Path:
+    # mooring_workflow.py -> orcaflex -> digitalmodel -> src -> <repo root>
+    return Path(__file__).resolve().parents[3]
+
+
+def _resolve_repo_root(repo_root: Any) -> Optional[Path]:
+    """Resolve the cfg ``repo_root`` (the wiki-base dir for citation resolution).
+
+    A relative value is resolved against the digitalmodel repo root so a committed
+    fixture stays portable across machines AND across the #3307 embed path (which
+    rebases ``_config_dir_path`` to a throwaway tempdir -- so the wiki base must NOT
+    be resolved relative to the config dir). ``None`` => the resolver's own
+    precedence chain (LLM_WIKI_PATH / parent-walk / standalone) applies.
+    """
+    if not repo_root:
+        return None
+    path = Path(repo_root)
+    if not path.is_absolute():
+        path = _digitalmodel_repo_root() / path
+    return path
 
 
 def _citation_to_dict(citation: Any) -> dict[str, Optional[str]]:

--- a/src/digitalmodel/orcaflex/mooring_workflow.py
+++ b/src/digitalmodel/orcaflex/mooring_workflow.py
@@ -1,0 +1,72 @@
+# ABOUTME: Engine router for the DNV-OS-E301 mooring MBL safety-factor pilot under a
+# ABOUTME: NEW basename "mooring_mbl" (workspace-hub#3285). Does NOT touch reserved "mooring".
+"""Engine route for the mooring MBL safety-factor calc-citation pilot (#2685).
+
+The ``orcaflex/mooring_design.py`` ``MooringLineDesign.check_mbl_with_safety_factor``
+pilot is the live DNV-OS-E301 calc-citation surface. ``engine.py``'s existing
+``mooring`` basename is RESERVED for the separate ``subsea/mooring_analysis/``
+subsystem (it raises a redirect ``NotImplementedError``), so this pilot gets a NEW
+non-colliding basename ``mooring_mbl`` -- the reserved ``mooring`` arm is left
+untouched.
+
+``kind: in_memory`` -- the result (per-segment utilisation + DNV-OS-E301 citation
+sidecar) is parked on ``cfg["mooring_mbl"]``. Citations are serialised to plain
+dicts so the in-memory payload is JSON-clean for the determinism hash, and the
+digitalmodel runner lifts them into ``provenance.standard_revisions``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from digitalmodel.orcaflex.mooring_design import MooringLineDesign
+
+
+class MooringMBLWorkflow:
+    """Engine adapter for the mooring MBL pilot (NEW basename ``mooring_mbl``)."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        mbl_cfg = cfg.get("mooring_mbl_design")
+        if not mbl_cfg:
+            raise KeyError(
+                "mooring_mbl workflow requires a 'mooring_mbl_design' block with "
+                "'design' and 'max_tension_kn' keys"
+            )
+
+        design = MooringLineDesign(**mbl_cfg.get("design", {}))
+        repo_root = mbl_cfg.get("repo_root")
+        out = design.check_mbl_with_safety_factor(
+            float(mbl_cfg["max_tension_kn"]),
+            condition=mbl_cfg.get("condition", "intact"),
+            repo_root=Path(repo_root) if repo_root else None,
+        )
+
+        # Serialise Citation sidecars to plain dicts -> JSON-clean in_memory payload.
+        out = dict(out)
+        out["citations"] = [_citation_to_dict(c) for c in out.get("citations", [])]
+
+        cfg[cfg["basename"]] = out
+        return cfg
+
+
+def _citation_to_dict(citation: Any) -> dict[str, Optional[str]]:
+    """Normalise a Citation (frozen dataclass) or dict to a plain dict."""
+    if isinstance(citation, dict):
+        src = citation
+    elif is_dataclass(citation):
+        src = asdict(citation)
+    else:  # pragma: no cover - defensive
+        src = {
+            k: getattr(citation, k, None)
+            for k in ("code_id", "publisher", "revision", "section", "wiki_path", "note")
+        }
+    return {
+        "code_id": src.get("code_id"),
+        "publisher": src.get("publisher"),
+        "revision": src.get("revision"),
+        "section": src.get("section"),
+        "wiki_path": src.get("wiki_path"),
+        "note": src.get("note", ""),
+    }

--- a/src/digitalmodel/structural/buckling_workflow.py
+++ b/src/digitalmodel/structural/buckling_workflow.py
@@ -1,0 +1,83 @@
+# ABOUTME: Engine router making the DNV-RP-C201 buckling_parametric sweep callable
+# ABOUTME: under basename "buckling_parametric" (workspace-hub#3285-OWNED). kind: files.
+"""Engine route for the parametric plate-buckling sweep.
+
+#3285 OWNS-CREATES this route: the scope-named ``structural/buckling_parametric.py``
+producer (PR #1044) was a pure-Python parametric layer with no engine basename and
+no registry row. This adapter gives it the basename ``buckling_parametric`` so it is
+callable from the durable CLI path AND from
+``digitalmodel.workflow_api.run_workflow("buckling-parametric", ...)`` via a bare
+in-repo id, and writes ``results.json`` (+ ``cases.csv``) into the engine-resolved
+result folder so the registry ``result: {kind: files}`` descriptor can content-hash it.
+
+``write_outputs(..., timestamp=None)`` deliberately omits ``meta.generated_at`` so the
+emitted ``results.json`` is byte-stable -- the property the reference golden relies on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.structural.buckling_parametric import (
+    DEFAULT_SHIP_PLATE_SWEEP,
+    BucklingSweepConfig,
+    run_sweep,
+    utility_curves,
+    write_outputs,
+)
+
+
+class BucklingParametricWorkflow:
+    """Engine adapter for the buckling parametric sweep (basename ``buckling_parametric``)."""
+
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        sweep = _build_sweep(cfg.get("buckling_parametric", {}))
+        rows = run_sweep(sweep)
+        curves = utility_curves(sweep)
+
+        out_dir = _result_dir(cfg)
+        # timestamp=None => no meta.generated_at => byte-stable results.json (golden).
+        written = write_outputs(
+            rows, curves, out_dir, gamma_m=sweep.gamma_m, timestamp=None
+        )
+
+        # Thin in-memory summary on cfg[basename] for downstream/report consumers;
+        # the authoritative result surface for this row is kind: files (results.json).
+        cfg[cfg["basename"]] = {
+            "n_cases": len(rows),
+            "standard": "DNV-RP-C201",
+            "result_folder": str(out_dir),
+            "outputs": {key: str(path) for key, path in written.items()},
+        }
+        return cfg
+
+
+def _build_sweep(sweep_cfg: dict[str, Any]) -> BucklingSweepConfig:
+    """Build a sweep config from cfg, defaulting to the full ship-plate sweep."""
+    sweep = sweep_cfg.get("sweep") if sweep_cfg else None
+    if not sweep:
+        return DEFAULT_SHIP_PLATE_SWEEP
+    return BucklingSweepConfig(
+        thicknesses=[float(t) for t in sweep["thicknesses"]],
+        widths=[float(w) for w in sweep["widths"]],
+        plate_lengths=[float(L) for L in sweep["plate_lengths"]],
+        load_cases=[tuple(float(v) for v in lc) for lc in sweep["load_cases"]],
+        grades=list(sweep["grades"]),
+        gamma_m=float(sweep.get("gamma_m", 1.15)),
+    )
+
+
+def _result_dir(cfg: dict[str, Any]) -> Path:
+    """Engine-resolved result folder.
+
+    On the durable CLI path this is ``<config dir>/results``; on the #3307 embed
+    path it is the injected ``root_folder/results`` (configure_embed rebases both
+    ``Analysis.result_folder`` and ``_config_dir_path`` to the injected root).
+    """
+    analysis = cfg.get("Analysis", {}) or {}
+    result_folder = analysis.get("result_folder")
+    if result_folder:
+        return Path(result_folder)
+    config_dir = cfg.get("_config_dir_path")
+    return (Path(config_dir) if config_dir else Path.cwd()) / "results"

--- a/src/digitalmodel/workflow_api/__init__.py
+++ b/src/digitalmodel/workflow_api/__init__.py
@@ -1,0 +1,27 @@
+# ABOUTME: Public surface for digitalmodel's deterministic workflow API (workspace-hub#3285).
+"""Deterministic, in-process workflow API for digitalmodel.
+
+Re-exports the SHARED, assetutilities-owned :class:`ResultEnvelope` contract
+(#3282) and exposes digitalmodel's own ``run_workflow`` built on the #3307
+embeddable engine path. The envelope/locator/hashing/provenance helpers are
+imported from assetutilities -- never redefined here.
+"""
+
+from assetutilities.workflow_api import ResultEnvelope
+
+from digitalmodel.workflow_api.runner import (
+    build_cfg,
+    load_registry,
+    registry_path,
+    resolve_registry_row,
+    run_workflow,
+)
+
+__all__ = [
+    "ResultEnvelope",
+    "run_workflow",
+    "build_cfg",
+    "load_registry",
+    "registry_path",
+    "resolve_registry_row",
+]

--- a/src/digitalmodel/workflow_api/runner.py
+++ b/src/digitalmodel/workflow_api/runner.py
@@ -1,0 +1,214 @@
+# ABOUTME: digitalmodel-bound run_workflow() — drives digitalmodel's #3307-embeddable
+# ABOUTME: engine, reusing the SHARED assetutilities ResultEnvelope contract (#3285).
+"""Deterministic, in-process workflow runner for digitalmodel.
+
+``run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)``
+returns a typed :class:`assetutilities.workflow_api.ResultEnvelope`.
+
+This is the per-repo runner the re-locked #3282 contract calls for: each adopting
+repo provides its own ``run_workflow`` that drives ITS engine + resolves ITS
+registry, while REUSING (never redefining) the shared ``ResultEnvelope`` +
+``ResultLocator`` + ``extract_result`` + hashing/provenance helpers imported from
+assetutilities. Two digitalmodel-specific bindings:
+
+* it drives ``digitalmodel.engine.engine(cfg=..., embed=True, root_folder=, log_to_file=False)``
+  (the workspace-hub#3307 embed path), and resolves a BARE single-registry id in
+  digitalmodel's own ``docs/registry/workflows.yaml`` (cross-repo ``repo:id@version``
+  resolution is #3284-owned and out of scope here);
+* it stamps ``code_version("digitalmodel")`` and lifts any DNV/API ``citations``
+  sidecar from an ``in_memory`` payload into ``provenance.standard_revisions``.
+
+Side-effect-freeness comes entirely from the embed path: all result + log writes
+land under a throwaway ``tempfile.mkdtemp()`` root which is ``rmtree``'d after the
+content hash is taken, leaving the repo/example dirs byte-for-byte untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+import tempfile
+import shutil
+from pathlib import Path
+
+import yaml
+
+from assetutilities.common.update_deep import update_deep_dictionary
+from assetutilities.workflow_api import (
+    ResultEnvelope,
+    ResultLocator,
+    extract_result,
+)
+from assetutilities.workflow_api.envelope import (
+    compute_reproducible,
+    input_hash,
+    make_provenance,
+    result_hash,
+    utc_now_iso,
+)
+
+PACKAGE_NAME = "digitalmodel"
+
+
+def _repo_root() -> Path:
+    # runner.py -> workflow_api -> digitalmodel -> src -> <repo root>
+    return Path(__file__).resolve().parents[3]
+
+
+def registry_path() -> Path:
+    return _repo_root() / "docs" / "registry" / "workflows.yaml"
+
+
+def load_registry() -> dict:
+    with open(registry_path()) as fh:
+        return yaml.safe_load(fh)
+
+
+def resolve_registry_row(workflow_id: str) -> dict:
+    """Resolve a BARE in-repo id against digitalmodel's registry (fail-closed).
+
+    Cross-repo ``repo:id@version`` resolution is #3284-owned and intentionally not
+    handled here. When several rows share an id, prefer the one flagged
+    ``latest: true``, else the first.
+    """
+    rows = [
+        row
+        for row in load_registry().get("workflows", [])
+        if row.get("id") == workflow_id
+    ]
+    if not rows:
+        raise KeyError(
+            f"unknown workflow_id '{workflow_id}' (not in {registry_path()})"
+        )
+    for row in rows:
+        if row.get("latest") is True:
+            return row
+    return rows[0]
+
+
+def lookup_row_for_cfg(cfg: dict) -> dict | None:
+    basename = cfg.get("basename")
+    if not basename:
+        return None
+    for row in load_registry().get("workflows", []):
+        if row.get("basename") == basename or row.get("id") == basename:
+            return row
+    return None
+
+
+def resolve_example_path(rel_input: str) -> Path:
+    return _repo_root() / rel_input
+
+
+def build_cfg(row: dict, params: dict | None) -> dict:
+    """Build the run cfg from a registry row + caller params (params win)."""
+    cfg: dict = {"basename": row["basename"]}
+    input_rel = row.get("input")
+    if input_rel:
+        with open(resolve_example_path(input_rel)) as fh:
+            example_cfg = yaml.safe_load(fh) or {}
+        cfg = update_deep_dictionary(cfg, example_cfg)
+    if params:
+        cfg = update_deep_dictionary(cfg, copy.deepcopy(params))
+    return cfg
+
+
+def _standard_revisions_from_payload(payload: dict) -> list:
+    """Lift a DNV/API ``citations`` sidecar (in_memory payload) into provenance.
+
+    The mooring-MBL route carries a DNV-OS-E301 ``citations`` list; surface each as
+    a ``standard_revisions`` entry. Absent/empty (e.g. standalone mode without a
+    wiki tree) yields ``[]`` -- never raises.
+    """
+    if not isinstance(payload, dict) or payload.get("kind") != "in_memory":
+        return []
+    value = payload.get("value")
+    if not isinstance(value, dict):
+        return []
+    revisions = []
+    for citation in value.get("citations", []) or []:
+        if isinstance(citation, dict):
+            revisions.append(
+                {
+                    "code_id": citation.get("code_id"),
+                    "publisher": citation.get("publisher"),
+                    "revision": citation.get("revision"),
+                    "section": citation.get("section"),
+                }
+            )
+    return revisions
+
+
+def _run_once(cfg: dict, locator: ResultLocator):
+    """One side-effect-free embed run. Returns ``(payload, warnings, result_hash)``."""
+    # Imported lazily -- the digitalmodel engine import is heavy.
+    from digitalmodel.engine import engine
+
+    root = tempfile.mkdtemp(prefix="dmwf_")
+    try:
+        cfg_base = engine(
+            cfg=copy.deepcopy(cfg),
+            embed=True,
+            root_folder=root,
+            log_to_file=False,
+        )
+        payload, warns = extract_result(cfg_base, locator, root)
+        return payload, warns, result_hash(payload)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def run_workflow(
+    workflow_id: str | None = None,
+    params: dict | None = None,
+    cfg: dict | None = None,
+    verify_reproducible: bool = False,
+) -> ResultEnvelope:
+    """Run a digitalmodel registry workflow in-process; return a typed ResultEnvelope.
+
+    Fail-closed: an unknown id or a router exception is returned as a
+    ``status="error"`` envelope, never raised.
+    """
+    wid = workflow_id or "(inline-cfg)"
+    try:
+        if cfg is None:
+            row = resolve_registry_row(workflow_id)
+            cfg = build_cfg(row, params)
+            locator = ResultLocator.from_row(row)
+        else:
+            cfg = copy.deepcopy(cfg)
+            row = lookup_row_for_cfg(cfg)
+            locator = (
+                ResultLocator.from_row(row)
+                if row
+                else ResultLocator.default_for(cfg)
+            )
+
+        ihash = input_hash(cfg)
+        payload, warns, rhash = _run_once(cfg, locator)
+        repro = compute_reproducible(
+            lambda: _run_once(cfg, locator)[2], rhash, verify_reproducible
+        )
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="ok",
+            result=payload,
+            provenance=make_provenance(
+                ihash,
+                package_name=PACKAGE_NAME,
+                standard_revisions=_standard_revisions_from_payload(payload),
+                data_as_of=utc_now_iso(),
+            ),
+            determinism={"result_hash": rhash, "reproducible": repro},
+            confidence=None,
+            warnings=warns,
+        )
+    except Exception as exc:  # fail-closed -> error envelope, never a raw traceback
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="error",
+            result={},
+            provenance=make_provenance(None, package_name=PACKAGE_NAME),
+            determinism={"result_hash": None, "reproducible": None},
+            confidence=None,
+            warnings=[str(exc)],
+        )

--- a/tests/workflow_api/golden_helpers.py
+++ b/tests/workflow_api/golden_helpers.py
@@ -1,0 +1,52 @@
+# ABOUTME: Shared golden helpers for the workflow-API adoption tests (workspace-hub#3285).
+"""Golden-comparison helpers for the digitalmodel workflow-API tests.
+
+#3283's ``golden_workflow_test`` template is not yet merged into assetutilities, so
+these tests carry a small self-contained golden helper. Two determinism signals:
+
+* ``reproducible is True`` -- a double-run (``verify_reproducible=True``) in two
+  separate tempdir roots yields an identical content hash (in-env determinism).
+* a committed golden -- the result payload is pinned. For ``kind: files`` and the
+  fully-rounded mooring payload the exact ``result_hash`` is asserted; for the FFS
+  in_memory payload (which carries unrounded floats whose last ULP can shift across
+  numpy builds) the VALUE is compared with tolerance instead of the exact hash.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+GOLDENS = Path(__file__).resolve().parent / "goldens"
+
+# Wiki base for DNV-OS-E301 citation resolution in the mooring route. The committed
+# fixture tree is the only copy of the page in this public repo (the real wiki is the
+# private llm-wiki). The mooring example fixture points repo_root here too.
+FIXTURE_WIKI_ROOT = Path(__file__).resolve().parents[1] / "citations" / "fixtures"
+
+
+def load_golden(name: str) -> dict:
+    return json.loads((GOLDENS / name).read_text())
+
+
+def deep_approx(actual, expected, *, rel: float = 1e-9, abs_: float = 1e-12) -> None:
+    """Assert ``actual`` matches ``expected`` with float tolerance on numbers."""
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), f"expected dict, got {type(actual)}"
+        assert set(actual) == set(expected), (
+            f"key mismatch: {set(actual) ^ set(expected)}"
+        )
+        for key in expected:
+            deep_approx(actual[key], expected[key], rel=rel, abs_=abs_)
+    elif isinstance(expected, list):
+        assert isinstance(actual, list) and len(actual) == len(expected)
+        for a, e in zip(actual, expected):
+            deep_approx(a, e, rel=rel, abs_=abs_)
+    elif isinstance(expected, bool):
+        assert actual is expected or actual == expected
+    elif isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        assert actual == pytest.approx(expected, rel=rel, abs=abs_)
+    else:
+        assert actual == expected

--- a/tests/workflow_api/goldens/buckling_parametric.json
+++ b/tests/workflow_api/goldens/buckling_parametric.json
@@ -1,0 +1,19 @@
+{
+  "result": {
+    "kind": "files",
+    "outputs": [
+      {
+        "basename": "cases.csv",
+        "sha256": "b4112638edcf29365a08f3d62196ff87981d235d2279488c4815bb538e9be102",
+        "size": 924
+      },
+      {
+        "basename": "results.json",
+        "sha256": "7f248c60a07caca9b9527b436d3fdfa8869169db14e6ade6176dd071efad812c",
+        "size": 5426
+      }
+    ]
+  },
+  "result_hash": "8e59bb951a101a6b7383dd9898489c4b40f4785f8ea9a8c170175cad7f2e9734",
+  "standard_revisions": []
+}

--- a/tests/workflow_api/goldens/ffs_metal_loss.json
+++ b/tests/workflow_api/goldens/ffs_metal_loss.json
@@ -1,0 +1,26 @@
+{
+  "result": {
+    "kind": "in_memory",
+    "value": {
+      "assessment_type": "LML",
+      "code_reference": "API 579-1/ASME FFS-1 (2021)",
+      "component_id": "LINE-001",
+      "fca_in": 0.0,
+      "folias_factor": 1.5812689937754407,
+      "level_reached": 1,
+      "passes": true,
+      "remaining_life_yr": 25.945512820512818,
+      "rerated_pressure_psi": 1000.0,
+      "rsf": 1.0,
+      "rsf_a": 0.9,
+      "sufficiency_status": "TAKE_MORE",
+      "t_measured_avg_in": 0.4894444444444444,
+      "t_measured_min_in": 0.3,
+      "t_min_in": 0.1702724358974359,
+      "t_nominal_in": 0.5,
+      "verdict": "ACCEPT"
+    }
+  },
+  "result_hash": "6e4cd62678aedf127b27f7f561560609b702814c3b8a5a78747adb8e783da1cf",
+  "standard_revisions": []
+}

--- a/tests/workflow_api/goldens/mooring_mbl.json
+++ b/tests/workflow_api/goldens/mooring_mbl.json
@@ -1,0 +1,40 @@
+{
+  "result": {
+    "kind": "in_memory",
+    "value": {
+      "citations": [
+        {
+          "code_id": "DNV-OS-E301",
+          "note": "Design factor for intact-quasi-static condition",
+          "publisher": "DNV",
+          "revision": "2021-07",
+          "section": "Section 2.2.3 (intact, quasi-static)",
+          "wiki_path": "wikis/engineering/wiki/standards/dnv-os-e301.md"
+        }
+      ],
+      "condition": "intact",
+      "results": {
+        "160mm_polyester": {
+          "passes": true,
+          "utilisation_no_sf": 0.3529,
+          "utilisation_with_sf": 0.5894
+        },
+        "R4_84mm_chain": {
+          "passes": true,
+          "utilisation_no_sf": 0.4299,
+          "utilisation_with_sf": 0.718
+        }
+      },
+      "safety_factor": 1.67
+    }
+  },
+  "result_hash": "8a1ec69407f11969d2480edc195265687516807274a02e61709680eb2d034afa",
+  "standard_revisions": [
+    {
+      "code_id": "DNV-OS-E301",
+      "publisher": "DNV",
+      "revision": "2021-07",
+      "section": "Section 2.2.3 (intact, quasi-static)"
+    }
+  ]
+}

--- a/tests/workflow_api/goldens/wall_thickness.json
+++ b/tests/workflow_api/goldens/wall_thickness.json
@@ -1,0 +1,12 @@
+{
+  "stable_files": {
+    "wall_thickness_quickcheck.csv": {
+      "sha256": "574ef0286378de422fd06cea2ff214ff62fcf97271d2000f9faa42d72c91880a",
+      "size": 312
+    },
+    "wall_thickness_quickcheck.json": {
+      "sha256": "2ad6acd9120aa509cec5f00e7c2876665649569020ddc51dd0ef93675ddf12f4",
+      "size": 42003
+    }
+  }
+}

--- a/tests/workflow_api/test_result_descriptors.py
+++ b/tests/workflow_api/test_result_descriptors.py
@@ -1,0 +1,67 @@
+# ABOUTME: Registry result: descriptors parse + ResultLocator + fail-closed + embed isolation (#3285).
+"""Cross-cutting workflow-API tests: descriptor parsing, fail-closed, embed isolation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from assetutilities.workflow_api import ResultLocator
+
+from digitalmodel.workflow_api import load_registry, run_workflow
+from digitalmodel.workflow_api.runner import resolve_registry_row
+
+NEW_ROWS = {"ffs-metal-loss", "buckling-parametric", "mooring-design-mbl"}
+
+
+def test_result_descriptors_parse_and_match_locator():
+    rows = load_registry()["workflows"]
+    by_id = {row["id"]: row for row in rows}
+    # every row with a result: descriptor parses into a valid ResultLocator
+    for row in rows:
+        if "result" in row:
+            locator = ResultLocator.from_row(row)
+            assert locator.kind in {"files", "in_memory"}
+            if locator.kind == "in_memory":
+                assert locator.key, f"{row['id']} in_memory missing key"
+    # the four #3285 descriptors specifically
+    assert ResultLocator.from_row(by_id["ffs-metal-loss"]).kind == "in_memory"
+    assert ResultLocator.from_row(by_id["ffs-metal-loss"]).key == "ffs"
+    assert ResultLocator.from_row(by_id["buckling-parametric"]).kind == "files"
+    assert ResultLocator.from_row(by_id["mooring-design-mbl"]).key == "mooring_mbl"
+    assert ResultLocator.from_row(by_id["wall-thickness-quickcheck"]).kind == "files"
+
+
+def test_descriptor_absence_still_valid_superset():
+    # a row WITHOUT a result: descriptor still yields a valid (default files) locator
+    rows = load_registry()["workflows"]
+    no_descriptor = next(r for r in rows if "result" not in r)
+    assert ResultLocator.from_row(no_descriptor).kind == "files"
+
+
+def test_new_rows_are_full_durable_rows():
+    # MAJOR-1: the new rows carry the full durable key-set (not descriptor-only),
+    # so tests/workflows/test_durable_workflows.py parametrizes over them w/o KeyError.
+    for wid in NEW_ROWS:
+        row = resolve_registry_row(wid)
+        for key in ("basename", "input", "outputs", "test", "runtime"):
+            assert key in row, f"{wid} missing durable key {key}"
+
+
+def test_run_workflow_unknown_id_error_envelope():
+    env = run_workflow("does-not-exist")
+    assert env.status == "error"
+    assert env.result == {}
+    assert env.determinism["result_hash"] is None
+    assert env.warnings
+
+
+def test_embed_run_writes_only_under_root(tmp_path, monkeypatch):
+    # consume #3307: run_workflow leaves nothing outside its throwaway tempdir root
+    # and does not change cwd (depends on #3307's _config_dir_path rebase).
+    monkeypatch.chdir(tmp_path)
+    before = set(os.listdir(tmp_path))
+    env = run_workflow("ffs-metal-loss")
+    assert env.status == "ok", env.warnings
+    assert set(os.listdir(tmp_path)) == before  # no stray writes into cwd
+    assert Path.cwd() == tmp_path

--- a/tests/workflow_api/test_run_workflow_buckling.py
+++ b/tests/workflow_api/test_run_workflow_buckling.py
@@ -1,0 +1,39 @@
+# ABOUTME: run_workflow envelope + reference golden for the buckling sweep route (#3285-OWNED).
+"""Tests for ``run_workflow("buckling-parametric")`` (G2, kind: files).
+
+#3285 OWNS-CREATES this reference golden, runnable via the BARE in-repo id
+``run_workflow("buckling-parametric", ...)`` (no #3284). #3283 references it only as
+an illustrative consumer example; any cross-repo ``digitalmodel:buckling-parametric``
+form is #3284-gated.
+"""
+
+from __future__ import annotations
+
+from digitalmodel.workflow_api import ResultEnvelope, run_workflow
+
+from tests.workflow_api.golden_helpers import load_golden
+
+
+def test_run_workflow_buckling_files():
+    env = run_workflow("buckling-parametric")
+    assert isinstance(env, ResultEnvelope)
+    assert env.status == "ok", env.warnings
+    assert env.result["kind"] == "files"
+    basenames = {f["basename"] for f in env.result["outputs"]}
+    # the save_cfg cfg-dump is EXCLUDED; only the genuine router outputs remain
+    assert basenames == {"results.json", "cases.csv"}
+
+
+def test_buckling_reference_golden_bare_in_repo_id():
+    # the #3285-owned reference golden, runnable via the BARE in-repo id (no #3284).
+    # results.json is byte-stable (meta.generated_at omitted) + cases.csv is rounded,
+    # so the kind:files content hash is exact-stable across runs and machines.
+    env = run_workflow("buckling-parametric", verify_reproducible=True)
+    assert env.status == "ok", env.warnings
+    assert env.determinism["reproducible"] is True
+    golden = load_golden("buckling_parametric.json")
+    assert env.determinism["result_hash"] == golden["result_hash"]
+    # per-file content digests pinned too
+    actual = {f["basename"]: f["sha256"] for f in env.result["outputs"]}
+    expected = {f["basename"]: f["sha256"] for f in golden["result"]["outputs"]}
+    assert actual == expected

--- a/tests/workflow_api/test_run_workflow_ffs.py
+++ b/tests/workflow_api/test_run_workflow_ffs.py
@@ -1,0 +1,41 @@
+# ABOUTME: run_workflow envelope + determinism golden for the FFS metal-loss route (#3285).
+"""Tests for ``run_workflow("ffs-metal-loss")`` (G1, kind: in_memory)."""
+
+from __future__ import annotations
+
+from digitalmodel.workflow_api import ResultEnvelope, run_workflow
+
+from tests.workflow_api.golden_helpers import deep_approx, load_golden
+
+FFS_KEYS = {
+    "component_id", "assessment_type", "level_reached", "t_nominal_in", "t_min_in",
+    "t_measured_min_in", "t_measured_avg_in", "fca_in", "rsf", "rsf_a",
+    "folias_factor", "remaining_life_yr", "verdict", "rerated_pressure_psi",
+    "sufficiency_status", "passes", "code_reference",
+}
+
+
+def test_run_workflow_ffs_in_memory():
+    env = run_workflow("ffs-metal-loss")
+    assert isinstance(env, ResultEnvelope)
+    assert env.status == "ok", env.warnings
+    assert env.result["kind"] == "in_memory"
+    value = env.result["value"]
+    # the #1066 indexed 16-key FFSAssessmentResult.to_dict() surface
+    assert set(value) == FFS_KEYS
+    assert value["assessment_type"] == "LML"
+    # the measurement-sufficiency catch: an L1-ACCEPT that is under-measured
+    assert value["verdict"] == "ACCEPT"
+    assert value["sufficiency_status"] == "TAKE_MORE"
+    # digitalmodel stamps its OWN package version, not assetutilities'
+    assert "package_version" in env.provenance["code_version"]
+
+
+def test_ffs_golden():
+    # double-run determinism (in-env) + value golden (cross-env-robust: FFS to_dict
+    # carries unrounded floats, so VALUE-with-tolerance is pinned, not the exact hash).
+    env = run_workflow("ffs-metal-loss", verify_reproducible=True)
+    assert env.status == "ok", env.warnings
+    assert env.determinism["reproducible"] is True
+    golden = load_golden("ffs_metal_loss.json")
+    deep_approx(env.result, golden["result"], rel=1e-6)

--- a/tests/workflow_api/test_run_workflow_mooring_mbl.py
+++ b/tests/workflow_api/test_run_workflow_mooring_mbl.py
@@ -1,0 +1,44 @@
+# ABOUTME: run_workflow envelope + golden + reserved-basename guard for mooring MBL (#3285).
+"""Tests for ``run_workflow("mooring-design-mbl")`` (G3, NEW basename ``mooring_mbl``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.engine import engine
+from digitalmodel.workflow_api import ResultEnvelope, run_workflow
+
+from tests.workflow_api.golden_helpers import deep_approx, load_golden
+
+
+def test_run_workflow_mooring_mbl_citation_preserved():
+    env = run_workflow("mooring-design-mbl")
+    assert isinstance(env, ResultEnvelope)
+    assert env.status == "ok", env.warnings
+    value = env.result["value"]
+    assert value["condition"] == "intact"
+    assert value["safety_factor"] == pytest.approx(1.67)
+    # DNV-OS-E301 citation sidecar preserved on the payload ...
+    citations = value["citations"]
+    assert len(citations) == 1
+    assert citations[0]["code_id"] == "DNV-OS-E301"
+    # ... and lifted into provenance.standard_revisions
+    revs = env.provenance["standard_revisions"]
+    assert any(r["code_id"] == "DNV-OS-E301" for r in revs)
+
+
+def test_mooring_mbl_golden():
+    env = run_workflow("mooring-design-mbl", verify_reproducible=True)
+    assert env.status == "ok", env.warnings
+    assert env.determinism["reproducible"] is True
+    golden = load_golden("mooring_mbl.json")
+    # payload is fully rounded -> exact hash AND value are stable
+    deep_approx(env.result, golden["result"], rel=1e-9)
+    assert env.determinism["result_hash"] == golden["result_hash"]
+
+
+def test_mooring_basename_still_reserved():
+    # the NEW mooring_mbl arm must NOT have disturbed the reserved `mooring` arm,
+    # which redirects to subsea/mooring_analysis/ via NotImplementedError.
+    with pytest.raises(NotImplementedError):
+        engine(cfg={"basename": "mooring"}, config_flag=False)

--- a/tests/workflow_api/test_run_workflow_wall_thickness.py
+++ b/tests/workflow_api/test_run_workflow_wall_thickness.py
@@ -1,0 +1,52 @@
+# ABOUTME: run_workflow envelope + stable-files golden for wall-thickness quickcheck (#3285).
+"""Tests for ``run_workflow("wall-thickness-quickcheck")`` (G4, kind: files).
+
+The quickcheck reads a cached payload that is config-relative; under the #3307 embed
+path ``_config_dir_path`` is rebased to a throwaway root, so the cache must be passed
+as an ABSOLUTE path via ``params``. Its HTML report embeds the (per-run, abspath)
+output path, so the OVERALL kind:files hash is not machine-stable -- only the
+sorted-key JSON + the CSV are byte-stable, so the golden pins THOSE per-file digests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from digitalmodel.workflow_api import ResultEnvelope, run_workflow
+
+from tests.workflow_api.golden_helpers import load_golden
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CACHE = (
+    REPO_ROOT
+    / "examples/workflows/wall-thickness-quickcheck/data/quickcheck_cache.json"
+)
+PARAMS = {"wall_thickness": {"quickcheck": {"cache": str(CACHE)}}}
+
+
+def test_run_workflow_wall_thickness_envelope():
+    env = run_workflow("wall-thickness-quickcheck", params=PARAMS)
+    assert isinstance(env, ResultEnvelope)
+    assert env.status == "ok", env.warnings
+    assert env.result["kind"] == "files"
+    basenames = {f["basename"] for f in env.result["outputs"]}
+    # save_cfg dump excluded; the three router outputs present
+    assert {
+        "wall_thickness_quickcheck.json",
+        "wall_thickness_quickcheck.csv",
+        "wall_thickness_quickcheck.html",
+    } <= basenames
+
+
+def test_wall_thickness_golden():
+    # the byte-stable JSON + CSV per-file digests are pinned (the HTML embeds an
+    # abspath so it is intentionally excluded from the golden).
+    env = run_workflow("wall-thickness-quickcheck", params=PARAMS)
+    assert env.status == "ok", env.warnings
+    golden = load_golden("wall_thickness.json")["stable_files"]
+    actual = {
+        f["basename"]: {"sha256": f["sha256"], "size": f["size"]}
+        for f in env.result["outputs"]
+        if f["basename"].endswith((".json", ".csv"))
+    }
+    assert actual == golden

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1,3 +1,4 @@
+import json
 import math
 from pathlib import Path
 
@@ -1418,6 +1419,56 @@ def test_workflow_registry(workflow, monkeypatch):
         assert result["annual_damage"] > 0.0
         assert result["value"] > 0.0  # fatigue life (years)
         assert result["screening_status"] in {"pass", "fail"}
+    elif workflow["id"] == "ffs-metal-loss":
+        # workflow-API adoption row (workspace-hub#3285): the `ffs` route parks the
+        # #1066 indexed 16-key FFSAssessmentResult.to_dict() on cfg["ffs"].
+        result = cfg["ffs"]
+        assert result["component_id"] == "LINE-001"
+        assert result["assessment_type"] == "LML"  # 2-cell deep local thin spot
+        assert result["verdict"] == "ACCEPT"
+        # the measurement-sufficiency catch: an L1-ACCEPT that is under-measured
+        assert result["sufficiency_status"] == "TAKE_MORE"
+        assert result["passes"] is True
+        assert result["t_nominal_in"] == pytest.approx(0.5)
+        assert result["t_measured_min_in"] == pytest.approx(0.3)
+        assert result["folias_factor"] >= 1.0
+        assert set(result) == {
+            "component_id", "assessment_type", "level_reached", "t_nominal_in",
+            "t_min_in", "t_measured_min_in", "t_measured_avg_in", "fca_in", "rsf",
+            "rsf_a", "folias_factor", "remaining_life_yr", "verdict",
+            "rerated_pressure_psi", "sufficiency_status", "passes", "code_reference",
+        }
+    elif workflow["id"] == "buckling-parametric":
+        # workflow-API adoption row (workspace-hub#3285-OWNED): the
+        # buckling_parametric route writes a byte-stable results.json.
+        result = cfg["buckling_parametric"]
+        assert result["standard"] == "DNV-RP-C201"
+        assert result["n_cases"] == 8  # 2 grades x 2 thk x 1 width x 1 length x 2 loads
+        results_json = Path(result["outputs"]["results_json"])
+        if not results_json.is_absolute():
+            results_json = REPO_ROOT / results_json
+        payload = json.loads(results_json.read_text())
+        assert payload["meta"]["n_cases"] == 8
+        assert payload["meta"]["standard"] == "DNV-RP-C201"
+        # timestamp=None => meta.generated_at omitted => byte-stable golden
+        assert "generated_at" not in payload["meta"]
+        assert len(payload["index"]) == 8
+        assert set(payload["meta"]["grades"]) == {"Grade A", "AH36"}
+    elif workflow["id"] == "mooring-design-mbl":
+        # workflow-API adoption row (workspace-hub#3285): NEW `mooring_mbl` basename
+        # (the reserved `mooring` arm is untouched). DNV-OS-E301 SF + citation sidecar.
+        result = cfg["mooring_mbl"]
+        assert result["condition"] == "intact"
+        assert result["safety_factor"] == pytest.approx(1.67)
+        assert set(result["results"]) == {"R4_84mm_chain", "160mm_polyester"}
+        for seg in result["results"].values():
+            assert seg["utilisation_with_sf"] == pytest.approx(
+                seg["utilisation_no_sf"] * result["safety_factor"], rel=1e-3
+            )
+        citations = result["citations"]
+        assert len(citations) == 1
+        assert citations[0]["code_id"] == "DNV-OS-E301"
+        assert citations[0]["publisher"] == "DNV"
     elif workflow["id"] in FIELD_DEV_PRODUCTION_WORKFLOWS:
         assert_field_dev_production_workflow(workflow["id"], cfg)
     else:


### PR DESCRIPTION
Implements **workspace-hub#3285** — digitalmodel adopts the deterministic workflow-API contract (epic workspace-hub#3281).

Consumes the already-merged contract:
- assetutilities `workflow_api` (`ResultEnvelope` / `run_workflow` / `result:` descriptor) — workspace-hub#3282
- digitalmodel engine embed path `engine(embed=True, root_folder=, log_to_file=False)` — workspace-hub#3307 (merged, `6c9c09cf`)

### What this PR adds (additive — zero regression to the CLI/durable path)
- **Three NEW non-colliding engine routes** in `engine.py`: `ffs`, `buckling_parametric`, `mooring_mbl`. The reserved `mooring` arm (redirect to `subsea/mooring_analysis/`) and the legacy `API579` / `plate_buckling` arms are **untouched**.
- **Thin routers** (no new calc):
  - `asset_integrity/assessment/ffs_workflow.py` → `assess_component` → `cfg["ffs"] = FFSAssessmentResult.to_dict()` (the #1066 indexed 16-key surface), `kind: in_memory`.
  - `structural/buckling_workflow.py` (#3285-OWNED) → `run_sweep`/`write_outputs` → `results.json` + `cases.csv`, `kind: files`. `timestamp=None` ⇒ byte-stable `results.json` (the reference golden).
  - `orcaflex/mooring_workflow.py` → `check_mbl_with_safety_factor` (DNV-OS-E301 pilot #2685) → `cfg["mooring_mbl"]`, `kind: in_memory`, citation sidecar preserved.
- **digitalmodel-bound `run_workflow`** (`workflow_api/runner.py`) driving the #3307-embeddable engine, **reusing** (never redefining) the imported assetutilities `ResultEnvelope`/`ResultLocator`/`extract_result`/hashing/provenance; resolves a **bare in-repo id**; stamps `code_version("digitalmodel")` and lifts the DNV-OS-E301 citation into `provenance.standard_revisions`.
- **Registry**: `result:` descriptor added to `wall-thickness-quickcheck`; three **FULL durable rows** (`ffs-metal-loss`, `buckling-parametric`, `mooring-design-mbl`) with `input:`/`outputs:`/`test:`/`runtime:`/`result:` + committed `examples/workflows/<id>/input.yml` fixtures, so `tests/workflows/test_durable_workflows.py` parametrizes over them green (no `KeyError`).
- **Goldens + tests** under `tests/workflow_api/`.

### Ownership
- **#3285 OWNS-CREATES** the `buckling-parametric` registry row + `buckling_parametric` route + reference golden, runnable via the **bare in-repo id** `run_workflow("buckling-parametric", …)`. #3283 references that golden only illustratively; any cross-repo `digitalmodel:buckling-parametric` form is #3284-gated.

Do NOT merge — opened early per protocol; pushing commits as work completes.