### PR TITLE
feat(hydro): vessel library + explorer vessel picker (#1207)

### DIFF
--- a/docs/api/hydro/rudder-maneuvering-explorer.html
+++ b/docs/api/hydro/rudder-maneuvering-explorer.html
@@ -54,10 +54,16 @@
   <div class="sub">Low-speed turning, threshold speed &amp; heading-hold under current</div>
 
   <div class="ctl">
+    <label>Vessel</label>
+    <select id="sel-vessel" style="width:100%;padding:7px;border-radius:8px;border:1px solid var(--line);background:var(--soft);color:var(--ink);font-size:12.5px;font-weight:600"></select>
+    <div class="sub" id="vessel-meta" style="margin:5px 0 0"></div>
+  </div>
+
+  <div class="ctl">
     <label>Loading condition</label>
     <div class="seg" id="seg-load">
-      <button data-load="laden" class="on">Laden (T 12.2 m)</button>
-      <button data-load="ballast">Ballast (T 7 m)</button>
+      <button data-load="laden" class="on">Laden <span id="lbl-laden"></span></button>
+      <button data-load="ballast">Ballast <span id="lbl-ballast"></span></button>
     </div>
   </div>
 
@@ -94,7 +100,8 @@
 <main>
   <div class="hero">
     <h2>Low-speed manoeuvring &amp; station-keeping explorer</h2>
-    <p>For a representative single-screw tanker (Lpp ≈ 225 m, beam ≈ 32 m, laden draft ≈ 12 m).
+    <p>Pick a vessel in the sidebar — from a VLCC to a harbour tug (two are published
+    manoeuvring-benchmark hulls; the rest are class-typical estimates).
     Answers three operational questions —
     <b>can I turn within the channel?</b> (turning circle vs the IMO 5L limit),
     <b>do I still have steerage?</b> (threshold speed vs wind, by loading),
@@ -119,7 +126,10 @@
     engine-on rudder authority from the Söding/Brix slipstream model
     (yaw ∝ C<sub>rp</sub>·F<sub>prop</sub>·[1+1/√(1+C<sub>th</sub>)]·sinδ);
     current load from the OCIMF form N = C<sub>XYc</sub>·½ρV<sub>c</sub>²·L²·T, F<sub>y</sub> = C<sub>Yc</sub>·½ρV<sub>c</sub>²·L·T.
-    Not a class/IMO compliance proof and not a full MMG/6-DOF model.
+    Not a class/IMO compliance proof and not a full MMG/6-DOF model. Per-vessel K'
+    (turning), windage and ballast rudder-emergence are screening estimates derived
+    from each vessel's geometry. Ducted/gate/twin-rudder vessels carry system side
+    force the bare-rudder lift slope under-predicts.
     Source: <code>naval_architecture/maneuvering_envelope.py</code> and <code>data/rudder_database.yml</code>.
   </div>
 </main>
@@ -127,14 +137,43 @@
 <script>
 // ---- Constants & reference-tanker particulars (generic ~225 m single-screw tanker) ----
 const KN = 0.514444, RHO_W = 1025, RHO_AIR = 1.225, DEG = Math.PI/180;
-const L = 225.5, B = 32.26, X_R = 0.6*L;          // Barrass rudder lever 135.3 m
-const KP_LADEN = 1.02;                             // calibrated Nomoto K' (laden, 35deg -> TD/L 3.2)
-const C_RP = 0.5, T_DED = 0.2, W_WAKE = 0.25, D_PROP = 7.0; // propulsion
+const C_RP = 0.5, T_DED = 0.2, W_WAKE = 0.25, D_PROP = 7.0; // nominal single-screw propulsion
 const KT = [0.35, -0.30];                          // K_T = 0.35 - 0.30 J  (representative)
-const COND = {
-  laden:   {T:12.2, A_Re:44.94, span:9.0, A_L:2200, label:'Laden'},
-  ballast: {T:7.0,  A_Re:35.0,  span:8.0, A_L:3500, label:'Ballast'}
+
+// Vessel library (geometry from research; benchmark hulls carry published data,
+// others are class-typical estimates — see rudder_database.yml seed_vessels).
+// Derived screening quantities (K', windage A_L, ballast effective rudder area)
+// are computed from the geometry below via documented rules in applyVessel().
+const VESSELS = {
+  generic:      {name:'Generic single-screw tanker (~225 m)', L:225.5,area:44.94,span:9.0,Tlad:12.2,Tbal:7.0,type:'spade / semi-balanced'},
+  esso_osaka:   {name:'Esso Osaka — VLCC (benchmark)',        L:325.0,area:119.8,span:12.0,Tlad:21.8,Tbal:9.0,type:'semi-balanced horn', bench:true},
+  kvlcc2:       {name:'KVLCC2 — VLCC (benchmark)',            L:320.0,area:136.7,span:15.0,Tlad:20.8,Tbal:8.5,type:'semi-balanced horn', bench:true},
+  suezmax:      {name:'Suezmax crude tanker',                 L:264.0,area:82.0,span:10.5,Tlad:17.0,Tbal:8.0,type:'semi-balanced horn'},
+  aframax:      {name:'Aframax crude tanker',                 L:239.0,area:66.0,span:9.5,Tlad:14.9,Tbal:7.5,type:'spade'},
+  lr1:          {name:'LR1 / Panamax product tanker',         L:225.0,area:43.0,span:8.5,Tlad:12.5,Tbal:7.0,type:'spade'},
+  handysize:    {name:'Handysize product tanker',             L:176.0,area:31.0,span:7.0,Tlad:11.0,Tbal:6.0,type:'spade'},
+  capesize:     {name:'Capesize bulk carrier',                L:279.0,area:84.0,span:10.5,Tlad:18.2,Tbal:8.5,type:'semi-balanced horn'},
+  container:    {name:'Post-Panamax container ship',          L:320.0,area:67.0,span:11.0,Tlad:14.5,Tbal:9.0,type:'twisted spade'},
+  gate:         {name:'Feeder w/ gate rudder (Shigenobu-type)',L:165.0,area:30.0,span:6.5,Tlad:8.6,Tbal:5.5,type:'gate rudder', sys:true},
+  ropax:        {name:'ROPAX ferry (twin-screw)',             L:195.0,area:14.0,span:5.5,Tlad:7.1,Tbal:6.3,type:'flap / Becker', twin:true},
+  tug_schilling:{name:'Escort tug (Schilling)',               L:28.0,area:5.5,span:2.6,Tlad:4.2,Tbal:4.0,type:'Schilling', sys:true},
+  tug_nozzle:   {name:'Harbour tug (Kort nozzle)',            L:26.0,area:4.0,span:2.2,Tlad:3.8,Tbal:3.6,type:'Kort nozzle', sys:true},
 };
+// Mutable per-vessel state (set by applyVessel).
+let L, X_R, KP, COND, VESSEL;
+function applyVessel(id){
+  const v = VESSELS[id]; VESSEL = v;
+  L = v.L; X_R = 0.6 * v.L;                          // Barrass rudder lever ~0.6 Lpp
+  const arRatio = v.area / (v.L * v.Tlad);           // rudder area ratio A_R/(L*T)
+  KP = Math.max(0.6, Math.min(1.6, 1.02 * arRatio / 0.0163)); // K' tied to area ratio (screening)
+  const aReBal = v.area * 0.78;                      // ballast rudder emergence (~78%, screening)
+  const aLlad = v.L * v.Tlad * 0.75;                 // windage ~= 0.75x underwater lateral area (screening)
+  COND = {
+    laden:   {T:v.Tlad, A_Re:v.area,  span:v.span, A_L:aLlad, label:'Laden'},
+    ballast: {T:v.Tbal, A_Re:aReBal, span:v.span, A_L:aLlad + v.L*(v.Tlad-v.Tbal), label:'Ballast'}
+  };
+}
+applyVessel('generic');
 // Plot palette tuned for a LIGHT background (matches capabilities house style).
 const CLR = {teal:'#0f8a7e', blue:'#1f6feb', red:'#d1242f', amber:'#b7791f',
              now:'#0B3D91', ship:'#7a1fa2'};
@@ -172,7 +211,7 @@ const axStyle = {gridcolor:'#dbe4f0', zerolinecolor:'#c5d2e6', linecolor:'#c5d2e
 
 function recompute(){
   const c = COND[S.load];
-  const Kp = S.load==='laden' ? KP_LADEN : KP_LADEN*Math.sqrt(c.A_Re/COND.laden.A_Re);
+  const Kp = S.load==='laden' ? KP : KP*Math.sqrt(c.A_Re/COND.laden.A_Re);
   const RoverL = steadyRoverL(Kp, S.rud), TDoverL = 2*RoverL;
   const TD = TDoverL*L;
   const Vs = S.spd*KN, Vc = S.cur*KN, Vw = S.wnd*KN, Fprop = S.thr*1000;
@@ -288,6 +327,23 @@ bind('r-hdg','hdg','v-hdg',0);bind('r-wnd','wnd','v-wnd',0);bind('r-thr','thr','
 document.querySelectorAll('#seg-load button').forEach(b=>b.addEventListener('click',()=>{
   document.querySelectorAll('#seg-load button').forEach(x=>x.classList.remove('on'));
   b.classList.add('on');S.load=b.dataset.load;render();}));
+
+// Vessel picker
+function updateVesselUI(){
+  const v = VESSEL;
+  document.getElementById('lbl-laden').textContent = `(T ${v.Tlad} m)`;
+  document.getElementById('lbl-ballast').textContent = `(T ${v.Tbal} m)`;
+  const tag = v.bench ? 'published geometry' : 'class-typical estimate';
+  let flag = v.twin ? ' · twin-screw (single-screw model approximates)' :
+             v.sys ? ' · system side force (bare-rudder lift under-predicts)' : '';
+  document.getElementById('vessel-meta').innerHTML =
+    `Lpp ${v.L} m · rudder ${v.area} m² / ${v.span} m span · ${v.type} · <em>${tag}</em>${flag}`;
+}
+const sel = document.getElementById('sel-vessel');
+sel.innerHTML = Object.keys(VESSELS).map(k=>`<option value="${k}">${VESSELS[k].name}</option>`).join('');
+sel.value = 'generic';
+sel.addEventListener('change', ()=>{ applyVessel(sel.value); updateVesselUI(); render(); });
+updateVesselUI();
 render();
 window.addEventListener('resize',()=>['p-turn','p-thresh','p-hold','p-curr'].forEach(p=>Plotly.Plots.resize(p)));
 </script>

--- a/src/digitalmodel/naval_architecture/data/rudder_database.yml
+++ b/src/digitalmodel/naval_architecture/data/rudder_database.yml
@@ -143,3 +143,169 @@ worked_example_sirocco:
   loading_notes:
     laden: Full rudder immersion; maximum control authority; lowest steerage threshold.
     ballast: Reduced rudder immersion + propeller emergence; effective area ~35 m2 (~78%); higher windage. Stern trim used to restore immersion.
+
+# Seed vessels for the manoeuvring explorer's vessel picker + type illustration.
+# tag: PUB = published/benchmark value ; EST = engineering estimate.
+# rudder_projected_area_m2 for EST vessels ~= DNV rule (Lpp*T/100)(1+25(B/Lpp)^2).
+# Ballast drafts, unpublished Cb, and rudder spans are estimates. Two benchmark
+# hulls (Esso Osaka, KVLCC2) carry published geometry. No client/project vessels.
+seed_vessels:
+  - id: esso_osaka
+    display_name: Esso Osaka
+    vessel_class: VLCC crude tanker (278,000 dwt) — classic manoeuvring benchmark
+    lbp_m: 325.0            # PUB
+    beam_m: 53.0            # PUB
+    draft_laden_m: 21.79    # PUB (full load, even keel)
+    draft_ballast_m: 9.0    # EST
+    Cb: 0.831              # PUB
+    rudder_type: semi_balanced_horn      # PUB (Mariner-type horn rudder)
+    rudder_projected_area_m2: 119.8      # PUB (Crane 1979; DNV-rule cross-check 117.9, -1.6%)
+    rudder_span_m: 12.0                  # EST
+    single_screw: true                   # PUB
+    source: "Crane (1979) full-scale trials; ITTC 23rd/24th Manoeuvring Committee benchmark"
+  - id: kvlcc2
+    display_name: KVLCC2 (MOERI benchmark hull)
+    vessel_class: VLCC crude tanker (~300,000 dwt) — SIMMAN benchmark
+    lbp_m: 320.0           # PUB
+    beam_m: 58.0           # PUB
+    draft_laden_m: 20.8    # PUB (design)
+    draft_ballast_m: 8.5   # EST
+    Cb: 0.8098             # PUB
+    rudder_type: semi_balanced_horn      # PUB (horn rudder)
+    rudder_projected_area_m2: 136.7      # PUB (movable/lateral area; NOT the 273.3 total wetted surface)
+    rudder_span_m: 15.0                  # EST
+    single_screw: true                   # PUB
+    source: "MOERI / SIMMAN 2008/2014 benchmark data"
+  - id: suezmax_crude
+    display_name: Suezmax crude tanker (representative)
+    vessel_class: Suezmax crude tanker (~157,000 dwt)
+    lbp_m: 264.0           # EST
+    beam_m: 48.0           # EST
+    draft_laden_m: 17.0    # EST
+    draft_ballast_m: 8.0   # EST
+    Cb: 0.84              # EST
+    rudder_type: semi_balanced_horn
+    rudder_projected_area_m2: 82.0       # EST (DNV rule)
+    rudder_span_m: 10.5                  # EST
+    single_screw: true
+    source: "Class-typical Suezmax particulars; rudder area = DNV area rule"
+  - id: aframax_crude
+    display_name: Aframax crude tanker (representative)
+    vessel_class: Aframax crude tanker (~110,000 dwt)
+    lbp_m: 239.0           # EST
+    beam_m: 44.0           # EST
+    draft_laden_m: 14.9    # EST
+    draft_ballast_m: 7.5   # EST
+    Cb: 0.83              # EST
+    rudder_type: spade
+    rudder_projected_area_m2: 66.0       # EST (DNV rule)
+    rudder_span_m: 9.5                   # EST
+    single_screw: true
+    source: "Class-typical Aframax particulars; rudder area = DNV area rule"
+  - id: lr1_product_tanker
+    display_name: LR1 / Panamax product tanker (representative)
+    vessel_class: LR1 (Panamax) product/crude tanker (~74,000 dwt)
+    lbp_m: 225.0           # EST
+    beam_m: 32.2           # EST (Panamax beam limit)
+    draft_laden_m: 12.5    # EST
+    draft_ballast_m: 7.0   # EST
+    Cb: 0.82              # EST
+    rudder_type: spade
+    rudder_projected_area_m2: 43.0       # EST (DNV rule)
+    rudder_span_m: 8.5                   # EST
+    single_screw: true
+    source: "Class-typical LR1/Panamax product-tanker particulars; rudder area = DNV area rule"
+  - id: handysize_product_tanker
+    display_name: Handysize product tanker (representative)
+    vessel_class: Handysize/MR product tanker (~37,000-40,000 dwt)
+    lbp_m: 176.0           # EST
+    beam_m: 27.4           # EST
+    draft_laden_m: 11.0    # EST
+    draft_ballast_m: 6.0   # EST
+    Cb: 0.80              # EST
+    rudder_type: spade
+    rudder_projected_area_m2: 31.0       # EST (DNV rule)
+    rudder_span_m: 7.0                   # EST
+    single_screw: true
+    source: "Class-typical Handysize/MR particulars; rudder area = DNV area rule"
+  - id: capesize_bulker
+    display_name: Capesize bulk carrier (representative)
+    vessel_class: Capesize bulk carrier (~180,000 dwt)
+    lbp_m: 279.0           # EST
+    beam_m: 45.0           # EST
+    draft_laden_m: 18.2    # EST
+    draft_ballast_m: 8.5   # EST
+    Cb: 0.85              # EST
+    rudder_type: semi_balanced_horn
+    rudder_projected_area_m2: 84.0       # EST (DNV rule)
+    rudder_span_m: 10.5                  # EST
+    single_screw: true
+    source: "Class-typical Capesize particulars; rudder area = DNV area rule"
+  - id: post_panamax_container
+    display_name: Post-Panamax container ship (representative)
+    vessel_class: Post-Panamax container ship (~8,000-8,500 TEU)
+    lbp_m: 320.0           # EST
+    beam_m: 42.8           # EST
+    draft_laden_m: 14.5    # EST
+    draft_ballast_m: 9.0   # EST
+    Cb: 0.65              # EST
+    rudder_type: twisted_leading_edge
+    rudder_projected_area_m2: 67.0       # EST (DNV rule)
+    rudder_span_m: 11.0                  # EST
+    single_screw: true
+    source: "Class-typical Post-Panamax container-ship particulars; rudder area = DNV area rule"
+  - id: gate_rudder_feeder
+    display_name: Feeder container ship with gate rudder (Shigenobu-type)
+    vessel_class: Coastal/feeder container ship, GATE RUDDER-fitted
+    lbp_m: 165.0           # EST
+    beam_m: 27.0           # EST
+    draft_laden_m: 8.6     # EST
+    draft_ballast_m: 5.5   # EST
+    Cb: 0.68              # EST
+    rudder_type: gate_rudder             # real ship "Shigenobu" (2017); blade particulars EST
+    rudder_projected_area_m2: 30.0       # EST (two blades combined)
+    rudder_span_m: 6.5                   # EST (per blade)
+    single_screw: true
+    source: "Shigenobu (2017, first newbuild gate-rudder ship) / EU GATERS project; blade particulars ESTIMATED"
+    note: "Gate rudder provides system side force + thrust vectoring; bare-rudder lift slope under-predicts its low-speed authority."
+  - id: ropax_ferry
+    display_name: Large ROPAX ferry (representative)
+    vessel_class: ROPAX ferry (~210 m LOA), high-lift flap rudders
+    lbp_m: 195.0           # EST
+    beam_m: 30.5           # EST
+    draft_laden_m: 7.1     # EST
+    draft_ballast_m: 6.3   # EST
+    Cb: 0.60              # EST
+    rudder_type: flap_becker
+    rudder_projected_area_m2: 14.0       # EST (per rudder; twin-rudder installation)
+    rudder_span_m: 5.5                   # EST
+    single_screw: false                  # typically twin-screw + twin flap rudders
+    source: "Class-typical large ROPAX; twin-screw/twin high-lift flap rudder; area = EST"
+    note: "Twin-screw/twin-rudder; the single-screw engine-on heading-hold model does not map one-to-one."
+  - id: escort_tug_schilling
+    display_name: Escort/ship-handling tug (Schilling rudder)
+    vessel_class: Single-screw harbour/escort tug (~28 m), high-lift Schilling rudder
+    lbp_m: 28.0            # EST
+    beam_m: 9.5            # EST
+    draft_laden_m: 4.2     # EST
+    draft_ballast_m: 4.0   # EST
+    Cb: 0.56              # EST
+    rudder_type: schilling
+    rudder_projected_area_m2: 5.5        # EST
+    rudder_span_m: 2.6                   # EST
+    single_screw: true
+    source: "Class-typical single-screw ship-handling tug w/ Schilling high-lift rudder; area = EST"
+  - id: harbour_tug_nozzle
+    display_name: Harbour tug (Kort nozzle)
+    vessel_class: Single-screw harbour/berthing tug (~26 m), propeller in Kort nozzle
+    lbp_m: 26.0            # EST
+    beam_m: 8.5            # EST
+    draft_laden_m: 3.8     # EST
+    draft_ballast_m: 3.6   # EST
+    Cb: 0.55              # EST
+    rudder_type: kort_nozzle
+    rudder_projected_area_m2: 4.0        # EST (rudder behind nozzle)
+    rudder_span_m: 2.2                   # EST
+    single_screw: true
+    source: "Class-typical single-screw ducted (Kort 19A) harbour tug; area = EST"
+    note: "Ducted system side force differs from bare-rudder lift; low-speed authority is under-predicted."


### PR DESCRIPTION
Follow-up to #1207. Adds a real-vessel library to the database and a vessel picker to the manoeuvring explorer (you noted the backing data can hold actual ships).

## What
- `rudder_database.yml` — new `seed_vessels` block: 12 vessels spanning VLCC → harbour tug, exercising 7 rudder types. Two are **published manoeuvring benchmark hulls** (Esso Osaka, KVLCC2); the rest are class-typical. Every value tagged **PUB** (published) or **EST** (estimate); EST rudder areas from the DNV area rule (cross-checked to ~2% on Esso Osaka).
- `rudder-maneuvering-explorer.html` — sidebar **vessel picker**. Selecting a vessel switches Lpp / rudder area / span / drafts; per-vessel K′ (turning), windage and ballast rudder-emergence are derived from geometry via **documented screening rules** (shown in the method note). Loading-condition draft labels + a vessel-meta line update per vessel.

## Verification
Ran the picker logic across the range (Node): all vessels finite & sane — **generic default reproduces the prior calibration exactly (K′ 1.02, TD/L 3.20)**; VLCCs ~3.1 L; fine-hulled container ship wider (3.6 L); tug tight (2.05 L) — correct Cb/area-ratio trends. No client/vessel identifiers on the page (0 SIROCCO/B1528). Ducted/gate/twin-rudder vessels are flagged in-UI as carrying system side force the bare-rudder lift slope under-predicts.

Screening-level; benchmark hulls carry published geometry, others are estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)