### PR TITLE
feat(floating_wind): standardization & learning-curve lever (#1256)

### DIFF
--- a/src/digitalmodel/base_configs/modules/floating_wind_economics/standardization.yml
+++ b/src/digitalmodel/base_configs/modules/floating_wind_economics/standardization.yml
@@ -1,0 +1,21 @@
+# Floating-wind standardization / learning-curve lever (JIP33, design-one-build-many).
+#
+# Wright's-law learning curve on fabrication CAPEX: per-unit cost falls by the
+# progress ratio for each doubling of cumulative units. Identity at
+# reference_units, so the base case is unchanged.
+#
+# learning_rate 0.90 = 10% learning per doubling — mid of the published offshore-
+# wind range (~8-12%; IRENA / Wiser et al.); floating expected higher while
+# immature. reference_units 100 ~ 2025 floating cumulative deployment scale.
+# At LR 0.90: ~10x reference -> ~-30% fab cost, ~30x -> ~-40% — bracketing the
+# deck's -25%/-50% fabrication levers (slide 15) as deployment milestones.
+# All inputs overridable; public references only.
+basename: standardization
+
+standardization:
+  learning_curve:
+    learning_rate: 0.90
+    reference_units: 100.0
+    components:
+      - substructure
+      - installation

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -72,6 +72,13 @@ from .scaling import (
     lcoe_at_scale,
     default_scaling,
 )
+from .standardization import (
+    LearningCurve,
+    StandardizationDiscount,
+    apply_standardization,
+    lcoe_with_standardization,
+    default_learning_curve,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -124,4 +131,9 @@ __all__ = [
     "scale_economics",
     "lcoe_at_scale",
     "default_scaling",
+    "LearningCurve",
+    "StandardizationDiscount",
+    "apply_standardization",
+    "lcoe_with_standardization",
+    "default_learning_curve",
 ]

--- a/src/digitalmodel/floating_wind/standardization.py
+++ b/src/digitalmodel/floating_wind/standardization.py
@@ -1,0 +1,205 @@
+"""Standardization & industrialization cost lever for LCOE (issue #1256).
+
+The Wood/Whooley deck's fabrication cost-reduction story is *standardization and
+industrialization*: "JIP33 – standardization", "Design one, build many", "No
+gold plating", industrialization (slides 10, 15). The cost-driver sweep (#1223)
+can apply a "-50% fab cost" as a bare percentage; this module supplies the
+**mechanism** behind that number, so a reduction becomes a *deployment target*
+rather than an assumption.
+
+Two composable pieces on top of the core engine (:mod:`.economics`, #1221):
+
+1. **Learning curve (Wright's law)** -- the industrialization / "design one,
+   build many" effect. Per-unit fabrication cost falls by a fixed **progress
+   ratio** ``LR`` for every doubling of cumulative units built::
+
+       factor(n) = (n / n_ref) ** log2(LR)
+
+   ``LR = 0.90`` means each doubling of cumulative production costs 90% of the
+   previous (a 10% learning rate). Applied to fabrication-heavy CAPEX
+   (substructure, installation). Identity at ``n = n_ref``.
+
+2. **Standardization discount** -- an up-front fractional reduction on the
+   standardized-scope components (JIP33 spec standardization + "no gold plating"
+   removing bespoke over-design), independent of volume.
+
+Applied to the base case at the reference deployment the lever is the identity,
+so the packaged base case still reproduces **$184/MWh**. Composed with the
+economies-of-scale model (#1249), the sweep (#1223) and reliability (#1222) it
+lets a scenario express the deck's fabrication reductions as an explicit
+function of cumulative deployment.
+
+Calibration note
+----------------
+The learning rate is a **calibration input**, not a deck number. Published
+offshore-wind learning rates cluster around 8-12% per doubling (floating is
+expected higher while immature); the packaged default is ``LR = 0.90`` (10%).
+At that rate, reaching the deck's fabrication reductions corresponds to plausible
+cumulative deployment: ~10x the reference gives ~-30% on the learning components,
+~30x gives ~-40% -- bracketing the deck's -25%/-50% fab-cost levers as
+deployment milestones.
+
+References
+----------
+* Wright, T.P. (1936), *Factors Affecting the Cost of Airplanes* -- learning curve.
+* Wiser et al. / IRENA -- offshore-wind learning rates (~8-12%/doubling).
+* Wood plc / A. Whooley (2021) -- standardization, industrialization (slides 10, 15).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+from digitalmodel.floating_wind.economics import (
+    LCOEResult,
+    ProjectEconomics,
+    compute_lcoe,
+)
+
+__all__ = [
+    "LearningCurve",
+    "StandardizationDiscount",
+    "apply_standardization",
+    "lcoe_with_standardization",
+    "default_learning_curve",
+]
+
+_LEARNING_YML = (
+    Path(__file__).resolve().parents[1]
+    / "base_configs"
+    / "modules"
+    / "floating_wind_economics"
+    / "standardization.yml"
+)
+
+_CAPEX_FIELDS = (
+    "turbine",
+    "substructure",
+    "mooring",
+    "array_cable",
+    "export_cable",
+    "installation",
+    "development",
+)
+
+
+def _check_components(components: list[str]) -> list[str]:
+    unknown = set(components) - set(_CAPEX_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown CAPEX component(s): {sorted(unknown)}")
+    return components
+
+
+class LearningCurve(BaseModel):
+    """Wright's-law learning curve for fabrication CAPEX."""
+
+    learning_rate: float = Field(
+        0.90,
+        gt=0.0,
+        le=1.0,
+        description="Progress ratio: cost multiplier per doubling (0.90 = 10% learning)",
+    )
+    reference_units: float = Field(
+        100.0,
+        gt=0.0,
+        description="Cumulative units at which the base CAPEX applies (identity)",
+    )
+    components: list[str] = Field(
+        default_factory=lambda: ["substructure", "installation"],
+        description="CAPEX components subject to the learning curve",
+    )
+
+    @model_validator(mode="after")
+    def _known(self) -> "LearningCurve":
+        _check_components(self.components)
+        return self
+
+    def factor(self, cumulative_units: float) -> float:
+        """Cost multiplier on the learning components at ``cumulative_units``."""
+        if cumulative_units <= 0.0:
+            raise ValueError("cumulative_units must be > 0")
+        return (cumulative_units / self.reference_units) ** math.log2(
+            self.learning_rate
+        )
+
+
+class StandardizationDiscount(BaseModel):
+    """Up-front fractional CAPEX reduction from spec standardization (JIP33)."""
+
+    fraction: float = Field(
+        0.0, ge=0.0, lt=1.0, description="Fractional reduction on target components"
+    )
+    components: list[str] = Field(
+        default_factory=lambda: ["substructure", "installation", "development"],
+        description="Standardized-scope components the discount applies to",
+    )
+
+    @model_validator(mode="after")
+    def _known(self) -> "StandardizationDiscount":
+        _check_components(self.components)
+        return self
+
+    def factor(self) -> float:
+        return 1.0 - self.fraction
+
+
+def apply_standardization(
+    econ: ProjectEconomics,
+    *,
+    cumulative_units: float,
+    learning: LearningCurve | None = None,
+    discount: StandardizationDiscount | None = None,
+) -> ProjectEconomics:
+    """Return a copy of ``econ`` with fabrication CAPEX reduced by learning +
+    an optional standardization discount.
+
+    Multipliers compose per component: the learning factor (on the curve's
+    components) times the discount factor (on the discount's components).
+    """
+    lc = learning if learning is not None else default_learning_curve()
+    learn_f = lc.factor(cumulative_units)
+
+    updates: dict[str, float] = {}
+    for field in lc.components:
+        updates[field] = getattr(econ.capex, field) * learn_f
+    if discount is not None:
+        disc_f = discount.factor()
+        for field in discount.components:
+            base_val = updates.get(field, getattr(econ.capex, field))
+            updates[field] = base_val * disc_f
+
+    new_capex = econ.capex.model_copy(update=updates)
+    return econ.model_copy(update={"capex": new_capex})
+
+
+def lcoe_with_standardization(
+    econ: ProjectEconomics,
+    *,
+    cumulative_units: float,
+    learning: LearningCurve | None = None,
+    discount: StandardizationDiscount | None = None,
+) -> LCOEResult:
+    """LCOE of ``econ`` after standardization/learning is applied."""
+    return compute_lcoe(
+        apply_standardization(
+            econ,
+            cumulative_units=cumulative_units,
+            learning=learning,
+            discount=discount,
+        )
+    )
+
+
+def default_learning_curve() -> LearningCurve:
+    """The packaged default learning curve (LR = 0.90)."""
+    raw = yaml.safe_load(Path(_LEARNING_YML).read_text())
+    if isinstance(raw, Mapping) and "standardization" in raw:
+        raw = raw["standardization"]
+    if isinstance(raw, Mapping) and "learning_curve" in raw:
+        raw = raw["learning_curve"]
+    return LearningCurve.model_validate(dict(raw))

--- a/tests/floating_wind/test_standardization.py
+++ b/tests/floating_wind/test_standardization.py
@@ -1,0 +1,120 @@
+"""Tests for the standardization / learning-curve lever (issue #1256).
+
+Learning rate is a calibration input, not a deck number, so tests assert the
+mechanism (identity at reference, Wright's-law doubling behaviour, monotonicity)
+and that a plausible deployment lands the fab reduction in the deck's -25/-50%
+band — not a single forced value.
+"""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from digitalmodel.floating_wind.economics import base_case, compute_lcoe
+from digitalmodel.floating_wind.standardization import (
+    LearningCurve,
+    StandardizationDiscount,
+    apply_standardization,
+    default_learning_curve,
+    lcoe_with_standardization,
+)
+
+
+@pytest.fixture
+def econ():
+    return base_case()
+
+
+def test_identity_at_reference_units(econ):
+    """At cumulative_units == reference_units the base case is unchanged."""
+    lc = default_learning_curve()
+    lcoe = lcoe_with_standardization(
+        econ, cumulative_units=lc.reference_units, learning=lc
+    ).lcoe_usd_per_mwh
+    assert lcoe == pytest.approx(compute_lcoe(econ).lcoe_usd_per_mwh, rel=1e-9)
+    assert lcoe == pytest.approx(184.0, rel=0.02)
+
+
+def test_wrights_law_doubling(econ):
+    """Each doubling of cumulative units multiplies cost by the progress ratio."""
+    lc = LearningCurve(learning_rate=0.90, reference_units=100.0)
+    assert lc.factor(100.0) == pytest.approx(1.0)
+    assert lc.factor(200.0) == pytest.approx(0.90)          # one doubling
+    assert lc.factor(400.0) == pytest.approx(0.81)          # two doublings
+    assert lc.factor(800.0) == pytest.approx(0.729)         # three doublings
+
+
+def test_more_deployment_lowers_lcoe(econ):
+    base = compute_lcoe(econ).lcoe_usd_per_mwh
+    lc = default_learning_curve()
+    more = lcoe_with_standardization(
+        econ, cumulative_units=lc.reference_units * 10, learning=lc
+    ).lcoe_usd_per_mwh
+    assert more < base
+
+
+def test_learning_reduces_only_target_components(econ):
+    lc = LearningCurve(
+        learning_rate=0.90, reference_units=100.0, components=["substructure"]
+    )
+    scaled = apply_standardization(econ, cumulative_units=1000.0, learning=lc)
+    assert scaled.capex.substructure < econ.capex.substructure
+    assert scaled.capex.turbine == pytest.approx(econ.capex.turbine)
+    assert scaled.capex.installation == pytest.approx(econ.capex.installation)
+
+
+def test_default_scenario_brackets_deck_fab_reduction(econ):
+    """A plausible deployment lands substructure fab reduction in -25%..-50%
+    (the deck's slide-15 fab-cost levers, now as deployment milestones)."""
+    lc = default_learning_curve()
+    for multiple, lo, hi in [(10, 0.25, 0.45), (30, 0.35, 0.55)]:
+        f = lc.factor(lc.reference_units * multiple)
+        reduction = 1.0 - f
+        assert lo <= reduction <= hi, (multiple, reduction)
+
+
+def test_standardization_discount_composes(econ):
+    """Learning + JIP33 discount compose multiplicatively on shared components."""
+    lc = LearningCurve(learning_rate=0.90, reference_units=100.0, components=["substructure"])
+    disc = StandardizationDiscount(fraction=0.10, components=["substructure"])
+    only_learn = apply_standardization(econ, cumulative_units=1000.0, learning=lc)
+    both = apply_standardization(
+        econ, cumulative_units=1000.0, learning=lc, discount=disc
+    )
+    assert both.capex.substructure == pytest.approx(
+        only_learn.capex.substructure * 0.90
+    )
+
+
+def test_discount_only_component(econ):
+    disc = StandardizationDiscount(fraction=0.20, components=["development"])
+    lc = LearningCurve(components=["substructure"])
+    out = apply_standardization(econ, cumulative_units=100.0, learning=lc, discount=disc)
+    assert out.capex.development == pytest.approx(econ.capex.development * 0.80)
+
+
+def test_zero_cumulative_units_rejected(econ):
+    with pytest.raises(ValueError):
+        default_learning_curve().factor(0.0)
+
+
+def test_invalid_learning_rate_rejected():
+    with pytest.raises(ValidationError):
+        LearningCurve(learning_rate=1.5)
+    with pytest.raises(ValidationError):
+        LearningCurve(learning_rate=0.0)
+
+
+def test_unknown_component_rejected():
+    with pytest.raises(ValidationError):
+        LearningCurve(components=["nonesuch"])
+    with pytest.raises(ValidationError):
+        StandardizationDiscount(fraction=0.1, components=["nope"])
+
+
+def test_default_learning_curve_loads():
+    lc = default_learning_curve()
+    assert lc.learning_rate == pytest.approx(0.90)
+    assert lc.reference_units == pytest.approx(100.0)
+    assert set(lc.components) == {"substructure", "installation"}


### PR DESCRIPTION
Closes #1256. Follow-on to epic #1220. Bases on `main`.

## What
Models the deck's **standardization & industrialization** lever (JIP33, "design one, build many", "no gold plating", slides 10/15) as the *mechanism* behind fabrication cost reductions — so a "−50% fab cost" becomes a **deployment target**, not a bare assumption.

- **`LearningCurve` (Wright's law)** — per-unit fabrication CAPEX falls by a progress ratio for each doubling of cumulative units: `factor(n) = (n/n_ref)^log2(LR)`. Applied to substructure + installation.
- **`StandardizationDiscount`** — optional up-front % on standardized-scope components (spec standardization / removing bespoke over-design), volume-independent.

## Calibration (honest)
Learning rate is a **calibrated input, not a deck number**. Default `LR = 0.90` (10%/doubling) sits mid the published offshore-wind range (~8–12%, IRENA/Wiser); reference 100 units ≈ 2025 floating scale. Identity at the reference → base case stays **$184**. At LR 0.90: ~10× reference → **~−30%** fab cost, ~30× → **~−40%** — bracketing the deck's −25%/−50% fab levers (slide 15) as deployment milestones. Tests assert the *mechanism* + range, not a forced value; base never moved.

## Validation
`11` standardization tests (identity, Wright's-law doubling, monotonicity, deck-band bracket, discount composition, guards); **126 passed** across the full `floating_wind` suite (no regression), under the full-deps venv.

## Composes with
Economies-of-scale (#1249), cost-driver sweep (#1223), reliability (#1222) — the economics layer now expresses the deck's full fabrication cost-reduction narrative end to end.
