### PR TITLE
feat(workflows): casing-design durable workflow — production casing design-factor screen (#1305)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -925,6 +925,16 @@ workflows:
       - examples/workflows/liquefaction/results/liquefaction/liquefaction_summary.json
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[liquefaction-triggering]
     runtime: offline
+  - id: casing-design
+    basename: casing_design
+    title: Production casing design-factor screen (burst/collapse/tension/triaxial + frac limit + NACE sour)
+    input: examples/workflows/casing-design/input.yml
+    outputs:
+      - examples/workflows/casing-design/results/input.yml
+      - examples/workflows/casing-design/results/casing_design/casing_design_summary.json
+      - examples/workflows/casing-design/results/casing_design/casing_design_products.csv
+    test: tests/workflows/test_durable_workflows.py::test_workflow_registry[casing-design]
+    runtime: offline
   - id: well-bore-design
     basename: well_bore_design
     title: Standard offshore wellbore casing/cost/risk screen

--- a/examples/workflows/casing-design/input.yml
+++ b/examples/workflows/casing-design/input.yml
@@ -1,0 +1,36 @@
+basename: casing_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+casing_design:
+  well:
+    td_ft: 12000.0
+    mud_ppg: 10.0
+    toc_ft: 4000.0
+    outer_shoe_ft: 8000.0
+    reservoir_pressure_psi: 8500.0
+    packer_fluid_ppg: 9.0
+    frac_surface_pressure_psi: 9000.0
+    frac_fluid_ppg: 8.6
+    mix_water_ppg: 8.4
+  products:
+    - {grade: J55, od_in: 5.5, weight_ppf: 14.0}
+    - {grade: N80, od_in: 5.5, weight_ppf: 17.0}
+    - {grade: P110, od_in: 5.5, weight_ppf: 17.0}
+    - {grade: N80, od_in: 5.5, weight_ppf: 20.0}
+    - {grade: P110, od_in: 5.5, weight_ppf: 20.0}
+    - {grade: P110, od_in: 5.5, weight_ppf: 23.0}
+    - {grade: Q125, od_in: 5.5, weight_ppf: 23.0}
+    - {grade: P110, od_in: 7.0, weight_ppf: 26.0}
+  sour_service:
+    h2s_ppm: 100.0
+    total_pressure_psia: 8500.0
+    well_type: gas
+    service_temp_f: 180.0
+  outputs:
+    directory: results/casing_design

--- a/src/digitalmodel/base_configs/modules/casing_design/casing_design.yml
+++ b/src/digitalmodel/base_configs/modules/casing_design/casing_design.yml
@@ -1,0 +1,10 @@
+basename: casing_design
+
+default:
+  log_level: INFO
+  config:
+    generate_plots: false
+    overwrite:
+      output: true
+
+casing_design: {}

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -659,6 +659,10 @@ def engine(
         from digitalmodel.well.workflow import run_swab_surge
 
         cfg_base = run_swab_surge(cfg_base)
+    elif basename == "casing_design":
+        from digitalmodel.well.workflow import run_casing_design
+
+        cfg_base = run_casing_design(cfg_base)
     elif basename == "pore_pressure":
         from digitalmodel.well.drilling.pore_pressure import (
             router as run_pore_pressure,

--- a/src/digitalmodel/well/workflow.py
+++ b/src/digitalmodel/well/workflow.py
@@ -301,3 +301,132 @@ def run_tubular_design(cfg: dict[str, Any]) -> dict[str, Any]:
     cfg["outputs"]["envelope_csv"] = str(csv_path)
     cfg["tubular_design"] = {**params, "summary": summary}
     return cfg
+
+
+def run_casing_design(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Run the production casing design-check screen over candidate products.
+
+    Config: a well (depths, gradients, reservoir, frac plan), a list of
+    candidate casing products (grade + OD + nominal weight) and optional
+    design-factor overrides.  Each product is checked for burst / collapse /
+    tension / triaxial design factors plus the maximum allowable frac surface
+    pressure, with an optional NACE MR0175 sour-service screen.
+
+    Source: Hansen (Devon Energy), EPA Hydraulic Fracturing Technical
+    Workshop Session 2, 2011; API 5C3 / API 5CT / NACE MR0175 (#1290, #1305).
+    """
+    from digitalmodel.well.tubulars.casing import casing as build_casing
+    from digitalmodel.well.tubulars.casing_design import (
+        DesignFactors,
+        ProductionCasingWell,
+        api_round_force_lbf,
+        api_round_pressure_psi,
+        burst_external_profile,
+        check_production_casing,
+        max_frac_surface_pressure,
+        sour_service_screen,
+    )
+
+    params = cfg.get("casing_design", {})
+    well = ProductionCasingWell(**params["well"])
+    factors = DesignFactors(**params.get("design_factors", {}))
+
+    external = burst_external_profile(
+        well.mud_ppg,
+        well.toc_ft,
+        well.outer_shoe_ft,
+        well.td_ft,
+        mix_water_ppg=well.mix_water_ppg,
+        pore_ppg=well.pore_ppg,
+    )
+
+    rows: list[dict[str, Any]] = []
+    for product_cfg in params["products"]:
+        product = build_casing(
+            product_cfg["grade"],
+            od_in=float(product_cfg["od_in"]),
+            weight_ppf=float(product_cfg["weight_ppf"]),
+        )
+        checks = check_production_casing(
+            product, float(product_cfg["weight_ppf"]), well, factors)
+        p_frac_max = max_frac_surface_pressure(
+            product, well.frac_fluid_ppg, external, well.td_ft, factors)
+        row: dict[str, Any] = {
+            "label": (f"{product.od_in:g}\" {product_cfg['weight_ppf']:g}# "
+                      f"{product.grade.name}"),
+            "grade": product.grade.name,
+            "od_in": product.od_in,
+            "weight_ppf": float(product_cfg["weight_ppf"]),
+            "wall_in": product.wt_in,
+            "burst_rating_psi": api_round_pressure_psi(product.burst_psi),
+            "collapse_rating_psi": api_round_pressure_psi(
+                product.collapse_psi),
+            "collapse_regime": product.collapse_regime,
+            "body_yield_lbf": api_round_force_lbf(product.body_yield_lbf),
+            "max_frac_surface_pressure_psi": round(p_frac_max, 1),
+            "passes_all": all(res.passes for res in checks.values()),
+        }
+        for mode, res in checks.items():
+            row[f"{mode}_df"] = (round(res.min_design_factor, 3)
+                                 if res.min_design_factor != float("inf")
+                                 else None)
+            row[f"{mode}_required_df"] = res.required_design_factor
+            row[f"{mode}_governing_depth_ft"] = res.governing_depth_ft
+            row[f"{mode}_passes"] = res.passes
+        rows.append(row)
+
+    summary: dict[str, Any] = {
+        "calculation": "casing_design",
+        "reference": ("Hansen (Devon Energy), EPA HF workshop 2011; "
+                      "API 5C3 / API 5CT / NACE MR0175"),
+        "well": params["well"],
+        "design_factors": {
+            "burst": factors.burst,
+            "burst_low_sicp": factors.burst_low_sicp,
+            "collapse": factors.collapse,
+            "tension": factors.tension,
+            "compression": factors.compression,
+            "triaxial": factors.triaxial,
+        },
+        "product_count": len(rows),
+        "passing_products": [r["label"] for r in rows if r["passes_all"]],
+        "products": rows,
+    }
+
+    sour_cfg = params.get("sour_service")
+    if sour_cfg:
+        assessment = sour_service_screen(
+            float(sour_cfg["h2s_ppm"]),
+            float(sour_cfg["total_pressure_psia"]),
+            well_type=sour_cfg.get("well_type", "gas"),
+            service_temp_f=sour_cfg.get("service_temp_f"),
+        )
+        summary["sour_service"] = {
+            "is_sour": assessment.is_sour,
+            "h2s_partial_psia": round(assessment.h2s_partial_psia, 4),
+            "acceptable_grades": list(assessment.acceptable_grades),
+            "reference": assessment.reference,
+        }
+
+    output_cfg = params.get("outputs", {})
+    summary["summary_json"] = str(
+        _write_summary(
+            cfg,
+            output_cfg,
+            summary,
+            "results/casing_design",
+            "casing_design_summary.json",
+        )
+    )
+
+    directory = Path(cfg["outputs"]["directory"])
+    csv_path = directory / output_cfg.get(
+        "products_csv", "casing_design_products.csv")
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    cfg["outputs"]["products_csv"] = str(csv_path)
+
+    cfg["casing_design"] = {**params, "summary": summary}
+    return cfg

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -1091,6 +1091,29 @@ def test_workflow_registry(workflow, monkeypatch):
         )
         assert result["screening_status"] == "fail"
         assert cfg["screening_status"] == "fail"
+    elif workflow["id"] == "casing-design":
+        summary = cfg["casing_design"]["summary"]
+        assert summary["product_count"] == 8
+        assert summary["passing_products"] == [
+            '5.5" 20# P110',
+            '5.5" 23# P110',
+            '5.5" 23# Q125',
+        ]
+        golden = next(p for p in summary["products"]
+                      if p["label"] == '5.5" 23# P110')
+        # Barlow worked example from the source deck: 14,520 psi API-rounded.
+        assert golden["burst_rating_psi"] == pytest.approx(14520.0)
+        assert golden["collapse_rating_psi"] == pytest.approx(14540.0)
+        assert golden["body_yield_lbf"] == pytest.approx(729000.0)
+        assert golden["max_frac_surface_pressure_psi"] == pytest.approx(
+            11616.0)
+        assert golden["passes_all"] is True
+        sour = summary["sour_service"]
+        # 100 ppm at 8,500 psia -> 0.85 psia partial pressure -> sour.
+        assert sour["is_sour"] is True
+        assert sour["h2s_partial_psia"] == pytest.approx(0.85)
+        assert "P110" in sour["acceptable_grades"]  # 180 F >= 175 F window
+        assert "Q125" not in sour["acceptable_grades"]  # needs >= 225 F
     elif workflow["id"] == "well-bore-design":
         block = cfg["well_bore_design"]
         summary = block["summary"]


### PR DESCRIPTION
Closes #1305. Round-2 follow-up to #1290 / PR #1300 (rudder #1228 precedent): the capabilities card's API envelope now has a real registered workflow behind it.

- `run_casing_design` adapter in `well/workflow.py`: config = well + candidate products + optional design-factor overrides → per-product burst/collapse/tension/triaxial DFs with governing depths, API-rounded ratings, max allowable frac surface pressure, optional NACE MR0175 sour screen. Writes `casing_design_summary.json` + `casing_design_products.csv`.
- Engine route `basename: casing_design` + base config.
- Registry row `casing-design` (runtime offline) with `examples/workflows/casing-design/input.yml` — same demo well as the live explorer, so the two surfaces agree.
- Fail-closed assertions in `test_workflow_registry[casing-design]`: golden 5-1/2" 23# P110 burst 14,520 psi (source-deck worked example), max frac 11,616 psi at DF 1.25, sour screen 0.85 psia partial pressure with the 175/225 °F grade windows.

Tests: full `tests/workflows/test_durable_workflows.py` = 127 passed, 2 skipped (runtime-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)