### PR TITLE
feat(floating_wind): reliability→OPEX driver (#1222)

### DIFF
--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -27,6 +27,11 @@ from .economics import (
     compute_lcoe,
     base_case,
 )
+from .reliability import (
+    ReliabilityScenario,
+    apply_reliability,
+    lcoe_with_reliability,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -46,4 +51,7 @@ __all__ = [
     "LCOEResult",
     "compute_lcoe",
     "base_case",
+    "ReliabilityScenario",
+    "apply_reliability",
+    "lcoe_with_reliability",
 ]

--- a/src/digitalmodel/floating_wind/reliability.py
+++ b/src/digitalmodel/floating_wind/reliability.py
@@ -1,0 +1,104 @@
+"""Reliability -> OPEX driver for floating-wind LCOE (issue #1222).
+
+The single biggest OPEX lever the Wood/Whooley deck identifies is **reliability**:
+the API 17N whole-of-life reliability process, credited with reducing subsea
+failure rates "by an order of magnitude". This module turns a **failure-rate
+reduction** into its LCOE effect, on top of the core engine (:mod:`.economics`,
+issue #1221).
+
+Two physical mechanisms, both driven by the same failure-rate reduction ``r``
+(0 = base reliability, 1 = failures eliminated):
+
+1. **OPEX** -- a fraction :attr:`ReliabilityScenario.failure_related_opex_fraction`
+   of O&M is unplanned/corrective (inspection, repair, mobilisation). Reducing
+   failures cuts that fraction proportionally: ``OPEX(r) = OPEX_0 (1 - phi r)``.
+2. **Availability** -- failures also cost energy (downtime). A base availability
+   loss :attr:`ReliabilityScenario.base_availability_loss` is recovered in
+   proportion to ``r``, raising the effective capacity factor.
+
+Applied to the base case these defaults reproduce the deck's operations
+sensitivity (slide 17): failure-rate reduction of 25 / 50 / 100% ->
+**$173 / $162 / $139 per MWh** (from the $184 base), to <0.5%.
+
+The API 17N Technology Readiness Level (TRL) tags carried here are metadata for
+the technology-qualification gate (issue #1225); they do not alter the LCOE.
+
+References
+----------
+* API RP 17N, *Recommended Practice for Subsea Production System Reliability,
+  Technical Risk, and Integrity Management* -- whole-of-life reliability process.
+* Wood plc / A. Whooley (2021), operations focus-area sensitivity (slide 17).
+* ORE Catapult floating-wind O&M cost breakdown -- corrective/unplanned share.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .economics import LCOEResult, ProjectEconomics, compute_lcoe
+
+__all__ = [
+    "ReliabilityScenario",
+    "apply_reliability",
+    "lcoe_with_reliability",
+]
+
+
+class ReliabilityScenario(BaseModel):
+    """A failure-rate reduction and how it maps to OPEX and availability.
+
+    The two coefficients are calibrated so the base case reproduces the deck's
+    operations sensitivity; both are inputs and can be overridden per project.
+    """
+
+    failure_rate_reduction: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Fractional reduction in failure rate vs base (0..1)",
+    )
+    failure_related_opex_fraction: float = Field(
+        0.93,
+        ge=0.0,
+        le=1.0,
+        description="Fraction of OPEX that is failure-driven (unplanned/corrective)",
+    )
+    base_availability_loss: float = Field(
+        0.033,
+        ge=0.0,
+        lt=1.0,
+        description="Energy fraction lost to failure downtime at base reliability",
+    )
+
+    @property
+    def opex_multiplier(self) -> float:
+        """Multiplier applied to OPEX for this failure-rate reduction."""
+        return 1.0 - self.failure_related_opex_fraction * self.failure_rate_reduction
+
+    @property
+    def availability_gain(self) -> float:
+        """Fractional uplift to energy production from recovered availability."""
+        lam = self.base_availability_loss
+        return lam * self.failure_rate_reduction / (1.0 - lam)
+
+
+def apply_reliability(
+    econ: ProjectEconomics, scenario: ReliabilityScenario
+) -> ProjectEconomics:
+    """Return a copy of ``econ`` with OPEX and capacity factor adjusted.
+
+    OPEX is scaled down by the failure-related fraction; the capacity factor is
+    raised by the recovered availability (capped at 1.0).
+    """
+    new_opex = econ.opex_per_kw_year * scenario.opex_multiplier
+    new_cf = min(1.0, econ.capacity_factor * (1.0 + scenario.availability_gain))
+    return econ.model_copy(
+        update={"opex_per_kw_year": new_opex, "capacity_factor": new_cf}
+    )
+
+
+def lcoe_with_reliability(
+    econ: ProjectEconomics, scenario: ReliabilityScenario
+) -> LCOEResult:
+    """Compute LCOE for ``econ`` under a reliability scenario."""
+    return compute_lcoe(apply_reliability(econ, scenario))

--- a/tests/floating_wind/test_reliability.py
+++ b/tests/floating_wind/test_reliability.py
@@ -1,0 +1,81 @@
+"""Tests for the reliability -> OPEX driver (issue #1222).
+
+Anchor: the deck's operations sensitivity (slide 17) -- failure-rate reduction
+of 25 / 50 / 100% takes the $184 base to $173 / $162 / $139 per MWh.
+"""
+
+import pytest
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.reliability import (
+    ReliabilityScenario,
+    apply_reliability,
+    lcoe_with_reliability,
+)
+
+# Deck slide 17 operations sensitivity.
+_DECK = {0.25: 173.0, 0.50: 162.0, 1.00: 139.0}
+_TOL = 0.02  # +/- 2%
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+@pytest.mark.parametrize("reduction,expected", list(_DECK.items()))
+def test_reproduces_deck_operations_sensitivity(econ, reduction, expected):
+    scenario = ReliabilityScenario(failure_rate_reduction=reduction)
+    lcoe = lcoe_with_reliability(econ, scenario).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(expected, rel=_TOL)
+
+
+def test_zero_reduction_is_base_case(econ):
+    scenario = ReliabilityScenario(failure_rate_reduction=0.0)
+    base = compute_lcoe(econ).lcoe_usd_per_mwh
+    assert lcoe_with_reliability(econ, scenario).lcoe_usd_per_mwh == pytest.approx(
+        base, rel=1e-9
+    )
+
+
+def test_reduction_is_monotonic(econ):
+    lcoes = [
+        lcoe_with_reliability(
+            econ, ReliabilityScenario(failure_rate_reduction=r)
+        ).lcoe_usd_per_mwh
+        for r in (0.0, 0.25, 0.5, 0.75, 1.0)
+    ]
+    assert lcoes == sorted(lcoes, reverse=True)  # strictly decreasing
+
+
+def test_apply_reliability_cuts_opex_and_lifts_cf(econ):
+    scenario = ReliabilityScenario(failure_rate_reduction=1.0)
+    adj = apply_reliability(econ, scenario)
+    assert adj.opex_per_kw_year < econ.opex_per_kw_year
+    assert adj.capacity_factor > econ.capacity_factor
+    assert adj.capacity_factor <= 1.0
+
+
+def test_availability_gain_capped_at_full_cf():
+    econ = base_case().model_copy(update={"capacity_factor": 0.99})
+    adj = apply_reliability(
+        econ, ReliabilityScenario(failure_rate_reduction=1.0)
+    )
+    assert adj.capacity_factor == pytest.approx(1.0)
+
+
+def test_multipliers():
+    s = ReliabilityScenario(
+        failure_rate_reduction=0.5,
+        failure_related_opex_fraction=0.8,
+        base_availability_loss=0.10,
+    )
+    assert s.opex_multiplier == pytest.approx(1.0 - 0.8 * 0.5)
+    assert s.availability_gain == pytest.approx(0.10 * 0.5 / 0.90)
+
+
+def test_reduction_out_of_range_rejected():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ReliabilityScenario(failure_rate_reduction=1.5)


### PR DESCRIPTION
Closes #1222. Part of epic #1220. **Stacked on #1227 (#1221 engine)** — base branch is `feat/fow-lcoe-economics-1221`; GitHub will retarget to `main` once #1227 merges.

## What
Turns an **API 17N failure-rate reduction** into its LCOE effect, using the #1221 engine. Two physical mechanisms driven by the same reduction `r`:
1. **OPEX** — cut the failure-driven fraction (`OPEX(r) = OPEX_0·(1 − φr)`).
2. **Availability** — recover base downtime loss → higher effective capacity factor.

## Validation
Calibrated defaults (φ=0.93 failure-driven OPEX, λ=0.033 availability loss — both defensible for FOW O&M, both YAML-overridable) reproduce the deck's operations sensitivity (slide 17):

| failure-rate reduction | model | deck |
|---|---|---|
| 25% | ~172.6 | 173 |
| 50% | ~161.4 | 162 |
| 100% | ~139.5 | 139 |

Max error <0.5%. `21 passed` (economics + reliability). API 17N TRL tags are carried as metadata for the qualification gate (#1225); they don't alter LCOE.
