### PR TITLE
fix(ci): exempt known-clone llm-wiki fallback path in drilling_riser golden test (#1277)

### DIFF
--- a/tests/drilling_riser/test_assembly_golden.py
+++ b/tests/drilling_riser/test_assembly_golden.py
@@ -23,7 +23,7 @@ from digitalmodel.drilling_riser.assembly import (
 
 REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
 _KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
     Path.home() / "workspace-hub" / "llm-wiki",
 )
 


### PR DESCRIPTION
**Baseline-red cleanup.** On main HEAD (`7f6fe5bad`) the `Check no developer-machine absolute paths` gate fails on a single line:

```
tests/drilling_riser/test_assembly_golden.py:26:  Path("/mnt/local-analysis/llm-wiki"),
```

This is a **known-clone fallback path** — one of a tuple of llm-wiki clone locations, paired with a relative `Path.home()/workspace-hub/llm-wiki` alternative on the next line. It is exactly the case the enforcement script's `# abs-path-allowed` trailing exemption exists for.

Because this step fails, `Run Quality Gates` is skipped and both **Quality Gates** and **Deploy Docs to Pages** go red repo-wide (blocking every PR's gate and the docs deploy). One-line exemption restores green.

Unblocks the FFS build-wave PRs (#1326/#1327/#1328/#1340/#1341/#1342) and the Pages deploy.

Refs #1277