### PR TITLE
feat(well/tubulars): tubing catalog + production tubing design checks (#1313)

### DIFF
--- a/src/digitalmodel/well/tubulars/__init__.py
+++ b/src/digitalmodel/well/tubulars/__init__.py
@@ -15,6 +15,7 @@ from digitalmodel.well.tubulars.design_envelope import (
 from digitalmodel.well.tubulars.casing import (
     API_5CT_GRADES,
     CASING_SIZES,
+    TUBING_SIZES,
     Casing,
     CasingGrade,
     casing,
@@ -22,7 +23,10 @@ from digitalmodel.well.tubulars.casing import (
     collapse_pressure,
     internal_yield_pressure,
     list_sizes,
+    list_tubing_sizes,
     pipe_body_yield_strength,
+    tubing,
+    tubing_wall_for_size,
     wall_for_size,
 )
 from digitalmodel.well.tubulars.casing_design import (
@@ -53,6 +57,13 @@ from digitalmodel.well.tubulars.casing_design import (
     sour_service_screen,
     tubing_leak_internal_profile,
 )
+from digitalmodel.well.tubulars.tubing_design import (
+    TubingWell,
+    check_production_tubing,
+    packer_fluid_annulus_profile,
+    shut_in_piston_force_lbf,
+    shut_in_tubing_profile,
+)
 from digitalmodel.well.tubulars.sucker_rod import (
     API_11B_ROD_GRADES,
     ROD_SIZES_IN,
@@ -74,9 +85,10 @@ __all__ = [
     "compute_hoop_stress",
     "compute_vme_stress",
     "design_envelope_points",
-    # casing (API 5CT / API 5C3)
+    # casing + tubing catalog (API 5CT / API 5C3)
     "API_5CT_GRADES",
     "CASING_SIZES",
+    "TUBING_SIZES",
     "Casing",
     "CasingGrade",
     "casing",
@@ -84,7 +96,10 @@ __all__ = [
     "collapse_pressure",
     "internal_yield_pressure",
     "list_sizes",
+    "list_tubing_sizes",
     "pipe_body_yield_strength",
+    "tubing",
+    "tubing_wall_for_size",
     "wall_for_size",
     # casing design checks (Hansen/Devon EPA workshop; API 5C3, NACE MR0175)
     "CONNECTION_CLASSES",
@@ -113,6 +128,12 @@ __all__ = [
     "max_frac_surface_pressure",
     "sour_service_screen",
     "tubing_leak_internal_profile",
+    # production tubing design checks
+    "TubingWell",
+    "check_production_tubing",
+    "packer_fluid_annulus_profile",
+    "shut_in_piston_force_lbf",
+    "shut_in_tubing_profile",
     # sucker rod (API 11B / modified Goodman)
     "API_11B_ROD_GRADES",
     "ROD_SIZES_IN",

--- a/src/digitalmodel/well/tubulars/casing.py
+++ b/src/digitalmodel/well/tubulars/casing.py
@@ -105,6 +105,24 @@ CASING_SIZES: dict[tuple[float, float], float] = {
 
 
 # ---------------------------------------------------------------------------
+# Tubing dimensions: (OD in, nominal weight ppf) -> wall thickness (in).
+# Standard API 5CT tubing sizes (API 5CT tubing dimension tables; walls match
+# the published API tubing tables, e.g. 2-3/8" 4.7# -> 0.190" (ID 1.995"),
+# 2-7/8" 6.5# -> 0.217" (ID 2.441"), 3-1/2" 9.3# -> 0.254" (ID 2.992"),
+# 4" 11.0# -> 0.262" (ID 3.476"), 4-1/2" 12.75# -> 0.271" (ID 3.958")).
+# Kept separate from CASING_SIZES: 4-1/2" exists in both catalogs with
+# different standard weights.
+# ---------------------------------------------------------------------------
+TUBING_SIZES: dict[tuple[float, float], float] = {
+    (2.375, 4.70): 0.190, (2.375, 5.95): 0.254,
+    (2.875, 6.50): 0.217, (2.875, 8.70): 0.308,
+    (3.5, 9.30): 0.254, (3.5, 12.95): 0.375,
+    (4.0, 11.00): 0.262,
+    (4.5, 12.75): 0.271,
+}
+
+
+# ---------------------------------------------------------------------------
 # API 5C3 performance formulas
 # ---------------------------------------------------------------------------
 def internal_yield_pressure(od_in: float, wt_in: float,
@@ -281,6 +299,52 @@ def casing(
         raise ValueError("Specify either weight_ppf or wt_in, not both")
     if weight_ppf is not None:
         wt = wall_for_size(od_in, weight_ppf)
+    elif wt_in is not None:
+        wt = wt_in
+    else:
+        raise ValueError("Provide weight_ppf or wt_in for the wall thickness")
+    return Casing(od_in=od_in, wt_in=wt, grade=g, weight_ppf=weight_ppf)
+
+
+def list_tubing_sizes() -> list[tuple[float, float]]:
+    """All tubing-catalog (OD, weight ppf) pairs, sorted."""
+    return sorted(TUBING_SIZES)
+
+
+def tubing_wall_for_size(od_in: float, weight_ppf: float) -> float:
+    """Wall thickness (in) for a tubing-catalog (OD, weight) pair."""
+    key = (od_in, weight_ppf)
+    if key not in TUBING_SIZES:
+        raise KeyError(
+            f"No tubing catalog wall for OD {od_in}, weight {weight_ppf}")
+    return TUBING_SIZES[key]
+
+
+def tubing(
+    grade: "str | CasingGrade",
+    *,
+    od_in: float,
+    weight_ppf: Optional[float] = None,
+    wt_in: Optional[float] = None,
+) -> Casing:
+    """Build a tubing product (a :class:`Casing`) from grade, OD and weight.
+
+    Tubing shares the API 5CT grades and the API 5C3 rating machinery with
+    casing — only the dimensional catalog differs — so this returns the same
+    :class:`Casing` product class with the wall looked up in
+    :data:`TUBING_SIZES`.
+
+    Args:
+        grade: API 5CT grade name or :class:`CasingGrade`.
+        od_in: Outside diameter (inches).
+        weight_ppf: Nominal weight (lb/ft); looks up the tubing-catalog wall.
+        wt_in: Explicit wall thickness (inches), instead of ``weight_ppf``.
+    """
+    g = grade if isinstance(grade, CasingGrade) else casing_grade(grade)
+    if weight_ppf is not None and wt_in is not None:
+        raise ValueError("Specify either weight_ppf or wt_in, not both")
+    if weight_ppf is not None:
+        wt = tubing_wall_for_size(od_in, weight_ppf)
     elif wt_in is not None:
         wt = wt_in
     else:

--- a/src/digitalmodel/well/tubulars/tubing_design.py
+++ b/src/digitalmodel/well/tubulars/tubing_design.py
@@ -1,0 +1,197 @@
+# ABOUTME: Production tubing design checks — shut-in burst, evacuated collapse,
+# ABOUTME: buoyed weight + packer piston tension, composing casing_design.
+"""Production tubing design-check layer, composing the casing primitives.
+
+The tubing counterpart of
+:mod:`~digitalmodel.well.tubulars.casing_design`: the same
+:class:`~digitalmodel.well.tubulars.casing_design.PressureProfile` /
+:class:`~digitalmodel.well.tubulars.casing_design.DesignFactors` /
+``check_*`` machinery, applied to the production tubing load cases from the
+source deck:
+
+* **Burst** — shut-in tubing: SITP at surface plus the produced-gas gradient
+  down the string (internal), backed up by the packer-fluid column in the
+  tubing-casing annulus (external; no credit taken for annulus surface
+  pressure — conservative).
+* **Collapse** — evacuated tubing (zero pressure inside, e.g. blown down or
+  gas-lifted dry) against the packer-fluid annulus, optionally with a
+  surface casing pressure applied on top of the annulus (conservative).
+* **Tension** — buoyed string weight in the packer fluid plus the shut-in
+  piston force the pressures exert on the tubing at the packer bore
+  (``F = (Ap - Ai)*P_tbg - (Ap - Ao)*P_ann``); compression relief from a
+  negative piston force is not credited.
+
+``check_production_tubing`` orchestrates the three modes and returns
+``dict[str, ModeCheckResult]`` exactly like
+:func:`~digitalmodel.well.tubulars.casing_design.check_production_casing`.
+
+Source: B. Hansen (Devon Energy), *Production Casing Design Considerations*,
+EPA Hydraulic Fracturing Technical Workshop — Session 2: Well Design, 2011
+(the deck covers casing *and* tubing design).  Rating formulas per API 5C3 /
+API TR 5C3; piston force per the classic tubing-packer force analysis
+(Lubinski et al.).
+
+Worked golden example preserved in the tests: 2-7/8" 6.5# N80 — burst
+``0.875 * 2 * 80,000 * 0.217 / 2.875 = 10,567 -> 10,570 psi`` (API rounding),
+body yield ``80,000 * 1.812 in^2 = 144,962 -> 145,000 lbf``, collapse
+``11,160 psi``.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+from digitalmodel.well.tubulars.casing import Casing
+from digitalmodel.well.tubulars.casing_design import (
+    DEFAULT_GAS_GRADIENT_PSI_FT,
+    DesignFactors,
+    ModeCheckResult,
+    PressureProfile,
+    check_burst,
+    check_collapse,
+    check_tension,
+    fluid_column_profile,
+    shut_in_tubing_pressure,
+)
+
+SOURCE_REFERENCE = (
+    "Hansen (Devon Energy), EPA Hydraulic Fracturing Technical Workshop, "
+    "Session 2: Well Design, 2011; API 5C3"
+)
+
+
+# ---------------------------------------------------------------------------
+# Load-case profile builders
+# ---------------------------------------------------------------------------
+def shut_in_tubing_profile(
+    sitp_psi: float,
+    td_ft: float,
+    gas_gradient_psi_ft: float = DEFAULT_GAS_GRADIENT_PSI_FT,
+) -> PressureProfile:
+    """Internal shut-in tubing profile: surface SITP + gas gradient down.
+
+    A shut-in producer holds the shut-in tubing pressure at surface with the
+    produced-gas column below, so the internal pressure at depth ``z`` is
+    ``SITP + G_gas * z``.  Use
+    :func:`~digitalmodel.well.tubulars.casing_design.shut_in_tubing_pressure`
+    to derive the SITP from a reservoir pressure.
+    """
+    if td_ft <= 0.0:
+        raise ValueError("td_ft must be positive")
+    return PressureProfile(
+        (0.0, td_ft),
+        (sitp_psi, sitp_psi + gas_gradient_psi_ft * td_ft),
+        "shut-in tubing (SITP on gas gradient)",
+    )
+
+
+def packer_fluid_annulus_profile(
+    packer_fluid_ppg: float,
+    td_ft: float,
+    surface_pressure_psi: float = 0.0,
+) -> PressureProfile:
+    """Packer-fluid column in the tubing-casing annulus.
+
+    Optionally pressurized on top by an applied surface casing pressure
+    (``surface_pressure_psi``) — used as the collapse load on the tubing.
+    """
+    p = fluid_column_profile(packer_fluid_ppg, td_ft,
+                             surface_pressure_psi=surface_pressure_psi)
+    return PressureProfile(p.depths_ft, p.pressures_psi,
+                           "packer-fluid annulus")
+
+
+# ---------------------------------------------------------------------------
+# Packer piston force
+# ---------------------------------------------------------------------------
+def shut_in_piston_force_lbf(
+    packer_bore_in: float,
+    tubing_product: Casing,
+    tubing_pressure_psi: float,
+    annulus_pressure_psi: float = 0.0,
+) -> float:
+    """Shut-in piston force on the tubing at the packer bore, lbf.
+
+    Classic tubing-packer piston (Lubinski F1) term — the pressure-area
+    force at the packer, positive = added tension at surface::
+
+        F = (Ap - Ai) * P_tbg - (Ap - Ao) * P_ann
+
+    where ``Ap = pi/4 * d_bore^2`` is the packer seal-bore area, ``Ai`` /
+    ``Ao`` the tubing ID / OD areas, and the pressures are evaluated at the
+    packer depth.  With the seal bore equal to the tubing OD this reduces to
+    the shut-in ``dP * A`` term on the tubing wall annulus,
+    ``(Ao - Ai) * P_tbg``.
+    """
+    if packer_bore_in <= 0.0:
+        raise ValueError("packer_bore_in must be positive")
+    ap = math.pi / 4.0 * packer_bore_in ** 2
+    ai = math.pi / 4.0 * tubing_product.id_in ** 2
+    ao = math.pi / 4.0 * tubing_product.od_in ** 2
+    return (ap - ai) * tubing_pressure_psi - (ap - ao) * annulus_pressure_psi
+
+
+# ---------------------------------------------------------------------------
+# Orchestrated design check
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class TubingWell:
+    """The well-side inputs for a production tubing design check.
+
+    ``td_ft`` is the tubing setting / packer depth (assumed at the reservoir
+    for the gas-column translation).  ``packer_bore_in`` defaults to the
+    tubing OD when not given, reducing the piston force to the shut-in
+    ``dP * A`` term on the tubing wall.
+    """
+
+    td_ft: float
+    packer_fluid_ppg: float
+    reservoir_pressure_psi: float
+    surface_casing_pressure_psi: float = 0.0
+    packer_bore_in: Optional[float] = None
+    gas_gradient_psi_ft: float = DEFAULT_GAS_GRADIENT_PSI_FT
+
+
+def check_production_tubing(
+    tubing_product: Casing,
+    weight_ppf: float,
+    well: TubingWell,
+    factors: DesignFactors = DesignFactors(),
+) -> dict[str, ModeCheckResult]:
+    """Run the standard production-tubing design checks for one product.
+
+    Returns the shut-in burst check (SITP + gas gradient inside vs the
+    packer-fluid annulus outside; the SITP is also used for the low-SICP
+    burst-DF relaxation), the evacuated-tubing collapse check (packer fluid
+    plus any surface casing pressure outside, zero inside), and the tension
+    check (buoyed weight in packer fluid plus the shut-in packer piston
+    force; compression relief is not credited).
+    """
+    sitp = shut_in_tubing_pressure(well.reservoir_pressure_psi, well.td_ft,
+                                   well.gas_gradient_psi_ft)
+    internal = shut_in_tubing_profile(sitp, well.td_ft,
+                                      well.gas_gradient_psi_ft)
+    burst_backup = packer_fluid_annulus_profile(well.packer_fluid_ppg,
+                                                well.td_ft)
+    collapse_external = packer_fluid_annulus_profile(
+        well.packer_fluid_ppg, well.td_ft,
+        surface_pressure_psi=well.surface_casing_pressure_psi)
+
+    bore = (well.packer_bore_in if well.packer_bore_in is not None
+            else tubing_product.od_in)
+    piston = shut_in_piston_force_lbf(
+        bore, tubing_product,
+        tubing_pressure_psi=float(internal.at(well.td_ft)),
+        annulus_pressure_psi=float(collapse_external.at(well.td_ft)))
+
+    return {
+        "burst": check_burst(tubing_product, internal, burst_backup,
+                             well.td_ft, factors, sicp_psi=sitp),
+        "collapse": check_collapse(tubing_product, collapse_external,
+                                   well.td_ft, factors=factors),
+        "tension": check_tension(tubing_product, weight_ppf, well.td_ft,
+                                 well.packer_fluid_ppg,
+                                 extra_tension_lbf=max(piston, 0.0),
+                                 factors=factors),
+    }

--- a/tests/well/tubulars/test_tubing_design.py
+++ b/tests/well/tubulars/test_tubing_design.py
@@ -1,0 +1,277 @@
+# ABOUTME: Tests for the production tubing design-check layer (tubing_design)
+# ABOUTME: and the API 5CT tubing catalog. Golden: 2-7/8" 6.5# N80 ratings.
+"""Tests for :mod:`digitalmodel.well.tubulars.tubing_design` + tubing catalog.
+
+Golden values are the published API ratings for 2-7/8" 6.5# N80 tubing
+(API 5C3 / standard vendor tubing tables): internal yield (burst) 10,570 psi,
+pipe-body yield 145,000 lbf, collapse ~11,160 psi (see the collapse test for
+the 10-psi API-rounding delta).  Tubing dimensions per API 5CT.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from digitalmodel.well.tubulars.casing import (
+    TUBING_SIZES,
+    Casing as _Casing,
+    list_tubing_sizes,
+    tubing as build_tubing,
+    tubing_wall_for_size,
+)
+from digitalmodel.well.tubulars.casing_design import (
+    DesignFactors,
+    PPG_TO_PSI_PER_FT,
+    api_round_force_lbf,
+    api_round_pressure_psi,
+    buoyancy_factor,
+    shut_in_tubing_pressure,
+)
+from digitalmodel.well.tubulars.tubing_design import (
+    TubingWell,
+    check_production_tubing,
+    packer_fluid_annulus_profile,
+    shut_in_piston_force_lbf,
+    shut_in_tubing_profile,
+)
+
+
+@pytest.fixture
+def n80_278_65() -> _Casing:
+    """The golden product: 2-7/8\" 6.5# N80 tubing."""
+    return build_tubing("N80", od_in=2.875, weight_ppf=6.5)
+
+
+# ---------------------------------------------------------------------------
+# Tubing catalog (API 5CT)
+# ---------------------------------------------------------------------------
+class TestTubingCatalog:
+    def test_published_api_5ct_walls(self):
+        # API 5CT tubing dimension tables (wall in inches).
+        assert TUBING_SIZES[(2.375, 4.70)] == 0.190   # ID 1.995"
+        assert TUBING_SIZES[(2.375, 5.95)] == 0.254   # ID 1.867"
+        assert TUBING_SIZES[(2.875, 6.50)] == 0.217   # ID 2.441"
+        assert TUBING_SIZES[(2.875, 8.70)] == 0.308   # ID 2.259"
+        assert TUBING_SIZES[(3.5, 9.30)] == 0.254     # ID 2.992"
+        assert TUBING_SIZES[(3.5, 12.95)] == 0.375    # ID 2.750"
+        assert TUBING_SIZES[(4.0, 11.00)] == 0.262    # ID 3.476"
+        assert TUBING_SIZES[(4.5, 12.75)] == 0.271    # ID 3.958"
+
+    def test_list_tubing_sizes_sorted_and_complete(self):
+        sizes = list_tubing_sizes()
+        assert sizes == sorted(TUBING_SIZES)
+        assert len(sizes) == 8
+        assert {od for od, _ in sizes} == {2.375, 2.875, 3.5, 4.0, 4.5}
+
+    def test_wall_lookup_and_unknown_size_raises(self):
+        assert tubing_wall_for_size(2.875, 6.5) == 0.217
+        with pytest.raises(KeyError):
+            tubing_wall_for_size(2.875, 99.0)
+
+    def test_builder_returns_casing_product(self, n80_278_65):
+        assert isinstance(n80_278_65, _Casing)
+        assert n80_278_65.grade.name == "N80"
+        assert n80_278_65.od_in == 2.875
+        assert n80_278_65.weight_ppf == 6.5
+
+    def test_builder_explicit_wall(self):
+        t = build_tubing("L80", od_in=2.875, wt_in=0.217)
+        assert t.wt_in == 0.217
+
+    def test_builder_error_paths(self):
+        with pytest.raises(ValueError):
+            build_tubing("N80", od_in=2.875, weight_ppf=6.5, wt_in=0.217)
+        with pytest.raises(ValueError):
+            build_tubing("N80", od_in=2.875)
+        with pytest.raises(KeyError):
+            build_tubing("X999", od_in=2.875, weight_ppf=6.5)
+
+
+# ---------------------------------------------------------------------------
+# Golden published ratings: 2-7/8" 6.5# N80
+# ---------------------------------------------------------------------------
+class TestGoldenN80Tubing:
+    def test_wall_and_id(self, n80_278_65):
+        assert n80_278_65.wt_in == pytest.approx(0.217)
+        assert n80_278_65.id_in == pytest.approx(2.441)
+
+    def test_burst_rounds_to_published_10570_psi(self, n80_278_65):
+        # Barlow: 0.875 * 2 * 80,000 * 0.217 / 2.875 = 10,567 psi
+        assert n80_278_65.burst_psi == pytest.approx(10_566.96, abs=0.1)
+        assert api_round_pressure_psi(n80_278_65.burst_psi) == 10_570.0
+
+    def test_body_yield_rounds_to_published_145000_lbf(self, n80_278_65):
+        # A = pi/4 * (2.875^2 - 2.441^2) = 1.812 in^2; * 80,000 = 144,962 lbf
+        assert n80_278_65.body_yield_lbf == pytest.approx(144_962.1, abs=1.0)
+        assert api_round_force_lbf(n80_278_65.body_yield_lbf) == 145_000.0
+
+    def test_collapse_near_published_11160_psi(self, n80_278_65):
+        # Published API rating is 11,160 psi.  The code's 4-regime API 5C3
+        # collapse gives 11,165.0 psi (D/t = 13.25 falls in the YIELD regime,
+        # boundary at 13.38 for 80 ksi), which API-rounds to 11,170 psi —
+        # a 10 psi (0.09%) delta from the published table value, attributable
+        # to rounding conventions in the legacy tables.  Assert the code's
+        # own value and its closeness to the published number.
+        assert n80_278_65.collapse_regime == "yield"
+        assert n80_278_65.collapse_psi == pytest.approx(11_165.0, abs=0.1)
+        assert api_round_pressure_psi(n80_278_65.collapse_psi) == 11_170.0
+        assert n80_278_65.collapse_psi == pytest.approx(11_160.0, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Load-case profile builders
+# ---------------------------------------------------------------------------
+class TestProfileBuilders:
+    def test_shut_in_tubing_profile_is_sitp_plus_gas_gradient(self):
+        prof = shut_in_tubing_profile(3_200.0, 8_000.0,
+                                      gas_gradient_psi_ft=0.1)
+        assert float(prof.at(0.0)) == pytest.approx(3_200.0)
+        assert float(prof.at(8_000.0)) == pytest.approx(3_200.0 + 800.0)
+        assert "shut-in" in prof.label
+
+    def test_shut_in_profile_rejects_nonpositive_td(self):
+        with pytest.raises(ValueError):
+            shut_in_tubing_profile(3_200.0, 0.0)
+
+    def test_packer_fluid_annulus_gradient_and_surface_pressure(self):
+        prof = packer_fluid_annulus_profile(9.0, 8_000.0,
+                                            surface_pressure_psi=500.0)
+        assert float(prof.at(0.0)) == pytest.approx(500.0)
+        assert float(prof.at(8_000.0)) == pytest.approx(
+            500.0 + PPG_TO_PSI_PER_FT * 9.0 * 8_000.0)
+        assert prof.label == "packer-fluid annulus"
+
+
+# ---------------------------------------------------------------------------
+# Packer piston force
+# ---------------------------------------------------------------------------
+class TestPistonForce:
+    def test_lubinski_piston_formula(self, n80_278_65):
+        # F = (Ap - Ai) * P_tbg - (Ap - Ao) * P_ann
+        bore = 3.25
+        ap = math.pi / 4.0 * bore ** 2
+        ai = math.pi / 4.0 * 2.441 ** 2
+        ao = math.pi / 4.0 * 2.875 ** 2
+        expected = (ap - ai) * 5_000.0 - (ap - ao) * 1_000.0
+        got = shut_in_piston_force_lbf(bore, n80_278_65, 5_000.0, 1_000.0)
+        assert got == pytest.approx(expected)
+
+    def test_bore_equal_to_od_reduces_to_dp_on_wall_area(self, n80_278_65):
+        # Ap = Ao -> F = (Ao - Ai) * P_tbg (the metal-area dP term).
+        got = shut_in_piston_force_lbf(2.875, n80_278_65, 4_000.0, 3_744.0)
+        assert got == pytest.approx(n80_278_65.metal_area_in2 * 4_000.0)
+
+    def test_zero_pressures_zero_force(self, n80_278_65):
+        assert shut_in_piston_force_lbf(3.25, n80_278_65, 0.0, 0.0) == 0.0
+
+    def test_nonpositive_bore_raises(self, n80_278_65):
+        with pytest.raises(ValueError):
+            shut_in_piston_force_lbf(0.0, n80_278_65, 1_000.0)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrated check
+# ---------------------------------------------------------------------------
+class TestCheckProductionTubing:
+    @pytest.fixture
+    def moderate_well(self) -> TubingWell:
+        return TubingWell(td_ft=8_000.0, packer_fluid_ppg=9.0,
+                          reservoir_pressure_psi=4_000.0)
+
+    def test_modes_present_and_n80_passes(self, n80_278_65, moderate_well):
+        results = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        assert set(results) == {"burst", "collapse", "tension"}
+        for mode, res in results.items():
+            assert res.passes, mode
+            assert res.min_design_factor > 0.0, mode
+
+    def test_burst_governs_at_surface_with_sitp(self, n80_278_65,
+                                                moderate_well):
+        results = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        res = results["burst"]
+        sitp = shut_in_tubing_pressure(4_000.0, 8_000.0)
+        assert res.rating == 10_570.0
+        # Gas inside vs packer fluid outside: net differential is greatest
+        # at surface, where the backup is zero.
+        assert res.governing_depth_ft == 0.0
+        assert res.max_load == pytest.approx(sitp)
+        # SITP < 5,000 psi -> relaxed burst DF minimum (operator practice).
+        assert res.required_design_factor == 1.1
+
+    def test_collapse_evacuated_governs_at_packer(self, n80_278_65,
+                                                  moderate_well):
+        results = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        res = results["collapse"]
+        assert res.governing_depth_ft == moderate_well.td_ft
+        assert res.max_load == pytest.approx(
+            PPG_TO_PSI_PER_FT * 9.0 * 8_000.0)
+        assert res.rating == 11_170.0
+
+    def test_surface_casing_pressure_reduces_collapse_margin(
+            self, n80_278_65, moderate_well):
+        pressurized = TubingWell(td_ft=8_000.0, packer_fluid_ppg=9.0,
+                                 reservoir_pressure_psi=4_000.0,
+                                 surface_casing_pressure_psi=1_500.0)
+        base = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        loaded = check_production_tubing(n80_278_65, 6.5, pressurized)
+        assert (loaded["collapse"].min_design_factor
+                < base["collapse"].min_design_factor)
+        assert loaded["collapse"].max_load == pytest.approx(
+            1_500.0 + PPG_TO_PSI_PER_FT * 9.0 * 8_000.0)
+
+    def test_tension_includes_buoyed_weight_plus_piston(self, n80_278_65,
+                                                        moderate_well):
+        results = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        res = results["tension"]
+        assert res.rating == 145_000.0
+        assert res.governing_depth_ft == 0.0
+        buoyed = 6.5 * 8_000.0 * buoyancy_factor(9.0)
+        # Default bore = tubing OD -> piston = (Ao - Ai) * P_tbg at packer;
+        # shut-in tubing pressure at the packer equals reservoir pressure.
+        piston = n80_278_65.metal_area_in2 * 4_000.0
+        assert res.max_load == pytest.approx(buoyed + piston)
+        assert res.passes
+
+    def test_explicit_packer_bore_changes_tension_load(self, n80_278_65,
+                                                       moderate_well):
+        big_bore = TubingWell(td_ft=8_000.0, packer_fluid_ppg=9.0,
+                              reservoir_pressure_psi=4_000.0,
+                              packer_bore_in=3.25)
+        base = check_production_tubing(n80_278_65, 6.5, moderate_well)
+        wide = check_production_tubing(n80_278_65, 6.5, big_bore)
+        assert (wide["tension"].max_load
+                != pytest.approx(base["tension"].max_load))
+
+    def test_negative_piston_force_not_credited(self, n80_278_65):
+        # Depleted reservoir + heavy annulus + big bore -> negative piston
+        # force; the tension check must not take credit for the relief.
+        well = TubingWell(td_ft=8_000.0, packer_fluid_ppg=15.0,
+                          reservoir_pressure_psi=1_500.0,
+                          surface_casing_pressure_psi=2_000.0,
+                          packer_bore_in=4.0)
+        sitp = shut_in_tubing_pressure(1_500.0, 8_000.0)
+        p_tbg = sitp + 0.1 * 8_000.0
+        p_ann = 2_000.0 + PPG_TO_PSI_PER_FT * 15.0 * 8_000.0
+        assert shut_in_piston_force_lbf(4.0, n80_278_65, p_tbg, p_ann) < 0.0
+        res = check_production_tubing(n80_278_65, 6.5, well)["tension"]
+        buoyed = 6.5 * 8_000.0 * buoyancy_factor(15.0)
+        assert res.max_load == pytest.approx(buoyed)
+
+    def test_undersized_string_fails_burst(self):
+        weak = build_tubing("J55", od_in=2.375, weight_ppf=4.7)
+        hot = TubingWell(td_ft=12_000.0, packer_fluid_ppg=9.0,
+                         reservoir_pressure_psi=11_000.0)
+        results = check_production_tubing(weak, 4.7, hot)
+        # J55 burst = 0.875 * 2 * 55,000 * 0.190 / 2.375 = 7,700 psi vs
+        # SITP = 11,000 - 1,200 = 9,800 psi.
+        assert results["burst"].rating == 7_700.0
+        assert not results["burst"].passes
+
+    def test_custom_design_factors_flow_through(self, n80_278_65,
+                                                moderate_well):
+        strict = DesignFactors(collapse=5.0)
+        results = check_production_tubing(n80_278_65, 6.5, moderate_well,
+                                          factors=strict)
+        assert results["collapse"].required_design_factor == 5.0
+        assert not results["collapse"].passes


### PR DESCRIPTION
Implements #1313 — the tubing counterpart of the production casing design layer merged in #1300/#1306.

## What

**Catalog (`casing.py`)**
- `TUBING_SIZES` — API 5CT tubing walls, kept separate from `CASING_SIZES` (4-1/2" exists in both with different standard weights): 2-3/8" (4.7#/0.190, 5.95#/0.254), 2-7/8" (6.5#/0.217, 8.7#/0.308), 3-1/2" (9.3#/0.254, 12.95#/0.375), 4" (11.0#/0.262), 4-1/2" (12.75#/0.271).
- `tubing(grade, od_in=..., weight_ppf=...)` builder returning the existing `Casing` product class (identical API 5C3 rating machinery), plus `list_tubing_sizes()` / `tubing_wall_for_size()`.

**Design checks (`tubing_design.py`, new)** — composes `casing_design` primitives, no duplication:
- **Burst**: `shut_in_tubing_profile` (surface SITP + produced-gas gradient down) vs packer-fluid annulus backup; SITP feeds the existing low-SICP burst-DF relaxation.
- **Collapse**: evacuated tubing (zero inside) vs packer fluid + optional surface casing pressure.
- **Tension**: buoyed weight + shut-in piston force on the packer bore, `F = (Ap−Ai)·P_tbg − (Ap−Ao)·P_ann` (Lubinski F1; bore defaults to tubing OD → reduces to the ΔP·A wall-area term); compression relief not credited; wired through `check_tension`'s `extra_tension_lbf`.
- `check_production_tubing(product, weight_ppf, TubingWell(...), factors)` returns `dict[str, ModeCheckResult]` like the casing orchestrator.

## Goldens (2-7/8" 6.5# N80, published API ratings)
- Burst: Barlow `0.875·2·80,000·0.217/2.875 = 10,567` → API-rounded **10,570 psi** ✅ exact match
- Body yield: `80,000 · 1.812 in² = 144,962` → **145,000 lbf** ✅ exact match
- Collapse: code's 4-regime API 5C3 gives **11,165.0 psi** (D/t 13.25 = yield regime) → API-rounds to 11,170, a 10 psi (0.09%) delta from the published 11,160; test asserts the computed value and documents the delta.

## Tests
- `tests/well/tubulars/test_tubing_design.py`: 26 new tests (catalog, goldens, profile builders, piston formula, orchestrator, error paths).
- Full `tests/well` suite: **345 passed**, no regressions.

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)