### PR TITLE
feat(openfoam): 'openfoam doctor' CFD readiness diagnostics (#1161 Phase 1)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/cli.py
+++ b/src/digitalmodel/solvers/openfoam/cli.py
@@ -250,6 +250,64 @@ def run_cmd(
         sys.exit(2)  # asked for a real solve but OpenFOAM was unavailable
 
 
+# ============================================================================
+# openfoam doctor
+# ============================================================================
+
+
+@cli.command("doctor")
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output root to test for writability (default: /mnt/ace/cfd-output).",
+)
+@click.option(
+    "--require-solver",
+    is_flag=True,
+    default=False,
+    help="Exit nonzero if the host cannot actually solve (dry-run only).",
+)
+def doctor_cmd(output_dir: str | None, require_solver: bool) -> None:
+    """Diagnose OpenFOAM CFD readiness on this host.
+
+    Reports PASS/WARN/FAIL for the OpenFOAM utilities, solvers, version, the
+    Python post-processing/meshing stack, and output-root writability, then
+    states whether the host is solver-capable or dry-run only.
+
+    Exit policy: 0 = host usable (dry-run-only is a supported mode);
+    nonzero = any FAIL check, or dry-run-only with --require-solver.
+    """
+    from .doctor import has_failure, run_doctor
+
+    click.echo("=" * 80)
+    click.echo("OpenFOAM CFD Doctor")
+    click.echo("=" * 80)
+
+    checks, capability = run_doctor(
+        output_dir=Path(output_dir) if output_dir else None,
+    )
+    colors = {"PASS": "green", "WARN": "yellow", "FAIL": "red"}
+    for check in checks:
+        click.echo(
+            click.style(f"[{check.status:4}] ", fg=colors[check.status])
+            + f"{check.name}: {check.detail}"
+        )
+
+    if has_failure(checks):
+        click.echo(click.style("\n[FAIL] Hard failures present.", fg="red"))
+        sys.exit(1)
+    if require_solver and capability == "dry-run-only":
+        click.echo(
+            click.style(
+                "\n[FAIL] --require-solver: host is dry-run only.", fg="red"
+            )
+        )
+        sys.exit(1)
+    click.echo(click.style(f"\n[OK] Host usable ({capability}).", fg="green"))
+
+
 def main() -> None:
     """Main CLI entry point."""
     cli()

--- a/src/digitalmodel/solvers/openfoam/doctor.py
+++ b/src/digitalmodel/solvers/openfoam/doctor.py
@@ -1,0 +1,195 @@
+"""OpenFOAM CFD environment readiness diagnostics (#1161 Phase 1).
+
+Surfaces the runner's detection logic (are the OpenFOAM utilities on PATH?
+is the Python post-processing stack importable? is the output root writable?)
+as a PASS/WARN/FAIL report, so a user knows whether a host can actually solve
+*before* preparing a large case — instead of discovering the runner's
+fail-closed dry-run fallback afterwards.
+
+Mirrors ``orcawave_doctor`` (#613). Exit-code policy is enforced by the CLI:
+- ``0`` — host usable, including dry-run-only hosts (a supported mode);
+- nonzero — any FAIL check (e.g. unwritable output root), or a dry-run-only
+  host when ``--require-solver`` was passed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import platform
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Utilities the runner invokes (mesh -> solve -> convert). blockMesh is the
+# availability sentinel used by OpenFOAMRunner._openfoam_available().
+_CORE_UTILITIES = ("blockMesh", "foamToVTK")
+# Solvers the marine/aero setups select; at least one should be present.
+_SOLVERS = ("interFoam", "simpleFoam", "pimpleFoam")
+# Default shared output root (env spec §6); overridable.
+DEFAULT_OUTPUT_ROOT = Path("/mnt/ace/cfd-output")
+
+
+@dataclass
+class DoctorCheck:
+    """One diagnostic line: PASS / WARN / FAIL plus human detail."""
+
+    name: str
+    status: str
+    detail: str
+
+
+def _which(name: str) -> Optional[str]:
+    return shutil.which(name)
+
+
+def _openfoam_version() -> Optional[str]:
+    """Best-effort OpenFOAM version from the environment (set by etc/bashrc)."""
+    for var in ("WM_PROJECT_VERSION", "FOAM_API"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    return None
+
+
+def _module_available(module: str) -> bool:
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _memory_gb() -> Optional[float]:
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                return round(int(line.split()[1]) / 1024 / 1024, 1)
+    except OSError:
+        pass
+    return None
+
+
+def run_doctor(
+    output_dir: Path | None = None,
+) -> tuple[list[DoctorCheck], str]:
+    """Run all readiness checks.
+
+    Returns ``(checks, capability)`` where capability is ``"solver-capable"``
+    (the OpenFOAM toolchain can run a case) or ``"dry-run-only"`` (case
+    generation works but no solve — the runner will fail-close to DRY_RUN).
+    """
+    checks: list[DoctorCheck] = []
+
+    # --- OpenFOAM core utilities -----------------------------------------
+    missing_core = [u for u in _CORE_UTILITIES if _which(u) is None]
+    core_present = not missing_core
+    checks.append(
+        DoctorCheck(
+            "OpenFOAM utilities",
+            "PASS" if core_present else "WARN",
+            "blockMesh + foamToVTK on PATH"
+            if core_present
+            else (
+                f"missing {missing_core} — is the OpenFOAM environment sourced? "
+                "(source .../etc/bashrc)"
+            ),
+        )
+    )
+
+    # --- at least one solver ---------------------------------------------
+    solvers_found = [s for s in _SOLVERS if _which(s) is not None]
+    checks.append(
+        DoctorCheck(
+            "OpenFOAM solvers",
+            "PASS" if solvers_found else "WARN",
+            f"available: {solvers_found}"
+            if solvers_found
+            else f"none of {list(_SOLVERS)} found on PATH",
+        )
+    )
+
+    # --- version (informational) -----------------------------------------
+    version = _openfoam_version()
+    checks.append(
+        DoctorCheck(
+            "OpenFOAM version",
+            "PASS" if version else "WARN",
+            f"WM_PROJECT_VERSION={version}"
+            if version
+            else "version env not set (etc/bashrc not sourced?)",
+        )
+    )
+
+    # --- Python post-processing / meshing stack --------------------------
+    for module, role in (("pyvista", "post-processing"), ("meshio", "mesh I/O")):
+        present = _module_available(module)
+        checks.append(
+            DoctorCheck(
+                f"Python: {module}",
+                "PASS" if present else "FAIL",
+                f"importable ({role})"
+                if present
+                else f"not importable — required for {role}",
+            )
+        )
+    gmsh_present = _module_available("gmsh")
+    checks.append(
+        DoctorCheck(
+            "Python: gmsh",
+            "PASS" if gmsh_present else "WARN",
+            "importable (meshing)"
+            if gmsh_present
+            else "not importable — install with 'uv sync --extra solvers'",
+        )
+    )
+
+    # --- output root writability (env spec §6) ---------------------------
+    target = Path(output_dir) if output_dir is not None else DEFAULT_OUTPUT_ROOT
+    checks.append(_check_writable(target))
+
+    # --- threads / memory guidance ---------------------------------------
+    cpu = os.cpu_count() or 1
+    mem = _memory_gb()
+    guidance = f"{cpu} CPUs"
+    if mem is not None:
+        guidance += f", {mem} GB RAM"
+    guidance += ". Use decomposePar/MPI for 3D cases; match subdomain count to cores."
+    checks.append(DoctorCheck("Threads/memory", "PASS", guidance))
+
+    # --- overall capability ----------------------------------------------
+    capability = "solver-capable" if core_present and solvers_found else "dry-run-only"
+    checks.append(
+        DoctorCheck(
+            "Host capability",
+            "PASS" if capability == "solver-capable" else "WARN",
+            "solver-capable — cases can be meshed and solved here"
+            if capability == "solver-capable"
+            else (
+                f"dry-run only on this {platform.system()} host — cases will be "
+                "generated but not solved (runner fail-closes to DRY_RUN)"
+            ),
+        )
+    )
+    return checks, capability
+
+
+def _check_writable(target: Path) -> DoctorCheck:
+    """Probe the output root without creating a deep tree if it's absent."""
+    if not target.exists():
+        return DoctorCheck(
+            "Output root",
+            "WARN",
+            f"'{target}' does not exist — create it or pass --output-dir",
+        )
+    try:
+        with tempfile.NamedTemporaryFile(dir=target, prefix=".cfd_doctor_"):
+            pass
+    except OSError as error:
+        return DoctorCheck("Output root", "FAIL", f"'{target}' not writable: {error}")
+    return DoctorCheck("Output root", "PASS", f"'{target}' is writable")
+
+
+def has_failure(checks: list[DoctorCheck]) -> bool:
+    return any(c.status == "FAIL" for c in checks)

--- a/tests/solvers/openfoam/test_doctor.py
+++ b/tests/solvers/openfoam/test_doctor.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Unit tests for the OpenFOAM CFD doctor. OpenFOAM is not required — the
+toolchain probes (shutil.which, importlib, /proc/meminfo) are mocked so both the
+solver-capable and dry-run-only verdicts are exercised deterministically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.solvers.openfoam import doctor as doc
+
+
+def _statuses(checks):
+    return {c.name: c.status for c in checks}
+
+
+class TestDryRunOnlyHost:
+    """No OpenFOAM on PATH -> dry-run-only, but not a hard failure."""
+
+    def test_no_openfoam_is_dry_run_only(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(doc.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(doc, "_module_available", lambda _m: True)
+        checks, capability = doc.run_doctor(output_dir=tmp_path)
+        assert capability == "dry-run-only"
+        # missing solver is a WARN, never a hard FAIL (case-gen still works)
+        assert not doc.has_failure(checks)
+        st = _statuses(checks)
+        assert st["OpenFOAM utilities"] == "WARN"
+        assert st["Host capability"] == "WARN"
+
+
+class TestSolverCapableHost:
+    """All utilities + solvers present -> solver-capable."""
+
+    def test_full_toolchain_is_solver_capable(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(doc.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(doc, "_module_available", lambda _m: True)
+        monkeypatch.setenv("WM_PROJECT_VERSION", "v2406")
+        checks, capability = doc.run_doctor(output_dir=tmp_path)
+        assert capability == "solver-capable"
+        assert not doc.has_failure(checks)
+        st = _statuses(checks)
+        assert st["OpenFOAM utilities"] == "PASS"
+        assert st["OpenFOAM solvers"] == "PASS"
+        assert st["OpenFOAM version"] == "PASS"
+        assert st["Host capability"] == "PASS"
+
+
+class TestHardFailures:
+    """Required Python deps or an unwritable output root are hard FAILs."""
+
+    def test_missing_pyvista_is_hard_failure(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(doc.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            doc, "_module_available", lambda m: m != "pyvista"
+        )
+        checks, _ = doc.run_doctor(output_dir=tmp_path)
+        assert doc.has_failure(checks)
+        assert _statuses(checks)["Python: pyvista"] == "FAIL"
+
+    def test_unwritable_output_root_is_hard_failure(self, monkeypatch):
+        monkeypatch.setattr(doc.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(doc, "_module_available", lambda _m: True)
+        # Point at an existing path, force the write probe to fail.
+        def boom(*_a, **_k):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(doc.tempfile, "NamedTemporaryFile", boom)
+        checks = [doc._check_writable(Path("/"))]
+        assert doc.has_failure(checks)
+        assert checks[0].status == "FAIL"
+
+    def test_absent_output_root_is_warn_not_fail(self, tmp_path: Path):
+        check = doc._check_writable(tmp_path / "does_not_exist")
+        assert check.status == "WARN"
+
+
+class TestMissingGmshIsWarn:
+    """gmsh is optional (meshing) -> WARN, not FAIL."""
+
+    def test_missing_gmsh_warns(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(doc.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(doc, "_module_available", lambda m: m != "gmsh")
+        checks, _ = doc.run_doctor(output_dir=tmp_path)
+        assert _statuses(checks)["Python: gmsh"] == "WARN"
+        assert not doc.has_failure(checks)


### PR DESCRIPTION
Completes **Phase 1** of the CFD epic (#1161). Builds the `cfd doctor` command contracted in the [environment spec §5](https://github.com/vamseeachanta/digitalmodel/blob/main/docs/plans/2026-06-29-cfd-environment-spec.md).

### Why
The runner (#1163) fail-closes to `DRY_RUN` when OpenFOAM is absent — correct, but users had no way to know a host couldn't solve *before* preparing a case. `openfoam doctor` surfaces that readiness up front.

### What
`solvers/openfoam/doctor.py` + `openfoam doctor` CLI command (mirrors `orcawave_doctor`, #613). Reports PASS/WARN/FAIL for:
- OpenFOAM core utilities (`blockMesh`, `foamToVTK`) + at least one solver + version
- the Python stack (`pyvista`/`meshio` required → FAIL if missing; `gmsh` optional → WARN)
- output-root writability (`/mnt/ace/cfd-output`, overridable)
- threads/memory guidance

…then states **solver-capable** vs **dry-run-only**.

**Exit policy:** `0` = host usable (dry-run-only is a supported mode); nonzero = any hard FAIL, or dry-run-only with `--require-solver`. Missing OpenFOAM/gmsh are WARN (case generation still works), never FAIL.

### Verified
Runs correctly on this host — diagnoses it as **dry-run-only** (OpenFOAM not installed → WARN; pyvista/meshio PASS; exit 0):
```
[WARN] OpenFOAM utilities: missing ['blockMesh', 'foamToVTK'] — is the OpenFOAM environment sourced?
[PASS] Python: pyvista: importable
[WARN] Host capability: dry-run only on this Linux host
[OK] Host usable (dry-run-only).
```

### Tests
6 new (toolchain probes mocked — **no OpenFOAM install required**): dry-run-only verdict, solver-capable verdict, hard-FAIL on missing pyvista / unwritable output root, WARN on missing gmsh / absent output root. Full suite **142 green**.

Refs #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)