### PR TITLE
fix(openfoam): runner false-positived every successful OpenFOAM run (banner FPE string)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/runner.py
+++ b/src/digitalmodel/solvers/openfoam/runner.py
@@ -35,10 +35,14 @@ from pathlib import Path
 from typing import Optional
 
 # OpenFOAM utilities can return rc=0 yet write a fatal error to their log.
+# NOTE: do NOT add "Floating point exception" here — OpenFOAM's normal startup
+# banner prints "trapFpe: Floating point exception trapping enabled (FOAM_SIGFPE)."
+# on EVERY successful run, so a substring match false-positives every solve. A
+# real FPE *crash* aborts the process with a non-zero return code, which the
+# return_code != 0 check below already catches.
 _ERROR_MARKERS = (
     "FOAM FATAL ERROR",
     "FOAM FATAL IO ERROR",
-    "Floating point exception",
 )
 # Divergence markers — present in solver logs when the solution blows up.
 _DIVERGENCE_MARKERS = ("bounding", "Maximum number of iterations exceeded")

--- a/tests/solvers/openfoam/test_runner.py
+++ b/tests/solvers/openfoam/test_runner.py
@@ -160,3 +160,31 @@ class TestStagedExecution:
         result = OpenFOAMRunner().run(case)
         assert result.status is OpenFOAMRunStatus.FAILED
         assert "FOAM FATAL ERROR" in result.stages[0].error_message
+
+    def test_benign_sigfpe_banner_is_not_an_error(self, tmp_path: Path, monkeypatch):
+        """Regression: OpenFOAM prints the FPE-trapping banner on EVERY successful
+        run; a substring match on 'Floating point exception' false-positived every
+        solve. rc=0 + banner must be COMPLETED, not FAILED."""
+        case = _make_case(tmp_path, application="simpleFoam")
+        # The exact line real blockMesh/solvers emit at startup.
+        banner = (
+            "Create time\n\n"
+            "trapFpe: Floating point exception trapping enabled (FOAM_SIGFPE).\n"
+            "...\nEnd\n"
+        )
+        self._patch(monkeypatch, returncode=0, stdout=banner)
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.COMPLETED, result.error_message
+        assert all(s.ok for s in result.stages)
+
+    def test_real_fpe_crash_caught_by_return_code(self, tmp_path: Path, monkeypatch):
+        """A genuine FPE crash aborts with a non-zero rc — still caught."""
+        case = _make_case(tmp_path)
+        self._patch(
+            monkeypatch,
+            returncode=136,  # 128 + SIGFPE(8)
+            stdout="trapFpe: Floating point exception trapping enabled (FOAM_SIGFPE).\n",
+        )
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.FAILED
+        assert "136" in result.stages[0].error_message


### PR DESCRIPTION
**Real bug found by running the validation cases against actual OpenFOAM (v2312)** — something the runner's mocked unit tests structurally could not catch.

### Symptom
Every real solve was reported `FAILED` at the first stage, e.g. `blockMesh ... log contains 'Floating point exception'` — even though `blockMesh`/`simpleFoam` completed successfully (rc=0, valid mesh).

### Root cause
`_ERROR_MARKERS` substring-matched `"Floating point exception"` against OpenFOAM's **benign startup banner**, which every utility prints on success:
```
trapFpe: Floating point exception trapping enabled (FOAM_SIGFPE).
```
So the marker false-positived 100% of successful runs. The mocked tests fed synthetic stdout that never contained the real banner.

### Fix
Removed `"Floating point exception"` from the stdout markers. A genuine FPE *crash* aborts the process with a **non-zero return code**, already caught by the `return_code != 0` check — so the string marker was both wrong and redundant. Kept `FOAM FATAL ERROR` / `FOAM FATAL IO ERROR` (those can appear with rc=0).

### Tests (+2 regression)
- benign SIGFPE banner with rc=0 → `COMPLETED`
- real FPE crash (rc=136 = 128+SIGFPE) → `FAILED`
Full runner suite green.

### Verified on real OpenFOAM
After this fix, the flat-plate validation case progresses past `blockMesh` (`ok=True`) into `simpleFoam`. (A separate case-numerics issue — `simpleFoam` diverges at iteration 1 — is filed as a follow-up; it is *not* this runner bug.)

Refs #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)