### PR TITLE
feat(drilling_riser): stack-up assembly engine + API RP 16Q tension chain (#1280)

### DIFF
--- a/docs/riser_database.md
+++ b/docs/riser_database.md
@@ -121,3 +121,20 @@ on water depth only, one band per source dataset family.
 registry makes the in-context reconciliation test fail here until the table
 gains the row — a conscious update, never silent drift. Public issues, PRs
 and commit messages about this table family carry bands and handles only.
+
+## Assembly engine (#1280)
+
+`drilling_riser/assembly.py` turns component records + counts into a
+`RiserStackupModel` (parts from the public wed component vocabulary via
+`from_component_counts`, or caller/wiki-side records via `from_records`) with
+fail-closed aggregates — notably `gross_submerged_weight_and_uplift()`, which
+REFUSES to degrade to net weight when a buoyed joint lacks uplift data
+(non-conservative for the factored 16Q split). `minimum_top_tension_16q`
+applies the tensioner-system factor N/(Rf·(N−n)) and fleet-angle allowance to
+a minimum slip-ring tension; `check_rig_capability` evaluates the demand
+against a `rig_riser_interface` row (wireline rigs count wires, direct-acting
+count units; missing data → INSUFFICIENT_DATA, never guessed). The in-context
+golden asserts the chain against the RSU-0007 calc contract (machine-readable
+YAML on the private registry page — keys public, values wiki-side; tolerance
+abs ≤ 0.5 t / rel ≤ 0.15%, an order of magnitude tighter than any
+formula-omission error).

--- a/src/digitalmodel/drilling_riser/__init__.py
+++ b/src/digitalmodel/drilling_riser/__init__.py
@@ -19,6 +19,14 @@ from digitalmodel.drilling_riser.section import (
     section_properties_imperial,
     shear_modulus,
 )
+from digitalmodel.drilling_riser.assembly import (
+    RigCapabilityCheck,
+    RiserStackupModel,
+    StackupItem,
+    check_rig_capability,
+    minimum_top_tension_16q,
+    tensioner_system_factor,
+)
 from digitalmodel.drilling_riser.stackup import (
     effective_tension,
     minimum_slip_ring_tension,
@@ -26,6 +34,7 @@ from digitalmodel.drilling_riser.stackup import (
     wall_thickness_required,
 )
 from digitalmodel.drilling_riser.adapter import (
+    KIPS_TO_KN,
     compute_riser_string_weight_kn,
     normalize_riser_component_record,
     register_riser_components,

--- a/src/digitalmodel/drilling_riser/adapter.py
+++ b/src/digitalmodel/drilling_riser/adapter.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 _KIPS_TO_KN = 4.44822
+#: Public alias (#1280) — the single kips->kN constant for drilling_riser.
+KIPS_TO_KN = _KIPS_TO_KN
 _IN_TO_MM = 25.4
 _FT_TO_M = 0.3048
 _PSI_TO_MPA = 0.00689476
@@ -69,6 +71,10 @@ _SI_FLOAT_FIELDS: tuple[tuple[str, str, float, bool], ...] = (
     ("LENGTH_FT", "length_m", _FT_TO_M, True),
     ("WEIGHT_AIR_KIPS", "weight_air_kn", _KIPS_TO_KN, True),
     ("WEIGHT_WATER_KIPS", "submerged_weight_kn", _KIPS_TO_KN, False),
+    # Optional (#1280): gross buoyancy uplift force. WEIGHT_WATER_KIPS is
+    # NET of buoyancy; the 16Q factored split (f_wt*Ws - f_bt*Bn) needs the
+    # gross/uplift decomposition, so sources that have it can carry it.
+    ("BUOYANCY_UPLIFT_KIPS", "buoyancy_uplift_kn", _KIPS_TO_KN, True),
     ("BUOYANCY_OD_IN", "buoyancy_od_mm", _IN_TO_MM, True),
     ("PRESSURE_RATING_PSI", "pressure_mpa", _PSI_TO_MPA, True),
     ("BORE_SIZE_IN", "bore_size_mm", _IN_TO_MM, True),

--- a/src/digitalmodel/drilling_riser/assembly.py
+++ b/src/digitalmodel/drilling_riser/assembly.py
@@ -1,0 +1,298 @@
+"""Stack-up assembly engine (#1280, epic #1279 child B).
+
+Assembles a rig-specific riser string from normalized component records (the
+``adapter`` SI vocabulary — sourced from the public wed component library or
+from caller/wiki-side data) and evaluates the API RP 16Q minimum-top-tension
+chain against a rig's tensioner system.
+
+Two "top tension" answers coexist in this package by design:
+
+* :func:`digitalmodel.drilling_riser.stackup.top_tension_required` — a flat
+  dynamic-factor screening estimate;
+* :func:`minimum_top_tension_16q` (here) — the code-basis minimum after
+  tensioner-failure, efficiency and fleet-angle allowances.
+
+Provenance discipline: this module carries NO standards-derived numeric
+defaults — ``efficiency`` and ``fleet_angle_factor`` are required kwargs
+supplied by the caller/rig data (the 16Q citation getters arrive with #1246).
+Illustrative docstring numbers are deliberately disjoint from any documented
+project calculation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Optional
+
+from digitalmodel.drilling_riser.adapter import (
+    KIPS_TO_KN,
+    compute_riser_string_weight_kn,
+)
+
+__all__ = [
+    "RigCapabilityCheck",
+    "RiserStackupModel",
+    "StackupItem",
+    "check_rig_capability",
+    "minimum_top_tension_16q",
+    "tensioner_system_factor",
+]
+
+
+@dataclass(frozen=True)
+class StackupItem:
+    """One component type in a stack-up: normalized record + joint count."""
+
+    component: Mapping[str, object]
+    count: int
+
+    def __post_init__(self) -> None:
+        if self.count < 1:
+            raise ValueError(f"count must be >= 1, got {self.count}")
+
+    @property
+    def component_id(self) -> str:
+        return str(self.component.get("component_id", "?"))
+
+
+@dataclass(frozen=True)
+class RiserStackupModel:
+    """A quantity-expanded riser string with fail-closed aggregates.
+
+    ``rsu_id``/``rig_ref`` are provenance HANDLES only (they resolve in the
+    private registry / ``riser_database`` tables); this model never fetches
+    wiki-side values itself.
+    """
+
+    items: tuple[StackupItem, ...]
+    rsu_id: str = ""
+    rig_ref: str = ""
+
+    # -- constructors -------------------------------------------------------------
+
+    @classmethod
+    def from_component_counts(
+        cls,
+        counts: Mapping[str, int],
+        registry: Mapping[str, Mapping[str, object]],
+        *,
+        rsu_id: str = "",
+        rig_ref: str = "",
+    ) -> "RiserStackupModel":
+        """Build from ``{component_id: count}`` against an adapter registry
+        (e.g. the vendored wed component library). Unknown ids raise KeyError
+        (escalate — no fuzzy matching)."""
+        items = tuple(
+            StackupItem(component=registry[component_id], count=count)
+            for component_id, count in counts.items()
+        )
+        return cls(items=items, rsu_id=rsu_id, rig_ref=rig_ref)
+
+    @classmethod
+    def from_records(
+        cls,
+        records: Iterable[Mapping[str, object]],
+        *,
+        rsu_id: str = "",
+        rig_ref: str = "",
+    ) -> "RiserStackupModel":
+        """Build from caller-supplied normalized records (count defaults to 1;
+        pass an explicit ``count`` key per record to expand)."""
+        items = tuple(
+            StackupItem(component=rec, count=int(rec.get("count", 1)))
+            for rec in records
+        )
+        return cls(items=items, rsu_id=rsu_id, rig_ref=rig_ref)
+
+    # -- aggregates (fail-closed) ---------------------------------------------------
+
+    def total_submerged_weight_kn(self) -> float:
+        """NET submerged weight (buoyed joints contribute negative values)."""
+        return sum(
+            compute_riser_string_weight_kn([item.component]) * item.count
+            for item in self.items
+        )
+
+    def total_dry_weight_kn(self) -> float:
+        total = 0.0
+        for item in self.items:
+            if "weight_air_kn" not in item.component:
+                raise ValueError(
+                    f"Component {item.component_id} lacks weight_air_kn"
+                )
+            total += float(item.component["weight_air_kn"]) * item.count
+        return total
+
+    def gross_submerged_weight_and_uplift(self) -> tuple[float, float]:
+        """(gross submerged steel weight Ws, buoyancy uplift Bn), both kN.
+
+        The 16Q factored split (f_wt*Ws - f_bt*Bn) needs the gross/uplift
+        decomposition. A buoyed item (negative net submerged weight) WITHOUT
+        ``buoyancy_uplift_kn`` raises — silently degrading to net weight
+        under-estimates the factored demand (non-conservative), so the split
+        fails closed and the caller must supply uplift data.
+        """
+        gross = 0.0
+        uplift = 0.0
+        offenders: list[str] = []
+        for item in self.items:
+            net = float(item.component["submerged_weight_kn"]) * item.count
+            item_uplift = item.component.get("buoyancy_uplift_kn")
+            if item_uplift is not None:
+                item_uplift_total = float(item_uplift) * item.count
+                gross += net + item_uplift_total
+                uplift += item_uplift_total
+            elif net < 0:
+                offenders.append(item.component_id)
+            else:
+                gross += net
+        if offenders:
+            raise ValueError(
+                "buoyed components without buoyancy_uplift_kn (cannot split "
+                f"gross weight/uplift; net degrade is non-conservative): {offenders}"
+            )
+        return gross, uplift
+
+    def total_length_m(
+        self, length_overrides: Optional[Mapping[str, float]] = None
+    ) -> float:
+        """Stack length: ``length_m``, else ``height_m``, else a caller
+        override keyed by component id (the caller states the convention,
+        e.g. telescopic-joint effective length at a stroke position);
+        still-unresolvable components raise, listing their ids."""
+        overrides = dict(length_overrides or {})
+        total = 0.0
+        offenders: list[str] = []
+        for item in self.items:
+            if item.component_id in overrides:
+                total += overrides[item.component_id] * item.count
+                continue
+            value = item.component.get("length_m", item.component.get("height_m"))
+            if value is None:
+                offenders.append(item.component_id)
+                continue
+            total += float(value) * item.count
+        if offenders:
+            raise ValueError(
+                f"components with no length_m/height_m and no override: {offenders}"
+            )
+        return total
+
+
+# -- API RP 16Q minimum top tension chain ---------------------------------------------
+
+
+def tensioner_system_factor(
+    n_units: int | float, n_fail: int | float, efficiency: float
+) -> float:
+    """N / (Rf * (N - n)): the tensioner-system allowance for ``n_fail``
+    sudden unit/wire failures at mechanical efficiency ``Rf``."""
+    n = int(n_units)
+    f = int(n_fail)
+    if n < 1:
+        raise ValueError(f"n_units must be >= 1, got {n_units}")
+    if not 0 <= f < n:
+        raise ValueError(f"n_fail must be in [0, n_units), got {n_fail}")
+    if not 0.0 < efficiency <= 1.0:
+        raise ValueError(f"efficiency must be in (0, 1], got {efficiency}")
+    return n / (efficiency * (n - f))
+
+
+def minimum_top_tension_16q(
+    t_srmin_kn: float,
+    *,
+    n_units: int | float,
+    n_fail: int | float,
+    efficiency: float,
+    fleet_angle_factor: float = 1.0,
+) -> float:
+    """API RP 16Q minimum top tension: T_SRmin scaled by the tensioner-system
+    factor and the fleet-angle factor.
+
+    ``t_srmin_kn`` is the factored minimum slip-ring tension — see
+    :func:`digitalmodel.drilling_riser.stackup.minimum_slip_ring_tension` for
+    the Ws/Bn/mud composition. ``efficiency`` has no default here (supply it
+    from rig data); ``fleet_angle_factor`` defaults to the neutral 1.0.
+    The function is linear in ``t_srmin_kn`` (unit-consistent in/out).
+
+    Example (synthetic): ``minimum_top_tension_16q(1000.0, n_units=8,
+    n_fail=1, efficiency=0.9, fleet_angle_factor=1.02)``.
+    """
+    if fleet_angle_factor < 1.0:
+        raise ValueError(
+            f"fleet_angle_factor must be >= 1.0, got {fleet_angle_factor}"
+        )
+    return (
+        t_srmin_kn
+        * tensioner_system_factor(n_units, n_fail, efficiency)
+        * fleet_angle_factor
+    )
+
+
+# -- rig capability -------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RigCapabilityCheck:
+    """Outcome of checking a tension demand against a rig's tensioner system."""
+
+    min_top_tension_kn: float
+    capacity_kn: Optional[float]
+    utilization: Optional[float]
+    n_units: Optional[int]
+    verdict: str  # PASS | EXCEEDS | INSUFFICIENT_DATA
+    reason: str = ""
+
+
+def _unit_count(rig) -> Optional[int]:
+    """Unit-count selection rule: wireline rigs tension through wires
+    (``n_tension_wires``); direct-acting rigs through tensioner units
+    (``n_tensioners``)."""
+    raw = (
+        rig.n_tension_wires
+        if getattr(rig, "tensioner_type", "") == "wireline"
+        else rig.n_tensioners
+    )
+    return None if raw is None else int(raw)
+
+
+def check_rig_capability(
+    min_top_tension_kn: float,
+    rig,
+    *,
+    n_fail: int,
+) -> RigCapabilityCheck:
+    """Check a 16Q minimum-top-tension demand against a
+    ``RigRiserInterfaceRow``. Missing capability data yields
+    ``INSUFFICIENT_DATA`` — never a guessed verdict. ``n_fail`` is
+    caller-supplied (failure allowances are prose-only in the rig table)."""
+    n_units = _unit_count(rig)
+    capacity_kips = rig.tensioner_capacity_kips
+    if n_units is None or capacity_kips is None:
+        missing = "n_units" if n_units is None else "tensioner_capacity_kips"
+        return RigCapabilityCheck(
+            min_top_tension_kn=min_top_tension_kn,
+            capacity_kn=None,
+            utilization=None,
+            n_units=n_units,
+            verdict="INSUFFICIENT_DATA",
+            reason=f"rig row {rig.rig_ref!r} lacks {missing}",
+        )
+    surviving = n_units - int(n_fail)
+    if surviving < 1:
+        return RigCapabilityCheck(
+            min_top_tension_kn=min_top_tension_kn,
+            capacity_kn=None,
+            utilization=None,
+            n_units=n_units,
+            verdict="INSUFFICIENT_DATA",
+            reason=f"n_fail={n_fail} leaves no surviving units of {n_units}",
+        )
+    capacity_kn = surviving * float(capacity_kips) * KIPS_TO_KN
+    utilization = min_top_tension_kn / capacity_kn
+    return RigCapabilityCheck(
+        min_top_tension_kn=min_top_tension_kn,
+        capacity_kn=capacity_kn,
+        utilization=utilization,
+        n_units=n_units,
+        verdict="PASS" if utilization <= 1.0 else "EXCEEDS",
+    )

--- a/tests/drilling_riser/test_assembly.py
+++ b/tests/drilling_riser/test_assembly.py
@@ -1,0 +1,185 @@
+"""#1280 suites: stack-up assembly engine — model/aggregates, the API RP 16Q
+minimum-top-tension chain, and rig-capability checks.
+
+Public/deterministic layer only (the in-context golden lives in
+test_assembly_golden.py). Fixture = the already-vendored wed component CSV
+(sanctioned public vocabulary); adapter registries are always passed
+explicitly (never the module-global).
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.drilling_riser import assembly
+from digitalmodel.drilling_riser.adapter import (
+    KIPS_TO_KN,
+    register_riser_components,
+)
+from digitalmodel.drilling_riser.assembly import (
+    RigCapabilityCheck,
+    RiserStackupModel,
+    StackupItem,
+    check_rig_capability,
+    minimum_top_tension_16q,
+    tensioner_system_factor,
+)
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "drilling_riser_components.csv"
+
+
+@pytest.fixture()
+def registry() -> dict:
+    reg: dict = {}
+    added, _skipped = register_riser_components(FIXTURE, registry=reg)
+    assert added >= 30
+    return reg
+
+
+# -- model + aggregates ----------------------------------------------------------
+
+
+def test_from_component_counts_aggregates(registry):
+    model = RiserStackupModel.from_component_counts(
+        {"RJ-21-75-BARE": 10, "RJ-21-75-BUOY": 5}, registry
+    )
+    # Hand-computed from the vendored wed vocabulary:
+    # bare 3.8 kips net submerged, buoyed -4.2 kips net; air 22.5 kips each.
+    expected_subm = (10 * 3.8 + 5 * -4.2) * KIPS_TO_KN
+    expected_dry = (15 * 22.5) * KIPS_TO_KN
+    assert model.total_submerged_weight_kn() == pytest.approx(expected_subm)
+    assert model.total_dry_weight_kn() == pytest.approx(expected_dry)
+    # 75 ft joints -> 22.86 m each
+    assert model.total_length_m() == pytest.approx(15 * 75.0 * 0.3048)
+
+
+def test_unknown_component_escalates(registry):
+    with pytest.raises(KeyError):
+        RiserStackupModel.from_component_counts({"NO-SUCH-ID": 1}, registry)
+
+
+def test_dry_weight_fail_closed():
+    model = RiserStackupModel.from_records(
+        [{"component_id": "x", "submerged_weight_kn": 1.0}]
+    )
+    with pytest.raises(ValueError, match="weight_air_kn"):
+        model.total_dry_weight_kn()
+
+
+def test_split_weights_fail_closed_on_buoyed_without_uplift():
+    # A buoyed item (negative net submerged weight) WITHOUT uplift data must
+    # raise — degrading to net weight is NON-conservative for the 16Q chain.
+    model = RiserStackupModel.from_records(
+        [
+            {"component_id": "bare", "submerged_weight_kn": 100.0},
+            {"component_id": "buoyed", "submerged_weight_kn": -10.0},
+        ]
+    )
+    with pytest.raises(ValueError, match="buoyed"):
+        model.gross_submerged_weight_and_uplift()
+
+
+def test_split_weights_when_uplift_present():
+    model = RiserStackupModel.from_records(
+        [
+            {"component_id": "bare", "submerged_weight_kn": 100.0},
+            {
+                "component_id": "buoyed",
+                "submerged_weight_kn": -10.0,
+                "buoyancy_uplift_kn": 60.0,
+            },
+        ]
+    )
+    gross, uplift = model.gross_submerged_weight_and_uplift()
+    # gross = net + uplift for the buoyed item: -10 + 60 = 50 gross
+    assert gross == pytest.approx(150.0)
+    assert uplift == pytest.approx(60.0)
+    # identity: net == gross - uplift
+    assert model.total_submerged_weight_kn() == pytest.approx(gross - uplift)
+
+
+def test_length_rule_height_fallback_and_overrides(registry):
+    model = RiserStackupModel.from_component_counts(
+        {"RJ-21-75-BARE": 1, "BOP-SUB-18.75-15K": 1}, registry
+    )
+    # BOP has height_m only -> fallback engages (no raise).
+    assert model.total_length_m() > 22.86
+    # A component with neither (flex joint) requires an explicit override.
+    fj_model = RiserStackupModel.from_component_counts(
+        {"RJ-21-75-BARE": 1, "FJ-UPPER-21": 1}, registry
+    )
+    with pytest.raises(ValueError, match="FJ-UPPER-21"):
+        fj_model.total_length_m()
+    assert fj_model.total_length_m(
+        length_overrides={"FJ-UPPER-21": 0.9}
+    ) == pytest.approx(75.0 * 0.3048 + 0.9)
+
+
+# -- 16Q chain --------------------------------------------------------------------
+
+
+def test_tensioner_system_factor_identity_edges():
+    assert tensioner_system_factor(16, 0, 1.0) == pytest.approx(1.0)
+    assert tensioner_system_factor(4, 1, 1.0) == pytest.approx(4.0 / 3.0)
+    assert tensioner_system_factor(16, 2, 0.95) == pytest.approx(
+        16.0 / (0.95 * 14.0)
+    )
+
+
+@pytest.mark.parametrize(
+    "n_units,n_fail,efficiency",
+    [(0, 0, 1.0), (4, 4, 1.0), (4, 5, 1.0), (4, 1, 0.0), (4, 1, 1.5)],
+)
+def test_tensioner_system_factor_validation(n_units, n_fail, efficiency):
+    with pytest.raises(ValueError):
+        tensioner_system_factor(n_units, n_fail, efficiency)
+
+
+def test_minimum_top_tension_16q_composition():
+    # Synthetic tuple, deliberately disjoint from any documented calculation.
+    t = minimum_top_tension_16q(
+        1000.0, n_units=8, n_fail=1, efficiency=0.9, fleet_angle_factor=1.02
+    )
+    assert t == pytest.approx(1000.0 * (8.0 / (0.9 * 7.0)) * 1.02)
+
+
+def test_minimum_top_tension_requires_kwargs():
+    with pytest.raises(TypeError):
+        minimum_top_tension_16q(1000.0, 8, 1, 0.9, 1.02)  # positional forbidden
+
+
+# -- rig capability ---------------------------------------------------------------
+
+
+def _rig_rows():
+    from digitalmodel.riser_database import RiserDatabase
+
+    db = RiserDatabase.load()
+    return db.rig("drillship-6g-16x3600k-dat"), db.rig("drillship-16w-wireline")
+
+
+def test_check_rig_capability_pass_and_exceeds():
+    dat, _ = _rig_rows()
+    # 16 x 3600 kips direct-acting: far above a modest demand -> PASS
+    ok = check_rig_capability(10_000.0, dat, n_fail=1)
+    assert isinstance(ok, RigCapabilityCheck)
+    assert ok.verdict == "PASS"
+    assert ok.utilization is not None and 0 < ok.utilization < 1
+    # absurd demand -> EXCEEDS
+    assert check_rig_capability(1e9, dat, n_fail=1).verdict == "EXCEEDS"
+
+
+def test_check_rig_capability_insufficient_data():
+    _, wireline = _rig_rows()
+    # wireline row carries n_tension_wires but no capacity -> INSUFFICIENT_DATA
+    assert check_rig_capability(10_000.0, wireline, n_fail=2).verdict == (
+        "INSUFFICIENT_DATA"
+    )
+
+
+def test_unit_count_selection_rule():
+    dat, wireline = _rig_rows()
+    assert assembly._unit_count(dat) == 16  # direct-acting -> n_tensioners
+    assert assembly._unit_count(wireline) == 16  # wireline -> n_tension_wires

--- a/tests/drilling_riser/test_assembly_golden.py
+++ b/tests/drilling_riser/test_assembly_golden.py
@@ -1,0 +1,103 @@
+"""#1280 in-context golden: the API RP 16Q minimum-top-tension chain vs the
+RSU-0007 calc contract (machine-readable YAML block on the PRIVATE registry
+page — dm carries only key names; values resolve wiki-side at test time).
+
+Loud skip standalone. Tolerance: abs <= 0.5 t AND rel <= 0.15%, derived from
+the contract inputs' quantization. This CANNOT mask a wrong formula: omitting
+the fleet-angle factor alone produces ~1.48% error (10x the tolerance);
+efficiency or n-fail mistakes are larger still.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.drilling_riser.assembly import (
+    minimum_top_tension_16q,
+    tensioner_system_factor,
+)
+
+REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
+_KNOWN_WIKI_CLONES = (
+    Path("/mnt/local-analysis/llm-wiki"),
+    Path.home() / "workspace-hub" / "llm-wiki",
+)
+
+_CONTRACT_KEYS = {
+    "rsu_id",
+    "calc",
+    "factored_submerged_steel_t",
+    "factored_buoyancy_t",
+    "n_wires",
+    "n_fail",
+    "efficiency",
+    "fleet_angle_factor",
+    "min_top_tension_t",
+    "connector_pull_t",
+    "tension_setting_t",
+}
+
+
+def _calc_contract(rsu_id: str, calc: str) -> dict:
+    candidates = []
+    env = os.environ.get("LLM_WIKI_PATH")
+    if env:
+        candidates.append(Path(env))
+    candidates.extend(_KNOWN_WIKI_CLONES)
+    for base in candidates:
+        page = base / REGISTRY_REL
+        if not page.is_file():
+            continue
+        blocks = re.findall(r"```yaml\n(.*?)```", page.read_text(), re.DOTALL)
+        for block in blocks:
+            doc = yaml.safe_load(block)
+            if not isinstance(doc, dict) or "calc_contracts" not in doc:
+                continue
+            for contract in doc["calc_contracts"]:
+                if contract.get("rsu_id") == rsu_id and contract.get("calc") == calc:
+                    missing = _CONTRACT_KEYS - set(contract)
+                    assert not missing, (
+                        f"calc contract schema drift — missing keys: {missing}"
+                    )
+                    return contract
+        pytest.fail(
+            f"registry page found but no {calc} contract for {rsu_id} — "
+            "the paired llm-wiki calc-contract change is not on this clone"
+        )
+    pytest.skip(
+        "llm-wiki registry not available (standalone mode) — the 16Q golden "
+        "is part of the in-context merge gate"
+    )
+
+
+def test_16q_min_top_tension_golden():
+    c = _calc_contract("RSU-0007", "16q-min-top-tension")
+    factored_net_t = c["factored_submerged_steel_t"] + c["factored_buoyancy_t"]
+    system = tensioner_system_factor(c["n_wires"], c["n_fail"], c["efficiency"])
+    result_t = minimum_top_tension_16q(
+        factored_net_t,
+        n_units=c["n_wires"],
+        n_fail=c["n_fail"],
+        efficiency=c["efficiency"],
+        fleet_angle_factor=c["fleet_angle_factor"],
+    )
+    documented_t = c["min_top_tension_t"]
+    assert abs(result_t - documented_t) <= 0.5  # tonnes
+    assert abs(result_t - documented_t) / documented_t <= 0.0015
+    # The chain's own consistency: system factor from the contract's inputs
+    # must equal the composition the engine applied.
+    assert result_t == pytest.approx(factored_net_t * system * c["fleet_angle_factor"])
+
+
+def test_setting_side_values_present_but_not_asserted():
+    """The contract carries setting-side values as DATA (composition not yet
+    reconciled against the underlying workbook — explicitly out of #1280
+    scope). This test only pins their presence so the contract can't silently
+    shed them before the follow-up slice."""
+    c = _calc_contract("RSU-0007", "16q-min-top-tension")
+    assert c["connector_pull_t"] > 0
+    assert c["tension_setting_t"] > c["min_top_tension_t"]

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -50,6 +50,11 @@ _PUBLIC_ARTIFACTS = (
     REPO_ROOT / "docs" / "riser_database.md",
     REPO_ROOT / "src" / "digitalmodel" / "riser_database" / "loader.py",
     REPO_ROOT / "src" / "digitalmodel" / "riser_database" / "getters.py",
+    # #1280 assembly engine artifacts (discuss the 16Q formula; must carry
+    # no provenance tokens):
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "assembly.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_assembly.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_assembly_golden.py",
 )
 
 


### PR DESCRIPTION
Closes #1280 (child B of epic #1279). Implements the **user-approved plan v2** (T2 review REJECT 2/2 → all 11 blocking findings folded; the 16Q chain itself was independently re-derived by both reviewers to 0.05% against the documented calc).

## What ships
- **`assembly.py`** — `RiserStackupModel` (parts from the vendored wed component vocabulary or caller/wiki-side records; unknown ids escalate), fail-closed aggregates incl. `gross_submerged_weight_and_uplift()` which **refuses to degrade to net weight** when a buoyed joint lacks uplift data (non-conservative for the factored split); `tensioner_system_factor` N/(Rf·(N−n)); `minimum_top_tension_16q` (**efficiency is a required kwarg — no standards-derived literals in public code**); `check_rig_capability` against `rig_riser_interface` rows (wireline→wires, direct-acting→units; `INSUFFICIENT_DATA` never guessed).
- **Adapter extension (sanctioned by the issue text):** optional `BUOYANCY_UPLIFT_KIPS` mapping (the wed water weight is net-of-buoyancy) + public `KIPS_TO_KN`; wed-side column arrives via wed#698.
- **Golden = data contract, not prose regex:** the in-context test parses the RSU-0007 **YAML calc contract** on the private registry page (**paired llm-wiki PR #818 — merge it FIRST**), asserts the chain within abs ≤ 0.5 t / rel ≤ 0.15% (10× tighter than the smallest formula-omission error). Setting-side values are pinned present but NOT asserted (composition unreconciled — explicitly out of scope).
- Provenance tripwire covers the three new public artifacts.

## Gate evidence
- **75/75 green** (assembly + golden + full riser_database suites) with the contract resolvable (`LLM_WIKI_PATH` → paired branch).
- **Gate-bite proof:** against a clone WITHOUT the contract the golden fails loudly ("paired llm-wiki calc-contract change is not on this clone") — by design, not skip.
- Full drilling_riser regression: 82 passed (the 2 fails are the golden vs the pre-#818 clone, above).
- `legal-sanity-scan --diff-only` (add -N window): **PASS**.

## Merge order
1. llm-wiki **#818** (calc contract) → 2. this PR → 3. `git -C llm-wiki pull --ff-only` on dev boxes so the in-context golden sees the contract.