### PR TITLE
fix(ci): unbreak Quality Gates — exempt riser_database known-clone paths from abs-path check

### DIFF
--- a/tests/riser_database/test_crosswalk.py
+++ b/tests/riser_database/test_crosswalk.py
@@ -15,7 +15,7 @@ import pytest
 from digitalmodel.riser_database.loader import RiserDatabase
 
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 

--- a/tests/riser_database/test_leak_gate.py
+++ b/tests/riser_database/test_leak_gate.py
@@ -59,7 +59,7 @@ def test_layer_a_public_rows_structurally_clean():
 # -- Layer B: private deny list (in-context hard gate) -----------------------------
 
 _KNOWN_HUB_ROOTS = (
-    Path("/mnt/local-analysis/workspace-hub"),
+    Path("/mnt/local-analysis/workspace-hub"),  # abs-path-allowed
     Path.home() / "workspace-hub",
 )
 


### PR DESCRIPTION
Quality Gates has been failing on every main push since the riser_database tests merged (first red run: 28560073203). Cause: `tests/riser_database/test_crosswalk.py` and `test_leak_gate.py` declare deliberate known-clone fallback paths (checked only after the `LLM_WIKI_PATH` / `WORKSPACE_HUB_ROOT` env overrides), which trip `scripts/enforcement/check-no-abs-paths.sh`.

Fix: the gate's own single-line `# abs-path-allowed` exemption on the two lines. Verified locally: `check-no-abs-paths.sh` passes and `pytest tests/riser_database/` is 41 passed.

Unblocks CI for #1262 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)