### PR TITLE
riser_database: wire 16Q tension-factor getters + resolve_dff (#1246)

### DIFF
--- a/docs/riser_database.md
+++ b/docs/riser_database.md
@@ -44,25 +44,38 @@ raise with reason.
 ## Citation getters
 
 ```python
-from digitalmodel.riser_database import get_riser_dff, get_riser_scf, riser_citations
+from digitalmodel.riser_database import (
+    get_riser_dff, get_riser_scf,
+    get_tension_weight_factor, get_buoyancy_tension_factor, riser_citations,
+)
 
-get_riser_dff().value              # 10.0 — DNV-OS-F201 (allowable damage = 1/DFF)
-get_riser_scf().value              # 1.0  — DNV-RP-C203 methodology (neutral default)
-get_riser_dff(override=3.0)        # user override wins; note records both values
-riser_citations()                  # consumer helper: {} + one-shot RuntimeWarning standalone
+get_riser_dff().value                  # 10.0 — DNV-OS-F201 (allowable damage = 1/DFF)
+get_riser_scf().value                  # 1.0  — DNV-RP-C203 methodology (neutral default)
+get_tension_weight_factor().value      # 1.05 — API RP 16Q (1st Ed. 1993) §3.3, f_wt
+get_buoyancy_tension_factor().value    # 0.96 — API RP 16Q (1st Ed. 1993) §3.3, f_bt
+get_riser_dff(override=3.0)            # user override wins; note records both values
+riser_citations()                      # {dff, scf, f_wt, f_bt}; {} + RuntimeWarning standalone
 ```
 
 Direct getter calls are **fail-closed** (`CitationResolutionError` carrying the
 `code_id`); only the consumer helper degrades in standalone/`pip install` mode
 (one-shot `RuntimeWarning`) — same contract as the mooring pilot. Values match
-today's riser literals (`touchdown.py` `dff=10.0`, `scf=1.0`) so #1246 wiring
-inherits day-one parity.
+the riser literals (`touchdown.py` `dff=10.0`, `scf=1.0`; `stackup.py`
+`F_WT_DEFAULT=1.05`, `F_BT_DEFAULT=0.96`) so the #1246 wiring has day-one
+parity. `riser_fatigue/workflow.py` resolves DFF through `resolve_dff()`:
+an explicit `dff` in settings wins; an absent `dff` resolves the cited
+DNV-OS-F201 default in-context and **raises** standalone (never a silent
+default on a pass/fail input).
 
 Getter provenance discipline: a getter only cites a standard the code actually
-sources the value from. Hence this slice has **no** API RP 16Q getters (the
-wiki page's revision frontmatter is a not-citation-ready sentinel — fix it in
-llm-wiki first; deferred to #1246) and **no** Barlow-SF citation
-(`stackup.py` gives it no standards attribution; it is a project default).
+sources the value from. #1246 adds the two API RP 16Q **1st Ed. 1993**
+(reaffirmed 2001) §3.3 tension factors — the revision string is pinned to
+`1993` to match the 1993-numbered clause locators (a 2nd Edition, 2017,
+exists but is not the citation basis; the wiki page's `revision_note` records
+the drift, mirroring the DNV-RP-C203 2021-vs-2024-10 precedent). The
+top-tension safety factor (**1.25**) has **no** corresponding 16Q provision, so
+it carries no getter and stays a project default in `stackup.py`; the Barlow-SF
+likewise carries no standards attribution (generic formula, project default).
 
 ## Leak gate (suite 6 — hard merge gate)
 
@@ -84,9 +97,10 @@ attach the output to the PR as evidence.
 
 ## Extension map
 
-* **#1246** — wire `drilling_riser/stackup.py` + `riser_fatigue` dff to the
-  getters (user-override-wins; day-one parity), add the 16Q getters after the
-  llm-wiki frontmatter fix.
+* **#1246** — *done*: added the two API RP 16Q §3.3 tension-factor getters
+  (behind the llm-wiki `api-rp-16q` revision-`1993` pin), corrected the
+  `stackup.py` attribution comments (1.25 has no 16Q provision), and wired
+  `riser_fatigue/workflow.py` DFF through `resolve_dff()`.
 * **#1247** — orcaflex riser citation surface (net-new; no parity baseline).
 * **#1199d** (T3, frontier-gated) — de-identified ACE result precedent,
   `private_sidecar` route; extends the leak gate to those rows.

--- a/src/digitalmodel/drilling_riser/assembly.py
+++ b/src/digitalmodel/drilling_riser/assembly.py
@@ -14,9 +14,11 @@ Two "top tension" answers coexist in this package by design:
 
 Provenance discipline: this module carries NO standards-derived numeric
 defaults — ``efficiency`` and ``fleet_angle_factor`` are required kwargs
-supplied by the caller/rig data (the 16Q citation getters arrive with #1246).
-Illustrative docstring numbers are deliberately disjoint from any documented
-project calculation.
+supplied by the caller/rig data. The 16Q §3.3 tension factors f_wt/f_bt that
+compose ``t_srmin_kn`` upstream now resolve as cited values via
+``riser_database.getters.get_tension_weight_factor`` /
+``get_buoyancy_tension_factor`` (#1246). Illustrative docstring numbers are
+deliberately disjoint from any documented project calculation.
 """
 from __future__ import annotations
 
@@ -185,7 +187,13 @@ def tensioner_system_factor(
     n_units: int | float, n_fail: int | float, efficiency: float
 ) -> float:
     """N / (Rf * (N - n)): the tensioner-system allowance for ``n_fail``
-    sudden unit/wire failures at mechanical efficiency ``Rf``."""
+    sudden unit/wire failures at mechanical efficiency ``Rf``.
+
+    Note on the 16Q mapping (§3.3.2): API RP 16Q folds the mechanical
+    efficiency and the fleet-angle allowance into a single reduction factor
+    Rf. This implementation splits them — ``efficiency`` here (the Rf in this
+    N/(Rf(N-n)) expression) and ``fleet_angle_factor`` in
+    :func:`minimum_top_tension_16q` — so a rig can vary them independently."""
     n = int(n_units)
     f = int(n_fail)
     if n < 1:

--- a/src/digitalmodel/drilling_riser/stackup.py
+++ b/src/digitalmodel/drilling_riser/stackup.py
@@ -1,17 +1,23 @@
 """Drilling riser stackup calculations — tension, wall thickness, effective tension.
 
-Implements tension requirements per 2H-TNE-0050-03 §3.1 and API RP 16Q §3.3,
-wall thickness per Barlow's formula, and effective tension along riser string.
+Implements tension requirements (the 1.25 top-tension factor per
+2H-TNE-0050-03 §3.1, a project default; f_wt/f_bt per API RP 16Q, 1st Ed.
+1993, §3.3), wall thickness per Barlow's formula, and effective tension along
+the riser string.
 """
 
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Tension safety factors (2H-TNE-0050-03 §3.1, API RP 16Q §3.3)
+# Tension safety factors
+#   F_WT / F_BT — API RP 16Q, 1st Ed. 1993 (reaffirmed 2001), §3.3; also
+#     resolvable as cited values via riser_database.getters (#1246).
+#   SAFETY_FACTOR_TENSION (1.25) — no corresponding provision identified in
+#     API RP 16Q; retained as a project/methodology default, uncited.
 # ---------------------------------------------------------------------------
-SAFETY_FACTOR_TENSION: float = 1.25  # [-] minimum top tension safety factor
-F_WT_DEFAULT: float = 1.05  # [-] submerged weight tolerance factor (§3.1.2)
-F_BT_DEFAULT: float = 0.96  # [-] buoyancy loss and tolerance factor (§3.1.2)
+SAFETY_FACTOR_TENSION: float = 1.25  # [-] min top-tension factor (project default, uncited)
+F_WT_DEFAULT: float = 1.05  # [-] submerged weight tolerance factor (API RP 16Q §3.3)
+F_BT_DEFAULT: float = 0.96  # [-] buoyancy loss and tolerance factor (API RP 16Q §3.3)
 
 # ---------------------------------------------------------------------------
 # Wall thickness (Barlow's formula)
@@ -25,7 +31,9 @@ def top_tension_required(
 ) -> float:
     """Calculate minimum required top tension for drilling riser.
 
-    Per 2H-TNE-0050-03 §3.1 and API RP 16Q §3.3.
+    Per 2H-TNE-0050-03 §3.1 (project methodology). The default 1.25
+    ``dynamic_factor`` has no API RP 16Q provision — see the module header;
+    the 16Q-sourced factors are f_wt/f_bt in :func:`minimum_slip_ring_tension`.
 
     Parameters
     ----------
@@ -112,6 +120,11 @@ def minimum_slip_ring_tension(
     f_bt: float = F_BT_DEFAULT,
 ) -> float:
     """Minimum tension at the slip ring per 2H-TNE-0050-03 Eq 3.2.
+
+    This T_SRmin formula matches API RP 16Q (1st Ed. 1993) §3.3.2; the f_wt /
+    f_bt factors are the 16Q §3.3 tension factors (parity with
+    ``riser_database.getters.get_tension_weight_factor`` /
+    ``get_buoyancy_tension_factor``, #1246).
 
     T_SRmin = Ws * fwt - Bn * fbt + Ai * (dm * Hm - dw * Hw)
 

--- a/src/digitalmodel/riser_database/__init__.py
+++ b/src/digitalmodel/riser_database/__init__.py
@@ -5,8 +5,10 @@ Public tables carry identifiers and references only; standards-derived values
 come through the citation getters (fail-closed against the private llm-wiki).
 """
 from digitalmodel.riser_database.getters import (
+    get_buoyancy_tension_factor,
     get_riser_dff,
     get_riser_scf,
+    get_tension_weight_factor,
     riser_citations,
 )
 from digitalmodel.riser_database.loader import (
@@ -29,7 +31,9 @@ __all__ = [
     "RigRiserInterfaceRow",
     "RiserStackupRow",
     "StandardsCrosswalkRow",
+    "get_buoyancy_tension_factor",
     "get_riser_dff",
     "get_riser_scf",
+    "get_tension_weight_factor",
     "riser_citations",
 ]

--- a/src/digitalmodel/riser_database/getters.py
+++ b/src/digitalmodel/riser_database/getters.py
@@ -8,10 +8,13 @@ public repo — only these well-known scalar factors plus clause identifiers,
 with values resolving against the private llm-wiki.
 
 Provenance discipline (plan D6): a getter only cites the standard the code
-actually sources the value from. That is why this slice ships exactly two
-getters — the API RP 16Q-attributed factors (top-tension SF) are deferred to
-#1246 behind an llm-wiki frontmatter fix, and the Barlow wall-thickness safety
-factor carries no standards citation at all (generic formula, project default).
+actually sources the value from. #1245 shipped the two DNV factors (dff, scf);
+#1246 adds the two API RP 16Q (1st Ed. 1993) §3.3 tension factors — f_wt (1.05)
+and f_bt (0.96) — resolved against the now-pinned engineering-standards
+``api-rp-16q`` page. The top-tension safety factor (1.25) has NO corresponding
+API RP 16Q provision identified, so it carries no getter and stays a project
+default in ``drilling_riser.stackup``; the Barlow wall-thickness safety factor
+likewise carries no standards citation (generic formula, project default).
 
 Failure modes (plan D3):
 
@@ -48,12 +51,28 @@ _DNV_RP_C203_CITATION_TEMPLATE: Final = {
     "wiki_path": "wikis/engineering-standards/wiki/standards/dnv-rp-c203.md",
 }
 
+#: API RP 16Q, 1st Edition 1993 (reaffirmed 2001). The revision string pairs
+#: with the 1993-numbered clause locators (§3.3); the wiki page's revision_note
+#: records the 2nd-edition (2017) drift.
+_API_RP_16Q_CITATION_TEMPLATE: Final = {
+    "code_id": "api-rp-16q",
+    "publisher": "API",
+    "revision": "1993",
+    "wiki_path": "wikis/engineering-standards/wiki/standards/api-rp-16q.md",
+}
+
 #: Matches riser_fatigue/touchdown.py TouchdownFatigueInput.dff — the live
 #: riser literal these getters must stay in parity with (#1246 wires the calc).
 RISER_DFF_DEFAULT: Final[float] = 10.0
 #: Matches riser_fatigue touchdown.py scf default and workflow.py wave scf
 #: default: 1.0 = no stress concentration applied (neutral default).
 RISER_SCF_DEFAULT: Final[float] = 1.0
+#: Matches drilling_riser/stackup.py F_WT_DEFAULT — submerged-weight tolerance
+#: factor, API RP 16Q (1st Ed. 1993) §3.3.
+RISER_F_WT_DEFAULT: Final[float] = 1.05
+#: Matches drilling_riser/stackup.py F_BT_DEFAULT — buoyancy loss and tolerance
+#: factor, API RP 16Q (1st Ed. 1993) §3.3.
+RISER_F_BT_DEFAULT: Final[float] = 0.96
 
 
 def get_riser_dff(
@@ -106,11 +125,62 @@ def get_riser_scf(
     return CitedValue(value=value, citation=citation, units="dimensionless")
 
 
+def get_tension_weight_factor(
+    *, override: Optional[float] = None, repo_root: Optional[Path] = None
+) -> CitedValue:
+    """Submerged-weight tolerance factor f_wt (API RP 16Q, 1st Ed. 1993 §3.3).
+
+    Scales the submerged-weight term of the minimum slip-ring tension
+    (``drilling_riser.stackup.minimum_slip_ring_tension``, and its default
+    ``F_WT_DEFAULT``). ``override`` wins when provided (user-override-wins
+    defense); the note then records both the override and the standard value.
+    """
+    value = RISER_F_WT_DEFAULT
+    note = "Submerged-weight tolerance factor (f_wt) for minimum slip-ring tension"
+    if override is not None:
+        value = float(override)
+        note = f"user override; standard value {RISER_F_WT_DEFAULT}"
+    citation = Citation(
+        section="Sec.3.3 (tension factors)",
+        note=note,
+        **_API_RP_16Q_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="dimensionless")
+
+
+def get_buoyancy_tension_factor(
+    *, override: Optional[float] = None, repo_root: Optional[Path] = None
+) -> CitedValue:
+    """Buoyancy loss and tolerance factor f_bt (API RP 16Q, 1st Ed. 1993 §3.3).
+
+    Scales the buoyancy-uplift term of the minimum slip-ring tension (and its
+    default ``F_BT_DEFAULT``). Distinct from the tensioner-system reduction
+    factor Rf that 16Q §3.3.2 applies to the top-tension chain — that is a
+    rig-specific input handled in
+    ``drilling_riser.assembly.tensioner_system_factor``. ``override`` wins when
+    provided.
+    """
+    value = RISER_F_BT_DEFAULT
+    note = "Buoyancy loss and tolerance factor (f_bt) for minimum slip-ring tension"
+    if override is not None:
+        value = float(override)
+        note = f"user override; standard value {RISER_F_BT_DEFAULT}"
+    citation = Citation(
+        section="Sec.3.3 (tension factors)",
+        note=note,
+        **_API_RP_16Q_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="dimensionless")
+
+
 _CITATION_WARNED = False
 
 
 def riser_citations(repo_root: Optional[Path] = None) -> dict:
-    """Return ``{"dff", "scf"}`` CitedValues for the riser design factors.
+    """Return ``{"dff", "scf", "f_wt", "f_bt"}`` CitedValues for the riser
+    design factors.
 
     Consumer-wrapper degradation (template:
     ``mooring_resilience.screening.safety_factor_citations``): where the wiki
@@ -123,6 +193,8 @@ def riser_citations(repo_root: Optional[Path] = None) -> dict:
         return {
             "dff": get_riser_dff(repo_root=repo_root),
             "scf": get_riser_scf(repo_root=repo_root),
+            "f_wt": get_tension_weight_factor(repo_root=repo_root),
+            "f_bt": get_buoyancy_tension_factor(repo_root=repo_root),
         }
     except CitationResolutionError as exc:
         if not _CITATION_WARNED:

--- a/src/digitalmodel/riser_fatigue/workflow.py
+++ b/src/digitalmodel/riser_fatigue/workflow.py
@@ -28,12 +28,13 @@ from __future__ import annotations
 import csv
 import math
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import pandas as pd
 
 from digitalmodel.fatigue.damage import miner_damage
 from digitalmodel.fatigue.sn_curves import get_sn_curve
+from digitalmodel.riser_database.getters import get_riser_dff
 from digitalmodel.riser_fatigue.touchdown import (
     RiserSection,
     TouchdownFatigueInput,
@@ -44,10 +45,27 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SECONDS_PER_YEAR = 365.25 * 24.0 * 3600.0
 
 
+def resolve_dff(settings: dict, repo_root: Optional[Path] = None) -> float:
+    """Resolve the design fatigue factor (DFF) for a riser-fatigue run (#1246).
+
+    Precedence (fail-closed):
+
+    * an explicit ``dff`` in ``settings`` wins — validated exactly as before
+      (positive float); every existing config is behaviourally unchanged;
+    * when ``dff`` is absent, the cited standard default resolves via
+      :func:`digitalmodel.riser_database.getters.get_riser_dff` (DNV-OS-F201) —
+      10.0 where the llm-wiki resolves, and raises ``CitationResolutionError``
+      standalone. A pass/fail-driving input never silently defaults.
+    """
+    if settings.get("dff") is not None:
+        return _positive_float(settings, "dff")
+    return get_riser_dff(repo_root=repo_root).value
+
+
 def router(cfg: dict) -> dict:
     settings = cfg.get("riser_fatigue") or {}
     design_life_years = _positive_float(settings, "design_life_years")
-    dff = _positive_float(settings, "dff")
+    dff = resolve_dff(settings)
     default_curve, default_env = _curve_settings(settings)
 
     rows: list[dict[str, Any]] = []

--- a/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/FIXTURE_PROVENANCE.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/FIXTURE_PROVENANCE.md
@@ -64,3 +64,36 @@ and this provenance file in the same commit, then rerun:
 ```bash
 .venv/bin/python -m pytest tests/riser_database/ -q
 ```
+
+---
+
+# Fixture Provenance - `api-rp-16q.md` (#1246)
+
+Vendored for the riser-database 16Q tension-factor getters
+(`get_tension_weight_factor`, `get_buoyancy_tension_factor`). Same contract as
+the fixtures above: resolver frontmatter and a short description only — no
+standard text, tables, formulas, or licensed source material.
+
+## Canonical source
+
+- **Repo:** `vamseeachanta/llm-wiki`
+- `wikis/engineering-standards/wiki/standards/api-rp-16q.md` —
+  canonical SHA at vendoring time: `2252d2c3f9c69b11a70ccce011e33d9f306bb63e`
+  (the revision "1993" pin landed by llm-wiki PR #820; before that the page
+  carried the `public-metadata-required-before-citation-use` sentinel).
+
+## Vendored copy
+
+- **Vendored on:** 2026-07-02
+- **Used by:** `tests/riser_database/test_citations.py`
+
+## Freshness contract
+
+Review monthly. If the canonical page frontmatter changes, update the fixture,
+the `_API_RP_16Q_CITATION_TEMPLATE` in
+`src/digitalmodel/riser_database/getters.py`, and this provenance file in the
+same commit, then rerun:
+
+```bash
+.venv/bin/python -m pytest tests/riser_database/ -q
+```

--- a/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/api-rp-16q.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/api-rp-16q.md
@@ -1,0 +1,18 @@
+---
+title: "API RP 16Q Drilling Riser Systems — citation fixture"
+code_id: api-rp-16q
+publisher: API
+revision: "1993"
+tags: ["standard", "api", "drilling-risers", "fixture"]
+---
+
+# API RP 16Q — Drilling Riser Systems (vendored citation fixture)
+
+Minimal fixture so riser citation tests can validate frontmatter resolution
+standalone (see FIXTURE_PROVENANCE.md). Resolver frontmatter only — no
+standard text, tables, formulas, or licensed source material.
+
+API RP 16Q (1st Edition, 1993, reaffirmed 2001) §3.3 sources the submerged-
+weight (f_wt) and buoyancy (f_bt) tension factors consumed by
+`digitalmodel.riser_database.getters`. A 2nd Edition (2017) exists but is not
+the basis for the 1993-numbered clause locators.

--- a/tests/riser_database/test_citations.py
+++ b/tests/riser_database/test_citations.py
@@ -88,6 +88,41 @@ def test_get_riser_scf_emits_c203_citation():
     assert "methodology" in cv.citation.note.lower()
 
 
+def test_get_tension_weight_factor_emits_16q_citation():
+    cv = getters.get_tension_weight_factor(repo_root=_fixture_repo_root())
+    assert cv.value == 1.05
+    assert cv.citation.code_id == "api-rp-16q"
+    assert cv.citation.publisher == "API"
+    assert cv.citation.revision == "1993"  # 1st Ed. 1993, not 2017
+    assert cv.citation.source_sibling == "generic"
+    assert "3.3" in cv.citation.section
+    assert cv.units == "dimensionless"
+
+
+def test_get_buoyancy_tension_factor_emits_16q_citation():
+    cv = getters.get_buoyancy_tension_factor(repo_root=_fixture_repo_root())
+    assert cv.value == 0.96
+    assert cv.citation.code_id == "api-rp-16q"
+    assert cv.citation.publisher == "API"
+    assert cv.citation.revision == "1993"
+    assert cv.citation.source_sibling == "generic"
+    assert "3.3" in cv.citation.section
+
+
+def test_16q_getters_are_in_parity_with_stackup_literals():
+    """The getters must return exactly the drilling_riser.stackup literals —
+    the calc still uses the module constants; the getters cite the same values.
+    """
+    from digitalmodel.drilling_riser import stackup
+
+    f_wt = getters.get_tension_weight_factor(repo_root=_fixture_repo_root())
+    f_bt = getters.get_buoyancy_tension_factor(repo_root=_fixture_repo_root())
+    assert f_wt.value == stackup.F_WT_DEFAULT == 1.05
+    assert f_bt.value == stackup.F_BT_DEFAULT == 0.96
+    # And no getter exists for the 1.25 top-tension factor (no 16Q provision).
+    assert not hasattr(getters, "get_tension_safety_factor")
+
+
 # -- defense (a): fail-closed ----------------------------------------------------
 
 
@@ -117,6 +152,20 @@ def test_user_override_wins_for_scf():
     assert "1.0" in cv.citation.note
 
 
+def test_user_override_wins_for_f_wt():
+    cv = getters.get_tension_weight_factor(override=1.1, repo_root=_fixture_repo_root())
+    assert cv.value == 1.1
+    assert "user override" in cv.citation.note
+    assert "1.05" in cv.citation.note  # standard value still cited
+
+
+def test_user_override_wins_for_f_bt():
+    cv = getters.get_buoyancy_tension_factor(override=0.9, repo_root=_fixture_repo_root())
+    assert cv.value == 0.9
+    assert "user override" in cv.citation.note
+    assert "0.96" in cv.citation.note
+
+
 # -- defenses (c)+(d) + pip-no-wiki path ------------------------------------------
 
 
@@ -140,6 +189,8 @@ def test_pip_no_wiki_helper_warns_once_and_degrades(_no_wiki_anywhere):
 
 def test_helper_returns_cited_values_in_context():
     cited = getters.riser_citations(repo_root=_fixture_repo_root())
-    assert set(cited) == {"dff", "scf"}
+    assert set(cited) == {"dff", "scf", "f_wt", "f_bt"}
     assert cited["dff"].value == 10.0
     assert cited["scf"].value == 1.0
+    assert cited["f_wt"].value == 1.05
+    assert cited["f_bt"].value == 0.96

--- a/tests/riser_fatigue/test_resolve_dff.py
+++ b/tests/riser_fatigue/test_resolve_dff.py
@@ -1,0 +1,44 @@
+"""#1246: resolve_dff() DFF precedence for the riser-fatigue workflow.
+
+Three behaviors, all fail-closed:
+  * an explicit ``dff`` in settings wins (every existing config unchanged);
+  * an absent ``dff`` resolves the cited DNV-OS-F201 default in-context (10.0);
+  * an absent ``dff`` with no resolvable wiki RAISES — a pass/fail-driving
+    input never silently defaults.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.citations import CitationResolutionError
+from digitalmodel.riser_fatigue.workflow import resolve_dff
+
+
+def _fixture_repo_root() -> Path:
+    """Vendored wiki fixture root (shared with the getter citation tests)."""
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+def test_explicit_dff_wins_and_skips_the_wiki(tmp_path):
+    # tmp_path has no wiki page; an explicit dff must never touch resolution.
+    assert resolve_dff({"dff": 3.0}, repo_root=tmp_path) == 3.0
+
+
+def test_explicit_dff_is_validated_positive():
+    with pytest.raises(ValueError):
+        resolve_dff({"dff": 0.0})
+    with pytest.raises(ValueError):
+        resolve_dff({"dff": -1.0})
+
+
+def test_absent_dff_resolves_cited_default_in_context():
+    assert resolve_dff({}, repo_root=_fixture_repo_root()) == 10.0
+
+
+def test_absent_dff_standalone_raises(tmp_path):
+    # No wiki page under repo_root => fail closed, not a silent default.
+    with pytest.raises(CitationResolutionError) as exc:
+        resolve_dff({}, repo_root=tmp_path)
+    assert exc.value.code_id == "dnv-os-f201"


### PR DESCRIPTION
Closes #1246 (child 1199b of #1199; epic #1279 child prerequisite for #1281).

## ⚠️ Merge order

Merge the **paired llm-wiki PR first** — vamseeachanta/llm-wiki#820 (pins the
`api-rp-16q` page revision to `1993`). Until it lands on the wiki's `main`, the
new getters **fail closed** (`CitationResolutionError: frontmatter_mismatch:
revision`) against the not-citation-ready sentinel page. That fail-closed
behaviour is verified below.

## What

Adds the two clause-verified **API RP 16Q, 1st Edition 1993 (reaffirmed 2001)
§3.3** tension factors as citation getters, and wires the riser-fatigue DFF to
the citation layer.

- `get_tension_weight_factor()` → **1.05** (f_wt), `api-rp-16q` rev `1993` §3.3
- `get_buoyancy_tension_factor()` → **0.96** (f_bt), `api-rp-16q` rev `1993` §3.3
- `riser_citations()` grows to `{dff, scf, f_wt, f_bt}` (fail-closed in-context;
  one-shot `RuntimeWarning` + `{}` standalone — unchanged contract).
- **No getter for the 1.25 top-tension safety factor** — no corresponding
  provision was identified in API RP 16Q (verified during T2 review). It stays
  an uncited project default in `stackup.py`. *(Scope delta vs the issue's
  headline target — approved.)*

## Wiring / attribution corrections

- `riser_fatigue/workflow.py`: `resolve_dff(settings, repo_root=None)` at the
  DFF call site — an explicit `dff` wins (every existing config is unchanged);
  an absent `dff` resolves the cited DNV-OS-F201 default in-context and
  **raises** standalone (a pass/fail-driving input never silently defaults).
- `drilling_riser/stackup.py`: corrected the tension-factor attribution
  comments — `1.25` no longer cites 16Q; `f_wt`/`f_bt` cite §3.3; the T_SRmin
  docstring cross-refs §3.3.2.
- `drilling_riser/assembly.py`: docstrings cross-reference the getters and note
  that 16Q's single reduction factor Rf bundles what `tensioner_system_factor`
  splits into `efficiency` × `fleet_angle_factor`.

## Edition-drift note

The revision is pinned to **`1993`** to match the 1993-numbered clause
locators. A 2nd Edition (2017) exists but is not the citation basis here;
pairing a 2017 revision with those locators would be internally inconsistent.
The wiki page's `revision_note` records this, mirroring the DNV-RP-C203
2021-vs-2024-10 precedent. Citations carry **edition + clause locator only**.

## Verification

- **217** riser + citation tests green (`riser_database`, `riser_fatigue`,
  `drilling_riser`, `citations`).
- Getters resolve **green in-context** against the fixed wiki branch
  (`LLM_WIKI_PATH` → the #820 branch: f_wt=1.05, f_bt=0.96, rev `1993`).
- Getters **fail loud** against the unfixed sentinel page
  (`frontmatter_mismatch:revision:...!='1993'`) — the gate bites.
- `legal-sanity-scan.sh --repo=digitalmodel --diff-only` **PASS** over all
  changed files (new files staged with `git add -N` first, so the diff scan is
  not vacuous).
- Vendored `api-rp-16q` citation fixture (revision `1993`, resolver frontmatter
  only) so standalone CI needs no wiki checkout.