### PR TITLE
test(drilling_riser): fix baseline-red abs-path gate (allowlist marker, #1338)

### DIFF
--- a/tests/drilling_riser/test_assembly_golden.py
+++ b/tests/drilling_riser/test_assembly_golden.py
@@ -23,7 +23,7 @@ from digitalmodel.drilling_riser.assembly import (
 
 REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 


### PR DESCRIPTION
One-line baseline-red fix: adds the `# abs-path-allowed` marker to `test_assembly_golden.py:26`, matching its sibling files for the identical wiki-clone discovery default. #1280/#1325 omitted it, making the abs-path Quality Gate red on main and on every open PR's merge commit.

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)