### PR TITLE
feat(ffs): dent and dent-gouge screening for pipelines — API 579-1 Part 12 scope (#1271)

### DIFF
--- a/src/digitalmodel/asset_integrity/dent_assessment.py
+++ b/src/digitalmodel/asset_integrity/dent_assessment.py
@@ -1,0 +1,398 @@
+# ABOUTME: Dent and dent-gouge screening for pipelines (API 579-1 Part 12 scope)
+# ABOUTME: — depth screen, ASME B31.8 Appendix R strain estimate, conservative routing.
+"""Dent and dent-gouge screening assessment for pipelines.
+
+Level 1/2 *screening* of dents in line pipe, in the scope of API 579-1/ASME
+FFS-1 Part 12 (dents, gouges and dent-gouge combinations), built from the
+well-published closed-form criteria:
+
+**1. Plain-dent depth screen.** A plain (smooth, no metal loss, weld-free)
+dent is screened on its depth ratio ``d / OD``.  The default acceptance
+threshold is the widely published **7 % OD** plain-dent limit (EPRG
+guidelines on the assessment of mechanical damage, Roovers et al.; reproduced
+in the Pipeline Defect Assessment Manual).  ASME B31.8 uses a 6 % OD
+operational acceptance limit for plain dents — pass
+``plain_dent_depth_limit=0.06`` to apply it.  The threshold is a parameter,
+not a constant.
+
+**2. Dent strain estimate (ASME B31.8, Nonmandatory Appendix R).**  With the
+dent lengths measured in both directions the bending + membrane strains are
+estimated from dent geometry (all lengths in consistent units; strains are
+dimensionless):
+
+    R0 = OD / 2                     initial pipe surface radius
+    R1 = signed transverse (circumferential-plane) radius at the dent apex
+    R2 = signed longitudinal-plane radius at the dent apex
+         (negative when the dent reverses the surface curvature)
+
+    eps1 = (t / 2) * (1/R0 - 1/R1)      circumferential bending strain
+    eps2 = -(t / 2) * (1/R2)            longitudinal bending strain
+    eps3 = (1/2) * (d / L)**2           longitudinal membrane strain
+    eps_i = sqrt(eps1**2 - eps1*(eps2 + eps3) + (eps2 + eps3)**2)   (inside)
+
+``eps_i`` is the Appendix R inside-surface combined strain as widely
+reproduced in the dent-assessment literature.  The outside surface is checked
+with the same effective-strain combination with the bending signs reversed
+(membrane unchanged):
+
+    eps_o = sqrt(eps1**2 + eps1*(eps3 - eps2) + (eps3 - eps2)**2)
+
+and the maximum of the two governs.  When only depth and lengths are
+measured, the apex radii are estimated with the parabolic-profile relation
+``R = L**2 / (8 d)`` (pure geometry; slightly smaller than the circular-arc
+sagitta radius, hence conservative) and the dent is assumed to *reverse* the
+surface curvature in both planes (conservative screening assumption):
+
+    1/R1 = -8 d / Lc**2        R2 = -LL**2 / (8 d)
+
+The default strain acceptance limit is the published **6 %** plain-dent
+strain limit (ASME B31.8 practice for strain-based acceptance of plain
+dents); parameterized via ``strain_limit``.
+
+**3. Dent-gouge screen (conservative).**  Dents interacting with gouges,
+grooves, scratches, arc burns or other metal loss are **not** acceptable by
+closed-form screening: dent-gouge failure is fracture-controlled (PDAM,
+EPRG), highly sensitive to gouge depth, toughness and dent rerounding, and
+the published screening position is rejection / detailed assessment.  Such
+combinations always return ``NEEDS_ASSESSMENT`` routing to a Level 3 /
+quantitative dent-gouge model (EPRG dent-gouge fracture model is a stated
+follow-up, not implemented here).
+
+**4. Restraint and location modifiers.**  Dents on seam or girth welds
+tolerate far less strain than the pipe body: the default weld screen accepts
+only shallow dents (**2 % OD** default, the widely applied limit for dents
+affecting welds, cf. 49 CFR 192.309(b) construction acceptance and ASME
+B31.8 practice) and then only as ``MONITOR``; deeper dents on welds are
+rejected at screening level (retention would require a Level 3 engineering
+critical assessment).  Rock-/soil-restrained dents that would otherwise pass
+are capped at ``MONITOR``: restrained dents do not reround under pressure and
+carry additional fatigue / restraint-removal uncertainty.
+
+Verdicts (ordered): ``ACCEPT`` < ``MONITOR`` < ``NEEDS_ASSESSMENT`` <
+``REJECT``.  Every threshold above is a keyword parameter with the published
+value as its documented default — no proprietary table values are embedded.
+
+Units are US customary (inches) for geometry, psi for the optional SMYS
+(recorded for downstream pressure-based methods; not used by these
+geometric/strain screens).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+from digitalmodel.codes import API_579, ASME_B31_8
+
+# --- Published screening defaults (all parameterized in assess_dent) --------
+#: Plain-dent depth acceptance, d/OD.  EPRG plain-dent guideline (7 % OD);
+#: ASME B31.8 operational acceptance uses 6 % OD (pass 0.06 to apply).
+PLAIN_DENT_DEPTH_LIMIT = 0.07
+#: Depth acceptance for dents affecting seam/girth welds, d/OD (2 % OD,
+#: cf. 49 CFR 192.309(b) for pipe > NPS 12; widely used integrity screen).
+WELD_DENT_DEPTH_LIMIT = 0.02
+#: Strain acceptance for plain dents (ASME B31.8 strain-based practice, 6 %).
+PLAIN_DENT_STRAIN_LIMIT = 0.06
+
+#: Verdict severity ordering (higher = worse).
+VERDICT_ORDER = {"ACCEPT": 0, "MONITOR": 1, "NEEDS_ASSESSMENT": 2, "REJECT": 3}
+
+_CITATIONS = [
+    f"{API_579.label} Part 12 — Assessment of Dents, Gouges, and "
+    "Dent-Gouge Combinations (scope and Level 1/2 screening framework)",
+    f"{ASME_B31_8.label} Nonmandatory Appendix R — Estimating Strain in Dents "
+    "(bending/membrane strain equations)",
+    "EPRG guidelines on the assessment of mechanical damage "
+    "(Roovers et al.) — 7 % OD plain-dent acceptance",
+    "Pipeline Defect Assessment Manual (Cosham & Hopkins) — dent-gouge "
+    "failure is fracture-controlled; screening rejection is the "
+    "conservative position",
+    "49 CFR 192.309(b) — 2 % OD acceptance for dents affecting welds "
+    "(pipe > NPS 12)",
+]
+
+
+@dataclass
+class DentStrain:
+    """ASME B31.8 Appendix R strain estimate for a dent (see module docstring)."""
+
+    eps_circ_bending: float    # eps1 = (t/2)(1/R0 - 1/R1)
+    eps_long_bending: float    # eps2 = -(t/2)(1/R2)
+    eps_long_membrane: float   # eps3 = (1/2)(d/L)^2
+    eps_inside: float          # combined strain, inside surface
+    eps_outside: float         # combined strain, outside surface
+    eps_max: float             # max(eps_inside, eps_outside) — governs
+    r0_in: float               # OD/2
+    r1_in: float               # signed transverse apex radius (negative=reversed)
+    r2_in: float               # signed longitudinal apex radius (negative=reversed)
+
+
+@dataclass
+class DentAssessment:
+    """Screening result for a pipeline dent (API 579-1 Part 12 scope)."""
+
+    od_in: float
+    wt_in: float
+    dent_depth_in: float
+    depth_ratio: float                    # d / OD
+    verdict: str                          # ACCEPT|MONITOR|NEEDS_ASSESSMENT|REJECT
+    governing_criterion: str
+    strain: Optional[DentStrain] = None   # None when dent lengths not given
+    on_weld: bool = False
+    restrained: bool = False
+    with_gouge_or_metal_loss: bool = False
+    thresholds: dict = field(default_factory=dict)
+    citations: list = field(default_factory=list)
+    validity_notes: list = field(default_factory=list)
+    code_reference: str = ""
+
+
+def _effective_strain(eps_x: float, eps_y: float) -> float:
+    """Plane effective-strain combination sqrt(x^2 - x*y + y^2)."""
+    return math.sqrt(eps_x * eps_x - eps_x * eps_y + eps_y * eps_y)
+
+
+def dent_strain_b31_8(
+    od_in: float,
+    wt_in: float,
+    dent_depth_in: float,
+    dent_length_axial_in: float,
+    dent_length_circ_in: float,
+) -> DentStrain:
+    """ASME B31.8 Appendix R dent strain estimate from depth and lengths.
+
+    Implements exactly the formulation written out in the module docstring:
+    parabolic apex radii ``R = L^2/(8 d)`` with curvature assumed *reversed*
+    in both planes (conservative screening assumption), then
+
+        eps1  = (t/2) * (1/R0 - 1/R1)   with  1/R1 = -8 d / Lc^2
+        eps2  = -(t/2) * (1/R2)         with  R2   = -LL^2 / (8 d)
+        eps3  = (1/2) * (d / LL)^2
+        eps_i = sqrt(eps1^2 - eps1*(eps2 + eps3) + (eps2 + eps3)^2)
+        eps_o = sqrt(eps1^2 + eps1*(eps3 - eps2) + (eps3 - eps2)^2)
+
+    Args:
+        od_in: pipe outside diameter (in).
+        wt_in: nominal wall thickness (in).
+        dent_depth_in: dent depth d (in), measured from original surface.
+        dent_length_axial_in: dent length LL along the pipe axis (in).
+        dent_length_circ_in: dent length Lc around the circumference (in).
+    """
+    _validate_geometry(od_in, wt_in)
+    d = dent_depth_in
+    if d <= 0:
+        raise ValueError(f"dent depth must be > 0 for a strain estimate (got {d}).")
+    ll, lc = dent_length_axial_in, dent_length_circ_in
+    if ll is None or lc is None or ll <= 0 or lc <= 0:
+        raise ValueError("dent lengths (axial and circumferential) must be > 0.")
+
+    t = wt_in
+    r0 = od_in / 2.0
+    r1 = -(lc * lc) / (8.0 * d)          # signed; negative = reversed curvature
+    r2 = -(ll * ll) / (8.0 * d)          # signed; negative = reversed curvature
+
+    eps1 = (t / 2.0) * (1.0 / r0 - 1.0 / r1)
+    eps2 = -(t / 2.0) * (1.0 / r2)
+    eps3 = 0.5 * (d / ll) ** 2
+
+    eps_i = _effective_strain(eps1, eps2 + eps3)
+    eps_o = _effective_strain(-eps1, -eps2 + eps3)
+    return DentStrain(
+        eps_circ_bending=eps1,
+        eps_long_bending=eps2,
+        eps_long_membrane=eps3,
+        eps_inside=eps_i,
+        eps_outside=eps_o,
+        eps_max=max(eps_i, eps_o),
+        r0_in=r0,
+        r1_in=r1,
+        r2_in=r2,
+    )
+
+
+def assess_dent(
+    od_in: float,
+    wt_in: float,
+    dent_depth_in: float,
+    dent_length_axial_in: Optional[float] = None,
+    dent_length_circ_in: Optional[float] = None,
+    *,
+    on_weld: bool = False,
+    restrained: bool = False,
+    with_gouge_or_metal_loss: bool = False,
+    smys_psi: Optional[float] = None,
+    plain_dent_depth_limit: float = PLAIN_DENT_DEPTH_LIMIT,
+    weld_dent_depth_limit: float = WELD_DENT_DEPTH_LIMIT,
+    strain_limit: float = PLAIN_DENT_STRAIN_LIMIT,
+) -> DentAssessment:
+    """Screen a pipeline dent (API 579-1 Part 12 scope). See module docstring.
+
+    Args:
+        od_in: pipe outside diameter (in).
+        wt_in: nominal wall thickness (in).
+        dent_depth_in: dent depth (in) from the original surface.  For
+            unrestrained dents use the depth measured under pressure /
+            after rerounding where available.
+        dent_length_axial_in: dent length along the pipe axis (in); with
+            ``dent_length_circ_in`` enables the Appendix R strain estimate.
+        dent_length_circ_in: dent length around the circumference (in).
+        on_weld: dent affects a seam or girth weld -> much stricter screen.
+        restrained: dent is held by rock/support (does not reround) -> a
+            passing dent is capped at MONITOR.
+        with_gouge_or_metal_loss: dent coincident with a gouge/groove/
+            scratch/arc burn or corrosion metal loss -> NEEDS_ASSESSMENT
+            (fracture-controlled; outside screening scope).
+        smys_psi: specified minimum yield strength (psi).  Recorded only;
+            the geometric/strain screens implemented here do not use it
+            (reserved for pressure-based dent-gouge follow-up models).
+        plain_dent_depth_limit: plain-dent d/OD acceptance (default 0.07,
+            EPRG; ASME B31.8 operational practice = 0.06).
+        weld_dent_depth_limit: d/OD acceptance for dents on welds
+            (default 0.02, cf. 49 CFR 192.309(b)).
+        strain_limit: dent strain acceptance (default 0.06, ASME B31.8
+            plain-dent strain practice).
+    """
+    _validate_geometry(od_in, wt_in)
+    if dent_depth_in < 0:
+        raise ValueError(f"dent depth must be >= 0 (got {dent_depth_in}).")
+    if dent_depth_in >= od_in:
+        raise ValueError(
+            f"dent depth {dent_depth_in} must be smaller than OD {od_in}."
+        )
+    for name, val in (("dent_length_axial_in", dent_length_axial_in),
+                      ("dent_length_circ_in", dent_length_circ_in)):
+        if val is not None and val <= 0:
+            raise ValueError(f"{name} must be > 0 if given (got {val}).")
+    if not (0.0 < weld_dent_depth_limit <= plain_dent_depth_limit):
+        raise ValueError(
+            "weld_dent_depth_limit must be in (0, plain_dent_depth_limit] — "
+            "dents on welds are screened more strictly than the pipe body."
+        )
+
+    depth_ratio = dent_depth_in / od_in
+    notes: list = []
+
+    # Strain estimate (needs both lengths and a non-zero depth).
+    strain: Optional[DentStrain] = None
+    if dent_length_axial_in is not None and dent_length_circ_in is not None \
+            and dent_depth_in > 0:
+        strain = dent_strain_b31_8(
+            od_in, wt_in, dent_depth_in,
+            dent_length_axial_in, dent_length_circ_in)
+        for label, length in (("axial", dent_length_axial_in),
+                              ("circumferential", dent_length_circ_in)):
+            if dent_depth_in / length > 0.5:
+                notes.append(
+                    f"dent depth exceeds half the {label} length — the "
+                    "parabolic apex-radius estimate is unreliable for such "
+                    "sharp dents; measure the actual profile radii.")
+    elif dent_depth_in > 0:
+        notes.append(
+            "dent lengths not provided in both directions — no Appendix R "
+            "strain estimate; screening is on depth ratio alone. Measure "
+            "axial and circumferential dent lengths to enable the strain "
+            "screen.")
+
+    # --- Verdict ------------------------------------------------------------
+    if with_gouge_or_metal_loss:
+        verdict = "NEEDS_ASSESSMENT"
+        governing = (
+            "dent-gouge / dent + metal-loss interaction: fracture-controlled "
+            "failure mode, not acceptable by closed-form screening (PDAM/EPRG "
+            "position) — route to Level 3 / quantitative dent-gouge model")
+        notes.append(
+            "quantitative EPRG dent-gouge fracture model is a stated "
+            "follow-up; this screen conservatively rejects all dent-gouge "
+            "combinations from screening-level acceptance.")
+    elif on_weld:
+        if depth_ratio <= weld_dent_depth_limit:
+            verdict = "MONITOR"
+            governing = (
+                f"dent on weld with d/OD = {depth_ratio:.4f} <= "
+                f"{weld_dent_depth_limit:.2%} OD weld screen — shallow enough "
+                "to retain, but dents affecting welds are monitored, not "
+                "screening-accepted")
+        else:
+            verdict = "REJECT"
+            governing = (
+                f"dent on weld with d/OD = {depth_ratio:.4f} > "
+                f"{weld_dent_depth_limit:.2%} OD weld screen — repair/replace "
+                "per screening practice (retention would require a Level 3 "
+                "engineering critical assessment of the weld)")
+    else:
+        strain_ok = strain is not None and strain.eps_max <= strain_limit
+        strain_bad = strain is not None and strain.eps_max > strain_limit
+        if depth_ratio <= plain_dent_depth_limit:
+            if strain_bad:
+                verdict = "NEEDS_ASSESSMENT"
+                governing = (
+                    f"plain-dent depth screen passes (d/OD = "
+                    f"{depth_ratio:.4f} <= {plain_dent_depth_limit:.2%}) but "
+                    f"estimated dent strain {strain.eps_max:.3f} exceeds the "
+                    f"{strain_limit:.0%} strain limit — strain governs; "
+                    "detailed assessment required")
+            else:
+                verdict = "ACCEPT"
+                governing = (
+                    f"plain dent, d/OD = {depth_ratio:.4f} <= "
+                    f"{plain_dent_depth_limit:.2%} OD depth screen"
+                    + (f"; strain {strain.eps_max:.3f} <= "
+                       f"{strain_limit:.0%}" if strain is not None else ""))
+        else:
+            if strain_ok:
+                verdict = "MONITOR"
+                governing = (
+                    f"d/OD = {depth_ratio:.4f} exceeds the "
+                    f"{plain_dent_depth_limit:.2%} OD depth screen but "
+                    f"estimated strain {strain.eps_max:.3f} <= "
+                    f"{strain_limit:.0%} (strain-qualified per ASME B31.8 "
+                    "Appendix R practice) — monitor; confirm ILI passage and "
+                    "operational constraints")
+            else:
+                verdict = "NEEDS_ASSESSMENT"
+                governing = (
+                    f"d/OD = {depth_ratio:.4f} exceeds the "
+                    f"{plain_dent_depth_limit:.2%} OD plain-dent depth screen"
+                    + (f" and estimated strain {strain.eps_max:.3f} exceeds "
+                       f"the {strain_limit:.0%} limit"
+                       if strain_bad else " with no qualifying strain "
+                       "estimate") + " — detailed assessment required")
+
+    if restrained and verdict == "ACCEPT":
+        verdict = "MONITOR"
+        governing += (
+            "; dent is restrained (rock/support) — capped at MONITOR: "
+            "restrained dents do not reround and carry fatigue / "
+            "restraint-removal uncertainty")
+    if restrained:
+        notes.append(
+            "restrained dent: depth may increase if the restraint is "
+            "removed; include in fatigue-susceptibility review.")
+
+    return DentAssessment(
+        od_in=od_in,
+        wt_in=wt_in,
+        dent_depth_in=dent_depth_in,
+        depth_ratio=depth_ratio,
+        verdict=verdict,
+        governing_criterion=governing,
+        strain=strain,
+        on_weld=on_weld,
+        restrained=restrained,
+        with_gouge_or_metal_loss=with_gouge_or_metal_loss,
+        thresholds={
+            "plain_dent_depth_limit": plain_dent_depth_limit,
+            "weld_dent_depth_limit": weld_dent_depth_limit,
+            "strain_limit": strain_limit,
+            "smys_psi": smys_psi,
+        },
+        citations=list(_CITATIONS),
+        validity_notes=notes,
+        code_reference=API_579.label,
+    )
+
+
+def _validate_geometry(od_in: float, wt_in: float) -> None:
+    if od_in <= 0 or wt_in <= 0 or wt_in >= od_in / 2.0:
+        raise ValueError(f"Invalid geometry: OD={od_in}, t={wt_in}.")

--- a/tests/asset_integrity/test_dent_assessment.py
+++ b/tests/asset_integrity/test_dent_assessment.py
@@ -1,0 +1,244 @@
+# ABOUTME: Tests for dent / dent-gouge screening — depth-threshold behaviour,
+# ABOUTME: Appendix R strain derivation anchor, monotonicity, routing, validation.
+"""Tests for digitalmodel.asset_integrity.dent_assessment.
+
+Validation basis
+----------------
+* DERIVATION-ANCHOR -- the strain expectations are computed inside the test
+  from the same written-out ASME B31.8 Appendix R formulation documented in
+  the module docstring (parabolic apex radii, reversed-curvature screening
+  assumption).  No published worked dent-strain example with numeric output
+  was embedded; the anchors guard the implemented formula, not a standard's
+  table value.
+* The 7 % OD plain-dent and 6 % strain thresholds are published values
+  (EPRG plain-dent guideline; ASME B31.8 strain practice); the tests only
+  exercise threshold *behaviour* around them.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.asset_integrity.dent_assessment import (
+    PLAIN_DENT_DEPTH_LIMIT,
+    PLAIN_DENT_STRAIN_LIMIT,
+    VERDICT_ORDER,
+    WELD_DENT_DEPTH_LIMIT,
+    DentAssessment,
+    assess_dent,
+    dent_strain_b31_8,
+)
+
+# Reference pipe: 24 in OD x 0.500 in WT (depth-only screens unless noted).
+OD, WT = 24.0, 0.500
+
+
+# --- Plain-dent depth screen around 7 % OD ----------------------------------
+def test_defaults_are_the_published_values():
+    assert PLAIN_DENT_DEPTH_LIMIT == pytest.approx(0.07)
+    assert WELD_DENT_DEPTH_LIMIT == pytest.approx(0.02)
+    assert PLAIN_DENT_STRAIN_LIMIT == pytest.approx(0.06)
+
+
+def test_depth_just_below_7pct_accepts():
+    r = assess_dent(OD, WT, 0.069 * OD)
+    assert isinstance(r, DentAssessment)
+    assert r.verdict == "ACCEPT"
+    assert r.depth_ratio == pytest.approx(0.069)
+    assert "depth screen" in r.governing_criterion
+
+
+def test_depth_just_above_7pct_needs_assessment_without_strain():
+    r = assess_dent(OD, WT, 0.071 * OD)
+    assert r.verdict == "NEEDS_ASSESSMENT"
+    assert "exceeds" in r.governing_criterion
+    # No lengths given -> no strain estimate, and the result says so.
+    assert r.strain is None
+    assert any("strain" in n for n in r.validity_notes)
+
+
+def test_depth_exactly_at_limit_accepts():
+    r = assess_dent(OD, WT, PLAIN_DENT_DEPTH_LIMIT * OD)
+    assert r.verdict == "ACCEPT"
+
+
+def test_threshold_is_parameterized():
+    # ASME B31.8 operational practice (6 % OD) via the parameter.
+    r = assess_dent(OD, WT, 0.065 * OD, plain_dent_depth_limit=0.06)
+    assert r.verdict == "NEEDS_ASSESSMENT"
+    assert assess_dent(OD, WT, 0.065 * OD).verdict == "ACCEPT"
+
+
+# --- Appendix R strain estimate (DERIVATION-ANCHOR) --------------------------
+def test_strain_hand_check_derivation_anchor():
+    """DERIVATION-ANCHOR: expected strain computed here from the written-out
+    Appendix R formulation (module docstring), independently of the module."""
+    d, ll, lc = 1.2, 12.0, 10.0
+    t, r0 = WT, OD / 2.0
+    eps1 = (t / 2.0) * (1.0 / r0 + 8.0 * d / lc**2)   # 1/R1 = -8d/Lc^2
+    eps2 = (t / 2.0) * (8.0 * d / ll**2)              # R2 = -LL^2/(8d)
+    eps3 = 0.5 * (d / ll) ** 2
+    y_i = eps2 + eps3
+    eps_i = math.sqrt(eps1**2 - eps1 * y_i + y_i**2)
+    y_o = eps3 - eps2
+    eps_o = math.sqrt(eps1**2 + eps1 * y_o + y_o**2)
+
+    s = dent_strain_b31_8(OD, WT, d, ll, lc)
+    assert s.eps_circ_bending == pytest.approx(eps1, rel=1e-12)
+    assert s.eps_long_bending == pytest.approx(eps2, rel=1e-12)
+    assert s.eps_long_membrane == pytest.approx(eps3, rel=1e-12)
+    assert s.eps_inside == pytest.approx(eps_i, rel=1e-12)
+    assert s.eps_outside == pytest.approx(eps_o, rel=1e-12)
+    assert s.eps_max == pytest.approx(max(eps_i, eps_o), rel=1e-12)
+    # Signed radii carry the reversed-curvature screening assumption.
+    assert s.r1_in == pytest.approx(-(lc**2) / (8 * d))
+    assert s.r2_in == pytest.approx(-(ll**2) / (8 * d))
+    assert s.r0_in == pytest.approx(12.0)
+
+
+def test_strain_numeric_spot_value():
+    # OD=24, t=0.5, d=1.68 (7 % OD), LL=Lc=12:
+    # eps1 = 0.25*(2/24 + 8*1.68/144) = 0.0441667
+    # eps2 = 0.25*(8*1.68/144)        = 0.0233333
+    # eps3 = 0.5*(1.68/12)^2          = 0.0098
+    s = dent_strain_b31_8(OD, WT, 1.68, 12.0, 12.0)
+    assert s.eps_circ_bending == pytest.approx(0.0441667, rel=1e-5)
+    assert s.eps_long_bending == pytest.approx(0.0233333, rel=1e-5)
+    assert s.eps_long_membrane == pytest.approx(0.0098, rel=1e-5)
+    assert s.eps_inside == pytest.approx(
+        math.sqrt(0.0441667**2 - 0.0441667 * 0.0331333 + 0.0331333**2),
+        rel=1e-4)
+
+
+def test_strain_increases_with_depth():
+    strains = [dent_strain_b31_8(OD, WT, d, 12.0, 12.0).eps_max
+               for d in (0.3, 0.8, 1.5, 2.4, 3.0)]
+    assert all(b > a for a, b in zip(strains, strains[1:]))
+
+
+def test_strain_governs_when_depth_screen_passes():
+    # Sharp, short dent: depth 1.5 in (6.25 % OD, passes depth) but strains
+    # over 6 % because the dent is only 5 in long in each direction.
+    r = assess_dent(OD, WT, 1.5, 5.0, 5.0)
+    assert r.strain is not None and r.strain.eps_max > PLAIN_DENT_STRAIN_LIMIT
+    assert r.verdict == "NEEDS_ASSESSMENT"
+    assert "strain" in r.governing_criterion
+
+
+def test_deep_but_strain_qualified_dent_is_monitor():
+    # Long smooth dent on a large pipe: 7.5 % OD (over the depth screen) but
+    # estimated strain well under 6 % -> strain-qualified MONITOR.
+    r = assess_dent(42.0, 0.5, 0.075 * 42.0, 60.0, 60.0)
+    assert r.strain is not None and r.strain.eps_max < PLAIN_DENT_STRAIN_LIMIT
+    assert r.verdict == "MONITOR"
+    assert "strain-qualified" in r.governing_criterion
+
+
+# --- Monotonicity: deeper is never better ------------------------------------
+def test_verdict_monotonic_in_depth_with_strain():
+    depths = [0.2, 0.5, 1.0, 1.5, 1.9, 2.4, 3.0, 3.6]
+    ranks = [VERDICT_ORDER[assess_dent(OD, WT, d, 12.0, 12.0).verdict]
+             for d in depths]
+    assert ranks == sorted(ranks)
+    assert ranks[0] == VERDICT_ORDER["ACCEPT"]
+    assert ranks[-1] >= VERDICT_ORDER["NEEDS_ASSESSMENT"]
+
+
+def test_verdict_monotonic_in_depth_depth_only():
+    depths = [0.01 * OD, 0.05 * OD, 0.08 * OD, 0.15 * OD]
+    ranks = [VERDICT_ORDER[assess_dent(OD, WT, d).verdict] for d in depths]
+    assert ranks == sorted(ranks)
+
+
+# --- Dent-gouge routing -------------------------------------------------------
+def test_dent_gouge_always_needs_assessment():
+    for depth in (0.005 * OD, 0.05 * OD, 0.12 * OD):
+        r = assess_dent(OD, WT, depth, with_gouge_or_metal_loss=True)
+        assert r.verdict == "NEEDS_ASSESSMENT"
+        assert "fracture-controlled" in r.governing_criterion
+
+
+def test_dent_gouge_overrides_weld_and_strain_paths():
+    r = assess_dent(OD, WT, 0.10 * OD, 12.0, 12.0,
+                    on_weld=True, with_gouge_or_metal_loss=True)
+    assert r.verdict == "NEEDS_ASSESSMENT"
+    assert "dent-gouge" in r.governing_criterion
+
+
+# --- Weld and restraint modifiers --------------------------------------------
+def test_on_weld_is_stricter_than_body():
+    depth = 0.05 * OD  # ACCEPT on the body, over the 2 % OD weld screen
+    body = assess_dent(OD, WT, depth)
+    weld = assess_dent(OD, WT, depth, on_weld=True)
+    assert body.verdict == "ACCEPT"
+    assert weld.verdict == "REJECT"
+    assert VERDICT_ORDER[weld.verdict] > VERDICT_ORDER[body.verdict]
+
+
+def test_shallow_dent_on_weld_is_monitor_not_accept():
+    r = assess_dent(OD, WT, 0.015 * OD, on_weld=True)
+    assert r.verdict == "MONITOR"
+    assert "weld" in r.governing_criterion
+
+
+def test_weld_threshold_parameterized():
+    r = assess_dent(OD, WT, 0.015 * OD, on_weld=True,
+                    weld_dent_depth_limit=0.01)
+    assert r.verdict == "REJECT"
+
+
+def test_restrained_caps_accept_at_monitor():
+    depth = 0.04 * OD
+    assert assess_dent(OD, WT, depth).verdict == "ACCEPT"
+    r = assess_dent(OD, WT, depth, restrained=True)
+    assert r.verdict == "MONITOR"
+    assert any("restrained" in n for n in r.validity_notes)
+
+
+# --- Result metadata ----------------------------------------------------------
+def test_citations_and_code_reference_present():
+    r = assess_dent(OD, WT, 0.5, smys_psi=52_000.0)
+    assert r.code_reference.startswith("API 579-1/ASME FFS-1")
+    assert any("Appendix R" in c for c in r.citations)
+    assert any("EPRG" in c for c in r.citations)
+    assert r.thresholds["smys_psi"] == 52_000.0
+    assert r.thresholds["plain_dent_depth_limit"] == pytest.approx(0.07)
+
+
+def test_sharp_dent_gets_profile_reliability_note():
+    r = assess_dent(OD, WT, 3.0, 5.0, 12.0)  # d/LL = 0.6 > 0.5
+    assert any("half the axial length" in n for n in r.validity_notes)
+
+
+def test_zero_depth_accepts_with_no_strain():
+    r = assess_dent(OD, WT, 0.0)
+    assert r.verdict == "ACCEPT"
+    assert r.strain is None
+    assert r.depth_ratio == 0.0
+
+
+# --- Validation ---------------------------------------------------------------
+def test_validity_errors():
+    with pytest.raises(ValueError):
+        assess_dent(-24.0, WT, 0.5)                      # bad OD
+    with pytest.raises(ValueError):
+        assess_dent(OD, 0.0, 0.5)                        # bad WT
+    with pytest.raises(ValueError):
+        assess_dent(OD, 13.0, 0.5)                       # WT >= OD/2
+    with pytest.raises(ValueError):
+        assess_dent(OD, WT, -0.1)                        # negative depth
+    with pytest.raises(ValueError):
+        assess_dent(OD, WT, 25.0)                        # depth >= OD
+    with pytest.raises(ValueError):
+        assess_dent(OD, WT, 0.5, -1.0, 6.0)              # bad axial length
+    with pytest.raises(ValueError):
+        assess_dent(OD, WT, 0.5, 6.0, 0.0)               # bad circ length
+    with pytest.raises(ValueError):
+        assess_dent(OD, WT, 0.5, weld_dent_depth_limit=0.5)  # weld > plain
+
+
+def test_strain_function_validates():
+    with pytest.raises(ValueError):
+        dent_strain_b31_8(OD, WT, 0.0, 12.0, 12.0)       # zero depth
+    with pytest.raises(ValueError):
+        dent_strain_b31_8(OD, WT, 0.5, 12.0, None)       # missing length


### PR DESCRIPTION
Closes #1271. Parent epic: #1057.

## What

New standalone module `src/digitalmodel/asset_integrity/dent_assessment.py` implementing the well-published closed-form dent screens in the scope of API 579-1/ASME FFS-1 Part 12, in the house style of `corroded_pipe.py` / `dnv_rp_f101.py` (dataclass result, ordered verdicts, citations carried on the result, validity notes, parameterized thresholds).

### Screens and thresholds (all parameterized, published defaults)

| Screen | Default | Basis |
|---|---|---|
| Plain-dent depth, d/OD | 7 % OD | EPRG plain-dent guideline (Roovers et al.); ASME B31.8 operational 6 % OD available via `plain_dent_depth_limit=0.06` |
| Dent strain | 6 % | ASME B31.8 Nonmandatory Appendix R strain practice |
| Dent on seam/girth weld, d/OD | 2 % OD | 49 CFR 192.309(b) practice; shallow-on-weld is capped at MONITOR, deeper REJECT |
| Dent-gouge / dent + metal loss | always NEEDS_ASSESSMENT | fracture-controlled (PDAM/EPRG); screening rejection is the conservative published position |
| Restrained (rock) dent | passing dent capped at MONITOR | no rerounding; fatigue / restraint-removal uncertainty |

### Strain estimate (ASME B31.8 Appendix R form, written out in the docstring)

`eps1 = (t/2)(1/R0 - 1/R1)`, `eps2 = -(t/2)(1/R2)`, `eps3 = (1/2)(d/L)^2`, combined inside-surface strain `sqrt(eps1^2 - eps1(eps2+eps3) + (eps2+eps3)^2)`; the outside surface is checked with the same effective-strain combination with bending signs reversed, max governs. Apex radii from depth + lengths use the parabolic relation `R = L^2/(8d)` with the conservative reversed-curvature screening assumption — documented as a screening assumption, not a standard's table value.

## Honest validation basis

- No published worked dent example with numeric output is embedded: the strain tests are **DERIVATION-ANCHOR** — expectations computed inside the test from the same written-out formulation, guarding the implemented formula.
- The 7 % OD / 6 % strain / 2 % OD numbers are the widely published values only; everything else is a keyword parameter with a documented default. No fabricated standard table values.
- `smys_psi` is accepted and recorded but unused by these geometric/strain screens (reserved for pressure-based follow-ups).

## Follow-ups (stated, not in scope)

- Quantitative EPRG dent-gouge fracture model (Level 2/3) to replace the conservative NEEDS_ASSESSMENT routing.
- Benchmark against a specific published EPRG/PDAM worked example once a citable numeric case is sourced (issue #1271 asks for this; flagged as PUBLISHED-VALIDATED work to come).
- Integration with ffs_router/ffs_coordinator (dents come from caliper/geometry data, not UT grids — intentionally standalone here).

## Tests

`tests/asset_integrity/test_dent_assessment.py` — 23 tests: threshold behaviour around 7 % OD (below/at/above, parameterized), Appendix R strain derivation anchors and numeric spot value, strain and verdict monotonicity in depth, dent-gouge always NEEDS_ASSESSMENT (including override of weld/strain paths), on-weld stricter than body, restrained capping, metadata/citations, validity errors.

Full `tests/asset_integrity/` suite run locally in batches (shared runner under heavy I/O contention): **578 passed, 8 skipped** across all 38 files, including the 23 new tests. `scripts/enforcement/check-no-abs-paths.sh` passes; uv.lock untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)