### PR TITLE
feat(asset_integrity): circumferential + combined-loading metal-loss FFS (API 579 Part 5 / DNV-RP-F101) [#1094]

### DIFF
--- a/docs/domains/circumferential-defect-validation-2026-06-29.md
+++ b/docs/domains/circumferential-defect-validation-2026-06-29.md
@@ -1,0 +1,147 @@
+# Circumferential / combined-loading metal-loss FFS — validation
+
+**Module:** `src/digitalmodel/asset_integrity/circumferential_defect.py`
+**Tests:** `tests/asset_integrity/test_circumferential_defect.py` (17 tests, all green)
+**Issue:** digitalmodel #1094 extension
+**Date:** 2026-06-29
+
+This module extends the existing corroded-pipe / longitudinal-LTA FFS work
+(`corroded_pipe.py`, `dnv_rp_f101.py`) with the assessments that govern a
+*circumferentially* extensive or axially-loaded metal-loss flaw. It imports the
+DNV-RP-F101 single-defect primitive rather than duplicating it.
+
+## What is implemented vs. stubbed
+
+| # | Method | Status | Golden |
+|---|--------|--------|--------|
+| 1 | API 579-1 Part 5 longitudinal LTA RSF | **Implemented (fully verified)** | RSF = 0.8907 |
+| 2 | API 579-1 Part 5 circumferential extent — net-section membrane RSF | **Implemented (verified)** | RSF_circ = 0.9001 |
+| 3 | DNV-RP-F101 Sec. 3.7.4 combined loading (H1) | **STUB / NotImplemented** | see below |
+
+---
+
+## 1. API 579-1/ASME FFS-1 Part 5 longitudinal LTA — RSF (FULLY VERIFIED)
+
+Level-1/Level-2 cylindrical-shell metal-loss screen.
+
+- Shell parameter: `lambda = 1.285 * s / sqrt(D * Tc)`
+- Folias factor (Part 5 **cylinder**, longitudinal): `M_t = sqrt( sum_{i=0..10} a_i * lambda^i )`, valid `lambda <= 20`.
+- Remaining-thickness ratio: `Rt = (tmm - FCA) / Tc`
+- **RSF = Rt / (1 - (1/M_t)*(1 - Rt))**
+- Accept if `RSF >= RSF_a` (default 0.90); else reduce MAWP: `MAWP_r = MAWP * RSF/RSF_a`.
+
+### Part 5 cylinder Folias polynomial coefficients (a0..a10)
+
+```
+a0 =  1.0010
+a1 = -0.014195
+a2 =  0.29090
+a3 = -0.096420
+a4 =  0.020890
+a5 = -0.0030540
+a6 =  2.9570e-4
+a7 = -1.8462e-5
+a8 =  7.1553e-7
+a9 = -1.5631e-8
+a10 = 1.4656e-10
+```
+
+Source: API 579-1/ASME FFS-1 Part 5 cylinder (longitudinal flaw) Mt polynomial.
+Independently reproduced the supplied golden to 4 decimals.
+
+### Golden (D=39 in, Tc=0.5, s=6, tmm=0.30, FCA=0 → Rt=0.60)
+
+| Quantity | Value |
+|----------|-------|
+| lambda | 1.746 |
+| M_t | 1.2255 |
+| Rt | 0.60 |
+| **RSF** | **0.8907** → FAIL (< 0.90) |
+| MAWP_r factor (RSF/0.90) | 0.9897 |
+
+---
+
+## 2. API 579-1 Part 5 circumferential extent — NET-SECTION membrane (VERIFIED)
+
+> **IMPORTANT:** this is a **net-section / screening** solution for the axial
+> (longitudinal-stress) capacity of a circumferentially extensive flaw. It is
+> **NOT** a "circumferential Folias" and deliberately does **not** reuse the
+> longitudinal `M_t` above. Labelled "net-section membrane RSF" in code + docs.
+
+- Level-1 circumferential extent screen: `c <= 2*s*(E_L/E_C)` (E_L, E_C = weld joint efficiencies; 1.0 seamless).
+- **RSF_circ = 1 - (d/t) * (c / (pi * Dm))**
+- Allowable axial membrane stress = `RSF_circ * sigma_flow`.
+
+### Golden (d/t = 0.40, 90° arc: c = 31.0 in, Dm = 39.5)
+
+`RSF_circ = 1 - 0.40 * (31.0 / (pi * 39.5)) = ` **0.9001**.
+(90° arc check: `pi*Dm/4 = 31.02 ≈ c`.)
+
+---
+
+## 3. DNV-RP-F101 Sec. 3.7.4 combined loading — STUB (no fabricated H1)
+
+Internal pressure + superimposed **longitudinal compressive** stress reduces the
+pure-pressure single-defect capacity by a factor `H1 < 1`:
+
+```
+p_corr,comp = [pure-pressure capacity] * H1
+```
+
+where the pure-pressure base reuses
+`dnv_rp_f101.dnv_f101_single_defect` (= `2*t*f_u/(D-t) * (1-d/t)/(1-(d/t)/Q)`).
+
+### Why this is stubbed
+
+The exact closed form of `H1` is given in DNV-RP-F101 Sec. 3.7.4. The published
+editions accessible during this work typeset that equation **as an image**, so
+the extracted text layer is corrupt/garbled (e.g. `H1 = (1 + .../(ξ·SMTS·A_r)) /
+(1 - γ_m·.../(...(1-γ_d(d/t)*)))` could not be read unambiguously). The symbol
+set was confirmed (ξ = usage factor for longitudinal stress; θ = c/(π·D);
+A_r = corroded-area ratio; structure
+`p_corr,comp = γ_m·2t·SMTS·(1-γ_d(d/t)*) / [(D-t)(1-γ_d(d/t)*/Q)] · H1`), but the
+`H1` fraction itself was **not** obtained verbatim.
+
+Per the task instruction, `H1` is **not approximated or guessed**. The
+combined-loading entry point `dnv_f101_combined_loading(...)` computes the real
+pure-pressure base and then raises `NotImplementedError` (with the base capacity
+in the message), rather than ship a fabricated `H1`.
+
+### Validation anchor recorded for a future exact implementation
+
+From the DNV Sesam *RP-F101* user manual worked example (Part A, "Combined
+loading" sheet). **Not used as a passing test** because `H1` is not implemented:
+
+| Input | Value |
+|-------|-------|
+| sigma_L (compressive longitudinal stress) | -190.00 MPa |
+| c (circumferential length of corroded region) | 50.00 mm |
+| theta = c/(pi*D) | 0.02 |
+| d/t (base case) | 0.250 |
+| gamma_m | 0.85 |
+| gamma_d | 1.275 |
+| f_u | 495.26 MPa |
+| **p_corr (pure pressure)** | **171.6 bar** |
+| **p_corr,comp (combined)** | **163.31 bar** |
+
+Implied `H1 = 163.31 / 171.6 = 0.9517`. A single worked point is **insufficient**
+to uniquely validate a multi-parameter closed form; an exact transcription of
+the Sec. 3.7.4 `H1` equation from a clean copy of DNV-RP-F101 is required before
+this path is implemented.
+
+### Sources consulted
+
+- DNV Sesam *RP-F101* user manual (worked example; references "Sec. 3.7.4" without reproducing the equation) — https://sesam.dnv.com/download/userdocumentation/rp-f101-user-manual.pdf
+- BSEE TAP report 265AH (BG/DNV background to RP-F101; Sec. 3.3 combined loading — equation is an image, text layer garbled) — https://www.bsee.gov/sites/bsee.gov/files/tap-technical-assessment-program//265ah.pdf
+- ISOPE 1999 "Introduction and Background to DNV RP-F101" (background; no clean H1) — http://publications.isope.org/proceedings/ISOPE/ISOPE%201999/papers/I99v2p117.pdf
+
+---
+
+## Conventions
+
+- Two `# ABOUTME:` lines on the module + test file.
+- Result dataclasses (`Part5LongitudinalRSFResult`, `NetSectionCircumferentialResult`) follow the `CorrodedPipeResult` / `DNVF101Result` pattern (`method`, `details`, `code_reference`).
+- `code_reference` from `digitalmodel.codes` (`API_579.label`, `DNV_RP_F101.label`).
+- No pandas (numpy / stdlib `math` only — pandas FutureWarning is a CI error).
+- `black --check` + `flake8 --select=E9,F63,F7,F82,F401,F811,F841` clean.
+- Run: `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/asset_integrity/test_circumferential_defect.py -p no:cacheprovider -o addopts="" -q`

--- a/src/digitalmodel/asset_integrity/circumferential_defect.py
+++ b/src/digitalmodel/asset_integrity/circumferential_defect.py
@@ -1,0 +1,353 @@
+# ABOUTME: API 579-1 Part 5 metal-loss RSF — longitudinal LTA (cylinder Folias Mt)
+# ABOUTME: + circumferential extent net-section membrane; DNV-RP-F101 combined loading (stub).
+"""Circumferential / combined-loading metal-loss fitness-for-service.
+
+Extends the corroded-pipe (B31G / DNV-RP-F101) and longitudinal LTA work with
+the two metal-loss assessments that govern a *circumferentially* extensive or
+axially-loaded flaw, plus a placeholder for DNV-RP-F101 combined loading.
+
+Three methods are provided:
+
+1. **API 579-1/ASME FFS-1 Part 5 longitudinal LTA — Remaining Strength Factor.**
+   The Level-1/Level-2 cylindrical-shell metal-loss screen.  With the Part 5
+   shell parameter
+
+       lambda = 1.285 * s / sqrt(D * Tc)
+
+   (``s`` axial flaw length, ``D`` inside diameter, ``Tc`` corroded wall away
+   from the LTA) and the Part 5 *cylinder* Folias bulging factor ``M_t`` from
+   the 10th-order polynomial of Table 5.2 (valid ``lambda <= 20``), the
+   remaining-thickness ratio ``Rt = (t - FCA)/Tc`` gives
+
+       RSF = Rt / (1 - (1/M_t)*(1 - Rt))
+
+   The flaw is acceptable if ``RSF >= RSF_a`` (default 0.90); otherwise the
+   MAWP is reduced to ``MAWP_r = MAWP * RSF/RSF_a`` (Part 5 para. 5.4.2.2).
+
+2. **API 579-1 Part 5 circumferential extent — net-section membrane RSF.**
+   This is the *net-section / screening* solution for the axial (longitudinal-
+   stress) capacity of a circumferentially extensive flaw — it is **NOT** a
+   "circumferential Folias" and deliberately does not reuse ``M_t`` above.  A
+   Level-1 circumferential extent screen ``c <= 2*s*(E_L/E_C)`` is checked and
+   the net-section membrane RSF is
+
+       RSF_circ = 1 - (d/t) * (c / (pi * Dm))
+
+   (``c`` circumferential flaw width, ``Dm`` mean diameter, ``d`` flaw depth).
+   The allowable axial membrane stress is ``RSF_circ * sigma_flow``.
+
+3. **DNV-RP-F101 combined loading (Sec. 3.7.4) — STUB / NotImplemented.**
+   Internal pressure plus superimposed longitudinal compressive stress reduces
+   the pure-pressure capacity by a factor ``H1``.  The exact published ``H1``
+   closed form (Sec. 3.7.4) could not be transcribed verbatim from an
+   authoritative source, so the combined-loading capacity is **not** computed
+   here — see :func:`dnv_f101_combined_loading` and the validation note in
+   ``docs/domains/circumferential-defect-validation-2026-06-29.md``.  The
+   pure-pressure base is real (delegates to ``dnv_f101_single_defect``); only
+   the ``H1`` reduction is withheld rather than approximated.
+
+Units are US customary throughout (inches, psi) unless noted.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+from digitalmodel.asset_integrity.dnv_rp_f101 import dnv_f101_single_defect
+from digitalmodel.codes import API_579, DNV_RP_F101
+
+# ---------------------------------------------------------------------------
+# API 579-1/ASME FFS-1 Part 5 — cylinder (longitudinal) Folias factor M_t.
+# Table 5.2 polynomial: M_t = sqrt( sum_{i=0..10} a_i * lambda^i ), lambda <= 20.
+# Coefficients per API 579-1/ASME FFS-1 Part 5 (longitudinal flaw, cylinder).
+# ---------------------------------------------------------------------------
+_PART5_MT_COEFFS = (
+    1.0010,  # a0
+    -0.014195,  # a1
+    0.29090,  # a2
+    -0.096420,  # a3
+    0.020890,  # a4
+    -0.0030540,  # a5
+    2.9570e-4,  # a6
+    -1.8462e-5,  # a7
+    7.1553e-7,  # a8
+    -1.5631e-8,  # a9
+    1.4656e-10,  # a10
+)
+
+# Part 5 shell-parameter coefficient: lambda = 1.285 * s / sqrt(D*Tc).
+_PART5_LAMBDA_COEFF = 1.285
+# Validity limit on the Part 5 shell parameter for the M_t polynomial.
+_PART5_LAMBDA_MAX = 20.0
+# Default allowable Remaining Strength Factor (API 579-1 Part 2, RSF_a).
+_DEFAULT_RSF_A = 0.90
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+@dataclass
+class Part5LongitudinalRSFResult:
+    """API 579-1 Part 5 longitudinal LTA remaining-strength result."""
+
+    method: str  # "API579-Part5-longitudinal"
+    rsf: float  # Remaining Strength Factor
+    rsf_allowable: float  # RSF_a (acceptance threshold)
+    acceptable: bool  # RSF >= RSF_a
+    folias_Mt: float  # Part 5 cylinder Folias factor M_t
+    shell_parameter: float  # lambda = 1.285 s / sqrt(D Tc)
+    Rt: float  # remaining-thickness ratio (t-FCA)/Tc
+    mawp_psi: Optional[float] = None  # supplied MAWP (intact)
+    mawp_reduced_psi: Optional[float] = None  # MAWP * RSF/RSF_a when RSF < RSF_a
+    details: dict = field(default_factory=dict)
+    code_reference: str = API_579.label
+
+
+@dataclass
+class NetSectionCircumferentialResult:
+    """API 579-1 Part 5 circumferential-extent net-section membrane result."""
+
+    method: str  # "API579-Part5-circumferential-net-section"
+    rsf_netsection: float  # net-section membrane RSF
+    sigma_flow_psi: float  # flow stress used
+    allowable_axial_stress_psi: float  # RSF_netsection * sigma_flow
+    level1_screen_ok: Optional[bool] = None  # c <= 2 s (E_L/E_C) if s given
+    details: dict = field(default_factory=dict)
+    code_reference: str = API_579.label
+
+
+# ---------------------------------------------------------------------------
+# 1) API 579-1 Part 5 — cylinder Folias factor and longitudinal LTA RSF
+# ---------------------------------------------------------------------------
+def part5_folias_mt(lam: float) -> float:
+    """API 579-1 Part 5 cylinder (longitudinal) Folias factor ``M_t``.
+
+    ``M_t = sqrt( sum_i a_i * lambda^i )`` for the Part 5 cylinder polynomial,
+    valid for ``lambda <= 20`` (raises outside that range).
+    """
+    if lam < 0:
+        raise ValueError(f"shell parameter lambda={lam} must be >= 0.")
+    if lam > _PART5_LAMBDA_MAX:
+        raise ValueError(
+            f"lambda={lam:.3f} exceeds the Part 5 M_t polynomial validity "
+            f"limit {_PART5_LAMBDA_MAX:.0f}; flaw is beyond the Level-1/2 "
+            "cylinder screen."
+        )
+    poly = sum(c * lam**i for i, c in enumerate(_PART5_MT_COEFFS))
+    if poly <= 0:
+        raise ValueError(f"non-physical M_t polynomial value {poly} at lambda={lam}.")
+    return math.sqrt(poly)
+
+
+def part5_shell_parameter(D: float, Tc: float, s: float) -> float:
+    """API 579-1 Part 5 shell parameter ``lambda = 1.285 s / sqrt(D Tc)``."""
+    if D <= 0 or Tc <= 0:
+        raise ValueError(f"Invalid geometry: D={D}, Tc={Tc} (need both > 0).")
+    if s < 0:
+        raise ValueError(f"axial flaw length s={s} must be >= 0.")
+    return _PART5_LAMBDA_COEFF * s / math.sqrt(D * Tc)
+
+
+def api579_part5_longitudinal_rsf(
+    D: float,
+    Tc: float,
+    s: float,
+    tmm: float,
+    *,
+    FCA: float = 0.0,
+    rsf_allowable: float = _DEFAULT_RSF_A,
+    MAWP_psi: Optional[float] = None,
+) -> Part5LongitudinalRSFResult:
+    """API 579-1/ASME FFS-1 Part 5 longitudinal LTA Remaining Strength Factor.
+
+    Args:
+        D: inside diameter of the cylinder (in).
+        Tc: corroded wall thickness away from the LTA (in) — the reference wall
+            used for ``lambda`` and ``Rt``.
+        s: axial (meridional) length of the flaw (in).
+        tmm: minimum measured remaining thickness within the LTA (in).
+        FCA: future corrosion allowance (in), subtracted from ``tmm`` for ``Rt``.
+        rsf_allowable: acceptance threshold ``RSF_a`` (default 0.90).
+        MAWP_psi: intact maximum allowable working pressure; if given and the
+            flaw fails (``RSF < RSF_a``), the reduced ``MAWP_r`` is returned.
+
+    Returns:
+        :class:`Part5LongitudinalRSFResult` with ``RSF``, ``M_t``, ``lambda``,
+        ``Rt``, the accept/reject flag and (on failure) the reduced MAWP.
+    """
+    if Tc <= 0 or D <= 0:
+        raise ValueError(f"Invalid geometry: D={D}, Tc={Tc} (need both > 0).")
+    if tmm < 0:
+        raise ValueError(f"measured thickness tmm={tmm} must be >= 0.")
+    if FCA < 0:
+        raise ValueError(f"FCA={FCA} must be >= 0.")
+
+    lam = part5_shell_parameter(D, Tc, s)
+    Mt = part5_folias_mt(lam)
+    Rt = (tmm - FCA) / Tc
+    # Part 5 Level-1/2 longitudinal-extent RSF.
+    rsf = Rt / (1.0 - (1.0 / Mt) * (1.0 - Rt))
+    acceptable = rsf >= rsf_allowable
+
+    mawp_reduced = None
+    if MAWP_psi is not None and not acceptable:
+        mawp_reduced = MAWP_psi * (rsf / rsf_allowable)
+
+    return Part5LongitudinalRSFResult(
+        method="API579-Part5-longitudinal",
+        rsf=rsf,
+        rsf_allowable=rsf_allowable,
+        acceptable=bool(acceptable),
+        folias_Mt=Mt,
+        shell_parameter=lam,
+        Rt=Rt,
+        mawp_psi=MAWP_psi,
+        mawp_reduced_psi=mawp_reduced,
+        details={
+            "D_in": D,
+            "Tc_in": Tc,
+            "s_in": s,
+            "tmm_in": tmm,
+            "FCA_in": FCA,
+            "within_lambda_limit": bool(lam <= _PART5_LAMBDA_MAX),
+        },
+        code_reference=API_579.label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2) API 579-1 Part 5 — circumferential extent, net-section membrane RSF
+# ---------------------------------------------------------------------------
+def api579_part5_circumferential_netsection(
+    Dm: float,
+    t: float,
+    d: float,
+    c: float,
+    sigma_flow_psi: float,
+    *,
+    s: Optional[float] = None,
+    E_L: float = 1.0,
+    E_C: float = 1.0,
+) -> NetSectionCircumferentialResult:
+    """API 579-1 Part 5 circumferential-extent **net-section membrane** RSF.
+
+    Net-section (screening) axial capacity of a circumferentially extensive
+    metal-loss flaw under longitudinal membrane stress.  This is **not** a
+    "circumferential Folias" solution — it is the net-section membrane balance
+
+        RSF_circ = 1 - (d/t) * (c / (pi * Dm))
+
+    and the allowable axial membrane stress ``RSF_circ * sigma_flow``.
+
+    Args:
+        Dm: mean pipe diameter (in).
+        t: nominal/corroded wall thickness (in).
+        d: flaw depth (in), ``0 <= d <= t``.
+        c: circumferential flaw width measured along the arc (in).
+        sigma_flow_psi: flow stress (psi).
+        s: optional axial flaw length (in) for the Level-1 circumferential
+            extent screen ``c <= 2 s (E_L/E_C)``.
+        E_L, E_C: longitudinal / circumferential weld joint efficiencies
+            (default 1.0 for seamless).
+    """
+    if Dm <= 0 or t <= 0:
+        raise ValueError(f"Invalid geometry: Dm={Dm}, t={t} (need both > 0).")
+    if not (0.0 <= d <= t):
+        raise ValueError(f"flaw depth d={d} must be in [0, t={t}].")
+    if c < 0:
+        raise ValueError(f"circumferential width c={c} must be >= 0.")
+    if E_C <= 0:
+        raise ValueError(f"E_C={E_C} must be > 0.")
+    circ = math.pi * Dm
+    if c > circ:
+        raise ValueError(
+            f"circumferential width c={c} exceeds circumference " f"pi*Dm={circ:.3f}."
+        )
+
+    rsf_circ = 1.0 - (d / t) * (c / circ)
+    allowable_axial = rsf_circ * sigma_flow_psi
+
+    screen_ok: Optional[bool] = None
+    screen_limit = None
+    if s is not None:
+        if s < 0:
+            raise ValueError(f"axial flaw length s={s} must be >= 0.")
+        screen_limit = 2.0 * s * (E_L / E_C)
+        screen_ok = c <= screen_limit
+
+    return NetSectionCircumferentialResult(
+        method="API579-Part5-circumferential-net-section",
+        rsf_netsection=rsf_circ,
+        sigma_flow_psi=sigma_flow_psi,
+        allowable_axial_stress_psi=allowable_axial,
+        level1_screen_ok=(None if screen_ok is None else bool(screen_ok)),
+        details={
+            "Dm_in": Dm,
+            "t_in": t,
+            "d_in": d,
+            "c_in": c,
+            "d_over_t": d / t,
+            "circumference_in": circ,
+            "theta_fraction": c / circ,
+            "screen_limit_in": screen_limit,
+            "E_L": E_L,
+            "E_C": E_C,
+            "solution_type": "net-section membrane (not circumferential Folias)",
+        },
+        code_reference=API_579.label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3) DNV-RP-F101 Sec. 3.7.4 combined loading — STUB (no fabricated H1)
+# ---------------------------------------------------------------------------
+def dnv_f101_combined_loading(
+    D: float,
+    t: float,
+    d: float,
+    L: float,
+    c: float,
+    smts_psi: float,
+    sigma_L_psi: float,
+    *args,
+    **kwargs,
+):
+    """DNV-RP-F101 Sec. 3.7.4 combined loading — **NOT IMPLEMENTED**.
+
+    Internal pressure plus a superimposed longitudinal compressive stress
+    ``sigma_L`` (negative in compression) reduces the pure-pressure capacity of
+    a single longitudinal corrosion defect by a factor ``H1``:
+
+        p_corr,comp = [pure-pressure capacity] * H1.
+
+    The pure-pressure base is computed here via
+    :func:`digitalmodel.asset_integrity.dnv_rp_f101.dnv_f101_single_defect`
+    (real), but the published ``H1`` closed form (DNV-RP-F101 Sec. 3.7.4)
+    could not be transcribed verbatim from an authoritative source — the
+    equation is typeset as an image in the publicly available editions and the
+    extracted text is corrupt.  Rather than approximate or guess ``H1`` (which
+    would be a fabricated safety calculation), this path is intentionally left
+    unimplemented.
+
+    Known validation anchor (DNV Sesam RP-F101 user manual worked example, for
+    a *future* exact implementation, NOT used here): base-case pure-pressure
+    capacity ``p_corr = 171.6 bar`` reduces to ``p_corr,comp = 163.31 bar`` for
+    ``sigma_L = -190 MPa``, ``c = 50 mm``, ``theta = c/(pi*D) = 0.02``,
+    ``d/t = 0.250``, ``gamma_m = 0.85``, ``gamma_d = 1.275``,
+    ``f_u = 495.26 MPa``.
+
+    Raises:
+        NotImplementedError: always — the H1 factor is not available.
+    """
+    # Pure-pressure base is real and verifiable; H1 is what is missing.
+    base = dnv_f101_single_defect(D, t, d, L, smts_psi)
+    raise NotImplementedError(
+        "DNV-RP-F101 Sec. 3.7.4 combined-loading factor H1 is not implemented: "
+        "the exact published H1 closed form was not obtained from an "
+        "authoritative source and will not be approximated. Pure-pressure "
+        f"capacity (DNV-RP-F101 single defect) is {base.capacity_pressure_psi:.2f} "
+        f"psi; see {DNV_RP_F101.label} Sec. 3.7.4 and the validation doc. "
+        f"(inputs c={c}, sigma_L={sigma_L_psi} psi)"
+    )

--- a/tests/asset_integrity/test_circumferential_defect.py
+++ b/tests/asset_integrity/test_circumferential_defect.py
@@ -1,0 +1,192 @@
+# ABOUTME: Tests for circumferential / combined-loading metal-loss FFS — API 579-1
+# ABOUTME: Part 5 longitudinal RSF + circumferential net-section golden values; DNV combined-loading stub.
+import math
+
+import pytest
+
+from digitalmodel.asset_integrity.circumferential_defect import (
+    api579_part5_circumferential_netsection,
+    api579_part5_longitudinal_rsf,
+    dnv_f101_combined_loading,
+    part5_folias_mt,
+    part5_shell_parameter,
+)
+from digitalmodel.asset_integrity.dnv_rp_f101 import dnv_f101_single_defect
+
+
+# ===========================================================================
+# 1) API 579-1 Part 5 longitudinal LTA RSF — fully verified golden
+#    D=39, Tc=0.5, s=6, tmm=0.30 (Rt=0.60)
+#    -> lambda=1.746, M_t=1.2255, RSF=0.8907 (FAIL), MAWP_r = MAWP * 0.9897
+# ===========================================================================
+def test_part5_longitudinal_rsf_golden():
+    res = api579_part5_longitudinal_rsf(D=39.0, Tc=0.5, s=6.0, tmm=0.30)
+    assert res.shell_parameter == pytest.approx(1.746, abs=5e-4)
+    assert res.folias_Mt == pytest.approx(1.2255, abs=5e-4)
+    assert res.Rt == pytest.approx(0.60, rel=1e-12)
+    assert res.rsf == pytest.approx(0.8907, abs=5e-4)
+    assert res.acceptable is False  # 0.8907 < 0.90
+    assert res.method == "API579-Part5-longitudinal"
+
+
+def test_part5_longitudinal_mawp_reduction_golden():
+    res = api579_part5_longitudinal_rsf(
+        D=39.0, Tc=0.5, s=6.0, tmm=0.30, MAWP_psi=1000.0
+    )
+    # MAWP_r = MAWP * RSF/RSF_a = 1000 * 0.8907/0.90 = 989.7
+    assert res.mawp_reduced_psi == pytest.approx(0.9897 * 1000.0, abs=0.5)
+    assert res.mawp_reduced_psi == pytest.approx(
+        res.mawp_psi * res.rsf / 0.90, rel=1e-12
+    )
+
+
+def test_part5_shell_parameter_golden():
+    lam = part5_shell_parameter(D=39.0, Tc=0.5, s=6.0)
+    assert lam == pytest.approx(1.285 * 6.0 / math.sqrt(39.0 * 0.5), rel=1e-12)
+    assert lam == pytest.approx(1.746, abs=5e-4)
+
+
+def test_part5_folias_mt_unit_at_zero():
+    # lambda=0 -> M_t = sqrt(a0) = sqrt(1.0010) ~ 1.0005 (flat plate limit).
+    assert part5_folias_mt(0.0) == pytest.approx(math.sqrt(1.0010), rel=1e-12)
+
+
+def test_part5_folias_mt_monotonic_increasing():
+    prev = part5_folias_mt(0.0)
+    for lam in (0.5, 1.0, 2.0, 4.0, 8.0, 15.0):
+        cur = part5_folias_mt(lam)
+        assert cur > prev
+        prev = cur
+
+
+def test_part5_rsf_accepts_shallow_flaw():
+    # Shallow flaw (Rt high) should pass RSF_a = 0.90.
+    res = api579_part5_longitudinal_rsf(D=39.0, Tc=0.5, s=6.0, tmm=0.47)
+    assert res.Rt == pytest.approx(0.94, rel=1e-12)
+    assert res.rsf >= 0.90
+    assert res.acceptable is True
+    assert res.mawp_reduced_psi is None
+
+
+def test_part5_rt_uses_fca():
+    res = api579_part5_longitudinal_rsf(D=39.0, Tc=0.5, s=6.0, tmm=0.30, FCA=0.05)
+    assert res.Rt == pytest.approx((0.30 - 0.05) / 0.5, rel=1e-12)
+
+
+def test_part5_lambda_validity_limit():
+    with pytest.raises(ValueError):
+        part5_folias_mt(20.0001)
+    # A flaw long enough to exceed lambda=20 should raise on RSF as well.
+    with pytest.raises(ValueError):
+        api579_part5_longitudinal_rsf(D=39.0, Tc=0.5, s=80.0, tmm=0.30)
+
+
+# ===========================================================================
+# 2) API 579-1 Part 5 circumferential extent — net-section membrane RSF
+#    d/t=0.40, 90deg arc (c=31.0 in, Dm=39.5) -> RSF_circ = 0.9001
+# ===========================================================================
+def test_circumferential_netsection_golden():
+    # d/t = 0.40 -> with t=0.5, d=0.20.
+    res = api579_part5_circumferential_netsection(
+        Dm=39.5, t=0.5, d=0.20, c=31.0, sigma_flow_psi=50_000.0
+    )
+    assert res.rsf_netsection == pytest.approx(0.9001, abs=5e-4)
+    assert res.details["d_over_t"] == pytest.approx(0.40, rel=1e-12)
+    assert res.allowable_axial_stress_psi == pytest.approx(0.9001 * 50_000.0, abs=30.0)
+    assert res.method == "API579-Part5-circumferential-net-section"
+    assert "net-section membrane" in res.details["solution_type"]
+
+
+def test_circumferential_netsection_formula():
+    Dm, t, d, c = 39.5, 0.5, 0.20, 31.0
+    expect = 1.0 - (d / t) * (c / (math.pi * Dm))
+    res = api579_part5_circumferential_netsection(
+        Dm=Dm, t=t, d=d, c=c, sigma_flow_psi=1.0
+    )
+    assert res.rsf_netsection == pytest.approx(expect, rel=1e-12)
+
+
+def test_circumferential_full_circumference_depth_limit():
+    # c = full circumference, d/t=0.40 -> RSF = 1 - 0.40 = 0.60.
+    Dm, t, d = 39.5, 0.5, 0.20
+    res = api579_part5_circumferential_netsection(
+        Dm=Dm, t=t, d=d, c=math.pi * Dm, sigma_flow_psi=1.0
+    )
+    assert res.rsf_netsection == pytest.approx(0.60, rel=1e-9)
+
+
+def test_circumferential_zero_depth_is_full_strength():
+    res = api579_part5_circumferential_netsection(
+        Dm=39.5, t=0.5, d=0.0, c=31.0, sigma_flow_psi=50_000.0
+    )
+    assert res.rsf_netsection == pytest.approx(1.0, rel=1e-12)
+    assert res.allowable_axial_stress_psi == pytest.approx(50_000.0, rel=1e-12)
+
+
+def test_circumferential_level1_screen_flag():
+    # Screen c <= 2 s (E_L/E_C); seamless E_L=E_C=1.
+    ok = api579_part5_circumferential_netsection(
+        Dm=39.5, t=0.5, d=0.20, c=31.0, sigma_flow_psi=1.0, s=20.0
+    )
+    assert ok.level1_screen_ok is True  # 31.0 <= 40.0
+    fail = api579_part5_circumferential_netsection(
+        Dm=39.5, t=0.5, d=0.20, c=31.0, sigma_flow_psi=1.0, s=10.0
+    )
+    assert fail.level1_screen_ok is False  # 31.0 > 20.0
+    none = api579_part5_circumferential_netsection(
+        Dm=39.5, t=0.5, d=0.20, c=31.0, sigma_flow_psi=1.0
+    )
+    assert none.level1_screen_ok is None
+
+
+def test_circumferential_deeper_lowers_rsf():
+    prev = 1.1
+    for d in (0.05, 0.10, 0.20, 0.40, 0.49):
+        res = api579_part5_circumferential_netsection(
+            Dm=39.5, t=0.5, d=d, c=31.0, sigma_flow_psi=1.0
+        )
+        assert res.rsf_netsection < prev
+        prev = res.rsf_netsection
+
+
+def test_circumferential_validation():
+    with pytest.raises(ValueError):
+        api579_part5_circumferential_netsection(
+            Dm=39.5, t=0.5, d=0.6, c=31.0, sigma_flow_psi=1.0
+        )  # d > t
+    with pytest.raises(ValueError):
+        api579_part5_circumferential_netsection(
+            Dm=39.5, t=0.5, d=0.2, c=200.0, sigma_flow_psi=1.0
+        )  # c > circumference
+    with pytest.raises(ValueError):
+        api579_part5_circumferential_netsection(
+            Dm=-1.0, t=0.5, d=0.2, c=31.0, sigma_flow_psi=1.0
+        )  # Dm <= 0
+
+
+# ===========================================================================
+# 3) DNV-RP-F101 combined loading — STUB (no fabricated H1)
+# ===========================================================================
+def test_combined_loading_is_not_implemented():
+    with pytest.raises(NotImplementedError):
+        dnv_f101_combined_loading(
+            D=30.0,
+            t=0.375,
+            d=0.15,
+            L=8.0,
+            c=2.0,
+            smts_psi=66_700.0,
+            sigma_L_psi=-27_557.0,
+        )
+
+
+def test_combined_loading_pure_pressure_base_matches_single_defect():
+    # The stub computes (and the message embeds) the real pure-pressure base;
+    # confirm that base equals dnv_f101_single_defect before it raises.
+    D, t, d, L, smts = 30.0, 0.375, 0.15, 8.0, 66_700.0
+    base = dnv_f101_single_defect(D, t, d, L, smts).capacity_pressure_psi
+    with pytest.raises(NotImplementedError) as exc:
+        dnv_f101_combined_loading(
+            D=D, t=t, d=d, L=L, c=2.0, smts_psi=smts, sigma_L_psi=-1000.0
+        )
+    assert f"{base:.2f}" in str(exc.value)


### PR DESCRIPTION
## Summary

New FFS module `src/digitalmodel/asset_integrity/circumferential_defect.py` adding the metal-loss assessments that govern a circumferentially extensive or axially-loaded flaw. Extends the existing `corroded_pipe.py` / `dnv_rp_f101.py` work (imports the DNV single-defect primitive; does not edit those files). Extension of #1094.

## What's implemented

1. **API 579-1/ASME FFS-1 Part 5 longitudinal LTA RSF** (fully verified)
   - `lambda = 1.285*s/sqrt(D*Tc)`; Part 5 **cylinder** Folias `M_t` (10-term polynomial, valid `lambda<=20`); `Rt=(tmm-FCA)/Tc`
   - **`RSF = Rt/(1-(1/M_t)*(1-Rt))`**; accept if `RSF>=RSF_a` (0.90) else `MAWP_r = MAWP*RSF/RSF_a`
   - Golden: D=39, Tc=0.5, s=6, tmm=0.30 (Rt=0.60) -> lambda=1.746, M_t=1.2255, **RSF=0.8907** (FAIL), MAWP_r=MAWP*0.9897

2. **API 579-1 Part 5 circumferential extent — net-section membrane RSF** (verified)
   - Labelled "net-section membrane RSF" — **not** a circumferential Folias; does not reuse the longitudinal `M_t`
   - Level-1 screen `c<=2*s*(E_L/E_C)`; **`RSF_circ = 1-(d/t)*(c/(pi*Dm))`**; allowable axial stress = `RSF_circ*sigma_flow`
   - Golden: d/t=0.40, 90deg arc (c=31.0, Dm=39.5) -> **RSF_circ=0.9001**

3. **DNV-RP-F101 Sec. 3.7.4 combined loading — documented STUB**
   - The exact published `H1` closed form could not be transcribed verbatim (it is typeset as an image in the editions consulted; extracted text is garbled). Per the spec, `H1` is **not approximated or guessed**.
   - `dnv_f101_combined_loading(...)` computes the real pure-pressure base (`dnv_f101_single_defect`) then raises `NotImplementedError`.
   - Worked-example anchor recorded for a future exact impl (171.6 bar pure -> 163.31 bar combined, sigma_L=-190 MPa) — **not** used as a passing test.

## Tests

`tests/asset_integrity/test_circumferential_defect.py` — **17 tests, all green**. Golden values, monotonicity, validity guards, Level-1 screen, and the combined-loading NotImplemented stub. `black --check` + `flake8 (E9,F63,F7,F82,F401,F811,F841)` clean; numpy/`math` only (no pandas).

Validation doc: `docs/domains/circumferential-defect-validation-2026-06-29.md` (methods, golden values + sources, implemented vs stubbed).

Relevant CI signal: `tests-asset-integrity`. Do not merge without review.