### PR TITLE
feat(motion_forecast): keystone 6-DOF motion reconstruction engine (#1358)

### DIFF
--- a/.planning/plan-approved/1358.md
+++ b/.planning/plan-approved/1358.md
@@ -1,0 +1,11 @@
+# #1358 motion_forecast keystone — plan approved
+
+Owner approved 2026-07-04 ("Go with recommended defaults"), after adversarial
+plan review (REWORK -> reworked). Recommended defaults adopted:
+- #1357 interface: discrete {omega, a, phi, heading} + phase_reference_location.
+- Long-crested first (directional spreading = fast-follow).
+- Deep-water dispersion k = omega^2 / g (finite-depth parametrised).
+- Canonical RAO convention: normalise AQWA -> OrcaFlex.
+
+Plan: docs/plans/2026-07-03-issue-1358-motion-forecast-keystone.md
+Core engine (Tasks 1-5) implemented; Task 6 (seastate_limits RAO path) = fast-follow.

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -278,6 +278,12 @@ def engine(
         )
 
         cfg_base = rao_tabulation(cfg_base)
+    elif basename == "motion_forecast":
+        from digitalmodel.motion_forecast.workflow import (
+            router as motion_forecast,
+        )
+
+        cfg_base = motion_forecast(cfg_base)
     elif basename == "installation":
         orc_install = OrcInstallation()
         if cfg_base["structure"]["flag"]:

--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -1,0 +1,44 @@
+"""Short-horizon vessel/structure motion forecasting (digitalmodel #1358).
+
+Reconstructs the time-domain 6-DOF motion of an asset a short horizon ahead
+from a phase-resolved incident-wave forecast transferred through the asset RAO,
+bounded by the predictable zone. Keystone of epic #1356.
+"""
+
+from .conventions import RAOSource, heading_going_to_deg, normalize_phase_deg
+from .models import (
+    DOF_NAMES,
+    ROTATION_DOFS,
+    MotionForecast,
+    WaveComponent,
+    WaveForecast,
+)
+from .rao_adapter import AnalyticRAO, GridRAO
+from .reconstruct import (
+    reconstruct_motion,
+    time_derivative,
+    vertical_motion_at,
+    wavenumber,
+)
+from .wave_source import jonswap_spectrum, synthesize_forecast
+from .workflow import router
+
+__all__ = [
+    "RAOSource",
+    "normalize_phase_deg",
+    "heading_going_to_deg",
+    "DOF_NAMES",
+    "ROTATION_DOFS",
+    "WaveComponent",
+    "WaveForecast",
+    "MotionForecast",
+    "AnalyticRAO",
+    "GridRAO",
+    "reconstruct_motion",
+    "vertical_motion_at",
+    "time_derivative",
+    "wavenumber",
+    "jonswap_spectrum",
+    "synthesize_forecast",
+    "router",
+]

--- a/src/digitalmodel/motion_forecast/conventions.py
+++ b/src/digitalmodel/motion_forecast/conventions.py
@@ -1,0 +1,74 @@
+"""RAO phase / heading conventions (digitalmodel #1358).
+
+There is no phase-convention normalisation anywhere in the RAO parsers today —
+``aqwa_lis_parser`` and ``orcaflex_yml_parser`` both store phase **raw** (deg).
+AQWA and OrcaFlex differ in phase sign (lead vs lag) and heading direction, so a
+forecast that mixes sources, or transfers a wave phased at a sensing point, must
+pin a single internal convention. This module *defines and enforces* it.
+
+Canonical internal convention (per owner decision 2026-07-04, "normalise
+AQWA -> OrcaFlex"):
+
+- Wave elevation:  ``eta = a * cos(omega*t + phi)``  (cosine, phase in rad).
+- RAO transfer:    ``x = a * |H| * cos(omega*t + phi + arg H)`` where
+  ``arg H`` is a **phase lead** of the response over the incident wave.
+- Heading:         *going-to*, degrees from +x.
+
+OrcaFlex displacement-RAO phase is taken as the canonical lead. AQWA reports a
+phase **lag**, so AQWA phase is negated to reach the canonical lead.
+
+IMPORTANT: the AQWA sign is an explicit, documented assumption pending
+validation against a matched-vessel dataset (no such fixture exists in-repo).
+It is centralised here so a single constant flips it if a validation says so.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+
+
+class RAOSource(Enum):
+    """Origin of an RAO dataset — selects the phase-normalisation rule."""
+
+    ORCAFLEX = "orcaflex"   # canonical
+    AQWA = "aqwa"           # phase lag -> negated to canonical lead
+    CANONICAL = "canonical"  # already in internal convention (e.g. analytic)
+
+
+# Per-source multiplier applied to the RAO phase to reach the canonical lead.
+# Centralised so a validated correction is a one-line change.
+_PHASE_SIGN = {
+    RAOSource.ORCAFLEX: +1.0,
+    RAOSource.AQWA: -1.0,
+    RAOSource.CANONICAL: +1.0,
+}
+
+
+def normalize_phase_deg(phase_deg: np.ndarray, source: RAOSource) -> np.ndarray:
+    """Return RAO phase (deg) in the canonical lead convention.
+
+    Parameters
+    ----------
+    phase_deg:
+        Raw RAO phase array as parsed, in degrees.
+    source:
+        Which solver produced it (selects the sign rule).
+    """
+    return _PHASE_SIGN[source] * np.asarray(phase_deg, dtype=float)
+
+
+def heading_going_to_deg(heading_deg: float, coming_from: bool) -> float:
+    """Convert a heading to the internal *going-to* convention (deg).
+
+    Parameters
+    ----------
+    heading_deg:
+        Heading in the source convention.
+    coming_from:
+        True if the source measures the direction the wave comes *from*
+        (add 180 deg to get going-to); False if already going-to.
+    """
+    h = heading_deg + (180.0 if coming_from else 0.0)
+    return float(h % 360.0)

--- a/src/digitalmodel/motion_forecast/models.py
+++ b/src/digitalmodel/motion_forecast/models.py
@@ -1,0 +1,99 @@
+"""Data models for short-horizon motion forecasting (digitalmodel #1358).
+
+The engine reconstructs the time-domain 6-DOF motion of an asset a short
+horizon ahead, from a *phased* incident-wave forecast propagated to the asset
+location and transferred through the asset's RAO.
+
+Design notes
+------------
+- ``WaveForecast`` carries discrete phased components **and** the
+  ``phase_reference_location`` those phases are referenced to. This is the seam
+  #1357 (``wave_forecast``) plugs into; any object exposing these attributes is
+  accepted (structural typing).
+- Motion is stored per DOF: translations (surge/sway/heave) in metres,
+  rotations (roll/pitch/yaw) in **degrees** (matching ``DisplacementRAO`` units).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+GRAVITY = 9.80665  # m/s^2
+
+DOF_NAMES: Tuple[str, ...] = ("surge", "sway", "heave", "roll", "pitch", "yaw")
+ROTATION_DOFS: Tuple[str, ...] = ("roll", "pitch", "yaw")
+
+
+@dataclass(frozen=True)
+class WaveComponent:
+    """A single phased wave component.
+
+    Attributes
+    ----------
+    omega:
+        Angular frequency (rad/s).
+    amplitude:
+        Component amplitude (m).
+    phase:
+        Phase (rad) at ``WaveForecast.phase_reference_location`` under the
+        cosine convention ``eta = amplitude * cos(omega * t + phase)``.
+    heading:
+        Propagation heading (deg), *going-to* convention, measured from +x.
+    """
+
+    omega: float
+    amplitude: float
+    phase: float
+    heading: float = 0.0
+
+
+@dataclass
+class WaveForecast:
+    """A phase-resolved short-horizon wave forecast at a reference location.
+
+    ``#1357`` produces this (or any duck-typed equivalent). The engine only
+    reads these attributes.
+    """
+
+    components: List[WaveComponent]
+    horizon: float                                   # s, predictable-zone length
+    origin_time: float = 0.0                          # s, "now"
+    phase_reference_location: Tuple[float, float] = (0.0, 0.0)  # (x, y) m
+    water_depth: Optional[float] = None               # m; None => deep water
+
+    def frequencies(self) -> np.ndarray:
+        return np.array([c.omega for c in self.components], dtype=float)
+
+    def amplitudes(self) -> np.ndarray:
+        return np.array([c.amplitude for c in self.components], dtype=float)
+
+
+@dataclass
+class MotionForecast:
+    """Reconstructed 6-DOF motion over a time grid.
+
+    ``dof`` maps each DOF name to a time series aligned with ``t`` — translations
+    in metres, rotations in degrees. ``horizon``/``origin_time`` carry the
+    predictable-zone bounds the forecast is valid within.
+    """
+
+    t: np.ndarray
+    dof: Dict[str, np.ndarray]
+    origin_time: float
+    horizon: float
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+    def significant(self, dof_name: str) -> float:
+        """Significant (2*std) amplitude of a DOF over the record."""
+        return 2.0 * float(np.std(self.dof[dof_name]))
+
+    def max_abs(self, dof_name: str) -> float:
+        return float(np.max(np.abs(self.dof[dof_name])))
+
+    def as_arrays(self) -> Dict[str, np.ndarray]:
+        out = {"t": self.t}
+        out.update(self.dof)
+        return out

--- a/src/digitalmodel/motion_forecast/rao_adapter.py
+++ b/src/digitalmodel/motion_forecast/rao_adapter.py
@@ -1,0 +1,102 @@
+"""RAO adapters exposing a complex transfer ``H(dof, omega, heading)``.
+
+Two providers implement the same tiny interface the reconstruction core needs:
+
+- :class:`GridRAO` — wraps a parsed ``DisplacementRAO`` grid (from
+  ``unified_rao_reader``) and does **complex** (amplitude * e^{i*phase}) bilinear
+  interpolation over (frequency, heading). Interpolating the complex value, not
+  raw degrees, avoids phase-wraparound artefacts. Phase is normalised to the
+  canonical lead convention (:mod:`.conventions`) on construction.
+- :class:`AnalyticRAO` — closed-form ``H`` callables per DOF, for tests and for
+  a quick idealised asset without a solver file.
+
+Consuming ``DisplacementRAO`` directly (not ``rao_interpolator.interpolate_2d``)
+sidesteps the ``UnifiedRAOData`` vs ``rao_processor.RAOData`` shape mismatch.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+import numpy as np
+
+from .conventions import RAOSource, normalize_phase_deg
+from .models import DOF_NAMES
+
+
+def _interp_complex(
+    freqs: np.ndarray, headings: np.ndarray, grid: np.ndarray,
+    omega: float, heading: float,
+) -> complex:
+    """Bilinear interpolation of a complex (n_freq, n_head) grid.
+
+    Flat extrapolation outside range (np.interp semantics). Single-heading grids
+    interpolate over frequency only.
+    """
+    def _interp_freq(col: np.ndarray) -> complex:
+        re = np.interp(omega, freqs, col.real)
+        im = np.interp(omega, freqs, col.imag)
+        return complex(re, im)
+
+    if headings.size == 1:
+        return _interp_freq(grid[:, 0])
+
+    # bracket heading (no periodic wrap; RAO heading axis assumed monotonic)
+    h = float(np.clip(heading, headings[0], headings[-1]))
+    j = int(np.searchsorted(headings, h))
+    if j <= 0:
+        return _interp_freq(grid[:, 0])
+    if j >= headings.size:
+        return _interp_freq(grid[:, -1])
+    h0, h1 = headings[j - 1], headings[j]
+    c0 = _interp_freq(grid[:, j - 1])
+    c1 = _interp_freq(grid[:, j])
+    w = 0.0 if h1 == h0 else (h - h0) / (h1 - h0)
+    return (1.0 - w) * c0 + w * c1
+
+
+class GridRAO:
+    """Complex transfer built from a parsed ``DisplacementRAO`` grid."""
+
+    def __init__(self, displacement_rao, source: RAOSource):
+        rao = displacement_rao
+        self.freqs = np.asarray(rao.frequencies, dtype=float)     # rad/s
+        self.headings = np.asarray(rao.headings, dtype=float)     # deg
+        self.source = source
+        self._H: Dict[str, np.ndarray] = {}
+        for dof in DOF_NAMES:
+            d = rao.get_dof_data(dof)
+            phase_rad = np.deg2rad(normalize_phase_deg(d.phase, source))
+            self._H[dof] = np.asarray(d.amplitude, dtype=float) * np.exp(1j * phase_rad)
+
+    @classmethod
+    def from_unified(cls, unified, source: RAOSource) -> "GridRAO":
+        if not unified.has_displacement():
+            raise ValueError("UnifiedRAOData has no displacement RAO")
+        return cls(unified.displacement, source)
+
+    @classmethod
+    def from_file(cls, file_path: str, source: RAOSource) -> "GridRAO":
+        from digitalmodel.marine_ops.marine_analysis.unified_rao_reader import (
+            read_rao_file,
+        )
+        unified = read_rao_file(file_path)
+        return cls.from_unified(unified, source)
+
+    def H(self, dof: str, omega: float, heading: float = 0.0) -> complex:
+        return _interp_complex(self.freqs, self.headings, self._H[dof], omega, heading)
+
+
+class AnalyticRAO:
+    """Closed-form transfer: ``callables[dof](omega, heading) -> complex``.
+
+    Missing DOFs return ``0`` (no response). Amplitudes are motion-per-unit-wave
+    (m/m for translations, deg/m for rotations); phase is the canonical lead.
+    """
+
+    def __init__(self, callables: Dict[str, Callable[[float, float], complex]]):
+        self._c = dict(callables)
+
+    def H(self, dof: str, omega: float, heading: float = 0.0) -> complex:
+        f: Optional[Callable[[float, float], complex]] = self._c.get(dof)
+        return complex(0.0) if f is None else complex(f(omega, heading))

--- a/src/digitalmodel/motion_forecast/rao_adapter.py
+++ b/src/digitalmodel/motion_forecast/rao_adapter.py
@@ -59,15 +59,28 @@ class GridRAO:
     """Complex transfer built from a parsed ``DisplacementRAO`` grid."""
 
     def __init__(self, displacement_rao, source: RAOSource):
+        """Wrap a ``DisplacementRAO``.
+
+        Headings are assumed to be in the *going-to* convention consistent with
+        the forecast components (convert with
+        :func:`.conventions.heading_going_to_deg` at ingest if the source reports
+        "coming-from"). Axes are sorted ascending so the interpolation's
+        ``np.interp``/``searchsorted`` assumptions always hold.
+        """
         rao = displacement_rao
-        self.freqs = np.asarray(rao.frequencies, dtype=float)     # rad/s
-        self.headings = np.asarray(rao.headings, dtype=float)     # deg
+        freqs = np.asarray(rao.frequencies, dtype=float)     # rad/s
+        headings = np.asarray(rao.headings, dtype=float)     # deg
+        fo = np.argsort(freqs)                               # ascending order
+        ho = np.argsort(headings)
+        self.freqs = freqs[fo]
+        self.headings = headings[ho]
         self.source = source
         self._H: Dict[str, np.ndarray] = {}
         for dof in DOF_NAMES:
             d = rao.get_dof_data(dof)
             phase_rad = np.deg2rad(normalize_phase_deg(d.phase, source))
-            self._H[dof] = np.asarray(d.amplitude, dtype=float) * np.exp(1j * phase_rad)
+            grid = np.asarray(d.amplitude, dtype=float) * np.exp(1j * phase_rad)
+            self._H[dof] = grid[np.ix_(fo, ho)]
 
     @classmethod
     def from_unified(cls, unified, source: RAOSource) -> "GridRAO":

--- a/src/digitalmodel/motion_forecast/reconstruct.py
+++ b/src/digitalmodel/motion_forecast/reconstruct.py
@@ -1,0 +1,138 @@
+"""Core: time-domain 6-DOF motion reconstruction (digitalmodel #1358).
+
+For each phased wave component *i* the incident phase is propagated from the
+forecast's ``phase_reference_location`` to the asset location using the
+dispersion relation, then transferred through the asset RAO::
+
+    theta_i(t) = omega_i*t + phi_i - k_i * (d_hat_i . (x_asset - x_ref))
+                 + arg H_dof(omega_i, heading_i)
+    x_dof(t)   = sum_i a_i * |H_dof(omega_i, heading_i)| * cos(theta_i(t))
+
+The ``-k*Delta x`` term is the point of a *forecast*: a wave phased at a sensing
+point must be propagated to where the asset actually is. Translations come out
+in metres, rotations in degrees (``DisplacementRAO`` units).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .models import DOF_NAMES, GRAVITY, MotionForecast, WaveForecast
+
+
+def wavenumber(omega: float, water_depth: Optional[float] = None) -> float:
+    """Wavenumber k from the linear dispersion relation.
+
+    Deep water (``water_depth is None``): ``k = omega^2 / g``. Finite depth:
+    solve ``omega^2 = g k tanh(k h)`` by fixed-point iteration.
+    """
+    k_deep = omega * omega / GRAVITY
+    if water_depth is None or water_depth <= 0 or not np.isfinite(water_depth):
+        return k_deep
+    k = k_deep
+    for _ in range(100):
+        k_new = omega * omega / (GRAVITY * np.tanh(k * water_depth))
+        if abs(k_new - k) < 1e-12:
+            k = k_new
+            break
+        k = k_new
+    return float(k)
+
+
+def reconstruct_motion(
+    forecast: WaveForecast,
+    rao,
+    *,
+    asset_location: Tuple[float, float] = (0.0, 0.0),
+    dt: float = 0.2,
+    t_grid: Optional[Sequence[float]] = None,
+    dofs: Sequence[str] = DOF_NAMES,
+) -> MotionForecast:
+    """Reconstruct 6-DOF asset motion over the predictable-zone horizon.
+
+    Parameters
+    ----------
+    forecast:
+        Phased incident-wave forecast (with ``phase_reference_location``).
+    rao:
+        Object exposing ``H(dof, omega, heading) -> complex`` (see
+        :mod:`.rao_adapter`).
+    asset_location:
+        (x, y) of the asset (m); the wave phase is propagated here from the
+        forecast reference location.
+    dt:
+        Time step (s) for the default grid.
+    t_grid:
+        Explicit times (s). **Fail-closed**: any time outside
+        ``[origin_time, origin_time + horizon]`` raises — no extrapolation
+        beyond the predictable zone.
+    """
+    t0 = forecast.origin_time
+    t1 = forecast.origin_time + forecast.horizon
+    if t_grid is None:
+        n = max(2, int(round(forecast.horizon / dt)) + 1)
+        t = np.linspace(t0, t1, n)
+    else:
+        t = np.asarray(t_grid, dtype=float)
+        eps = 1e-9
+        if t.min() < t0 - eps or t.max() > t1 + eps:
+            raise ValueError(
+                f"t_grid [{t.min():.3f}, {t.max():.3f}] exceeds predictable "
+                f"zone [{t0:.3f}, {t1:.3f}] (fail-closed; no extrapolation)"
+            )
+
+    xr, yr = forecast.phase_reference_location
+    xa, ya = asset_location
+    dx, dy = xa - xr, ya - yr
+
+    out: Dict[str, np.ndarray] = {d: np.zeros_like(t) for d in dofs}
+
+    for comp in forecast.components:
+        k = wavenumber(comp.omega, forecast.water_depth)
+        brad = np.deg2rad(comp.heading)
+        # projection of the reference->asset offset onto the propagation dir
+        proj = np.cos(brad) * dx + np.sin(brad) * dy
+        spatial_phase = -k * proj
+        wave_phase = comp.omega * t + comp.phase + spatial_phase
+        for d in dofs:
+            H = rao.H(d, comp.omega, comp.heading)
+            mag = abs(H)
+            if mag == 0.0:
+                continue
+            out[d] += comp.amplitude * mag * np.cos(wave_phase + np.angle(H))
+
+    return MotionForecast(
+        t=t, dof=out, origin_time=t0, horizon=forecast.horizon,
+        metadata={
+            "asset_location": (xa, ya),
+            "phase_reference_location": (xr, yr),
+            "water_depth": forecast.water_depth,
+            "n_components": len(forecast.components),
+        },
+    )
+
+
+def vertical_motion_at(
+    motion: MotionForecast, offset: Tuple[float, float, float]
+) -> np.ndarray:
+    """Vertical displacement (m) at a rigid-body point ``offset=(rx,ry,rz)``.
+
+    Small-angle rigid-body kinematics referenced to the motion origin::
+
+        z(r, t) = heave - rx*pitch + ry*roll     (angles in rad)
+
+    Used for structure-interface points (crane tip, gangway tip, deployment
+    point). ``rz`` is accepted for API symmetry (no vertical lever term).
+    """
+    rx, ry, _rz = offset
+    heave = motion.dof["heave"]
+    pitch = np.deg2rad(motion.dof["pitch"])
+    roll = np.deg2rad(motion.dof["roll"])
+    return heave - rx * pitch + ry * roll
+
+
+def time_derivative(t: np.ndarray, x: np.ndarray) -> np.ndarray:
+    """Numerical derivative dx/dt on a (possibly non-uniform) grid."""
+    return np.gradient(x, t)

--- a/src/digitalmodel/motion_forecast/reconstruct.py
+++ b/src/digitalmodel/motion_forecast/reconstruct.py
@@ -26,19 +26,43 @@ def wavenumber(omega: float, water_depth: Optional[float] = None) -> float:
     """Wavenumber k from the linear dispersion relation.
 
     Deep water (``water_depth is None``): ``k = omega^2 / g``. Finite depth:
-    solve ``omega^2 = g k tanh(k h)`` by fixed-point iteration.
+    solve ``omega^2 = g k tanh(k h)`` for k.
+
+    The residual ``f(k) = g k tanh(k h) - omega^2`` is strictly increasing in k,
+    so this uses **bisection** (guaranteed convergent, unlike the fixed-point map
+    ``k <- omega^2/(g tanh(kh))`` which oscillates in shallow water) with a
+    relative tolerance, and raises if it fails to converge.
     """
+    if omega <= 0:
+        return 0.0
     k_deep = omega * omega / GRAVITY
     if water_depth is None or water_depth <= 0 or not np.isfinite(water_depth):
         return k_deep
-    k = k_deep
-    for _ in range(100):
-        k_new = omega * omega / (GRAVITY * np.tanh(k * water_depth))
-        if abs(k_new - k) < 1e-12:
-            k = k_new
+
+    def f(k: float) -> float:
+        return GRAVITY * k * np.tanh(k * water_depth) - omega * omega
+
+    # bracket: f(0+) < 0; grow hi until f(hi) > 0 (true k >= k_deep for finite h)
+    lo, hi = 0.0, max(k_deep, 1.0 / water_depth)
+    for _ in range(200):
+        if f(hi) > 0:
             break
-        k = k_new
-    return float(k)
+        hi *= 2.0
+    else:  # pragma: no cover - unreachable for physical inputs
+        raise RuntimeError(f"could not bracket wavenumber (omega={omega}, h={water_depth})")
+
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        fm = f(mid)
+        if abs(fm) <= 1e-10 * omega * omega or (hi - lo) <= 1e-12 * mid:
+            return float(mid)
+        if fm > 0:
+            hi = mid
+        else:
+            lo = mid
+    raise RuntimeError(
+        f"wavenumber bisection did not converge (omega={omega}, h={water_depth})"
+    )
 
 
 def reconstruct_motion(
@@ -68,7 +92,15 @@ def reconstruct_motion(
         Explicit times (s). **Fail-closed**: any time outside
         ``[origin_time, origin_time + horizon]`` raises — no extrapolation
         beyond the predictable zone.
+
+    Notes
+    -----
+    Component headings and the RAO's heading axis must share the *going-to*
+    convention (deg from +x). Convert a source RAO's headings at ingest with
+    :func:`.conventions.heading_going_to_deg` if it reports "coming-from".
     """
+    if not forecast.components:
+        raise ValueError("forecast has no wave components")
     t0 = forecast.origin_time
     t1 = forecast.origin_time + forecast.horizon
     if t_grid is None:

--- a/src/digitalmodel/motion_forecast/wave_source.py
+++ b/src/digitalmodel/motion_forecast/wave_source.py
@@ -1,0 +1,102 @@
+"""Fallback synthetic phased-sea generator (digitalmodel #1358).
+
+Produces a :class:`WaveForecast` of discrete phased components from a JONSWAP
+sea state with deterministic (seeded) phases. This is the seam that #1357
+(``wave_forecast``) replaces with a real phase-resolved surface; until then it
+lets the engine build and be validated standalone.
+
+Component amplitudes follow ``a_i = sqrt(2 * S(omega_i) * d_omega)`` so the
+component set carries the spectrum's variance (``sum(0.5*a_i^2) = m0``).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from .models import WaveComponent, WaveForecast
+
+
+def jonswap_spectrum(
+    omega: np.ndarray, hs: float, tp: float, gamma: float = 3.3
+) -> np.ndarray:
+    """JONSWAP one-sided spectral density S(omega) (m^2 s / rad).
+
+    Normalised so that ``4*sqrt(trapz(S, omega)) == hs`` to close numerical
+    error in the peak-shape/gamma factors.
+    """
+    omega = np.asarray(omega, dtype=float)
+    wp = 2.0 * np.pi / tp
+    sigma = np.where(omega <= wp, 0.07, 0.09)
+    # Pierson-Moskowitz base * peak-enhancement
+    with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+        pm = (
+            5.0 / 16.0 * hs**2 * wp**4 / omega**5
+            * np.exp(-1.25 * (wp / omega) ** 4)
+        )
+        r = np.exp(-((omega - wp) ** 2) / (2.0 * sigma**2 * wp**2))
+        s = pm * gamma**r
+    s = np.where(np.isfinite(s) & (omega > 0), s, 0.0)
+    # renormalise to the requested Hs
+    _trapz = np.trapezoid if hasattr(np, "trapezoid") else np.trapz
+    m0 = float(_trapz(s, omega))
+    if m0 > 0:
+        s = s * (hs / (4.0 * np.sqrt(m0))) ** 2
+    return s
+
+
+def synthesize_forecast(
+    hs: float,
+    tp: float,
+    *,
+    gamma: float = 3.3,
+    heading: float = 0.0,
+    n_components: int = 48,
+    horizon: float = 90.0,
+    omega_range: Optional[Tuple[float, float]] = None,
+    phase_reference_location: Tuple[float, float] = (0.0, 0.0),
+    water_depth: Optional[float] = None,
+    origin_time: float = 0.0,
+    seed: int = 20260704,
+) -> WaveForecast:
+    """Synthesize a deterministic phased :class:`WaveForecast` from a sea state.
+
+    Parameters
+    ----------
+    hs, tp, gamma:
+        JONSWAP significant height (m), peak period (s), peak factor.
+    heading:
+        Propagation heading (deg, going-to) applied to all components
+        (long-crested — directional spreading is a #1358 fast-follow).
+    n_components:
+        Number of discrete components across ``omega_range``.
+    horizon:
+        Predictable-zone length (s) carried on the forecast.
+    seed:
+        Seeds the component phases (deterministic sea).
+    """
+    wp = 2.0 * np.pi / tp
+    lo, hi = omega_range or (0.4 * wp, 3.2 * wp)
+    edges = np.linspace(lo, hi, n_components + 1)
+    omega = 0.5 * (edges[:-1] + edges[1:])
+    d_omega = np.diff(edges)
+
+    s = jonswap_spectrum(omega, hs, tp, gamma)
+    amp = np.sqrt(2.0 * s * d_omega)
+
+    rng = np.random.default_rng(seed)
+    phases = rng.uniform(0.0, 2.0 * np.pi, size=n_components)
+
+    components = [
+        WaveComponent(omega=float(omega[i]), amplitude=float(amp[i]),
+                      phase=float(phases[i]), heading=float(heading))
+        for i in range(n_components)
+    ]
+    return WaveForecast(
+        components=components,
+        horizon=horizon,
+        origin_time=origin_time,
+        phase_reference_location=phase_reference_location,
+        water_depth=water_depth,
+    )

--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -1,0 +1,104 @@
+"""Durable workflow entry point for motion_forecast (digitalmodel #1358).
+
+Mirrors the repo convention (e.g. ``vessel_seakeeping.workflow``): ``router``
+takes the config dict, does the work, writes results back under the module key,
+and returns the (mutated) cfg. ``engine.py`` dispatches ``basename ==
+"motion_forecast"`` here.
+
+Config shape (under ``cfg['motion_forecast']``)::
+
+    sea:   {hs, tp, gamma?, heading?, n_components?, horizon?, seed?}
+    rao:   {source: "file"|"analytic",
+            file?: <path>, format?: "aqwa"|"orcaflex",
+            preset?: "generic_vessel"}      # analytic fallback
+    asset: {location?: [x, y], dt?: <s>}
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+from .conventions import RAOSource
+from .models import DOF_NAMES
+from .rao_adapter import AnalyticRAO, GridRAO
+from .reconstruct import reconstruct_motion
+from .wave_source import synthesize_forecast
+
+
+def generic_vessel_rao() -> AnalyticRAO:
+    """A simple, documented analytic displacement RAO for smoke/demo use.
+
+    Not a real vessel — a second-order heave/pitch/roll response with a
+    short-wave roll-off, in the canonical lead convention. Amplitudes are
+    m/m (translations) and deg/m (rotations).
+    """
+    g = 9.80665
+
+    def _mech(omega: float, tn: float, zeta: float) -> complex:
+        wn = 2.0 * np.pi / tn
+        r = omega / wn
+        return 1.0 / complex(1.0 - r * r, 2.0 * zeta * r)
+
+    def _rolloff(omega: float, length_scale: float) -> float:
+        k = omega * omega / g
+        return float(np.exp(-((k * length_scale) ** 2)))
+
+    def heave(omega, heading):
+        return _mech(omega, 10.0, 0.2) * _rolloff(omega, 12.0)
+
+    def pitch(omega, heading):
+        k = omega * omega / g
+        return k * _mech(omega, 12.0, 0.15) * _rolloff(omega, 15.0) * 40.0
+
+    def roll(omega, heading):
+        k = omega * omega / g
+        return k * _mech(omega, 13.0, 0.06) * 60.0
+
+    return AnalyticRAO({"heave": heave, "pitch": pitch, "roll": roll})
+
+
+def _build_rao(rao_cfg: Dict):
+    source = rao_cfg.get("source", "analytic")
+    if source == "file":
+        fmt = rao_cfg.get("format", "orcaflex").lower()
+        src = RAOSource.AQWA if fmt == "aqwa" else RAOSource.ORCAFLEX
+        return GridRAO.from_file(rao_cfg["file"], src)
+    # analytic
+    preset = rao_cfg.get("preset", "generic_vessel")
+    if preset != "generic_vessel":
+        raise ValueError(f"Unknown analytic RAO preset: {preset}")
+    return generic_vessel_rao()
+
+
+def router(cfg: Dict) -> Dict:
+    """Run a motion forecast and write results back into ``cfg``."""
+    mf = cfg.setdefault("motion_forecast", {})
+    sea = mf.get("sea", {})
+    rao_cfg = mf.get("rao", {})
+    asset = mf.get("asset", {})
+
+    forecast = synthesize_forecast(
+        hs=float(sea.get("hs", 2.5)),
+        tp=float(sea.get("tp", 9.0)),
+        gamma=float(sea.get("gamma", 3.3)),
+        heading=float(sea.get("heading", 0.0)),
+        n_components=int(sea.get("n_components", 48)),
+        horizon=float(sea.get("horizon", 90.0)),
+        seed=int(sea.get("seed", 20260704)),
+    )
+    rao = _build_rao(rao_cfg)
+    location = tuple(asset.get("location", (0.0, 0.0)))
+    motion = reconstruct_motion(
+        forecast, rao, asset_location=location, dt=float(asset.get("dt", 0.2))
+    )
+
+    mf["results"] = {
+        "t": motion.t.tolist(),
+        "dof": {d: motion.dof[d].tolist() for d in DOF_NAMES},
+        "significant": {d: motion.significant(d) for d in DOF_NAMES},
+        "horizon": motion.horizon,
+        "n_components": len(forecast.components),
+    }
+    return cfg

--- a/tests/motion_forecast/test_conventions.py
+++ b/tests/motion_forecast/test_conventions.py
@@ -1,0 +1,60 @@
+"""RAO phase / heading convention tests (digitalmodel #1358).
+
+No matched AQWA/OrcaFlex vessel fixture pair exists in-repo, so these tests
+verify the normalisation is *applied consistently* (the sign rule and its
+effect on the complex transfer), not that it matches a real matched dataset.
+"""
+
+import numpy as np
+
+from digitalmodel.motion_forecast.conventions import (
+    RAOSource,
+    heading_going_to_deg,
+    normalize_phase_deg,
+)
+from digitalmodel.motion_forecast.rao_adapter import GridRAO
+
+
+def test_phase_sign_rules():
+    assert np.allclose(normalize_phase_deg([90.0], RAOSource.ORCAFLEX), [90.0])
+    assert np.allclose(normalize_phase_deg([90.0], RAOSource.CANONICAL), [90.0])
+    assert np.allclose(normalize_phase_deg([90.0], RAOSource.AQWA), [-90.0])
+
+
+def test_heading_going_to():
+    assert heading_going_to_deg(30.0, coming_from=True) == 210.0
+    assert heading_going_to_deg(30.0, coming_from=False) == 30.0
+    assert heading_going_to_deg(200.0, coming_from=True) == 20.0
+
+
+def _one_freq_rao(phase_deg):
+    """Minimal single-frequency, single-heading DisplacementRAO (heave only)."""
+    from digitalmodel.marine_ops.marine_analysis.models.rao_data import (
+        DisplacementRAO, DOFData,
+    )
+
+    freqs = np.array([0.8])
+    heads = np.array([0.0])
+    amp = np.array([[1.0]])
+    zero = DOFData(np.zeros((1, 1)), np.zeros((1, 1)))
+    heave = DOFData(amp, np.array([[phase_deg]]))
+    return DisplacementRAO(
+        frequencies=freqs, headings=heads,
+        surge=zero, sway=zero, heave=heave,
+        roll=DOFData(np.zeros((1, 1)), np.zeros((1, 1))),
+        pitch=DOFData(np.zeros((1, 1)), np.zeros((1, 1))),
+        yaw=DOFData(np.zeros((1, 1)), np.zeros((1, 1))),
+    )
+
+
+def test_aqwa_normalises_to_orcaflex():
+    """AQWA raw phase psi (lag) and OrcaFlex raw phase -psi (lead) -> same H."""
+    psi = 37.0
+    aqwa = GridRAO(_one_freq_rao(psi), RAOSource.AQWA)
+    orca = GridRAO(_one_freq_rao(-psi), RAOSource.ORCAFLEX)
+    Ha = aqwa.H("heave", 0.8, 0.0)
+    Ho = orca.H("heave", 0.8, 0.0)
+    assert np.isclose(Ha, Ho)
+    # both carry amplitude 1 at the canonical lead angle -psi
+    assert np.isclose(abs(Ha), 1.0)
+    assert np.isclose(np.angle(Ha, deg=True), -psi)

--- a/tests/motion_forecast/test_reconstruct.py
+++ b/tests/motion_forecast/test_reconstruct.py
@@ -68,9 +68,18 @@ def test_finite_depth_wavenumber_reduces_to_deep():
     assert wavenumber(w, None) == pytest.approx(w * w / GRAVITY)
     # deep-water limit: large depth -> tanh -> 1
     assert wavenumber(w, 100000.0) == pytest.approx(w * w / GRAVITY, rel=1e-6)
-    # dispersion holds: omega^2 = g k tanh(k h)
-    k = wavenumber(w, 40.0)
-    assert w * w == pytest.approx(GRAVITY * k * np.tanh(k * 40.0), rel=1e-9)
+
+
+@pytest.mark.parametrize("w", [0.3, 0.6, 0.9, 1.4])
+@pytest.mark.parametrize("h", [2.0, 5.0, 10.0, 40.0])
+def test_finite_depth_dispersion_holds_in_shallow_water(w, h):
+    """The solver must satisfy omega^2 = g k tanh(k h) even in shallow water
+    (the old fixed-point iteration diverged and returned a wrong k silently)."""
+    k = wavenumber(w, h)
+    assert k > 0
+    assert w * w == pytest.approx(GRAVITY * k * np.tanh(k * h), rel=1e-6)
+    # finite depth shortens waves: k >= deep-water k
+    assert k >= w * w / GRAVITY - 1e-12
 
 
 def test_vertical_motion_lever_arm():

--- a/tests/motion_forecast/test_reconstruct.py
+++ b/tests/motion_forecast/test_reconstruct.py
@@ -1,0 +1,91 @@
+"""Reconstruction core tests (digitalmodel #1358).
+
+Regular-wave analytic checks are the *sole phase guard* (the irregular
+cross-check in test_validation is phase-blind), so they verify amplitude AND
+signed phase, including the incident-wave spatial-phase transfer term.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast import (
+    AnalyticRAO,
+    WaveComponent,
+    WaveForecast,
+    reconstruct_motion,
+    vertical_motion_at,
+    wavenumber,
+)
+from digitalmodel.motion_forecast.models import GRAVITY
+
+
+def _const_rao(mag, ang):
+    return AnalyticRAO({"heave": lambda w, b: mag * np.exp(1j * ang)})
+
+
+def test_regular_wave_amplitude_and_phase():
+    w0, a0, phi0 = 0.7, 1.3, 0.4
+    mag, ang = 0.8, 0.5
+    fc = WaveForecast([WaveComponent(w0, a0, phi0, heading=0.0)], horizon=60.0)
+    mf = reconstruct_motion(fc, _const_rao(mag, ang), dt=0.1)
+    expected = a0 * mag * np.cos(w0 * mf.t + phi0 + ang)
+    assert np.allclose(mf.dof["heave"], expected, atol=1e-6)
+
+
+def test_spatial_phase_transfer_term():
+    """Moving the asset downwave shifts the phase by -k*dx (dispersion)."""
+    w0, a0, phi0 = 0.9, 1.0, 0.0
+    mag, ang = 1.0, 0.0
+    Lx = 120.0
+    fc = WaveForecast(
+        [WaveComponent(w0, a0, phi0, heading=0.0)],
+        horizon=60.0, phase_reference_location=(0.0, 0.0),
+    )
+    mf = reconstruct_motion(fc, _const_rao(mag, ang), asset_location=(Lx, 0.0), dt=0.1)
+    k = w0 * w0 / GRAVITY
+    expected = a0 * mag * np.cos(w0 * mf.t + phi0 - k * Lx + ang)
+    assert np.allclose(mf.dof["heave"], expected, atol=1e-6)
+
+
+def test_heading_projects_offset():
+    """A beam-going wave (heading 90) is unaffected by an along-x offset."""
+    w0 = 0.8
+    fc = WaveForecast([WaveComponent(w0, 1.0, 0.0, heading=90.0)], horizon=40.0)
+    base = reconstruct_motion(fc, _const_rao(1.0, 0.0), asset_location=(0.0, 0.0), dt=0.2)
+    shifted = reconstruct_motion(fc, _const_rao(1.0, 0.0), asset_location=(200.0, 0.0), dt=0.2)
+    # propagation is +y; x-offset has zero projection -> identical series
+    assert np.allclose(base.dof["heave"], shifted.dof["heave"], atol=1e-9)
+
+
+def test_horizon_fail_closed():
+    fc = WaveForecast([WaveComponent(0.7, 1.0, 0.0)], horizon=30.0, origin_time=0.0)
+    with pytest.raises(ValueError, match="predictable"):
+        reconstruct_motion(fc, _const_rao(1.0, 0.0), t_grid=np.linspace(0.0, 45.0, 10))
+
+
+def test_finite_depth_wavenumber_reduces_to_deep():
+    w = 0.9
+    assert wavenumber(w, None) == pytest.approx(w * w / GRAVITY)
+    # deep-water limit: large depth -> tanh -> 1
+    assert wavenumber(w, 100000.0) == pytest.approx(w * w / GRAVITY, rel=1e-6)
+    # dispersion holds: omega^2 = g k tanh(k h)
+    k = wavenumber(w, 40.0)
+    assert w * w == pytest.approx(GRAVITY * k * np.tanh(k * 40.0), rel=1e-9)
+
+
+def test_vertical_motion_lever_arm():
+    """z at (rx,0,0) = heave - rx*pitch(rad)."""
+    from digitalmodel.motion_forecast.models import MotionForecast
+
+    t = np.linspace(0, 10, 51)
+    heave = np.sin(t)
+    pitch_deg = 3.0 * np.cos(t)  # degrees
+    mf = MotionForecast(
+        t=t,
+        dof={"heave": heave, "pitch": pitch_deg, "roll": np.zeros_like(t),
+             "surge": np.zeros_like(t), "sway": np.zeros_like(t), "yaw": np.zeros_like(t)},
+        origin_time=0.0, horizon=10.0,
+    )
+    rx = 40.0
+    z = vertical_motion_at(mf, (rx, 0.0, 0.0))
+    assert np.allclose(z, heave - rx * np.deg2rad(pitch_deg), atol=1e-9)

--- a/tests/motion_forecast/test_validation.py
+++ b/tests/motion_forecast/test_validation.py
@@ -1,10 +1,17 @@
-"""Validation against the existing tested spectral engine (digitalmodel #1358).
+"""Spectral bookkeeping + realised-variance validation (digitalmodel #1358).
 
-The irregular cross-check compares the reconstruction's **analytic variance**
-``sum(0.5*a_i^2*|H_i|^2)`` against the ``hydrodynamics.seakeeping`` oracle m0 on
-a shared grid. Both are discretisations of ``integral(|H|^2 S dω)`` so they
-agree deterministically — a naive "FFT the record and compare m0" would inject
-one-realisation chi-square scatter and false-fail.
+Two complementary checks:
+
+- ``test_analytic_variance_matches_oracle_m0`` — a *bookkeeping/convergence*
+  check that the variance the reconstruction will realise,
+  ``sum(0.5*a_i^2*|H_i|^2)``, equals the ``hydrodynamics.seakeeping`` spectral
+  m0 ``integral(|H|^2 S dω)`` on a fine grid. Both sides use the same S and |H|,
+  so this validates the amplitude/energy bookkeeping (a_i = sqrt(2 S dω)), not
+  the time-domain engine itself.
+- ``test_realized_record_variance_close_to_analytic`` — drives
+  ``reconstruct_motion`` and checks the realised record variance matches, which
+  *does* exercise the engine (phase-preservation itself is guarded by the
+  regular-wave tests in test_reconstruct).
 """
 
 import numpy as np

--- a/tests/motion_forecast/test_validation.py
+++ b/tests/motion_forecast/test_validation.py
@@ -1,0 +1,70 @@
+"""Validation against the existing tested spectral engine (digitalmodel #1358).
+
+The irregular cross-check compares the reconstruction's **analytic variance**
+``sum(0.5*a_i^2*|H_i|^2)`` against the ``hydrodynamics.seakeeping`` oracle m0 on
+a shared grid. Both are discretisations of ``integral(|H|^2 S dω)`` so they
+agree deterministically — a naive "FFT the record and compare m0" would inject
+one-realisation chi-square scatter and false-fail.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrodynamics.seakeeping import (
+    compute_response_spectrum,
+    spectral_moments,
+)
+from digitalmodel.motion_forecast import (
+    AnalyticRAO,
+    reconstruct_motion,
+    synthesize_forecast,
+)
+from digitalmodel.motion_forecast.wave_source import jonswap_spectrum
+
+
+def _heave_H(omega, heading=0.0):
+    """Smooth 2nd-order-ish heave transfer (complex), Tn=10s, zeta=0.2."""
+    wn = 2.0 * np.pi / 10.0
+    r = omega / wn
+    return 1.0 / complex(1.0 - r * r, 2.0 * 0.2 * r)
+
+
+def test_energy_conservation_of_synthesis():
+    hs, tp = 3.0, 10.0
+    fc = synthesize_forecast(hs, tp, n_components=300, horizon=90.0)
+    a = fc.amplitudes()
+    m0 = float(np.sum(0.5 * a**2))
+    assert 4.0 * np.sqrt(m0) == pytest.approx(hs, rel=0.01)
+
+
+def test_analytic_variance_matches_oracle_m0():
+    hs, tp = 2.5, 9.0
+    fc = synthesize_forecast(hs, tp, n_components=400, horizon=90.0)
+
+    # reconstruction-side analytic variance: sum 0.5 a_i^2 |H_i|^2
+    var_recon = 0.0
+    for c in fc.components:
+        var_recon += 0.5 * c.amplitude**2 * abs(_heave_H(c.omega)) ** 2
+
+    # oracle on a fine grid: m0 = integral(|H|^2 S dω)
+    wp = 2.0 * np.pi / tp
+    w = np.linspace(0.4 * wp, 3.2 * wp, 4000)
+    S = jonswap_spectrum(w, hs, tp)
+    rao_amp = np.array([abs(_heave_H(wi)) for wi in w])
+    S_resp = compute_response_spectrum(rao_amp, S)
+    m0 = spectral_moments(w, S_resp, orders=[0])[0]
+
+    assert var_recon == pytest.approx(m0, rel=0.02)
+
+
+def test_realized_record_variance_close_to_analytic():
+    """A long reconstructed record realises the analytic variance (looser)."""
+    hs, tp = 2.5, 9.0
+    fc = synthesize_forecast(hs, tp, n_components=400, horizon=1500.0, seed=7)
+    rao = AnalyticRAO({"heave": _heave_H})
+    mf = reconstruct_motion(fc, rao, dt=0.25)
+
+    var_recon = sum(0.5 * c.amplitude**2 * abs(_heave_H(c.omega)) ** 2
+                    for c in fc.components)
+    realized = float(np.var(mf.dof["heave"]))
+    assert realized == pytest.approx(var_recon, rel=0.12)

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -1,0 +1,34 @@
+"""Workflow + engine-dispatch tests (digitalmodel #1358)."""
+
+from pathlib import Path
+
+from digitalmodel.motion_forecast import DOF_NAMES
+from digitalmodel.motion_forecast.workflow import router
+
+
+def test_router_produces_results():
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.5, "tp": 9.0, "horizon": 60.0, "n_components": 32},
+            "rao": {"source": "analytic", "preset": "generic_vessel"},
+            "asset": {"location": [0.0, 0.0], "dt": 0.25},
+        },
+    }
+    out = router(cfg)
+    assert out is cfg  # mutates + returns cfg (repo convention)
+    res = cfg["motion_forecast"]["results"]
+    assert set(res["dof"]) == set(DOF_NAMES)
+    assert len(res["t"]) == len(res["dof"]["heave"])
+    assert res["significant"]["heave"] > 0.0
+    assert res["n_components"] == 32
+
+
+def test_engine_dispatch_wired():
+    """Guard: engine.py routes basename 'motion_forecast' to the workflow."""
+    engine_src = (
+        Path(__file__).resolve().parents[2]
+        / "src" / "digitalmodel" / "engine.py"
+    ).read_text()
+    assert 'basename == "motion_forecast"' in engine_src
+    assert "motion_forecast.workflow import" in engine_src


### PR DESCRIPTION
## What

The **keystone engine** of epic #1356 (plan approved: `docs/plans/2026-07-03-issue-1358-motion-forecast-keystone.md`). New package `src/digitalmodel/motion_forecast/` reconstructs the **time-domain 6-DOF motion** of an asset a short horizon ahead, from a *phased* incident-wave forecast **propagated to the asset location** and transferred through the asset RAO (amplitude **and** phase):

```
x_dof(t) = Σ_i a_i·|H_dof(ω_i,β_i)|·cos(ω_i t + φ_i − k_i·(d̂_i·(x_asset − x_ref)) + arg H_dof)
```

The `−k·Δx` term is the point of a *forecast*: a wave phased at a sensing point must be dispersion-propagated to where the asset actually is.

### Modules
| File | Role |
|---|---|
| `models.py` | `WaveComponent` / `WaveForecast` (carries `phase_reference_location`) + `MotionForecast` |
| `conventions.py` | canonical lead convention; normalise **AQWA → OrcaFlex** (centralised, documented) |
| `wave_source.py` | deterministic JONSWAP phased-sea fallback (the seam #1357 replaces) |
| `rao_adapter.py` | `GridRAO` (complex bilinear interp of `DisplacementRAO`) + `AnalyticRAO` |
| `reconstruct.py` | superposition core, finite-depth wavenumber, lever-arm POI, fail-closed horizon |
| `workflow.py` | `router(cfg)` (mutates + returns cfg) + `engine.py` basename dispatch |

Consuming `DisplacementRAO` directly (not `rao_interpolator.interpolate_2d`) sidesteps the `UnifiedRAOData`↔`rao_processor.RAOData` shape mismatch the plan flagged. Interpolating the **complex** transfer (amp·e^{iφ}) avoids phase-wraparound.

## Validation — 30 tests, all green
- **Regular-wave (exact, the phase guard):** reconstructed amplitude **and signed phase** match analytic incl. the spatial-transfer term (`atol 1e-6`).
- **Phase convention:** AQWA(+ψ) and OrcaFlex(−ψ) → identical `H` post-normalisation.
- **Analytic variance vs seakeeping m0:** `Σ½aᵢ²|Hᵢ|²` matches the oracle within 2% (bookkeeping); realized-record variance matches within 12% (exercises the engine).
- **Finite-depth dispersion:** ω²=g·k·tanh(kh) holds across ω×depth incl. shallow water.
- Energy conservation, horizon fail-closed, lever-arm POI, `router`/dispatch smoke.

## Cross-review (Route C gate)
Adversarial code review → **APPROVE-WITH-CHANGES**; physics confirmed correct. Fixed:
- **[blocker]** `wavenumber()` — replaced the divergent fixed-point iteration (silently returned a wrong `k` in shallow water) with guaranteed-convergent **bisection** + relative tol + raise-on-failure; added parametrized shallow-water dispersion tests.
- **[should-fix]** `GridRAO` sorts freq/heading axes ascending on construction (robust interp); `reconstruct_motion` raises on empty components + documents the going-to heading convention; softened the analytic-variance test docstring.

## Scope / remaining (not in this PR)
Core engine = plan Tasks 1–5. **Fast-follow** (own PRs): Task 6 (`seastate_limits.py` RAO-based path, feature-flagged) and real-file `GridRAO.from_file` validation against a solver fixture. Directional spreading and the IRF/Cummins path remain deferred per plan.

Pure-numerical (no license); heavy imports make the suite ~1.5 min.

Refs #1358 #1356
