### PR TITLE
docs(capabilities): add installation vessel pamphlet live link

### DIFF
--- a/docs/api/capabilities/index.html
+++ b/docs/api/capabilities/index.html
@@ -125,6 +125,9 @@
     <a class="card linkcard" href="../buckling/ship-panel-buckling.html"><h3>Stiffened-panel buckling explorer →</h3>
       <div class="std">DNV-RP-C201</div>
       <ul><li>plate-field / column / tripping interaction</li></ul></a>
+    <a class="card linkcard" href="https://vamseeachanta.github.io/deckhand-sandbox/domains/floating-marine/deckhand-deliverables/2026/2026-06-28/installation-vessel-pamphlet-bokalift2/report.html"><h3>Installation vessel pamphlet — BokaLift 2 →</h3>
+      <div class="std">DNV-RP-H103 · DNV-ST-N001 · IMCA · HSE RR444</div>
+      <ul><li>crane lift suitability, operational + per-structure splash-zone Hs/Tp envelopes, weather-window operability, DP/mooring failure-risk, live weather monitor</li></ul></a>
   </div>
 
   <h2>Provenance</h2>


### PR DESCRIPTION
Adds a **Live dashboards & explorers** card on the capabilities page (`docs/api/capabilities/index.html`) linking to the BokaLift 2 **installation vessel pamphlet** — the deterministic `installation_pamphlet` workflow output (#1105): crane lift suitability, operational + per-structure splash-zone Hs/Tp envelopes, weather-window operability, DP/mooring failure-risk, live weather monitor.

Links to the live gallery page on deckhand-sandbox; updatable in place as the comprehensive work evolves. One-line additive change; mkdocs `pages.yml` rebuilds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)