### PR TITLE
feat(dev): ensure-worktree-deps.sh — resolve path-dep siblings in agent worktrees (#1057)

### DIFF
--- a/scripts/dev/ensure-worktree-deps.sh
+++ b/scripts/dev/ensure-worktree-deps.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ensure-worktree-deps.sh — make path-dependency siblings resolvable from agent
+# worktrees under .claude/worktrees/ (digitalmodel).
+#
+# digitalmodel's pyproject pins path deps relative to the checkout, e.g.
+#   assetutilities = { path = "../assetutilities", editable = true }
+# From a worktree at .claude/worktrees/agent-XXXX/ the string `../assetutilities`
+# resolves to .claude/worktrees/assetutilities (nonexistent) instead of the real
+# sibling next to the main checkout — so `uv run` / pytest fail to build in any
+# worktree. Create a symlink at .claude/worktrees/<dep> pointing at the real
+# sibling so the relative path resolves for every worktree. Idempotent; safe to
+# run repeatedly. .claude/worktrees/ is gitignored, so the link is never tracked.
+#
+# Usage: scripts/dev/ensure-worktree-deps.sh    # run from anywhere in the repo
+# Exit 0 always for present siblings (missing siblings warn but don't fail — you
+# may simply not have that sibling checked out).
+
+set -euo pipefail
+
+# Path-dep siblings to bridge (basename == pyproject `path = "../<name>"`).
+DEPS=(assetutilities)
+
+# Resolve the MAIN worktree root (first `git worktree list` entry), which is
+# robust whether we're invoked from the main checkout or a nested worktree.
+main_root="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')"
+if [[ -z "${main_root:-}" ]]; then
+  main_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+[[ -n "${main_root:-}" ]] || { echo "ensure-worktree-deps: not inside a git repo" >&2; exit 2; }
+
+wt_dir="${main_root}/.claude/worktrees"
+
+for dep in "${DEPS[@]}"; do
+  target="$(cd "${main_root}/../${dep}" 2>/dev/null && pwd || true)"
+  link="${wt_dir}/${dep}"
+  if [[ -z "${target}" ]]; then
+    echo "ensure-worktree-deps: sibling '${dep}' not found beside ${main_root} — skipping" >&2
+    continue
+  fi
+  mkdir -p "${wt_dir}"
+  if [[ -L "${link}" && "$(readlink "${link}")" == "${target}" ]]; then
+    echo "ensure-worktree-deps: ${dep} -> ${target} (already linked)"
+  else
+    ln -sfn "${target}" "${link}"
+    echo "ensure-worktree-deps: linked ${dep} -> ${target}"
+  fi
+done

--- a/tests/scripts/test_ensure_worktree_deps.py
+++ b/tests/scripts/test_ensure_worktree_deps.py
@@ -1,0 +1,102 @@
+"""Tests for scripts/dev/ensure-worktree-deps.sh (digitalmodel, wh#3368 #4).
+
+Fully hermetic: each test builds a throwaway git repo + a sibling dir in
+tmp_path and runs the script — no dependence on the real digitalmodel checkout.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Resolve the script whether run from the repo (scripts/dev/) or the scratchpad.
+_here = Path(__file__).resolve()
+_candidates = [
+    _here.parent / "ensure-worktree-deps.sh",
+    _here.parents[2] / "scripts" / "dev" / "ensure-worktree-deps.sh",
+]
+SCRIPT = next((p for p in _candidates if p.exists()), _candidates[0])
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """A main checkout named 'digitalmodel' with a 'assetutilities' sibling."""
+    root = tmp_path / "digitalmodel"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@e.com")
+    _git(root, "config", "user.name", "T")
+    _git(root, "config", "commit.gpgsign", "false")
+    (root / "README.md").write_text("# dm\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "init")
+    return root
+
+
+def _run(cwd: Path):
+    return subprocess.run(["bash", str(SCRIPT)], cwd=str(cwd),
+                          capture_output=True, text=True)
+
+
+def test_creates_symlink_to_real_sibling(tmp_path: Path):
+    root = _make_repo(tmp_path)
+    sibling = tmp_path / "assetutilities"
+    sibling.mkdir()
+    r = _run(root)
+    assert r.returncode == 0, r.stderr
+    link = root / ".claude" / "worktrees" / "assetutilities"
+    assert link.is_symlink()
+    assert link.resolve() == sibling.resolve()
+
+
+def test_idempotent_second_run_reports_already_linked(tmp_path: Path):
+    root = _make_repo(tmp_path)
+    (tmp_path / "assetutilities").mkdir()
+    _run(root)
+    r = _run(root)
+    assert r.returncode == 0
+    assert "already linked" in r.stdout
+    link = root / ".claude" / "worktrees" / "assetutilities"
+    assert link.is_symlink()
+
+
+def test_missing_sibling_warns_but_does_not_fail_or_link(tmp_path: Path):
+    root = _make_repo(tmp_path)  # no sibling created
+    r = _run(root)
+    assert r.returncode == 0
+    assert "not found" in r.stderr
+    assert not (root / ".claude" / "worktrees" / "assetutilities").exists()
+
+
+def test_resolves_from_inside_a_worktree(tmp_path: Path):
+    """Run from a nested worktree — the link must land at the MAIN root."""
+    root = _make_repo(tmp_path)
+    (tmp_path / "assetutilities").mkdir()
+    wt = root / ".claude" / "worktrees" / "agent-xyz"
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    _git(root, "worktree", "add", "-q", "--detach", str(wt))
+    r = _run(wt)
+    assert r.returncode == 0, r.stderr
+    # Link created under the MAIN root, not under the worktree.
+    link = root / ".claude" / "worktrees" / "assetutilities"
+    assert link.is_symlink()
+    assert link.resolve() == (tmp_path / "assetutilities").resolve()
+
+
+def test_replaces_a_stale_wrong_symlink(tmp_path: Path):
+    root = _make_repo(tmp_path)
+    sibling = tmp_path / "assetutilities"
+    sibling.mkdir()
+    link = root / ".claude" / "worktrees" / "assetutilities"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(tmp_path / "nowhere")  # stale/broken link
+    r = _run(root)
+    assert r.returncode == 0
+    assert link.resolve() == sibling.resolve()


### PR DESCRIPTION
Small dev-ergonomics guard (session-grounded — workspace-hub #3368 item 4).

**Friction:** `uv run` / pytest fails in any `.claude/worktrees/agent-*` worktree because pyproject's `assetutilities = { path = "../assetutilities" }` resolves to `.claude/worktrees/assetutilities` (nonexistent) instead of the real sibling next to the main checkout. This bit the FFS build wave — every recovered-agent test run needed a manual symlink first.

**Fix:** `scripts/dev/ensure-worktree-deps.sh` creates `.claude/worktrees/<dep>` → the real sibling (idempotent; derives paths from `git worktree list`, no hardcoded absolutes; `.claude/worktrees/` is gitignored so the link is never tracked). Run it once after creating a worktree.

Verified with 5 hermetic tests (`tests/scripts/test_ensure_worktree_deps.py`, `workflows` domain) covering: link creation, idempotency, missing-sibling warn-not-fail, resolution from *inside* a nested worktree, and stale-link replacement. All green.

Refs #1057 · workspace-hub#3368