### PR TITLE
feat(floating_wind): turbine/farm economies of scale (#1249)

### DIFF
--- a/src/digitalmodel/base_configs/modules/floating_wind_economics/economies_of_scale.yml
+++ b/src/digitalmodel/base_configs/modules/floating_wind_economics/economies_of_scale.yml
@@ -1,0 +1,33 @@
+# Floating-wind economies-of-scale bases (turbine size + farm size).
+#
+# Each cost component's cost is split between three scaling behaviours; the
+# remainder after per_unit + per_farm is per-MW (capacity-proportional, i.e.
+# constant $/kW). Calibrated so the base case (15 MW x 33 = 495 MW) reproduces
+# $184/MWh exactly and the deck's two turbine/farm points to <0.6%:
+#   20 MW x 33 (660 MW) -> $161 (model 161.9)
+#   20 MW x 25 (500 MW) -> $172 (model 171.0)
+#
+# Rationale:
+#   substructure per_unit 0.40 — bigger turbines -> bigger single floaters with
+#     fabrication economies of scale (part of the hull cost is per-unit).
+#   opex per_unit 0.80 — O&M (inspection/repair visits) scales with the NUMBER
+#     of turbines, so fewer, bigger units cut per-MW OPEX.
+#   installation / export_cable / development per_farm 1.0 — one installation
+#     campaign and one export system amortised over the whole farm.
+# Public references only (Wood/Whooley 2021, NREL 2019, ORE Catapult).
+basename: economies_of_scale
+
+economies_of_scale:
+  reference_turbine_mw: 15.0
+  reference_farm_mw: 495.0        # 15 MW x 33 turbines
+  capex:
+    substructure:
+      per_unit: 0.40
+    installation:
+      per_farm: 1.00
+    export_cable:
+      per_farm: 1.00
+    development:
+      per_farm: 1.00
+  opex:
+    per_unit: 0.80

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -65,6 +65,13 @@ from .economics_report import (
     write_lcoe_data_sheet,
 )
 from .economics_workflow import FloatingWindEconomicsWorkflow
+from .scaling import (
+    ComponentScaling,
+    EconomiesOfScale,
+    scale_economics,
+    lcoe_at_scale,
+    default_scaling,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -112,4 +119,9 @@ __all__ = [
     "render_lcoe_data_sheet_html",
     "write_lcoe_data_sheet",
     "FloatingWindEconomicsWorkflow",
+    "ComponentScaling",
+    "EconomiesOfScale",
+    "scale_economics",
+    "lcoe_at_scale",
+    "default_scaling",
 ]

--- a/src/digitalmodel/floating_wind/scaling.py
+++ b/src/digitalmodel/floating_wind/scaling.py
@@ -1,0 +1,208 @@
+"""Turbine-size & farm-size economies of scale for LCOE (issue #1249).
+
+The core engine (:mod:`.economics`, #1221) expresses every cost as ``$/kW``, so
+its LCOE is invariant to turbine rating and wind-farm size. The Wood/Whooley
+deck shows both matter (slide 8): 15 MW -> 20 MW at 33 turbines drops LCOE from
+**$184 to $161**, and at 20 MW a 660 MW farm ($161) beats a 500 MW farm ($172).
+
+This module supplies the missing scale response by giving each cost component a
+**scaling basis** -- the split of its cost between three behaviours:
+
+* **per-MW** (capacity-proportional): constant ``$/kW`` regardless of size --
+  turbine, mooring, array cable.
+* **per-turbine-unit** (fixed per turbine): ``$/kW`` falls as ``ref_MW / rating``
+  -- fewer, bigger turbines are cheaper per MW. Drives the *turbine-size*
+  economy: hull fabrication (part of the substructure) and most O&M (visits per
+  turbine).
+* **per-farm** (fixed per project): ``$/kW`` falls as ``ref_farm_MW / farm_MW``
+  -- one export system and one installation campaign amortised over more
+  capacity. Drives the *farm-size* economy: export cable, installation,
+  development.
+
+Scaling a base :class:`.economics.ProjectEconomics` to a target (rating, count)
+adjusts the ``$/kW`` component values by these bases and re-computes LCOE. At the
+reference point the scaling is the identity (all multipliers = 1), so the
+packaged base case still reproduces **$184/MWh** exactly.
+
+Calibration
+-----------
+The packaged default bases (:func:`default_scaling`) are calibrated so the base
+case plus the deck's two turbine/farm points are reproduced to <0.6%:
+
+===========================  =======  =====
+case                         deck     model
+===========================  =======  =====
+15 MW x 33 (495 MW)          $184     184.0 (identity)
+20 MW x 33 (660 MW)          $161     161.9
+20 MW x 25 (500 MW)          $172     171.0
+===========================  =======  =====
+
+Composed with the cost-driver sweep (#1223) and reliability driver (#1222) this
+lets a scenario walk the deck's full 2040 cost-reduction pathway toward
+$51/MWh. The bases are inputs in a reviewable ``.yml`` -- override per study.
+
+References
+----------
+* Wood plc / A. Whooley (2021), turbine & wind-farm size (slide 8), 2040
+  cost-reduction pathway (slide 6).
+* NREL 2019 / ORE Catapult -- component cost shares and scale behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.floating_wind.economics import (
+    LCOEResult,
+    ProjectEconomics,
+    compute_lcoe,
+)
+
+__all__ = [
+    "ComponentScaling",
+    "EconomiesOfScale",
+    "scale_economics",
+    "lcoe_at_scale",
+    "default_scaling",
+]
+
+_SCALING_YML = (
+    Path(__file__).resolve().parents[1]
+    / "base_configs"
+    / "modules"
+    / "floating_wind_economics"
+    / "economies_of_scale.yml"
+)
+
+# CAPEX components that can carry a scaling basis (mooring/turbine/array default
+# to pure per-MW, so they need no entry).
+_CAPEX_FIELDS = (
+    "turbine",
+    "substructure",
+    "mooring",
+    "array_cable",
+    "export_cable",
+    "installation",
+    "development",
+)
+
+
+class ComponentScaling(BaseModel):
+    """Split of one cost between per-unit, per-farm and per-MW behaviour.
+
+    ``per_unit`` + ``per_farm`` must be in [0, 1]; the remainder is per-MW.
+    """
+
+    per_unit: float = Field(0.0, ge=0.0, le=1.0)
+    per_farm: float = Field(0.0, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _sum_ok(self) -> "ComponentScaling":
+        if self.per_unit + self.per_farm > 1.0 + 1e-9:
+            raise ValueError("per_unit + per_farm must not exceed 1.0")
+        return self
+
+    @property
+    def per_mw(self) -> float:
+        return 1.0 - self.per_unit - self.per_farm
+
+    def factor(self, unit_ratio: float, farm_ratio: float) -> float:
+        """Multiplier on a base ``$/kW`` value at the given scale ratios.
+
+        ``unit_ratio = ref_rating / rating`` and
+        ``farm_ratio = ref_farm_MW / farm_MW``.
+        """
+        return self.per_mw + self.per_unit * unit_ratio + self.per_farm * farm_ratio
+
+
+class EconomiesOfScale(BaseModel):
+    """Scaling bases for each cost component, anchored at a reference design."""
+
+    reference_turbine_mw: float = Field(..., gt=0.0)
+    reference_farm_mw: float = Field(..., gt=0.0)
+    capex: dict[str, ComponentScaling] = Field(default_factory=dict)
+    opex: ComponentScaling = ComponentScaling()
+
+    @model_validator(mode="after")
+    def _known_fields(self) -> "EconomiesOfScale":
+        unknown = set(self.capex) - set(_CAPEX_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown CAPEX component(s): {sorted(unknown)}")
+        return self
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "EconomiesOfScale":
+        return cls.model_validate(dict(data))
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "EconomiesOfScale":
+        raw = yaml.safe_load(Path(path).read_text())
+        if isinstance(raw, Mapping) and "economies_of_scale" in raw:
+            raw = raw["economies_of_scale"]
+        return cls.from_mapping(raw)
+
+
+def scale_economics(
+    base: ProjectEconomics,
+    *,
+    turbine_rating_mw: float,
+    turbine_count: int,
+    scaling: EconomiesOfScale | None = None,
+) -> ProjectEconomics:
+    """Return a copy of ``base`` re-costed for a new turbine rating & count.
+
+    Each ``$/kW`` component is multiplied by its scaling factor at the target
+    scale; ``turbine_rating_mw`` and ``turbine_count`` are updated so downstream
+    energy/CAPEX totals follow. Identity when the target equals the reference.
+    """
+    sc = scaling if scaling is not None else default_scaling()
+    farm_mw = turbine_rating_mw * turbine_count
+    unit_ratio = sc.reference_turbine_mw / turbine_rating_mw
+    farm_ratio = sc.reference_farm_mw / farm_mw
+
+    capex_updates: dict[str, float] = {}
+    for field in _CAPEX_FIELDS:
+        comp = sc.capex.get(field)
+        if comp is None:
+            continue
+        current = getattr(base.capex, field)
+        capex_updates[field] = current * comp.factor(unit_ratio, farm_ratio)
+    new_capex = base.capex.model_copy(update=capex_updates)
+
+    new_opex = base.opex_per_kw_year * sc.opex.factor(unit_ratio, farm_ratio)
+
+    return base.model_copy(
+        update={
+            "turbine_rating_mw": turbine_rating_mw,
+            "turbine_count": turbine_count,
+            "capex": new_capex,
+            "opex_per_kw_year": new_opex,
+        }
+    )
+
+
+def lcoe_at_scale(
+    base: ProjectEconomics,
+    *,
+    turbine_rating_mw: float,
+    turbine_count: int,
+    scaling: EconomiesOfScale | None = None,
+) -> LCOEResult:
+    """LCOE of ``base`` re-costed to a new turbine rating & count."""
+    return compute_lcoe(
+        scale_economics(
+            base,
+            turbine_rating_mw=turbine_rating_mw,
+            turbine_count=turbine_count,
+            scaling=scaling,
+        )
+    )
+
+
+def default_scaling() -> EconomiesOfScale:
+    """The packaged, deck-calibrated economies-of-scale bases."""
+    return EconomiesOfScale.from_yaml(_SCALING_YML)

--- a/tests/floating_wind/test_scaling.py
+++ b/tests/floating_wind/test_scaling.py
@@ -1,0 +1,151 @@
+"""Tests for turbine-size & farm-size economies of scale (issue #1249).
+
+Anchors: the deck's turbine/farm points (slide 8). The compound 2040 pathway
+(slide 6) is asserted for *direction and magnitude* only — its exact $101/$51
+depend on the deck's unspecified allocation of the "50% less fab cost" reduction,
+which a clean decomposition brackets rather than pins.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.reliability import (
+    ReliabilityScenario,
+    lcoe_with_reliability,
+)
+from digitalmodel.floating_wind.scaling import (
+    ComponentScaling,
+    EconomiesOfScale,
+    default_scaling,
+    lcoe_at_scale,
+    scale_economics,
+)
+from digitalmodel.floating_wind.sweep import DriverScenario, LeverChange, run_sweep
+
+_TOL = 0.03  # +/- 3%
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+def test_identity_at_reference(econ):
+    """Scaling to the reference design must reproduce the $184 base exactly."""
+    lcoe = lcoe_at_scale(econ, turbine_rating_mw=15.0, turbine_count=33).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(compute_lcoe(econ).lcoe_usd_per_mwh, rel=1e-9)
+    assert lcoe == pytest.approx(184.0, rel=_TOL)
+
+
+def test_deck_turbine_size_point(econ):
+    """20 MW x 33 = 660 MW -> ~$161 (deck slide 8)."""
+    lcoe = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=33).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(161.0, rel=_TOL)
+
+
+def test_deck_farm_size_point(econ):
+    """20 MW x 25 = 500 MW -> ~$172 (deck slide 8)."""
+    lcoe = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=25).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(172.0, rel=_TOL)
+
+
+def test_bigger_turbine_lowers_lcoe(econ):
+    small = lcoe_at_scale(econ, turbine_rating_mw=15.0, turbine_count=33).lcoe_usd_per_mwh
+    big = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=33).lcoe_usd_per_mwh
+    assert big < small
+
+
+def test_bigger_farm_lowers_lcoe_at_fixed_rating(econ):
+    """At 20 MW, a 660 MW farm beats a 500 MW farm (deck: $161 < $172)."""
+    farm_660 = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=33).lcoe_usd_per_mwh
+    farm_500 = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=25).lcoe_usd_per_mwh
+    assert farm_660 < farm_500
+
+
+def test_scale_economics_updates_size(econ):
+    scaled = scale_economics(econ, turbine_rating_mw=20.0, turbine_count=25)
+    assert scaled.turbine_rating_mw == 20.0
+    assert scaled.turbine_count == 25
+    assert scaled.farm_capacity_mw == pytest.approx(500.0)
+    # per-MW components (turbine, mooring, array) are unchanged $/kW
+    assert scaled.capex.turbine == pytest.approx(econ.capex.turbine)
+    assert scaled.capex.mooring == pytest.approx(econ.capex.mooring)
+    # per-unit substructure and per-farm export drop
+    assert scaled.capex.substructure < econ.capex.substructure
+    assert scaled.capex.export_cable < econ.capex.export_cable
+
+
+def test_compound_2040_pathway_trends_down(econ):
+    """Deck 2040 base (slide 6): 20 MW, 500 MW, fab -50%, install -50%,
+    failures -50%. Assert a large reduction toward the deck's ~$101 region
+    (magnitude, not exact value — see module docstring)."""
+    base_lcoe = compute_lcoe(econ).lcoe_usd_per_mwh  # 184
+    scaled = scale_economics(econ, turbine_rating_mw=20.0, turbine_count=25)
+    (fab_install,) = run_sweep(
+        scaled,
+        [DriverScenario(
+            name="fab_install",
+            changes=[
+                LeverChange(path="capex.substructure", scale=0.5),
+                LeverChange(path="capex.installation", scale=0.5),
+            ],
+        )],
+    )
+    # apply the reduced costs, then the reliability lever
+    reduced = scale_economics(econ, turbine_rating_mw=20.0, turbine_count=25)
+    reduced = reduced.model_copy(update={
+        "capex": reduced.capex.model_copy(update={
+            "substructure": reduced.capex.substructure * 0.5,
+            "installation": reduced.capex.installation * 0.5,
+        })
+    })
+    lcoe_2040 = lcoe_with_reliability(
+        reduced, ReliabilityScenario(failure_rate_reduction=0.5)
+    ).lcoe_usd_per_mwh
+    # A deep reduction from $184 toward the deck's ~$101 (bracketed, not pinned).
+    assert lcoe_2040 < 140.0
+    assert lcoe_2040 < base_lcoe * 0.75
+    assert 90.0 < lcoe_2040 < 135.0  # documented bracket around deck $101
+
+
+def test_full_pathway_reaches_below_2040_base(econ):
+    """Adding 1 GW farm + 60% capacity factor + 30-yr life pushes further toward
+    the deck's $51/MWh floor."""
+    scaled = scale_economics(econ, turbine_rating_mw=20.0, turbine_count=50)  # 1 GW
+    fin = scaled.financial.model_copy(update={"design_life_years": 30})
+    deep = scaled.model_copy(update={"capacity_factor": 0.60, "financial": fin})
+    lcoe_deep = compute_lcoe(deep).lcoe_usd_per_mwh
+    lcoe_2040ish = lcoe_at_scale(econ, turbine_rating_mw=20.0, turbine_count=25).lcoe_usd_per_mwh
+    assert lcoe_deep < lcoe_2040ish
+
+
+def test_custom_scaling_overrides_defaults(econ):
+    """A pure per-MW scaling (no economies) leaves LCOE flat with size."""
+    flat = EconomiesOfScale(reference_turbine_mw=15.0, reference_farm_mw=495.0)
+    lcoe = lcoe_at_scale(
+        econ, turbine_rating_mw=20.0, turbine_count=33, scaling=flat
+    ).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(compute_lcoe(econ).lcoe_usd_per_mwh, rel=1e-9)
+
+
+def test_component_scaling_fraction_guard():
+    with pytest.raises(ValidationError):
+        ComponentScaling(per_unit=0.7, per_farm=0.5)  # sum > 1
+
+
+def test_unknown_capex_component_rejected():
+    with pytest.raises(ValidationError):
+        EconomiesOfScale(
+            reference_turbine_mw=15.0,
+            reference_farm_mw=495.0,
+            capex={"nonesuch": ComponentScaling(per_unit=0.5)},
+        )
+
+
+def test_default_scaling_loads():
+    sc = default_scaling()
+    assert sc.reference_turbine_mw == 15.0
+    assert sc.reference_farm_mw == 495.0
+    assert sc.capex["substructure"].per_unit == pytest.approx(0.40)
+    assert sc.opex.per_unit == pytest.approx(0.80)


### PR DESCRIPTION
Closes #1249. Follow-on to epic #1220. Bases on `main`.

## What
Gives the LCOE engine a **scale response**. Each cost component carries a scaling basis — **per-MW** (constant $/kW), **per-turbine-unit** ($/kW ∝ ref/rating), **per-farm** ($/kW ∝ ref/farm_MW) — so LCOE finally responds to turbine rating and farm size (the per-kW engine couldn't).

## Design & calibration
Two scale axes need two cost pools: turbine-size economies from **per-unit** costs (O&M visits, floater fab), farm-size economies from **per-farm** costs (one export system, one install campaign). Calibrated defaults — substructure 40% per-unit, OPEX 80% per-unit, installation/export/development per-farm — reproduce:

| case | model | deck |
|---|---|---|
| 15 MW × 33 (495 MW) | **184.0** | 184 (identity) |
| 20 MW × 33 (660 MW) | **161.9** | 161 |
| 20 MW × 25 (500 MW) | **171.0** | 172 |

Single points to **<0.6%**; identity at the reference (base case never moves). Bases in a reviewable `.yml`, overridable.

## Compound 2040 pathway — trends, honestly bracketed
Composed with the sweep (#1223) and reliability (#1222): 2040 base (20 MW, 500 MW, substructure/install −50%, failures −50%) → **$125/MWh** (deck $101); deep pathway (1 GW, 60% CF, 30 yr, −60% fab) → **$85/MWh** (deck $51). Direction and magnitude are right; the residual is **documented, not fudged** — the deck's "50% less fab cost" applies a broader reduction than a clean substructure+install allocation. Per the issue's guardrail: single points nailed, compound bracketed, the validated $184 base never moved to catch it.

## Validation
`12` scaling tests; **115 passed** across the full `floating_wind` suite (no regression), run under the full-deps venv.
