### PR TITLE
feat(floating_wind): cost-driver sensitivity sweep (#1223)

### DIFF
--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -27,6 +27,13 @@ from .economics import (
     compute_lcoe,
     base_case,
 )
+from .sweep import (
+    LeverChange,
+    DriverScenario,
+    SweepRow,
+    apply_change,
+    run_sweep,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -46,4 +53,9 @@ __all__ = [
     "LCOEResult",
     "compute_lcoe",
     "base_case",
+    "LeverChange",
+    "DriverScenario",
+    "SweepRow",
+    "apply_change",
+    "run_sweep",
 ]

--- a/src/digitalmodel/floating_wind/sweep.py
+++ b/src/digitalmodel/floating_wind/sweep.py
@@ -1,0 +1,160 @@
+"""Cost-driver sensitivity sweep for floating-wind LCOE (issue #1223).
+
+The Wood/Whooley deck frames the cost-reduction story as a set of **driver
+sensitivities** on LCOE -- design life, turbine/farm size, fabrication cost,
+installation vessel rates, capacity factor -- taken individually and in
+combination. This module runs those sweeps against the core engine
+(:mod:`.economics`, issue #1221): apply one or more **lever changes** to a base
+project, recompute LCOE, and roll the results into a tidy table with the delta
+versus base.
+
+A lever change targets any numeric input by dotted path -- a top-level field
+(``capacity_factor``), a financial field (``financial.design_life_years``) or a
+CAPEX component (``capex.substructure``) -- and either scales it (relative) or
+sets it (absolute). Scenarios combine several changes, so a single call can
+reproduce the deck's compound pathways as well as one-lever sensitivities.
+
+Reproduced deck single-driver points (base $184/MWh), each within +/-2%:
+
+===========================  =======  ====
+lever                        deck     model
+===========================  =======  ====
+design life 25 -> 30 yr      $178     ~176
+substructure CAPEX -25%      $172     ~174
+substructure CAPEX -50%      $161     ~164
+turbine CAPEX -25%           $173     ~174
+turbine CAPEX -50%           $162     ~163
+installation cost -50%       $177     ~174
+===========================  =======  ====
+
+Note: the deck's *vessel-rate* lever is a sub-fraction of the bundled
+``installation`` CAPEX line (which also carries commissioning), so scaling the
+whole line up (e.g. doubling) overshoots; the sign is always correct. Turbine-
+size economies of scale (the deck's $51/MWh 2040 pathway) need a turbine-size
+cost-scaling assumption and are out of scope for this tier.
+
+References
+----------
+* Wood plc / A. Whooley (2021) -- cost-driver sensitivities (slides 5-8, 15-17).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from .economics import ProjectEconomics, compute_lcoe
+
+__all__ = [
+    "LeverChange",
+    "DriverScenario",
+    "SweepRow",
+    "apply_change",
+    "run_sweep",
+]
+
+# Fields that live one level down, keyed by their sub-model attribute.
+_NESTED_GROUPS = ("financial", "capex")
+
+
+class LeverChange(BaseModel):
+    """A single change to one numeric input, by dotted ``path``.
+
+    Exactly one of ``scale`` (relative multiplier) or ``value`` (absolute) must
+    be given.
+    """
+
+    path: str = Field(
+        ...,
+        description="Dotted field path, e.g. 'capex.substructure' or 'capacity_factor'",
+    )
+    scale: float | None = Field(None, description="Relative multiplier (e.g. 0.75)")
+    value: float | None = Field(None, description="Absolute replacement value")
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "LeverChange":
+        if (self.scale is None) == (self.value is None):
+            raise ValueError("provide exactly one of 'scale' or 'value'")
+        return self
+
+
+class DriverScenario(BaseModel):
+    """A named set of lever changes applied together."""
+
+    name: str
+    changes: list[LeverChange] = Field(default_factory=list)
+
+
+class SweepRow(BaseModel):
+    """One scenario's result."""
+
+    name: str
+    lcoe_usd_per_mwh: float
+    delta_vs_base: float
+    pct_vs_base: float
+
+
+def _split(path: str) -> tuple[str | None, str]:
+    """Split a dotted path into (group, field). group is None for top level."""
+    if "." in path:
+        group, field = path.split(".", 1)
+        if group not in _NESTED_GROUPS or "." in field:
+            raise ValueError(f"unsupported field path: {path!r}")
+        return group, field
+    return None, path
+
+
+def _current(econ: ProjectEconomics, group: str | None, field: str) -> float:
+    obj = getattr(econ, group) if group else econ
+    if not hasattr(obj, field):
+        raise ValueError(f"unknown field: {field!r}")
+    return getattr(obj, field)
+
+
+def apply_change(econ: ProjectEconomics, change: LeverChange) -> ProjectEconomics:
+    """Return a copy of ``econ`` with a single lever change applied."""
+    group, field = _split(change.path)
+    if change.value is not None:
+        new_val: Any = change.value
+    else:
+        new_val = _current(econ, group, field) * change.scale
+    # Preserve int-typed fields (e.g. design_life_years).
+    if isinstance(_current(econ, group, field), int) and not isinstance(
+        new_val, bool
+    ):
+        new_val = round(new_val)
+
+    if group is None:
+        return econ.model_copy(update={field: new_val})
+    sub = getattr(econ, group).model_copy(update={field: new_val})
+    return econ.model_copy(update={group: sub})
+
+
+def _apply_scenario(
+    econ: ProjectEconomics, scenario: DriverScenario
+) -> ProjectEconomics:
+    out = econ
+    for change in scenario.changes:
+        out = apply_change(out, change)
+    return out
+
+
+def run_sweep(
+    base: ProjectEconomics, scenarios: list[DriverScenario]
+) -> list[SweepRow]:
+    """Run each scenario against ``base`` and tabulate LCOE vs the base case."""
+    base_lcoe = compute_lcoe(base).lcoe_usd_per_mwh
+    rows: list[SweepRow] = []
+    for scenario in scenarios:
+        lcoe = compute_lcoe(_apply_scenario(base, scenario)).lcoe_usd_per_mwh
+        delta = lcoe - base_lcoe
+        rows.append(
+            SweepRow(
+                name=scenario.name,
+                lcoe_usd_per_mwh=lcoe,
+                delta_vs_base=delta,
+                pct_vs_base=100.0 * delta / base_lcoe,
+            )
+        )
+    return rows

--- a/tests/floating_wind/test_sweep.py
+++ b/tests/floating_wind/test_sweep.py
@@ -1,0 +1,123 @@
+"""Tests for the cost-driver sensitivity sweep (issue #1223).
+
+Anchors: the deck's single-driver sensitivities (slides 7, 15, 16) that the
+core engine reproduces within +/-2%. Vessel-rate *doubling* is asserted for
+sign only (it scales the bundled installation line; see module docstring).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.sweep import (
+    DriverScenario,
+    LeverChange,
+    apply_change,
+    run_sweep,
+)
+
+_TOL = 0.02
+
+# Deck single-driver points reproduced within +/-2%.
+_DECK_SCENARIOS = [
+    (DriverScenario(
+        name="design_life_30yr",
+        changes=[LeverChange(path="financial.design_life_years", value=30)],
+    ), 178.0),
+    (DriverScenario(
+        name="substructure_-25%",
+        changes=[LeverChange(path="capex.substructure", scale=0.75)],
+    ), 172.0),
+    (DriverScenario(
+        name="substructure_-50%",
+        changes=[LeverChange(path="capex.substructure", scale=0.50)],
+    ), 161.0),
+    (DriverScenario(
+        name="turbine_-25%",
+        changes=[LeverChange(path="capex.turbine", scale=0.75)],
+    ), 173.0),
+    (DriverScenario(
+        name="turbine_-50%",
+        changes=[LeverChange(path="capex.turbine", scale=0.50)],
+    ), 162.0),
+    (DriverScenario(
+        name="installation_-50%",
+        changes=[LeverChange(path="capex.installation", scale=0.50)],
+    ), 177.0),
+]
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+@pytest.mark.parametrize(
+    "scenario,expected", _DECK_SCENARIOS, ids=[s.name for s, _ in _DECK_SCENARIOS]
+)
+def test_reproduces_deck_single_driver(econ, scenario, expected):
+    (row,) = run_sweep(econ, [scenario])
+    assert row.lcoe_usd_per_mwh == pytest.approx(expected, rel=_TOL)
+
+
+def test_sweep_row_delta_and_pct(econ):
+    base = compute_lcoe(econ).lcoe_usd_per_mwh
+    (row,) = run_sweep(
+        econ,
+        [DriverScenario(name="cf_up", changes=[LeverChange(path="capacity_factor", value=0.60)])],
+    )
+    assert row.lcoe_usd_per_mwh < base
+    assert row.delta_vs_base == pytest.approx(row.lcoe_usd_per_mwh - base)
+    assert row.pct_vs_base == pytest.approx(100.0 * row.delta_vs_base / base)
+
+
+def test_vessel_rate_doubling_sign_only(econ):
+    """Doubling the bundled installation line raises LCOE (magnitude approx)."""
+    base = compute_lcoe(econ).lcoe_usd_per_mwh
+    (row,) = run_sweep(
+        econ,
+        [DriverScenario(name="install_x2", changes=[LeverChange(path="capex.installation", scale=2.0)])],
+    )
+    assert row.lcoe_usd_per_mwh > base
+
+
+def test_combined_levers_apply_together(econ):
+    """A scenario with several changes reproduces a compound reduction."""
+    scenario = DriverScenario(
+        name="fab_and_life",
+        changes=[
+            LeverChange(path="capex.substructure", scale=0.5),
+            LeverChange(path="capex.turbine", scale=0.75),
+            LeverChange(path="financial.design_life_years", value=30),
+        ],
+    )
+    (row,) = run_sweep(econ, [scenario])
+    # Each lever cuts LCOE; combined must beat any single one.
+    singles = run_sweep(econ, [DriverScenario(name=c.path, changes=[c]) for c in scenario.changes])
+    assert row.lcoe_usd_per_mwh < min(s.lcoe_usd_per_mwh for s in singles)
+
+
+def test_apply_change_preserves_int_field(econ):
+    changed = apply_change(econ, LeverChange(path="financial.design_life_years", scale=1.2))
+    assert isinstance(changed.financial.design_life_years, int)
+    assert changed.financial.design_life_years == 30  # round(25*1.2)
+
+
+def test_apply_change_does_not_mutate_original(econ):
+    before = econ.capex.substructure
+    apply_change(econ, LeverChange(path="capex.substructure", scale=0.5))
+    assert econ.capex.substructure == before
+
+
+def test_lever_requires_exactly_one_operation():
+    with pytest.raises(ValidationError):
+        LeverChange(path="capacity_factor")  # neither
+    with pytest.raises(ValidationError):
+        LeverChange(path="capacity_factor", scale=0.9, value=0.5)  # both
+
+
+def test_unknown_path_rejected(econ):
+    with pytest.raises(ValueError):
+        apply_change(econ, LeverChange(path="capex.nonesuch", scale=0.5))
+    with pytest.raises(ValueError):
+        apply_change(econ, LeverChange(path="a.b.c", scale=0.5))


### PR DESCRIPTION
Closes #1223. Part of epic #1220. **Stacked on #1227 (#1221 engine)** — base branch `feat/fow-lcoe-economics-1221`; auto-retargets to `main` when #1227 merges.

## What
A cost-driver sensitivity sweep on the #1221 engine. A `LeverChange` targets any numeric input by dotted path (`capex.substructure`, `financial.design_life_years`, `capacity_factor`) and scales or sets it; a `DriverScenario` combines several; `run_sweep()` tabulates LCOE + delta-vs-base. Single-lever *and* compound pathways in one call.

## Validation — deck single-driver points (base $184), each within ±2%
| lever | deck | model |
|---|---|---|
| design life 25→30 yr | $178 | ~176 |
| substructure CAPEX −25% | $172 | ~174 |
| substructure CAPEX −50% | $161 | ~164 |
| turbine CAPEX −25% | $173 | ~174 |
| turbine CAPEX −50% | $162 | ~163 |
| installation −50% | $177 | ~174 |

`25 passed`. **Honest scoping:** the deck's *vessel-rate* lever is a sub-fraction of the bundled `installation` CAPEX line, so doubling the whole line overshoots — asserted sign-only, documented. Turbine-size economies of scale (the $51/MWh 2040 pathway) need a turbine-size cost-scaling assumption and are deliberately out of this tier's scope.
