### PR TITLE
docs(capabilities): add Computational Fluid Dynamics (CFD) section (#1161)

### DIFF
--- a/docs/api/capabilities/index.html
+++ b/docs/api/capabilities/index.html
@@ -151,6 +151,7 @@
     <div class="navgroup"><a class="navh" href="#ffs">Fitness-for-service</a></div>
     <div class="navgroup"><a class="navh" href="#structural">Ship structural strength</a></div>
     <div class="navgroup"><a class="navh" href="#hydro">Hydrodynamics &amp; diffraction</a></div>
+    <div class="navgroup"><a class="navh" href="#cfd">Computational fluid dynamics</a></div>
     <div class="navgroup"><a class="navh" href="#risers">Risers &amp; pipelines</a></div>
     <div class="navgroup"><a class="navh" href="#subsea">Subsea</a></div>
     <div class="navgroup"><a class="navh" href="#installation">Installation</a></div>
@@ -203,6 +204,19 @@
       <div class="card"><h3>Solver correlation heatmap</h3><div class="std">WAMIT · AQWA · OrcaWave</div><p>Heatmap of cross-solver agreement across DOFs and frequencies for the unit-box benchmark.</p><div class="actions"><a class="open" href="../hydro/unit-box-benchmark/benchmark_heatmap.html">Open &rarr;</a><a class="sec" href="pdf/unitbox-heatmap.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/unitbox-heatmap.html">API &rarr;</a></div></div>
       <div class="card"><h3>OCIMF coefficient explorer</h3><div class="std">OCIMF MEG3 / MEG4</div><p>Wind &amp; current force / moment coefficients interpolated by heading and loading condition.</p><div class="actions"><a class="open" href="../hydro/ocimf-coefficient-explorer.html">Open &rarr;</a><a class="sec" href="pdf/ocimf.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/ocimf.html">API &rarr;</a></div></div>
       <div class="card"><h3>Passing-ship interaction benchmark</h3><div class="std">Wang (1975)</div><p>Sway-force and yaw-moment interaction validated against the published closed-form solution.</p><div class="actions"><a class="open" href="../hydro/passing-ship-benchmark.html">Open &rarr;</a><a class="sec" href="pdf/passing-ship.pdf" download>PDF &darr;</a><a class="sec api" data-tip="How to run — send the starting prompt to @the_deckhand_bot, or POST /api/run. Click for the prompt, request &amp; live report." href="api/passing-ship.html">API &rarr;</a></div></div>
+    </div>
+  </section>
+
+  <section class="chan" id="cfd">
+    <div class="chanhead"><h2>Computational fluid dynamics (CFD)</h2></div>
+    <p class="lead">Open-source CFD (OpenFOAM) verified against classical analytical and benchmark
+    solutions &mdash; known-answer verification across steady-laminar, transient-laminar and
+    turbulent (RANS) regimes, computed on real OpenFOAM v2312 (not mocked).</p>
+    <div class="grid">
+      <div class="card"><h3>CFD verification suite</h3><div class="std">OpenFOAM · 3 cases</div><p>Landing page tying the three verification cases together: philosophy, summary table, toolchain and engineering depth.</p><div class="actions"><a class="open" href="../cfd/">Open &rarr;</a></div></div>
+      <div class="card"><h3>Flat-plate boundary layer</h3><div class="std">Blasius · laminar</div><p>Steady simpleFoam skin friction within 4.6% of the Blasius law; velocity profiles collapse onto the similarity solution.</p><div class="actions"><a class="open" href="../cfd/flat-plate-blasius-verification.html">Open &rarr;</a></div></div>
+      <div class="card"><h3>Cylinder vortex shedding (Re=100)</h3><div class="std">Williamson · transient</div><p>Transient pimpleFoam K&aacute;rm&aacute;n street on a body-fitted O-grid: mean drag within 0.5% and Strouhal within 0.9% of benchmark.</p><div class="actions"><a class="open" href="../cfd/cylinder-re100-verification.html">Open &rarr;</a></div></div>
+      <div class="card"><h3>Turbulent flat plate</h3><div class="std">k-&omega; SST · RANS</div><p>Wall-resolved k-&omega; SST (y&#8314;&asymp;0.13): the velocity profile collapses onto the universal law of the wall; skin friction within ~9% of turbulent correlations.</p><div class="actions"><a class="open" href="../cfd/turbulent-flat-plate-verification.html">Open &rarr;</a></div></div>
     </div>
   </section>
 


### PR DESCRIPTION
Adds a **Computational fluid dynamics (CFD)** section to the engineering capabilities page (`docs/api/capabilities/index.html`), surfacing the merged CFD verification work alongside the other engineering capabilities.

- New sidebar nav entry (grouped after *Hydrodynamics & diffraction*).
- New `#cfd` section with four cards matching the existing card markup:
  - **CFD verification suite** → `../cfd/`
  - **Flat-plate boundary layer** (Blasius, laminar) — Cf within 4.6%
  - **Cylinder vortex shedding (Re=100)** (Williamson, transient) — Cd within 0.5%, St within 0.9%
  - **Turbulent flat plate** (k-ω SST, RANS) — law of the wall + Cf within ~9%

Single-file change; rendered headless (rc=0), section/tag balance verified (9/9 sections).

Refs #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)