### PR TITLE
feat(openfoam): prescribed single-DOF tank motion engine (#658)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/__init__.py
+++ b/src/digitalmodel/solvers/openfoam/__init__.py
@@ -16,6 +16,13 @@ from .models import (
 )
 from .case_builder import OpenFOAMCaseBuilder
 from .domain_builder import DomainBuilder
+from .motion import (
+    MotionType,
+    PrescribedMotion,
+    render_dynamic_mesh_dict,
+    render_dynamic_mesh_dict_body,
+    write_dynamic_mesh_dict,
+)
 from .runner import (
     OpenFOAMRunConfig,
     OpenFOAMRunner,
@@ -38,8 +45,13 @@ __all__ = [
     "CaseType",
     "DomainConfig",
     "DomainBuilder",
+    "MotionType",
     "OpenFOAMCase",
     "OpenFOAMCaseBuilder",
+    "PrescribedMotion",
+    "render_dynamic_mesh_dict",
+    "render_dynamic_mesh_dict_body",
+    "write_dynamic_mesh_dict",
     "OpenFOAMRunConfig",
     "OpenFOAMRunner",
     "OpenFOAMRunResult",

--- a/src/digitalmodel/solvers/openfoam/case_builder.py
+++ b/src/digitalmodel/solvers/openfoam/case_builder.py
@@ -19,6 +19,7 @@ from .initial_fields import (
     write_velocity_field,
 )
 from .models import OpenFOAMCase, TurbulenceType
+from .motion import render_dynamic_mesh_dict_body
 from .templates import (
     FV_SOLUTION_SOLVERS,
     PIMPLE_BLOCK,
@@ -305,6 +306,15 @@ mergePatchPairs
         self._write_turbulence_properties(constant_dir)
         if self._case.solver_config.is_multiphase:
             self._write_gravity(constant_dir)
+        if self._case.motion is not None:
+            self._write_dynamic_mesh_dict(constant_dir)
+
+    def _write_dynamic_mesh_dict(self, constant_dir: Path) -> None:
+        """Write constant/dynamicMeshDict for a prescribed forced motion (#658)."""
+        content = _foam_header("dictionary", "dynamicMeshDict")
+        content += "\n" + render_dynamic_mesh_dict_body(self._case.motion) + "\n"
+        content += _FOOTER
+        (constant_dir / "dynamicMeshDict").write_text(content)
 
     def _write_transport_properties(self, constant_dir: Path) -> None:
         """Write constant/transportProperties for water and air."""

--- a/src/digitalmodel/solvers/openfoam/marine_solvers.py
+++ b/src/digitalmodel/solvers/openfoam/marine_solvers.py
@@ -20,6 +20,7 @@ from .models import (
     TurbulenceModel,
     TurbulenceType,
 )
+from .motion import PrescribedMotion
 
 
 # ============================================================================
@@ -158,13 +159,21 @@ class SloshingSetup:
     Models free-surface sloshing inside LNG cargo tanks or ballast tanks
     using the VOF method with mesh motion capability.
 
+    When ``motion`` is supplied, the case emits a ``constant/dynamicMeshDict``
+    that drives the whole (rigid) mesh with the prescribed single-DOF forcing —
+    the forced-roll rig for a ballast-tank sloshing study (#658). Without it the
+    case is a static-tank VOF setup.
+
     Attributes:
-        fill_level: Tank fill level as fraction of tank height (0-1).
+        fill_level: Tank fill level as fraction of tank height (0-1). Consumed by
+            the partial-fill setFields wrapper (#659).
         name: Case directory name.
+        motion: Optional ``motion.PrescribedMotion`` forced excitation.
     """
 
     fill_level: float = 0.5
     name: str = "sloshing"
+    motion: Optional["PrescribedMotion"] = None
 
     def __post_init__(self) -> None:
         cfg = SolverConfig(
@@ -182,6 +191,7 @@ class SloshingSetup:
             case_type=CaseType.SLOSHING,
             solver_config=cfg,
             turbulence_model=tm,
+            motion=self.motion,
         )
 
 

--- a/src/digitalmodel/solvers/openfoam/models.py
+++ b/src/digitalmodel/solvers/openfoam/models.py
@@ -305,6 +305,8 @@ class OpenFOAMCase:
         domain: Computational domain definition.
         boundary_conditions: List of boundary conditions.
         metadata: Free-form metadata dict.
+        motion: Optional prescribed single-DOF forced motion
+            (motion.PrescribedMotion); when set, a dynamic-mesh dict is emitted.
     """
 
     name: str
@@ -316,6 +318,10 @@ class OpenFOAMCase:
     domain: DomainConfig = field(default_factory=DomainConfig)
     boundary_conditions: List[BoundaryCondition] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
+    # Optional prescribed single-DOF forced motion (motion.PrescribedMotion).
+    # Typed Any to avoid a models<-motion import cycle; when set, the case
+    # builder emits constant/dynamicMeshDict (#658).
+    motion: Optional[Any] = None
 
     @classmethod
     def for_case_type(cls, case_type: CaseType, name: str) -> "OpenFOAMCase":

--- a/src/digitalmodel/solvers/openfoam/motion.py
+++ b/src/digitalmodel/solvers/openfoam/motion.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Prescribed single-DOF rigid-body motion engine for OpenFOAM dynamic-mesh
+cases. Generates a ``constant/dynamicMeshDict`` that drives the whole mesh with a
+``solidBodyMotionFvMesh`` sinusoidal forcing — sinusoidal roll (or pitch/yaw)
+rotation, or sway/surge/heave translation — for forced tank-sloshing studies.
+
+The imposed law is a single sinusoid ``x(t) = A * sin(omega * t)``:
+
+  * rotation  -> OpenFOAM ``oscillatingRotatingMotion`` (amplitude in DEGREES,
+    Euler-angle vector about x/y/z; ``origin`` = centre of rotation),
+  * translation -> OpenFOAM ``oscillatingLinearMotion`` (amplitude in METRES,
+    displacement vector along x/y/z).
+
+This is a *rigid* whole-mesh motion via the ESI ``solidBody`` motion solver
+(``dynamicMotionSolverFvMesh`` + ``motionSolver solidBody``, no ``cellZone`` so
+the whole mesh moves). It prescribes a rigid transform — no Laplacian point
+solve — so it is robust on 2-D slab meshes (unlike the displacement-Laplacian
+path that FPE'd in prior overset work). Gravity stays in the global frame, so
+rotating the tank reproduces the physical oscillating body force used in
+canonical forced-roll sloshing benchmarks (e.g. SPHERIC Test 10 and the ESI
+``interFoam/testTubeMixer`` tutorial).
+
+Syntax note: ESI OpenFOAM (v2312) does NOT provide the Foundation-branch
+``solidBodyMotionFvMesh`` dynamicFvMesh type — the solid-body function is a
+``motionSolver`` instead. This engine targets the ESI form and is verified
+against OpenFOAM v2312 ``moveDynamicMesh``.
+
+Reference: digitalmodel #658 (prescribed single-DOF tank motion engine).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Tuple
+
+
+class MotionType(Enum):
+    """Single degree of freedom to force.
+
+    Rotational DOFs use ``oscillatingRotatingMotion`` (amplitude in degrees);
+    translational DOFs use ``oscillatingLinearMotion`` (amplitude in metres).
+    """
+
+    ROLL = "roll"      # rotation about x
+    PITCH = "pitch"    # rotation about y
+    YAW = "yaw"        # rotation about z
+    SURGE = "surge"    # translation along x
+    SWAY = "sway"      # translation along y
+    HEAVE = "heave"    # translation along z
+
+    @property
+    def is_rotational(self) -> bool:
+        return self in (MotionType.ROLL, MotionType.PITCH, MotionType.YAW)
+
+    @property
+    def axis_index(self) -> int:
+        """Index (0=x, 1=y, 2=z) of the active axis for this DOF."""
+        return {
+            MotionType.ROLL: 0,
+            MotionType.PITCH: 1,
+            MotionType.YAW: 2,
+            MotionType.SURGE: 0,
+            MotionType.SWAY: 1,
+            MotionType.HEAVE: 2,
+        }[self]
+
+
+Vec3 = Tuple[float, float, float]
+
+
+@dataclass
+class PrescribedMotion:
+    """A single-DOF sinusoidal forced motion ``x(t) = A * sin(omega * t)``.
+
+    Attributes:
+        motion_type: Which DOF to force (roll/pitch/yaw or surge/sway/heave).
+        amplitude: Oscillation amplitude ``A``. Degrees for rotational DOFs,
+            metres for translational DOFs. Must be > 0.
+        period: Forcing period ``T`` (s); ``omega = 2*pi/T``. Must be > 0.
+            For a tank-sloshing sweep this is the vessel roll natural period or
+            one of the target excitation periods.
+        origin: Centre of rotation (m), used only for rotational DOFs. For a
+            ballast tank this is typically the tank/roll rotation centre.
+    """
+
+    motion_type: MotionType
+    amplitude: float
+    period: float
+    origin: Vec3 = (0.0, 0.0, 0.0)
+
+    def __post_init__(self) -> None:
+        if self.period <= 0.0:
+            raise ValueError(f"period must be > 0, got {self.period}")
+        if self.amplitude <= 0.0:
+            raise ValueError(f"amplitude must be > 0, got {self.amplitude}")
+        if len(self.origin) != 3:
+            raise ValueError("origin must be a 3-tuple (x y z)")
+
+    # ---- derived kinematics --------------------------------------------- #
+
+    @property
+    def omega(self) -> float:
+        """Circular frequency of the forcing (rad/s)."""
+        return 2.0 * math.pi / self.period
+
+    @property
+    def frequency_hz(self) -> float:
+        """Forcing frequency (Hz)."""
+        return 1.0 / self.period
+
+    @property
+    def amplitude_vector(self) -> Vec3:
+        """Amplitude as an (x, y, z) vector on the active axis.
+
+        Degrees for rotation, metres for translation.
+        """
+        v = [0.0, 0.0, 0.0]
+        v[self.motion_type.axis_index] = float(self.amplitude)
+        return (v[0], v[1], v[2])
+
+    # ---- constructors --------------------------------------------------- #
+
+    @classmethod
+    def from_frequency_hz(
+        cls,
+        motion_type: MotionType,
+        amplitude: float,
+        frequency_hz: float,
+        origin: Vec3 = (0.0, 0.0, 0.0),
+    ) -> "PrescribedMotion":
+        """Build from a frequency in Hz instead of a period."""
+        if frequency_hz <= 0.0:
+            raise ValueError(f"frequency_hz must be > 0, got {frequency_hz}")
+        return cls(motion_type, amplitude, 1.0 / frequency_hz, origin)
+
+    @classmethod
+    def from_omega(
+        cls,
+        motion_type: MotionType,
+        amplitude: float,
+        omega: float,
+        origin: Vec3 = (0.0, 0.0, 0.0),
+    ) -> "PrescribedMotion":
+        """Build from a circular frequency omega (rad/s)."""
+        if omega <= 0.0:
+            raise ValueError(f"omega must be > 0, got {omega}")
+        return cls(motion_type, amplitude, 2.0 * math.pi / omega, origin)
+
+
+def _fmt(x: float) -> str:
+    """Format a float for an OpenFOAM dict (trim trailing zeros, keep precision)."""
+    return f"{x:.10g}"
+
+
+def _vec(v: Vec3) -> str:
+    return f"({_fmt(v[0])} {_fmt(v[1])} {_fmt(v[2])})"
+
+
+def render_dynamic_mesh_dict_body(motion: PrescribedMotion) -> str:
+    """Return the ``dynamicMeshDict`` entries (no FoamFile header).
+
+    Suitable for embedding under a caller-supplied header (e.g. the
+    ``OpenFOAMCaseBuilder`` header) or for the standalone writer below.
+    """
+    if motion.motion_type.is_rotational:
+        coeffs = (
+            "solidBodyMotionFunction oscillatingRotatingMotion;\n"
+            "oscillatingRotatingMotionCoeffs\n"
+            "{\n"
+            f"    origin      {_vec(motion.origin)};\n"
+            f"    omega       {_fmt(motion.omega)};  // rad/s\n"
+            f"    amplitude   {_vec(motion.amplitude_vector)};  // degrees, Euler angles\n"
+            "}\n"
+        )
+    else:
+        coeffs = (
+            "solidBodyMotionFunction oscillatingLinearMotion;\n"
+            "oscillatingLinearMotionCoeffs\n"
+            "{\n"
+            f"    amplitude   {_vec(motion.amplitude_vector)};  // metres\n"
+            f"    omega       {_fmt(motion.omega)};  // rad/s\n"
+            "}\n"
+        )
+
+    return (
+        f"// Prescribed single-DOF forcing: {motion.motion_type.value}, "
+        f"A={_fmt(motion.amplitude)} "
+        f"{'deg' if motion.motion_type.is_rotational else 'm'}, "
+        f"T={_fmt(motion.period)} s (omega={_fmt(motion.omega)} rad/s)\n"
+        "// ESI whole-mesh rigid motion (entire mesh moves; no sub-zone).\n"
+        "dynamicFvMesh    dynamicMotionSolverFvMesh;\n"
+        "motionSolverLibs (fvMotionSolvers);\n"
+        "motionSolver     solidBody;\n\n"
+        f"{coeffs}"
+    )
+
+
+_FOAM_HEADER = """/*--------------------------------*- C++ -*----------------------------------*\\
+| =========                 |                                                 |
+| \\\\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\\\    /   O peration     |                                                 |
+|   \\\\  /    A nd           | digitalmodel prescribed-motion engine (#658)    |
+|    \\\\/     M anipulation  |                                                 |
+\\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      dynamicMeshDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+"""
+
+
+def render_dynamic_mesh_dict(motion: PrescribedMotion) -> str:
+    """Return a complete ``dynamicMeshDict`` file (FoamFile header + entries)."""
+    return _FOAM_HEADER + render_dynamic_mesh_dict_body(motion)
+
+
+def write_dynamic_mesh_dict(motion: PrescribedMotion, constant_dir: Path) -> Path:
+    """Write ``constant/dynamicMeshDict`` for the given motion.
+
+    Args:
+        motion: The prescribed single-DOF forcing.
+        constant_dir: The case ``constant/`` directory (created if needed).
+
+    Returns:
+        Path to the written ``dynamicMeshDict``.
+    """
+    constant_dir = Path(constant_dir)
+    constant_dir.mkdir(parents=True, exist_ok=True)
+    target = constant_dir / "dynamicMeshDict"
+    target.write_text(render_dynamic_mesh_dict(motion))
+    return target

--- a/tests/solvers/openfoam/test_motion.py
+++ b/tests/solvers/openfoam/test_motion.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for the prescribed single-DOF forced-motion engine (#658) —
+kinematics (omega/frequency/amplitude vector), dynamicMeshDict rendering for
+rotational and translational DOFs, the standalone file writer, and integration
+with the case builder / SloshingSetup.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.solvers.openfoam.motion import (
+    MotionType,
+    PrescribedMotion,
+    render_dynamic_mesh_dict,
+    render_dynamic_mesh_dict_body,
+    write_dynamic_mesh_dict,
+)
+from digitalmodel.solvers.openfoam.case_builder import OpenFOAMCaseBuilder
+from digitalmodel.solvers.openfoam.marine_solvers import SloshingSetup
+
+
+# ============================================================================
+# Kinematics
+# ============================================================================
+
+
+class TestKinematics:
+    def test_omega_from_period(self):
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        assert m.omega == pytest.approx(2.0 * math.pi / 18.0)
+
+    def test_frequency_hz(self):
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        assert m.frequency_hz == pytest.approx(1.0 / 18.0)
+
+    def test_from_frequency_hz_roundtrip(self):
+        m = PrescribedMotion.from_frequency_hz(MotionType.ROLL, 5.0, 0.05)
+        assert m.period == pytest.approx(20.0)
+        assert m.frequency_hz == pytest.approx(0.05)
+
+    def test_from_omega_roundtrip(self):
+        omega = 0.35
+        m = PrescribedMotion.from_omega(MotionType.SWAY, 0.2, omega)
+        assert m.omega == pytest.approx(omega)
+
+    @pytest.mark.parametrize(
+        "dof,idx",
+        [
+            (MotionType.ROLL, 0),
+            (MotionType.PITCH, 1),
+            (MotionType.YAW, 2),
+            (MotionType.SURGE, 0),
+            (MotionType.SWAY, 1),
+            (MotionType.HEAVE, 2),
+        ],
+    )
+    def test_amplitude_vector_axis(self, dof, idx):
+        m = PrescribedMotion(dof, amplitude=7.5, period=10.0)
+        vec = m.amplitude_vector
+        assert vec[idx] == pytest.approx(7.5)
+        assert sum(1 for v in vec if v != 0.0) == 1
+
+    @pytest.mark.parametrize(
+        "dof,rot",
+        [
+            (MotionType.ROLL, True),
+            (MotionType.PITCH, True),
+            (MotionType.YAW, True),
+            (MotionType.SURGE, False),
+            (MotionType.SWAY, False),
+            (MotionType.HEAVE, False),
+        ],
+    )
+    def test_is_rotational(self, dof, rot):
+        assert dof.is_rotational is rot
+
+
+class TestValidation:
+    def test_zero_period_rejected(self):
+        with pytest.raises(ValueError):
+            PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=0.0)
+
+    def test_negative_amplitude_rejected(self):
+        with pytest.raises(ValueError):
+            PrescribedMotion(MotionType.ROLL, amplitude=-1.0, period=10.0)
+
+    def test_bad_origin_rejected(self):
+        with pytest.raises(ValueError):
+            PrescribedMotion(
+                MotionType.ROLL, amplitude=10.0, period=10.0, origin=(0.0, 0.0)
+            )
+
+    def test_from_frequency_hz_zero_rejected(self):
+        with pytest.raises(ValueError):
+            PrescribedMotion.from_frequency_hz(MotionType.ROLL, 1.0, 0.0)
+
+
+# ============================================================================
+# Dict rendering
+# ============================================================================
+
+
+class TestRenderRotational:
+    def test_uses_esi_solid_body_motion_solver(self):
+        # ESI v2312: dynamicMotionSolverFvMesh + motionSolver solidBody
+        # (Foundation-branch solidBodyMotionFvMesh does NOT exist in v2312).
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        body = render_dynamic_mesh_dict_body(m)
+        assert "dynamicFvMesh    dynamicMotionSolverFvMesh;" in body
+        assert "motionSolver     solidBody;" in body
+        assert "solidBodyMotionFvMesh" not in body  # Foundation-only type
+
+    def test_uses_oscillating_rotating_motion(self):
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        body = render_dynamic_mesh_dict_body(m)
+        assert "oscillatingRotatingMotion" in body
+        assert "oscillatingLinearMotion" not in body
+
+    def test_encodes_origin_omega_amplitude(self):
+        m = PrescribedMotion(
+            MotionType.ROLL, amplitude=10.0, period=18.0, origin=(17.5, 0.0, 2.0)
+        )
+        body = render_dynamic_mesh_dict_body(m)
+        assert "origin      (17.5 0 2);" in body
+        # amplitude on the x (roll) axis, in degrees
+        assert "amplitude   (10 0 0);" in body
+        # omega = 2*pi/18 rad/s
+        assert f"{2.0 * math.pi / 18.0:.10g}" in body
+
+    def test_whole_mesh_no_cellzone(self):
+        # No cellZone => the whole rigid mesh moves (the forced-tank rig).
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        assert "cellZone" not in render_dynamic_mesh_dict_body(m)
+
+    def test_pitch_amplitude_on_y_axis(self):
+        m = PrescribedMotion(MotionType.PITCH, amplitude=4.0, period=12.0)
+        body = render_dynamic_mesh_dict_body(m)
+        assert "amplitude   (0 4 0);" in body
+
+
+class TestRenderTranslational:
+    def test_uses_oscillating_linear_motion(self):
+        m = PrescribedMotion(MotionType.SWAY, amplitude=0.3, period=8.0)
+        body = render_dynamic_mesh_dict_body(m)
+        assert "oscillatingLinearMotion" in body
+        assert "oscillatingRotatingMotion" not in body
+
+    def test_amplitude_metres_on_axis(self):
+        m = PrescribedMotion(MotionType.SWAY, amplitude=0.3, period=8.0)
+        body = render_dynamic_mesh_dict_body(m)
+        assert "amplitude   (0 0.3 0);" in body
+
+
+class TestFullFileRender:
+    def test_has_foam_header_and_object(self):
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        text = render_dynamic_mesh_dict(m)
+        assert "FoamFile" in text
+        assert "object      dynamicMeshDict;" in text
+        assert "dynamicMotionSolverFvMesh" in text
+
+    def test_write_dynamic_mesh_dict(self, tmp_path):
+        m = PrescribedMotion(MotionType.ROLL, amplitude=10.0, period=18.0)
+        constant_dir = tmp_path / "constant"
+        target = write_dynamic_mesh_dict(m, constant_dir)
+        assert target.exists()
+        assert target.name == "dynamicMeshDict"
+        content = target.read_text()
+        assert "FoamFile" in content
+        assert "oscillatingRotatingMotion" in content
+
+
+# ============================================================================
+# Integration with the case builder / SloshingSetup
+# ============================================================================
+
+
+class TestCaseBuilderIntegration:
+    def test_motion_emits_dynamic_mesh_dict(self, tmp_path):
+        motion = PrescribedMotion(
+            MotionType.ROLL, amplitude=8.0, period=18.0, origin=(17.5, 0.0, 1.5)
+        )
+        setup = SloshingSetup(fill_level=0.5, name="slosh_forced", motion=motion)
+        case_dir = OpenFOAMCaseBuilder(setup.case).build(tmp_path)
+        dmd = case_dir / "constant" / "dynamicMeshDict"
+        assert dmd.exists()
+        content = dmd.read_text()
+        assert "dynamicMotionSolverFvMesh" in content
+        assert "motionSolver     solidBody;" in content
+        assert "oscillatingRotatingMotion" in content
+        assert "amplitude   (8 0 0);" in content
+
+    def test_no_motion_no_dynamic_mesh_dict(self, tmp_path):
+        setup = SloshingSetup(fill_level=0.5, name="slosh_static")
+        case_dir = OpenFOAMCaseBuilder(setup.case).build(tmp_path)
+        assert not (case_dir / "constant" / "dynamicMeshDict").exists()
+
+    def test_sloshing_setup_forwards_motion_to_case(self):
+        motion = PrescribedMotion(MotionType.ROLL, amplitude=8.0, period=18.0)
+        setup = SloshingSetup(motion=motion)
+        assert setup.case.motion is motion


### PR DESCRIPTION
Closes #658. Critical-path engine for the ballast-tank forced-roll sloshing study (#637 cluster, ACMA B1546 Noble Drilling DS Noble Valiant).

## What
A forced-motion engine (`solvers/openfoam/motion.py`) that generates `constant/dynamicMeshDict` for rigid whole-mesh oscillation `x(t) = A·sin(ωt)`:
- **rotational** (roll/pitch/yaw) → `oscillatingRotatingMotion` (amplitude in degrees),
- **translational** (surge/sway/heave) → `oscillatingLinearMotion` (amplitude in metres).

`PrescribedMotion` carries the DOF, amplitude, forcing period (→ `omega`, `frequency_hz`), and rotation origin, with `from_frequency_hz` / `from_omega` constructors.

## ESI v2312 syntax note
Targets **`dynamicMotionSolverFvMesh` + `motionSolver solidBody`** (whole mesh, no `cellZone`). ESI OpenFOAM v2312 has **no** Foundation-branch `solidBodyMotionFvMesh` dynamicFvMesh type — an initial draft using it FATAL'd and was caught + fixed by a real `moveDynamicMesh` run. This is a rigid prescribed transform (no Laplacian point solve), so it is robust on 2-D slab meshes (unlike the displacement-Laplacian path that FPE'd in prior overset work).

## Wiring (no behaviour change when unused)
- `OpenFOAMCase.motion` (optional, `Any`-typed to avoid an import cycle).
- `OpenFOAMCaseBuilder` emits `constant/dynamicMeshDict` when `motion` is set.
- `SloshingSetup(motion=...)` forwards it.
- Package exports: `MotionType`, `PrescribedMotion`, `render_dynamic_mesh_dict[_body]`, `write_dynamic_mesh_dict`.

## Verification
- **32 new unit tests** — kinematics (ω/frequency/amplitude-vector per DOF), dict rendering (rotational + translational), input validation, and case-builder integration.
- **Real OpenFOAM v2312** `moveDynamicMesh` on a 2-D box: the mesh oscillates through the cycle and returns to zero roll after exactly one forcing period (θ = 10·sin(2π) = 0). ✅
- Full fast `tests/solvers/openfoam/` suite: **181 passed**.

## Next in the cluster
dm#659 (partial-fill `setFields`, wire `SloshingSetup.fill_level`) and dm#639 (2-D starter case) build directly on this to produce the first validated 2-D sloshing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)