### PR TITLE
feat(riser_database): riser_stackup + rig_riser_interface tables (#1259)

### DIFF
--- a/data/riser_database/manifest.yaml
+++ b/data/riser_database/manifest.yaml
@@ -11,6 +11,14 @@ tables:
     file: material_sn_scf_dff.csv
     rows: 3
     sha256: 121a4d08df0a271b12e59ba8344893dd6aa71fc310a09d4c8b2bed3509a98c2f
+  rig_riser_interface:
+    file: rig_riser_interface.csv
+    rows: 3
+    sha256: a7602f37afc3bcda207cad9daba55f24a681d93972011d3f512f731053e2a59e
+  riser_stackup:
+    file: riser_stackup.csv
+    rows: 9
+    sha256: f7d949cd0ffeceecc174c9e0c7b03845374fb34d395138c94cda4b85017de64a
   standards_crosswalk:
     file: standards_crosswalk.csv
     rows: 4

--- a/data/riser_database/rig_riser_interface.csv
+++ b/data/riser_database/rig_riser_interface.csv
@@ -1,0 +1,4 @@
+rig_ref,rig_type,n_tensioners,tensioner_type,tensioner_capacity_kips,tensioner_stroke_ft,tj_stroke_ft,n_tension_wires,moonpool_length_ft,moonpool_width_ft,drill_floor_elev_ft,wed_rig_name,wiki_path,note
+drillship-16w-wireline,drillship,,wireline,,,,16,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,wireline-tensioner drillship class; two wires may fail per the tension criterion
+drillship-6g-16x3600k-dat,drillship,16,direct-acting,3600,,60,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,sixth-generation drillship class with direct-acting tensioners
+drillship-generic-market,drillship,,direct-acting,3500,50,65,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,market-typical capability figures for screening

--- a/data/riser_database/riser_stackup.csv
+++ b/data/riser_database/riser_stackup.csv
@@ -1,0 +1,10 @@
+rsu_id,topology_class,stackup_type,operation,riser_od_in,water_depth_band,rig_ref,wiki_path,note
+RSU-0001,conventional-bop-on-wellhead,as-planned-stackup,drilling,21,2000-3000m,drillship-6g-16x3600k-dat,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0002,completion-bop-on-ths,as-planned-stackup,completion,21,2000-3000m,drillship-6g-16x3600k-dat,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0003,intervention-bop-on-tree,as-planned-stackup,intervention,21,2000-3000m,drillship-6g-16x3600k-dat,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0004,mpd-surface-stack,as-planned-stackup,mpd,21,1000-1500m,drillship-16w-wireline,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0005,mpd-surface-stack,as-run-tally,mpd,21,1000-1500m,drillship-16w-wireline,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0006,none,weight-table,drilling,21,1000-1500m,drillship-16w-wireline,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0007,none,joint-library,drilling,21,1000-1500m,drillship-16w-wireline,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0008,production-scr-hangoff,component-library,,12.75,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,
+RSU-0009,conventional-bop-on-wellhead,as-planned-stackup,drilling,21,2000-3000m,,wikis/riser-projects/wiki/datasets/stackup-registry.md,

--- a/docs/riser_database.md
+++ b/docs/riser_database.md
@@ -94,3 +94,30 @@ attach the output to the PR as evidence.
   `atlases/riser_database*` per `parametric.atlas` conventions — deliberately
   NOT used for these relational tables (binary Parquet is invisible to
   text-based leak scanning).
+
+## riser_stackup + rig_riser_interface (#1259)
+
+The stack-up layer publishes **handles + banded envelopes only**. Each row of
+`riser_stackup` carries an `rsu_id` (resolving into the PRIVATE llm-wiki
+stack-up registry via `wiki_path` — always the registry page itself, never
+per-source pages), a `topology_class` from a controlled vocabulary (so
+depth-collapsed queries are first-class), a coarse `water_depth_band`
+(synthetic example: a dataset at an exact depth of, say, 1,234 m publishes
+only `1000-1500m`), and the `rig_ref` **residency join**: a riser string is
+stationed on a rig, so every stack-up row can join to a rig-class row in
+`rig_riser_interface` (tensioner/TJ capability columns; `wed_rig_name` joins
+the worldenergydata rig fleet and is populated only for rows sourced from
+public rig specifications).
+
+**De-id rules (enforced by tests):** no exact depths/masses/joint counts, no
+unit-bearing values, no registry generic-name strings, and no provenance name
+tokens or project numbers anywhere in the public artifacts (`tests/
+riser_database/test_stackup_rig.py`, `test_provenance_tripwire.py` — the
+latter auto-extracts tokens from the private registry's source pages, so it
+runs in-context and is part of the merge gate). Banding is decided wiki-side,
+on water depth only, one band per source dataset family.
+
+**Cross-repo coupling (by design):** registering a new RSU id in the llm-wiki
+registry makes the in-context reconciliation test fail here until the table
+gains the row — a conscious update, never silent drift. Public issues, PRs
+and commit messages about this table family carry bands and handles only.

--- a/scripts/riser_database/build_tables.py
+++ b/scripts/riser_database/build_tables.py
@@ -46,6 +46,36 @@ CROSSWALK_COLUMNS = [
     "registry_revision",
     "note",
 ]
+STACKUP_COLUMNS = [
+    "rsu_id",
+    "topology_class",
+    "stackup_type",
+    "operation",
+    "riser_od_in",
+    "water_depth_band",
+    "rig_ref",
+    "wiki_path",
+    "note",
+]
+RIG_COLUMNS = [
+    "rig_ref",
+    "rig_type",
+    "n_tensioners",
+    "tensioner_type",
+    "tensioner_capacity_kips",
+    "tensioner_stroke_ft",
+    "tj_stroke_ft",
+    "n_tension_wires",
+    "moonpool_length_ft",
+    "moonpool_width_ft",
+    "drill_floor_elev_ft",
+    "wed_rig_name",
+    "wiki_path",
+    "note",
+]
+#: The ONLY wiki_path the public stack-up/rig tables may carry (#1259 review:
+#: per-source page slugs leak provenance; the registry page is the resolver).
+REGISTRY_WIKI_PATH = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
 MATERIAL_COLUMNS = [
     "ref_id",
     "sn_curve_name",
@@ -138,6 +168,10 @@ def main() -> int:
 
     crosswalk_rows = sorted(spec["crosswalk_rows"], key=lambda r: r["code_id"])
     material_rows = sorted(spec["material_rows"], key=lambda r: r["ref_id"])
+    stackup_rows = sorted(spec["stackup_rows"], key=lambda r: r["rsu_id"])
+    rig_rows = sorted(spec["rig_rows"], key=lambda r: r["rig_ref"])
+    for row in stackup_rows + rig_rows:
+        row["wiki_path"] = REGISTRY_WIKI_PATH
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     tables = {
@@ -149,6 +183,12 @@ def main() -> int:
         ),
         "material_sn_scf_dff": _write_csv(
             OUT_DIR / "material_sn_scf_dff.csv", MATERIAL_COLUMNS, material_rows
+        ),
+        "riser_stackup": _write_csv(
+            OUT_DIR / "riser_stackup.csv", STACKUP_COLUMNS, stackup_rows
+        ),
+        "rig_riser_interface": _write_csv(
+            OUT_DIR / "rig_riser_interface.csv", RIG_COLUMNS, rig_rows
         ),
     }
     manifest = {

--- a/scripts/riser_database/sources.yml
+++ b/scripts/riser_database/sources.yml
@@ -110,3 +110,109 @@ material_rows:
     code_id: dnv-rp-c203
     wiki_path: wikis/engineering-standards/wiki/standards/dnv-rp-c203.md
     note: alternative girth-weld detail class for riser fatigue screening
+
+# riser_stackup (#1259): registry HANDLES + banded envelopes ONLY. The private
+# stack-up registry (wiki_path below) is the value authority; exact depths,
+# masses, joint counts and the registry generic-name strings must NEVER appear
+# in this file or the generated CSVs (de-id + provenance tripwires enforce).
+stackup_rows:
+  - rsu_id: RSU-0001
+    topology_class: conventional-bop-on-wellhead
+    stackup_type: as-planned-stackup
+    operation: drilling
+    riser_od_in: "21"
+    water_depth_band: 2000-3000m
+    rig_ref: drillship-6g-16x3600k-dat
+  - rsu_id: RSU-0002
+    topology_class: completion-bop-on-ths
+    stackup_type: as-planned-stackup
+    operation: completion
+    riser_od_in: "21"
+    water_depth_band: 2000-3000m
+    rig_ref: drillship-6g-16x3600k-dat
+  - rsu_id: RSU-0003
+    topology_class: intervention-bop-on-tree
+    stackup_type: as-planned-stackup
+    operation: intervention
+    riser_od_in: "21"
+    water_depth_band: 2000-3000m
+    rig_ref: drillship-6g-16x3600k-dat
+  - rsu_id: RSU-0004
+    topology_class: mpd-surface-stack
+    stackup_type: as-planned-stackup
+    operation: mpd
+    riser_od_in: "21"
+    water_depth_band: 1000-1500m
+    rig_ref: drillship-16w-wireline
+  - rsu_id: RSU-0005
+    topology_class: mpd-surface-stack
+    stackup_type: as-run-tally
+    operation: mpd
+    riser_od_in: "21"
+    water_depth_band: 1000-1500m
+    rig_ref: drillship-16w-wireline
+  - rsu_id: RSU-0006
+    topology_class: none
+    stackup_type: weight-table
+    operation: drilling
+    riser_od_in: "21"
+    water_depth_band: 1000-1500m
+    rig_ref: drillship-16w-wireline
+  - rsu_id: RSU-0007
+    topology_class: none
+    stackup_type: joint-library
+    operation: drilling
+    riser_od_in: "21"
+    water_depth_band: 1000-1500m
+    rig_ref: drillship-16w-wireline
+  - rsu_id: RSU-0008
+    topology_class: production-scr-hangoff
+    stackup_type: component-library
+    operation: ""
+    riser_od_in: "12.75"
+    water_depth_band: ""
+    rig_ref: ""
+  - rsu_id: RSU-0009
+    topology_class: conventional-bop-on-wellhead
+    stackup_type: as-planned-stackup
+    operation: drilling
+    riser_od_in: "21"
+    water_depth_band: 2000-3000m
+    rig_ref: ""
+
+# rig_riser_interface (#1259): generic rig-class slugs; wed_rig_name joins the
+# worldenergydata 2,268-rig identity space and is populated ONLY for rows
+# sourced from public rig specifications (none in this slice). Capability
+# numerics are rig-class brochure-grade values; moonpool/drill-floor columns
+# ship empty until public-safe seeds exist.
+rig_rows:
+  - rig_ref: drillship-6g-16x3600k-dat
+    rig_type: drillship
+    n_tensioners: "16"
+    tensioner_type: direct-acting
+    tensioner_capacity_kips: "3600"
+    tensioner_stroke_ft: ""
+    tj_stroke_ft: "60"
+    n_tension_wires: ""
+    wed_rig_name: ""
+    note: sixth-generation drillship class with direct-acting tensioners
+  - rig_ref: drillship-16w-wireline
+    rig_type: drillship
+    n_tensioners: ""
+    tensioner_type: wireline
+    tensioner_capacity_kips: ""
+    tensioner_stroke_ft: ""
+    tj_stroke_ft: ""
+    n_tension_wires: "16"
+    wed_rig_name: ""
+    note: wireline-tensioner drillship class; two wires may fail per the tension criterion
+  - rig_ref: drillship-generic-market
+    rig_type: drillship
+    n_tensioners: ""
+    tensioner_type: direct-acting
+    tensioner_capacity_kips: "3500"
+    tensioner_stroke_ft: "50"
+    tj_stroke_ft: "65"
+    n_tension_wires: ""
+    wed_rig_name: ""
+    note: market-typical capability figures for screening

--- a/src/digitalmodel/riser_database/__init__.py
+++ b/src/digitalmodel/riser_database/__init__.py
@@ -11,6 +11,8 @@ from digitalmodel.riser_database.getters import (
 )
 from digitalmodel.riser_database.loader import (
     DEFAULT_DB_ROOT,
+    RigRiserInterfaceRow,
+    RiserStackupRow,
     MaterialSnScfDffRow,
     RiserConfigRow,
     RiserDatabase,
@@ -24,6 +26,8 @@ __all__ = [
     "RiserConfigRow",
     "RiserDatabase",
     "RiserDatabaseError",
+    "RigRiserInterfaceRow",
+    "RiserStackupRow",
     "StandardsCrosswalkRow",
     "get_riser_dff",
     "get_riser_scf",

--- a/src/digitalmodel/riser_database/loader.py
+++ b/src/digitalmodel/riser_database/loader.py
@@ -94,13 +94,69 @@ class MaterialSnScfDffRow:
     note: str
 
 
-_NUMERIC_CONFIG_COLUMNS = ("water_depth_m", "od_mm", "wt_mm")
+@dataclass(frozen=True)
+class RiserStackupRow:
+    """Registry HANDLE + banded envelope (#1259): joint-by-joint values live
+    wiki-side; ``water_depth_band`` is a coarse band, never an exact depth;
+    ``rig_ref`` is the rig-residency join into ``rig_riser_interface``."""
+
+    rsu_id: str
+    topology_class: str
+    stackup_type: str
+    operation: str
+    riser_od_in: Optional[float]
+    water_depth_band: str
+    rig_ref: str
+    wiki_path: str
+    note: str
+
+
+@dataclass(frozen=True)
+class RigRiserInterfaceRow:
+    """Rig-class riser-handling capability (#1259). ``rig_ref`` is a generic
+    technical-signature slug; ``wed_rig_name`` joins the worldenergydata
+    2,268-rig identity space and is populated ONLY for rows sourced from
+    public rig specifications (named-rig <-> engagement mapping stays
+    wiki-side)."""
+
+    rig_ref: str
+    rig_type: str
+    n_tensioners: Optional[float]
+    tensioner_type: str
+    tensioner_capacity_kips: Optional[float]
+    tensioner_stroke_ft: Optional[float]
+    tj_stroke_ft: Optional[float]
+    n_tension_wires: Optional[float]
+    moonpool_length_ft: Optional[float]
+    moonpool_width_ft: Optional[float]
+    drill_floor_elev_ft: Optional[float]
+    wed_rig_name: str
+    wiki_path: str
+    note: str
+
+
+_NUMERIC_CONFIG_COLUMNS = (
+    "water_depth_m",
+    "od_mm",
+    "wt_mm",
+    "riser_od_in",
+    "n_tensioners",
+    "tensioner_capacity_kips",
+    "tensioner_stroke_ft",
+    "tj_stroke_ft",
+    "n_tension_wires",
+    "moonpool_length_ft",
+    "moonpool_width_ft",
+    "drill_floor_elev_ft",
+)
 #: Known tables: csv file, key column, row type. Anything else in the
 #: manifest is rejected (bounded reads: no discovery, no globbing).
 _TABLE_SPECS = {
     "config_catalog": ("config_catalog.csv", "config_id", RiserConfigRow),
     "standards_crosswalk": ("standards_crosswalk.csv", "code_id", StandardsCrosswalkRow),
     "material_sn_scf_dff": ("material_sn_scf_dff.csv", "ref_id", MaterialSnScfDffRow),
+    "riser_stackup": ("riser_stackup.csv", "rsu_id", RiserStackupRow),
+    "rig_riser_interface": ("rig_riser_interface.csv", "rig_ref", RigRiserInterfaceRow),
 }
 
 
@@ -159,10 +215,14 @@ class RiserDatabase:
         configs: Mapping[str, RiserConfigRow],
         crosswalk: Mapping[str, StandardsCrosswalkRow],
         materials: Mapping[str, MaterialSnScfDffRow],
+        stackups: Mapping[str, RiserStackupRow],
+        rigs: Mapping[str, RigRiserInterfaceRow],
     ) -> None:
         self._configs = dict(configs)
         self._crosswalk = dict(crosswalk)
         self._materials = dict(materials)
+        self._stackups = dict(stackups)
+        self._rigs = dict(rigs)
 
     @classmethod
     def load(cls, root: Path = DEFAULT_DB_ROOT) -> "RiserDatabase":
@@ -190,6 +250,8 @@ class RiserDatabase:
             configs=loaded["config_catalog"],
             crosswalk=loaded["standards_crosswalk"],
             materials=loaded["material_sn_scf_dff"],
+            stackups=loaded["riser_stackup"],
+            rigs=loaded["rig_riser_interface"],
         )
 
     # -- accessors: unknown key escalates (never defaults) -----------------------
@@ -202,6 +264,12 @@ class RiserDatabase:
 
     def material(self, ref_id: str) -> MaterialSnScfDffRow:
         return self._lookup("material_sn_scf_dff", self._materials, ref_id)
+
+    def stackup(self, rsu_id: str) -> RiserStackupRow:
+        return self._lookup("riser_stackup", self._stackups, rsu_id)
+
+    def rig(self, rig_ref: str) -> RigRiserInterfaceRow:
+        return self._lookup("rig_riser_interface", self._rigs, rig_ref)
 
     @staticmethod
     def _lookup(table: str, rows: Mapping[str, object], key: str):
@@ -224,13 +292,25 @@ class RiserDatabase:
     def materials(self) -> tuple[MaterialSnScfDffRow, ...]:
         return tuple(self._materials.values())
 
+    @property
+    def stackups(self) -> tuple[RiserStackupRow, ...]:
+        return tuple(self._stackups.values())
+
+    @property
+    def rigs(self) -> tuple[RigRiserInterfaceRow, ...]:
+        return tuple(self._rigs.values())
+
     def iter_public_rows(self) -> Iterator[tuple[str, str, str]]:
         """Yield ``(table, key, flattened-row-text)`` for every public-route
-        row — the substrate the leak gate (suite 6) scans."""
+        row — the substrate the leak gate (suite 6) scans. Kept in lockstep
+        with ``_TABLE_SPECS`` (a new table must appear here; the coverage
+        test derives its expectation from ``_TABLE_SPECS``)."""
         for table, rows in (
             ("config_catalog", self._configs),
             ("standards_crosswalk", self._crosswalk),
             ("material_sn_scf_dff", self._materials),
+            ("riser_stackup", self._stackups),
+            ("rig_riser_interface", self._rigs),
         ):
             for key, row in rows.items():
                 flat = " | ".join(

--- a/tests/riser_database/test_leak_gate.py
+++ b/tests/riser_database/test_leak_gate.py
@@ -21,7 +21,11 @@ from pathlib import Path
 import pytest
 import yaml
 
-from digitalmodel.riser_database.loader import DEFAULT_DB_ROOT, RiserDatabase
+from digitalmodel.riser_database.loader import (
+    _TABLE_SPECS as rdb_loader_specs,
+    DEFAULT_DB_ROOT,
+    RiserDatabase,
+)
 
 # -- Layer A: structural patterns (public-safe) ----------------------------------
 
@@ -34,12 +38,11 @@ STRUCTURAL_PATTERNS = (
     (re.compile(r"(?i)https?://"), "URL"),
 )
 
-_DATA_FILES = (
-    "config_catalog.csv",
-    "standards_crosswalk.csv",
-    "material_sn_scf_dff.csv",
-    "manifest.yaml",
-)
+# Derived from the loader's table specs so a new table can never drift out of
+# the raw-file scan (#1259 review finding), plus the non-CSV public files.
+_DATA_FILES = tuple(
+    spec[0] for spec in rdb_loader_specs.values()
+) + ("manifest.yaml",)
 
 
 def test_layer_a_public_rows_structurally_clean():

--- a/tests/riser_database/test_loader.py
+++ b/tests/riser_database/test_loader.py
@@ -173,8 +173,12 @@ def test_oversized_table_fail_closed(tmp_path, monkeypatch):
 
 
 def test_iter_public_rows_covers_all_tables():
+    # Derived from _TABLE_SPECS so an added table can never silently escape
+    # the leak gate's row substrate (#1259 review finding).
     db = RiserDatabase.load()
     tables = {table for table, _key, _flat in db.iter_public_rows()}
-    assert tables == {"config_catalog", "standards_crosswalk", "material_sn_scf_dff"}
+    assert tables == set(rdb_loader._TABLE_SPECS)
     n_rows = sum(1 for _ in db.iter_public_rows())
-    assert n_rows == len(db.configs) + len(db.crosswalk_rows) + len(db.materials)
+    assert n_rows == len(db.configs) + len(db.crosswalk_rows) + len(
+        db.materials
+    ) + len(db.stackups) + len(db.rigs)

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -1,0 +1,120 @@
+"""#1259 provenance-token tripwire (plan v2 D4) — in-context hard gate.
+
+Auto-extracts provenance name tokens and project numbers from the PRIVATE
+registry's linked source pages (slugs + `sources:` frontmatter) and asserts
+none appear, case/separator-normalized, in ANY public riser-DB artifact.
+
+This is the scoped, regex-capable complement to the workspace-hub deny list:
+famous public-domain field/rig names cannot live in the GLOBAL deny list
+(they legitimately appear in worldenergydata's regulatory datasets), so THIS
+test is where they are enforced for digitalmodel. Loud skip standalone.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.riser_database.loader import DEFAULT_DB_ROOT
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
+_KNOWN_WIKI_CLONES = (
+    Path("/mnt/local-analysis/llm-wiki"),
+    Path.home() / "workspace-hub" / "llm-wiki",
+)
+
+#: Generic engineering/document words that appear in slugs but are not
+#: provenance names. Anything NOT here and >=4 chars is treated as a name.
+_STOPWORDS = {
+    "analysis", "assessment", "basis", "compliant", "concept", "conductors",
+    "data", "design", "deep", "development", "drilling", "engineering",
+    "fatigue", "foundation", "joint", "library", "mode", "multi", "normalization",
+    "overview", "presentation", "proj", "projects", "registry", "results",
+    "riser", "risers", "sidetrack", "source", "sources", "stackup", "study",
+    "summary", "ttr", "well", "wellhead", "wellheads", "wells", "wiki", "wikis",
+    "workbook", "client", "share", "operational", "market",
+}
+
+_PUBLIC_ARTIFACTS = (
+    DEFAULT_DB_ROOT / "config_catalog.csv",
+    DEFAULT_DB_ROOT / "standards_crosswalk.csv",
+    DEFAULT_DB_ROOT / "material_sn_scf_dff.csv",
+    DEFAULT_DB_ROOT / "riser_stackup.csv",
+    DEFAULT_DB_ROOT / "rig_riser_interface.csv",
+    DEFAULT_DB_ROOT / "manifest.yaml",
+    REPO_ROOT / "scripts" / "riser_database" / "sources.yml",
+    REPO_ROOT / "scripts" / "riser_database" / "build_tables.py",
+    REPO_ROOT / "docs" / "riser_database.md",
+    REPO_ROOT / "src" / "digitalmodel" / "riser_database" / "loader.py",
+    REPO_ROOT / "src" / "digitalmodel" / "riser_database" / "getters.py",
+)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"[\s_\-]+", "", text).casefold()
+
+
+def _wiki_base() -> Path:
+    candidates = []
+    env = os.environ.get("LLM_WIKI_PATH")
+    if env:
+        candidates.append(Path(env))
+    candidates.extend(_KNOWN_WIKI_CLONES)
+    for base in candidates:
+        if (base / REGISTRY_REL).is_file():
+            return base
+    pytest.skip(
+        "llm-wiki not available (standalone mode) — the provenance-token "
+        "tripwire is part of the in-context merge gate"
+    )
+
+
+def _provenance_tokens() -> tuple[set[str], set[str]]:
+    """(name_tokens, number_tokens) from registry-linked source pages."""
+    base = _wiki_base()
+    registry = (base / REGISTRY_REL).read_text()
+    linked = set(re.findall(r"\.\./sources/([a-z0-9\-]+)\.md", registry))
+    names: set[str] = set()
+    numbers: set[str] = set()
+
+    def harvest(text: str) -> None:
+        for word in re.findall(r"[A-Za-z]{4,}", text):
+            if word.casefold() not in _STOPWORDS:
+                names.add(word.casefold())
+        for num in re.findall(r"\b[1-9]\d{3,4}\b", text):
+            numbers.add(num)
+
+    for slug in linked:
+        harvest(slug.replace("-", " "))
+        page = base / "wikis/riser-projects/wiki/sources" / f"{slug}.md"
+        if not page.is_file():
+            continue
+        frontmatter = page.read_text().split("---", 2)[1]
+        for line in frontmatter.splitlines():
+            if "ace-share:" in line:
+                harvest(line)
+    assert names or numbers, "token extraction came back empty — parser drift?"
+    return names, numbers
+
+
+def test_no_provenance_tokens_in_public_artifacts():
+    names, numbers = _provenance_tokens()
+    violations = []
+    for path in _PUBLIC_ARTIFACTS:
+        if not path.is_file():
+            continue
+        raw = path.read_text()
+        normalized = _normalize(raw)
+        for token in names:
+            if _normalize(token) in normalized:
+                violations.append((path.name, f"name-token #{sorted(names).index(token)}"))
+        for num in numbers:
+            if re.search(rf"\b{num}\b", raw):
+                violations.append((path.name, f"project-number {num}"))
+    assert not violations, (
+        "provenance tokens leaked into public artifacts (tokens not echoed): "
+        f"{violations}"
+    )

--- a/tests/riser_database/test_stackup_rig.py
+++ b/tests/riser_database/test_stackup_rig.py
@@ -1,0 +1,237 @@
+"""#1259 suites: riser_stackup + rig_riser_interface — loader, controlled
+vocabularies, the rig-residency join, wiki_path structural tripwire, de-id
+tripwire, and RSU-registry reconciliation.
+
+Governance (plan v2): public rows carry HANDLES + BANDED envelopes only.
+No exact depths/masses/names anywhere in the public artifacts — the de-id
+tripwire below enforces the shape, the provenance-token tripwire (separate
+module) enforces the names.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.riser_database import loader as rdb_loader
+from digitalmodel.riser_database.loader import (
+    DEFAULT_DB_ROOT,
+    RigRiserInterfaceRow,
+    RiserDatabase,
+    RiserDatabaseError,
+    RiserStackupRow,
+)
+
+REGISTRY_WIKI_PATH = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
+
+TOPOLOGY_VOCAB = {
+    "conventional-bop-on-wellhead",
+    "completion-bop-on-ths",
+    "intervention-bop-on-tree",
+    "mpd-surface-stack",
+    "production-scr-hangoff",
+    "none",
+}
+STACKUP_TYPE_VOCAB = {
+    "as-planned-stackup",
+    "as-run-tally",
+    "weight-table",
+    "joint-library",
+    "component-library",
+}
+OPERATION_VOCAB = {"drilling", "completion", "intervention", "mpd", "pa", ""}
+WATER_DEPTH_BAND_VOCAB = {
+    "0-500m",
+    "500-1000m",
+    "1000-1500m",
+    "1500-2000m",
+    "2000-3000m",
+    "",
+}
+
+# Unit-bearing exact-value patterns (de-id tripwire). Bare numerics in typed
+# numeric COLUMNS are fine (rig capability data); what must never appear is a
+# number WITH a length/mass unit — the signature of exact depths/weights.
+DEID_PATTERNS = (
+    re.compile(r"\d{3,5}(\.\d+)?\s?(m|ft)\b", re.IGNORECASE),
+    re.compile(r"\d{2,4}(\.\d+)?\s?(t|te|lb|lbs|kips)\b", re.IGNORECASE),
+)
+
+
+# -- loader ---------------------------------------------------------------------
+
+
+def test_row_counts_pinned():
+    db = RiserDatabase.load()
+    assert len(db.stackups) == 9
+    assert len(db.rigs) == 3
+    assert all(isinstance(r, RiserStackupRow) for r in db.stackups)
+    assert all(isinstance(r, RigRiserInterfaceRow) for r in db.rigs)
+
+
+@pytest.mark.parametrize("accessor", ["stackup", "rig"])
+def test_unknown_key_escalates(accessor):
+    db = RiserDatabase.load()
+    with pytest.raises(RiserDatabaseError) as exc:
+        getattr(db, accessor)("no-such-key")
+    assert "unknown" in exc.value.reason
+
+
+def test_iter_public_rows_covers_five_tables():
+    tables = {t for t, _k, _f in RiserDatabase.load().iter_public_rows()}
+    assert tables == {
+        "config_catalog",
+        "standards_crosswalk",
+        "material_sn_scf_dff",
+        "riser_stackup",
+        "rig_riser_interface",
+    }
+
+
+# -- controlled vocabularies -------------------------------------------------------
+
+
+def test_stackup_vocabularies():
+    for row in RiserDatabase.load().stackups:
+        assert row.topology_class in TOPOLOGY_VOCAB, row.rsu_id
+        assert row.stackup_type in STACKUP_TYPE_VOCAB, row.rsu_id
+        assert row.operation in OPERATION_VOCAB, row.rsu_id
+        assert row.water_depth_band in WATER_DEPTH_BAND_VOCAB, row.rsu_id
+        assert re.fullmatch(r"RSU-\d{4}", row.rsu_id)
+
+
+def test_topology_grain():
+    """The depth-collapsed grain: 5 topology classes + none-sentinel rows."""
+    classes = {r.topology_class for r in RiserDatabase.load().stackups}
+    assert classes == TOPOLOGY_VOCAB - {"none"} | {"none"}
+
+
+def test_property_library_rows_use_none_sentinel():
+    db = RiserDatabase.load()
+    for rsu_id in ("RSU-0006", "RSU-0007"):
+        assert db.stackup(rsu_id).topology_class == "none"
+
+
+# -- rig-residency join --------------------------------------------------------------
+
+
+def test_rig_ref_join_integrity():
+    db = RiserDatabase.load()
+    rig_keys = {r.rig_ref for r in db.rigs}
+    for row in db.stackups:
+        if row.rig_ref:
+            assert row.rig_ref in rig_keys, (row.rsu_id, row.rig_ref)
+
+
+def test_wed_rig_name_empty_for_engagement_rows():
+    # This slice ships no public-spec-sourced rig rows -> all wed_rig_name empty.
+    # Populating one requires a public rig-spec source documented in sources.yml.
+    for rig in RiserDatabase.load().rigs:
+        assert rig.wed_rig_name == "", rig.rig_ref
+
+
+# -- wiki_path structural tripwire ---------------------------------------------------
+
+
+def test_wiki_path_registry_page_only():
+    db = RiserDatabase.load()
+    forbidden = re.compile(r"/sources/|/entities/|\b\d{5}\b")
+    for row in list(db.stackups) + list(db.rigs):
+        assert row.wiki_path == REGISTRY_WIKI_PATH, row
+        assert row.wiki_path.startswith("wikis/riser-projects/wiki/datasets/")
+        assert not forbidden.search(row.wiki_path)
+
+
+# -- de-id tripwire ------------------------------------------------------------------
+
+_PUBLIC_FILES = (
+    "riser_stackup.csv",
+    "rig_riser_interface.csv",
+    "manifest.yaml",
+)
+
+
+def test_no_exact_unit_bearing_values_in_rows():
+    violations = []
+    for table, key, flat in RiserDatabase.load().iter_public_rows():
+        if table not in ("riser_stackup", "rig_riser_interface"):
+            continue
+        row = (
+            RiserDatabase.load().stackup(key)
+            if table == "riser_stackup"
+            else RiserDatabase.load().rig(key)
+        )
+        for field_name in row.__dataclass_fields__:
+            value = getattr(row, field_name)
+            if field_name == "water_depth_band" or value is None:
+                continue
+            text = str(value)
+            for pattern in DEID_PATTERNS:
+                if pattern.search(text):
+                    violations.append((table, key, field_name, text))
+    assert not violations, violations
+
+
+def test_no_exact_unit_bearing_values_in_raw_files():
+    sources_spec = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "riser_database"
+        / "sources.yml"
+    )
+    targets = [DEFAULT_DB_ROOT / name for name in _PUBLIC_FILES] + [sources_spec]
+    violations = []
+    for path in targets:
+        for line in path.read_text().splitlines():
+            if "water_depth_band" in line or re.search(r"\b\d{3,4}-\d{3,4}m\b", line):
+                continue  # band vocabulary lines are asserted separately
+            for pattern in DEID_PATTERNS:
+                if pattern.search(line):
+                    violations.append((path.name, line.strip()[:80]))
+    assert not violations, violations
+
+
+def test_registry_generic_names_not_republished():
+    """The registry's generic-name strings embed exact WD/tonnage — they must
+    not appear verbatim in any public row (in-context; loud skip standalone)."""
+    registry = _registry_text()
+    names = re.findall(r"\|\s*(2[01]?[\d.]*in [^|]{10,})\|", registry)
+    flat_all = " ".join(f for _t, _k, f in RiserDatabase.load().iter_public_rows())
+    for name in names:
+        assert name.strip() not in flat_all
+
+
+# -- RSU registry reconciliation (in-context) ---------------------------------------
+
+_KNOWN_WIKI_CLONES = (
+    Path("/mnt/local-analysis/llm-wiki"),
+    Path.home() / "workspace-hub" / "llm-wiki",
+)
+
+
+def _registry_text() -> str:
+    candidates = []
+    env = os.environ.get("LLM_WIKI_PATH")
+    if env:
+        candidates.append(Path(env))
+    candidates.extend(_KNOWN_WIKI_CLONES)
+    for base in candidates:
+        page = base / REGISTRY_WIKI_PATH
+        if page.is_file():
+            return page.read_text()
+    pytest.skip(
+        "llm-wiki stack-up registry not available (standalone mode) — this "
+        "reconciliation test is part of the in-context merge gate"
+    )
+
+
+def test_registry_reconciliation_bidirectional():
+    registry_ids = set(re.findall(r"RSU-\d{4}", _registry_text()))
+    table_ids = {r.rsu_id for r in RiserDatabase.load().stackups}
+    assert table_ids == registry_ids, (
+        f"table-only: {sorted(table_ids - registry_ids)}; "
+        f"registry-only (new RSU needs a conscious table update): "
+        f"{sorted(registry_ids - table_ids)}"
+    )


### PR DESCRIPTION
Closes #1259 (child A of epic #1279). Implements the **user-approved plan v2** (T2 adversarial review: R1 APPROVE-WITH-CHANGES + R2 REJECT, all 8 blocking findings folded; public-surface remediation applied before this PR).

## What ships (12 files, +654)
- **`riser_stackup`** — 9 registry handles (`RSU-####`) with **banded envelopes only**: `topology_class` controlled vocabulary (the depth-collapsed grain is a first-class column), coarse `water_depth_band`, `wiki_path` pinned to the private registry page (per-source slugs leak provenance — review finding), and the **`rig_ref` residency join** (user principle: a riser string is stationed on a rig).
- **`rig_riser_interface`** — 3 generic rig-class rows with riser-handling capability columns; `wed_rig_name` joins the worldenergydata 2,268-rig fleet and ships empty for engagement-derived rows (named-rig↔engagement mapping stays wiki-side).
- **Loader extension** — 2 frozen dataclasses, `_TABLE_SPECS`/accessors/`iter_public_rows`; the leak-gate raw-file list and coverage pins are now **derived from `_TABLE_SPECS`** so a future table can never silently escape scanning.
- **Two new gates** — de-id tripwire (unit-bearing exact values banned from every cell and raw file; registry generic-name strings banned verbatim) and the **provenance-token tripwire** (auto-extracts name tokens + project numbers from the private registry's source pages and asserts them absent from all public artifacts — the scoped, regex-capable complement to the global deny list).

## Gate evidence (in-context, ace-linux-1)
- `pytest tests/riser_database/` → **56/56 green, 0 skipped** — registry reconciliation and the provenance tripwire ran against the LIVE private registry before first push.
- Regression: atlas coverage + mooring citations + citations suites → **77 passed**.
- The 3 pre-existing CSVs regenerate **byte-identical** (generator determinism regression).
- `legal-sanity-scan.sh --repo=digitalmodel --diff-only` over all changes (`git add -N` window, with the new provenance patterns active): **PASS**.
- Gate-prep landed separately: workspace-hub deny-list additions → **PR vamseeachanta/workspace-hub#3346** (with a flagged, justified deviation: famous public-domain field/rig names are enforced by the dm-scoped tripwire, not the global list, to avoid false-positives on wed's public regulatory datasets).

## Follow-ups
wed-side issue (riser-handling columns for the rig fleet + component-library growth) — filed next and linked from #1279. #1280 (assembly engine) is unblocked once this merges.