### PR TITLE
feat(floating_wind): collaboration / JIP de-risking overlay (#1285)

### DIFF
--- a/src/digitalmodel/base_configs/modules/floating_wind_economics/collaboration.yml
+++ b/src/digitalmodel/base_configs/modules/floating_wind_economics/collaboration.yml
@@ -1,0 +1,27 @@
+# Floating-wind collaboration / JIP de-risking program (Wood/Whooley slide 13).
+#
+# Each Joint Industry Project advances the maturity of the qualification criteria
+# it targets (feeds the technology-qualification gate, #1225). Uplifts targeting
+# the same criterion sum, capped at 1.0. The uplift is a calibration input, not a
+# deck number: ~0.10 ≈ one DNV-RP-A203 TRL step (of the 0..7 scale). Override per
+# assessment. Public references only.
+basename: collaboration
+
+collaboration:
+  jips:
+    - name: Cability
+      targets: [technology_readiness]
+      maturity_uplift: 0.10
+      description: Cable-stability JIP — de-risks dynamic-cable configuration
+    - name: CALM
+      targets: [technology_readiness]
+      maturity_uplift: 0.10
+      description: Cable failure RQA JIP — dynamic-cable reliability
+    - name: SURF-IM
+      targets: [track_record]
+      maturity_uplift: 0.10
+      description: Subsea integrity-management JIP — operational track record
+    - name: SUREFLEX
+      targets: [technology_readiness]
+      maturity_uplift: 0.10
+      description: Flexible-riser integrity JIP — riser/dynamic-system maturity

--- a/src/digitalmodel/floating_wind/__init__.py
+++ b/src/digitalmodel/floating_wind/__init__.py
@@ -79,6 +79,13 @@ from .standardization import (
     lcoe_with_standardization,
     default_learning_curve,
 )
+from .collaboration import (
+    JointIndustryProject,
+    CollaborationProgram,
+    apply_collaboration,
+    requalify_with_collaboration,
+    default_collaboration_program,
+)
 
 __all__ = [
     "RHO_SEAWATER",
@@ -136,4 +143,9 @@ __all__ = [
     "apply_standardization",
     "lcoe_with_standardization",
     "default_learning_curve",
+    "JointIndustryProject",
+    "CollaborationProgram",
+    "apply_collaboration",
+    "requalify_with_collaboration",
+    "default_collaboration_program",
 ]

--- a/src/digitalmodel/floating_wind/collaboration.py
+++ b/src/digitalmodel/floating_wind/collaboration.py
@@ -1,0 +1,140 @@
+"""Collaboration / Joint Industry Project (JIP) de-risking overlay (issue #1285).
+
+The last Wood/Whooley cost lever: **cross-industry collaboration**. The deck
+(slide 13) frames Joint Industry Projects -- Cability (cable stability), CALM
+(cable failure RQA), SURF-IM (subsea integrity), SUREFLEX (flexible-riser
+integrity) -- as the mechanism that *advances technology readiness*, de-risking
+novel floater / mooring / dynamic-cable subsystems so they clear qualification.
+
+This module is that overlay on the technology-qualification gate
+(:mod:`.qualification`, #1225): a :class:`JointIndustryProject` raises the
+**maturity** of the criteria it targets, and a :class:`CollaborationProgram`
+(a set of JIPs) re-scores a concept -- so a concept that was ``conditional`` can
+become ``qualified`` once the relevant JIPs de-risk its weak subsystem.
+
+Uplifts targeting the same criterion **sum** but the result is **capped at 1.0**
+-- collaboration cannot push a subsystem past fully-proven. Applying an empty
+program is the identity.
+
+Calibration note
+----------------
+The maturity uplift per JIP is a **calibration input**, not a deck number. The
+packaged default gives each of the four deck JIPs a modest ~0.10 uplift (roughly
+one DNV-RP-A203 TRL step of the 0..7 scale); override per assessment. Tests
+assert the *mechanism* (targeted, summed, capped, requalification), not a forced
+score.
+
+References
+----------
+* Wood plc / A. Whooley (2021), collaboration / JIPs (slide 13).
+* DNV-RP-A203 -- technology qualification / TRL (the maturity scale uplifted).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from pydantic import BaseModel, Field
+
+from digitalmodel.floating_wind.qualification import (
+    ConceptMaturity,
+    QualificationCriteria,
+    QualificationResult,
+    score_concept,
+)
+
+__all__ = [
+    "JointIndustryProject",
+    "CollaborationProgram",
+    "apply_collaboration",
+    "requalify_with_collaboration",
+    "default_collaboration_program",
+]
+
+_COLLAB_YML = (
+    Path(__file__).resolve().parents[1]
+    / "base_configs"
+    / "modules"
+    / "floating_wind_economics"
+    / "collaboration.yml"
+)
+
+
+class JointIndustryProject(BaseModel):
+    """A JIP that advances the maturity of the criteria it targets."""
+
+    name: str
+    targets: list[str] = Field(
+        ..., min_length=1, description="Qualification criterion keys this JIP de-risks"
+    )
+    maturity_uplift: float = Field(
+        ..., gt=0.0, le=1.0, description="Maturity added to each targeted criterion"
+    )
+    description: str = ""
+
+
+class CollaborationProgram(BaseModel):
+    """A set of JIPs applied together as a de-risking program."""
+
+    jips: list[JointIndustryProject] = Field(default_factory=list)
+
+    def total_uplift(self) -> dict[str, float]:
+        """Summed uplift per targeted criterion across all JIPs."""
+        out: dict[str, float] = {}
+        for jip in self.jips:
+            for key in jip.targets:
+                out[key] = out.get(key, 0.0) + jip.maturity_uplift
+        return out
+
+    def uplift_scores(self, scores: Mapping[str, float]) -> dict[str, float]:
+        """Return a copy of ``scores`` with targeted maturities uplifted (cap 1.0).
+
+        A targeted criterion absent from ``scores`` is treated as starting from 0
+        (an un-evidenced subsystem the JIP begins to de-risk).
+        """
+        result = dict(scores)
+        for key, up in self.total_uplift().items():
+            result[key] = min(1.0, result.get(key, 0.0) + up)
+        return result
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "CollaborationProgram":
+        return cls.model_validate(dict(data))
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "CollaborationProgram":
+        raw = yaml.safe_load(Path(path).read_text())
+        if isinstance(raw, Mapping) and "collaboration" in raw:
+            raw = raw["collaboration"]
+        return cls.from_mapping(raw)
+
+
+def apply_collaboration(
+    concept: ConceptMaturity, program: CollaborationProgram
+) -> ConceptMaturity:
+    """Return a copy of ``concept`` with the program's maturity uplifts applied."""
+    return ConceptMaturity(
+        name=concept.name, scores=program.uplift_scores(concept.scores)
+    )
+
+
+def requalify_with_collaboration(
+    concept: ConceptMaturity,
+    program: CollaborationProgram,
+    criteria: QualificationCriteria,
+) -> tuple[QualificationResult, QualificationResult]:
+    """Qualification result before and after the collaboration program.
+
+    Returns ``(before, after)`` so callers can show the de-risking effect (e.g.
+    a ``conditional -> qualified`` move).
+    """
+    before = score_concept(concept, criteria)
+    after = score_concept(apply_collaboration(concept, program), criteria)
+    return before, after
+
+
+def default_collaboration_program() -> CollaborationProgram:
+    """The packaged default program (the deck's four JIPs)."""
+    return CollaborationProgram.from_yaml(_COLLAB_YML)

--- a/tests/floating_wind/test_collaboration.py
+++ b/tests/floating_wind/test_collaboration.py
@@ -1,0 +1,106 @@
+"""Tests for the collaboration / JIP de-risking overlay (issue #1285).
+
+Uplift magnitudes are calibration inputs, so tests assert the mechanism:
+targeted uplift, summing, the 1.0 cap, identity for an empty program, and a
+conditional -> qualified requalification through the gate (#1225).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from digitalmodel.floating_wind.collaboration import (
+    CollaborationProgram,
+    JointIndustryProject,
+    apply_collaboration,
+    default_collaboration_program,
+    requalify_with_collaboration,
+)
+from digitalmodel.floating_wind.qualification import (
+    ConceptMaturity,
+    QualificationVerdict,
+    default_criteria,
+)
+
+
+def test_default_program_has_deck_jips():
+    prog = default_collaboration_program()
+    names = {j.name for j in prog.jips}
+    assert names == {"Cability", "CALM", "SURF-IM", "SUREFLEX"}
+
+
+def test_total_uplift_sums_per_criterion():
+    prog = default_collaboration_program()
+    tot = prog.total_uplift()
+    # 3 JIPs target technology_readiness (Cability, CALM, SUREFLEX) @0.10
+    assert tot["technology_readiness"] == pytest.approx(0.30)
+    assert tot["track_record"] == pytest.approx(0.10)
+
+
+def test_uplift_targets_only_named_criteria():
+    prog = CollaborationProgram(
+        jips=[JointIndustryProject(name="X", targets=["technology_readiness"], maturity_uplift=0.2)]
+    )
+    scores = {"technology_readiness": 0.5, "cost_confidence": 0.6}
+    out = prog.uplift_scores(scores)
+    assert out["technology_readiness"] == pytest.approx(0.7)
+    assert out["cost_confidence"] == pytest.approx(0.6)  # untouched
+
+
+def test_uplift_capped_at_one():
+    prog = CollaborationProgram(
+        jips=[JointIndustryProject(name="X", targets=["technology_readiness"], maturity_uplift=0.5)]
+    )
+    out = prog.uplift_scores({"technology_readiness": 0.8})
+    assert out["technology_readiness"] == pytest.approx(1.0)  # 0.8+0.5 capped
+
+
+def test_uplift_adds_absent_criterion_from_zero():
+    prog = CollaborationProgram(
+        jips=[JointIndustryProject(name="X", targets=["track_record"], maturity_uplift=0.15)]
+    )
+    out = prog.uplift_scores({"technology_readiness": 0.5})
+    assert out["track_record"] == pytest.approx(0.15)
+
+
+def test_empty_program_is_identity():
+    prog = CollaborationProgram()
+    scores = {"technology_readiness": 0.4, "track_record": 0.6}
+    assert prog.uplift_scores(scores) == scores
+
+
+def test_apply_collaboration_returns_new_concept():
+    prog = default_collaboration_program()
+    c = ConceptMaturity(name="semi", scores={"technology_readiness": 0.5})
+    out = apply_collaboration(c, prog)
+    assert out.name == "semi"
+    assert out.scores["technology_readiness"] == pytest.approx(0.8)  # 0.5+0.30
+    assert c.scores["technology_readiness"] == pytest.approx(0.5)  # original intact
+
+
+def test_jips_move_conditional_to_qualified():
+    """A concept weak on technology_readiness clears the gate after de-risking."""
+    criteria = default_criteria()
+    concept = ConceptMaturity(
+        name="novel_tlp",
+        scores={
+            "technology_readiness": 0.50,
+            "track_record": 0.70,
+            "supply_chain_readiness": 0.70,
+            "cost_confidence": 0.70,
+        },
+    )
+    before, after = requalify_with_collaboration(
+        concept, default_collaboration_program(), criteria
+    )
+    assert before.verdict is QualificationVerdict.CONDITIONAL
+    assert after.verdict is QualificationVerdict.QUALIFIED
+    assert after.score > before.score
+
+
+def test_jip_requires_targets_and_positive_uplift():
+    with pytest.raises(ValidationError):
+        JointIndustryProject(name="bad", targets=[], maturity_uplift=0.1)
+    with pytest.raises(ValidationError):
+        JointIndustryProject(name="bad", targets=["technology_readiness"], maturity_uplift=0.0)
+    with pytest.raises(ValidationError):
+        JointIndustryProject(name="bad", targets=["technology_readiness"], maturity_uplift=1.5)


### PR DESCRIPTION
Closes #1285. Follow-on to epic #1220 — **the last Wood/Whooley cost lever.** Bases on `main`.

## What
Models the deck's **cross-industry collaboration** theme (slide 13: the Cability, CALM, SURF-IM, SUREFLEX JIPs) as a **technology de-risking overlay** on the qualification gate (#1225):
- `JointIndustryProject` — raises the maturity of the criteria it targets.
- `CollaborationProgram` — a set of JIPs; `apply_collaboration` / `requalify_with_collaboration` re-score a concept, so a `conditional` concept can become `qualified` once the relevant JIPs de-risk its weak subsystem.
- Uplifts targeting the same criterion **sum**, **capped at 1.0** (collaboration can't exceed fully-proven); empty program is the identity.

## Calibration (honest)
Per-JIP uplift is a **calibration input, not a deck number** — default ~0.10 (≈ one DNV-RP-A203 TRL step); the packaged program is the deck's four JIPs, overridable via `collaboration.yml`. Tests assert the mechanism (targeted, summed, capped, `conditional → qualified`), not a forced score.

## Validation
`9` collaboration tests; **135 passed** across the full `floating_wind` suite (no regression), under the full-deps venv.

## Completes the deck
Every Wood/Whooley cost-reduction lever is now modelled: engine · reliability · sweep · qualification · trade-space LCOE · data sheet/workflow · economies of scale · standardization/learning · **collaboration/JIP** (this PR).
