### PR TITLE
drilling_riser: operating-envelope analytical tier (#1281a)

### DIFF
--- a/docs/riser_database.md
+++ b/docs/riser_database.md
@@ -102,6 +102,10 @@ attach the output to the PR as evidence.
   `stackup.py` attribution comments (1.25 has no 16Q provision), and wired
   `riser_fatigue/workflow.py` DFF through `resolve_dff()`.
 * **#1247** — orcaflex riser citation surface (net-new; no parity baseline).
+* **#1281a** — *done*: operating-envelope analytical tier (beam-column response
+  model + sweep engine + von-Mises / flex-joint getters). See the
+  operating-envelope section below. **#1281b** (AMJIG + WH-moment + data
+  columns) and **#1281c** (solver-backed tier stub) follow.
 * **#1199d** (T3, frontier-gated) — de-identified ACE result precedent,
   `private_sidecar` route; extends the leak gate to those rows.
 * Future numeric response-surface atlases (metocean, VIV) live under
@@ -152,3 +156,37 @@ golden asserts the chain against the RSU-0007 calc contract (machine-readable
 YAML on the private registry page — keys public, values wiki-side; tolerance
 abs ≤ 0.5 t / rel ≤ 0.15%, an order of magnitude tighter than any
 formula-omission error).
+
+## Operating-envelope engine (#1281a, epic #1279 child C)
+
+Two-tier, split into grandchild slices C1/C2/C3.
+
+**C1 (this slice) — analytical screening tier.**
+`drilling_riser/riser_response.py` solves the static tensioned beam-column BVP
+`EI y'''' − T y'' = w(z)` (pinned flex-joint ends, top offset BC, uniform
+current-drag load) in stable closed form → deflection, flex-joint angles, and
+the bending moment `M(z)`. Provenance is standard tensioned-beam / beam-column
+marine-riser mechanics (NOT any licensed project material); it is a **static
+screening** model with no dynamic amplification.
+
+`drilling_riser/envelope.py` (`compute_operating_envelope`) sweeps
+**offset × current × seastate** and evaluates four limits — flex-joint angle,
+von Mises utilisation, tensioner/TJ stroke, moonpool clearance. Offset and
+current move the responses through the beam-column model (the von Mises check
+feeds `orcaflex.code_check_engine.check_api_rp_2rd` the model's `M(z)`, so it is
+bending-aware); seastate enters via a linear RAO motion contribution. The
+operating mode (`OperatingMode` drilling / connected / hang-off) selects the
+active limit set via `envelope_modes.yml`.
+
+Criteria are fail-closed cited getters: flex-joint angle limits (mean 2° / max
+4°) cite **API RP 16Q**; the von Mises design factor (0.67) cites **API STD
+2RD** — both resolve against existing wiki pages (no paired wiki PR). Stroke
+margin and moonpool clearance are **uncited project defaults** (no public
+standards provision identified — the Barlow / top-tension-SF precedent). No new
+public data columns, so the leak surface is unchanged.
+
+**Deferred:** the wellhead/conductor-moment limit (needs a net-new rig data
+column) and the AMJIG per-category extreme/survival criteria (licensed) are
+**#1281b**; the OrcaFlex-backed dynamic tier (dynamic per-seastate envelope,
+drift-off, recoil, VIV) is stubbed via `parametric.library` in **#1281c**.
+Standard selection (16Q vs AMJIG) is a query-time *threshold*, not a sweep axis.

--- a/src/digitalmodel/drilling_riser/envelope.py
+++ b/src/digitalmodel/drilling_riser/envelope.py
@@ -1,0 +1,268 @@
+"""Drilling riser operating-envelope engine — analytical screening tier (#1281a).
+
+Sweeps vessel offset x surface current x seastate for an assembled, rig-specific
+riser string and evaluates each response against its operating limit, producing
+an allowable-region (envelope) surface. Child C of epic #1279.
+
+Responses (all move with the sweep — the anti-degeneracy requirement):
+  * flex-joint angle   — static beam-column angle (offset + current) plus an
+    RAO motion contribution (seastate Hs);
+  * von Mises utilisation — API STD 2RD combined tension+bending check fed the
+    beam-column bending moment M(z) (so it responds to offset/current);
+  * tensioner / TJ stroke — geometric setdown(offset) + RAO heave(Hs);
+  * moonpool clearance — vessel excursion vs the moonpool half-dimension.
+
+Criteria: flex-joint angle limits (API RP 16Q) and the von Mises design factor
+(API STD 2RD) resolve fail-closed through cited getters
+(:mod:`digitalmodel.riser_database.getters`). Stroke margin and moonpool
+clearance are UNCITED project defaults (no corresponding public standards
+provision identified — the Barlow / top-tension-SF precedent).
+
+This is the ANALYTICAL tier: static tensioned beam-column response + a linear
+RAO seastate contribution. Dynamic amplification, drift-off, recoil and VIV are
+the solver tier (#1281c). Wellhead/conductor-moment limits need a net-new data
+column and land in #1281b. SI internally.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+import yaml
+
+from digitalmodel.drilling_riser.operability import watch_circle_radius_m
+from digitalmodel.drilling_riser.riser_response import solve_static_response
+from digitalmodel.orcaflex.code_check_engine import APIRP2RDInput, check_api_rp_2rd
+
+#: Externalized mode -> active-limit mapping (externalize-config rule).
+_MODE_CONFIG_PATH = Path(__file__).with_name("envelope_modes.yml")
+
+
+@lru_cache(maxsize=1)
+def _mode_active_limits() -> dict:
+    cfg = yaml.safe_load(_MODE_CONFIG_PATH.read_text(encoding="utf-8"))
+    return {m: set(v["active_limits"]) for m, v in cfg["modes"].items()}
+
+#: Uncited project defaults (no public standards provision identified).
+DEFAULT_MOONPOOL_CLEARANCE_MARGIN_M: float = 0.5
+#: Public hydrodynamic-coefficient values (AMJIG sub-critical Cd; seawater rho).
+_DRAG_COEFFICIENT: float = 1.2
+_SEAWATER_DENSITY_KG_M3: float = 1025.0
+
+
+class OperatingMode(str, Enum):
+    """Riser operating mode; selects the active criteria set."""
+
+    DRILLING = "drilling"
+    CONNECTED = "connected"  # connected non-drilling / extreme
+    HANG_OFF = "hang_off"
+
+
+@dataclass(frozen=True)
+class SeaState:
+    hs_m: float
+    tp_s: float
+
+
+@dataclass(frozen=True)
+class CurrentProfile:
+    """Minimal current input for the sweep. #1282 refines to a depth profile."""
+
+    surface_speed_mps: float
+    profile: str = "uniform"
+
+    def drag_load_n_per_m(self, diameter_m: float) -> float:
+        """Uniform static drag per unit length: w = 1/2 rho Cd D U^2 (SI)."""
+        return (
+            0.5
+            * _SEAWATER_DENSITY_KG_M3
+            * _DRAG_COEFFICIENT
+            * diameter_m
+            * self.surface_speed_mps**2
+        )
+
+
+@dataclass(frozen=True)
+class RiserSection:
+    outer_diameter_m: float
+    wall_thickness_m: float
+    youngs_modulus_pa: float = 2.07e11
+    smys_pa: float = 4.48e8
+
+    @property
+    def inner_diameter_m(self) -> float:
+        return self.outer_diameter_m - 2.0 * self.wall_thickness_m
+
+    @property
+    def second_moment_m4(self) -> float:
+        return math.pi / 64.0 * (self.outer_diameter_m**4 - self.inner_diameter_m**4)
+
+    @property
+    def ei_nm2(self) -> float:
+        return self.youngs_modulus_pa * self.second_moment_m4
+
+
+@dataclass(frozen=True)
+class RigEnvelopeLimits:
+    """Rig capability that bounds the envelope (from rig_riser_interface data)."""
+
+    tj_stroke_m: Optional[float] = None
+    tensioner_stroke_m: Optional[float] = None
+    moonpool_half_min_m: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class EnvelopeCriteria:
+    flexjoint_angle_mean_deg: float
+    flexjoint_angle_max_deg: float
+    von_mises_design_factor: float
+
+
+@dataclass(frozen=True)
+class EnvelopeResult:
+    """Envelope surface over (offset, current, seastate) for one mode.
+
+    ``per_limit_utilisation`` maps a limit name to an array of shape
+    ``(n_offset, n_current, n_seastate)``; NaN marks a limit with no data
+    (excluded from governing/allowable). ``allowable_mask`` is True where every
+    evaluated limit is within its allowable.
+    """
+
+    mode: OperatingMode
+    offsets_pct: np.ndarray
+    current_speeds_mps: np.ndarray
+    seastates: tuple
+    per_limit_utilisation: dict
+    governing_limit: np.ndarray
+    allowable_mask: np.ndarray
+
+    @property
+    def operable_fraction(self) -> float:
+        return float(self.allowable_mask.mean())
+
+
+def resolve_envelope_criteria(
+    mode: OperatingMode = OperatingMode.DRILLING, *, repo_root=None
+) -> EnvelopeCriteria:
+    """Resolve the cited criteria (fail-closed) for a mode.
+
+    Flex-joint angle limits cite API RP 16Q; the von Mises design factor cites
+    API STD 2RD. Raises ``CitationResolutionError`` if the wiki does not resolve.
+    (The mode currently selects the same 16Q/2RD criteria set; per-category /
+    AMJIG divergence is #1281b.)
+    """
+    from digitalmodel.riser_database.getters import (
+        get_flexjoint_angle_limit,
+        get_von_mises_design_factor,
+    )
+
+    return EnvelopeCriteria(
+        flexjoint_angle_mean_deg=get_flexjoint_angle_limit("mean", repo_root=repo_root).value,
+        flexjoint_angle_max_deg=get_flexjoint_angle_limit("max", repo_root=repo_root).value,
+        von_mises_design_factor=get_von_mises_design_factor(repo_root=repo_root).value,
+    )
+
+
+def _von_mises_utilisation(
+    section: RiserSection,
+    response,
+    tension_n: float,
+    design_factor: float,
+) -> float:
+    pipe = APIRP2RDInput(
+        outer_diameter=section.outer_diameter_m,
+        wall_thickness=section.wall_thickness_m,
+        smys=section.smys_pa,
+        design_factor=design_factor,
+    )
+    n = response.z_m.size
+    tensions_kn = np.full(n, tension_n / 1000.0)   # constant screening tension
+    moments_knm = response.bending_moment_nm / 1000.0
+    results = check_api_rp_2rd(pipe, response.z_m, tensions_kn, moments_knm)
+    return max(r.utilisation for r in results)
+
+
+def compute_operating_envelope(
+    *,
+    section: RiserSection,
+    water_depth_m: float,
+    length_m: float,
+    tension_n: float,
+    criteria: EnvelopeCriteria,
+    offsets_pct: Sequence[float],
+    current_speeds_mps: Sequence[float],
+    seastates: Sequence[SeaState],
+    rig_limits: Optional[RigEnvelopeLimits] = None,
+    rao_angle_deg_per_m: float = 0.0,
+    rao_heave_m_per_m: float = 0.0,
+    mode: OperatingMode = OperatingMode.DRILLING,
+) -> EnvelopeResult:
+    """Sweep offset x current x seastate → envelope surface. See module docstring."""
+    rig_limits = rig_limits or RigEnvelopeLimits()
+    offsets = np.asarray(offsets_pct, dtype=float)
+    currents = np.asarray(current_speeds_mps, dtype=float)
+    seas = tuple(seastates)
+    shape = (offsets.size, currents.size, len(seas))
+
+    util = {k: np.full(shape, np.nan) for k in ("flexjoint_angle", "von_mises", "stroke", "moonpool")}
+    diameter = section.outer_diameter_m
+
+    for i, off_pct in enumerate(offsets):
+        x_offset = watch_circle_radius_m(float(off_pct), water_depth_m)
+        setdown = x_offset**2 / (2.0 * length_m)
+        for j, u in enumerate(currents):
+            w = CurrentProfile(float(u)).drag_load_n_per_m(diameter)
+            resp = solve_static_response(
+                length_m=length_m,
+                top_offset_m=x_offset,
+                tension_n=tension_n,
+                ei_nm2=section.ei_nm2,
+                current_load_n_per_m=w,
+            )
+            static_angle_deg = max(abs(resp.angle_lower_deg), abs(resp.angle_upper_deg))
+            vm = _von_mises_utilisation(section, resp, tension_n, criteria.von_mises_design_factor)
+            for k, sea in enumerate(seas):
+                dyn_angle = rao_angle_deg_per_m * sea.hs_m
+                total_angle = static_angle_deg + dyn_angle
+                # governing of the mean-limit (static) and max-limit (total) checks
+                util["flexjoint_angle"][i, j, k] = max(
+                    static_angle_deg / criteria.flexjoint_angle_mean_deg,
+                    total_angle / criteria.flexjoint_angle_max_deg,
+                )
+                util["von_mises"][i, j, k] = vm
+                heave = rao_heave_m_per_m * sea.hs_m
+                stroke_avail = rig_limits.tj_stroke_m or rig_limits.tensioner_stroke_m
+                if stroke_avail:
+                    util["stroke"][i, j, k] = (setdown + heave) / stroke_avail
+                if rig_limits.moonpool_half_min_m:
+                    allow = rig_limits.moonpool_half_min_m - DEFAULT_MOONPOOL_CLEARANCE_MARGIN_M
+                    util["moonpool"][i, j, k] = x_offset / allow if allow > 0 else np.inf
+
+    # Apply the mode's active-limit set: limits not gating this mode -> NaN
+    # (excluded from governing/allowable), per envelope_modes.yml.
+    active = _mode_active_limits().get(mode.value, set(util.keys()))
+    for k in list(util):
+        if k not in active:
+            util[k][:] = np.nan
+
+    stacked_names = list(util.keys())
+    stacked = np.stack([util[k] for k in stacked_names], axis=-1)  # (..., n_limits)
+    with np.errstate(invalid="ignore"):
+        gov_idx = np.nanargmax(np.where(np.isnan(stacked), -np.inf, stacked), axis=-1)
+        governing = np.array(stacked_names, dtype=object)[gov_idx]
+        allowable = np.nanmax(np.where(np.isnan(stacked), -np.inf, stacked), axis=-1) <= 1.0
+
+    return EnvelopeResult(
+        mode=mode,
+        offsets_pct=offsets,
+        current_speeds_mps=currents,
+        seastates=seas,
+        per_limit_utilisation=util,
+        governing_limit=governing,
+        allowable_mask=allowable,
+    )

--- a/src/digitalmodel/drilling_riser/envelope_modes.yml
+++ b/src/digitalmodel/drilling_riser/envelope_modes.yml
@@ -1,0 +1,22 @@
+# Operating-mode -> active envelope-limit set (#1281a, epic #1279 child C).
+#
+# This file selects WHICH limits gate each operating mode. The criteria VALUES
+# are NOT here — they resolve through cited getters (riser_database.getters:
+# flex-joint angle -> API RP 16Q, von Mises design factor -> API STD 2RD).
+# Only the API RP 16Q / API STD 2RD criteria set is wired in C1; the AMJIG
+# per-category (extreme/survival) divergence lands in #1281b.
+#
+# Limit names must match the keys produced by
+# drilling_riser.envelope.compute_operating_envelope.
+modes:
+  drilling:
+    # connected + drilling: the full operating limit set applies
+    active_limits: [flexjoint_angle, von_mises, stroke, moonpool]
+  connected:
+    # connected non-drilling / extreme: same physical limits, criteria escalate
+    # (per-category ceilings are #1281b)
+    active_limits: [flexjoint_angle, von_mises, stroke, moonpool]
+  hang_off:
+    # riser disconnected from the well and hung off: flex-joint angle and
+    # moonpool clearance are not the governing gates; tension/stroke dominate
+    active_limits: [von_mises, stroke]

--- a/src/digitalmodel/drilling_riser/riser_response.py
+++ b/src/digitalmodel/drilling_riser/riser_response.py
@@ -1,0 +1,130 @@
+"""Static tensioned beam-column riser response — analytical screening tier (#1281a).
+
+Solves the tensioned beam-column boundary-value problem
+
+    EI y'''' - T y'' = w        (SI: y[m], z[m], T[N], EI[N.m^2], w[N/m])
+
+for a top-tensioned drilling riser under a static vessel offset and a uniform
+current-drag load, yielding the deflected shape, the flex-joint angles (slopes
+at the ends) and the bending-moment distribution ``M(z) = EI y''(z)``.
+
+``z`` runs 0 (lower flex-joint, at the wellhead/BOP) to L (upper flex-joint, at
+the vessel). Flex-joints transmit ~no moment, so the boundary conditions are
+pinned (``M=0``) at both ends with ``y(0)=0`` and ``y(L)=offset`` (the vessel
+watch-circle radius).
+
+This is a STATIC SCREENING model: constant effective tension, uniform current
+load, no dynamic amplification / VIV / vessel-motion dynamics — those require
+the solver tier (#1281c). Provenance: standard tensioned-beam / beam-column
+marine-riser mechanics (e.g. Sparks, *Fundamentals of Marine Riser Mechanics*),
+NOT any licensed project material.
+
+Closed-form solution (stable exponential form, avoiding the cosh/sinh
+cancellation that blows up at the large ``kL`` of a real riser):
+
+    k = sqrt(T/EI),  C = EI w / T^2,  eps = exp(-kL),  P = Q = C/(1+eps)
+    y(z) = -C + B z - w z^2/(2T) + P e^{-kz} + Q e^{-k(L-z)},  B = X/L + wL/(2T)
+    M(z) = -EI w/T + T P e^{-kz} + T Q e^{-k(L-z)}
+
+Sanity: pure offset (w=0) -> rigid tilt y=Xz/L, both angles X/L, zero moment;
+pure current -> lower-joint angle ~ wL/(2T) with a small -w/(kT) beam
+correction, and a nonzero interior moment.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class RiserResponse:
+    """Result of :func:`solve_static_response` (SI units).
+
+    ``angle_*`` are the flex-joint rotations (slopes) at the ends, radians,
+    signed; ``bending_moment_nm`` is ``M(z)`` along ``z_m``.
+    """
+
+    z_m: np.ndarray
+    deflection_m: np.ndarray
+    bending_moment_nm: np.ndarray
+    angle_lower_rad: float
+    angle_upper_rad: float
+
+    @property
+    def angle_lower_deg(self) -> float:
+        return math.degrees(self.angle_lower_rad)
+
+    @property
+    def angle_upper_deg(self) -> float:
+        return math.degrees(self.angle_upper_rad)
+
+    @property
+    def max_bending_moment_nm(self) -> float:
+        return float(np.max(np.abs(self.bending_moment_nm)))
+
+
+def solve_static_response(
+    *,
+    length_m: float,
+    top_offset_m: float,
+    tension_n: float,
+    ei_nm2: float,
+    current_load_n_per_m: float,
+    n_nodes: int = 201,
+) -> RiserResponse:
+    """Solve the static tensioned beam-column BVP; see module docstring.
+
+    Parameters
+    ----------
+    length_m : float
+        Riser length between flex-joints L [m].
+    top_offset_m : float
+        Vessel offset at the upper flex-joint X [m] (e.g. watch-circle radius).
+    tension_n : float
+        Effective (constant, screening) tension T [N], must be > 0.
+    ei_nm2 : float
+        Bending stiffness EI [N.m^2], must be > 0.
+    current_load_n_per_m : float
+        Uniform lateral current-drag load w [N/m] (w = 1/2 rho Cd D U^2).
+    n_nodes : int
+        Number of z-grid nodes (>= 3).
+    """
+    if length_m <= 0 or tension_n <= 0 or ei_nm2 <= 0:
+        raise ValueError("length_m, tension_n, ei_nm2 must all be positive")
+    if n_nodes < 3:
+        raise ValueError("n_nodes must be >= 3")
+
+    L = float(length_m)
+    X = float(top_offset_m)
+    T = float(tension_n)
+    EI = float(ei_nm2)
+    w = float(current_load_n_per_m)
+
+    k = math.sqrt(T / EI)
+    C = EI * w / (T * T)
+    eps = math.exp(-k * L)  # tiny for a real riser; kept for correctness
+    P = C / (1.0 + eps)
+    Q = P
+    B = X / L + w * L / (2.0 * T)
+
+    z = np.linspace(0.0, L, n_nodes)
+    e_lo = np.exp(-k * z)          # boundary layer at z=0
+    e_hi = np.exp(-k * (L - z))    # boundary layer at z=L
+
+    y = -C + B * z - w * z * z / (2.0 * T) + P * e_lo + Q * e_hi
+    moment = -EI * w / T + T * P * e_lo + T * Q * e_hi
+
+    # slopes at the ends (analytic derivative of y)
+    # y'(z) = B - w z/T - P k e^{-kz} + Q k e^{-k(L-z)}
+    angle_lower = B - 0.0 - P * k * 1.0 + Q * k * eps
+    angle_upper = B - w * L / T - P * k * eps + Q * k * 1.0
+
+    return RiserResponse(
+        z_m=z,
+        deflection_m=y,
+        bending_moment_nm=moment,
+        angle_lower_rad=float(angle_lower),
+        angle_upper_rad=float(angle_upper),
+    )

--- a/src/digitalmodel/riser_database/__init__.py
+++ b/src/digitalmodel/riser_database/__init__.py
@@ -6,9 +6,11 @@ come through the citation getters (fail-closed against the private llm-wiki).
 """
 from digitalmodel.riser_database.getters import (
     get_buoyancy_tension_factor,
+    get_flexjoint_angle_limit,
     get_riser_dff,
     get_riser_scf,
     get_tension_weight_factor,
+    get_von_mises_design_factor,
     riser_citations,
 )
 from digitalmodel.riser_database.loader import (
@@ -32,8 +34,10 @@ __all__ = [
     "RiserStackupRow",
     "StandardsCrosswalkRow",
     "get_buoyancy_tension_factor",
+    "get_flexjoint_angle_limit",
     "get_riser_dff",
     "get_riser_scf",
     "get_tension_weight_factor",
+    "get_von_mises_design_factor",
     "riser_citations",
 ]

--- a/src/digitalmodel/riser_database/getters.py
+++ b/src/digitalmodel/riser_database/getters.py
@@ -61,6 +61,15 @@ _API_RP_16Q_CITATION_TEMPLATE: Final = {
     "wiki_path": "wikis/engineering-standards/wiki/standards/api-rp-16q.md",
 }
 
+#: API STD 2RD, 3rd Edition 2025 (formerly API RP 2RD; API reclassified it as
+#: STD 2RD). Home of the von Mises equivalent-stress design factor.
+_API_STD_2RD_CITATION_TEMPLATE: Final = {
+    "code_id": "api-std-2rd",
+    "publisher": "API",
+    "revision": "3e-2025",
+    "wiki_path": "wikis/engineering-standards/wiki/standards/api-std-2rd.md",
+}
+
 #: Matches riser_fatigue/touchdown.py TouchdownFatigueInput.dff — the live
 #: riser literal these getters must stay in parity with (#1246 wires the calc).
 RISER_DFF_DEFAULT: Final[float] = 10.0
@@ -73,6 +82,14 @@ RISER_F_WT_DEFAULT: Final[float] = 1.05
 #: Matches drilling_riser/stackup.py F_BT_DEFAULT — buoyancy loss and tolerance
 #: factor, API RP 16Q (1st Ed. 1993) §3.3.
 RISER_F_BT_DEFAULT: Final[float] = 0.96
+#: Von Mises equivalent-stress design factor (API STD 2RD): allowable = DF*SMYS.
+#: The well-known 2/3 operating design case; matches the public default in
+#: orcaflex/code_check_engine.py APIRP2RDInput.design_factor. Envelope: #1281a.
+RISER_VON_MISES_DESIGN_FACTOR: Final[float] = 0.67
+#: Drilling operating flex-joint angle limits (API RP 16Q): the well-known
+#: mean 2.0 deg / max 4.0 deg operating envelope. Envelope criteria (#1281a).
+RISER_FLEXJOINT_ANGLE_MEAN_DEG: Final[float] = 2.0
+RISER_FLEXJOINT_ANGLE_MAX_DEG: Final[float] = 4.0
 
 
 def get_riser_dff(
@@ -175,18 +192,75 @@ def get_buoyancy_tension_factor(
     return CitedValue(value=value, citation=citation, units="dimensionless")
 
 
+def get_von_mises_design_factor(
+    *, override: Optional[float] = None, repo_root: Optional[Path] = None
+) -> CitedValue:
+    """Von Mises equivalent-stress design factor (API STD 2RD): allow = DF·SMYS.
+
+    The well-known operating design case (2/3). Consumed by the operating-
+    envelope engine (``drilling_riser.envelope``) and matches the public default
+    in ``orcaflex.code_check_engine.APIRP2RDInput.design_factor``. ``override``
+    wins when provided.
+    """
+    value = RISER_VON_MISES_DESIGN_FACTOR
+    note = "Von Mises equivalent-stress design factor (allowable = DF x SMYS)"
+    if override is not None:
+        value = float(override)
+        note = f"user override; standard value {RISER_VON_MISES_DESIGN_FACTOR}"
+    citation = Citation(
+        section="Sec.5 (dynamic riser design criteria)",
+        note=note,
+        **_API_STD_2RD_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="dimensionless")
+
+
+def get_flexjoint_angle_limit(
+    kind: str = "max",
+    *,
+    override: Optional[float] = None,
+    repo_root: Optional[Path] = None,
+) -> CitedValue:
+    """Drilling operating flex-joint angle limit (API RP 16Q), degrees.
+
+    ``kind`` selects the ``"mean"`` (2.0 deg) or ``"max"`` (4.0 deg) operating
+    limit — the well-known drilling operating envelope. ``override`` wins when
+    provided. Raises ``ValueError`` for an unknown ``kind``.
+    """
+    if kind not in ("mean", "max"):
+        raise ValueError(f"kind must be 'mean' or 'max', got {kind!r}")
+    standard = (
+        RISER_FLEXJOINT_ANGLE_MEAN_DEG if kind == "mean" else RISER_FLEXJOINT_ANGLE_MAX_DEG
+    )
+    value = standard
+    note = f"Drilling operating flex-joint {kind} angle limit"
+    if override is not None:
+        value = float(override)
+        note = f"user override; standard value {standard}"
+    citation = Citation(
+        section="operating limits (flex-joint angle)",
+        note=note,
+        **_API_RP_16Q_CITATION_TEMPLATE,
+    )
+    validate_citation(citation, repo_root=repo_root)
+    return CitedValue(value=value, citation=citation, units="degrees")
+
+
 _CITATION_WARNED = False
 
 
 def riser_citations(repo_root: Optional[Path] = None) -> dict:
-    """Return ``{"dff", "scf", "f_wt", "f_bt"}`` CitedValues for the riser
-    design factors.
+    """Return ``{"dff", "scf", "f_wt", "f_bt", "von_mises_df"}`` CitedValues for
+    the riser design factors.
 
     Consumer-wrapper degradation (template:
     ``mooring_resilience.screening.safety_factor_citations``): where the wiki
     resolves, a missing or mismatched page fails closed (raises); in
     standalone mode (no resolvable wiki at all) it emits a one-shot
-    ``RuntimeWarning`` and returns ``{}``.
+    ``RuntimeWarning`` and returns ``{}``. (The parameterized flex-joint angle
+    operating limit is resolved via ``get_flexjoint_angle_limit``, not bundled
+    here.)
     """
     global _CITATION_WARNED
     try:
@@ -195,6 +269,7 @@ def riser_citations(repo_root: Optional[Path] = None) -> dict:
             "scf": get_riser_scf(repo_root=repo_root),
             "f_wt": get_tension_weight_factor(repo_root=repo_root),
             "f_bt": get_buoyancy_tension_factor(repo_root=repo_root),
+            "von_mises_df": get_von_mises_design_factor(repo_root=repo_root),
         }
     except CitationResolutionError as exc:
         if not _CITATION_WARNED:

--- a/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/FIXTURE_PROVENANCE.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/FIXTURE_PROVENANCE.md
@@ -97,3 +97,37 @@ same commit, then rerun:
 ```bash
 .venv/bin/python -m pytest tests/riser_database/ -q
 ```
+
+---
+
+# Fixture Provenance - `api-std-2rd.md` (#1281a)
+
+Vendored for the operating-envelope von Mises design-factor getter
+(`get_von_mises_design_factor`). Same contract as the fixtures above: resolver
+frontmatter and a short description only — no standard text, tables, formulas,
+or licensed source material.
+
+## Canonical source
+
+- **Repo:** `vamseeachanta/llm-wiki`
+- `wikis/engineering-standards/wiki/standards/api-std-2rd.md` —
+  canonical SHA at vendoring time: `74aeb6f3e47806c377fc614b152d80c31b61bb5e`
+  (revision `3e-2025`; the page was already citation-ready — no paired wiki PR
+  was needed for #1281a).
+
+## Vendored copy
+
+- **Vendored on:** 2026-07-03
+- **Used by:** `tests/riser_database/test_citations.py`,
+  `tests/drilling_riser/test_envelope.py`
+
+## Freshness contract
+
+Review monthly. If the canonical page frontmatter changes, update the fixture,
+the `_API_STD_2RD_CITATION_TEMPLATE` in
+`src/digitalmodel/riser_database/getters.py`, and this provenance file in the
+same commit, then rerun:
+
+```bash
+.venv/bin/python -m pytest tests/riser_database/ tests/drilling_riser/ -q
+```

--- a/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/api-std-2rd.md
+++ b/tests/citations/fixtures/knowledge/wikis/engineering-standards/wiki/standards/api-std-2rd.md
@@ -1,0 +1,18 @@
+---
+title: "API STD 2RD Dynamic Risers — citation fixture"
+code_id: api-std-2rd
+publisher: API
+revision: "3e-2025"
+tags: ["standard", "api", "risers", "fixture"]
+---
+
+# API STD 2RD — Dynamic Risers (vendored citation fixture)
+
+Minimal fixture so riser citation tests can validate frontmatter resolution
+standalone (see FIXTURE_PROVENANCE.md). Resolver frontmatter only — no
+standard text, tables, formulas, or licensed source material.
+
+API STD 2RD (3rd Edition, 2025; formerly API RP 2RD — API reclassified it as
+STD 2RD) sources the von Mises equivalent-stress design factor consumed by
+`digitalmodel.riser_database.getters.get_von_mises_design_factor` and the
+operating-envelope engine.

--- a/tests/drilling_riser/test_envelope.py
+++ b/tests/drilling_riser/test_envelope.py
@@ -1,0 +1,147 @@
+"""#1281a: operating-envelope engine (offset x current x seastate).
+
+The load-bearing checks are the anti-degeneracy guards the T2 review demanded:
+the von Mises utilisation MUST rise with current (via the beam-column moment)
+and the flex-joint utilisation MUST rise with offset. An envelope whose
+responses don't move with its inputs is worthless.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from digitalmodel.drilling_riser.envelope import (
+    EnvelopeCriteria,
+    EnvelopeResult,
+    OperatingMode,
+    RigEnvelopeLimits,
+    RiserSection,
+    SeaState,
+    compute_operating_envelope,
+    resolve_envelope_criteria,
+)
+
+
+def _fixture_repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent / "citations" / "fixtures"
+
+
+_SECTION = RiserSection(outer_diameter_m=0.5334, wall_thickness_m=0.0254)
+_CRITERIA = EnvelopeCriteria(
+    flexjoint_angle_mean_deg=2.0, flexjoint_angle_max_deg=4.0, von_mises_design_factor=0.67
+)
+_BASE = dict(
+    section=_SECTION,
+    water_depth_m=1500.0,
+    length_m=1500.0,
+    tension_n=3.0e6,
+    criteria=_CRITERIA,
+)
+
+
+def _env(offsets, currents, seastates, **kw):
+    return compute_operating_envelope(
+        offsets_pct=offsets, current_speeds_mps=currents, seastates=seastates, **_BASE, **kw
+    )
+
+
+# -- criteria resolution (fail-closed, fixture) --------------------------------
+
+
+def test_resolve_criteria_from_fixture():
+    crit = resolve_envelope_criteria(OperatingMode.DRILLING, repo_root=_fixture_repo_root())
+    assert crit.flexjoint_angle_mean_deg == 2.0
+    assert crit.flexjoint_angle_max_deg == 4.0
+    assert crit.von_mises_design_factor == 0.67
+
+
+# -- shape / typing ------------------------------------------------------------
+
+
+def test_envelope_shape_and_type():
+    r = _env([1.0, 2.0, 3.0], [0.5, 1.0], [SeaState(3.0, 10.0)])
+    assert isinstance(r, EnvelopeResult)
+    assert r.allowable_mask.shape == (3, 2, 1)
+    assert r.per_limit_utilisation["flexjoint_angle"].shape == (3, 2, 1)
+    assert 0.0 <= r.operable_fraction <= 1.0
+
+
+# -- ANTI-DEGENERACY GUARDS (the core T2 fix) ----------------------------------
+
+
+def test_von_mises_utilisation_rises_with_current():
+    r = _env([2.0], [0.25, 0.75, 1.5], [SeaState(2.0, 9.0)])
+    vm = r.per_limit_utilisation["von_mises"][0, :, 0]
+    assert vm[0] < vm[1] < vm[2]  # current moves the bending -> von Mises
+
+
+def test_flexjoint_utilisation_rises_with_offset():
+    r = _env([0.5, 1.5, 3.0], [0.5], [SeaState(2.0, 9.0)])
+    fj = r.per_limit_utilisation["flexjoint_angle"][:, 0, 0]
+    assert fj[0] < fj[1] < fj[2]  # offset moves the flex-joint angle
+
+
+def test_seastate_moves_flexjoint_via_rao():
+    # Low static offset/current so the dynamic (max-angle) check governs — the
+    # regime where sea state actually drives the flex-joint utilisation.
+    r = _env([0.2], [0.1], [SeaState(1.0, 9.0), SeaState(6.0, 12.0)], rao_angle_deg_per_m=0.3)
+    fj = r.per_limit_utilisation["flexjoint_angle"][0, 0, :]
+    assert fj[1] > fj[0]  # bigger Hs -> bigger motion-driven max angle
+
+
+# -- allowable region behaviour ------------------------------------------------
+
+
+def test_benign_point_allowable_extreme_point_not():
+    r = _env(
+        [0.5, 8.0],            # benign vs large offset (% WD)
+        [0.2, 2.5],            # mild vs strong current
+        [SeaState(2.0, 9.0)],
+    )
+    assert bool(r.allowable_mask[0, 0, 0]) is True     # benign corner allowable
+    assert bool(r.allowable_mask[1, 1, 0]) is False    # extreme corner excluded
+
+
+def test_governing_limit_is_a_known_name():
+    r = _env([4.0], [1.5], [SeaState(3.0, 10.0)])
+    assert r.governing_limit[0, 0, 0] in {"flexjoint_angle", "von_mises", "stroke", "moonpool"}
+
+
+# -- optional rig limits populate / NaN when absent ----------------------------
+
+
+def test_operating_mode_selects_active_limits():
+    common = dict(
+        offsets_pct=[2.0], current_speeds_mps=[1.0], seastates=[SeaState(3.0, 10.0)],
+        rig_limits=RigEnvelopeLimits(tj_stroke_m=18.0, moonpool_half_min_m=3.5),
+    )
+    drilling = compute_operating_envelope(**_BASE, mode=OperatingMode.DRILLING, **common)
+    hang = compute_operating_envelope(**_BASE, mode=OperatingMode.HANG_OFF, **common)
+    # drilling gates on flex-joint angle + moonpool; hang-off does not
+    assert not np.isnan(drilling.per_limit_utilisation["flexjoint_angle"]).all()
+    assert np.isnan(hang.per_limit_utilisation["flexjoint_angle"]).all()
+    assert np.isnan(hang.per_limit_utilisation["moonpool"]).all()
+    assert not np.isnan(hang.per_limit_utilisation["von_mises"]).all()
+
+
+def test_stroke_and_moonpool_nan_without_rig_data():
+    r = _env([2.0], [0.5], [SeaState(2.0, 9.0)])
+    assert np.isnan(r.per_limit_utilisation["stroke"]).all()
+    assert np.isnan(r.per_limit_utilisation["moonpool"]).all()
+
+
+def test_stroke_and_moonpool_populate_with_rig_data():
+    r = _env(
+        [1.0, 5.0],
+        [0.5],
+        [SeaState(2.0, 9.0)],
+        rig_limits=RigEnvelopeLimits(tj_stroke_m=18.0, moonpool_half_min_m=3.5),
+        rao_heave_m_per_m=0.6,
+    )
+    assert not np.isnan(r.per_limit_utilisation["stroke"]).any()
+    assert not np.isnan(r.per_limit_utilisation["moonpool"]).any()
+    # moonpool excursion grows with offset
+    mp = r.per_limit_utilisation["moonpool"][:, 0, 0]
+    assert mp[1] > mp[0]

--- a/tests/drilling_riser/test_riser_response.py
+++ b/tests/drilling_riser/test_riser_response.py
@@ -1,0 +1,110 @@
+"""#1281a: static tensioned beam-column riser-response model.
+
+Test oracles are the closed-form solution of ``EI y'''' - T y'' = w`` with pinned
+(moment-free) flex-joint ends, y(0)=0, y(L)=offset:
+
+  * no offset, no current  -> zero deflection / angle / moment
+  * offset, no current      -> rigid tilt y = X z/L; both flex-joint angles = X/L
+                               (rad); ZERO bending moment (pinned-pinned tension member)
+  * current, no offset      -> nonzero angles + interior bending moment
+  * monotonicity            -> angle increases with offset; angle AND peak moment
+                               increase with current (the anti-degeneracy guard)
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from digitalmodel.drilling_riser.riser_response import (
+    RiserResponse,
+    solve_static_response,
+)
+
+# A representative highly-tensioned 21" drilling riser (SI, synthetic screening values).
+_BASE = dict(
+    length_m=1500.0,
+    tension_n=3.0e6,          # ~674 kip effective tension
+    ei_nm2=2.5e9,             # E*I for a 21" x 1" steel section, order of magnitude
+    n_nodes=201,
+)
+
+
+def _drag_load_n_per_m(current_speed_mps: float, diameter_m: float = 0.5334) -> float:
+    """Static current drag per unit length: w = 1/2 rho Cd D U^2 (SI)."""
+    rho_sw, cd = 1025.0, 1.2
+    return 0.5 * rho_sw * cd * diameter_m * current_speed_mps**2
+
+
+# -- oracle 1: quiescent -> zero everything ------------------------------------
+
+
+def test_no_offset_no_current_is_zero():
+    r = solve_static_response(top_offset_m=0.0, current_load_n_per_m=0.0, **_BASE)
+    assert isinstance(r, RiserResponse)
+    assert r.angle_lower_rad == pytest.approx(0.0, abs=1e-12)
+    assert r.angle_upper_rad == pytest.approx(0.0, abs=1e-12)
+    assert np.allclose(r.deflection_m, 0.0, atol=1e-9)
+    assert np.max(np.abs(r.bending_moment_nm)) == pytest.approx(0.0, abs=1e-3)
+
+
+# -- oracle 2: pure offset -> rigid tilt, no bending ---------------------------
+
+
+def test_pure_offset_is_rigid_tilt_no_moment():
+    offset = 30.0  # m (2% of 1500 m WD)
+    r = solve_static_response(top_offset_m=offset, current_load_n_per_m=0.0, **_BASE)
+    expected_slope = offset / _BASE["length_m"]
+    # both flex joints rotate by X/L; deflection is a straight line X z/L
+    assert r.angle_lower_rad == pytest.approx(expected_slope, rel=1e-6)
+    assert r.angle_upper_rad == pytest.approx(expected_slope, rel=1e-6)
+    line = expected_slope * r.z_m
+    assert np.allclose(r.deflection_m, line, atol=1e-6)
+    # a pinned-pinned tensioned member under pure end offset carries NO moment
+    assert np.max(np.abs(r.bending_moment_nm)) == pytest.approx(0.0, abs=1.0)
+
+
+# -- oracle 3: pure current -> angles + interior moment ------------------------
+
+
+def test_pure_current_bends_the_riser():
+    w = _drag_load_n_per_m(1.0)  # 1 m/s surface-equivalent uniform current
+    r = solve_static_response(top_offset_m=0.0, current_load_n_per_m=w, **_BASE)
+    # cable-limit lower-joint angle ~ w L / (2 T); sign nonzero, small-angle
+    approx_cable = w * _BASE["length_m"] / (2.0 * _BASE["tension_n"])
+    assert r.angle_lower_rad == pytest.approx(approx_cable, rel=0.05)
+    # moment is zero at the pinned ends, nonzero in the interior
+    assert abs(r.bending_moment_nm[0]) == pytest.approx(0.0, abs=1.0)
+    assert abs(r.bending_moment_nm[-1]) == pytest.approx(0.0, abs=1.0)
+    assert np.max(np.abs(r.bending_moment_nm)) > 0.0
+
+
+# -- oracle 4: monotonicity (the anti-degeneracy guard) ------------------------
+
+
+def test_angle_increases_with_offset():
+    a = solve_static_response(top_offset_m=15.0, current_load_n_per_m=0.0, **_BASE)
+    b = solve_static_response(top_offset_m=45.0, current_load_n_per_m=0.0, **_BASE)
+    assert b.angle_lower_rad > a.angle_lower_rad > 0.0
+
+
+def test_angle_and_moment_increase_with_current():
+    a = solve_static_response(
+        top_offset_m=20.0, current_load_n_per_m=_drag_load_n_per_m(0.5), **_BASE
+    )
+    b = solve_static_response(
+        top_offset_m=20.0, current_load_n_per_m=_drag_load_n_per_m(1.5), **_BASE
+    )
+    assert b.max_bending_moment_nm > a.max_bending_moment_nm > 0.0
+    assert abs(b.angle_lower_rad) > abs(a.angle_lower_rad)
+
+
+# -- degrees convenience + shape ----------------------------------------------
+
+
+def test_degrees_and_grid_shape():
+    r = solve_static_response(top_offset_m=30.0, current_load_n_per_m=_drag_load_n_per_m(1.0), **_BASE)
+    assert r.angle_lower_deg == pytest.approx(math.degrees(r.angle_lower_rad))
+    assert r.z_m.shape == r.deflection_m.shape == r.bending_moment_nm.shape
+    assert r.z_m[0] == 0.0 and r.z_m[-1] == pytest.approx(_BASE["length_m"])

--- a/tests/riser_database/test_citations.py
+++ b/tests/riser_database/test_citations.py
@@ -166,6 +166,41 @@ def test_user_override_wins_for_f_bt():
     assert "0.96" in cv.citation.note
 
 
+# -- #1281a envelope criteria getters --------------------------------------------
+
+
+def test_get_von_mises_design_factor_emits_2rd_citation():
+    cv = getters.get_von_mises_design_factor(repo_root=_fixture_repo_root())
+    assert cv.value == 0.67
+    assert cv.citation.code_id == "api-std-2rd"
+    assert cv.citation.publisher == "API"
+    assert cv.citation.revision == "3e-2025"
+    assert cv.citation.source_sibling == "generic"
+    assert cv.units == "dimensionless"
+
+
+def test_get_flexjoint_angle_limit_mean_and_max():
+    mean = getters.get_flexjoint_angle_limit("mean", repo_root=_fixture_repo_root())
+    mx = getters.get_flexjoint_angle_limit("max", repo_root=_fixture_repo_root())
+    assert mean.value == 2.0 and mx.value == 4.0
+    assert mean.citation.code_id == mx.citation.code_id == "api-rp-16q"
+    assert mean.citation.revision == "1993"
+    assert mean.units == "degrees"
+
+
+def test_get_flexjoint_angle_limit_rejects_unknown_kind():
+    with pytest.raises(ValueError):
+        getters.get_flexjoint_angle_limit("median", repo_root=_fixture_repo_root())
+
+
+def test_von_mises_getter_matches_code_check_engine_default():
+    """Parity: the getter value equals the public APIRP2RDInput.design_factor."""
+    from digitalmodel.orcaflex.code_check_engine import APIRP2RDInput
+
+    cv = getters.get_von_mises_design_factor(repo_root=_fixture_repo_root())
+    assert cv.value == APIRP2RDInput().design_factor == 0.67
+
+
 # -- defenses (c)+(d) + pip-no-wiki path ------------------------------------------
 
 
@@ -189,8 +224,9 @@ def test_pip_no_wiki_helper_warns_once_and_degrades(_no_wiki_anywhere):
 
 def test_helper_returns_cited_values_in_context():
     cited = getters.riser_citations(repo_root=_fixture_repo_root())
-    assert set(cited) == {"dff", "scf", "f_wt", "f_bt"}
+    assert set(cited) == {"dff", "scf", "f_wt", "f_bt", "von_mises_df"}
     assert cited["dff"].value == 10.0
     assert cited["scf"].value == 1.0
     assert cited["f_wt"].value == 1.05
     assert cited["f_bt"].value == 0.96
+    assert cited["von_mises_df"].value == 0.67


### PR DESCRIPTION
Child **C1** of epic #1279 (rig-specific drilling riser operating envelopes) — the analytical screening tier of the envelope engine (#1281). Implements the plan approved on #1281; no paired wiki PR (both standards pages already citation-ready). Standalone.

## Why the shape

The T2 review rejected a prior scoping that deferred the riser mechanics — the envelope was **vacuous** (every response static across the sweep). This slice makes the keystone **own** the static response model, so offset and current actually move the responses.

## Response model — `drilling_riser/riser_response.py`

`solve_static_response` solves the tensioned beam-column BVP `EI y'''' − T y'' = w(z)` (pinned flex-joint ends, top offset BC, uniform current-drag load) in a **numerically stable closed form** (avoids the cosh/sinh cancellation at real-riser `kL`). Returns deflection, flex-joint angles, and `M(z)`. **Static screening only** — no dynamic amplification; provenance is public tensioned-beam marine-riser mechanics, not any licensed material. Oracle tests: pure offset → rigid tilt / zero moment; pure current → cable-limit angle + interior moment.

## Envelope engine — `drilling_riser/envelope.py`

`compute_operating_envelope` sweeps **offset × current × seastate** over four limits:
- **flex-joint angle** (mean via static, max via static + RAO motion),
- **von Mises utilisation** — *bending-aware*: feeds the model's `M(z)` into `orcaflex.code_check_engine.check_api_rp_2rd`,
- **tensioner/TJ stroke** (geometric setdown + RAO heave),
- **moonpool clearance** (excursion vs half-dimension).

`OperatingMode` (drilling / connected / hang-off) selects the active limit set via externalized `envelope_modes.yml`. `EnvelopeResult` carries per-limit utilisation arrays, the governing limit, and the allowable mask.

## Criteria (fail-closed, cited)

- `get_von_mises_design_factor()` → **0.67** (`api-std-2rd` 3e-2025; matches the public `APIRP2RDInput.design_factor` default).
- `get_flexjoint_angle_limit(mean=2.0 / max=4.0 deg)` citing `api-rp-16q` rev 1993.
- `riser_citations()` grows to include `von_mises_df`; assertion updated.
- **Stroke margin + moonpool clearance are uncited project defaults** (no public provision identified — Barlow / top-tension-SF precedent). **No AMJIG** (licensed → #1281b). **No new public data columns** → leak surface unchanged.
- Vendored `api-std-2rd` fixture (rev 3e-2025) + provenance for standalone CI.

## Verification

- **237** riser + citation tests green, incl. the **anti-degeneracy guards** (von Mises rises with current; flex-joint rises with offset) and the beam-column closed-form oracles.
- New getters resolve **GREEN** vs the merged wiki main and **fail-closed** (loud `CitationResolutionError`) when the page is absent.
- `legal-sanity-scan --repo=digitalmodel --diff-only` **PASS** over all 11 changed files (`git add -N` first).

## Deferred (own plan→review→approval)

- **#1281b** — wellhead/conductor-moment limit (net-new rig data column + paired wed issue) + the **AMJIG** per-category extreme/survival criteria. *AMJIG governance ruling still open* (it is proprietary JIP content — its values may not be public literals).
- **#1281c** — OrcaFlex-backed dynamic tier stub via `parametric.library` (dynamic per-seastate envelope, drift-off, recoil, VIV). Standard (16Q vs AMJIG) is a query-time threshold, not a sweep axis.