### PR TITLE
feat(ffs): API 579-1 Part 6 pitting assessment via equivalent-LTA bounding (#1269)

### DIFF
--- a/src/digitalmodel/asset_integrity/assessment/__init__.py
+++ b/src/digitalmodel/asset_integrity/assessment/__init__.py
@@ -30,6 +30,13 @@ from .measurement_sufficiency import (
     SufficiencyAction,
     SufficiencyResult,
 )
+from .pitting import (
+    PitFieldCharacterization,
+    assess_pitting,
+    assess_pitting_level2_equivalent_lta,
+    characterize_pit_field,
+    screen_pitting_level1,
+)
 from .ffs_coordinator import (
     FFSComponent,
     FFSAssessmentResult,
@@ -49,4 +56,9 @@ __all__ = [
     "FFSAssessmentResult",
     "assess_component",
     "FFSReport",
+    "PitFieldCharacterization",
+    "assess_pitting",
+    "assess_pitting_level2_equivalent_lta",
+    "characterize_pit_field",
+    "screen_pitting_level1",
 ]

--- a/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
@@ -38,6 +38,11 @@ from .grid_parser import GridParser
 from .level1_screener import Level1Screener
 from .level2_engine import Level2Engine
 from .measurement_sufficiency import MeasurementSufficiency
+from .pitting import (
+    assess_pitting_level2_equivalent_lta,
+    characterize_pit_field,
+    screen_pitting_level1,
+)
 
 GridLike = Union[pd.DataFrame, np.ndarray, str, Path]
 
@@ -63,7 +68,7 @@ class FFSAssessmentResult:
     """Unified FFS result — the canonical record for downstream consumers."""
 
     component_id: str
-    assessment_type: str           # "GML" | "LML"
+    assessment_type: str           # "GML" | "LML" | "PITTING"
     level_reached: int             # 1 (screening sufficed) or 2 (RSF needed)
     t_nominal_in: float
     t_min_in: float
@@ -126,7 +131,8 @@ def assess_component(
         grid: wall-thickness measurement grid — a pandas DataFrame, a 2-D numpy
             array, or a path to a CSV.
         input_units: ``"in"`` (default) or ``"mm"`` — passed to GridParser.
-        force_type: override the GML/LML auto-classification ("GML"/"LML").
+        force_type: override the auto-classification
+            ("GML"/"LML"/"PITTING").
     """
     df = _to_grid_df(grid, input_units)
 
@@ -146,13 +152,37 @@ def assess_component(
     t_am = GridParser.mean_thickness(df)
     l1 = screener.evaluate(t_mm)
 
-    l2 = Level2Engine(
-        assessment_type=atype,
-        nominal_od_in=component.nominal_od_in,
-        nominal_wt_in=component.nominal_wt_in,
-        t_min_in=t_min,
-        rsf_a=component.rsf_a,
-    ).evaluate(df)
+    pit_char = None
+    if atype == "PITTING":
+        # API 579-1 Part 6 (tracer): characterize the pit field, apply the
+        # conservative closed-form Level 1 screen on top of the code t_min
+        # check, and bound Level 2 by an equivalent LTA run through the
+        # validated Part 5 engine (see assessment/pitting.py for the basis).
+        pit_char = characterize_pit_field(df, component.nominal_wt_in)
+        pit_l1 = screen_pitting_level1(
+            pit_char, t_min_in=t_min, fca_in=component.fca_in
+        )
+        combined_verdict = (
+            "ACCEPT"
+            if l1["verdict"] == "ACCEPT" and pit_l1["verdict"] == "ACCEPT"
+            else "FAIL_LEVEL_1"
+        )
+        l1 = {**l1, "verdict": combined_verdict, "pitting_screen": pit_l1}
+        l2 = assess_pitting_level2_equivalent_lta(
+            pit_char,
+            nominal_od_in=component.nominal_od_in,
+            nominal_wt_in=component.nominal_wt_in,
+            t_min_in=t_min,
+            rsf_a=component.rsf_a,
+        )
+    else:
+        l2 = Level2Engine(
+            assessment_type=atype,
+            nominal_od_in=component.nominal_od_in,
+            nominal_wt_in=component.nominal_wt_in,
+            t_min_in=t_min,
+            rsf_a=component.rsf_a,
+        ).evaluate(df)
 
     decision = FFSDecision.decide(
         level1_verdict=l1["verdict"],
@@ -199,7 +229,18 @@ def assess_component(
         level1=l1,
         level2=l2,
         decision=decision,
-        details={"router": route, "design_code": component.design_code},
+        details={
+            "router": route,
+            "design_code": component.design_code,
+            **(
+                {
+                    "pitting_characterization": pit_char.to_dict(),
+                    "assessment_basis": l2.get("assessment_basis"),
+                }
+                if pit_char is not None
+                else {}
+            ),
+        },
     )
 
 

--- a/src/digitalmodel/asset_integrity/assessment/ffs_router.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_router.py
@@ -1,4 +1,4 @@
-"""FFS assessment router — API 579-1 Part 4 (GML) vs Part 5 (LML).
+"""FFS assessment router — API 579-1 Part 4 (GML) / Part 5 (LML) / Part 6 (pitting).
 
 Classification logic follows the applicability criteria of API 579-1/ASME FFS-1
 2021 Edition:
@@ -10,12 +10,30 @@ Classification logic follows the applicability criteria of API 579-1/ASME FFS-1
 * Local Metal Loss (LML, Part 5): degradation is confined to a localised
   region whose longitudinal extent is small relative to the shell diameter.
 
+* Pitting (Part 6): many small, mutually separated sharp minima standing
+  against an essentially sound background — as opposed to contiguous loss.
+  Detected by a simple, documented heuristic (all conditions must hold, so
+  grids that previously classified GML/LML keep their classification):
+
+    1. at least ``_PITTING_MIN_PIT_COUNT`` distinct pits (connected
+       components of readings below the pit threshold),
+    2. the pitted cells cover at most ``_PITTING_MAX_PITTED_FRACTION`` of
+       the grid (sharp minima, not area loss),
+    3. the largest single pit spans at most
+       ``_PITTING_MAX_COMPONENT_FRACTION`` of the grid (no contiguous LTA
+       hiding among the pits), and
+    4. the background (non-pitted) median thickness is at least
+       ``_PITTING_MIN_BACKGROUND_FRACTION`` of nominal (clear contrast).
+
+  Pitting routes to
+  :mod:`digitalmodel.asset_integrity.assessment.pitting` (conservative
+  Part 6 tracer: characterization + Level 1 screen + Level 2 equivalent-LTA
+  bounding).
+
 The router computes the fraction of grid cells that have degraded below
 (nominal_wt - DEGRADED_THRESHOLD_FRACTION * nominal_wt) to separate uniform
-from localised loss patterns.  Engineers may override via ``force_type``.
-
-Part 6 (pitting) is out of scope for Phase 1 — the router will raise if pitting
-morphology detection logic is invoked.
+from localised loss patterns.  Engineers may override via ``force_type``
+('GML', 'LML' or 'PITTING').
 """
 
 from __future__ import annotations
@@ -28,11 +46,17 @@ _DEGRADED_FRACTION_OF_NOMINAL = 0.10  # >10 % loss counts as degraded cell
 # If more than this fraction of all cells are degraded, classify as GML
 _GML_FRACTION_THRESHOLD = 0.25
 
-_VALID_FORCE_TYPES = {"GML", "LML"}
+# --- Pitting-morphology heuristic (all must hold; see module docstring) ----
+_PITTING_MIN_PIT_COUNT = 5
+_PITTING_MAX_PITTED_FRACTION = 0.10
+_PITTING_MAX_COMPONENT_FRACTION = 0.02
+_PITTING_MIN_BACKGROUND_FRACTION = 0.95
+
+_VALID_FORCE_TYPES = {"GML", "LML", "PITTING"}
 
 
 class FFSRouter:
-    """Classify a wall-thickness grid as GML or LML per API 579 Part 4/5."""
+    """Classify a wall-thickness grid as GML, LML or PITTING per API 579."""
 
     @staticmethod
     def classify(
@@ -48,21 +72,25 @@ class FFSRouter:
             grid_df: Normalised wall-thickness grid (inches), rows × cols.
             nominal_od_in: Nominal pipe outside diameter (inches).
             nominal_wt_in: Nominal pipe wall thickness (inches).
-            force_type: User override — ``'GML'`` or ``'LML'``.  When
-                provided the classification heuristic is bypassed and the
+            force_type: User override — ``'GML'``, ``'LML'`` or ``'PITTING'``.
+                When provided the classification heuristic is bypassed and the
                 user-specified type is returned.  Any other value raises
                 :class:`ValueError`.
 
         Returns:
             dict with keys:
-                assessment_type (str): ``'GML'`` or ``'LML'``
+                assessment_type (str): ``'GML'``, ``'LML'`` or ``'PITTING'``
                 degraded_fraction (float): fraction of cells below threshold
                 nominal_od_in (float): echoed input
                 nominal_wt_in (float): echoed input
                 auto_classified (bool): True when heuristic was used
+                pitting (dict): heuristic metrics when auto-classified —
+                    detected flag, pit_count, pitted_cell_fraction,
+                    largest_pit_fraction, background_median_ratio
 
         Raises:
-            ValueError: If force_type is not ``'GML'``, ``'LML'``, or None.
+            ValueError: If force_type is not ``'GML'``, ``'LML'``,
+                ``'PITTING'``, or None.
         """
         if force_type is not None:
             _normalised = force_type.upper().strip()
@@ -85,9 +113,14 @@ class FFSRouter:
         degraded_fraction = FFSRouter._compute_degraded_fraction(
             grid_df, nominal_wt_in
         )
-        assessment_type = (
-            "GML" if degraded_fraction >= _GML_FRACTION_THRESHOLD else "LML"
-        )
+
+        pitting_metrics = FFSRouter._pitting_morphology(grid_df, nominal_wt_in)
+        if pitting_metrics["detected"]:
+            assessment_type = "PITTING"
+        else:
+            assessment_type = (
+                "GML" if degraded_fraction >= _GML_FRACTION_THRESHOLD else "LML"
+            )
 
         return {
             "assessment_type": assessment_type,
@@ -95,6 +128,42 @@ class FFSRouter:
             "nominal_od_in": nominal_od_in,
             "nominal_wt_in": nominal_wt_in,
             "auto_classified": True,
+            "pitting": pitting_metrics,
+        }
+
+    @staticmethod
+    def _pitting_morphology(
+        grid_df: pd.DataFrame, nominal_wt_in: float
+    ) -> dict:
+        """Evaluate the documented pitting-morphology heuristic.
+
+        Returns a small metrics dict with a ``detected`` flag.  Conservative
+        by design: ALL four conditions must hold, so contiguous-loss grids
+        (GML/LML) never flip to PITTING.
+        """
+        # Local import: pitting depends on level2_engine; keep router import light.
+        from .pitting import characterize_pit_field
+
+        char = characterize_pit_field(grid_df, nominal_wt_in)
+        total = max(char.total_valid_cells, 1)
+        largest_fraction = char.largest_pit_cells / total
+        background_ratio = (
+            char.background_median_in / nominal_wt_in if nominal_wt_in > 0 else 0.0
+        )
+
+        detected = (
+            char.pit_count >= _PITTING_MIN_PIT_COUNT
+            and 0.0 < char.pitted_cell_fraction <= _PITTING_MAX_PITTED_FRACTION
+            and largest_fraction <= _PITTING_MAX_COMPONENT_FRACTION
+            and background_ratio >= _PITTING_MIN_BACKGROUND_FRACTION
+        )
+
+        return {
+            "detected": bool(detected),
+            "pit_count": char.pit_count,
+            "pitted_cell_fraction": char.pitted_cell_fraction,
+            "largest_pit_fraction": largest_fraction,
+            "background_median_ratio": background_ratio,
         }
 
     @staticmethod

--- a/src/digitalmodel/asset_integrity/assessment/pitting.py
+++ b/src/digitalmodel/asset_integrity/assessment/pitting.py
@@ -1,0 +1,419 @@
+# ABOUTME: API 579-1 Part 6 pitting assessment — pit-field characterization,
+# ABOUTME: conservative Level 1 screening, Level 2 via equivalent-LTA bounding.
+"""Pitting assessment per the METHODOLOGY of API 579-1/ASME FFS-1 Part 6.
+
+Honesty statement (assessment basis)
+------------------------------------
+API 579-1 Part 6 Level 1 works by comparing the observed pit field to the
+standard's coupled-pit damage charts, and Level 2 computes an RSF from the
+pit-couple grid.  Those charts / tabulated coefficients are NOT transcribed
+here (no verified copy is available to this implementation, and fabricating
+table values is prohibited).  Instead this module implements the documented,
+conservative bounding practice that Part 6 itself sanctions for widespread
+pitting:
+
+1. **Pit-field characterization** — pure data reduction from a UT C-scan grid:
+   pits are connected components of readings below a threshold fraction of
+   nominal WT (default 0.90, i.e. > 10 % loss) that stand against a sounder
+   background (contrast is inherent to the component labelling: every cell
+   bordering a pit reads at/above the threshold).  Reported: pit count, max
+   and average pit depth ratio w/t, pit-couple centre-to-centre spacing
+   statistics, and pitted-region extent.  Derivation-anchored — no standard
+   values involved.
+
+2. **Level 1 screening (conservative closed form)** — consistent with the
+   Part 6 Level 1 philosophy (average remaining thickness in the pitted
+   region must satisfy the code minimum, and no single pit may approach
+   through-wall):
+
+   * average criterion:  t_avg_pit - FCA >= t_min
+   * deep-pit criterion: R_t = (t_min_pit - FCA) / t_nom >= R_t_min
+     (default R_t_min = 0.20 — a configurable conservative screening
+     parameter chosen consistent with the remaining-thickness-ratio
+     applicability limits used across API 579-1 metal-loss parts; it is NOT
+     a transcription of a Part 6 chart value).
+
+3. **Level 2 via equivalent LTA** — the pit field is bounded by an
+   equivalent local thin area: effective uniform depth = average pit depth
+   over the pitted cells, longitudinal extent = pitted-region length.  The
+   equivalent LTA is then assessed with the EXISTING validated Part 5 Level 2
+   engine (:class:`~digitalmodel.asset_integrity.assessment.level2_engine.Level2Engine`,
+   Folias/RSF).  Treating a pit field as an equivalent region of local metal
+   loss is the documented conservative practice for widespread pitting
+   (API 579-1 Part 6 permits assessing pitting as an equivalent LTA per
+   Part 5); the result carries an ``assessment_basis`` note stating exactly
+   this.
+
+What a full Part 6 implementation would add later: the standard pit-couple
+charts (Level 1) and the pit-couple RSF summation (Level 2), which can credit
+ligament interaction between pit pairs and is therefore typically less
+conservative than the equivalent-LTA bound used here.
+
+Units: inches throughout (grids are normalised by
+:class:`~digitalmodel.asset_integrity.assessment.grid_parser.GridParser`).
+
+References (methodology only):
+  API 579-1/ASME FFS-1 2021 Edition, Part 6 (pitting corrosion) — assessment
+  philosophy and the Part-5-equivalent-LTA bounding option; Part 5 §5.4
+  (Level 2 RSF / Folias factor, implemented in ``level2_engine``).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from scipy import ndimage
+
+from .level2_engine import Level2Engine
+
+# --- Characterization defaults --------------------------------------------
+# Readings below this fraction of nominal WT are pit candidates (>10 % loss).
+DEFAULT_PIT_THRESHOLD_FRACTION = 0.90
+
+_ASSESSMENT_BASIS = (
+    "Pit field bounded by an equivalent local thin area (effective depth = "
+    "average pit depth over the pitted cells, longitudinal extent = "
+    "pitted-region length) and assessed with the validated API 579-1 Part 5 "
+    "Level 2 LML engine (Folias/RSF). This is the documented conservative "
+    "bounding practice API 579-1 Part 6 permits for widespread pitting; the "
+    "standard's coupled-pit charts are NOT transcribed here."
+)
+
+
+@dataclass
+class PitFieldCharacterization:
+    """Pure data reduction of a UT grid's pit morphology (inches)."""
+
+    nominal_wt_in: float
+    pit_threshold_in: float        # absolute threshold used (inches)
+    pit_count: int                 # connected components below threshold
+    pitted_cell_count: int
+    total_valid_cells: int
+    pitted_cell_fraction: float
+    max_pit_depth_in: float        # w_max = t_nom - min reading in any pit
+    max_pit_depth_ratio: float     # w_max / t_nom
+    avg_pit_depth_in: float        # mean (t_nom - reading) over pitted cells
+    avg_pit_depth_ratio: float
+    t_min_pit_in: float            # deepest remaining ligament (min reading)
+    t_avg_pit_in: float            # mean reading over pitted cells
+    background_median_in: float    # median reading of non-pitted cells
+    largest_pit_cells: int         # size (cells) of the largest component
+    pit_spacing_mean_in: Optional[float]   # nearest-neighbour centre spacing
+    pit_spacing_min_in: Optional[float]
+    pitted_region_row_count: int   # axial rows spanned by the pit field
+    pitted_region_length_in: float # axial extent (rows x row spacing)
+    pitted_region_col_count: int   # circumferential columns spanned
+    row_spacing_in: float          # inferred from the grid index
+    pit_sizes_cells: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """JSON-serialisable summary."""
+        d = {k: getattr(self, k) for k in (
+            "nominal_wt_in", "pit_threshold_in", "pit_count",
+            "pitted_cell_count", "total_valid_cells", "pitted_cell_fraction",
+            "max_pit_depth_in", "max_pit_depth_ratio", "avg_pit_depth_in",
+            "avg_pit_depth_ratio", "t_min_pit_in", "t_avg_pit_in",
+            "background_median_in", "largest_pit_cells",
+            "pit_spacing_mean_in", "pit_spacing_min_in",
+            "pitted_region_row_count", "pitted_region_length_in",
+            "pitted_region_col_count", "row_spacing_in",
+        )}
+        return d
+
+
+def characterize_pit_field(
+    grid_df: pd.DataFrame,
+    nominal_wt_in: float,
+    *,
+    pit_threshold_fraction: float = DEFAULT_PIT_THRESHOLD_FRACTION,
+) -> PitFieldCharacterization:
+    """Characterize the pit field in a normalised wall-thickness grid.
+
+    Pits are 4-connected components of cells reading below
+    ``pit_threshold_fraction * nominal_wt_in``.  Because components are cut at
+    the threshold, every cell bordering a pit reads at or above the threshold
+    — i.e. detected pits are genuine local minima with neighbourhood contrast
+    by construction.
+
+    Args:
+        grid_df: Normalised wall-thickness grid (inches), rows = axial.
+        nominal_wt_in: Nominal wall thickness (inches).
+        pit_threshold_fraction: Fraction of nominal WT below which a reading
+            is a pit candidate (default 0.90).
+
+    Returns:
+        :class:`PitFieldCharacterization` (all lengths in inches; spacing in
+        grid units scaled by the inferred row spacing).
+    """
+    values = grid_df.to_numpy(dtype=float)
+    valid = np.isfinite(values)
+    n_valid = int(valid.sum())
+    threshold = pit_threshold_fraction * nominal_wt_in
+    row_spacing = Level2Engine._infer_spacing(grid_df.index)
+
+    pit_mask = valid & (values < threshold)
+    labels, n_pits = ndimage.label(pit_mask)  # 4-connectivity default
+
+    if n_pits == 0 or n_valid == 0:
+        return PitFieldCharacterization(
+            nominal_wt_in=nominal_wt_in,
+            pit_threshold_in=threshold,
+            pit_count=0,
+            pitted_cell_count=0,
+            total_valid_cells=n_valid,
+            pitted_cell_fraction=0.0,
+            max_pit_depth_in=0.0,
+            max_pit_depth_ratio=0.0,
+            avg_pit_depth_in=0.0,
+            avg_pit_depth_ratio=0.0,
+            t_min_pit_in=float(nominal_wt_in),
+            t_avg_pit_in=float(nominal_wt_in),
+            background_median_in=(
+                float(np.median(values[valid])) if n_valid else float(nominal_wt_in)
+            ),
+            largest_pit_cells=0,
+            pit_spacing_mean_in=None,
+            pit_spacing_min_in=None,
+            pitted_region_row_count=0,
+            pitted_region_length_in=0.0,
+            pitted_region_col_count=0,
+            row_spacing_in=row_spacing,
+            pit_sizes_cells=[],
+        )
+
+    pitted_values = values[pit_mask]
+    sizes = np.bincount(labels.ravel())[1:]  # per-component cell counts
+
+    # Pit-couple spacing: nearest-neighbour distance between pit centroids,
+    # in grid-cell units scaled by the row spacing (columns treated at the
+    # same pitch — a documented simplification of the physical arc length).
+    centroids = np.asarray(
+        ndimage.center_of_mass(pit_mask, labels, range(1, n_pits + 1)),
+        dtype=float,
+    )
+    spacing_mean: Optional[float] = None
+    spacing_min: Optional[float] = None
+    if n_pits >= 2:
+        deltas = centroids[:, None, :] - centroids[None, :, :]
+        dist = np.sqrt((deltas ** 2).sum(axis=2))
+        np.fill_diagonal(dist, np.inf)
+        nearest = dist.min(axis=1) * row_spacing
+        spacing_mean = float(nearest.mean())
+        spacing_min = float(nearest.min())
+
+    pit_rows = np.where(pit_mask.any(axis=1))[0]
+    pit_cols = np.where(pit_mask.any(axis=0))[0]
+    row_count = int(pit_rows[-1] - pit_rows[0] + 1)
+    col_count = int(pit_cols[-1] - pit_cols[0] + 1)
+
+    t_min_pit = float(pitted_values.min())
+    t_avg_pit = float(pitted_values.mean())
+    background = values[valid & ~pit_mask]
+
+    return PitFieldCharacterization(
+        nominal_wt_in=nominal_wt_in,
+        pit_threshold_in=threshold,
+        pit_count=int(n_pits),
+        pitted_cell_count=int(pit_mask.sum()),
+        total_valid_cells=n_valid,
+        pitted_cell_fraction=float(pit_mask.sum()) / float(n_valid),
+        max_pit_depth_in=float(nominal_wt_in - t_min_pit),
+        max_pit_depth_ratio=float(nominal_wt_in - t_min_pit) / nominal_wt_in,
+        avg_pit_depth_in=float(nominal_wt_in - t_avg_pit),
+        avg_pit_depth_ratio=float(nominal_wt_in - t_avg_pit) / nominal_wt_in,
+        t_min_pit_in=t_min_pit,
+        t_avg_pit_in=t_avg_pit,
+        background_median_in=(
+            float(np.median(background)) if background.size else t_avg_pit
+        ),
+        largest_pit_cells=int(sizes.max()),
+        pit_spacing_mean_in=spacing_mean,
+        pit_spacing_min_in=spacing_min,
+        pitted_region_row_count=row_count,
+        pitted_region_length_in=float(row_count) * row_spacing,
+        pitted_region_col_count=col_count,
+        row_spacing_in=row_spacing,
+        pit_sizes_cells=[int(s) for s in sizes],
+    )
+
+
+# --- Level 1 ---------------------------------------------------------------
+
+# Conservative deep-pit screening floor: minimum remaining thickness ratio at
+# the deepest pit, R_t = (t_min_pit - FCA) / t_nom.  Configurable screening
+# parameter chosen consistent with the remaining-thickness-ratio applicability
+# limits used across the API 579-1 metal-loss parts — NOT a Part 6 chart value.
+DEFAULT_RT_MIN = 0.20
+
+
+def screen_pitting_level1(
+    characterization: PitFieldCharacterization,
+    *,
+    t_min_in: float,
+    fca_in: float = 0.0,
+    rt_min: float = DEFAULT_RT_MIN,
+) -> dict:
+    """Conservative closed-form Level 1 pitting screen.
+
+    Consistent with the API 579-1 Part 6 Level 1 philosophy (widespread
+    pitting screened on average remaining thickness, with a separate limit on
+    the deepest single pit) WITHOUT using the standard's pit charts:
+
+    * average criterion:  t_avg_pit - FCA >= t_min
+    * deep-pit criterion: R_t = (t_min_pit - FCA) / t_nom >= rt_min
+
+    Args:
+        characterization: output of :func:`characterize_pit_field`.
+        t_min_in: code-required minimum wall thickness (inches).
+        fca_in: future corrosion allowance (inches).
+        rt_min: deep-pit remaining-thickness-ratio floor (default 0.20,
+            conservative screening parameter — see module docstring).
+
+    Returns:
+        dict with ``verdict`` ('ACCEPT'/'FAIL_LEVEL_1'), both criteria, and
+        the numbers behind them.
+    """
+    c = characterization
+    if c.pit_count == 0:
+        return {
+            "verdict": "ACCEPT",
+            "average_criterion_pass": True,
+            "deep_pit_criterion_pass": True,
+            "t_avg_pit_in": c.t_avg_pit_in,
+            "t_min_in": t_min_in,
+            "fca_in": fca_in,
+            "rt_deepest_pit": 1.0,
+            "rt_min": rt_min,
+            "basis": "No readings below the pit threshold — no pitting to screen.",
+        }
+
+    avg_ok = (c.t_avg_pit_in - fca_in) >= t_min_in
+    rt_deepest = (c.t_min_pit_in - fca_in) / c.nominal_wt_in
+    deep_ok = rt_deepest >= rt_min
+
+    return {
+        "verdict": "ACCEPT" if (avg_ok and deep_ok) else "FAIL_LEVEL_1",
+        "average_criterion_pass": bool(avg_ok),
+        "deep_pit_criterion_pass": bool(deep_ok),
+        "t_avg_pit_in": c.t_avg_pit_in,
+        "t_min_in": t_min_in,
+        "fca_in": fca_in,
+        "rt_deepest_pit": float(rt_deepest),
+        "rt_min": rt_min,
+        "basis": (
+            "Conservative closed-form screen (average pitted-region thickness "
+            "vs t_min; deepest-pit remaining-thickness ratio vs floor) "
+            "consistent with API 579-1 Part 6 Level 1 philosophy; standard "
+            "pit charts not transcribed."
+        ),
+    }
+
+
+# --- Level 2 (equivalent LTA) ----------------------------------------------
+
+def assess_pitting_level2_equivalent_lta(
+    characterization: PitFieldCharacterization,
+    *,
+    nominal_od_in: float,
+    nominal_wt_in: float,
+    t_min_in: float,
+    rsf_a: float = 0.9,
+) -> dict:
+    """Level 2 pitting assessment by bounding the pit field as an LTA.
+
+    The pit field is replaced by an equivalent local thin area of uniform
+    thickness ``t_avg_pit`` (average reading over the pitted cells) spanning
+    the pitted region's axial extent, and assessed with the existing validated
+    Part 5 Level 2 engine (Folias factor / RSF).
+
+    Returns:
+        The Level 2 result dict (same keys as
+        :meth:`Level2Engine.evaluate` for LML) with
+        ``assessment_type='PITTING'``, an ``assessment_basis`` note, and an
+        ``equivalent_lta`` sub-dict describing the bounding region.
+    """
+    c = characterization
+    if c.pit_count == 0:
+        return {
+            "verdict": "ACCEPT",
+            "rsf": 1.0,
+            "rsf_a": rsf_a,
+            "t_am_in": c.t_avg_pit_in,
+            "t_mm_in": c.t_min_pit_in,
+            "assessment_type": "PITTING",
+            "folias_factor": 1.0,
+            "flaw_length_in": 0.0,
+            "rt": 1.0,
+            "assessment_basis": (
+                "No readings below the pit threshold — no equivalent LTA "
+                "required; RSF = 1.0."
+            ),
+            "equivalent_lta": None,
+        }
+
+    n_rows = max(int(c.pitted_region_row_count), 1)
+    # Equivalent LTA grid: uniform effective thickness over the pitted-region
+    # axial extent; index carries the physical row spacing so the LML engine
+    # recovers the correct flaw length.
+    eq_grid = pd.DataFrame(
+        np.full((n_rows, 1), c.t_avg_pit_in),
+        index=np.arange(n_rows, dtype=float) * c.row_spacing_in,
+    )
+
+    engine = Level2Engine(
+        assessment_type="LML",
+        nominal_od_in=nominal_od_in,
+        nominal_wt_in=nominal_wt_in,
+        t_min_in=t_min_in,
+        rsf_a=rsf_a,
+    )
+    result = engine.evaluate(eq_grid)
+
+    result["assessment_type"] = "PITTING"
+    result["assessment_basis"] = _ASSESSMENT_BASIS
+    result["equivalent_lta"] = {
+        "effective_thickness_in": c.t_avg_pit_in,
+        "effective_depth_in": c.avg_pit_depth_in,
+        "axial_extent_in": c.pitted_region_length_in,
+        "axial_rows": n_rows,
+        "row_spacing_in": c.row_spacing_in,
+        "source_pit_count": c.pit_count,
+    }
+    return result
+
+
+# --- One-call convenience ---------------------------------------------------
+
+def assess_pitting(
+    grid_df: pd.DataFrame,
+    *,
+    nominal_od_in: float,
+    nominal_wt_in: float,
+    t_min_in: float,
+    rsf_a: float = 0.9,
+    fca_in: float = 0.0,
+    pit_threshold_fraction: float = DEFAULT_PIT_THRESHOLD_FRACTION,
+    rt_min: float = DEFAULT_RT_MIN,
+) -> dict:
+    """Characterize + Level 1 screen + Level 2 equivalent-LTA in one call.
+
+    Returns:
+        dict with keys ``characterization`` (:class:`PitFieldCharacterization`),
+        ``level1`` (dict), ``level2`` (dict incl. ``assessment_basis``).
+    """
+    char = characterize_pit_field(
+        grid_df, nominal_wt_in, pit_threshold_fraction=pit_threshold_fraction
+    )
+    l1 = screen_pitting_level1(char, t_min_in=t_min_in, fca_in=fca_in, rt_min=rt_min)
+    l2 = assess_pitting_level2_equivalent_lta(
+        char,
+        nominal_od_in=nominal_od_in,
+        nominal_wt_in=nominal_wt_in,
+        t_min_in=t_min_in,
+        rsf_a=rsf_a,
+    )
+    return {"characterization": char, "level1": l1, "level2": l2}

--- a/tests/asset_integrity/test_pitting.py
+++ b/tests/asset_integrity/test_pitting.py
@@ -1,0 +1,436 @@
+# ABOUTME: Tests for API 579-1 Part 6 pitting assessment (assessment/pitting.py)
+# ABOUTME: — characterization, Level 1 screen, equivalent-LTA Level 2, routing.
+"""Pitting assessment tests (#1269).
+
+Validation labelling (repo convention, see test_ffs_published_examples.py):
+
+* There are NO PUBLISHED-VALIDATED cases here — no verified API 579-1 Part 6
+  worked example was available to this implementation and the standard's
+  coupled-pit charts are deliberately NOT transcribed.
+* Synthetic-grid tests are derivation-anchored: every asserted number follows
+  from the documented closed forms (pit counting, thickness averages, the
+  Part 5 Level 2 RSF/Folias equations already validated elsewhere).
+* Real-fixture tests are REGRESSION-ANCHOR: they lock the current output of
+  this implementation on the anonymized real UT scan to catch silent drift.
+  They are NOT claims of agreement with an external authority.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from digitalmodel.asset_integrity.assessment.ffs_coordinator import (
+    FFSComponent,
+    assess_component,
+)
+from digitalmodel.asset_integrity.assessment.ffs_router import FFSRouter
+from digitalmodel.asset_integrity.assessment.grid_parser import GridParser
+from digitalmodel.asset_integrity.assessment.pitting import (
+    assess_pitting,
+    assess_pitting_level2_equivalent_lta,
+    characterize_pit_field,
+    screen_pitting_level1,
+)
+
+DATA = Path(__file__).parent / "test_data" / "real_inspection"
+REAL_GRID = DATA / "ut_grid_RJ-101-boxend_worstzone_fullres.csv"
+
+NOMINAL = 0.500  # inches, synthetic grids
+
+
+def _grid(rows=30, cols=40, background=NOMINAL, pits=None):
+    """Uniform grid with optional seeded pits: {(row, col): reading}."""
+    g = np.full((rows, cols), background, dtype=float)
+    for (r, c), v in (pits or {}).items():
+        g[r, c] = v
+    return pd.DataFrame(g)
+
+
+# Eight well-separated single-cell pits (readings in inches)
+EIGHT_PITS = {
+    (3, 5): 0.30,
+    (3, 20): 0.30,
+    (8, 10): 0.25,
+    (12, 30): 0.30,
+    (15, 4): 0.30,
+    (20, 22): 0.30,
+    (25, 12): 0.30,
+    (27, 35): 0.30,
+}
+
+
+# ===========================================================================
+# Pit-field characterization (derivation-anchored data reduction)
+# ===========================================================================
+
+
+class TestCharacterization:
+    def test_uniform_grid_has_no_pits(self):
+        char = characterize_pit_field(_grid(), NOMINAL)
+        assert char.pit_count == 0
+        assert char.pitted_cell_count == 0
+        assert char.pitted_cell_fraction == 0.0
+        assert char.max_pit_depth_ratio == 0.0
+
+    def test_pit_count_and_fraction(self):
+        char = characterize_pit_field(_grid(pits=EIGHT_PITS), NOMINAL)
+        assert char.pit_count == 8
+        assert char.pitted_cell_count == 8
+        assert char.pitted_cell_fraction == pytest.approx(8 / (30 * 40))
+
+    def test_depth_statistics(self):
+        char = characterize_pit_field(_grid(pits=EIGHT_PITS), NOMINAL)
+        # deepest pit reads 0.25 -> w/t = (0.500-0.25)/0.500 = 0.50
+        assert char.t_min_pit_in == pytest.approx(0.25)
+        assert char.max_pit_depth_ratio == pytest.approx(0.50)
+        t_avg = (7 * 0.30 + 0.25) / 8
+        assert char.t_avg_pit_in == pytest.approx(t_avg)
+        assert char.avg_pit_depth_ratio == pytest.approx((NOMINAL - t_avg) / NOMINAL)
+
+    def test_pitted_region_extent(self):
+        char = characterize_pit_field(_grid(pits=EIGHT_PITS), NOMINAL)
+        # pits span rows 3..27 inclusive -> 25 rows; unit row spacing
+        assert char.pitted_region_row_count == 25
+        assert char.pitted_region_length_in == pytest.approx(25.0)
+        # cols 4..35 inclusive
+        assert char.pitted_region_col_count == 32
+
+    def test_multicell_pit_counts_once(self):
+        pits = {(5, 5): 0.30, (5, 6): 0.30, (6, 5): 0.30, (6, 6): 0.30}
+        char = characterize_pit_field(_grid(pits=pits), NOMINAL)
+        assert char.pit_count == 1
+        assert char.largest_pit_cells == 4
+
+    def test_pit_couple_spacing(self):
+        pits = {(0, 0): 0.30, (0, 10): 0.30}
+        char = characterize_pit_field(_grid(pits=pits), NOMINAL)
+        assert char.pit_spacing_min_in == pytest.approx(10.0)
+        assert char.pit_spacing_mean_in == pytest.approx(10.0)
+
+    def test_spacing_none_for_single_pit(self):
+        char = characterize_pit_field(_grid(pits={(5, 5): 0.30}), NOMINAL)
+        assert char.pit_spacing_min_in is None
+        assert char.pit_spacing_mean_in is None
+
+    def test_threshold_is_strict(self):
+        # reading exactly at 0.9*t_nom is NOT a pit
+        char = characterize_pit_field(_grid(pits={(5, 5): 0.45}), NOMINAL)
+        assert char.pit_count == 0
+
+    def test_nan_cells_are_not_pits(self):
+        g = _grid(pits=EIGHT_PITS)
+        g.iloc[0, 0] = np.nan
+        char = characterize_pit_field(g, NOMINAL)
+        assert char.pit_count == 8
+        assert char.total_valid_cells == 30 * 40 - 1
+
+    def test_background_median_ignores_pits(self):
+        char = characterize_pit_field(_grid(pits=EIGHT_PITS), NOMINAL)
+        assert char.background_median_in == pytest.approx(NOMINAL)
+
+    def test_to_dict_is_serialisable(self):
+        d = characterize_pit_field(_grid(pits=EIGHT_PITS), NOMINAL).to_dict()
+        assert d["pit_count"] == 8
+        assert "pitted_region_length_in" in d
+
+
+# ===========================================================================
+# Level 1 conservative screen (derivation-anchored closed form)
+# ===========================================================================
+
+
+class TestLevel1Screen:
+    def _char(self, pits):
+        return characterize_pit_field(_grid(pits=pits), NOMINAL)
+
+    def test_shallow_pits_accept(self):
+        char = self._char({(5, 5): 0.40, (10, 10): 0.40})
+        r = screen_pitting_level1(char, t_min_in=0.35)
+        assert r["verdict"] == "ACCEPT"
+        assert r["average_criterion_pass"] and r["deep_pit_criterion_pass"]
+
+    def test_average_criterion_fails(self):
+        # t_avg_pit = 0.30 < t_min = 0.35
+        char = self._char({(5, 5): 0.30, (10, 10): 0.30})
+        r = screen_pitting_level1(char, t_min_in=0.35)
+        assert r["verdict"] == "FAIL_LEVEL_1"
+        assert not r["average_criterion_pass"]
+
+    def test_deep_pit_criterion_fails(self):
+        # deepest pit Rt = 0.05/0.50 = 0.10 < 0.20 floor
+        char = self._char({(5, 5): 0.45 - 1e-9, (10, 10): 0.05})
+        r = screen_pitting_level1(char, t_min_in=0.10)
+        assert not r["deep_pit_criterion_pass"]
+        assert r["verdict"] == "FAIL_LEVEL_1"
+        assert r["rt_deepest_pit"] == pytest.approx(0.10)
+
+    def test_fca_reduces_margin(self):
+        char = self._char({(5, 5): 0.40, (10, 10): 0.40})
+        assert screen_pitting_level1(char, t_min_in=0.35)["verdict"] == "ACCEPT"
+        r = screen_pitting_level1(char, t_min_in=0.35, fca_in=0.10)
+        assert r["verdict"] == "FAIL_LEVEL_1"
+
+    def test_no_pits_accepts(self):
+        char = characterize_pit_field(_grid(), NOMINAL)
+        r = screen_pitting_level1(char, t_min_in=0.45)
+        assert r["verdict"] == "ACCEPT"
+
+
+# ===========================================================================
+# Level 2 equivalent-LTA bounding (derivation-anchored to the validated
+# Part 5 engine; the bounding basis is stated on the result)
+# ===========================================================================
+
+
+class TestLevel2EquivalentLTA:
+    OD = 16.0
+    TMIN = 0.35
+
+    def _l2(self, pits):
+        char = characterize_pit_field(_grid(pits=pits), NOMINAL)
+        return assess_pitting_level2_equivalent_lta(
+            char,
+            nominal_od_in=self.OD,
+            nominal_wt_in=NOMINAL,
+            t_min_in=self.TMIN,
+            rsf_a=0.9,
+        )
+
+    def test_result_shape_and_basis(self):
+        r = self._l2(EIGHT_PITS)
+        assert r["assessment_type"] == "PITTING"
+        assert "equivalent local thin area" in r["assessment_basis"]
+        assert 0.0 < r["rsf"] <= 1.0
+        assert r["folias_factor"] >= 1.0
+        eq = r["equivalent_lta"]
+        assert eq["axial_rows"] == 25
+        assert eq["axial_extent_in"] == pytest.approx(25.0)
+        assert eq["source_pit_count"] == 8
+
+    def test_deeper_pits_lower_rsf(self):
+        shallow = {k: 0.30 for k in EIGHT_PITS}
+        deep = {k: 0.20 for k in EIGHT_PITS}
+        rsf_shallow = self._l2(shallow)["rsf"]
+        rsf_deep = self._l2(deep)["rsf"]
+        assert rsf_deep < rsf_shallow
+
+    def test_longer_pit_field_does_not_raise_rsf(self):
+        compact = {(3, 5): 0.30, (4, 10): 0.30, (5, 20): 0.30}
+        extended = {(3, 5): 0.30, (14, 10): 0.30, (27, 20): 0.30}
+        assert self._l2(extended)["rsf"] <= self._l2(compact)["rsf"]
+
+    def test_no_pits_gives_unity_rsf(self):
+        char = characterize_pit_field(_grid(), NOMINAL)
+        r = assess_pitting_level2_equivalent_lta(
+            char, nominal_od_in=self.OD, nominal_wt_in=NOMINAL, t_min_in=self.TMIN
+        )
+        assert r["rsf"] == 1.0
+        assert r["verdict"] == "ACCEPT"
+        assert r["equivalent_lta"] is None
+
+    def test_one_call_convenience(self):
+        r = assess_pitting(
+            _grid(pits=EIGHT_PITS),
+            nominal_od_in=self.OD,
+            nominal_wt_in=NOMINAL,
+            t_min_in=self.TMIN,
+        )
+        assert r["characterization"].pit_count == 8
+        assert r["level1"]["verdict"] in ("ACCEPT", "FAIL_LEVEL_1")
+        assert r["level2"]["assessment_type"] == "PITTING"
+
+
+# ===========================================================================
+# Router classification (documented heuristic; opt-in-safe)
+# ===========================================================================
+
+
+class TestRouterPittingClassification:
+    def test_many_sharp_pits_on_sound_background_route_to_pitting(self):
+        result = FFSRouter.classify(
+            _grid(pits=EIGHT_PITS), nominal_od_in=16.0, nominal_wt_in=NOMINAL
+        )
+        assert result["assessment_type"] == "PITTING"
+        assert result["auto_classified"] is True
+        assert result["pitting"]["detected"] is True
+        assert result["pitting"]["pit_count"] == 8
+
+    def test_uniform_loss_still_gml(self):
+        df = _grid(background=0.400)
+        result = FFSRouter.classify(df, nominal_od_in=16.0, nominal_wt_in=NOMINAL)
+        assert result["assessment_type"] == "GML"
+
+    def test_contiguous_patch_still_lml(self):
+        pits = {(r, c): 0.30 for r in range(4, 6) for c in range(4, 6)}
+        result = FFSRouter.classify(
+            _grid(rows=10, cols=20, pits=pits),
+            nominal_od_in=16.0,
+            nominal_wt_in=NOMINAL,
+        )
+        assert result["assessment_type"] == "LML"
+
+    def test_too_few_pits_not_pitting(self):
+        pits = {(3, 5): 0.30, (12, 30): 0.30, (25, 12): 0.30}
+        result = FFSRouter.classify(
+            _grid(pits=pits), nominal_od_in=16.0, nominal_wt_in=NOMINAL
+        )
+        assert result["assessment_type"] == "LML"
+        assert result["pitting"]["detected"] is False
+
+    def test_pits_on_corroded_background_not_pitting(self):
+        # background at 88 % of nominal -> no contrast -> contiguous-loss path
+        df = _grid(background=0.44, pits=EIGHT_PITS)
+        result = FFSRouter.classify(df, nominal_od_in=16.0, nominal_wt_in=NOMINAL)
+        assert result["assessment_type"] == "GML"
+        assert result["pitting"]["detected"] is False
+
+    def test_force_type_pitting(self):
+        result = FFSRouter.classify(
+            _grid(background=0.400),
+            nominal_od_in=16.0,
+            nominal_wt_in=NOMINAL,
+            force_type="PITTING",
+        )
+        assert result["assessment_type"] == "PITTING"
+        assert result["auto_classified"] is False
+
+    def test_invalid_force_type_still_raises(self):
+        with pytest.raises(ValueError, match="force_type"):
+            FFSRouter.classify(
+                _grid(), nominal_od_in=16.0, nominal_wt_in=NOMINAL, force_type="PART7"
+            )
+
+
+# ===========================================================================
+# Coordinator end-to-end
+# ===========================================================================
+
+
+def _component(**overrides):
+    kwargs = dict(
+        component_id="PIT-001",
+        design_code="B31.8",
+        nominal_od_in=16.0,
+        nominal_wt_in=NOMINAL,
+        design_pressure_psi=1000.0,
+        smys_psi=52_000.0,
+        corrosion_rate_in_per_yr=0.005,
+        rsf_a=0.90,
+    )
+    kwargs.update(overrides)
+    return FFSComponent(**kwargs)
+
+
+class TestCoordinatorPitting:
+    def test_force_type_pitting_end_to_end(self):
+        res = assess_component(_component(), _grid(pits=EIGHT_PITS),
+                               force_type="PITTING")
+        assert res.assessment_type == "PITTING"
+        assert res.verdict in ("ACCEPT", "MONITOR", "RE_RATE", "REPAIR", "REPLACE")
+        assert 0.0 < res.rsf <= 1.0
+        assert res.level2["assessment_type"] == "PITTING"
+        assert "equivalent local thin area" in res.level2["assessment_basis"]
+        assert res.details["pitting_characterization"]["pit_count"] == 8
+        assert res.level1["pitting_screen"]["verdict"] in (
+            "ACCEPT", "FAIL_LEVEL_1",
+        )
+        assert res.sufficiency_status in ("SUFFICIENT", "TAKE_MORE", "ESCALATE")
+
+    def test_auto_classification_dispatches_pitting(self):
+        res = assess_component(_component(), _grid(pits=EIGHT_PITS))
+        assert res.assessment_type == "PITTING"
+        assert res.details["router"]["pitting"]["detected"] is True
+
+    def test_healthy_grid_unaffected(self):
+        res = assess_component(_component(), _grid())
+        assert res.assessment_type in ("GML", "LML")
+
+    def test_deep_pit_field_fails_level1_screen(self):
+        # deep pits: Rt = 0.05/0.50 = 0.10 < 0.20 floor
+        pits = {k: 0.05 for k in EIGHT_PITS}
+        res = assess_component(_component(), _grid(pits=pits),
+                               force_type="PITTING")
+        assert res.level1["pitting_screen"]["deep_pit_criterion_pass"] is False
+        assert res.level1["verdict"] == "FAIL_LEVEL_1"
+
+
+# ===========================================================================
+# Real anonymized inspection fixture (REGRESSION-ANCHOR — locks the current
+# implementation's output on a real pit-morphology scan; not an external
+# validation)
+# ===========================================================================
+
+
+NOMINAL_OD_REAL = 21.25
+NOMINAL_WT_REAL = 0.875  # 22.225 mm
+
+
+class TestRealFixtureIntegration:
+    @pytest.fixture(scope="class")
+    def real_grid(self):
+        return GridParser.from_csv(str(REAL_GRID), input_units="mm")
+
+    def test_characterize_real_scan(self, real_grid):
+        char = characterize_pit_field(real_grid, NOMINAL_WT_REAL)
+        # REGRESSION-ANCHOR: current data reduction of the real severe scan
+        # (11 isolated pits over 29 037 readings, deepest ~32 % of WT, on a
+        # background whose median sits at ~98.6 % of nominal)
+        assert char.pit_count == 11
+        assert char.pitted_cell_count == 48
+        assert char.pitted_cell_fraction == pytest.approx(48 / 29037, rel=1e-9)
+        assert char.max_pit_depth_ratio == pytest.approx(0.3240, abs=1e-3)
+        assert char.avg_pit_depth_ratio == pytest.approx(0.2574, abs=1e-3)
+        assert char.background_median_in / NOMINAL_WT_REAL == pytest.approx(
+            0.9861, abs=1e-3
+        )
+        # physical sanity: deepest reading matches the fixture register (~15.0 mm)
+        assert char.t_min_pit_in == pytest.approx(15.02 / 25.4, abs=0.02)
+
+    def test_assess_real_scan_as_pitting(self, real_grid):
+        component = FFSComponent(
+            component_id="RJ-101-boxend",
+            design_code="B31.8",
+            nominal_od_in=NOMINAL_OD_REAL,
+            nominal_wt_in=NOMINAL_WT_REAL,
+            design_pressure_psi=500.0,
+            smys_psi=80_000.0,
+            corrosion_rate_in_per_yr=0.25 / 25.4,
+        )
+        res = assess_component(component, real_grid, force_type="PITTING")
+        assert res.assessment_type == "PITTING"
+        assert "equivalent local thin area" in res.level2["assessment_basis"]
+        # REGRESSION-ANCHOR: at 500 psi the code t_min is small, so the
+        # equivalent-LTA thickness ratio caps and the RSF is unity; both
+        # Level 1 screens pass.
+        assert res.rsf == pytest.approx(1.0, abs=1e-9)
+        assert res.verdict == "ACCEPT"
+        assert res.level1["pitting_screen"]["verdict"] == "ACCEPT"
+        assert res.details["pitting_characterization"]["pit_count"] == 11
+
+    def test_real_severe_scan_auto_routes_to_pitting(self, real_grid):
+        # REGRESSION-ANCHOR: the severe worst-zone scan is textbook pit
+        # morphology (11 sharp separated minima, ~0.17 % of cells, background
+        # median ~98.6 % of nominal) — the heuristic detects it.
+        route = FFSRouter.classify(
+            real_grid,
+            nominal_od_in=NOMINAL_OD_REAL,
+            nominal_wt_in=NOMINAL_WT_REAL,
+        )
+        assert route["assessment_type"] == "PITTING"
+        assert route["pitting"]["detected"] is True
+        assert route["pitting"]["pit_count"] == 11
+
+    def test_real_mild_scan_stays_lml(self):
+        # Opt-in safety: the mild scan has only 2 sub-threshold components —
+        # below the pit-count floor — so its default classification is
+        # unchanged by the pitting heuristic.
+        grid = GridParser.from_csv(
+            str(DATA / "ut_grid_RJ-103-pinend_ds8.csv"), input_units="mm"
+        )
+        route = FFSRouter.classify(
+            grid, nominal_od_in=NOMINAL_OD_REAL, nominal_wt_in=NOMINAL_WT_REAL
+        )
+        assert route["assessment_type"] == "LML"
+        assert route["pitting"]["detected"] is False

--- a/tests/asset_integrity/test_real_inspection_fixtures.py
+++ b/tests/asset_integrity/test_real_inspection_fixtures.py
@@ -59,7 +59,9 @@ def test_severe_worstzone_runs_canonical_ffs_chain():
         str(DATA / "ut_grid_RJ-101-boxend_worstzone_fullres.csv"),
         input_units="mm",
     )
-    assert result.assessment_type in {"GML", "LML"}
+    # PITTING joined the routing set in #1269 — this scan's isolated sharp
+    # minima on a near-nominal background are detected as pit morphology.
+    assert result.assessment_type in {"GML", "LML", "PITTING"}
     assert result.t_measured_min_in == pytest.approx(15.02 / 25.4, abs=0.02)
     assert result.t_measured_avg_in < NOMINAL_WT_IN
     if result.rsf is not None:


### PR DESCRIPTION
Closes #1269. Parent epic: #1057.

The FFS router previously raised for pitting morphology (Part 6 out of scope). This PR wires pitting through the canonical pipeline (`grid_parser` → `ffs_router` → `pitting` → `ffs_decision` → `ffs_coordinator`) as an **honest tracer** of the Part 6 methodology.

## What it does

**`assessment/pitting.py`** (new):
1. **Pit-field characterization** — pure data reduction from a UT C-scan grid: pits = connected components of readings below 0.90·t_nom (neighborhood contrast inherent to the component cut). Reports pit count, max/avg pit depth ratio w/t, pit-couple nearest-neighbour spacing stats, pitted-region extent. Derivation-anchored.
2. **Level 1 screen (conservative closed form)** — average pitted-region thickness − FCA ≥ t_min, plus a deepest-pit remaining-thickness-ratio floor (configurable, default R_t ≥ 0.20). Consistent with the Part 6 Level 1 philosophy; the parameter is a documented conservative screening default, **not** a transcribed chart value.
3. **Level 2 via equivalent LTA** — the pit field is bounded by an equivalent local thin area (effective depth = average pit depth over the pitted cells, extent = pitted-region axial length) and assessed with the **existing validated Part 5 Level 2 engine** (Folias/RSF). Every result carries an `assessment_basis` note stating exactly this basis.

**`ffs_router.py`** — pitting morphology classification (many separated sharp minima vs contiguous loss). All four conditions must hold (≥5 separated pits, ≤10 % pitted cells, largest pit ≤2 % of grid, background median ≥95 % of nominal), so contiguous-loss grids keep their existing GML/LML classification. `force_type="PITTING"` supported; invalid types still raise.

**`ffs_coordinator.py`** — `assessment_type == "PITTING"` returns a normal `FFSAssessmentResult`: combined Level 1 verdict (code t_min check AND pitting screen), RSF from the equivalent-LTA run, verdict via the existing `FFSDecision`, characterization + basis in `details`.

## Honesty statement

API 579-1 Part 6 Level 1 compares the pit field to the standard's coupled-pit damage charts, and Level 2 computes RSF from the pit-couple grid. Those charts/tabulated coefficients are **not transcribed here** (no verified copy available; fabricating table values is prohibited by repo convention). Instead the pit field is bounded by an equivalent LTA assessed with the validated Part 5 engine — the documented conservative practice Part 6 itself permits for widespread pitting. A full Part 6 implementation would later add the pit-couple charts and pit-couple RSF summation, which can credit ligament interaction between pit pairs and is typically **less** conservative than this bound.

## Validation

- No PUBLISHED-VALIDATED claims — no verified Part 6 worked example was available. Synthetic-grid tests are derivation-anchored (hand-computable closed forms); real-fixture tests are REGRESSION-ANCHOR per the repo convention.
- Real anonymized severe UT scan (`ut_grid_RJ-101-boxend_worstzone_fullres.csv`): 11 isolated pits over 29 037 readings, deepest w/t = 0.324, background median ≈ 98.6 % of nominal — textbook pit morphology, auto-routes to PITTING (anchored). The mild scan (2 sub-threshold components) stays LML, demonstrating the heuristic does not blanket-flip real grids.
- One existing assertion updated: `test_severe_worstzone_runs_canonical_ffs_chain` allowed-type set gains `"PITTING"` (that scan is now honestly detected as pit morphology; all its other assertions unchanged).
- `tests/asset_integrity/`: **591 passed, 8 skipped** (skips pre-existing). 36 new tests in `tests/asset_integrity/test_pitting.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)