### PR TITLE
drilling_riser: wellhead/conductor moment + flex-joint hardware rating (#1345)

### DIFF
--- a/data/riser_database/manifest.yaml
+++ b/data/riser_database/manifest.yaml
@@ -14,7 +14,7 @@ tables:
   rig_riser_interface:
     file: rig_riser_interface.csv
     rows: 3
-    sha256: a7602f37afc3bcda207cad9daba55f24a681d93972011d3f512f731053e2a59e
+    sha256: 56ea3f0707b51ee5d74f9add84e83a4e274ad88e1954630e7a9b7cd0b4e432a7
   riser_stackup:
     file: riser_stackup.csv
     rows: 9

--- a/data/riser_database/rig_riser_interface.csv
+++ b/data/riser_database/rig_riser_interface.csv
@@ -1,4 +1,4 @@
-rig_ref,rig_type,n_tensioners,tensioner_type,tensioner_capacity_kips,tensioner_stroke_ft,tj_stroke_ft,n_tension_wires,moonpool_length_ft,moonpool_width_ft,drill_floor_elev_ft,wed_rig_name,wiki_path,note
-drillship-16w-wireline,drillship,,wireline,,,,16,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,wireline-tensioner drillship class; two wires may fail per the tension criterion
-drillship-6g-16x3600k-dat,drillship,16,direct-acting,3600,,60,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,sixth-generation drillship class with direct-acting tensioners
-drillship-generic-market,drillship,,direct-acting,3500,50,65,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,market-typical capability figures for screening
+rig_ref,rig_type,n_tensioners,tensioner_type,tensioner_capacity_kips,tensioner_stroke_ft,tj_stroke_ft,n_tension_wires,moonpool_length_ft,moonpool_width_ft,drill_floor_elev_ft,conductor_moment_capacity_kn_m,flexjoint_angle_rating_deg,wed_rig_name,wiki_path,note
+drillship-16w-wireline,drillship,,wireline,,,,16,,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,wireline-tensioner drillship class; two wires may fail per the tension criterion
+drillship-6g-16x3600k-dat,drillship,16,direct-acting,3600,,60,,,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,sixth-generation drillship class with direct-acting tensioners
+drillship-generic-market,drillship,,direct-acting,3500,50,65,,,,,,,,wikis/riser-projects/wiki/datasets/stackup-registry.md,market-typical capability figures for screening

--- a/docs/riser_database.md
+++ b/docs/riser_database.md
@@ -103,9 +103,10 @@ attach the output to the PR as evidence.
   `riser_fatigue/workflow.py` DFF through `resolve_dff()`.
 * **#1247** — orcaflex riser citation surface (net-new; no parity baseline).
 * **#1281a** — *done*: operating-envelope analytical tier (beam-column response
-  model + sweep engine + von-Mises / flex-joint getters). See the
-  operating-envelope section below. **#1281b** (AMJIG + WH-moment + data
-  columns) and **#1281c** (solver-backed tier stub) follow.
+  model + sweep engine + von-Mises / flex-joint getters). **#1281c / #1346** —
+  *done*: solver-backed dynamic tier stub. **#1281b / #1345** — *done*:
+  wellhead/conductor moment + flex-joint hardware rating (AMJIG per-category
+  criteria still deferred). See the operating-envelope sections below.
 * **#1199d** (T3, frontier-gated) — de-identified ACE result precedent,
   `private_sidecar` route; extends the leak gate to those rows.
 * Future numeric response-surface atlases (metocean, VIV) live under
@@ -185,10 +186,24 @@ margin and moonpool clearance are **uncited project defaults** (no public
 standards provision identified — the Barlow / top-tension-SF precedent). No new
 public data columns, so the leak surface is unchanged.
 
-**Deferred:** the wellhead/conductor-moment limit (needs a net-new rig data
-column) and the AMJIG per-category extreme/survival criteria (licensed) are
-**#1281b**. Standard selection (16Q vs AMJIG) is a query-time *threshold*, not a
-sweep axis.
+**C2 (#1345, #1281b) — wellhead/conductor moment + flex-joint hardware rating.**
+`drilling_riser/conductor_response.py` models the conductor below the mudline as
+a Hetényi beam-on-elastic-foundation loaded by the riser lower-flex-joint shear
+`H` (added to `RiserResponse.shear_lower_n = T·X/L + w·L/2`) acting over the
+BOP/LMRP **stand-off** arm: the applied end moment `M0 = H·h_stack` dominates the
+soil-reaction peak, so the wellhead moment peaks at the mudline. The envelope
+gains a `wh_moment` limit (`M_conductor / conductor_moment_capacity`) and refines
+the flex-joint limit to the governing `min(operating-limit, hardware-rating)`.
+Two rated-capacity columns (`conductor_moment_capacity_kn_m`,
+`flexjoint_angle_rating_deg`) ship **empty** — a paired worldenergydata rig-spec
+issue populates them from public specs (client-specific ratings stay wiki-side).
+The allowable is a rated capacity (like `tensioner_capacity_kips`), **not** a
+cited getter — no wellhead-moment `code_id` is registered (ISO 13628-7 exists in
+the wiki but is unregistered/methodology-only). The analytical `envelope.py` +
+`conductor_response.py` are now inside the provenance-tripwire gate. Static
+screening (single Winkler `k`, no conductor axial load; layered p-y = solver
+tier). **Deferred: the AMJIG per-category extreme/survival criteria (licensed)**;
+standard selection (16Q vs AMJIG) is a query-time *threshold*, not a sweep axis.
 
 **C3 (#1346, #1281c) — solver-backed dynamic tier STUB.**
 `scripts/parametric/build_drilling_riser_envelope_library.py` builds a

--- a/scripts/riser_database/build_tables.py
+++ b/scripts/riser_database/build_tables.py
@@ -69,6 +69,8 @@ RIG_COLUMNS = [
     "moonpool_length_ft",
     "moonpool_width_ft",
     "drill_floor_elev_ft",
+    "conductor_moment_capacity_kn_m",
+    "flexjoint_angle_rating_deg",
     "wed_rig_name",
     "wiki_path",
     "note",

--- a/scripts/riser_database/sources.yml
+++ b/scripts/riser_database/sources.yml
@@ -183,8 +183,10 @@ stackup_rows:
 # rig_riser_interface (#1259): generic rig-class slugs; wed_rig_name joins the
 # worldenergydata 2,268-rig identity space and is populated ONLY for rows
 # sourced from public rig specifications (none in this slice). Capability
-# numerics are rig-class brochure-grade values; moonpool/drill-floor columns
-# ship empty until public-safe seeds exist.
+# numerics are rig-class brochure-grade values; moonpool/drill-floor and the
+# #1345 conductor_moment_capacity_kn_m / flexjoint_angle_rating_deg columns ship
+# empty until public-safe seeds exist (the latter two land via a paired wed
+# rig-spec sourcing issue; never seed from a wiki-side/client source).
 rig_rows:
   - rig_ref: drillship-6g-16x3600k-dat
     rig_type: drillship

--- a/src/digitalmodel/drilling_riser/conductor_response.py
+++ b/src/digitalmodel/drilling_riser/conductor_response.py
@@ -1,0 +1,93 @@
+"""Wellhead/conductor bending moment — analytical screening tier (#1345, C2).
+
+The drilling riser terminates at the lower flex-joint, which sits atop the
+BOP/LMRP stack a stand-off height ``h_stack`` ABOVE the mudline wellhead datum.
+The flex-joint transmits the riser's lateral shear ``H`` (and tension) but ~no
+moment; that shear acting over the rigid stand-off arm applies an end moment
+``M0 = H * h_stack`` at the top of the conductor. The conductor below the
+mudline is modelled as a semi-infinite beam on an elastic (Winkler) foundation
+loaded at its top by ``H`` and ``M0``:
+
+    EI_c y'''' + k y = 0,     b = (k / (4 EI_c))^(1/4)
+    M(x) = M0 e^{-bx}(cos bx + sin bx) - (H/b) e^{-bx} sin bx
+
+with ``x`` the depth below mudline. The bending moment peaks at the mudline
+(x=0, value M0) and decays over ~1/b. The stand-off moment M0 dominates the
+pure soil-reaction peak (~0.32 H/b), so it is the governing static term for the
+wellhead moment — omitting it understates the moment ~10x (non-conservative).
+
+Provenance: standard beam-on-elastic-foundation theory (Hetényi, *Beams on
+Elastic Foundation*, 1946; public), NOT any licensed project material. This is a
+STATIC screening model: a single Winkler modulus ``k`` (not a layered p-y
+curve) and NO conductor axial load (a real conductor carries axial load adding a
+beam-column term); layered p-y + dynamics are the solver tier (#1281c). SI.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ConductorResponse:
+    """Result of :func:`solve_conductor_moment` (SI). ``x_m`` is depth below the
+    mudline; ``moment_nm`` is M(x); ``stand_off_moment_nm`` is M0 = H*h_stack."""
+
+    x_m: np.ndarray
+    moment_nm: np.ndarray
+    beta_per_m: float
+    stand_off_moment_nm: float
+
+    @property
+    def max_moment_nm(self) -> float:
+        return float(np.max(np.abs(self.moment_nm)))
+
+
+def solve_conductor_moment(
+    *,
+    shear_n: float,
+    stand_off_m: float,
+    soil_modulus_n_per_m2: float,
+    ei_nm2: float,
+    n_char_lengths: float = 8.0,
+    n_nodes: int = 201,
+) -> ConductorResponse:
+    """Wellhead/conductor bending moment via a Hetényi beam-on-elastic-foundation.
+
+    Parameters
+    ----------
+    shear_n : float
+        Lateral shear H transmitted from the riser lower flex-joint [N] (>= 0).
+    stand_off_m : float
+        BOP/LMRP stand-off height h_stack from mudline to the flex-joint [m].
+    soil_modulus_n_per_m2 : float
+        Winkler subgrade modulus k (force / length / deflection) [N/m^2], > 0.
+    ei_nm2 : float
+        Conductor bending stiffness EI_c [N.m^2], > 0.
+    n_char_lengths : float
+        Depth of the grid in characteristic lengths 1/b (>= a few for decay).
+    n_nodes : int
+        Number of depth nodes (>= 2).
+    """
+    if soil_modulus_n_per_m2 <= 0 or ei_nm2 <= 0:
+        raise ValueError("soil_modulus_n_per_m2 and ei_nm2 must be positive")
+    if shear_n < 0 or stand_off_m < 0:
+        raise ValueError("shear_n and stand_off_m must be non-negative")
+
+    beta = (soil_modulus_n_per_m2 / (4.0 * ei_nm2)) ** 0.25
+    m0 = float(shear_n) * float(stand_off_m)
+
+    x = np.linspace(0.0, n_char_lengths / beta, n_nodes)
+    e = np.exp(-beta * x)
+    c = np.cos(beta * x)
+    s = np.sin(beta * x)
+    moment = m0 * e * (c + s) - (float(shear_n) / beta) * e * s
+
+    return ConductorResponse(
+        x_m=x,
+        moment_nm=moment,
+        beta_per_m=float(beta),
+        stand_off_moment_nm=m0,
+    )

--- a/src/digitalmodel/drilling_riser/envelope.py
+++ b/src/digitalmodel/drilling_riser/envelope.py
@@ -35,6 +35,7 @@ from typing import Optional, Sequence
 import numpy as np
 import yaml
 
+from digitalmodel.drilling_riser.conductor_response import solve_conductor_moment
 from digitalmodel.drilling_riser.operability import watch_circle_radius_m
 from digitalmodel.drilling_riser.riser_response import solve_static_response
 from digitalmodel.orcaflex.code_check_engine import APIRP2RDInput, check_api_rp_2rd
@@ -116,6 +117,28 @@ class RigEnvelopeLimits:
     tj_stroke_m: Optional[float] = None
     tensioner_stroke_m: Optional[float] = None
     moonpool_half_min_m: Optional[float] = None
+    #: Rated wellhead/conductor bending-moment capacity [kN.m] and flex-joint
+    #: hardware angular rating [deg] (#1345). None -> that limit is inactive
+    #: (the public data columns ship empty; the paired wed issue populates them).
+    conductor_moment_capacity_kn_m: Optional[float] = None
+    flexjoint_angle_rating_deg: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class ConductorInput:
+    """Below-mudline conductor properties for the wellhead-moment check (#1345)."""
+
+    outer_diameter_m: float
+    wall_thickness_m: float
+    soil_modulus_n_per_m2: float
+    stand_off_m: float
+    youngs_modulus_pa: float = 2.07e11
+
+    @property
+    def ei_nm2(self) -> float:
+        inner = self.outer_diameter_m - 2.0 * self.wall_thickness_m
+        second_moment = math.pi / 64.0 * (self.outer_diameter_m**4 - inner**4)
+        return self.youngs_modulus_pa * second_moment
 
 
 @dataclass(frozen=True)
@@ -209,6 +232,7 @@ def compute_operating_envelope(
     mode: OperatingMode = OperatingMode.DRILLING,
     dynamic: bool = False,
     atlas_root: Optional[Path] = None,
+    conductor: Optional["ConductorInput"] = None,
 ) -> EnvelopeResult:
     """Sweep offset x current x seastate → envelope surface. See module docstring.
 
@@ -233,7 +257,10 @@ def compute_operating_envelope(
     seas = tuple(seastates)
     shape = (offsets.size, currents.size, len(seas))
 
-    util = {k: np.full(shape, np.nan) for k in ("flexjoint_angle", "von_mises", "stroke", "moonpool")}
+    util = {
+        k: np.full(shape, np.nan)
+        for k in ("flexjoint_angle", "von_mises", "stroke", "moonpool", "wh_moment")
+    }
     diameter = section.outer_diameter_m
 
     for i, off_pct in enumerate(offsets):
@@ -250,14 +277,36 @@ def compute_operating_envelope(
             )
             static_angle_deg = max(abs(resp.angle_lower_deg), abs(resp.angle_upper_deg))
             vm = _von_mises_utilisation(section, resp, tension_n, criteria.von_mises_design_factor)
+            # Wellhead/conductor moment (#1345): the riser lower-flex-joint shear
+            # over the BOP/LMRP stand-off arm loads the conductor below mudline.
+            wh_moment_knm = None
+            if conductor is not None:
+                wh_moment_knm = (
+                    solve_conductor_moment(
+                        shear_n=resp.shear_lower_n,
+                        stand_off_m=conductor.stand_off_m,
+                        soil_modulus_n_per_m2=conductor.soil_modulus_n_per_m2,
+                        ei_nm2=conductor.ei_nm2,
+                    ).max_moment_nm
+                    / 1000.0
+                )
+            # Flex-joint max limit = governing min(16Q operating limit, per-rig
+            # hardware angular rating) when the rating is present (#1345).
+            fj_max_limit = criteria.flexjoint_angle_max_deg
+            if rig_limits.flexjoint_angle_rating_deg is not None:
+                fj_max_limit = min(fj_max_limit, rig_limits.flexjoint_angle_rating_deg)
             for k, sea in enumerate(seas):
                 dyn_angle = rao_angle_deg_per_m * sea.hs_m
                 total_angle = static_angle_deg + dyn_angle
                 # governing of the mean-limit (static) and max-limit (total) checks
                 util["flexjoint_angle"][i, j, k] = max(
                     static_angle_deg / criteria.flexjoint_angle_mean_deg,
-                    total_angle / criteria.flexjoint_angle_max_deg,
+                    total_angle / fj_max_limit,
                 )
+                if wh_moment_knm is not None and rig_limits.conductor_moment_capacity_kn_m:
+                    util["wh_moment"][i, j, k] = (
+                        wh_moment_knm / rig_limits.conductor_moment_capacity_kn_m
+                    )
                 util["von_mises"][i, j, k] = vm
                 if dyn_atlas is not None:
                     pred = dyn_atlas.predict({

--- a/src/digitalmodel/drilling_riser/envelope_modes.yml
+++ b/src/digitalmodel/drilling_riser/envelope_modes.yml
@@ -11,12 +11,13 @@
 modes:
   drilling:
     # connected + drilling: the full operating limit set applies
-    active_limits: [flexjoint_angle, von_mises, stroke, moonpool]
+    active_limits: [flexjoint_angle, von_mises, stroke, moonpool, wh_moment]
   connected:
     # connected non-drilling / extreme: same physical limits, criteria escalate
     # (per-category ceilings are #1281b)
-    active_limits: [flexjoint_angle, von_mises, stroke, moonpool]
+    active_limits: [flexjoint_angle, von_mises, stroke, moonpool, wh_moment]
   hang_off:
-    # riser disconnected from the well and hung off: flex-joint angle and
-    # moonpool clearance are not the governing gates; tension/stroke dominate
+    # riser disconnected from the well and hung off: flex-joint angle, moonpool
+    # clearance and the wellhead-moment (well disconnected) are not the governing
+    # gates; tension/stroke dominate
     active_limits: [von_mises, stroke]

--- a/src/digitalmodel/drilling_riser/riser_response.py
+++ b/src/digitalmodel/drilling_riser/riser_response.py
@@ -51,6 +51,10 @@ class RiserResponse:
     bending_moment_nm: np.ndarray
     angle_lower_rad: float
     angle_upper_rad: float
+    #: Lateral shear (transverse reaction) at the lower flex-joint, V(0) magnitude
+    #: [N]. A pinned end carries zero moment but non-zero shear; this is the
+    #: lateral load handed to the conductor model (#1345). Equals T*X/L + w*L/2.
+    shear_lower_n: float = 0.0
 
     @property
     def angle_lower_deg(self) -> float:
@@ -121,10 +125,16 @@ def solve_static_response(
     angle_lower = B - 0.0 - P * k * 1.0 + Q * k * eps
     angle_upper = B - w * L / T - P * k * eps + Q * k * 1.0
 
+    # Lateral shear at the lower flex-joint: V(0) = EI y'''(0) - T y'(0); the
+    # boundary-layer terms cancel (EI k^3 = T k), leaving V(0) = -T*B, so the
+    # magnitude is T*X/L + w*L/2 (rises with offset X and with current via w).
+    shear_lower = abs(T * B)
+
     return RiserResponse(
         z_m=z,
         deflection_m=y,
         bending_moment_nm=moment,
         angle_lower_rad=float(angle_lower),
         angle_upper_rad=float(angle_upper),
+        shear_lower_n=float(shear_lower),
     )

--- a/src/digitalmodel/riser_database/loader.py
+++ b/src/digitalmodel/riser_database/loader.py
@@ -130,6 +130,12 @@ class RigRiserInterfaceRow:
     moonpool_length_ft: Optional[float]
     moonpool_width_ft: Optional[float]
     drill_floor_elev_ft: Optional[float]
+    #: Rated wellhead/conductor bending-moment capacity [kN.m] and flex-joint
+    #: hardware angular rating [deg] (#1345). Public rows carry only public-spec
+    #: rated values; client-/well-specific ratings stay wiki-side. Ship EMPTY in
+    #: this slice — populated by the paired worldenergydata rig-spec sourcing.
+    conductor_moment_capacity_kn_m: Optional[float]
+    flexjoint_angle_rating_deg: Optional[float]
     wed_rig_name: str
     wiki_path: str
     note: str
@@ -148,6 +154,8 @@ _NUMERIC_CONFIG_COLUMNS = (
     "moonpool_length_ft",
     "moonpool_width_ft",
     "drill_floor_elev_ft",
+    "conductor_moment_capacity_kn_m",
+    "flexjoint_angle_rating_deg",
 )
 #: Known tables: csv file, key column, row type. Anything else in the
 #: manifest is rejected (bounded reads: no discovery, no globbing).

--- a/tests/drilling_riser/test_conductor_response.py
+++ b/tests/drilling_riser/test_conductor_response.py
@@ -1,0 +1,70 @@
+"""#1345 (C2): conductor wellhead-moment model (Hetényi beam-on-elastic-foundation).
+
+Oracles are the superposed semi-infinite-beam closed form for a top end-force H
+(the riser lower-flex-joint reaction) plus a stand-off end moment
+``M0 = H * h_stack`` (the flex-joint sits above the mudline atop the BOP/LMRP
+stack, so H acts over that arm):
+
+    M(x) = M0 e^{-bx}(cos bx + sin bx) - (H/b) e^{-bx} sin bx,   b = (k/4EI)^{1/4}
+
+The peak is at the mudline (x=0), dominated by M0 — NOT an interior peak. The
+stand-off term M0 dwarfs the pure soil-reaction peak (~0.32 H/b), so omitting it
+would understate the wellhead moment ~10x (non-conservative).
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from digitalmodel.drilling_riser.conductor_response import (
+    ConductorResponse,
+    solve_conductor_moment,
+)
+
+# 30" conductor in firm soil (SI, synthetic screening values).
+_OD, _WT, _E = 0.762, 0.0254, 2.07e11
+_I = math.pi / 64.0 * (_OD**4 - (_OD - 2 * _WT) ** 4)
+_EI = _E * _I
+_BASE = dict(soil_modulus_n_per_m2=5.0e6, ei_nm2=_EI)
+
+
+def test_zero_shear_zero_moment():
+    r = solve_conductor_moment(shear_n=0.0, stand_off_m=18.0, **_BASE)
+    assert isinstance(r, ConductorResponse)
+    assert r.max_moment_nm == pytest.approx(0.0, abs=1e-6)
+
+
+def test_peak_at_mudline_equals_standoff_moment():
+    H, h = 5.0e5, 18.0
+    r = solve_conductor_moment(shear_n=H, stand_off_m=h, **_BASE)
+    M0 = H * h
+    assert r.stand_off_moment_nm == pytest.approx(M0)
+    # peak is AT the mudline (x=0) and equals the stand-off moment
+    assert abs(r.moment_nm[0]) == pytest.approx(M0, rel=1e-9)
+    assert r.max_moment_nm == pytest.approx(M0, rel=1e-6)
+    assert int(np.argmax(np.abs(r.moment_nm))) == 0
+
+
+def test_standoff_moment_dominates_soil_reaction_term():
+    H, h = 5.0e5, 18.0
+    r = solve_conductor_moment(shear_n=H, stand_off_m=h, **_BASE)
+    soil_reaction_peak = 0.3224 * H / r.beta_per_m  # pure end-force Hetényi peak
+    # the stand-off moment is ~an order of magnitude larger (non-conservative to omit)
+    assert r.max_moment_nm > 5.0 * soil_reaction_peak
+
+
+def test_monotone_in_shear_and_standoff():
+    a = solve_conductor_moment(shear_n=2.0e5, stand_off_m=18.0, **_BASE)
+    b = solve_conductor_moment(shear_n=6.0e5, stand_off_m=18.0, **_BASE)
+    c = solve_conductor_moment(shear_n=2.0e5, stand_off_m=25.0, **_BASE)
+    assert b.max_moment_nm > a.max_moment_nm > 0.0     # more shear -> more moment
+    assert c.max_moment_nm > a.max_moment_nm            # more stand-off -> more moment
+
+
+def test_moment_decays_with_depth():
+    r = solve_conductor_moment(shear_n=5.0e5, stand_off_m=18.0, **_BASE)
+    # decayed to a small fraction of the mudline peak by the far end of the grid
+    assert abs(r.moment_nm[-1]) < 0.05 * r.max_moment_nm
+    assert r.beta_per_m > 0.0

--- a/tests/drilling_riser/test_envelope.py
+++ b/tests/drilling_riser/test_envelope.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from digitalmodel.drilling_riser.envelope import (
+    ConductorInput,
     EnvelopeCriteria,
     EnvelopeResult,
     OperatingMode,
@@ -21,6 +22,11 @@ from digitalmodel.drilling_riser.envelope import (
     SeaState,
     compute_operating_envelope,
     resolve_envelope_criteria,
+)
+
+_CONDUCTOR = ConductorInput(
+    outer_diameter_m=0.762, wall_thickness_m=0.0254,
+    soil_modulus_n_per_m2=5.0e6, stand_off_m=18.0,
 )
 
 
@@ -182,3 +188,47 @@ def test_dynamic_out_of_coverage_escalates_von_mises():
     )
     assert np.isnan(dyn.per_limit_utilisation["von_mises"][0, 0, 0])
     assert dyn.dynamic_provenance["escalated_points"] == 1
+
+
+# -- #1345 wellhead/conductor moment + flex-joint hardware rating ---------------
+
+
+def test_wh_moment_rises_with_offset_and_current():
+    r = compute_operating_envelope(
+        **_BASE, offsets_pct=[1.0, 4.0], current_speeds_mps=[0.5, 1.5],
+        seastates=[SeaState(2.0, 9.0)], conductor=_CONDUCTOR,
+        rig_limits=RigEnvelopeLimits(conductor_moment_capacity_kn_m=8000.0),
+    )
+    whm = r.per_limit_utilisation["wh_moment"]
+    assert not np.isnan(whm).any()
+    assert whm[1, 0, 0] > whm[0, 0, 0]  # rises with offset (via lower-FJ shear)
+    assert whm[0, 1, 0] > whm[0, 0, 0]  # rises with current
+
+
+def test_wh_moment_nan_without_conductor_or_capacity():
+    # no conductor input -> NaN
+    a = compute_operating_envelope(
+        **_BASE, offsets_pct=[2.0], current_speeds_mps=[1.0],
+        seastates=[SeaState(2.0, 9.0)],
+        rig_limits=RigEnvelopeLimits(conductor_moment_capacity_kn_m=8000.0),
+    )
+    assert np.isnan(a.per_limit_utilisation["wh_moment"]).all()
+    # conductor but no rated capacity (columns ship empty) -> NaN
+    b = compute_operating_envelope(
+        **_BASE, offsets_pct=[2.0], current_speeds_mps=[1.0],
+        seastates=[SeaState(2.0, 9.0)], conductor=_CONDUCTOR,
+    )
+    assert np.isnan(b.per_limit_utilisation["wh_moment"]).all()
+
+
+def test_flexjoint_governing_min_uses_hardware_rating():
+    common = dict(offsets_pct=[3.0], current_speeds_mps=[1.0], seastates=[SeaState(5.0, 11.0)],
+                  rao_angle_deg_per_m=0.2)
+    no_rating = compute_operating_envelope(**_BASE, **common)
+    # a hardware rating tighter than the 4.0 deg operating max RAISES the
+    # utilisation (governing min picks the smaller limit -> larger util)
+    with_rating = compute_operating_envelope(
+        **_BASE, **common, rig_limits=RigEnvelopeLimits(flexjoint_angle_rating_deg=1.0),
+    )
+    assert (with_rating.per_limit_utilisation["flexjoint_angle"][0, 0, 0]
+            > no_rating.per_limit_utilisation["flexjoint_angle"][0, 0, 0])

--- a/tests/drilling_riser/test_riser_response.py
+++ b/tests/drilling_riser/test_riser_response.py
@@ -108,3 +108,21 @@ def test_degrees_and_grid_shape():
     assert r.angle_lower_deg == pytest.approx(math.degrees(r.angle_lower_rad))
     assert r.z_m.shape == r.deflection_m.shape == r.bending_moment_nm.shape
     assert r.z_m[0] == 0.0 and r.z_m[-1] == pytest.approx(_BASE["length_m"])
+
+
+# -- lower-flex-joint shear (feeds the conductor model, #1345) -----------------
+
+
+def test_shear_lower_matches_closed_form():
+    X, w = 30.0, _drag_load_n_per_m(1.0)
+    r = solve_static_response(top_offset_m=X, current_load_n_per_m=w, **_BASE)
+    expected = _BASE["tension_n"] * X / _BASE["length_m"] + w * _BASE["length_m"] / 2.0
+    assert r.shear_lower_n == pytest.approx(expected, rel=1e-9)
+
+
+def test_shear_lower_rises_with_offset_and_current():
+    base = solve_static_response(top_offset_m=15.0, current_load_n_per_m=_drag_load_n_per_m(0.5), **_BASE)
+    more_offset = solve_static_response(top_offset_m=45.0, current_load_n_per_m=_drag_load_n_per_m(0.5), **_BASE)
+    more_current = solve_static_response(top_offset_m=15.0, current_load_n_per_m=_drag_load_n_per_m(1.5), **_BASE)
+    assert more_offset.shear_lower_n > base.shear_lower_n > 0.0
+    assert more_current.shear_lower_n > base.shear_lower_n

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -55,6 +55,13 @@ _PUBLIC_ARTIFACTS = (
     REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "assembly.py",
     REPO_ROOT / "tests" / "drilling_riser" / "test_assembly.py",
     REPO_ROOT / "tests" / "drilling_riser" / "test_assembly_golden.py",
+    # #1281 / #1345 operating-envelope + conductor analytical code: reproduces
+    # wellhead/conductor engagements, so it must carry no provenance tokens.
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "envelope.py",
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "riser_response.py",
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "conductor_response.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_envelope.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_conductor_response.py",
 )
 
 
@@ -123,3 +130,24 @@ def test_no_provenance_tokens_in_public_artifacts():
         "provenance tokens leaked into public artifacts (tokens not echoed): "
         f"{violations}"
     )
+
+
+def test_new_analytical_code_is_gated():
+    """#1345 [G-1]: the envelope + conductor analytical code must be inside the
+    scanned artifact set (it reproduces wellhead/conductor engagements)."""
+    scanned = {p.name for p in _PUBLIC_ARTIFACTS}
+    for required in ("envelope.py", "conductor_response.py", "riser_response.py"):
+        assert required in scanned, f"{required} is not gated by the provenance tripwire"
+
+
+def test_scan_would_catch_a_planted_token(tmp_path):
+    """Prove the scan mechanism catches a provenance token in a .py-style file
+    (the gate is only useful if it actually fires on the new file type)."""
+    names, _ = _provenance_tokens()
+    if not names:
+        pytest.skip("no name tokens in the private registry to plant")
+    planted = sorted(names)[0]
+    f = tmp_path / "conductor_like.py"
+    f.write_text(f'# soil calibration note from the {planted} job\nK = 5.0e6\n')
+    normalized = _normalize(f.read_text())
+    assert _normalize(planted) in normalized  # caught


### PR DESCRIPTION
Closes #1345 (envelopes **C2**; grandchild of #1281, epic #1279) — the **AMJIG-free** scope. Implements the plan approved on #1345. Paired public-sourcing issue: **worldenergydata#742**. No paired wiki PR (no citations added).

## Why the shape (T2 review reshaped it)

Two-lens T2 review rejected v1:
- **Mechanics** — a force-only conductor model omitted the **BOP/LMRP stand-off moment**. The lower flex-joint sits ~15–20 m above the mudline; the shear `H` acts over that arm, applying `M0 = H·h_stack` — which *dominates* the soil-reaction peak. Omitting it understated the wellhead moment ~10× (non-conservative). Fixed: superpose the end moment; the peak lands at the mudline.
- **Governance** — the new analytical code (`conductor_response.py`, `envelope.py`) was outside every content gate. Fixed: extended the provenance tripwire's `_PUBLIC_ARTIFACTS` + a coverage/planted-token test.

## What ships

- **`conductor_response.py`** — Hetényi beam-on-elastic-foundation for the conductor below mudline, loaded by the riser lower-flex-joint shear `H` **and** the stand-off moment `M0 = H·h_stack`. Provenance: public beam-on-elastic-foundation theory, not any licensed material. Static screening (single Winkler `k`, no conductor axial load — documented).
- **`RiserResponse.shear_lower_n`** = `T·X/L + w·L/2` (additive) — rises with offset and current, so the wellhead moment is non-degenerate across the sweep.
- **Two rated-capacity columns** (`conductor_moment_capacity_kn_m`, `flexjoint_angle_rating_deg`) added via the 5-file lockstep + manifest resha, **shipped EMPTY** — worldenergydata#742 populates them from public specs; client-specific ratings stay wiki-side. **No cited getter** (rated capacity; ISO 13628-7 is unregistered/methodology-only).
- **Gate extension** — the tripwire now scans `envelope.py`, `riser_response.py`, `conductor_response.py` (+ coverage + planted-token tests).
- **Envelope** — `wh_moment` limit (`M_conductor/capacity`; NaN when no conductor input / empty capacity) + flex-joint governing `min(operating-limit, hardware-rating)`; `envelope_modes.yml` gates `wh_moment` in drilling/connected.

## Verification

- **245** drilling_riser + riser_database + parametric + riser_fatigue tests green — incl. conductor closed-form oracles (peak at mudline = `M0`, monotone in `H`/stand-off, decays ~`1/β`), `wh_moment` rises with offset+current, FJ governing-min, and the gate-coverage tests.
- `build_tables.py` deterministic (`git diff --exit-code`); `legal-sanity-scan --repo=digitalmodel --diff-only` **PASS** over all 14 files.

## Epic status after this

#1281 child C: **C1 + C3 merged; C2 (this) completes the AMJIG-free envelope.** The only remaining item is the **AMJIG per-category criteria**, deferred pending the governance ruling (a/b/c).