### PR TITLE
feat(floating_wind): LCOE as a trade-space objective (#1224)

### DIFF
--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -51,6 +51,13 @@ from .qualification import (
     rank_concepts,
     default_criteria,
 )
+from .tradespace_economics import (
+    LCOE_METRIC_KEY,
+    variant_lcoe,
+    mean_steel_mass_t,
+    lcoe_records,
+    pareto_front_with_lcoe,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -88,4 +95,9 @@ __all__ = [
     "score_concept",
     "rank_concepts",
     "default_criteria",
+    "LCOE_METRIC_KEY",
+    "variant_lcoe",
+    "mean_steel_mass_t",
+    "lcoe_records",
+    "pareto_front_with_lcoe",
 ]

--- a/src/digitalmodel/floating_wind/tradespace_economics.py
+++ b/src/digitalmodel/floating_wind/tradespace_economics.py
@@ -1,0 +1,144 @@
+"""LCOE as a first-class trade-space objective (issue #1224).
+
+The concept-screening trade space (:mod:`.tradespace`, issue #1026) ranks
+variants on *physical* objectives -- steel mass, peak motion, stability margin.
+This module adds the **economics axis**: it attaches an ``lcoe_usd_per_mwh``
+metric to each variant record (via the core engine, :mod:`.economics`, issue
+#1221) so the Pareto front can trade **cost against feasibility**, which is the
+whole point of the Wood/Whooley "multi-dimensional evaluation" (slide 11).
+
+Variant -> LCOE mapping
+-----------------------
+A screening variant differs from the base project mainly in the **floater**, and
+the dominant floater cost driver is hull **steel mass**. So each variant's LCOE
+is the base project economics with the *substructure* CAPEX scaled by the
+variant's steel mass relative to a reference::
+
+    substructure_$/kW(variant) = base.substructure_$/kW * steel_mass_t / ref_t
+
+All other cost bases (turbine, mooring, cables, OPEX, financial) come from the
+base :class:`.economics.ProjectEconomics`. The reference steel mass defaults to
+the mean over the (feasible) variant set, so LCOE differences across the trade
+space reflect relative hull cost; pass ``reference_steel_mass_t`` to anchor it
+to a known design.
+
+The Pareto machinery (dominance, objective coercion) is reused from
+:mod:`.tradespace` unchanged -- this module only enriches the records, so a
+mixed objective set like ``[("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")]``
+just works.
+
+References
+----------
+* Wood plc / A. Whooley (2021), technology selection / multi-dimensional
+  evaluation (slide 11).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from digitalmodel.floating_wind.economics import ProjectEconomics, compute_lcoe
+from digitalmodel.floating_wind.screening import ScreeningResults, VariantScreening
+from digitalmodel.floating_wind.tradespace import (
+    Objective,
+    _coerce_objectives,
+    _dominates,
+    _variants,
+    variant_metrics,
+)
+
+__all__ = [
+    "LCOE_METRIC_KEY",
+    "variant_lcoe",
+    "mean_steel_mass_t",
+    "lcoe_records",
+    "pareto_front_with_lcoe",
+]
+
+LCOE_METRIC_KEY = "lcoe_usd_per_mwh"
+
+
+def variant_lcoe(
+    variant: VariantScreening,
+    base_econ: ProjectEconomics,
+    *,
+    reference_steel_mass_t: float,
+) -> float:
+    """LCOE ($/MWh) for one variant, scaling substructure CAPEX by steel mass."""
+    if reference_steel_mass_t <= 0.0:
+        raise ValueError("reference_steel_mass_t must be > 0")
+    scale = variant.properties.steel_mass_t / reference_steel_mass_t
+    capex = base_econ.capex.model_copy(
+        update={"substructure": base_econ.capex.substructure * scale}
+    )
+    return compute_lcoe(base_econ.model_copy(update={"capex": capex})).lcoe_usd_per_mwh
+
+
+def mean_steel_mass_t(variants: Iterable[VariantScreening]) -> float:
+    """Mean hull steel mass over ``variants`` (the default LCOE reference)."""
+    masses = [v.properties.steel_mass_t for v in variants]
+    if not masses:
+        raise ValueError("no variants to derive a reference steel mass from")
+    return sum(masses) / len(masses)
+
+
+def lcoe_records(
+    results: ScreeningResults | Iterable[VariantScreening],
+    base_econ: ProjectEconomics,
+    *,
+    reference_steel_mass_t: float | None = None,
+    feasible_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Metric records enriched with an ``lcoe_usd_per_mwh`` column."""
+    variants = _variants(results)
+    if feasible_only:
+        variants = [v for v in variants if v.feasible]
+    if not variants:
+        return []
+    ref = (
+        reference_steel_mass_t
+        if reference_steel_mass_t is not None
+        else mean_steel_mass_t(variants)
+    )
+    records: list[dict[str, Any]] = []
+    for v in variants:
+        rec = variant_metrics(v)
+        rec[LCOE_METRIC_KEY] = variant_lcoe(v, base_econ, reference_steel_mass_t=ref)
+        records.append(rec)
+    return records
+
+
+def pareto_front_with_lcoe(
+    results: ScreeningResults | Iterable[VariantScreening],
+    base_econ: ProjectEconomics,
+    objectives: list[Objective] | list[tuple[str, str]] | list[dict],
+    *,
+    reference_steel_mass_t: float | None = None,
+    passed_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Non-dominated records over ``objectives``, with LCOE available as a key.
+
+    Identical semantics to :func:`.tradespace.pareto_front`, but records carry
+    ``lcoe_usd_per_mwh`` so it can appear among the objectives, e.g.
+    ``[("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")]``.
+    """
+    objs = _coerce_objectives(objectives)
+    records = lcoe_records(
+        results,
+        base_econ,
+        reference_steel_mass_t=reference_steel_mass_t,
+        feasible_only=True,
+    )
+    if passed_only:
+        records = [r for r in records if r.get("passed")]
+
+    front: list[dict[str, Any]] = []
+    for i, rec in enumerate(records):
+        dominated = any(
+            _dominates(other, rec, objs)
+            for j, other in enumerate(records)
+            if j != i
+        )
+        if not dominated:
+            front.append(rec)
+    return front

--- a/tests/floating_wind/test_tradespace_economics.py
+++ b/tests/floating_wind/test_tradespace_economics.py
@@ -1,0 +1,140 @@
+"""Tests for LCOE as a trade-space objective (issue #1224).
+
+Builds lightweight screening variants that differ in hull steel mass and checks
+that LCOE tracks steel mass, that the Pareto front mixes LCOE with a physical
+objective, and that the base engine's LCOE is recovered at the reference mass.
+"""
+
+import pytest
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.floaters import FloaterArchetype, FloaterProperties
+from digitalmodel.floating_wind.screening import VariantScreening
+from digitalmodel.floating_wind.tradespace_economics import (
+    LCOE_METRIC_KEY,
+    lcoe_records,
+    mean_steel_mass_t,
+    pareto_front_with_lcoe,
+    variant_lcoe,
+)
+
+
+def _props(steel_mass_t: float) -> FloaterProperties:
+    """A plausible semi FloaterProperties differing only in steel mass."""
+    return FloaterProperties(
+        archetype=FloaterArchetype.SEMI,
+        draft_m=20.0,
+        displacement_t=16000.0,
+        steel_mass_t=steel_mass_t,
+        ballast_mass_t=2000.0,
+        topside_mass_t=2280.0,
+        total_mass_t=steel_mass_t + 4280.0,
+        waterplane_area_m2=350.0,
+        KB_m=10.0,
+        BM_m=25.0,
+        KG_m=18.0,
+        GM_m=17.0,
+        heave_natural_period_s=20.0,
+        pitch_natural_period_s=28.0,
+        pitch_radius_gyration_m=30.0,
+        tendon_stabilised=False,
+        feasible=True,
+    )
+
+
+def _variant(case_id: str, steel_mass_t: float, *, passed: bool = True) -> VariantScreening:
+    return VariantScreening(
+        case_id=case_id,
+        archetype=FloaterArchetype.SEMI,
+        params={"steel_mass_t": steel_mass_t},
+        properties=_props(steel_mass_t),
+        checks=[],
+        feasible=True,
+        passed=passed,
+        governing_check="stability",
+        governing_margin=1.2,
+    )
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+@pytest.fixture
+def variants():
+    return [
+        _variant("light", 3000.0),
+        _variant("mid", 4000.0),
+        _variant("heavy", 5000.0),
+    ]
+
+
+def test_lcoe_at_reference_mass_equals_base(econ):
+    """A variant at exactly the reference steel mass reproduces the base LCOE."""
+    v = _variant("ref", 4000.0)
+    lcoe = variant_lcoe(v, econ, reference_steel_mass_t=4000.0)
+    assert lcoe == pytest.approx(compute_lcoe(econ).lcoe_usd_per_mwh, rel=1e-9)
+
+
+def test_heavier_hull_costs_more(econ):
+    ref = 4000.0
+    light = variant_lcoe(_variant("l", 3000.0), econ, reference_steel_mass_t=ref)
+    heavy = variant_lcoe(_variant("h", 5000.0), econ, reference_steel_mass_t=ref)
+    assert light < heavy
+
+
+def test_lcoe_records_attach_metric(econ, variants):
+    recs = lcoe_records(variants, econ)
+    assert all(LCOE_METRIC_KEY in r for r in recs)
+    assert len(recs) == 3
+    # Ordered light->heavy by construction; LCOE must be increasing.
+    lcoes = [r[LCOE_METRIC_KEY] for r in recs]
+    assert lcoes == sorted(lcoes)
+
+
+def test_mean_steel_mass_reference(variants):
+    assert mean_steel_mass_t(variants) == pytest.approx(4000.0)
+
+
+def test_pareto_front_mixes_lcoe_and_physical(econ, variants):
+    """With LCOE(min) and steel_mass(min) both driven by steel mass, the
+    lightest variant dominates -> a single-point front."""
+    front = pareto_front_with_lcoe(
+        variants,
+        econ,
+        [("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")],
+    )
+    assert len(front) == 1
+    assert front[0]["case_id"] == "light"
+
+
+def test_pareto_front_tradeoff_gives_multiple(econ):
+    """When objectives conflict, the front keeps the non-dominated set."""
+    # Heavier hull (worse LCOE) but better stability margin -> both on the front.
+    a = _variant("cheap_wobbly", 3000.0)
+    b = _variant("dear_stable", 5000.0)
+    b.properties.GM_m = 30.0  # more stable
+    front = pareto_front_with_lcoe(
+        [a, b],
+        econ,
+        [("lcoe_usd_per_mwh", "min"), ("GM_m", "max")],
+    )
+    ids = {r["case_id"] for r in front}
+    assert ids == {"cheap_wobbly", "dear_stable"}
+
+
+def test_passed_only_filter(econ):
+    variants = [
+        _variant("ok", 3500.0, passed=True),
+        _variant("failed", 3000.0, passed=False),
+    ]
+    front = pareto_front_with_lcoe(
+        variants, econ, [("lcoe_usd_per_mwh", "min")], passed_only=True
+    )
+    assert {r["case_id"] for r in front} == {"ok"}
+
+
+def test_zero_reference_rejected(econ):
+    with pytest.raises(ValueError):
+        variant_lcoe(_variant("x", 4000.0), econ, reference_steel_mass_t=0.0)


### PR DESCRIPTION
Closes #1224. Part of epic #1220. Bases on `main` (all prior lanes merged).

## What
Adds **LCOE as a first-class trade-space objective**. A companion module attaches an `lcoe_usd_per_mwh` metric to each screening variant (via the #1221 engine), so the Pareto front can trade **cost × feasibility** — the deck's "multi-dimensional evaluation" (slide 11).

## Design
- **Variant → LCOE:** the base project economics with *substructure* CAPEX scaled by the variant's hull **steel mass** relative to a reference (mean over the feasible set by default; overridable to anchor to a known design). Steel mass is the dominant floater cost driver; all other cost bases come from the base `ProjectEconomics`.
- **Non-invasive:** reuses `tradespace`'s dominance + objective-coercion logic unchanged — `tradespace.py` is **not modified** (zero regression surface). Mixed objectives like `[("lcoe_usd_per_mwh","min"),("steel_mass_t","min")]` just work.

## Validation (run under the full-deps venv)
`8 passed` for this module: LCOE recovers the base at the reference mass, heavier hull → higher LCOE, Pareto front mixes LCOE with a physical objective (conflicting objectives keep both points; aligned ones collapse to one), `passed_only` filter. Full economics-layer suite **53 passed**; existing `test_tradespace.py` **6 passed** (untouched).
