### PR TITLE
fix(openfoam): accept dm#641 'points' key in from_sweep_manifest (#1353)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/sloshing_coupling.py
+++ b/src/digitalmodel/solvers/openfoam/sloshing_coupling.py
@@ -335,8 +335,9 @@ class SloshingCouplingModel:
         """Load the dm#641 sweep manifest (``.json`` or ``.csv``).
 
         JSON may be either a top-level list of rows or an object with a
-        ``"cases"`` (or ``"rows"``) list. CSV must have a header row whose names
-        match the contract keys.
+        ``"points"`` (as written by the dm#641 harness), ``"cases"``, or
+        ``"rows"`` list. CSV must have a header row whose names match the
+        contract keys.
 
         Args:
             path: Path to the manifest written by the dm#641 harness.
@@ -359,7 +360,12 @@ class SloshingCouplingModel:
         else:
             data = json.loads(path.read_text())
             if isinstance(data, dict):
-                rows = data.get("cases") or data.get("rows") or []
+                rows = (
+                    data.get("points")
+                    or data.get("cases")
+                    or data.get("rows")
+                    or []
+                )
             else:
                 rows = data
         if not rows:

--- a/tests/solvers/openfoam/test_sloshing_coupling.py
+++ b/tests/solvers/openfoam/test_sloshing_coupling.py
@@ -125,6 +125,14 @@ class TestLoader:
         m = SloshingCouplingModel.from_sweep_manifest(p)
         assert m.n_cases == 9
 
+    def test_from_json_manifest_points_key(self, tmp_path, manifest_rows):
+        # The dm#641 sweep harness writes the rows under "points" — the loader
+        # must accept that wrapper key (regression: end-to-end sweep -> coupling).
+        p = tmp_path / "sweep_manifest.json"
+        p.write_text(json.dumps({"study": "s", "issue": "#641", "points": manifest_rows}))
+        m = SloshingCouplingModel.from_sweep_manifest(p)
+        assert m.n_cases == 9
+
     def test_from_csv_manifest(self, tmp_path, manifest_rows):
         import csv
 


### PR DESCRIPTION
**Found by running the full 9-point production sweep end-to-end.** dm#641's sweep harness writes rows under a top-level `"points"` key, but `SloshingCouplingModel.from_sweep_manifest` (dm#643) only accepted `"cases"`/`"rows"` — so a real `sweep_manifest.json` raised `ValueError: No cases found`. Per-row contract fields already matched; only the wrapper key differed.

Fix: also accept `"points"`; +1 regression test (39 pass). Verified end-to-end: the coupling model now loads the real manifest and returns the best-anti-roll-fill result (70% fill, peak quad_coeff ≈ 2.02 N·m/(rad/s)).

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)