### PR TITLE
feat(floating_wind): tradespace-LCOE + cost data sheet + workflow (#1224, #1226)

### DIFF
--- a/examples/workflows/floating-wind-economics/input.yml
+++ b/examples/workflows/floating-wind-economics/input.yml
@@ -1,0 +1,51 @@
+# Floating-wind LCOE/TOTEX workflow — reproduces the Wood/OREC base case (~$184/MWh)
+# and a few cost-driver sensitivities.
+#
+#   uv run python -m digitalmodel examples/workflows/floating-wind-economics/input.yml
+#
+# Public references only (Wood/Whooley 2021, NREL 2019, ORE Catapult); no client data.
+basename: floating_wind_economics
+
+floating_wind_economics:
+  project:
+    name: wood_orec_base_case_2025
+    turbine_rating_mw: 15.0
+    turbine_count: 33          # -> 495 MW
+    capacity_factor: 0.50
+    water_depth_m: 100.0
+    distance_to_shore_km: 100.0
+    fabrication_region: Europe
+    financial:
+      discount_rate: 0.06
+      inflation_rate: 0.03
+      design_life_years: 25
+    capex:
+      turbine: 2356.0
+      substructure: 2278.0
+      mooring: 707.0
+      array_cable: 393.0
+      export_cable: 628.0
+      installation: 1100.0
+      development: 392.0
+    opex_per_kw_year: 140.0
+    decomex_per_kw: 250.0
+
+  # Optional: API 17N failure-rate reduction (deck slide 17).
+  reliability:
+    failure_rate_reduction: 0.50   # -> ~$162/MWh
+
+  # Optional: cost-driver sensitivities (deck slides 7, 15).
+  sensitivities:
+    - name: design_life_30yr
+      changes:
+        - {path: financial.design_life_years, value: 30}
+    - name: substructure_-50pct
+      changes:
+        - {path: capex.substructure, scale: 0.50}
+    - name: turbine_-25pct
+      changes:
+        - {path: capex.turbine, scale: 0.75}
+
+output:
+  summary_json: results/floating_wind_economics/summary.json
+  data_sheet_html: results/floating_wind_economics/lcoe_data_sheet.html

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -549,6 +549,12 @@ def engine(
         )
 
         cfg_base = FloatingWindSizingWorkflow().router(cfg_base)
+    elif basename == "floating_wind_economics":
+        from digitalmodel.floating_wind.economics_workflow import (
+            FloatingWindEconomicsWorkflow,
+        )
+
+        cfg_base = FloatingWindEconomicsWorkflow().router(cfg_base)
     elif basename == "fpso_mooring_full":
         from digitalmodel.marine_ops.marine_engineering.mooring_analysis.fpso_full_workflow import (
             FPSOMooringFullWorkflow,

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -51,6 +51,13 @@ from .qualification import (
     rank_concepts,
     default_criteria,
 )
+from .tradespace_economics import (
+    LCOE_METRIC_KEY,
+    variant_lcoe,
+    mean_steel_mass_t,
+    lcoe_records,
+    pareto_front_with_lcoe,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -88,4 +95,9 @@ __all__ = [
     "score_concept",
     "rank_concepts",
     "default_criteria",
+    "LCOE_METRIC_KEY",
+    "variant_lcoe",
+    "mean_steel_mass_t",
+    "lcoe_records",
+    "pareto_front_with_lcoe",
 ]

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -58,6 +58,13 @@ from .tradespace_economics import (
     lcoe_records,
     pareto_front_with_lcoe,
 )
+from .economics_report import (
+    LCOEDataSheetData,
+    lcoe_data_sheet,
+    render_lcoe_data_sheet_html,
+    write_lcoe_data_sheet,
+)
+from .economics_workflow import FloatingWindEconomicsWorkflow
 
 __all__ = [
     "RHO_SEAWATER",
@@ -100,4 +107,9 @@ __all__ = [
     "mean_steel_mass_t",
     "lcoe_records",
     "pareto_front_with_lcoe",
+    "LCOEDataSheetData",
+    "lcoe_data_sheet",
+    "render_lcoe_data_sheet_html",
+    "write_lcoe_data_sheet",
+    "FloatingWindEconomicsWorkflow",
 ]

--- a/src/digitalmodel/floating_wind/economics_report.py
+++ b/src/digitalmodel/floating_wind/economics_report.py
@@ -1,0 +1,284 @@
+"""Cost Data Sheet renderer for floating-wind LCOE/TOTEX (issue #1226).
+
+The closing piece of the floating-wind economics epic (#1220): a provenance-aware
+**one-page LCOE / TOTEX data sheet**, built on the *shared reporting backbone*
+(:mod:`digitalmodel.reporting`, issue #1018) -- the same backbone the concept
+data sheet (#1027) uses -- rather than a parallel renderer.
+
+For a :class:`~digitalmodel.floating_wind.economics.ProjectEconomics` and its
+:class:`~digitalmodel.floating_wind.economics.LCOEResult` the sheet presents, in
+order: the headline LCOE, the project & financial inputs, the CAPEX component
+stack, the discounted TOTEX breakdown with the per-MWh split, and -- when a
+cost-driver sweep (#1223) is supplied -- a sensitivity table.
+
+References
+----------
+* digitalmodel reporting block library (#1018) -- shared report backbone.
+* Wood plc / A. Whooley (2021); NREL 2019; ORE Catapult -- cost bases.
+"""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.floating_wind.economics import LCOEResult, ProjectEconomics
+from digitalmodel.floating_wind.sweep import SweepRow
+from digitalmodel.reporting import (
+    ReportBackbone,
+    ReportDataModel,
+    ReportRenderer,
+    ReportSection,
+    SectionMode,
+)
+
+__all__ = [
+    "LCOEDataSheetData",
+    "lcoe_data_sheet",
+    "render_lcoe_data_sheet_html",
+    "write_lcoe_data_sheet",
+    "LCOE_DATA_SHEET_BACKBONE",
+]
+
+
+class LCOEDataSheetData(ReportDataModel):
+    """Envelope for the LCOE/TOTEX data sheet."""
+
+    econ: ProjectEconomics
+    result: LCOEResult
+    sweep_rows: list[SweepRow] = []
+    title: str = "Floating-Wind LCOE / TOTEX Data Sheet"
+    references: tuple[str, ...] = (
+        "Wood plc / A. Whooley (2021), Translating O&G Cost Reduction into Floating Wind",
+        "NREL, 2019 Cost of Wind Energy Review (NREL/TP-5000-78471)",
+        "ORE Catapult, Floating Offshore Wind: Cost Reduction Pathways",
+    )
+
+
+def _num(x: float, fmt: str = ",.2f") -> str:
+    return format(x, fmt)
+
+
+def _section(title: str, body: str, *, anchor: str) -> str:
+    return f'<div class="section" id="{anchor}"><h2>{html.escape(title)}</h2>{body}</div>'
+
+
+def _sec_header(data: LCOEDataSheetData, **_: Any) -> str:
+    e, r = data.econ, data.result
+    return (
+        '<div class="report-header">'
+        f"<h1>{html.escape(data.title)}</h1>"
+        f'<div class="subtitle">{_num(e.turbine_rating_mw, ".0f")} MW '
+        f"× {e.turbine_count} = {_num(e.farm_capacity_mw, ',.0f')} MW "
+        f"· {html.escape(e.fabrication_region)} · "
+        f"{e.financial.design_life_years}-yr life</div>"
+        f'<div class="meta">LCOE '
+        f"<strong>${_num(r.lcoe_usd_per_mwh, ',.1f')}/MWh</strong></div>"
+        "</div>"
+    )
+
+
+def _sec_inputs(data: LCOEDataSheetData, **_: Any) -> str:
+    e = data.econ
+    f = e.financial
+    rows = [
+        ("Turbine rating", _num(e.turbine_rating_mw, ".1f"), "MW"),
+        ("Turbine count", str(e.turbine_count), ""),
+        ("Farm capacity", _num(e.farm_capacity_mw, ",.0f"), "MW"),
+        ("Capacity factor", _num(e.capacity_factor * 100, ".1f"), "%"),
+        ("Water depth", _num(e.water_depth_m, ",.0f"), "m"),
+        ("Distance to shore", _num(e.distance_to_shore_km, ",.0f"), "km"),
+        ("Discount rate", _num(f.discount_rate * 100, ".1f"), "%"),
+        ("Inflation (OPEX esc.)", _num(f.inflation_rate * 100, ".1f"), "%"),
+        ("Design life", str(f.design_life_years), "yr"),
+    ]
+    body = _kv_table(rows, cols=("Input", "Value", "Unit"))
+    return _section("Project & Financial Inputs", body, anchor="inputs")
+
+
+def _sec_capex(data: LCOEDataSheetData, **_: Any) -> str:
+    c = data.econ.capex
+    kw = data.econ.farm_capacity_kw
+    comps = [
+        ("Turbine", c.turbine),
+        ("Substructure", c.substructure),
+        ("Mooring", c.mooring),
+        ("Array cable", c.array_cable),
+        ("Export cable", c.export_cable),
+        ("Installation", c.installation),
+        ("Development", c.development),
+    ]
+    rows = "".join(
+        f"<tr><td>{html.escape(name)}</td><td>{_num(v, ',.0f')}</td>"
+        f"<td>{_num(v * kw / 1e9, ',.3f')}</td></tr>"
+        for name, v in comps
+    )
+    total = c.total_per_kw
+    rows += (
+        f'<tr class="total"><td><strong>Total overnight CAPEX</strong></td>'
+        f"<td><strong>{_num(total, ',.0f')}</strong></td>"
+        f"<td><strong>{_num(total * kw / 1e9, ',.3f')}</strong></td></tr>"
+    )
+    body = (
+        "<table><thead><tr><th>Component</th><th>$/kW</th>"
+        f"<th>$ billion</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+    return _section("CAPEX Breakdown", body, anchor="capex")
+
+
+def _sec_totex(data: LCOEDataSheetData, **_: Any) -> str:
+    r = data.result
+    rows = [
+        ("CAPEX (overnight)", r.capex_usd, r.capex_per_mwh),
+        ("OPEX (discounted)", r.opex_discounted_usd, r.opex_per_mwh),
+        ("DECOMEX (discounted)", r.decomex_discounted_usd, r.decomex_per_mwh),
+    ]
+    body_rows = "".join(
+        f"<tr><td>{html.escape(name)}</td>"
+        f"<td>{_num(usd / 1e9, ',.3f')}</td>"
+        f"<td>{_num(permwh, ',.1f')}</td></tr>"
+        for name, usd, permwh in rows
+    )
+    body_rows += (
+        f'<tr class="total"><td><strong>TOTEX / LCOE</strong></td>'
+        f"<td><strong>{_num(r.totex_discounted_usd / 1e9, ',.3f')}</strong></td>"
+        f"<td><strong>{_num(r.lcoe_usd_per_mwh, ',.1f')}</strong></td></tr>"
+    )
+    note = (
+        f'<p class="note">Discounted energy over life: '
+        f"{_num(r.energy_discounted_mwh / 1e6, ',.2f')} M MWh "
+        f"(AEP {_num(r.aep_mwh / 1e6, ',.3f')} M MWh/yr).</p>"
+    )
+    body = (
+        "<table><thead><tr><th>Component</th><th>$ billion (disc.)</th>"
+        f"<th>$/MWh</th></tr></thead><tbody>{body_rows}</tbody></table>{note}"
+    )
+    return _section("Discounted TOTEX → LCOE", body, anchor="totex")
+
+
+def _sec_sensitivities(data: LCOEDataSheetData, **_: Any) -> str:
+    if not data.sweep_rows:
+        return ""
+    rows = "".join(
+        f"<tr><td>{html.escape(row.name)}</td>"
+        f"<td>{_num(row.lcoe_usd_per_mwh, ',.1f')}</td>"
+        f"<td>{_num(row.delta_vs_base, '+,.1f')}</td>"
+        f"<td>{_num(row.pct_vs_base, '+.1f')}</td></tr>"
+        for row in data.sweep_rows
+    )
+    body = (
+        "<table><thead><tr><th>Scenario</th><th>LCOE $/MWh</th>"
+        "<th>Δ $/MWh</th><th>Δ %</th></tr></thead>"
+        f"<tbody>{rows}</tbody></table>"
+    )
+    return _section("Cost-Driver Sensitivities", body, anchor="sensitivities")
+
+
+def _sec_provenance(data: LCOEDataSheetData, **_: Any) -> str:
+    items = "".join(f"<li>{html.escape(ref)}</li>" for ref in data.references)
+    body = (
+        "<p>Cost bases from public references only; no client or proprietary "
+        f"data.</p><h3>References</h3><ul>{items}</ul>"
+    )
+    return _section("Provenance", body, anchor="provenance")
+
+
+def _kv_table(rows: list[tuple[str, str, str]], *, cols: tuple[str, str, str]) -> str:
+    head = "".join(f"<th>{html.escape(c)}</th>" for c in cols)
+    body = "".join(
+        f"<tr><td>{html.escape(a)}</td><td>{html.escape(b)}</td>"
+        f"<td>{html.escape(c)}</td></tr>"
+        for a, b, c in rows
+    )
+    return f"<table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table>"
+
+
+LCOE_DATA_SHEET_BACKBONE = ReportBackbone(
+    title="Floating-Wind LCOE / TOTEX Data Sheet",
+    sections=[
+        ReportSection("header", "Headline", SectionMode.ALWAYS, _sec_header),
+        ReportSection("inputs", "Inputs", SectionMode.ALWAYS, _sec_inputs),
+        ReportSection("capex", "CAPEX", SectionMode.ALWAYS, _sec_capex),
+        ReportSection("totex", "TOTEX", SectionMode.ALWAYS, _sec_totex),
+        ReportSection(
+            "sensitivities",
+            "Sensitivities",
+            SectionMode.COMPACT_SKIP,
+            _sec_sensitivities,
+        ),
+        ReportSection("provenance", "Provenance", SectionMode.ALWAYS, _sec_provenance),
+    ],
+)
+
+
+_LCOE_CSS = """\
+body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#222;margin:0}
+.container{max-width:900px;margin:0 auto;padding:24px}
+.report-header h1{margin:0 0 4px;font-size:1.6em}
+.report-header .subtitle{color:#555}
+.report-header .meta{margin-top:8px;font-size:1.2em}
+.section{margin:22px 0}
+.section h2{border-bottom:2px solid #1d76db;padding-bottom:4px;font-size:1.15em}
+table{border-collapse:collapse;width:100%;margin-top:8px}
+th,td{border:1px solid #ddd;padding:6px 10px;text-align:left}
+th{background:#f4f7fb}
+tr.total td{background:#eef5ff}
+td:nth-child(n+2){text-align:right}
+.note{color:#555;font-size:0.9em}
+"""
+
+
+def lcoe_data_sheet(
+    econ: ProjectEconomics,
+    result: LCOEResult,
+    *,
+    sweep_rows: list[SweepRow] | None = None,
+    title: str | None = None,
+    mode: str = "full",
+) -> list[str]:
+    """Render the LCOE/TOTEX data sheet to the backbone's section HTML list."""
+    data = LCOEDataSheetData(
+        econ=econ,
+        result=result,
+        sweep_rows=list(sweep_rows or []),
+        title=title or "Floating-Wind LCOE / TOTEX Data Sheet",
+    )
+    return LCOE_DATA_SHEET_BACKBONE.render(data, mode=mode)
+
+
+def render_lcoe_data_sheet_html(
+    econ: ProjectEconomics,
+    result: LCOEResult,
+    *,
+    sweep_rows: list[SweepRow] | None = None,
+    title: str | None = None,
+    mode: str = "full",
+) -> str:
+    """Render a complete standalone HTML LCOE/TOTEX data sheet document."""
+    sections = lcoe_data_sheet(
+        econ, result, sweep_rows=sweep_rows, title=title, mode=mode
+    )
+    return ReportRenderer().render_html(
+        sections,
+        title=title or "Floating-Wind LCOE / TOTEX Data Sheet",
+        css=_LCOE_CSS,
+        plotlyjs_src="",
+        container_class="container",
+    )
+
+
+def write_lcoe_data_sheet(
+    econ: ProjectEconomics,
+    result: LCOEResult,
+    output_path: str | Path,
+    *,
+    sweep_rows: list[SweepRow] | None = None,
+    title: str | None = None,
+    mode: str = "full",
+) -> Path:
+    """Render and write the LCOE/TOTEX data sheet HTML file; return its path."""
+    doc = render_lcoe_data_sheet_html(
+        econ, result, sweep_rows=sweep_rows, title=title, mode=mode
+    )
+    return ReportRenderer().write_html(doc, Path(output_path))

--- a/src/digitalmodel/floating_wind/economics_workflow.py
+++ b/src/digitalmodel/floating_wind/economics_workflow.py
@@ -1,0 +1,135 @@
+"""UV-workflow router for floating-wind LCOE/TOTEX (issue #1226).
+
+Closing slice of the economics epic (#1220): make the LCOE engine dispatchable
+from a committed ``input.yml`` via the digitalmodel engine::
+
+    uv run python -m digitalmodel examples/workflows/floating-wind-economics/input.yml
+
+(basename ``floating_wind_economics``). The router builds a project economics
+case from the config, computes LCOE, optionally runs a cost-driver sweep (#1223)
+and a reliability scenario (#1222), writes a JSON summary and -- when asked -- a
+one-page LCOE/TOTEX data sheet (#1226 report). Licence-free; no OrcaFlex.
+
+Config shape (under the ``floating_wind_economics`` key)::
+
+    floating_wind_economics:
+      project:            # ProjectEconomics fields (turbine, capex, financial, ...)
+        ...
+      reliability:        # optional — failure-rate reduction scenario
+        failure_rate_reduction: 0.5
+      sensitivities:      # optional — list of {name, changes:[{path, scale|value}]}
+        - name: design_life_30yr
+          changes: [{path: financial.design_life_years, value: 30}]
+    output:
+      summary_json: path/to/summary.json     # optional
+      data_sheet_html: path/to/datasheet.html # optional
+
+For back-compat the project fields may sit directly under
+``floating_wind_economics`` (no ``project`` wrapper) -- the packaged base case
+(#1221) is exactly that shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.floating_wind.economics import (
+    LCOEResult,
+    ProjectEconomics,
+    compute_lcoe,
+)
+from digitalmodel.floating_wind.reliability import (
+    ReliabilityScenario,
+    lcoe_with_reliability,
+)
+from digitalmodel.floating_wind.sweep import DriverScenario, run_sweep
+
+__all__ = ["FloatingWindEconomicsWorkflow"]
+
+
+class FloatingWindEconomicsWorkflow:
+    """Run a floating-wind LCOE/TOTEX case from a cfg dict."""
+
+    def router(self, cfg: dict) -> dict:
+        spec = cfg.get("floating_wind_economics") or {}
+        econ = ProjectEconomics.from_mapping(spec.get("project", spec))
+        result = compute_lcoe(econ)
+
+        summary: dict[str, Any] = {
+            "farm_capacity_mw": econ.farm_capacity_mw,
+            "lcoe": self._lcoe_summary(result),
+        }
+
+        rel = spec.get("reliability")
+        if rel:
+            scenario = ReliabilityScenario(**rel)
+            summary["reliability"] = {
+                "failure_rate_reduction": scenario.failure_rate_reduction,
+                "lcoe": self._lcoe_summary(lcoe_with_reliability(econ, scenario)),
+            }
+
+        sweep_rows = []
+        sens = spec.get("sensitivities")
+        if sens:
+            scenarios = [DriverScenario(**s) for s in sens]
+            sweep_rows = run_sweep(econ, scenarios)
+            summary["sensitivities"] = [
+                {
+                    "name": row.name,
+                    "lcoe_usd_per_mwh": round(row.lcoe_usd_per_mwh, 3),
+                    "delta_vs_base": round(row.delta_vs_base, 3),
+                    "pct_vs_base": round(row.pct_vs_base, 3),
+                }
+                for row in sweep_rows
+            ]
+
+        output = cfg.get("output") or {}
+        summary_path = self._write_summary(output.get("summary_json"), summary)
+        if summary_path is not None:
+            summary["summary_json"] = str(summary_path)
+        sheet_path = self._write_data_sheet(
+            output.get("data_sheet_html"), econ, result, sweep_rows
+        )
+        if sheet_path is not None:
+            summary["data_sheet_html"] = str(sheet_path)
+
+        cfg["floating_wind_economics"] = {**spec, "result": summary}
+        return cfg
+
+    # -- helpers ------------------------------------------------------------
+
+    def _lcoe_summary(self, result: LCOEResult) -> dict[str, Any]:
+        return {
+            "lcoe_usd_per_mwh": round(result.lcoe_usd_per_mwh, 3),
+            "capex_per_mwh": round(result.capex_per_mwh, 3),
+            "opex_per_mwh": round(result.opex_per_mwh, 3),
+            "decomex_per_mwh": round(result.decomex_per_mwh, 3),
+            "totex_discounted_usd": round(result.totex_discounted_usd, 1),
+            "capex_usd": round(result.capex_usd, 1),
+        }
+
+    def _write_summary(self, path: str | None, summary: dict) -> Path | None:
+        if not path:
+            return None
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(summary, indent=2))
+        return out
+
+    def _write_data_sheet(
+        self,
+        path: str | None,
+        econ: ProjectEconomics,
+        result: LCOEResult,
+        sweep_rows: list,
+    ) -> Path | None:
+        if not path:
+            return None
+        # Import lazily so the LCOE path never requires the reporting backbone.
+        from digitalmodel.floating_wind.economics_report import (
+            write_lcoe_data_sheet,
+        )
+
+        return write_lcoe_data_sheet(econ, result, path, sweep_rows=sweep_rows)

--- a/src/digitalmodel/floating_wind/tradespace_economics.py
+++ b/src/digitalmodel/floating_wind/tradespace_economics.py
@@ -1,0 +1,144 @@
+"""LCOE as a first-class trade-space objective (issue #1224).
+
+The concept-screening trade space (:mod:`.tradespace`, issue #1026) ranks
+variants on *physical* objectives -- steel mass, peak motion, stability margin.
+This module adds the **economics axis**: it attaches an ``lcoe_usd_per_mwh``
+metric to each variant record (via the core engine, :mod:`.economics`, issue
+#1221) so the Pareto front can trade **cost against feasibility**, which is the
+whole point of the Wood/Whooley "multi-dimensional evaluation" (slide 11).
+
+Variant -> LCOE mapping
+-----------------------
+A screening variant differs from the base project mainly in the **floater**, and
+the dominant floater cost driver is hull **steel mass**. So each variant's LCOE
+is the base project economics with the *substructure* CAPEX scaled by the
+variant's steel mass relative to a reference::
+
+    substructure_$/kW(variant) = base.substructure_$/kW * steel_mass_t / ref_t
+
+All other cost bases (turbine, mooring, cables, OPEX, financial) come from the
+base :class:`.economics.ProjectEconomics`. The reference steel mass defaults to
+the mean over the (feasible) variant set, so LCOE differences across the trade
+space reflect relative hull cost; pass ``reference_steel_mass_t`` to anchor it
+to a known design.
+
+The Pareto machinery (dominance, objective coercion) is reused from
+:mod:`.tradespace` unchanged -- this module only enriches the records, so a
+mixed objective set like ``[("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")]``
+just works.
+
+References
+----------
+* Wood plc / A. Whooley (2021), technology selection / multi-dimensional
+  evaluation (slide 11).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from digitalmodel.floating_wind.economics import ProjectEconomics, compute_lcoe
+from digitalmodel.floating_wind.screening import ScreeningResults, VariantScreening
+from digitalmodel.floating_wind.tradespace import (
+    Objective,
+    _coerce_objectives,
+    _dominates,
+    _variants,
+    variant_metrics,
+)
+
+__all__ = [
+    "LCOE_METRIC_KEY",
+    "variant_lcoe",
+    "mean_steel_mass_t",
+    "lcoe_records",
+    "pareto_front_with_lcoe",
+]
+
+LCOE_METRIC_KEY = "lcoe_usd_per_mwh"
+
+
+def variant_lcoe(
+    variant: VariantScreening,
+    base_econ: ProjectEconomics,
+    *,
+    reference_steel_mass_t: float,
+) -> float:
+    """LCOE ($/MWh) for one variant, scaling substructure CAPEX by steel mass."""
+    if reference_steel_mass_t <= 0.0:
+        raise ValueError("reference_steel_mass_t must be > 0")
+    scale = variant.properties.steel_mass_t / reference_steel_mass_t
+    capex = base_econ.capex.model_copy(
+        update={"substructure": base_econ.capex.substructure * scale}
+    )
+    return compute_lcoe(base_econ.model_copy(update={"capex": capex})).lcoe_usd_per_mwh
+
+
+def mean_steel_mass_t(variants: Iterable[VariantScreening]) -> float:
+    """Mean hull steel mass over ``variants`` (the default LCOE reference)."""
+    masses = [v.properties.steel_mass_t for v in variants]
+    if not masses:
+        raise ValueError("no variants to derive a reference steel mass from")
+    return sum(masses) / len(masses)
+
+
+def lcoe_records(
+    results: ScreeningResults | Iterable[VariantScreening],
+    base_econ: ProjectEconomics,
+    *,
+    reference_steel_mass_t: float | None = None,
+    feasible_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Metric records enriched with an ``lcoe_usd_per_mwh`` column."""
+    variants = _variants(results)
+    if feasible_only:
+        variants = [v for v in variants if v.feasible]
+    if not variants:
+        return []
+    ref = (
+        reference_steel_mass_t
+        if reference_steel_mass_t is not None
+        else mean_steel_mass_t(variants)
+    )
+    records: list[dict[str, Any]] = []
+    for v in variants:
+        rec = variant_metrics(v)
+        rec[LCOE_METRIC_KEY] = variant_lcoe(v, base_econ, reference_steel_mass_t=ref)
+        records.append(rec)
+    return records
+
+
+def pareto_front_with_lcoe(
+    results: ScreeningResults | Iterable[VariantScreening],
+    base_econ: ProjectEconomics,
+    objectives: list[Objective] | list[tuple[str, str]] | list[dict],
+    *,
+    reference_steel_mass_t: float | None = None,
+    passed_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Non-dominated records over ``objectives``, with LCOE available as a key.
+
+    Identical semantics to :func:`.tradespace.pareto_front`, but records carry
+    ``lcoe_usd_per_mwh`` so it can appear among the objectives, e.g.
+    ``[("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")]``.
+    """
+    objs = _coerce_objectives(objectives)
+    records = lcoe_records(
+        results,
+        base_econ,
+        reference_steel_mass_t=reference_steel_mass_t,
+        feasible_only=True,
+    )
+    if passed_only:
+        records = [r for r in records if r.get("passed")]
+
+    front: list[dict[str, Any]] = []
+    for i, rec in enumerate(records):
+        dominated = any(
+            _dominates(other, rec, objs)
+            for j, other in enumerate(records)
+            if j != i
+        )
+        if not dominated:
+            front.append(rec)
+    return front

--- a/tests/floating_wind/test_economics_workflow.py
+++ b/tests/floating_wind/test_economics_workflow.py
@@ -1,0 +1,123 @@
+"""Golden test for the LCOE/TOTEX workflow + data sheet (issue #1226).
+
+Runs the committed example ``input.yml`` end-to-end through the router and
+checks the base case reproduces the deck's $184/MWh, that optional reliability
+and sensitivity blocks populate, and that the JSON summary + HTML data sheet are
+written.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.economics_report import (
+    lcoe_data_sheet,
+    render_lcoe_data_sheet_html,
+)
+from digitalmodel.floating_wind.economics_workflow import (
+    FloatingWindEconomicsWorkflow,
+)
+
+_EXAMPLE_YML = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "workflows"
+    / "floating-wind-economics"
+    / "input.yml"
+)
+
+
+def _load_example() -> dict:
+    return yaml.safe_load(_EXAMPLE_YML.read_text())
+
+
+def test_example_input_exists():
+    assert _EXAMPLE_YML.is_file()
+    cfg = _load_example()
+    assert cfg["basename"] == "floating_wind_economics"
+
+
+def test_router_reproduces_base_case(tmp_path):
+    cfg = _load_example()
+    cfg["output"] = {
+        "summary_json": str(tmp_path / "summary.json"),
+        "data_sheet_html": str(tmp_path / "sheet.html"),
+    }
+    out = FloatingWindEconomicsWorkflow().router(cfg)
+    result = out["floating_wind_economics"]["result"]
+
+    assert result["farm_capacity_mw"] == pytest.approx(495.0)
+    assert result["lcoe"]["lcoe_usd_per_mwh"] == pytest.approx(184.0, rel=0.02)
+    # per-MWh split reconstitutes the LCOE
+    split = (
+        result["lcoe"]["capex_per_mwh"]
+        + result["lcoe"]["opex_per_mwh"]
+        + result["lcoe"]["decomex_per_mwh"]
+    )
+    assert split == pytest.approx(result["lcoe"]["lcoe_usd_per_mwh"], rel=1e-3)
+
+
+def test_router_reliability_block(tmp_path):
+    cfg = _load_example()
+    cfg["output"] = {}
+    out = FloatingWindEconomicsWorkflow().router(cfg)
+    rel = out["floating_wind_economics"]["result"]["reliability"]
+    # 50% failure-rate reduction -> ~$162/MWh (deck slide 17)
+    assert rel["failure_rate_reduction"] == pytest.approx(0.50)
+    assert rel["lcoe"]["lcoe_usd_per_mwh"] == pytest.approx(162.0, rel=0.02)
+
+
+def test_router_sensitivities_block(tmp_path):
+    cfg = _load_example()
+    cfg["output"] = {}
+    out = FloatingWindEconomicsWorkflow().router(cfg)
+    sens = {s["name"]: s for s in out["floating_wind_economics"]["result"]["sensitivities"]}
+    assert "design_life_30yr" in sens
+    # every listed sensitivity lowers LCOE vs the $184 base
+    for s in sens.values():
+        assert s["delta_vs_base"] < 0.0
+
+
+def test_router_writes_outputs(tmp_path):
+    cfg = _load_example()
+    summary_json = tmp_path / "out" / "summary.json"
+    sheet_html = tmp_path / "out" / "sheet.html"
+    cfg["output"] = {
+        "summary_json": str(summary_json),
+        "data_sheet_html": str(sheet_html),
+    }
+    FloatingWindEconomicsWorkflow().router(cfg)
+    assert summary_json.is_file()
+    assert sheet_html.is_file()
+    assert "184" in sheet_html.read_text()
+
+
+def test_router_without_output_is_noop_on_disk():
+    """No output config -> still computes, writes nothing."""
+    cfg = _load_example()
+    cfg.pop("output", None)
+    out = FloatingWindEconomicsWorkflow().router(cfg)
+    res = out["floating_wind_economics"]["result"]
+    assert "summary_json" not in res
+    assert "data_sheet_html" not in res
+
+
+def test_data_sheet_sections_and_compact_mode():
+    e = base_case()
+    r = compute_lcoe(e)
+    full = lcoe_data_sheet(e, r)
+    compact = lcoe_data_sheet(e, r, mode="compact")
+    # full renders all always-sections; both are non-empty HTML fragment lists
+    assert len(full) >= 5
+    assert all(isinstance(s, str) and s for s in full)
+    assert len(compact) <= len(full)
+
+
+def test_data_sheet_html_is_standalone_document():
+    e = base_case()
+    r = compute_lcoe(e)
+    doc = render_lcoe_data_sheet_html(e, r)
+    assert doc.lstrip().lower().startswith("<!doctype") or "<html" in doc.lower()
+    assert "LCOE" in doc

--- a/tests/floating_wind/test_tradespace_economics.py
+++ b/tests/floating_wind/test_tradespace_economics.py
@@ -1,0 +1,140 @@
+"""Tests for LCOE as a trade-space objective (issue #1224).
+
+Builds lightweight screening variants that differ in hull steel mass and checks
+that LCOE tracks steel mass, that the Pareto front mixes LCOE with a physical
+objective, and that the base engine's LCOE is recovered at the reference mass.
+"""
+
+import pytest
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.floaters import FloaterArchetype, FloaterProperties
+from digitalmodel.floating_wind.screening import VariantScreening
+from digitalmodel.floating_wind.tradespace_economics import (
+    LCOE_METRIC_KEY,
+    lcoe_records,
+    mean_steel_mass_t,
+    pareto_front_with_lcoe,
+    variant_lcoe,
+)
+
+
+def _props(steel_mass_t: float) -> FloaterProperties:
+    """A plausible semi FloaterProperties differing only in steel mass."""
+    return FloaterProperties(
+        archetype=FloaterArchetype.SEMI,
+        draft_m=20.0,
+        displacement_t=16000.0,
+        steel_mass_t=steel_mass_t,
+        ballast_mass_t=2000.0,
+        topside_mass_t=2280.0,
+        total_mass_t=steel_mass_t + 4280.0,
+        waterplane_area_m2=350.0,
+        KB_m=10.0,
+        BM_m=25.0,
+        KG_m=18.0,
+        GM_m=17.0,
+        heave_natural_period_s=20.0,
+        pitch_natural_period_s=28.0,
+        pitch_radius_gyration_m=30.0,
+        tendon_stabilised=False,
+        feasible=True,
+    )
+
+
+def _variant(case_id: str, steel_mass_t: float, *, passed: bool = True) -> VariantScreening:
+    return VariantScreening(
+        case_id=case_id,
+        archetype=FloaterArchetype.SEMI,
+        params={"steel_mass_t": steel_mass_t},
+        properties=_props(steel_mass_t),
+        checks=[],
+        feasible=True,
+        passed=passed,
+        governing_check="stability",
+        governing_margin=1.2,
+    )
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+@pytest.fixture
+def variants():
+    return [
+        _variant("light", 3000.0),
+        _variant("mid", 4000.0),
+        _variant("heavy", 5000.0),
+    ]
+
+
+def test_lcoe_at_reference_mass_equals_base(econ):
+    """A variant at exactly the reference steel mass reproduces the base LCOE."""
+    v = _variant("ref", 4000.0)
+    lcoe = variant_lcoe(v, econ, reference_steel_mass_t=4000.0)
+    assert lcoe == pytest.approx(compute_lcoe(econ).lcoe_usd_per_mwh, rel=1e-9)
+
+
+def test_heavier_hull_costs_more(econ):
+    ref = 4000.0
+    light = variant_lcoe(_variant("l", 3000.0), econ, reference_steel_mass_t=ref)
+    heavy = variant_lcoe(_variant("h", 5000.0), econ, reference_steel_mass_t=ref)
+    assert light < heavy
+
+
+def test_lcoe_records_attach_metric(econ, variants):
+    recs = lcoe_records(variants, econ)
+    assert all(LCOE_METRIC_KEY in r for r in recs)
+    assert len(recs) == 3
+    # Ordered light->heavy by construction; LCOE must be increasing.
+    lcoes = [r[LCOE_METRIC_KEY] for r in recs]
+    assert lcoes == sorted(lcoes)
+
+
+def test_mean_steel_mass_reference(variants):
+    assert mean_steel_mass_t(variants) == pytest.approx(4000.0)
+
+
+def test_pareto_front_mixes_lcoe_and_physical(econ, variants):
+    """With LCOE(min) and steel_mass(min) both driven by steel mass, the
+    lightest variant dominates -> a single-point front."""
+    front = pareto_front_with_lcoe(
+        variants,
+        econ,
+        [("lcoe_usd_per_mwh", "min"), ("steel_mass_t", "min")],
+    )
+    assert len(front) == 1
+    assert front[0]["case_id"] == "light"
+
+
+def test_pareto_front_tradeoff_gives_multiple(econ):
+    """When objectives conflict, the front keeps the non-dominated set."""
+    # Heavier hull (worse LCOE) but better stability margin -> both on the front.
+    a = _variant("cheap_wobbly", 3000.0)
+    b = _variant("dear_stable", 5000.0)
+    b.properties.GM_m = 30.0  # more stable
+    front = pareto_front_with_lcoe(
+        [a, b],
+        econ,
+        [("lcoe_usd_per_mwh", "min"), ("GM_m", "max")],
+    )
+    ids = {r["case_id"] for r in front}
+    assert ids == {"cheap_wobbly", "dear_stable"}
+
+
+def test_passed_only_filter(econ):
+    variants = [
+        _variant("ok", 3500.0, passed=True),
+        _variant("failed", 3000.0, passed=False),
+    ]
+    front = pareto_front_with_lcoe(
+        variants, econ, [("lcoe_usd_per_mwh", "min")], passed_only=True
+    )
+    assert {r["case_id"] for r in front} == {"ok"}
+
+
+def test_zero_reference_rejected(econ):
+    with pytest.raises(ValueError):
+        variant_lcoe(_variant("x", 4000.0), econ, reference_steel_mass_t=0.0)


### PR DESCRIPTION
**Closes #1224 and #1226. Completes epic #1220 (6/6).** Bases on `main`; consolidates the final two lanes into one PR (the #1226 branch was cut from #1224, so both land together with a single reconciled `__init__.py` — one clean merge, no export-list re-conflict). Supersedes #1243.

## #1224 — LCOE as a trade-space objective
`tradespace_economics.py` attaches an `lcoe_usd_per_mwh` metric to each screening variant (substructure CAPEX scaled by hull steel mass vs a reference), reusing `tradespace`'s dominance logic unchanged (`tradespace.py` not modified). Pareto front trades cost × feasibility.

## #1226 — Cost data sheet + uv-workflow router
- `economics_report.py` — one-page LCOE/TOTEX data sheet on the shared reporting backbone (#1018).
- `economics_workflow.py` — `FloatingWindEconomicsWorkflow` router (`input.yml` → LCOE + optional reliability/sweep → JSON + HTML), registered under basename `floating_wind_economics` in `engine.py`.
- `examples/workflows/floating-wind-economics/input.yml` — reproduces the base case.

## Validation (full-deps venv)
Golden: router on the committed `input.yml` → base **$184/MWh**, reliability 0.5 → **~$162**, sensitivities all negative, JSON + HTML written. **61 passed** across the whole economics layer; existing `test_tradespace.py` unaffected (6 passed).

## Epic #1220 — all six lanes done
#1221 engine · #1222 reliability · #1223 sweep · #1225 qualification (merged) · #1224 tradespace-LCOE · #1226 data sheet + workflow (this PR). Every deck quantitative anchor reproduced within tolerance; all cost/criteria bases externalised to `.yml`, public references only.
