### PR TITLE
feat(workflow-api): determinism golden harness (workspace-hub#3283)

### DIFF
--- a/docs/standards/2026-06-28-determinism-golden-refresh.md
+++ b/docs/standards/2026-06-28-determinism-golden-refresh.md
@@ -1,0 +1,77 @@
+# Determinism golden refresh / re-sanction procedure (workspace-hub#3283)
+
+> Scope: the `ResultEnvelope` determinism goldens consumed by
+> `digitalmodel.workflow_api.golden.golden_workflow_test` (e.g.
+> `tests/workflow_api/goldens/buckling_parametric.json`). This is the control-plane
+> procedure for the determinism guarantee the whole determinism epic
+> ([workspace-hub#3281](https://github.com/vamseeachanta/workspace-hub/issues/3281))
+> rests on.
+
+## What a determinism golden is
+
+A committed JSON snapshot pinning the `determinism.result_hash` (and, optionally, the
+volatile-pruned envelope) emitted by a `run_workflow` call. The test verdict is
+**string equality of `result_hash`** — the #3282-owned, content-based hash. It is
+NOT a value-tolerance comparison: if a single emitted output byte changes, the
+per-file `sha256` (and therefore the overall `result_hash`) flips and the golden
+fails. That is the point — drift must be loud.
+
+## When a golden legitimately changes
+
+A `result_hash` change is EXPECTED only when the producer's emitted artifact
+genuinely changes: a calc formula fix, a rounding-convention change, a new/removed
+output file, or a deliberate input-default change. It is NOT expected on:
+
+- a new commit (the `git_sha` is volatile — pruned by NAME, never hashed),
+- a release bump (`package_version` is volatile — pruned by NAME),
+- a data refresh (`data_as_of` is volatile by default),
+- a `reproducible` measurement flip (volatile by name).
+
+Those four live in `GOLDEN_VOLATILE_KEYS` (a KEY-ALLOWLIST applied by dotted
+key-name only — never a "looks like a date/path" value heuristic). If a golden
+breaks for one of those reasons, the bug is in the harness wiring, not the golden —
+fix the wiring, do NOT refresh the golden.
+
+## How to refresh (regen)
+
+```bash
+REGEN_GOLDENS=1 uv run pytest tests/workflow_api/test_determinism_harness.py -q
+```
+
+`REGEN_GOLDENS=1` causes `golden_workflow_test` to **rewrite** the golden from the
+current emission and then **`pytest.skip`** the test — it does NOT pass. A refreshed
+golden therefore can never be laundered into a green run; the skip forces a human
+to look at the diff.
+
+## Re-sanction (owner sign-off) — REQUIRED before commit
+
+A refreshed golden is an unverified baseline until re-sanctioned. Per the BSEE
+golden-baseline lesson ("golden baseline needs RE-SANCTIONING after refresh"), a
+golden change MUST NOT be committed without:
+
+1. **A documented reason** for the `result_hash` change (which calc/formula/default
+   moved, and why the new value is correct) in the PR description.
+2. **A diff review** of the old vs new golden (`git diff` on the `*.json`), confirming
+   only the intended fields moved.
+3. **Owner sign-off** on the PR that carries the refreshed golden. The agent that
+   regenerates the golden may NOT self-sanction it.
+
+If you cannot explain why the hash changed, the change is a regression — investigate
+the producer, do not refresh.
+
+## `data_as_of` pinning (opt-in)
+
+`provenance.data_as_of` is volatile by default so a data refresh does not break a
+pure-calc golden. A workflow whose determinism legitimately depends on a frozen data
+vintage may PIN it by passing `extra_volatile_keys` that EXCLUDES `data_as_of` and
+asserting `pin_structural=True` against a golden captured at that vintage. Default
+posture is record-don't-pin.
+
+## Related
+
+- Plan: `workspace-hub/docs/plans/2026-06-28-issue-3283-determinism-harness.md`
+- Harness: `src/digitalmodel/workflow_api/golden.py`, `.../provenance.py`
+- Upstream contract (#3282): `assetutilities.workflow_api.envelope`
+  (`result_hash`, `make_provenance`, `code_version`)
+- BSEE re-sanction lesson: `project_julia_field_economics_demo`,
+  `project_bsee_ogor_refresh_mechanics`

--- a/src/digitalmodel/workflow_api/__init__.py
+++ b/src/digitalmodel/workflow_api/__init__.py
@@ -9,6 +9,13 @@ imported from assetutilities -- never redefined here.
 
 from assetutilities.workflow_api import ResultEnvelope
 
+from digitalmodel.workflow_api.golden import (
+    GOLDEN_VOLATILE_KEYS,
+    capture_golden,
+    diff_results,
+    golden_workflow_test,
+)
+from digitalmodel.workflow_api.provenance import stamp_provenance
 from digitalmodel.workflow_api.runner import (
     build_cfg,
     load_registry,
@@ -24,4 +31,10 @@ __all__ = [
     "load_registry",
     "registry_path",
     "resolve_registry_row",
+    # workspace-hub#3283 determinism harness
+    "golden_workflow_test",
+    "GOLDEN_VOLATILE_KEYS",
+    "capture_golden",
+    "diff_results",
+    "stamp_provenance",
 ]

--- a/src/digitalmodel/workflow_api/golden.py
+++ b/src/digitalmodel/workflow_api/golden.py
@@ -1,0 +1,188 @@
+# ABOUTME: golden_workflow_test template + volatile-field KEY-ALLOWLIST for the
+# ABOUTME: determinism golden harness (workspace-hub#3283).
+"""Determinism golden-test harness (workspace-hub#3283).
+
+This is the consuming template the determinism epic (#3281) rests on. It runs a
+workflow via the #3285-owned ``run_workflow`` (the REAL emission -- no fabricated
+envelope), then asserts the emitted envelope's ``determinism.result_hash`` equals a
+committed golden's. The PASS/FAIL verdict is **string equality of the #3282-owned
+``result_hash``** -- never a value-delta heuristic. ``diff_results`` borrows the
+``compare_tool`` keyed-numeric-delta + ``max_abs_delta`` shape only to DESCRIBE
+what drifted in the failure message (human debugging), it is not the verdict.
+
+The volatile-field spec is a **KEY-ALLOWLIST of dotted key-names**
+(``GOLDEN_VOLATILE_KEYS``), applied by name only. A future volatile key is added by
+NAME, never by a "looks like a date/path" value heuristic -- so a result value that
+string-renders date-like or path-like is preserved. The result PAYLOAD is never
+value-pruned; it rides the #3282 ``result_hash``, which already excludes the
+``save_cfg`` dump and is content-based.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from digitalmodel.workflow_api.runner import run_workflow
+
+# ── THE VOLATILE-FIELD SPEC = a KEY-ALLOWLIST of DOTTED KEY-NAMES ──────────────
+# A key is volatile IFF its dotted name is in this set (or a per-call
+# extra_volatile_keys). Values are NEVER inspected to decide inclusion.
+GOLDEN_VOLATILE_KEYS = frozenset(
+    {
+        "provenance.code_version.git_sha",          # changes every commit
+        "provenance.code_version.package_version",  # changes on release bump
+        "provenance.data_as_of",                    # data-refresh dependent (record, don't pin)
+        "determinism.reproducible",                 # a measured bool/None, not a fixed expectation
+    }
+)
+
+
+def _prune_volatile(data: dict, volatile_keys=GOLDEN_VOLATILE_KEYS) -> dict:
+    """Recursively drop dotted keys present in ``volatile_keys``.
+
+    Matching is by DOTTED KEY-NAME only. Everything not listed is left
+    byte-for-byte; list values are returned unchanged (the result payload is never
+    value-pruned). Never inspects values to decide inclusion.
+    """
+
+    def _recurse(node, prefix: str):
+        if not isinstance(node, dict):
+            return node
+        out = {}
+        for key, value in node.items():
+            dotted = f"{prefix}.{key}" if prefix else key
+            if dotted in volatile_keys:
+                continue
+            out[key] = _recurse(value, dotted)
+        return out
+
+    return _recurse(data, "")
+
+
+def _golden_result_hash(golden: dict) -> str:
+    """Extract the pinned ``result_hash`` from a committed golden.
+
+    Tolerates both the #3285 reference-golden shape (top-level ``result_hash``) and
+    the ``capture_golden`` snapshot shape (also top-level ``result_hash``).
+    """
+    if "result_hash" in golden:
+        return golden["result_hash"]
+    determinism = golden.get("determinism") or golden.get("envelope_pruned", {}).get(
+        "determinism", {}
+    )
+    return determinism.get("result_hash")
+
+
+def _golden_result_payload(golden: dict):
+    """Best-effort extraction of the golden's result payload (for the diff message)."""
+    if "result" in golden:
+        return golden["result"]
+    return golden.get("envelope_pruned", {}).get("result")
+
+
+def capture_golden(envelope, golden_path) -> dict:
+    """Write a golden snapshot for ``envelope`` to ``golden_path``.
+
+    The snapshot pins the #3282-owned ``result_hash`` (consumed, not recomputed),
+    the result payload, and the volatile-pruned envelope. ``git_sha`` /
+    ``package_version`` / ``data_as_of`` / ``reproducible`` are dropped by NAME so a
+    commit or release bump does not spuriously break the golden.
+    """
+    snapshot = {
+        "workflow_id": envelope.workflow_id,
+        "status": envelope.status,
+        "result_hash": envelope.determinism["result_hash"],
+        "result": envelope.result,
+        "envelope_pruned": _prune_volatile(envelope.to_dict()),
+    }
+    Path(golden_path).write_text(json.dumps(snapshot, indent=2, sort_keys=True))
+    return snapshot
+
+
+def diff_results(golden_result, current_result) -> str:
+    """Describe what drifted between two result payloads (DEBUGGING AID ONLY).
+
+    Reuses the ``compare_tool`` keyed-numeric-delta + ``max_abs_delta`` shape to name
+    the drifted keys in a failure message. This is NEVER the verdict -- the verdict
+    is ``result_hash`` string equality in :func:`golden_workflow_test`.
+    """
+    deltas: dict[str, str] = {}
+    max_abs_delta = 0.0
+
+    def _walk(golden_node, current_node, prefix: str):
+        nonlocal max_abs_delta
+        if isinstance(golden_node, dict) and isinstance(current_node, dict):
+            for key in sorted(set(golden_node) | set(current_node)):
+                _walk(golden_node.get(key), current_node.get(key),
+                      f"{prefix}.{key}" if prefix else key)
+        elif isinstance(golden_node, (int, float)) and isinstance(
+            current_node, (int, float)
+        ) and not isinstance(golden_node, bool) and not isinstance(current_node, bool):
+            delta = current_node - golden_node
+            if delta != 0:
+                deltas[prefix] = f"{golden_node} -> {current_node} (Δ{delta:+})"
+                max_abs_delta = max(max_abs_delta, abs(delta))
+        else:
+            if golden_node != current_node:
+                deltas[prefix] = f"{golden_node!r} -> {current_node!r}"
+
+    _walk(golden_result, current_result, "")
+    if not deltas:
+        return "result_hash drifted but no per-key value delta found (structural change)"
+    lines = "\n".join(f"  {k}: {v}" for k, v in sorted(deltas.items()))
+    return f"result_hash drifted; {len(deltas)} key(s) changed (max_abs_delta={max_abs_delta}):\n{lines}"
+
+
+def golden_workflow_test(
+    workflow_id,
+    golden_path,
+    *,
+    params=None,
+    cfg=None,
+    pin_structural=False,
+    extra_volatile_keys=(),
+    runner=None,
+):
+    """Run ``workflow_id`` and assert determinism against a committed golden.
+
+    The load-bearing assertion is ``env.determinism["result_hash"] ==
+    golden_result_hash`` -- the #3282-owned content hash, consumed not recomputed.
+    The envelope is the REAL return of ``run_workflow`` (no fabricated path).
+
+    With ``REGEN_GOLDENS=1`` the golden is rewritten and the test is SKIPPED (the
+    re-sanction gate -- a refreshed golden requires owner sign-off before commit; it
+    must never silently pass). ``pin_structural`` additionally asserts the full
+    volatile-pruned envelope equals the golden's ``envelope_pruned`` (volatile keys
+    excluded BY NAME, plus any per-call ``extra_volatile_keys``).
+
+    ``runner`` is an injection seam (defaults to digitalmodel's ``run_workflow``) so
+    the template can be unit-tested over synthetic envelopes without the engine.
+    """
+    runner = runner or run_workflow
+    env = runner(workflow_id, params=params, cfg=cfg)
+    assert env.status == "ok", f"{workflow_id} errored: {env.warnings}"
+
+    golden_path = Path(golden_path)
+    if os.environ.get("REGEN_GOLDENS") == "1":
+        import pytest
+
+        capture_golden(env, golden_path)
+        pytest.skip(
+            f"golden {golden_path} refreshed -- re-sanction + owner sign-off "
+            "required before commit"
+        )
+
+    golden = json.loads(golden_path.read_text())
+    expected_hash = _golden_result_hash(golden)
+    actual_hash = env.determinism["result_hash"]
+    assert actual_hash == expected_hash, diff_results(
+        _golden_result_payload(golden), env.result
+    )
+
+    if pin_structural:
+        volatile = GOLDEN_VOLATILE_KEYS | frozenset(extra_volatile_keys)
+        assert _prune_volatile(env.to_dict(), volatile) == golden["envelope_pruned"]
+
+    return env

--- a/src/digitalmodel/workflow_api/provenance.py
+++ b/src/digitalmodel/workflow_api/provenance.py
@@ -1,0 +1,55 @@
+# ABOUTME: stamp_provenance -- the canonical reusable provenance assembler
+# ABOUTME: codifying the #3282 provenance SHAPE (workspace-hub#3283).
+"""Canonical reusable provenance assembler (workspace-hub#3283).
+
+``stamp_provenance`` is the named, reusable entry-point each adopting repo calls
+to stamp an envelope's ``provenance`` block. It DELEGATES to the #3282-owned
+:func:`assetutilities.workflow_api.envelope.make_provenance` so the emitted dict
+SHAPE can never drift from the one the runner already produces -- #3283 owns the
+reusable named assembler, #3282 owns the field set + the parameterized
+``code_version``. No second hashing function and no re-derivation of the
+``input_hash`` (it is consumed verbatim from #3282).
+
+``code_version`` is PARAMETERIZED by ``package_name`` (workspace-hub#3287): an
+``assethold`` or ``digitalmodel`` envelope must report ITS OWN package version,
+never a hardcoded ``assetutilities`` one.
+"""
+
+from __future__ import annotations
+
+from assetutilities.workflow_api.envelope import make_provenance
+
+
+def stamp_provenance(
+    input_hash: str | None,
+    *,
+    package_name: str = "digitalmodel",
+    standard_revisions: list | None = None,
+    data_as_of: str | None = None,
+) -> dict:
+    """Assemble the canonical ``provenance`` block for a ResultEnvelope.
+
+    Returns ``{code_version: {package_version, git_sha}, standard_revisions: [...],
+    data_as_of, input_hash}``.
+
+    Parameters
+    ----------
+    input_hash:
+        The #3282-owned ``input_hash`` value. Reused verbatim -- never recomputed
+        here. ``None`` is allowed (error envelopes carry no input hash).
+    package_name:
+        The package whose version + git sha are stamped under ``code_version``.
+        Parameterized so each adopter stamps its OWN version.
+    standard_revisions:
+        Optional list of citation dicts (``code_id`` / ``publisher`` / ``revision``)
+        lifted from a calc's DNV/API citation sidecar.
+    data_as_of:
+        Optional data-vintage stamp; ``None`` for pure-calc workflows whose
+        determinism does not depend on a refreshable dataset.
+    """
+    return make_provenance(
+        input_hash,
+        package_name=package_name,
+        standard_revisions=standard_revisions,
+        data_as_of=data_as_of,
+    )

--- a/tests/workflow_api/test_determinism_harness.py
+++ b/tests/workflow_api/test_determinism_harness.py
@@ -1,0 +1,224 @@
+# ABOUTME: Determinism golden harness tests (workspace-hub#3283) — stamp_provenance,
+# ABOUTME: KEY-allowlist pruning, golden_workflow_test verdict, + buckling reference golden.
+"""Tests for the #3283 determinism golden harness.
+
+The first groups (provenance + KEY-allowlist + golden-diff/verdict) run over
+SYNTHETIC envelopes via an injected fake runner -- no heavy engine import. The final
+reference test drives the REAL ``run_workflow`` on the BARE in-repo
+``buckling-parametric`` id and asserts the emitted ``result_hash`` against #3285's
+committed golden (the only test in this file that imports the digitalmodel engine).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assetutilities.workflow_api import ResultEnvelope
+
+from digitalmodel.workflow_api.golden import (
+    GOLDEN_VOLATILE_KEYS,
+    _prune_volatile,
+    capture_golden,
+    diff_results,
+    golden_workflow_test,
+)
+from digitalmodel.workflow_api.provenance import stamp_provenance
+
+GOLDENS = Path(__file__).resolve().parent / "goldens"
+
+
+# ── synthetic-envelope helpers ────────────────────────────────────────────────
+def _make_envelope(
+    *,
+    result_hash="hash-abc",
+    result=None,
+    git_sha="deadbeef",
+    package_version="1.2.3",
+    data_as_of="2026-06-28T00:00:00Z",
+    reproducible=None,
+    workflow_id="synthetic",
+):
+    return ResultEnvelope(
+        workflow_id=workflow_id,
+        status="ok",
+        result=result if result is not None else {"kind": "in_memory", "value": {"x": 1}},
+        provenance={
+            "code_version": {"package_version": package_version, "git_sha": git_sha},
+            "standard_revisions": [],
+            "data_as_of": data_as_of,
+            "input_hash": "ih-123",
+        },
+        determinism={"result_hash": result_hash, "reproducible": reproducible},
+        confidence=None,
+        warnings=[],
+    )
+
+
+def _fake_runner(envelope):
+    def _run(workflow_id, params=None, cfg=None):
+        return envelope
+
+    return _run
+
+
+# ── stamp_provenance ──────────────────────────────────────────────────────────
+def test_stamp_provenance_shape():
+    prov = stamp_provenance("ih")
+    assert set(prov) == {"code_version", "standard_revisions", "data_as_of", "input_hash"}
+    assert set(prov["code_version"]) == {"package_version", "git_sha"}
+
+
+def test_stamp_provenance_package_name_parameterized():
+    # digitalmodel is an installed package -> its version differs from a hardcoded
+    # assetutilities one; the point is the param flows into code_version.
+    dm = stamp_provenance("ih", package_name="digitalmodel")
+    au = stamp_provenance("ih", package_name="assetutilities")
+    assert dm["code_version"]["package_version"] != "<hardcoded>"
+    # both resolve their OWN package; git_sha key always present
+    assert "git_sha" in dm["code_version"] and "git_sha" in au["code_version"]
+
+
+def test_stamp_provenance_passes_input_hash_verbatim():
+    assert stamp_provenance("sha256:abc")["input_hash"] == "sha256:abc"
+
+
+def test_stamp_provenance_standard_revisions():
+    cite = {"code_id": "DNV-RP-C201", "publisher": "DNV", "revision": "2010-10"}
+    prov = stamp_provenance("ih", standard_revisions=[cite])
+    assert prov["standard_revisions"] == [cite]
+
+
+def test_stamp_provenance_none_input_hash_allowed():
+    assert stamp_provenance(None)["input_hash"] is None
+
+
+# ── KEY-ALLOWLIST (never a value heuristic) ───────────────────────────────────
+def test_volatile_keys_is_key_allowlist_not_value_heuristic():
+    # a RESULT value that string-renders date-like / path-like must SURVIVE pruning.
+    env = _make_envelope(
+        result={"kind": "in_memory", "value": {"governing": "2024-01-01", "key": "a/b/c"}}
+    )
+    pruned = _prune_volatile(env.to_dict())
+    assert pruned["result"]["value"]["governing"] == "2024-01-01"
+    assert pruned["result"]["value"]["key"] == "a/b/c"
+
+
+def test_prune_volatile_drops_git_sha_by_name():
+    a = _make_envelope(git_sha="aaaa").to_dict()
+    b = _make_envelope(git_sha="bbbb").to_dict()
+    assert _prune_volatile(a) == _prune_volatile(b)
+    assert "git_sha" not in _prune_volatile(a)["provenance"]["code_version"]
+
+
+def test_prune_volatile_drops_package_version_and_data_as_of_and_reproducible():
+    env = _make_envelope(package_version="9.9.9", data_as_of="X", reproducible=True)
+    pruned = _prune_volatile(env.to_dict())
+    assert "package_version" not in pruned["provenance"]["code_version"]
+    assert "data_as_of" not in pruned["provenance"]
+    assert "reproducible" not in pruned["determinism"]
+    # result_hash (non-volatile determinism field) survives
+    assert pruned["determinism"]["result_hash"] == "hash-abc"
+
+
+def test_prune_volatile_keeps_result_payload():
+    rich = {"kind": "in_memory", "value": {"a": [1, 2, 3], "b": {"c": "keep/me"}}}
+    env = _make_envelope(result=rich)
+    assert _prune_volatile(env.to_dict())["result"] == rich
+
+
+def test_extra_volatile_keys_drop_by_name():
+    env = _make_envelope().to_dict()
+    pruned = _prune_volatile(env, GOLDEN_VOLATILE_KEYS | {"provenance.input_hash"})
+    assert "input_hash" not in pruned["provenance"]
+
+
+# ── golden_workflow_test verdict (hash equality, not value delta) ─────────────
+def test_golden_pass_on_matching_result_hash(tmp_path):
+    env = _make_envelope(result_hash="match-1")
+    golden = tmp_path / "g.json"
+    golden.write_text(json.dumps({"result_hash": "match-1", "result": env.result}))
+    out = golden_workflow_test("wf", golden, runner=_fake_runner(env))
+    assert out is env
+
+
+def test_golden_fail_on_result_hash_drift(tmp_path):
+    golden_env = _make_envelope(
+        result_hash="golden", result={"kind": "in_memory", "value": {"utilization": 0.50}}
+    )
+    drifted = _make_envelope(
+        result_hash="drifted", result={"kind": "in_memory", "value": {"utilization": 0.91}}
+    )
+    golden = tmp_path / "g.json"
+    golden.write_text(json.dumps({"result_hash": "golden", "result": golden_env.result}))
+    with pytest.raises(AssertionError) as exc:
+        golden_workflow_test("wf", golden, runner=_fake_runner(drifted))
+    assert "utilization" in str(exc.value)  # the keyed-delta message names the drift
+
+
+def test_golden_verdict_is_hash_not_value_delta(tmp_path):
+    # identical result payload but DIFFERENT result_hash -> must FAIL (hash is the verdict).
+    same_result = {"kind": "in_memory", "value": {"x": 1}}
+    golden = tmp_path / "g.json"
+    golden.write_text(json.dumps({"result_hash": "h1", "result": same_result}))
+    drifted = _make_envelope(result_hash="h2", result=same_result)
+    with pytest.raises(AssertionError):
+        golden_workflow_test("wf", golden, runner=_fake_runner(drifted))
+
+
+def test_golden_fails_on_error_envelope(tmp_path):
+    err = ResultEnvelope(
+        workflow_id="wf", status="error", result={},
+        provenance={}, determinism={"result_hash": None}, warnings=["boom"],
+    )
+    golden = tmp_path / "g.json"
+    golden.write_text(json.dumps({"result_hash": "x"}))
+    with pytest.raises(AssertionError) as exc:
+        golden_workflow_test("wf", golden, runner=_fake_runner(err))
+    assert "errored" in str(exc.value)
+
+
+def test_regen_goldens_env_writes_and_skips(tmp_path, monkeypatch):
+    env = _make_envelope(result_hash="fresh-hash")
+    golden = tmp_path / "new.json"
+    monkeypatch.setenv("REGEN_GOLDENS", "1")
+    with pytest.raises(pytest.skip.Exception):
+        golden_workflow_test("wf", golden, runner=_fake_runner(env))
+    written = json.loads(golden.read_text())
+    assert written["result_hash"] == "fresh-hash"
+
+
+def test_capture_golden_prunes_volatile(tmp_path):
+    env = _make_envelope(git_sha="abc123", package_version="7.7.7")
+    snap = capture_golden(env, tmp_path / "cap.json")
+    assert snap["result_hash"] == "hash-abc"
+    assert "git_sha" not in snap["envelope_pruned"]["provenance"]["code_version"]
+    assert "package_version" not in snap["envelope_pruned"]["provenance"]["code_version"]
+
+
+def test_pin_structural_excludes_volatile_by_name(tmp_path):
+    env = _make_envelope(result_hash="ph", git_sha="X", package_version="Y")
+    golden = tmp_path / "g.json"
+    capture_golden(env, golden)
+    # a different git_sha/version must still pass the structural pin (volatile by name)
+    other = _make_envelope(result_hash="ph", git_sha="DIFFERENT", package_version="DIFF2")
+    golden_workflow_test("wf", golden, pin_structural=True, runner=_fake_runner(other))
+
+
+def test_diff_results_reports_max_abs_delta():
+    msg = diff_results({"value": {"a": 1.0}}, {"value": {"a": 1.5}})
+    assert "max_abs_delta=0.5" in msg
+
+
+# ── reference determinism test: REAL emission via run_workflow ────────────────
+def test_buckling_reference_golden_via_template():
+    # Hashes the REAL artifact emitted by run_workflow on the BARE in-repo id, and
+    # asserts it against #3285's committed golden through the #3283 template.
+    env = golden_workflow_test(
+        "buckling-parametric", GOLDENS / "buckling_parametric.json"
+    )
+    assert env.determinism["result_hash"] == json.loads(
+        (GOLDENS / "buckling_parametric.json").read_text()
+    )["result_hash"]


### PR DESCRIPTION
Implements the determinism golden harness for workspace-hub#3283 — the consuming template the determinism epic (workspace-hub#3281) rests on.

## What this adds (digitalmodel `workflow_api` package, layered on #3285's runner)

- **`stamp_provenance(input_hash, *, package_name, standard_revisions, data_as_of)`** — the canonical reusable provenance assembler. Delegates to the #3282-owned `make_provenance` so the emitted SHAPE never drifts; `code_version` is parameterized per adopter (workspace-hub#3287). Reuses `input_hash` verbatim — no second hashing function.
- **`golden_workflow_test(workflow_id, golden_path, ...)`** — pytest template that runs the REAL emission via `run_workflow` and asserts `determinism.result_hash` equals a committed golden's. Verdict = `result_hash` string equality, never a value-delta heuristic.
- **`GOLDEN_VOLATILE_KEYS`** — the volatile-field spec as a KEY-ALLOWLIST of dotted key-names, applied by NAME only (never value sniffing). The result payload is never value-pruned.
- **`_prune_volatile` / `capture_golden` / `diff_results`** — capture/refresh + a `compare_tool`-shaped keyed-delta failure message (human debugging only).
- **Reference determinism test** — `golden_workflow_test("buckling-parametric", ...)` hashes the REAL artifact emitted by `run_workflow` against #3285's committed `buckling_parametric.json` golden, using the BARE in-repo id (cross-repo `repo:id@version` resolution is #3284's, out of scope).
- **Golden-refresh / re-sanction doc** — `REGEN_GOLDENS=1` rewrites + `pytest.skip`s; owner sign-off required before commit (BSEE re-sanction lesson).

## Scope notes
- Based on #3285's branch (`feat/wf-api-3285-digitalmodel-adopt`) — CONSUMES #3285's buckling registry row + reference golden; does not author them.
- `result_hash`, `reproducible`, `input_hash`, the `ResultEnvelope` field set are #3282-owned and consumed verbatim.

Plan: `workspace-hub/docs/plans/2026-06-28-issue-3283-determinism-harness.md`. Do not merge before #3285.