### PR TITLE
docs: surface the live capabilities gallery from the README + docs home

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 > runs an engineering workflow and returns a **standards-traceable HTML report URL** — deterministic,
 > built on real code mapped to industry codes and standards (same input, same output, every time).
 > Live API paths → https://aceengineer.com/api-catalog.html · API reference: deckhand `docs/deckhand/API.md`
+>
+> **Explore the capabilities** → https://vamseeachanta.github.io/digitalmodel/capabilities/ — every live surface with a 1-page PDF, a self-contained workflow-API call, and a ready-to-run starting prompt.
 
 Engineering calculation library for offshore, subsea, and marine analysis. Single source of truth from standard clause to validated code.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,8 @@
 # digitalmodel API Reference
 
+> **[Engineering Capabilities →](capabilities/)** — the interactive gallery of every live
+> solver and validated report, each with a 1-page PDF and a self-contained workflow-API call.
+
 Auto-generated from source docstrings.
 
 ## Engine


### PR DESCRIPTION
The capabilities page wasn't reachable by browsing (not linked from the README or the docs homepage). Adds a live link in the README banner and a prominent link atop `docs/api/index.md` (the mkdocs site root). `mkdocs build --strict` passes; the link resolves to `site/capabilities/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)