### PR TITLE
fix(vessel_db): resolve WED curated fleet at new package path

### DIFF
--- a/src/digitalmodel/marine_ops/vessel_db/wed_adapter.py
+++ b/src/digitalmodel/marine_ops/vessel_db/wed_adapter.py
@@ -2,17 +2,21 @@
 ABOUTME: Adapter that lets digitalmodel CONSUME the worldenergydata vessel fleet
 as the single source of truth (it owns the collection/PDF/scrape/dedup pipeline).
 
-worldenergydata curates the real fleet at
-``data/modules/vessel_fleet/curated/{drilling_rigs,construction_vessels}.csv``
-(~2,268 drilling rigs + 17 construction vessels, deduped by IMO). digitalmodel
-needs the engineering view of that fleet (crane curves for installation, hull
-particulars for diffraction) WITHOUT re-collecting it.
+worldenergydata curates the real fleet as
+``curated/{drilling_rigs,construction_vessels}.csv`` (~2,268 drilling rigs +
+165 construction vessels, deduped by IMO). digitalmodel needs the engineering
+view of that fleet (crane curves for installation, hull particulars for
+diffraction) WITHOUT re-collecting it.
 
 Path resolution (mirrors the OCIMF/LLM_WIKI_PATH precedence used elsewhere):
   1. WED_VESSEL_FLEET_PATH  — points at the curated dir (or its parent)
   2. WORLDENERGYDATA_ROOT   — repo root; curated dir derived from it
   3. local clone fallbacks  — a local worldenergydata checkout (analysis root,
                               ~/workspace-hub, or a sibling of the digitalmodel repo)
+Under each candidate root the curated dir is probed at the legacy location
+(``data/modules/vessel_fleet/curated/``) first, then at the packaged location
+(``packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/
+_data/curated/``) where the WED monorepo split moved it.
 Resolves to None (not an exception) when absent, so consumers degrade gracefully
 in environments where worldenergydata is not checked out (e.g. external installs).
 """
@@ -20,13 +24,37 @@ in environments where worldenergydata is not checked out (e.g. external installs
 from __future__ import annotations
 
 import csv
+import logging
 import os
 from pathlib import Path
 from typing import Optional
 
 from digitalmodel.marine_ops.vessel_db.loader import Record, parse_value
 
+logger = logging.getLogger(__name__)
+
 _CURATED_REL = Path("data") / "modules" / "vessel_fleet" / "curated"
+_CURATED_REL_PACKAGE = (
+    Path("packages") / "worldenergydata-vessel_fleet" / "src"
+    / "worldenergydata" / "vessel_fleet" / "_data" / "curated"
+)
+# Probe order under each candidate WED root: legacy first, then package layout.
+_CURATED_RELS = (_CURATED_REL, _CURATED_REL_PACKAGE)
+
+
+def _local_wed_roots() -> list[Path]:
+    """Candidate local worldenergydata checkouts (used when no env var is set)."""
+    roots = [
+        Path("/mnt/local-analysis/worldenergydata"),  # abs-path-allowed
+        Path.home() / "workspace-hub" / "worldenergydata",
+    ]
+    # Sibling of the digitalmodel repo (…/<parent>/worldenergydata).
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "digitalmodel").is_dir() or parent.name == "digitalmodel":
+            roots.append(parent.parent / "worldenergydata")
+            break
+    return roots
 
 
 def resolve_wed_curated_dir(require: bool = False) -> Optional[Path]:
@@ -41,23 +69,15 @@ def resolve_wed_curated_dir(require: bool = False) -> Optional[Path]:
     env_fleet = os.environ.get("WED_VESSEL_FLEET_PATH")
     if env_fleet:
         p = Path(env_fleet)
-        candidates += [p, p / "curated", p / _CURATED_REL]
+        candidates += [p, p / "curated", *(p / rel for rel in _CURATED_RELS)]
 
     env_root = os.environ.get("WORLDENERGYDATA_ROOT")
     if env_root:
-        candidates.append(Path(env_root) / _CURATED_REL)
+        candidates += [Path(env_root) / rel for rel in _CURATED_RELS]
 
-    # Local-clone fallbacks.
-    candidates += [
-        Path("/mnt/local-analysis/worldenergydata") / _CURATED_REL,  # abs-path-allowed
-        Path.home() / "workspace-hub" / "worldenergydata" / _CURATED_REL,
-    ]
-    # Sibling of the digitalmodel repo (…/<parent>/worldenergydata).
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "digitalmodel").is_dir() or parent.name == "digitalmodel":
-            candidates.append(parent.parent / "worldenergydata" / _CURATED_REL)
-            break
+    # Local-clone fallbacks (legacy layout first, then package layout, per root).
+    for root in _local_wed_roots():
+        candidates += [root / rel for rel in _CURATED_RELS]
 
     for c in candidates:
         if (c / "construction_vessels.csv").is_file() or (c / "drilling_rigs.csv").is_file():
@@ -66,10 +86,19 @@ def resolve_wed_curated_dir(require: bool = False) -> Optional[Path]:
     if require:
         raise FileNotFoundError(
             "worldenergydata curated vessel fleet not found. Set WED_VESSEL_FLEET_PATH "
-            "to <worldenergydata>/data/modules/vessel_fleet/curated (or WORLDENERGYDATA_ROOT "
-            "to the repo root). worldenergydata is the source of truth for vessel collection "
+            "to the curated dir (data/modules/vessel_fleet/curated or packages/"
+            "worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/_data/curated "
+            "under <worldenergydata>), or WORLDENERGYDATA_ROOT to the repo root. "
+            "worldenergydata is the source of truth for vessel collection "
             "(https://github.com/vamseeachanta/worldenergydata)."
         )
+    logger.warning(
+        "worldenergydata curated vessel fleet not found (probed WED_VESSEL_FLEET_PATH, "
+        "WORLDENERGYDATA_ROOT and local-clone fallbacks for %s); WED-backed consumers "
+        "(construction_vessels/drilling_rigs/installation_vessels) will return 0 WED rows. "
+        "Set WED_VESSEL_FLEET_PATH to the curated dir to fix.",
+        " or ".join(str(rel) for rel in _CURATED_RELS),
+    )
     return None
 
 

--- a/tests/marine_ops/vessel_db/test_wed_adapter.py
+++ b/tests/marine_ops/vessel_db/test_wed_adapter.py
@@ -7,6 +7,9 @@ designed to degrade to None rather than error.
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+
 import pytest
 
 from digitalmodel.marine_ops.vessel_db import (
@@ -18,9 +21,33 @@ from digitalmodel.marine_ops.vessel_db import (
     normalize_vessel_name,
     resolve_wed_curated_dir,
 )
+from digitalmodel.marine_ops.vessel_db import wed_adapter
 
 _WED = resolve_wed_curated_dir()
 _skip_no_wed = pytest.mark.skipif(_WED is None, reason="worldenergydata not checked out")
+
+_MIN_CSV = (
+    "VESSEL_NAME,VESSEL_TYPE,OWNER,YEAR_BUILT,IMO_NUMBER,"
+    "MAIN_CRANE_CAPACITY_T,MAIN_CRANE_REACH_M,DP_CLASS,DATA_SOURCE,DATA_SOURCE_URL\n"
+    "Test Lifter,Heavy Lift Vessel,TestCo,2020,1234567,"
+    "5000,40,DP3,unit-test,https://example.test\n"
+)
+
+
+def _make_curated(d: Path) -> Path:
+    """Create a curated dir holding a minimal construction_vessels.csv."""
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "construction_vessels.csv").write_text(_MIN_CSV)
+    return d
+
+
+@pytest.fixture
+def isolated_resolution(monkeypatch):
+    """Blind the resolver to env vars and real local WED checkouts."""
+    monkeypatch.delenv("WED_VESSEL_FLEET_PATH", raising=False)
+    monkeypatch.delenv("WORLDENERGYDATA_ROOT", raising=False)
+    monkeypatch.setattr(wed_adapter, "_local_wed_roots", lambda: [])
+    return monkeypatch
 
 
 def test_normalize_collapses_type_prefixes():
@@ -32,6 +59,70 @@ def test_resolver_returns_none_or_dir():
     # Never raises without require=True.
     d = resolve_wed_curated_dir()
     assert d is None or (d / "construction_vessels.csv").is_file() or (d / "drilling_rigs.csv").is_file()
+
+
+def test_resolution_order_env_then_legacy_then_package(tmp_path, isolated_resolution):
+    """Probe order: WED_VESSEL_FLEET_PATH -> legacy data/ layout -> package layout."""
+    monkeypatch = isolated_resolution
+    root = tmp_path / "wed"
+    legacy = root / wed_adapter._CURATED_REL
+    package = root / wed_adapter._CURATED_REL_PACKAGE
+    monkeypatch.setattr(wed_adapter, "_local_wed_roots", lambda: [root])
+
+    # Nothing on disk -> None (no exception).
+    assert wed_adapter.resolve_wed_curated_dir() is None
+
+    # Package layout only (the current WED monorepo split) -> found there.
+    _make_curated(package)
+    assert wed_adapter.resolve_wed_curated_dir() == package
+
+    # Legacy layout appears too -> legacy wins (backwards compatible).
+    _make_curated(legacy)
+    assert wed_adapter.resolve_wed_curated_dir() == legacy
+
+    # WORLDENERGYDATA_ROOT beats local-clone fallbacks (package layout under it).
+    root2 = tmp_path / "wed2"
+    pkg2 = _make_curated(root2 / wed_adapter._CURATED_REL_PACKAGE)
+    monkeypatch.setenv("WORLDENERGYDATA_ROOT", str(root2))
+    assert wed_adapter.resolve_wed_curated_dir() == pkg2
+
+    # WED_VESSEL_FLEET_PATH beats everything, pointing straight at a curated dir…
+    direct = _make_curated(tmp_path / "direct")
+    monkeypatch.setenv("WED_VESSEL_FLEET_PATH", str(direct))
+    assert wed_adapter.resolve_wed_curated_dir() == direct
+
+    # …or at a WED repo root laid out package-style.
+    root3 = tmp_path / "wed3"
+    pkg3 = _make_curated(root3 / wed_adapter._CURATED_REL_PACKAGE)
+    monkeypatch.setenv("WED_VESSEL_FLEET_PATH", str(root3))
+    assert wed_adapter.resolve_wed_curated_dir() == pkg3
+
+
+def test_missing_curated_dir_warns_but_returns_none(tmp_path, isolated_resolution, caplog):
+    monkeypatch = isolated_resolution
+    monkeypatch.setattr(wed_adapter, "_local_wed_roots", lambda: [tmp_path / "nowhere"])
+    with caplog.at_level(logging.WARNING, logger=wed_adapter.__name__):
+        assert wed_adapter.resolve_wed_curated_dir() is None
+    assert "curated vessel fleet not found" in caplog.text
+    # require=True still raises an actionable error instead of warning.
+    with pytest.raises(FileNotFoundError, match="WED_VESSEL_FLEET_PATH"):
+        wed_adapter.resolve_wed_curated_dir(require=True)
+
+
+def test_installation_vessels_merges_wed_fixture(tmp_path, isolated_resolution):
+    """installation_vessels(include_wed=True) merges rows from a fixture curated dir."""
+    monkeypatch = isolated_resolution
+    curated = _make_curated(tmp_path / "curated")
+    monkeypatch.setenv("WED_VESSEL_FLEET_PATH", str(curated))
+
+    merged = installation_vessels(include_wed=True, include_curated=True)
+    assert "Test Lifter" in merged
+    info = merged["Test Lifter"]
+    assert info["source"] == "worldenergydata"
+    assert info["crane_curve"].max_hook_load_te == pytest.approx(5000.0)
+    assert float(info["crane_curve"].radii_m.max()) == pytest.approx(40.0)
+    # The in-repo curated records are still merged alongside the WED rows.
+    assert any(i.get("source") == "curated" for i in merged.values())
 
 
 def test_adapter_degrades_without_wed(monkeypatch):


### PR DESCRIPTION
Fixes #1297

## Root cause
`wed_adapter.resolve_wed_curated_dir()` only probed `<wed_root>/data/modules/vessel_fleet/curated/`. The worldenergydata monorepo split moved the curated files to `<wed_root>/packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/_data/curated/`, so resolution returned `None` and `construction_vessels()`, `drilling_rigs()`, `construction_crane_vessels()`, and `installation_vessels(include_wed=True)` **silently returned 0 WED rows** unless `WED_VESSEL_FLEET_PATH` was set.

## Resolution order (unchanged contract, extended probing)
1. `WED_VESSEL_FLEET_PATH` — the curated dir itself, `<path>/curated`, or a WED root in either layout
2. `WORLDENERGYDATA_ROOT` — legacy layout, then package layout
3. Local-clone fallbacks (`/mnt/local-analysis/worldenergydata`, `~/workspace-hub/worldenergydata`, sibling of the digitalmodel repo) — legacy layout first, then package layout, per root

When nothing is found: a clear `logging` warning is emitted (was: silent), but the function still returns `None` and consumers still degrade to empty — no hard fail, existing callers preserved. `require=True` still raises with an actionable message.

Local-clone root discovery is factored into `_local_wed_roots()` so unit tests can isolate resolution from the machine's real checkouts.

## Tests
New in `tests/marine_ops/vessel_db/test_wed_adapter.py` (fixtures only, no dependency on a real WED checkout):
- resolution-order test across tmp_path layouts (env direct dir, env repo root, `WORLDENERGYDATA_ROOT`, legacy-beats-package under one root, none-found)
- missing-dir warns via caplog + `require=True` raises
- `installation_vessels(include_wed=True)` merges rows from a fixture curated dir (WED-sourced entry with crane curve, alongside in-repo curated records)

`uv run pytest tests/marine_ops/vessel_db tests/marine_ops/installation/test_vessel_screening.py tests/marine_ops/installation/test_vessel_suitability.py tests/naval_architecture/test_vessel_fleet_adapter.py -q` → **153 passed, 5 skipped** (pre-existing skips). The previously-skipped real-WED tests in `test_wed_adapter.py` now actually run.

## Smoke vs real WED checkout (/mnt/local-analysis/worldenergydata)
| metric | before | after |
|---|---|---|
| resolved curated dir | `None` | `.../packages/worldenergydata-vessel_fleet/src/worldenergydata/vessel_fleet/_data/curated` |
| construction_vessels | 0 | **165** |
| drilling_rigs (offshore) | 0 | **2268** |
| construction_crane_vessels | 0 | **82** |
| installation_vessels merged | 3 (curated only) | **84** (81 WED + 3 curated) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)