### PR TITLE
fix(ci): exempt riser_database known-clone fallback paths from abs-path gate

### DIFF
--- a/tests/riser_database/test_crosswalk.py
+++ b/tests/riser_database/test_crosswalk.py
@@ -15,7 +15,7 @@ import pytest
 from digitalmodel.riser_database.loader import RiserDatabase
 
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 

--- a/tests/riser_database/test_leak_gate.py
+++ b/tests/riser_database/test_leak_gate.py
@@ -59,7 +59,7 @@ def test_layer_a_public_rows_structurally_clean():
 # -- Layer B: private deny list (in-context hard gate) -----------------------------
 
 _KNOWN_HUB_ROOTS = (
-    Path("/mnt/local-analysis/workspace-hub"),
+    Path("/mnt/local-analysis/workspace-hub"),  # abs-path-allowed
     Path.home() / "workspace-hub",
 )
 


### PR DESCRIPTION
Quality Gates has been red on main since #1252: two env-guarded developer-clone fallback path candidates trip `check-no-abs-paths.sh`. This adds the checker's own `# abs-path-allowed` exemption to those two lines (verified locally: gate passes). Unblocks every open PR's Quality Gates, including #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)