### PR TITLE
fix(tests): baseline-red cleanup — infrastructure-other/misc/orcaflex-solver/specialized (#1312)

### DIFF
--- a/src/digitalmodel/solvers/orcaflex/universal_cli.py
+++ b/src/digitalmodel/solvers/orcaflex/universal_cli.py
@@ -33,8 +33,9 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
-@click.option('--pattern', '-p', 
+@click.option('--pattern', '-p',
               default='*.yml',
+              show_default=True,
               help='File pattern to match (e.g., "*.yml", "fsts_*.dat")')
 @click.option('--input-dir', '-i',
               type=click.Path(exists=False),
@@ -57,6 +58,7 @@ logger = logging.getLogger(__name__)
 @click.option('--workers', '-w',
               type=int,
               default=30,
+              show_default=True,
               help='Maximum number of parallel workers')
 @click.option('--mock',
               is_flag=True,

--- a/tests/additional_engine_tests.py
+++ b/tests/additional_engine_tests.py
@@ -50,6 +50,10 @@ mock_modules = {
     'digitalmodel.infrastructure.base_solvers.marine.pipe_properties': MagicMock(),
     'loguru': MagicMock(),
     'digitalmodel.solvers.orcaflex.output_control': MagicMock(),
+    # Lazily-imported routing targets (engine imports these inside the
+    # basename dispatch, not at module level)
+    'digitalmodel.specialized.rigging.rigging': MagicMock(),
+    'digitalmodel.subsea.catenary_riser.legacy.catenary': MagicMock(),
 }
 
 for module_name, mock_obj in mock_modules.items():
@@ -112,6 +116,11 @@ def test_yaml_input_path():
                 # Setup validation and YAML loading
                 mock_app_manager.validate_arguments_run_methods.return_value = (temp_file, {})
                 mock_wwyaml.ymlInput.return_value = {"basename": "transformation"}
+                # engine now runs configure + configure_result_folder on the
+                # inputfile path too; the latter's return is tuple-unpacked
+                cfg_configured = MockAttributeDict({"basename": "transformation"})
+                mock_app_manager.configure.return_value = cfg_configured
+                mock_app_manager.configure_result_folder.return_value = ({}, cfg_configured)
 
                 with patch('digitalmodel.engine.logger'):
                     with patch('os.path.exists', return_value=True):
@@ -135,26 +144,34 @@ def test_output_control_levels():
 
     cfg = MockAttributeDict({"basename": "transformation"})
 
-    # Test QUIET output level
-    with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
-        from digitalmodel.solvers.orcaflex.output_control import OutputController
-        mock_output.return_value = OutputController.QUIET
+    # Transformation router must be identity so the cfg dict (with the
+    # quiet/verbose flags engine set) is what engine returns
+    with patch('digitalmodel.engine.Transformation') as mock_trans:
+        mock_trans.return_value.router.side_effect = lambda c: c
 
-        with patch('digitalmodel.engine.logger'):
-            result = engine(cfg=cfg, config_flag=False)
+        # Test QUIET output level
+        with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
+            # Use engine's own OutputController binding (sibling test modules
+            # swap sys.modules entries at collection time; re-importing from
+            # the mocked module path yields a different object)
+            from digitalmodel.engine import OutputController
+            mock_output.return_value = OutputController.QUIET
 
-        assert result.get('quiet') is True
-        assert result.get('verbose') is False
+            with patch('digitalmodel.engine.logger'):
+                result = engine(cfg=cfg, config_flag=False)
 
-    # Test VERBOSE output level
-    with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
-        mock_output.return_value = OutputController.VERBOSE
+            assert result.get('quiet') is True
+            assert result.get('verbose') is False
 
-        with patch('digitalmodel.engine.logger'):
-            result = engine(cfg=cfg, config_flag=False)
+        # Test VERBOSE output level
+        with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
+            mock_output.return_value = OutputController.VERBOSE
 
-        assert result.get('quiet') is False
-        assert result.get('verbose') is True
+            with patch('digitalmodel.engine.logger'):
+                result = engine(cfg=cfg, config_flag=False)
+
+            assert result.get('quiet') is False
+            assert result.get('verbose') is True
 
     print("✓ Output control levels tested")
 
@@ -184,12 +201,19 @@ def test_config_path_preservation():
         with patch('digitalmodel.engine.wwyaml') as mock_wwyaml:
             mock_app_manager.validate_arguments_run_methods.return_value = (test_file, {})
             mock_wwyaml.ymlInput.return_value = {"basename": "transformation"}
+            # engine copies _config_*_path onto configure()'s cfg, then
+            # tuple-unpacks configure_result_folder — return the same object
+            cfg_configured = MockAttributeDict({"basename": "transformation"})
+            mock_app_manager.configure.return_value = cfg_configured
+            mock_app_manager.configure_result_folder.return_value = ({}, cfg_configured)
 
-            with patch('os.path.exists', return_value=True):
-                with patch('os.path.abspath', return_value=test_file):
-                    with patch('os.path.dirname', return_value=test_dir):
-                        with patch('digitalmodel.engine.logger'):
-                            result = engine(inputfile=test_file, cfg=None)
+            with patch('digitalmodel.engine.Transformation') as mock_trans:
+                mock_trans.return_value.router.side_effect = lambda c: c
+                with patch('os.path.exists', return_value=True):
+                    with patch('os.path.abspath', return_value=test_file):
+                        with patch('os.path.dirname', return_value=test_dir):
+                            with patch('digitalmodel.engine.logger'):
+                                result = engine(inputfile=test_file, cfg=None)
 
             # Verify path tracking
             assert "_config_file_path" in result
@@ -204,7 +228,8 @@ def test_rigging_dynamic_import():
 
     cfg = MockAttributeDict({"basename": "rigging"})
 
-    with patch('digitalmodel.engine.Rigging') as mock_rigging:
+    # Rigging is lazily imported inside engine() from its source module
+    with patch('digitalmodel.specialized.rigging.rigging.Rigging') as mock_rigging:
         mock_instance = MagicMock()
         mock_instance.get_rigging_groups.return_value = cfg
         mock_rigging.return_value = mock_instance
@@ -224,7 +249,8 @@ def test_catenary_dynamic_import():
 
     cfg = MockAttributeDict({"basename": "catenary_analysis"})
 
-    with patch('digitalmodel.engine.Catenary') as mock_catenary:
+    # Catenary is lazily imported inside engine() from its source module
+    with patch('digitalmodel.subsea.catenary_riser.legacy.catenary.Catenary') as mock_catenary:
         mock_instance = MagicMock()
         mock_instance.router.return_value = cfg
         mock_catenary.return_value = mock_instance

--- a/tests/infrastructure/performance/test_benchmarks.py
+++ b/tests/infrastructure/performance/test_benchmarks.py
@@ -24,6 +24,15 @@ except ImportError:
     pytest.skip("DigitalModel modules not available", allow_module_level=True)
 
 
+def _cpu_intensive_task(n):
+    """CPU-intensive task for parallelization tests.
+
+    Module-level so ProcessPoolExecutor can pickle it (locally defined
+    functions are never picklable).
+    """
+    return sum(i * i for i in range(n))
+
+
 class TestMathematicalOperationsBenchmarks:
     """Benchmark tests for mathematical operations."""
 
@@ -100,6 +109,12 @@ class TestDataProcessingBenchmarks:
     """Benchmark tests for data processing operations."""
 
     @pytest.mark.performance
+    # pandas-internal numpy cast warning when hashing IntervalIndex
+    # categories (pandas 2.x); escalated to an error by the repo-wide
+    # `filterwarnings = error` — not a defect in the code under test.
+    @pytest.mark.filterwarnings(
+        "ignore:invalid value encountered in cast:RuntimeWarning"
+    )
     def test_dataframe_operations_benchmark(self, benchmark_runner, load_test_data):
         """Benchmark pandas DataFrame operations."""
 
@@ -108,7 +123,9 @@ class TestDataProcessingBenchmarks:
             # Simulate data processing pipeline
             result = df.copy()
             result['new_col'] = result['x'] * result['y']
-            result = result.groupby(pd.cut(result['z'], bins=10)).agg({
+            result = result.groupby(
+                pd.cut(result['z'], bins=10), observed=False
+            ).agg({
                 'x': 'mean',
                 'y': 'std',
                 'new_col': 'sum'
@@ -207,33 +224,31 @@ class TestConcurrencyBenchmarks:
     @pytest.mark.performance
     def test_parallel_processing_speedup(self, benchmark_runner):
         """Test that parallel processing provides expected speedup."""
-        import multiprocessing as mp
         from concurrent.futures import ProcessPoolExecutor
-
-        def cpu_intensive_task(n):
-            """CPU-intensive task for testing parallelization."""
-            return sum(i * i for i in range(n))
 
         # Sequential processing
         def sequential_processing(tasks):
-            return [cpu_intensive_task(task) for task in tasks]
+            return [_cpu_intensive_task(task) for task in tasks]
 
-        # Parallel processing
-        def parallel_processing(tasks):
-            with ProcessPoolExecutor(max_workers=2) as executor:
-                return list(executor.map(cpu_intensive_task, tasks))
+        tasks = [200000] * 4  # 4 tasks heavy enough to dwarf IPC overhead
 
-        tasks = [50000] * 4  # 4 tasks of moderate size
+        # Reuse one executor (spawning a pool per iteration measures process
+        # startup, not parallel throughput) and warm it up before timing.
+        with ProcessPoolExecutor(max_workers=2) as executor:
+            list(executor.map(_cpu_intensive_task, [1000] * 2))  # warm-up
 
-        # Benchmark sequential
-        seq_stats = benchmark_runner.run_benchmark(
-            sequential_processing, iterations=5, tasks=tasks
-        )
+            def parallel_processing(tasks):
+                return list(executor.map(_cpu_intensive_task, tasks))
 
-        # Benchmark parallel
-        par_stats = benchmark_runner.run_benchmark(
-            parallel_processing, iterations=5, tasks=tasks
-        )
+            # Benchmark sequential
+            seq_stats = benchmark_runner.run_benchmark(
+                sequential_processing, iterations=5, tasks=tasks
+            )
+
+            # Benchmark parallel
+            par_stats = benchmark_runner.run_benchmark(
+                parallel_processing, iterations=5, tasks=tasks
+            )
 
         # Parallel should be faster (allowing for overhead)
         speedup = seq_stats['mean'] / par_stats['mean']

--- a/tests/solvers/orcaflex/modular_generator/test_builder_registry.py
+++ b/tests/solvers/orcaflex/modular_generator/test_builder_registry.py
@@ -9,7 +9,11 @@ class TestBuilderRegistry:
     """Test the builder registry system."""
 
     def test_all_builders_registered(self):
-        """Verify all 13 builders are registered (10 original + 3 S-lay)."""
+        """Verify all 19 builders are registered.
+
+        10 original + 3 S-lay + 5 riser (drilling-riser automation epic #807)
+        + 1 generic-object builder (#495-#505 spec-to-YAML overhaul).
+        """
         from digitalmodel.solvers.orcaflex.modular_generator.builders.registry import (
             BuilderRegistry,
         )
@@ -17,7 +21,7 @@ class TestBuilderRegistry:
         import digitalmodel.solvers.orcaflex.modular_generator.builders  # noqa: F401
 
         ordered = BuilderRegistry.get_ordered_builders()
-        assert len(ordered) == 13
+        assert len(ordered) == 19
         file_names = [name for name, _ in ordered]
         assert "01_general.yml" in file_names
         assert "10_groups.yml" in file_names
@@ -25,6 +29,14 @@ class TestBuilderRegistry:
         assert "04_vessel_types.yml" in file_names
         assert "06_vessels.yml" in file_names
         assert "11_winches.yml" in file_names
+        # Riser builders (#807)
+        assert "04_riser_clump_types.yml" in file_names
+        assert "05_riser_line_types.yml" in file_names
+        assert "06_riser_vessels.yml" in file_names
+        assert "07_riser_lines.yml" in file_names
+        assert "08_riser_links.yml" in file_names
+        # Generic-object builder (#495-#505)
+        assert "20_generic_objects.yml" in file_names
 
     def test_execution_order(self):
         """Verify builders execute in correct dependency order."""
@@ -65,15 +77,21 @@ class TestBuilderRegistry:
             "02_var_data.yml",
             "03_environment.yml",
             "04_vessel_types.yml",
+            "04_riser_clump_types.yml",
             "05_line_types.yml",
+            "05_riser_line_types.yml",
+            "06_riser_vessels.yml",
             "06_vessels.yml",
             "13_supports.yml",
             "14_morison.yml",
             "09_shapes.yml",
             "08_buoys.yml",
             "07_lines.yml",
+            "07_riser_lines.yml",
+            "08_riser_links.yml",
             "11_winches.yml",
             "10_groups.yml",
+            "20_generic_objects.yml",
         ]
 
     def test_get_specific_builder(self):

--- a/tests/solvers/orcaflex/modular_generator/test_schema_compat.py
+++ b/tests/solvers/orcaflex/modular_generator/test_schema_compat.py
@@ -123,13 +123,22 @@ class TestSchemaValidation:
         with pytest.raises(ValidationError):
             Water(depth=-1, density=1.025)
 
-    def test_invalid_water_depth_too_deep(self):
+    def test_invalid_water_depth_zero(self):
         from pydantic import ValidationError
 
         from digitalmodel.solvers.orcaflex.modular_generator.schema import Water
 
         with pytest.raises(ValidationError):
-            Water(depth=6000, density=1.025)
+            Water(depth=0, density=1.025)
+
+    def test_deep_water_depth_allowed(self):
+        # The schema deliberately has no upper depth bound (gt=0 only):
+        # real OrcaFlex models exceed 5000 m and the #495-#505 audit kept
+        # depth unbounded above.
+        from digitalmodel.solvers.orcaflex.modular_generator.schema import Water
+
+        water = Water(depth=6000, density=1.025)
+        assert water.depth == 6000
 
     def test_invalid_wall_thickness(self):
         from pydantic import ValidationError

--- a/tests/solvers/orcaflex/mooring-tension-iteration/mooring_tension_iteration_test.py
+++ b/tests/solvers/orcaflex/mooring-tension-iteration/mooring_tension_iteration_test.py
@@ -3,11 +3,30 @@ import os
 import sys
 from typing import Any, Dict
 
+# Third party imports
+import pytest
+
 # Reader imports
 from assetutilities.modules.test_utilities.test_utilities import TestUtilities
 from digitalmodel.engine import engine
 
 tu = TestUtilities()
+
+# The input configs these tests feed to engine() were relocated off-repo at
+# the repo-slimming squash (2c185d2d) and engine has no basename routing arm
+# for mooring_tension_iteration yet. Skip until fixtures + routing are
+# restored — tracked in
+# https://github.com/vamseeachanta/digitalmodel/issues/1318.
+_TEST_DIR = os.path.dirname(__file__)
+_INPUT_FILES = [
+    os.path.join(_TEST_DIR, 'scripts', 'mooring_tension_iteration.yml'),
+    os.path.join(_TEST_DIR, 'single_line_iteration.yml'),
+    os.path.join(_TEST_DIR, 'multi_line_iteration.yml'),
+]
+pytestmark = pytest.mark.skipif(
+    not all(os.path.isfile(f) for f in _INPUT_FILES),
+    reason="input ymls relocated off-repo at repo slimming; restore tracked in #1318",
+)
 
 def run_process(input_file: str, expected_result: Dict[str, Any] = {}) -> None:
     """

--- a/tests/solvers/orcaflex/mooring_analysis/comprehensive_analysis/test_config.py
+++ b/tests/solvers/orcaflex/mooring_analysis/comprehensive_analysis/test_config.py
@@ -342,9 +342,9 @@ processing:
         
         warnings = config.validate()
         assert len(warnings) >= 3
-        assert any('tolerance' in w for w in warnings)
-        assert any('utilization' in w for w in warnings)
-        assert any('memory' in w for w in warnings)
+        assert any('tolerance' in w.lower() for w in warnings)
+        assert any('utilization' in w.lower() for w in warnings)
+        assert any('memory' in w.lower() for w in warnings)
 
 
 class TestCreateDefaultConfig:

--- a/tests/solvers/orcaflex/reporting/snapshot_helpers.py
+++ b/tests/solvers/orcaflex/reporting/snapshot_helpers.py
@@ -12,8 +12,27 @@ VOLATILE_PATTERNS: list[tuple[str, str]] = [
 ]
 
 
+def _fold_json_unicode_escapes(text: str) -> str:
+    """Fold JSON \\uXXXX escapes into literal characters.
+
+    Plotly's embedded-figure JSON is ASCII-escaped (``\\u00b7``) when orjson is
+    absent but keeps literal UTF-8 (``·``) when orjson is installed, so the
+    same report renders byte-differently across environments. Comparing on the
+    folded form makes snapshots environment-agnostic. Surrogate pairs are not
+    expected in these reports and are left untouched.
+    """
+    return re.sub(
+        r"\\u([0-9a-fA-F]{4})",
+        lambda m: chr(int(m.group(1), 16))
+        if not 0xD800 <= int(m.group(1), 16) <= 0xDFFF
+        else m.group(0),
+        text,
+    )
+
+
 def normalize_report_html(html_text: str) -> str:
     text = html_text.replace("\r\n", "\n")
+    text = _fold_json_unicode_escapes(text)
     for pattern, replacement in VOLATILE_PATTERNS:
         text = re.sub(pattern, replacement, text)
 

--- a/tests/solvers/orcaflex/test_orcaflex_cli.py
+++ b/tests/solvers/orcaflex/test_orcaflex_cli.py
@@ -204,7 +204,7 @@ class TestCLIModuleIntegration:
         """Test Python import works after CLI installation"""
         result = subprocess.run(
             [sys.executable, '-c',
-             'import digitalmodel.orcaflex; print(digitalmodel.solvers.orcaflex.__version__)'],
+             'import digitalmodel.solvers.orcaflex; print(digitalmodel.solvers.orcaflex.__version__)'],
             capture_output=True,
             text=True
         )

--- a/tests/solvers/orcaflex/test_orcaflex_converter_enhanced.py
+++ b/tests/solvers/orcaflex/test_orcaflex_converter_enhanced.py
@@ -29,25 +29,29 @@ from digitalmodel.solvers.orcaflex.orcaflex_converter_enhanced import OrcaFlexCo
 TEST_EXAMPLES_DIR = Path(__file__).resolve().parents[3] / "docs/domains/orcaflex/examples/raw"
 
 
+# Module-level fixtures: shared by TestOrcaFlexConverterEnhanced, TestPerformance
+# and TestCLI (class-scoped fixture definitions are invisible to sibling classes).
+@pytest.fixture
+def temp_output_dir():
+    """Create temporary output directory for tests."""
+    temp_dir = tempfile.mkdtemp()
+    yield Path(temp_dir)
+    # Cleanup
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def sample_dat_files():
+    """Get sample .dat files from repository examples."""
+    if TEST_EXAMPLES_DIR.exists():
+        dat_files = list(TEST_EXAMPLES_DIR.glob("**/*.dat"))[:5]  # First 5 files
+        return dat_files
+    else:
+        pytest.skip("Example files not found")
+
+
 class TestOrcaFlexConverterEnhanced:
     """Test suite for enhanced OrcaFlex converter."""
-
-    @pytest.fixture
-    def temp_output_dir(self):
-        """Create temporary output directory for tests."""
-        temp_dir = tempfile.mkdtemp()
-        yield Path(temp_dir)
-        # Cleanup
-        shutil.rmtree(temp_dir, ignore_errors=True)
-
-    @pytest.fixture
-    def sample_dat_files(self):
-        """Get sample .dat files from repository examples."""
-        if TEST_EXAMPLES_DIR.exists():
-            dat_files = list(TEST_EXAMPLES_DIR.glob("**/*.dat"))[:5]  # First 5 files
-            return dat_files
-        else:
-            pytest.skip("Example files not found")
 
     @pytest.fixture
     def converter_real(self, temp_output_dir):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -204,7 +204,11 @@ class TestEngineConfiguration:
 
         # Test quiet mode
         with patch('digitalmodel.engine.get_output_level_from_argv') as mock_output:
-            from digitalmodel.solvers.orcaflex.output_control import OutputController
+            # Use engine's own OutputController binding: sibling test modules
+            # replace sys.modules['...output_control'] with fresh mocks at
+            # collection time, so re-importing here yields a different object
+            # than the one engine compares against.
+            from digitalmodel.engine import OutputController
             mock_output.return_value = OutputController.QUIET
 
             with patch('digitalmodel.engine.Pipeline') as mock_mooring:

--- a/tests/test_engine_isolated.py
+++ b/tests/test_engine_isolated.py
@@ -76,9 +76,10 @@ def test_engine_import_and_basic_functionality():
         # Now import and test the engine
         from digitalmodel.engine import engine
 
-        # Test with simple config
+        # Test with a simple config routed to a mocked handler (engine
+        # raises for unknown basenames like "test_module" by design)
         cfg = MockAttributeDict({
-            "basename": "test_module",
+            "basename": "transformation",
             "inputs": {"test": "value"}
         })
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -9,7 +9,9 @@ import json
 import csv
 from datetime import datetime
 
-from digitalmodel.reporting import (
+# The "standard report" framework lives under visualization.reporting;
+# digitalmodel.reporting is the shared report *block* library (#1018).
+from digitalmodel.visualization.reporting import (
     StandardReport,
     ParameterSet,
     AnalysisResult,

--- a/tests/test_skill_resolver.py
+++ b/tests/test_skill_resolver.py
@@ -1,9 +1,16 @@
 # ABOUTME: Tests for skill versioning and dependency resolution
 # Tests skill loading, version compatibility, dependency resolution, and recommendations
+#
+# The tests run against a hermetic fixture skills directory built in tmp_path.
+# The repo's .claude/skills/ entries are symlinks into the machine-level
+# workspace-hub tree (broken in fresh clones and CI), so resolving the live
+# inventory is environment-dependent by design; the resolver behaviour is
+# what these tests pin down (see #1312).
 
 import json
+import textwrap
+
 import pytest
-from pathlib import Path
 
 from digitalmodel.skills.skill_resolver import (
     SkillResolver,
@@ -12,18 +19,138 @@ from digitalmodel.skills.skill_resolver import (
 )
 
 
+def _write_skill(
+    root,
+    name: str,
+    description: str,
+    category: str,
+    version: str,
+    triggers=(),
+    dependencies=None,
+    python_min_version=None,
+    orcaflex_version=None,
+):
+    skill_dir = root / name
+    skill_dir.mkdir()
+    trigger_lines = "\n".join(f"  - {t}" for t in triggers)
+    frontmatter = f"---\nname: {name}\ndescription: {description}\ncategory: {category}\n"
+    if triggers:
+        frontmatter += f"triggers:\n{trigger_lines}\n"
+    frontmatter += "---\n"
+
+    meta = {"version": version}
+    if python_min_version:
+        meta["python_min_version"] = python_min_version
+    if orcaflex_version:
+        meta["orcaflex_version"] = orcaflex_version
+    if dependencies:
+        meta["dependencies"] = dependencies
+
+    import yaml as _yaml
+
+    body = textwrap.dedent(
+        f"""
+        # {name}
+
+        {description}
+
+        ## Version Metadata
+
+        ```yaml
+        {{}}
+        ```
+        """
+    ).format(_yaml.safe_dump(meta).strip())
+
+    (skill_dir / "SKILL.md").write_text(frontmatter + body, encoding="utf-8")
+
+
+FIXTURE_SKILLS = [
+    "aqwa-analysis",
+    "hydrodynamics",
+    "signal-analysis",
+    "structural-analysis",
+    "fatigue-analysis",
+    "orcaflex-modeling",
+    "mooring-design",
+    "cad-engineering",
+]
+
+
+@pytest.fixture(scope="module")
+def skills_dir(tmp_path_factory):
+    """Build a self-contained skills directory exercising every resolver feature."""
+    root = tmp_path_factory.mktemp("skills")
+    _write_skill(
+        root, "aqwa-analysis",
+        description="Hydrodynamic diffraction analysis with ANSYS AQWA including RAO extraction",
+        category="hydrodynamics", version="3.1.2",
+        triggers=["AQWA", "RAO", "diffraction"],
+        dependencies={"hydrodynamics": ">=1.0.0"},
+    )
+    _write_skill(
+        root, "hydrodynamics",
+        description="Core hydrodynamics utilities and coefficients",
+        category="hydrodynamics", version="1.2.0",
+    )
+    _write_skill(
+        root, "signal-analysis",
+        description="Signal processing and spectral analysis",
+        category="signal-processing", version="1.0.3",
+        triggers=["signal", "spectral"],
+        python_min_version="3.10",
+    )
+    _write_skill(
+        root, "structural-analysis",
+        description="Structural capacity and stress analysis",
+        category="structural", version="1.4.0",
+        triggers=["structural", "stress"],
+    )
+    _write_skill(
+        root, "fatigue-analysis",
+        description="Fatigue damage and S-N curve analysis",
+        category="structural", version="2.0.1",
+        triggers=["fatigue", "S-N"],
+        dependencies={
+            "signal-analysis": ">=1.0.0",
+            "structural-analysis": ">=1.0.0",
+        },
+    )
+    _write_skill(
+        root, "orcaflex-modeling",
+        description="OrcaFlex model building and hydrodynamic simulation",
+        category="orcaflex", version="2.3.0",
+        triggers=["OrcaFlex", "simulation"],
+        orcaflex_version=">=11.0",
+    )
+    _write_skill(
+        root, "mooring-design",
+        description="Design and analyze mooring systems for floating structures",
+        category="marine", version="1.1.0",
+        triggers=["mooring", "design"],
+        dependencies={"hydrodynamics": ">=1.0.0"},
+    )
+    _write_skill(
+        root, "cad-engineering",
+        description="CAD geometry preparation and drawing automation",
+        category="cad", version="1.0.0",
+        triggers=["CAD", "geometry"],
+    )
+    return root
+
+
 @pytest.fixture
-def resolver():
-    """Create a skill resolver instance."""
-    return SkillResolver()
+def resolver(skills_dir):
+    """Create a skill resolver instance over the fixture skills directory."""
+    return SkillResolver(skills_directory=skills_dir)
 
 
 class TestSkillLoading:
     """Test skill metadata loading."""
 
     def test_loads_all_skills(self, resolver):
-        """Test that all skills are loaded."""
-        assert len(resolver.skills) >= 17  # We have 17 skills
+        """Test that every skill in the directory is loaded."""
+        assert set(resolver.skills) == set(FIXTURE_SKILLS)
 
     def test_skill_has_metadata(self, resolver):
         """Test that skills have required metadata fields."""
@@ -46,12 +173,13 @@ class TestSkillLoading:
         """Test listing all skill names."""
         skills = resolver.list_all_skills()
         assert isinstance(skills, list)
-        assert len(skills) >= 17
+        assert len(skills) == len(FIXTURE_SKILLS)
         assert "aqwa-analysis" in skills
         assert "orcaflex-modeling" in skills
 
-    def test_catalog_exists(self, resolver):
-        """Test that catalog file is created."""
+    def test_catalog_created_by_export(self, resolver):
+        """Test that catalog file is created by export_catalog()."""
+        resolver.export_catalog()
         assert resolver.catalog_path.exists()
 
         with open(resolver.catalog_path, 'r') as f:
@@ -59,7 +187,7 @@ class TestSkillLoading:
 
         assert "skills" in catalog
         assert "version" in catalog
-        assert len(catalog["skills"]) >= 17
+        assert len(catalog["skills"]) == len(FIXTURE_SKILLS)
 
 
 class TestVersionCompatibility:
@@ -206,37 +334,39 @@ class TestSkillRecommendation:
         """Test filtering by Python version."""
         # All skills should be compatible with Python 3.13.5
         recommendations = resolver.recommend_skills(
-            "analysis",
+            "spectral signal analysis",
             python_version="3.13.5"
         )
         assert len(recommendations) > 0
 
-        # Try incompatible Python version (should filter out)
+        # signal-analysis requires python >= 3.10, so 3.9.0 filters it out
         recommendations_old = resolver.recommend_skills(
-            "analysis",
+            "spectral signal analysis",
             python_version="3.9.0"
         )
-        # Should have fewer or same recommendations
-        assert len(recommendations_old) <= len(recommendations)
+        assert len(recommendations_old) < len(recommendations)
+        old_names = [r.skill.name for r in recommendations_old]
+        assert "signal-analysis" not in old_names
 
     def test_matched_keywords_included(self, resolver):
         """Test that matched keywords are included in recommendations."""
         recommendations = resolver.recommend_skills("AQWA diffraction")
-        if recommendations:
-            rec = recommendations[0]
-            assert isinstance(rec.matched_keywords, list)
+        assert recommendations
+        rec = recommendations[0]
+        assert isinstance(rec.matched_keywords, list)
+        assert rec.matched_keywords
 
     def test_dependencies_included(self, resolver):
         """Test that dependencies are included in recommendations."""
         recommendations = resolver.recommend_skills("fatigue analysis")
-        if recommendations:
-            rec = next(
-                (r for r in recommendations if r.skill.name == "fatigue-analysis"),
-                None
-            )
-            if rec:
-                # Should include dependency names
-                assert isinstance(rec.dependencies_included, list)
+        rec = next(
+            (r for r in recommendations if r.skill.name == "fatigue-analysis"),
+            None
+        )
+        assert rec is not None
+        # Should include dependency names
+        assert isinstance(rec.dependencies_included, list)
+        assert "signal-analysis" in rec.dependencies_included
 
 
 class TestOrcaFlexCompatibility:
@@ -296,6 +426,7 @@ class TestIntegration:
 
         # Resolve dependencies
         deps = resolver.resolve_dependencies(skill_name)
+        assert isinstance(deps, list)
 
         # Validate all dependencies
         validation = resolver.validate_dependencies(skill_name)


### PR DESCRIPTION
Fixes the 4 domain shards that were red on every PR (#1312). Every failure was git-archaeologied to decide which side drifted; fixes are per-root-cause, no vacuous assertions. One test file quarantined with a linked follow-up issue (#1318).

## Per-shard root causes

| Shard | Failure | Root cause | Fix |
|---|---|---|---|
| infrastructure-other | `test_reporting.py` ImportError `StandardReport` | The StandardReport framework lives in `digitalmodel.visualization.reporting`; `digitalmodel.reporting` was repurposed as the shared block library (#1018, c9bfdb33) | Test updated: import retargeted |
| infrastructure-other | `test_benchmarks.py` parallel speedup | Local fn passed to `ProcessPoolExecutor` (never picklable) + pool spawned per timed iteration (measured startup, not throughput) | Test fixed: module-level task, warmed reused pool, heavier tasks (stable ~1.9x) |
| infrastructure-other | `test_benchmarks.py` dataframe ops | pandas-internal `RuntimeWarning` (IntervalIndex category hashing) + `observed=` FutureWarning, escalated by repo-wide `filterwarnings = error` | Test fixed: `observed=False` + targeted `filterwarnings` mark |
| misc | engine mocks (`Rigging`/`Catenary` attrs, engine.py:214 unpack, `assert None is True`) | Engine intentionally moved to lazy in-function imports, added `configure_result_folder` unpack on the inputfile path, and correctly raises on unknown basenames; also cross-module `sys.modules` mock identity skew for `OutputController` | Tests updated: patch lazy-import source modules, mock the tuple return, use `digitalmodel.engine`'s own `OutputController` binding, route via `transformation` |
| orcaflex-solver | builder registry 13 vs 19 | Registry legitimately grew: +5 riser builders (drilling-riser epic #807) +1 generic-object builder (#495–#505 overhaul) | Test updated: 19 builders + explicit include-order incl. new files |
| orcaflex-solver | `test_schema_compat.py` DID-NOT-RAISE | `Water.depth` never had an upper bound in this repo's history (`gt=0` only, deliberate — real models exceed 5000 m) | Test updated: depth=0 invalid + deep-water-allowed test |
| orcaflex-solver | reporting snapshots mismatch | Plotly emits ASCII-escaped JSON (`·`) without orjson, literal UTF-8 with it; snapshot generated in an orjson env | Normalizer folds `\uXXXX` escapes → env-agnostic comparison |
| orcaflex-solver | converter fixture errors | `temp_output_dir`/`sample_dat_files` were class-scoped, invisible to sibling `TestPerformance`/`TestCLI` classes | Fixtures hoisted to module level |
| orcaflex-solver | CLI tests | Broken import (`import digitalmodel.orcaflex` then referencing `digitalmodel.solvers...`); universal_cli help showed no defaults | Test import fixed; `show_default=True` added to universal_cli (code fix matching documented contract) |
| orcaflex-solver | config validation | Case-sensitive `'memory' in w` vs "Memory limit must be positive" | Test matched case-insensitively |
| orcaflex-solver | mooring-tension-iteration FileNotFoundError | Input ymls relocated off-repo at slimming squash (2c185d2d) **and** engine has no `mooring_tension_iteration` basename routing arm — unreconstructible faithfully | **Quarantined**: `skipif` on missing inputs (self-heals when restored), follow-up #1318 |
| specialized | skill resolver finds 0 skills | `.claude/skills/*` entries are symlinks into the machine-level workspace-hub tree — broken in fresh clones/CI, several deleted by auto-sync 8ad6fc90; committed catalog also has 0 skills | Test rewritten against a hermetic fixture skills dir via the resolver's `skills_directory` arg; all behavioral assertions preserved |

## Local results (after merging origin/main @1ff4bdcb, full DOMAINS.md path lists)

- infrastructure-other: **86 passed, 1 skipped**
- misc: **82 passed, 1 skipped**
- specialized: **1413 passed, 41 skipped**
- orcaflex-solver: **1171 passed, 158 skipped**

Follow-up filed: #1318 (restore mooring-tension-iteration fixtures + engine routing arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)