### PR TITLE
feat(asset_integrity): 2D river-bottom effective-area (RSTRENG axial×circumferential grid) [#1094]

### DIFF
--- a/docs/domains/rstreng-2d-validation-2026-06-29.md
+++ b/docs/domains/rstreng-2d-validation-2026-06-29.md
@@ -1,0 +1,116 @@
+# RSTRENG 2D River-Bottom Effective-Area — Validation (2026-06-29)
+
+Module: `src/digitalmodel/asset_integrity/rstreng_2d.py`
+Tests: `tests/asset_integrity/test_rstreng_2d.py` (16 golden / behavioural)
+Issue: digitalmodel #1094 (extension)
+
+## Purpose
+
+Inline-inspection and laser-scan metal-loss data come as a 2D **grid**
+`d[a][c]` — depth at axial station `a` and circumferential column `c`. The
+validated 1D RSTRENG engine
+(`corroded_pipe.rstreng_effective_area(D, t, positions, depths, smys)`) only
+consumes a single **axial** river-bottom profile `d_eff(x)`.
+
+This module is a thin **projection layer**: it reduces the grid to a 1D
+effective axial profile `d_eff(x_a)` and then calls the 1D engine **verbatim**
+(no engine changes, `rstreng_effective_area` imported and reused unchanged). The
+1D engine already searches every axial sub-segment for the governing (lowest
+failure-pressure) flaw and applies the `d/t <= 0.80` B31G validity flag; both
+are surfaced through the 2D result.
+
+## Projection rules
+
+### MAX (default — conservative river-bottom)
+
+```
+d_eff[a] = max_c d(x_a, theta_c)
+```
+
+The deepest pit at each axial station. This is the standard, defensible way
+RSTRENG forms the river-bottom path: it never under-predicts metal loss because
+it takes the worst pit at every station, independent of whether the deepest
+pits actually line up axially.
+
+### AREA-WEIGHTED (alternative — less conservative)
+
+```
+d_eff[a] = (1 / w) * sum_c d(x_a, theta_c) * dtheta_c,   w = sum_c dtheta_c
+```
+
+An arc-width-weighted circumferential average over the affected width `w`.
+Because the 1D engine has **no notion of circumferential width**, this rule
+**requires an explicit affected-width input** — `circ_weights`, the arc width
+`dtheta_c` represented by each column (their sum is the affected width `w`).
+When `circ_weights` is omitted, equal angular spacing across the affected arc is
+assumed, so the rule reduces to the plain circumferential mean.
+
+> **Caveat.** Area-weighting **under-predicts** the hazard (predicts a higher,
+> less conservative burst pressure) when the deepest pits do not co-locate at
+> the same axial station — averaging dilutes an isolated deep pit. Use MAX for
+> fitness-for-service verdicts; AREA-WEIGHTED is for sensitivity / less-
+> conservative screening only.
+
+## Golden case (vetted, independently reproduced)
+
+`D = 24 in`, `t = 0.5 in`, X52 (`SMYS = 52000 psi`, flow = SMYS + 10 ksi =
+`62000 psi`). Axial `x = [0, 2, 4, 6, 8] in`; 3 circumferential columns:
+
+| x (in) | col 1 | col 2 | col 3 |
+|-------:|------:|------:|------:|
+| 0      | 0     | 0     | 0     |
+| 2      | 0.10  | 0.20  | 0.05  |
+| 4      | 0.15  | 0.30  | 0.10  |
+| 6      | 0.05  | 0.25  | 0.00  |
+| 8      | 0     | 0     | 0     |
+
+Intact flow-stress pressure: `2*flow*t/D = 2*62000*0.5/24 = 2583.3 psi`.
+
+Folias (Modified-B31G / RSTRENG): `M = sqrt(1 + 0.6275 z - 0.003375 z^2)` for
+`z = L^2/(D t) <= 50`. Failure pressure:
+`pf = (2 flow t/D) * (1 - A/A0) / (1 - (A/A0)/M)`.
+
+### MAX projection
+
+`d_eff = [0, 0.20, 0.30, 0.25, 0]`. The 1D engine's sub-segment search picks the
+governing segment **(1, 4)** (x = 2 → 8):
+
+- `L = 6 in`
+- Effective metal-loss area `A_eff = 1.30 in^2` (trapezoidal:
+  `0.5+0.55+0.25`), `A0 = t*L = 3.0`, `A/A0 = 0.4333`
+- `z = 36/12 = 3.000`, `M = 1.6888`
+- **`pf = 1969.2 psi`** → RSF = `1969.2/2583.3 = 0.7623`,
+  safe @ 1.39 = `1416.7 psi`
+
+### AREA-WEIGHTED projection (circumferential mean)
+
+`d_eff = [0, 0.1167, 0.1833, 0.10, 0]` (station means `0.35/3`, `0.55/3`,
+`0.30/3`). The governing segment is the **full length (0, 4)** (x = 0 → 8):
+
+- `L = 8 in`, `A/A0 = 0.2000`
+- `z = L^2/(D t) = 64/12 = **5.333**` (note: **not** 4.0)
+- `M = 2.0617`
+- **`pf = 2288.7 psi`** → RSF = `0.8859`, safe @ 1.39 = `1646.5 psi`
+
+Area-weighted is **~16 % higher** than MAX (`2288.7 / 1969.2 ≈ 1.16`),
+demonstrating projection-rule sensitivity: here the deepest pits (col 2) do not
+fully co-locate with the rest, so averaging materially relaxes the result.
+
+## Simplification / scope
+
+This is a **simple projection** (collapse each axial station to one scalar, then
+run the validated 1D method). It is **not** a full 2D interacting-flaw
+coalescence assessment: no circumferential interaction-spacing rules, no
+combined axial + circumferential (hoop/longitudinal) stress evaluation, no
+network/box growth of adjacent pits. The MAX rule is conservative for axial
+burst; circumferential-extent acceptance (e.g. for leak vs. rupture or
+longitudinal-stress checks) is out of scope and must be assessed separately.
+
+## Result surface
+
+`RiverBottom2DResult` exposes: `projection_rule`, `axial_positions_in`,
+`d_eff_in`, `governing_segment` `(i, j)`, `within_applicability` (max `d/t <=
+0.80`), `details` (`n_axial`, `n_circ`, `affected_width`, `critical_length_in`,
+`max_d_over_t`), and the full 1D `CorrodedPipeResult` as `result` (plus
+pass-through properties `failure_pressure_psi`, `intact_pressure_psi`,
+`safe_pressure_psi`, `rsf`).

--- a/src/digitalmodel/asset_integrity/rstreng_2d.py
+++ b/src/digitalmodel/asset_integrity/rstreng_2d.py
@@ -1,0 +1,238 @@
+# ABOUTME: 2D river-bottom effective-area — projects an axial x circumferential
+# ABOUTME: metal-loss grid to a 1D RSTRENG profile (max / area-weighted rules).
+"""2D river-bottom effective-area assessment for corroded pipe.
+
+The validated 1D RSTRENG effective-area engine
+(:func:`digitalmodel.asset_integrity.corroded_pipe.rstreng_effective_area`)
+consumes a single river-bottom *axial* metal-loss profile ``d(x)``. Inline
+inspection and laser-scan data, however, are a 2D **grid** of metal-loss depth
+over both the axial (``x``) and circumferential (``theta``) directions:
+``d[a][c]`` = depth at axial station ``a`` and circumferential column ``c``.
+
+This module is a thin **projection layer** that reduces the 2D grid to a 1D
+effective axial profile ``d_eff(x_a)`` and then calls the 1D engine *verbatim*
+(the engine is reused unchanged). Two projection rules are provided:
+
+* **MAX** (default, conservative — how RSTRENG forms the river-bottom path):
+  ``d_eff[a] = max_c d(x_a, theta_c)`` — the deepest pit at each axial station.
+  This is the standard, defensible river-bottom projection: it never
+  under-predicts metal loss because it takes the worst pit at every station,
+  regardless of whether the deepest pits actually line up axially.
+
+* **AREA-WEIGHTED** (alternative, less conservative):
+  ``d_eff[a] = (1/w) * sum_c d(x_a, theta_c) * dtheta_c`` averaged over the
+  affected circumferential width ``w = sum_c dtheta_c``. Because the 1D engine
+  has no notion of circumferential width, this rule **requires an explicit
+  affected-width input** (``circ_weights``, the arc width represented by each
+  column; their sum is the affected width ``w``). When ``circ_weights`` is
+  omitted, equal angular spacing across the affected arc is assumed, so the
+  rule reduces to the plain circumferential mean.
+
+  .. warning::
+     The area-weighted rule **under-predicts** the failure pressure hazard
+     (i.e. predicts a higher, less conservative burst pressure) when the
+     deepest pits do not co-locate at the same axial station, because averaging
+     dilutes an isolated deep pit. Prefer MAX for fitness-for-service verdicts;
+     AREA-WEIGHTED is offered for sensitivity / less-conservative screening.
+
+SIMPLIFICATION: this is a *simple projection* (collapse each axial station to a
+scalar, then run the validated 1D method). It is **not** a full 2D interacting-
+flaw coalescence assessment (e.g. circumferential interaction spacing rules,
+combined axial+circumferential stress). See the validation doc
+``docs/domains/rstreng-2d-validation-2026-06-29.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+import numpy as np
+
+from digitalmodel.asset_integrity.corroded_pipe import (
+    CorrodedPipeResult,
+    rstreng_effective_area,
+)
+
+# Default safety factor — mirrors corroded_pipe / ASME B31G practice (1.39).
+DEFAULT_SAFETY_FACTOR = 1.39
+
+PROJECTION_MAX = "max"
+PROJECTION_AREA_WEIGHTED = "area_weighted"
+_PROJECTIONS = (PROJECTION_MAX, PROJECTION_AREA_WEIGHTED)
+
+
+@dataclass
+class RiverBottom2DResult:
+    """Result of a 2D river-bottom effective-area assessment.
+
+    Surfaces the projection rule used and the governing axial segment, and
+    carries the full 1D :class:`CorrodedPipeResult` (``result``) so every
+    failure-pressure field is available unchanged.
+    """
+
+    projection_rule: str  # "max" | "area_weighted"
+    axial_positions_in: list  # the axial stations x_a (in)
+    d_eff_in: list  # projected 1D effective-depth profile
+    governing_segment: tuple  # (i, j) axial indices of worst segment
+    result: CorrodedPipeResult  # full 1D RSTRENG result (verbatim)
+    within_applicability: bool  # max(d)/t <= 0.80 (B31G validity)
+    details: dict = field(default_factory=dict)
+
+    # --- convenience pass-throughs to the embedded 1D result ---------------
+    @property
+    def failure_pressure_psi(self) -> float:
+        return self.result.failure_pressure_psi
+
+    @property
+    def intact_pressure_psi(self) -> float:
+        return self.result.intact_pressure_psi
+
+    @property
+    def safe_pressure_psi(self) -> float:
+        return self.result.safe_pressure_psi
+
+    @property
+    def rsf(self) -> float:
+        return self.result.rsf
+
+
+def project_grid(
+    depth_grid: Sequence[Sequence[float]],
+    t: float,
+    *,
+    projection: str = PROJECTION_MAX,
+    circ_weights: Optional[Sequence[float]] = None,
+) -> np.ndarray:
+    """Reduce a 2D metal-loss grid ``d[a][c]`` to a 1D axial profile ``d_eff``.
+
+    Args:
+        depth_grid: rectangular grid of metal-loss DEPTH (in); row = axial
+            station, column = circumferential measurement. 0 = full wall.
+        t: nominal wall thickness (in), for validation only.
+        projection: ``"max"`` (deepest pit per station) or ``"area_weighted"``
+            (arc-width-weighted circumferential mean over the affected width).
+        circ_weights: arc width ``dtheta_c`` represented by each circumferential
+            column (any consistent unit); their sum is the affected width ``w``.
+            Used only by the area-weighted rule; ``None`` => equal weights
+            (plain circumferential mean).
+
+    Returns:
+        1D numpy array ``d_eff`` of length = number of axial stations.
+    """
+    grid = np.asarray(depth_grid, dtype=float)
+    if grid.ndim != 2 or grid.shape[0] < 2 or grid.shape[1] < 1:
+        raise ValueError(
+            "depth_grid must be 2D with >=2 axial rows and >=1 circ column."
+        )
+    if np.any(grid < 0.0) or np.any(grid > t):
+        raise ValueError(f"all grid depths must be within [0, t={t}].")
+
+    if projection == PROJECTION_MAX:
+        return np.max(grid, axis=1)
+
+    if projection == PROJECTION_AREA_WEIGHTED:
+        n_circ = grid.shape[1]
+        if circ_weights is None:
+            weights = np.ones(n_circ, dtype=float)
+        else:
+            weights = np.asarray(circ_weights, dtype=float)
+            if weights.shape != (n_circ,):
+                raise ValueError(
+                    "circ_weights length must equal the number of circ columns."
+                )
+            if np.any(weights <= 0.0):
+                raise ValueError("circ_weights (arc widths) must be > 0.")
+        w = float(np.sum(weights))
+        return (grid * weights).sum(axis=1) / w
+
+    raise ValueError(f"projection must be one of {_PROJECTIONS}, got {projection!r}.")
+
+
+def rstreng_2d_river_bottom(
+    D: float,
+    t: float,
+    axial_positions_in: Sequence[float],
+    depth_grid: Sequence[Sequence[float]],
+    smys_psi: float,
+    *,
+    projection: str = PROJECTION_MAX,
+    circ_weights: Optional[Sequence[float]] = None,
+    maop_psi: Optional[float] = None,
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> RiverBottom2DResult:
+    """Assess a 2D axial x circumferential metal-loss grid via RSTRENG.
+
+    Projects the grid to a 1D effective axial profile using ``projection`` and
+    then calls the validated 1D engine
+    :func:`~digitalmodel.asset_integrity.corroded_pipe.rstreng_effective_area`
+    **unchanged**.
+
+    Args:
+        D: pipe outside diameter (in). t: nominal wall thickness (in).
+        axial_positions_in: axial positions ``x_a`` of the grid rows (in),
+            strictly increasing; length must equal the number of grid rows.
+        depth_grid: ``d[a][c]`` metal-loss depth grid (in); see
+            :func:`project_grid`.
+        smys_psi: specified minimum yield strength (psi).
+        projection: ``"max"`` (default, conservative) or ``"area_weighted"``.
+        circ_weights: per-column arc widths for the area-weighted rule.
+        maop_psi: maximum allowable operating pressure for an accept/reject flag.
+        safety_factor: applied to failure pressure for the safe pressure.
+
+    Returns:
+        :class:`RiverBottom2DResult` exposing the projection rule, governing
+        axial segment, applicability flag and the full 1D RSTRENG result.
+    """
+    if projection not in _PROJECTIONS:
+        raise ValueError(
+            f"projection must be one of {_PROJECTIONS}, got {projection!r}."
+        )
+    x = np.asarray(axial_positions_in, dtype=float)
+    grid = np.asarray(depth_grid, dtype=float)
+    if grid.ndim != 2 or x.shape != (grid.shape[0],):
+        raise ValueError(
+            "axial_positions_in length must equal the number of grid rows."
+        )
+
+    d_eff = project_grid(grid, t, projection=projection, circ_weights=circ_weights)
+
+    result = rstreng_effective_area(
+        D,
+        t,
+        x,
+        d_eff,
+        smys_psi,
+        maop_psi=maop_psi,
+        safety_factor=safety_factor,
+    )
+
+    i, j = result.details["critical_segment"]
+    governing_segment = (int(i), int(j))
+    within = bool(result.details.get("within_applicability", True))
+
+    affected_width = None
+    if projection == PROJECTION_AREA_WEIGHTED:
+        n_circ = grid.shape[1]
+        weights = (
+            np.ones(n_circ, dtype=float)
+            if circ_weights is None
+            else np.asarray(circ_weights, dtype=float)
+        )
+        affected_width = float(np.sum(weights))
+
+    return RiverBottom2DResult(
+        projection_rule=projection,
+        axial_positions_in=[float(v) for v in x],
+        d_eff_in=[float(v) for v in d_eff],
+        governing_segment=governing_segment,
+        result=result,
+        within_applicability=within,
+        details={
+            "n_axial": int(grid.shape[0]),
+            "n_circ": int(grid.shape[1]),
+            "affected_width": affected_width,
+            "critical_length_in": float(result.details["critical_length_in"]),
+            "max_d_over_t": float(result.details["d_over_t"]),
+        },
+    )

--- a/tests/asset_integrity/test_rstreng_2d.py
+++ b/tests/asset_integrity/test_rstreng_2d.py
@@ -1,0 +1,180 @@
+# ABOUTME: Tests for 2D river-bottom effective-area projection (max / area-
+# ABOUTME: weighted) onto the validated 1D RSTRENG engine — golden hand-calcs.
+"""Tests for digitalmodel.asset_integrity.rstreng_2d.
+
+Golden values (vetted, independently reproduced):
+  D=24 in, t=0.5 in, X52 (SMYS=52000); x=[0,2,4,6,8] in; 3 circumferential
+  columns; depths/in station1=[.10,.20,.05], station2=[.15,.30,.10],
+  station3=[.05,.25,0] (zeros at x=0 and x=8).
+  intact flow-stress pressure = 2*flow*t/D, flow=62000 -> 2583.3 psi.
+  MAX  : d_eff=[0,.20,.30,.25,0] -> seg(1,4), L=6, A_eff=1.30, ar=0.4333,
+         M=1.6888 -> pf=1969.2 psi (RSF=0.7623, safe@1.39=1416.7).
+  AREA : d_eff=[0,.1167,.1833,.10,0] -> seg(0,4), L=8, ar=0.2000, z=5.333,
+         M=2.0617 -> pf=2288.7 psi (RSF=0.8859, safe=1646.5) ~16% > MAX.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.asset_integrity.corroded_pipe import CorrodedPipeResult
+from digitalmodel.asset_integrity.rstreng_2d import (
+    DEFAULT_SAFETY_FACTOR,
+    PROJECTION_AREA_WEIGHTED,
+    PROJECTION_MAX,
+    RiverBottom2DResult,
+    project_grid,
+    rstreng_2d_river_bottom,
+)
+
+D, T, SMYS = 24.0, 0.5, 52_000.0
+X = [0.0, 2.0, 4.0, 6.0, 8.0]
+# Grid d[a][c]: row = axial station, col = circumferential measurement.
+GRID = [
+    [0.00, 0.00, 0.00],  # x=0
+    [0.10, 0.20, 0.05],  # x=2  (station1)
+    [0.15, 0.30, 0.10],  # x=4  (station2)
+    [0.05, 0.25, 0.00],  # x=6  (station3)
+    [0.00, 0.00, 0.00],  # x=8
+]
+INTACT = 2583.3
+
+
+# --- projection layer ------------------------------------------------------
+def test_project_max_profile():
+    d_eff = project_grid(GRID, T, projection=PROJECTION_MAX)
+    assert list(d_eff) == pytest.approx([0.0, 0.20, 0.30, 0.25, 0.0])
+
+
+def test_project_area_weighted_is_circ_mean():
+    d_eff = project_grid(GRID, T, projection=PROJECTION_AREA_WEIGHTED)
+    assert list(d_eff) == pytest.approx([0.0, 0.35 / 3, 0.55 / 3, 0.10, 0.0], rel=1e-6)
+
+
+def test_area_weighted_equal_circ_weights_match_mean():
+    # explicit equal arc widths must equal the implicit (None) mean
+    d_default = project_grid(GRID, T, projection=PROJECTION_AREA_WEIGHTED)
+    d_explicit = project_grid(
+        GRID,
+        T,
+        projection=PROJECTION_AREA_WEIGHTED,
+        circ_weights=[2.0, 2.0, 2.0],
+    )
+    assert list(d_explicit) == pytest.approx(list(d_default), rel=1e-12)
+
+
+# --- golden: MAX projection ------------------------------------------------
+def test_max_projection_golden():
+    r = rstreng_2d_river_bottom(D, T, X, GRID, SMYS, projection=PROJECTION_MAX)
+    assert isinstance(r, RiverBottom2DResult)
+    assert isinstance(r.result, CorrodedPipeResult)
+    assert r.projection_rule == "max"
+    assert r.d_eff_in == pytest.approx([0.0, 0.20, 0.30, 0.25, 0.0])
+    assert r.governing_segment == (1, 4)
+    assert r.result.details["critical_length_in"] == pytest.approx(6.0)
+    assert r.result.area_ratio == pytest.approx(0.4333, rel=1e-3)
+    assert r.result.folias_factor == pytest.approx(1.6888, rel=1e-3)
+    assert r.intact_pressure_psi == pytest.approx(INTACT, rel=1e-4)
+    assert r.failure_pressure_psi == pytest.approx(1969.2, rel=2e-3)
+    assert r.rsf == pytest.approx(0.7623, rel=2e-3)
+    assert r.safe_pressure_psi == pytest.approx(1416.7, rel=2e-3)
+    assert r.within_applicability is True
+
+
+def test_max_is_default_projection():
+    r_default = rstreng_2d_river_bottom(D, T, X, GRID, SMYS)
+    assert r_default.projection_rule == "max"
+    assert r_default.failure_pressure_psi == pytest.approx(1969.2, rel=2e-3)
+
+
+# --- golden: AREA-WEIGHTED projection --------------------------------------
+def test_area_weighted_projection_golden():
+    r = rstreng_2d_river_bottom(
+        D, T, X, GRID, SMYS, projection=PROJECTION_AREA_WEIGHTED
+    )
+    assert r.projection_rule == "area_weighted"
+    assert r.d_eff_in == pytest.approx([0.0, 0.35 / 3, 0.55 / 3, 0.10, 0.0], rel=1e-6)
+    assert r.governing_segment == (0, 4)
+    assert r.result.details["critical_length_in"] == pytest.approx(8.0)
+    assert r.result.area_ratio == pytest.approx(0.2000, rel=1e-3)
+    # intermediate z = L^2/(D*t) = 64/12 = 5.333 (NOT 4.0)
+    z = 8.0**2 / (D * T)
+    assert z == pytest.approx(5.3333, rel=1e-4)
+    assert r.result.folias_factor == pytest.approx(2.0617, rel=1e-3)
+    assert r.failure_pressure_psi == pytest.approx(2288.7, rel=2e-3)
+    assert r.rsf == pytest.approx(0.8859, rel=2e-3)
+    assert r.safe_pressure_psi == pytest.approx(1646.5, rel=2e-3)
+    assert r.details["affected_width"] == pytest.approx(3.0)
+
+
+def test_area_weighted_less_conservative_than_max():
+    r_max = rstreng_2d_river_bottom(D, T, X, GRID, SMYS, projection="max")
+    r_area = rstreng_2d_river_bottom(D, T, X, GRID, SMYS, projection="area_weighted")
+    # area-weighted predicts a HIGHER (less conservative) burst pressure
+    assert r_area.failure_pressure_psi > r_max.failure_pressure_psi
+    ratio = r_area.failure_pressure_psi / r_max.failure_pressure_psi
+    assert ratio == pytest.approx(1.16, abs=0.02)
+
+
+# --- result surfacing + applicability --------------------------------------
+def test_intact_pressure_formula():
+    r = rstreng_2d_river_bottom(D, T, X, GRID, SMYS)
+    flow = SMYS + 10_000.0
+    assert r.intact_pressure_psi == pytest.approx(2.0 * flow * T / D, rel=1e-9)
+    assert r.result.flow_stress_psi == pytest.approx(62_000.0)
+
+
+def test_maop_acceptance_flag_passthrough():
+    r = rstreng_2d_river_bottom(D, T, X, GRID, SMYS, maop_psi=1000.0)
+    # safe@1.39 = 1416.7 >= 1000 -> acceptable
+    assert r.result.acceptable is True
+    r2 = rstreng_2d_river_bottom(D, T, X, GRID, SMYS, maop_psi=2000.0)
+    assert r2.result.acceptable is False
+
+
+def test_deep_grid_flags_outside_applicability():
+    deep = [
+        [0.0, 0.0, 0.0],
+        [0.30, 0.45, 0.20],  # 0.45/0.5 = 0.90 > 0.80
+        [0.10, 0.20, 0.05],
+        [0.0, 0.0, 0.0],
+    ]
+    r = rstreng_2d_river_bottom(D, T, [0.0, 2.0, 4.0, 6.0], deep, SMYS)
+    assert r.within_applicability is False
+    assert r.details["max_d_over_t"] == pytest.approx(0.90, rel=1e-6)
+
+
+def test_default_safety_factor_value():
+    assert DEFAULT_SAFETY_FACTOR == 1.39
+
+
+# --- validation / errors ---------------------------------------------------
+def test_unknown_projection_raises():
+    with pytest.raises(ValueError, match="projection"):
+        rstreng_2d_river_bottom(D, T, X, GRID, SMYS, projection="median")
+
+
+def test_axial_length_mismatch_raises():
+    with pytest.raises(ValueError, match="number of grid rows"):
+        rstreng_2d_river_bottom(D, T, [0.0, 2.0, 4.0], GRID, SMYS)
+
+
+def test_depth_exceeds_wall_raises():
+    bad = [[0.0, 0.0, 0.0], [0.10, 0.60, 0.05], [0.0, 0.0, 0.0]]
+    with pytest.raises(ValueError, match=r"\[0, t"):
+        rstreng_2d_river_bottom(D, T, [0.0, 2.0, 4.0], bad, SMYS)
+
+
+def test_bad_circ_weights_length_raises():
+    with pytest.raises(ValueError, match="circ_weights"):
+        project_grid(
+            GRID,
+            T,
+            projection=PROJECTION_AREA_WEIGHTED,
+            circ_weights=[1.0, 1.0],
+        )
+
+
+def test_no_pandas_pure_numpy():
+    # guard: projection returns a numpy array, not a pandas object
+    d_eff = project_grid(GRID, T)
+    assert isinstance(d_eff, np.ndarray)


### PR DESCRIPTION
## Summary

Extends the validated 1D RSTRENG effective-area engine (#1094) to **2D** inline-inspection / laser-scan data without touching the engine.

New module `src/digitalmodel/asset_integrity/rstreng_2d.py` is a thin **projection layer**: it reduces a 2D axial×circumferential metal-loss depth grid `d[a][c]` to a 1D effective axial profile `d_eff(x)`, then calls `corroded_pipe.rstreng_effective_area(...)` **verbatim** (imported and reused UNCHANGED — `corroded_pipe.py` is not modified). The 1D engine still searches every axial sub-segment for the governing flaw and applies the `d/t <= 0.80` B31G validity flag; both are surfaced.

### Projection rules
- **MAX** (default, conservative river-bottom): `d_eff[a] = max_c d(x_a, theta_c)` — deepest pit per axial station, how RSTRENG forms the river-bottom path.
- **AREA-WEIGHTED** (alternative, less conservative): `d_eff[a] = (1/w) Σ_c d·dtheta_c` over an **explicit** affected width `w` (the 1D engine has no circumferential notion). Documented to under-predict when the deepest pits don't co-locate axially.

### Golden values (vetted, in tests)
`D=24 in, t=0.5 in, X52` (flow 62000 → intact 2583.3 psi):
- **MAX**: `d_eff=[0,.20,.30,.25,0]` → governing seg (1,4), L=6, A_eff=1.30, ar=0.4333, M=1.6888 → **pf=1969.2 psi** (RSF 0.7623, safe@1.39 1416.7).
- **AREA-WEIGHTED**: `d_eff=[0,.1167,.1833,.10,0]` → governing seg (0,4), full L=8, ar=0.2000, z=64/12=**5.333**, M=2.0617 → **pf=2288.7 psi** (RSF 0.8859, safe 1646.5) — **~16% higher** than MAX (projection-rule sensitivity).

### Result
`RiverBottom2DResult` surfaces the projection rule, governing axial segment `(i,j)`, `within_applicability`, and carries the full 1D `CorrodedPipeResult`.

## Tests
`tests/asset_integrity/test_rstreng_2d.py` — 16 passing (golden MAX + area-weighted, projection layer, applicability flag, MAOP passthrough, validation errors, pure-numpy guard). black + flake8 (E9,F63,F7,F82,F401,F811,F841) clean.

## Docs
`docs/domains/rstreng-2d-validation-2026-06-29.md` — projection rules, golden derivation, and the simplification (simple projection, **not** full 2D interacting-flaw coalescence).

## Scope / non-goals
Simple projection only. No circumferential interaction-spacing rules or combined axial+circumferential stress. Relevant CI signal: `tests-asset-integrity` (main is chronically red on unrelated domains).