### PR TITLE
docs: ecosystem tagline on README + capabilities page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # digitalmodel
 
+> *Everyday complex engineering — made deterministically simple.*
+
 > **Part of the Deckhand API — the API for real-world work.**
 > The standard-mapped functions in this repo back **Deckhand API paths**: one call (`POST /api/run`)
 > runs an engineering workflow and returns a **standards-traceable HTML report URL** — deterministic,

--- a/docs/api/capabilities/index.html
+++ b/docs/api/capabilities/index.html
@@ -170,6 +170,7 @@
 <main>
   <header class="hero">
     <h1>digitalmodel — Engineering Capabilities</h1>
+    <p style="font-style:italic;font-size:14px;margin-top:6px">Everyday complex engineering — made deterministically simple.</p>
     <p>Offshore &amp; ship structural strength, fitness-for-service, hydrodynamics &amp; diffraction,
     risers, pipelines and subsea cross-sections &mdash; each result computed by unit-tested domain
     code, checked against the governing code or an independent solver, and frozen into a static report.


### PR DESCRIPTION
Adds the ecosystem mantra — "Everyday complex engineering — made deterministically simple." — as an italic one-liner under the README title and as a small muted subtitle in the capabilities page hero. Tagline insertion only; no other content changes.