### PR TITLE
feat(asset-integrity): API 580-style RBI screening over FFS outputs (#1272)

### DIFF
--- a/src/digitalmodel/asset_integrity/rbi_screening.py
+++ b/src/digitalmodel/asset_integrity/rbi_screening.py
@@ -1,0 +1,488 @@
+# ABOUTME: Qualitative API 580-style RBI screening — PoF proxy from FFS outputs,
+# ABOUTME: CoF category input, 5x5 risk matrix, risk-scaled inspection interval.
+"""Risk-based inspection (RBI) screening layer over FFS outputs.
+
+A thin, deterministic, *qualitative* screening in the spirit of API RP 580
+(risk-based inspection framework). It is **not** a quantitative API RP 581
+implementation: no damage-factor tables, generic failure frequencies, or
+consequence-area models are reproduced here. Every band edge and scaling
+factor is a **practice parameter** with a documented default in
+:class:`RBIParameters` — override them to match an operator's own RBI
+procedure. Defaults are engineering-practice values chosen for screening,
+not values claimed from API 581.
+
+Pipeline (feeds the risk-prioritization phase of a 7-phase RBI cycle):
+
+1. **PoF proxy category (1-5)** from FFS outputs — the most conservative of
+   up to three sub-scores, each banded by parameterized edges:
+
+   * remaining-strength margin ``rsf / rsf_a`` (from the Level-2 FFS result),
+   * remaining-life ratio ``remaining_life / reference planned interval``,
+   * plus a +1 escalation when the corrosion rate exceeds a "high/active
+     corrosion" threshold (trend flag).
+
+2. **CoF category (1-5)** — a direct operator input: consequence class
+   ``A``-``E`` (safety / environment / production descriptors) mapped 1-5.
+   No consequence modelling is attempted here.
+
+3. **Risk matrix** — 5x5 cell ``(PoF, CoF)`` scored ``PoF * CoF`` and banded
+   LOW / MEDIUM / MEDIUM-HIGH / HIGH with a standard symmetric banding
+   (configurable edges).
+
+4. **Interval recommendation** — starts from the validated API 510/570/653
+   half-life interval in :mod:`digitalmodel.asset_integrity.inspection_planning`
+   (reused, not re-implemented) and applies a per-band interval cap. The
+   recommendation therefore never exceeds the half-life rule, the code
+   maximum interval, or the band cap.
+
+The seven RBI programme phases mirrored in workflow output
+(:data:`RBI_PHASES`): define elements -> grouping/baselining -> risk
+prioritization -> plan development -> execution -> results analysis ->
+programme updating (with a periodic, typically <= 5-yr, review). This module
+computes phase 3 and the interval part of phase 4.
+
+:data:`NON_RBI_BASELINE_INTERVALS_YR` carries fixed-calendar baseline
+heuristics (subsea pilot-corpus practice values, shown only as the non-RBI
+comparison row) — rigid riser 2 yr, catenary 3 yr, touchdown zone 5 yr,
+flexibles 3-5 yr.
+
+References: API RP 580 (risk-based inspection — framework only); API 510 /
+570 / 653 half-life interval logic via ``inspection_planning``. Code maximum
+intervals differ by code and component class, so ``code_max_interval_yr`` is
+a parameter (default 10 yr) rather than a hard-coded code citation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from .inspection_planning import InspectionPlan, plan_inspection
+
+# 7-phase RBI programme cycle (workflow framing; see module docstring).
+RBI_PHASES: tuple[str, ...] = (
+    "define elements",
+    "grouping and baselining",
+    "risk prioritization",
+    "plan development",
+    "execution",
+    "results analysis",
+    "programme updating (periodic review)",
+)
+
+# Fixed-calendar (non-RBI) baseline interval heuristics [yr] — practice values
+# from a subsea RBI pilot corpus, for comparison rows only (not code values).
+NON_RBI_BASELINE_INTERVALS_YR: dict[str, tuple[float, float]] = {
+    "rigid_riser": (2.0, 2.0),
+    "catenary_riser": (3.0, 3.0),
+    "touchdown_zone": (5.0, 5.0),
+    "flexible_riser": (3.0, 5.0),
+}
+
+RISK_BANDS: tuple[str, ...] = ("LOW", "MEDIUM", "MEDIUM-HIGH", "HIGH")
+
+_COF_CLASS_TO_CATEGORY: dict[str, int] = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5}
+
+# Operator-facing descriptors for the consequence classes (guidance only).
+COF_CLASS_DESCRIPTORS: dict[str, str] = {
+    "A": "negligible — no injury potential, no release, no production impact",
+    "B": "minor — first-aid level, trivial release, brief production upset",
+    "C": "moderate — recordable injury, reportable release, partial shutdown",
+    "D": "major — serious injury, significant release, extended shutdown",
+    "E": "severe — fatality potential, major release, long-term loss",
+}
+
+
+@dataclass(frozen=True)
+class RBIParameters:
+    """Practice parameters for the qualitative RBI screening.
+
+    All defaults are screening-practice values (documented here, echoed in
+    every result's ``basis``), **not** API 581 table values. Band edges are
+    descending; a value >= edge[i] lands in category ``i + 1``.
+
+    Attributes:
+        rsf_margin_edges: PoF sub-score edges on ``rsf / rsf_a``. Default
+            ``(1.10, 1.05, 1.00, 0.90)`` -> categories 1-5 (below the last
+            edge is category 5). ``rsf/rsf_a >= 1`` is an FFS pass, so
+            category <= 3 means "passes with margin".
+        life_ratio_edges: PoF sub-score edges on
+            ``remaining_life / reference_interval_yr``. Default
+            ``(8.0, 4.0, 2.0, 1.0)`` — a component whose remaining life is
+            below one planned interval is category 5.
+        reference_interval_yr: planned-interval denominator for the life
+            ratio. Default 5.0 yr (typical subsea campaign spacing).
+        high_corrosion_rate_mm_yr: corrosion-rate trend flag threshold;
+            at/above it the PoF category is escalated by +1 (capped at 5).
+            Default 0.25 mm/yr (screening value for "active corrosion").
+        risk_band_edges: 5x5 matrix banding on ``score = PoF * CoF``:
+            LOW <= edges[0] < MEDIUM <= edges[1] < MEDIUM-HIGH <= edges[2]
+            < HIGH. Default ``(4, 9, 15)`` — a standard symmetric banding.
+        band_interval_cap_yr: per-band inspection-interval cap [yr] applied
+            on top of the API 510/570/653 half-life interval. Default
+            LOW 10 / MEDIUM 6 / MEDIUM-HIGH 4 / HIGH 2.
+        code_max_interval_yr: code maximum interval passed to
+            ``inspection_planning.plan_inspection`` (default 10 yr;
+            set per the governing code and component class).
+    """
+
+    rsf_margin_edges: tuple[float, float, float, float] = (1.10, 1.05, 1.00, 0.90)
+    life_ratio_edges: tuple[float, float, float, float] = (8.0, 4.0, 2.0, 1.0)
+    reference_interval_yr: float = 5.0
+    high_corrosion_rate_mm_yr: float = 0.25
+    risk_band_edges: tuple[int, int, int] = (4, 9, 15)
+    band_interval_cap_yr: Mapping[str, float] = field(
+        default_factory=lambda: {
+            "LOW": 10.0,
+            "MEDIUM": 6.0,
+            "MEDIUM-HIGH": 4.0,
+            "HIGH": 2.0,
+        }
+    )
+    code_max_interval_yr: float = 10.0
+
+    def basis_notes(self) -> list[str]:
+        """Every parameter default in play, for the result's ``basis``."""
+        caps = ", ".join(
+            f"{band}={self.band_interval_cap_yr[band]:g} yr" for band in RISK_BANDS
+        )
+        return [
+            "qualitative API RP 580-style screening; practice parameters, "
+            "not API RP 581 table values",
+            f"PoF rsf/rsf_a band edges: {self.rsf_margin_edges}",
+            f"PoF remaining-life ratio band edges: {self.life_ratio_edges} "
+            f"(reference interval {self.reference_interval_yr:g} yr)",
+            "corrosion trend flag: +1 PoF at rate >= "
+            f"{self.high_corrosion_rate_mm_yr:g} mm/yr",
+            f"risk = PoF x CoF banded LOW/MEDIUM/MEDIUM-HIGH/HIGH at "
+            f"{self.risk_band_edges}",
+            f"interval = min(API 510/570/653 half-life interval, band cap): {caps}",
+            f"code maximum interval parameter: {self.code_max_interval_yr:g} yr",
+        ]
+
+
+@dataclass
+class RBIScreeningResult:
+    """Per-component RBI screening record (inputs echoed + parameter basis)."""
+
+    component_id: str
+    pof_category: int
+    cof_category: int
+    cof_class: str
+    risk_score: int
+    risk_band: str
+    recommended_interval_yr: float
+    half_life_interval_yr: Optional[float]
+    code_max_interval_yr: float
+    governing: str  # which limit set the interval
+    pof_subscores: dict[str, Optional[int]]
+    inputs: dict[str, Any]  # every input echoed
+    inspection_plan: Optional[InspectionPlan]
+    basis: list[str]
+    phases: tuple[str, ...] = RBI_PHASES
+
+    def to_dict(self) -> dict:
+        out = asdict(self)
+        out["phases"] = list(self.phases)
+        return out
+
+
+def _band_descending(value: float, edges: Sequence[float]) -> int:
+    """Category 1..len(edges)+1 — value >= edges[i] lands in category i+1."""
+    for i, edge in enumerate(edges):
+        if value >= edge:
+            return i + 1
+    return len(edges) + 1
+
+
+def cof_category(consequence_class: str | int) -> tuple[int, str]:
+    """Map an operator consequence class (A-E or 1-5) to (category, class)."""
+    if isinstance(consequence_class, str):
+        cls = consequence_class.strip().upper()
+        if cls not in _COF_CLASS_TO_CATEGORY:
+            raise ValueError(
+                f"consequence class must be A-E or 1-5, got {consequence_class!r}"
+            )
+        return _COF_CLASS_TO_CATEGORY[cls], cls
+    cat = int(consequence_class)
+    if not 1 <= cat <= 5:
+        raise ValueError(f"consequence category must be 1-5, got {consequence_class!r}")
+    return cat, "ABCDE"[cat - 1]
+
+
+def pof_category(
+    *,
+    rsf: Optional[float] = None,
+    rsf_a: Optional[float] = None,
+    remaining_life_yr: Optional[float] = None,
+    corrosion_rate_mm_yr: Optional[float] = None,
+    params: RBIParameters = RBIParameters(),
+) -> tuple[int, dict[str, Optional[int]]]:
+    """PoF proxy category 1-5 from FFS outputs (most conservative sub-score).
+
+    Returns ``(category, subscores)`` where ``subscores`` records each
+    contribution (``None`` when that input was not supplied). At least one of
+    the strength-margin or remaining-life inputs is required.
+    """
+    subscores: dict[str, Optional[int]] = {
+        "rsf_margin": None,
+        "life_ratio": None,
+        "corrosion_trend_bump": None,
+    }
+
+    if rsf is not None:
+        if rsf_a is None or rsf_a <= 0.0:
+            raise ValueError("rsf_a must be positive when rsf is supplied")
+        subscores["rsf_margin"] = _band_descending(rsf / rsf_a, params.rsf_margin_edges)
+
+    if remaining_life_yr is not None:
+        if params.reference_interval_yr <= 0.0:
+            raise ValueError("reference_interval_yr must be positive")
+        ratio = remaining_life_yr / params.reference_interval_yr
+        subscores["life_ratio"] = _band_descending(ratio, params.life_ratio_edges)
+
+    base_scores = [s for s in (subscores["rsf_margin"], subscores["life_ratio"]) if s]
+    if not base_scores:
+        raise ValueError(
+            "supply rsf (with rsf_a) and/or remaining_life_yr for a PoF category"
+        )
+    category = max(base_scores)
+
+    bump = 0
+    if (
+        corrosion_rate_mm_yr is not None
+        and corrosion_rate_mm_yr >= params.high_corrosion_rate_mm_yr
+    ):
+        bump = 1
+    subscores["corrosion_trend_bump"] = bump
+    return min(5, category + bump), subscores
+
+
+def risk_band(
+    pof: int, cof: int, params: RBIParameters = RBIParameters()
+) -> tuple[int, str]:
+    """5x5 matrix cell -> (score = PoF*CoF, band) with symmetric banding."""
+    if not (1 <= pof <= 5 and 1 <= cof <= 5):
+        raise ValueError(f"PoF and CoF categories must be 1-5, got ({pof}, {cof})")
+    score = pof * cof
+    low, med, med_high = params.risk_band_edges
+    if score <= low:
+        return score, "LOW"
+    if score <= med:
+        return score, "MEDIUM"
+    if score <= med_high:
+        return score, "MEDIUM-HIGH"
+    return score, "HIGH"
+
+
+def recommend_interval(
+    band: str,
+    inspection_plan: InspectionPlan,
+    params: RBIParameters = RBIParameters(),
+) -> tuple[float, str]:
+    """Risk-scaled interval = min(half-life-rule interval, band cap).
+
+    ``inspection_plan.next_inspection_interval_years`` already encodes the
+    API 510/570/653 rule ``min(remaining_life / 2, code_max)`` — this only
+    tightens it by the band cap, so the recommendation can never exceed the
+    half-life interval or the code maximum.
+    """
+    if band not in params.band_interval_cap_yr:
+        raise ValueError(f"unknown risk band {band!r}")
+    cap = float(params.band_interval_cap_yr[band])
+    base = inspection_plan.next_inspection_interval_years
+    interval = min(base, cap)
+    if inspection_plan.screening_status == "fail" and base <= 0.0:
+        return 0.0, "FFS/half-life screening failed — inspect/repair now"
+    if cap < base:
+        return interval, f"risk-band cap governs ({band}: {cap:g} yr)"
+    return interval, "API 510/570/653 half-life / code-max interval governs"
+
+
+def screen_component(
+    component_id: str,
+    consequence_class: str | int,
+    *,
+    current_mm: float,
+    required_mm: float,
+    corrosion_rate_mm_yr: float,
+    rsf: Optional[float] = None,
+    rsf_a: Optional[float] = None,
+    params: RBIParameters = RBIParameters(),
+) -> RBIScreeningResult:
+    """Full screening for one component from FFS-style condition data.
+
+    Reuses :func:`inspection_planning.plan_inspection` for remaining life and
+    the half-life interval, then layers PoF/CoF/risk-band/interval on top.
+    """
+    plan = plan_inspection(
+        current_mm=current_mm,
+        required_mm=required_mm,
+        code_max_interval_years=params.code_max_interval_yr,
+        corrosion_rate=corrosion_rate_mm_yr,
+    )
+    # None remaining life (zero corrosion rate) => effectively unbounded.
+    remaining_life = plan.remaining_life_years
+    life_for_pof = float("inf") if remaining_life is None else remaining_life
+
+    pof, subscores = pof_category(
+        rsf=rsf,
+        rsf_a=rsf_a,
+        remaining_life_yr=life_for_pof,
+        corrosion_rate_mm_yr=corrosion_rate_mm_yr,
+        params=params,
+    )
+    cof, cof_class = cof_category(consequence_class)
+    score, band = risk_band(pof, cof, params)
+    interval, governing = recommend_interval(band, plan, params)
+
+    return RBIScreeningResult(
+        component_id=component_id,
+        pof_category=pof,
+        cof_category=cof,
+        cof_class=cof_class,
+        risk_score=score,
+        risk_band=band,
+        recommended_interval_yr=interval,
+        half_life_interval_yr=plan.half_life_interval_years,
+        code_max_interval_yr=params.code_max_interval_yr,
+        governing=governing,
+        pof_subscores=subscores,
+        inputs={
+            "consequence_class": consequence_class,
+            "current_mm": current_mm,
+            "required_mm": required_mm,
+            "corrosion_rate_mm_yr": corrosion_rate_mm_yr,
+            "rsf": rsf,
+            "rsf_a": rsf_a,
+            "remaining_life_yr": remaining_life,
+        },
+        inspection_plan=plan,
+        basis=params.basis_notes(),
+    )
+
+
+def screen_ffs_result(
+    result: Any,
+    consequence_class: str | int,
+    *,
+    corrosion_rate_in_per_yr: Optional[float] = None,
+    params: RBIParameters = RBIParameters(),
+) -> RBIScreeningResult:
+    """Screen a :class:`~.assessment.ffs_coordinator.FFSAssessmentResult`.
+
+    Uses the coordinator's inch-based fields (converted to mm). When the
+    corrosion rate is not supplied it is back-calculated from the result's
+    ``remaining_life_yr`` so that ``plan_inspection`` reproduces the FFS
+    remaining life exactly (single source, no duplicated half-life logic).
+    """
+    mm = 25.4
+    current_mm = float(result.t_measured_min_in) * mm
+    required_mm = float(result.t_min_in) * mm
+    allowance_mm = current_mm - required_mm
+
+    if corrosion_rate_in_per_yr is not None:
+        rate_mm_yr = float(corrosion_rate_in_per_yr) * mm
+    else:
+        life = float(result.remaining_life_yr)
+        if allowance_mm > 0.0 and life > 0.0 and life != float("inf"):
+            rate_mm_yr = allowance_mm / life
+        else:
+            rate_mm_yr = 0.0 if allowance_mm > 0.0 else 1e-9  # fail path if <= t_min
+
+    return screen_component(
+        component_id=str(result.component_id),
+        consequence_class=consequence_class,
+        current_mm=current_mm,
+        required_mm=required_mm,
+        corrosion_rate_mm_yr=rate_mm_yr,
+        rsf=float(result.rsf),
+        rsf_a=float(result.rsf_a),
+        params=params,
+    )
+
+
+def rbi_rank_register(
+    register_df: pd.DataFrame,
+    *,
+    cof_by_joint: Optional[Mapping[str, str | int]] = None,
+    default_cof: str | int = "C",
+    params: RBIParameters = RBIParameters(),
+) -> pd.DataFrame:
+    """Rank an inspection register (one row per scan) by RBI screening.
+
+    Expects the GML results-register schema: ``component``, ``joint_id``,
+    ``measured_avg_wt_mm``, ``min_required_wt_mm``,
+    ``corrosion_rate_mm_per_year`` (``scan_location`` echoed when present).
+    ``cof_by_joint`` maps joint_id -> consequence class (A-E or 1-5); joints
+    not in the map fall back to ``default_cof``.
+
+    Returns one row per input row with PoF/CoF/risk band/recommended
+    interval, sorted most-critical first (risk score desc, remaining life
+    asc). This is the "risk prioritization" phase-3 feed of the RBI cycle.
+    """
+    cof_by_joint = cof_by_joint or {}
+    rows: list[dict[str, Any]] = []
+    for _, rec in register_df.iterrows():
+        joint = str(rec["joint_id"])
+        res = screen_component(
+            component_id=joint,
+            consequence_class=cof_by_joint.get(joint, default_cof),
+            current_mm=float(rec["measured_avg_wt_mm"]),
+            required_mm=float(rec["min_required_wt_mm"]),
+            corrosion_rate_mm_yr=float(rec["corrosion_rate_mm_per_year"]),
+            params=params,
+        )
+        rows.append(
+            {
+                "component": rec.get("component"),
+                "joint_id": joint,
+                "scan_location": rec.get("scan_location"),
+                "remaining_life_yr": res.inputs["remaining_life_yr"],
+                "corrosion_rate_mm_yr": float(rec["corrosion_rate_mm_per_year"]),
+                "pof_category": res.pof_category,
+                "cof_category": res.cof_category,
+                "cof_class": res.cof_class,
+                "risk_score": res.risk_score,
+                "risk_band": res.risk_band,
+                "half_life_interval_yr": res.half_life_interval_yr,
+                "recommended_interval_yr": res.recommended_interval_yr,
+                "governing": res.governing,
+            }
+        )
+    out = pd.DataFrame(rows)
+    return out.sort_values(
+        ["risk_score", "remaining_life_yr"],
+        ascending=[False, True],
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+
+def summarize_ranking(ranked_df: pd.DataFrame) -> dict[str, Any]:
+    """Counts per risk band + programme-level rollup (phase-3 output).
+
+    Returns band counts (all four bands always present), PoF distribution,
+    the fleet-minimum recommended interval, and the 7-phase framing so the
+    summary drops straight into an RBI programme document.
+    """
+    band_counts = {band: 0 for band in RISK_BANDS}
+    for band, n in ranked_df["risk_band"].value_counts().items():
+        band_counts[str(band)] = int(n)
+    pof_counts = {
+        int(k): int(v)
+        for k, v in sorted(ranked_df["pof_category"].value_counts().items())
+    }
+    return {
+        "n_rows": int(len(ranked_df)),
+        "band_counts": band_counts,
+        "pof_counts": pof_counts,
+        "min_recommended_interval_yr": float(
+            ranked_df["recommended_interval_yr"].min()
+        ),
+        "max_risk_score": int(ranked_df["risk_score"].max()),
+        "most_critical": ranked_df.iloc[0][["joint_id", "risk_band"]].to_dict(),
+        "rbi_phases": list(RBI_PHASES),
+        "phase": "risk prioritization",
+    }

--- a/tests/asset_integrity/test_rbi_screening.py
+++ b/tests/asset_integrity/test_rbi_screening.py
@@ -1,0 +1,325 @@
+# ABOUTME: Tests for the qualitative API 580-style RBI screening layer —
+# ABOUTME: PoF bands, risk matrix, risk-scaled intervals, real-register ranking.
+"""RBI screening tests (issue #1272).
+
+Covers band-edge behaviour, monotonicity (worse condition -> higher PoF ->
+higher risk -> shorter interval), 5x5 matrix corners, interval guardrails
+(never exceeds the half-life rule nor the code maximum), and an integration
+run over the real anonymized GML results register (regression-anchored).
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from digitalmodel.asset_integrity.assessment.ffs_coordinator import (
+    FFSAssessmentResult,
+)
+from digitalmodel.asset_integrity.inspection_planning import plan_inspection
+from digitalmodel.asset_integrity.rbi_screening import (
+    NON_RBI_BASELINE_INTERVALS_YR,
+    RBI_PHASES,
+    RBIParameters,
+    RBIScreeningResult,
+    cof_category,
+    pof_category,
+    rbi_rank_register,
+    recommend_interval,
+    risk_band,
+    screen_component,
+    screen_ffs_result,
+    summarize_ranking,
+)
+
+DATA = Path(__file__).parent / "test_data" / "real_inspection"
+PARAMS = RBIParameters()
+
+# REGRESSION-ANCHOR: RBI screening of the real GML results register (142 scans)
+# with default practice parameters and default consequence class "C".
+# Update deliberately only (parameter or register changes).
+ANCHOR_BAND_COUNTS_C = {"LOW": 18, "MEDIUM": 79, "MEDIUM-HIGH": 45, "HIGH": 0}
+ANCHOR_POF_COUNTS = {1: 18, 2: 66, 3: 13, 4: 36, 5: 9}
+ANCHOR_MIN_INTERVAL_YR = 1.4528  # half-life of the shortest-life scan (RJ-127)
+
+
+# ---------------------------------------------------------------- CoF mapping
+def test_cof_class_letters_map_1_to_5():
+    assert [cof_category(c)[0] for c in "ABCDE"] == [1, 2, 3, 4, 5]
+    assert cof_category("c") == (3, "C")  # case-insensitive
+
+
+def test_cof_integer_passthrough_and_validation():
+    assert cof_category(4) == (4, "D")
+    with pytest.raises(ValueError):
+        cof_category("F")
+    with pytest.raises(ValueError):
+        cof_category(0)
+    with pytest.raises(ValueError):
+        cof_category(6)
+
+
+# ------------------------------------------------------------------ PoF bands
+def test_pof_rsf_margin_band_edges():
+    """Values exactly at an edge land in the better (lower) category."""
+    rsf_a = 0.90
+    expected = {1.10: 1, 1.05: 2, 1.00: 3, 0.90: 4, 0.899: 5}
+    for margin, cat in expected.items():
+        got, _ = pof_category(rsf=margin * rsf_a, rsf_a=rsf_a, params=PARAMS)
+        assert got == cat, f"margin {margin} -> {got}, expected {cat}"
+
+
+def test_pof_life_ratio_band_edges():
+    """Default reference interval 5 yr => life edges 40/20/10/5 yr."""
+    expected = {40.0: 1, 20.0: 2, 10.0: 3, 5.0: 4, 4.99: 5}
+    for life, cat in expected.items():
+        got, _ = pof_category(remaining_life_yr=life, params=PARAMS)
+        assert got == cat, f"life {life} -> {got}, expected {cat}"
+
+
+def test_pof_takes_most_conservative_subscore():
+    # good margin, poor life -> life governs
+    cat, subs = pof_category(rsf=1.0, rsf_a=0.9, remaining_life_yr=3.0, params=PARAMS)
+    assert subs["rsf_margin"] == 1 and subs["life_ratio"] == 5
+    assert cat == 5
+
+
+def test_pof_corrosion_trend_bump_threshold_and_cap():
+    base, _ = pof_category(remaining_life_yr=50.0, corrosion_rate_mm_yr=0.24)
+    bumped, subs = pof_category(remaining_life_yr=50.0, corrosion_rate_mm_yr=0.25)
+    assert base == 1 and bumped == 2 and subs["corrosion_trend_bump"] == 1
+    capped, _ = pof_category(remaining_life_yr=1.0, corrosion_rate_mm_yr=0.5)
+    assert capped == 5  # bump never exceeds category 5
+
+
+def test_pof_requires_at_least_one_condition_input():
+    with pytest.raises(ValueError):
+        pof_category(corrosion_rate_mm_yr=0.1)
+    with pytest.raises(ValueError):
+        pof_category(rsf=0.95, rsf_a=None)
+
+
+def test_pof_monotonic_in_rsf_and_life():
+    rsf_grid = [1.0, 0.98, 0.95, 0.92, 0.88, 0.80]
+    cats = [pof_category(rsf=r, rsf_a=0.9)[0] for r in rsf_grid]
+    assert cats == sorted(cats)  # lower RSF -> PoF never decreases
+    life_grid = [100.0, 45.0, 25.0, 12.0, 6.0, 2.0]
+    cats = [pof_category(remaining_life_yr=y)[0] for y in life_grid]
+    assert cats == sorted(cats)  # shorter life -> PoF never decreases
+
+
+# ---------------------------------------------------------------- risk matrix
+def test_matrix_corners_and_center():
+    assert risk_band(1, 1) == (1, "LOW")
+    assert risk_band(5, 5) == (25, "HIGH")
+    assert risk_band(1, 5) == (5, "MEDIUM")
+    assert risk_band(5, 1) == (5, "MEDIUM")
+    assert risk_band(3, 3) == (9, "MEDIUM")
+    assert risk_band(4, 4) == (16, "HIGH")
+    assert risk_band(2, 5) == (10, "MEDIUM-HIGH")
+    assert risk_band(5, 3) == (15, "MEDIUM-HIGH")
+
+
+def test_matrix_symmetric_and_monotonic_in_cof():
+    for p in range(1, 6):
+        for c in range(1, 6):
+            assert risk_band(p, c) == risk_band(c, p)  # symmetric banding
+        scores = [risk_band(p, c)[0] for c in range(1, 6)]
+        assert scores == sorted(scores)  # higher CoF -> risk never decreases
+
+
+def test_matrix_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        risk_band(0, 3)
+    with pytest.raises(ValueError):
+        risk_band(3, 6)
+
+
+# --------------------------------------------------------------- intervals
+def _plan(current=22.0, required=19.0, rate=0.15, code_max=10.0):
+    return plan_inspection(
+        current_mm=current,
+        required_mm=required,
+        code_max_interval_years=code_max,
+        corrosion_rate=rate,
+    )
+
+
+def test_interval_scaled_down_by_risk_band():
+    plan = _plan()  # remaining life 20 yr -> half-life 10 yr -> code max 10 yr
+    intervals = [recommend_interval(b, plan)[0] for b in
+                 ("LOW", "MEDIUM", "MEDIUM-HIGH", "HIGH")]
+    assert intervals == [10.0, 6.0, 4.0, 2.0]
+    assert intervals == sorted(intervals, reverse=True)  # higher risk -> shorter
+
+
+def test_interval_never_exceeds_half_life_nor_code_max():
+    for rate in (0.05, 0.15, 0.4, 1.0):
+        plan = _plan(rate=rate)
+        for band in ("LOW", "MEDIUM", "MEDIUM-HIGH", "HIGH"):
+            interval, _ = recommend_interval(band, plan)
+            assert interval <= plan.next_inspection_interval_years
+            assert interval <= plan.code_max_interval_years
+            if plan.half_life_interval_years is not None:
+                assert interval <= plan.half_life_interval_years
+
+
+def test_interval_half_life_governs_when_shorter_than_band_cap():
+    plan = _plan(rate=1.0)  # remaining life 3 yr -> half-life 1.5 yr
+    interval, governing = recommend_interval("HIGH", plan)
+    assert interval == pytest.approx(1.5)
+    assert "half-life" in governing
+
+
+def test_interval_zero_on_failed_screening():
+    plan = _plan(current=19.0, required=19.33)  # at/below t_min
+    interval, governing = recommend_interval("LOW", plan)
+    assert interval == 0.0
+    assert "now" in governing
+
+
+# --------------------------------------------------------- component screening
+def test_screen_component_end_to_end_high_risk():
+    res = screen_component(
+        "J-1", "E", current_mm=20.2, required_mm=19.33, corrosion_rate_mm_yr=0.253
+    )
+    assert isinstance(res, RBIScreeningResult)
+    assert res.pof_category == 5 and res.cof_category == 5
+    assert res.risk_band == "HIGH"
+    # half-life (~1.72 yr) is shorter than the 2-yr HIGH cap
+    assert res.recommended_interval_yr == pytest.approx(0.87 / 0.253 / 2.0, rel=1e-6)
+    assert res.recommended_interval_yr <= 2.0
+    assert res.inputs["consequence_class"] == "E"
+    assert res.basis and any("API RP 581" in note for note in res.basis)
+    assert res.phases == RBI_PHASES
+    assert res.to_dict()["risk_band"] == "HIGH"
+
+
+def test_screen_component_low_risk_allows_code_max():
+    res = screen_component(
+        "J-2", "A", current_mm=25.0, required_mm=19.33, corrosion_rate_mm_yr=0.05
+    )
+    assert res.risk_band == "LOW"
+    assert res.recommended_interval_yr == PARAMS.code_max_interval_yr
+
+
+def test_screen_component_zero_corrosion_rate():
+    res = screen_component(
+        "J-3", "B", current_mm=25.0, required_mm=19.33, corrosion_rate_mm_yr=0.0
+    )
+    assert res.pof_category == 1
+    assert res.inputs["remaining_life_yr"] is None  # not corroding
+    assert res.recommended_interval_yr == PARAMS.code_max_interval_yr
+
+
+def test_screen_component_monotonic_interval_vs_cof():
+    intervals = []
+    for cls in "ABCDE":
+        res = screen_component(
+            "J", cls, current_mm=21.0, required_mm=19.33, corrosion_rate_mm_yr=0.1
+        )
+        intervals.append(res.recommended_interval_yr)
+    assert intervals == sorted(intervals, reverse=True)
+
+
+# ------------------------------------------------------------ FFS result hook
+def _ffs_result(**over):
+    base = dict(
+        component_id="FFS-1",
+        assessment_type="GML",
+        level_reached=2,
+        t_nominal_in=0.875,
+        t_min_in=0.761,
+        t_measured_min_in=0.820,
+        t_measured_avg_in=0.845,
+        fca_in=0.0,
+        rsf=0.96,
+        rsf_a=0.90,
+        folias_factor=1.1,
+        remaining_life_yr=15.0,
+        verdict="ACCEPT",
+        rerated_pressure_psi=1480.0,
+        sufficiency_status="SUFFICIENT",
+    )
+    base.update(over)
+    return FFSAssessmentResult(**base)
+
+
+def test_screen_ffs_result_reproduces_remaining_life():
+    res = screen_ffs_result(_ffs_result(), "C")
+    assert res.inputs["remaining_life_yr"] == pytest.approx(15.0)
+    assert res.inputs["rsf"] == pytest.approx(0.96)
+    assert res.pof_category == 3  # life ratio 15/5 = 3 -> band edge 2.0
+    assert res.risk_score == 9 and res.risk_band == "MEDIUM"
+
+
+def test_screen_ffs_result_low_rsf_raises_pof():
+    ok = screen_ffs_result(_ffs_result(), "C")
+    bad = screen_ffs_result(_ffs_result(rsf=0.78), "C")
+    assert bad.pof_category > ok.pof_category
+    assert bad.risk_score > ok.risk_score
+    assert bad.recommended_interval_yr <= ok.recommended_interval_yr
+
+
+def test_screen_ffs_result_explicit_rate_overrides():
+    res = screen_ffs_result(_ffs_result(), "C", corrosion_rate_in_per_yr=0.002)
+    assert res.inputs["corrosion_rate_mm_yr"] == pytest.approx(0.002 * 25.4)
+
+
+# --------------------------------------------------- register integration
+@pytest.fixture(scope="module")
+def register():
+    return pd.read_csv(DATA / "gml_results_register.csv")
+
+
+def test_register_ranking_regression_anchor(register):
+    ranked = rbi_rank_register(register)
+    assert len(ranked) == 142
+    summary = summarize_ranking(ranked)
+    # REGRESSION-ANCHOR: band counts on the real register with default
+    # parameters and default CoF class "C". Update deliberately only.
+    assert summary["band_counts"] == ANCHOR_BAND_COUNTS_C
+    assert summary["pof_counts"] == ANCHOR_POF_COUNTS
+    assert summary["n_rows"] == 142
+    assert summary["min_recommended_interval_yr"] == pytest.approx(
+        ANCHOR_MIN_INTERVAL_YR, abs=1e-4
+    )
+    assert summary["phase"] == "risk prioritization"
+    assert summary["rbi_phases"] == list(RBI_PHASES)
+
+
+def test_register_ranking_sorted_most_critical_first(register):
+    ranked = rbi_rank_register(register)
+    scores = ranked["risk_score"].tolist()
+    assert scores == sorted(scores, reverse=True)
+    # the shortest-life joint (RJ-101 box end, ~3.5 yr) ranks in the top rows
+    assert "RJ-101" in ranked.head(3)["joint_id"].tolist()
+
+
+def test_register_intervals_bounded_by_half_life_and_code_max(register):
+    ranked = rbi_rank_register(register)
+    assert (ranked["recommended_interval_yr"] <= PARAMS.code_max_interval_yr).all()
+    assert (
+        ranked["recommended_interval_yr"] <= ranked["half_life_interval_yr"] + 1e-12
+    ).all()
+    assert (ranked["recommended_interval_yr"] > 0.0).all()  # register all passes
+
+
+def test_register_cof_overrides_shift_bands(register):
+    low = summarize_ranking(rbi_rank_register(register, default_cof="A"))
+    high = summarize_ranking(rbi_rank_register(register, default_cof="E"))
+    assert low["band_counts"]["HIGH"] == 0
+    assert high["band_counts"]["HIGH"] >= 1
+    assert high["min_recommended_interval_yr"] <= low["min_recommended_interval_yr"]
+    # per-joint override: bump one joint to class E, its rows move up
+    ranked = rbi_rank_register(register, cof_by_joint={"RJ-103": "E"})
+    rj103 = ranked[ranked["joint_id"] == "RJ-103"]
+    assert (rj103["cof_category"] == 5).all()
+
+
+def test_baseline_heuristics_constant_shape():
+    assert set(NON_RBI_BASELINE_INTERVALS_YR) == {
+        "rigid_riser", "catenary_riser", "touchdown_zone", "flexible_riser"
+    }
+    for lo, hi in NON_RBI_BASELINE_INTERVALS_YR.values():
+        assert 0 < lo <= hi <= 5.0


### PR DESCRIPTION
Qualitative risk-based-inspection screening layer over FFS outputs (API RP 580 framework — **not** a quantitative API 581 implementation).

- **PoF proxy category (1–5)** = most conservative of `rsf/rsf_a` margin, remaining-life ratio, and a +1 corrosion-trend bump.
- **CoF category (1–5)** = operator consequence class A–E (no consequence modelling claimed).
- **5×5 risk matrix** scored `PoF × CoF`, banded LOW/MEDIUM/MEDIUM-HIGH/HIGH.
- **Interval** = `min(API 510/570/653 half-life interval, risk-band cap)` — reuses `inspection_planning.plan_inspection`, never exceeds the half-life rule or code max.
- Register-ranking helper feeds the RBI cycle's phase-3 prioritization.

All band edges/caps are documented practice parameters (`RBIParameters`), echoed in every result's `basis` — no API 581 table values transcribed. No new src package (lives in existing `asset_integrity/`), so no routing-contract change.

27 tests. No client/operator/rig/well names.

Closes #1272