### PR TITLE
fix(ci): unbreak main Quality Gates — abs-path sentinels on riser-DB test fallbacks

### DIFF
--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -22,7 +22,7 @@ from digitalmodel.riser_database.loader import DEFAULT_DB_ROOT
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 

--- a/tests/riser_database/test_stackup_rig.py
+++ b/tests/riser_database/test_stackup_rig.py
@@ -206,7 +206,7 @@ def test_registry_generic_names_not_republished():
 # -- RSU registry reconciliation (in-context) ---------------------------------------
 
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 


### PR DESCRIPTION
Main's Quality Gates ("Check no developer-machine absolute paths") has been red since 60b428e5 (#1289): `test_provenance_tripwire.py` and `test_stackup_rig.py` hardcode the primary llm-wiki clone path in `_KNOWN_WIKI_CLONES` fallbacks. `LLM_WIKI_PATH` takes precedence at runtime, so behavior is unchanged; the lines get the enforcement script's sanctioned `# abs-path-allowed` sentinel. Verified locally: `bash scripts/enforcement/check-no-abs-paths.sh` exits 0.

Unblocks Quality Gates for open PRs (#1315, #1316, #1312 branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)