### PR TITLE
feat(drilling_riser): telemetry ingestion → operating-envelope inputs (twin A #1373)

### DIFF
--- a/src/digitalmodel/drilling_riser/telemetry_inputs.py
+++ b/src/digitalmodel/drilling_riser/telemetry_inputs.py
@@ -1,0 +1,191 @@
+"""Telemetry inputs for the drilling-riser digital twin (twin A #1373, epic #1372).
+
+Turns a DP-drilling-vessel telemetry record stream (a live vessel-monitoring feed
+or a committed offline fixture) into the inputs the merged operating-envelope engine
+(#1279) consumes — mirroring the metocean-input pattern (#1282,
+:mod:`digitalmodel.drilling_riser.metocean_inputs`). This is a PURE reducer: no live
+client is committed (a vessel feed is session/vessel-specific — there is no public
+endpoint), and any future live iterator's network errors are caught by the shared
+``tests/metocean/netskip`` guard at the caller.
+
+Of the telemetry channels the twin ingests, the analytical envelope can honestly
+consume TWO today:
+
+  * ``snapshot_to_offset_pct`` maps measured vessel offset onto the sweep's
+    ``offset_pct`` — the exact inverse of the merged
+    :func:`digitalmodel.drilling_riser.operability.watch_circle_radius_m`
+    (``radius = offset_pct/100 * water_depth`` ⟹ ``offset_pct = 100*offset/wd``).
+  * ``snapshot_to_tension_n`` maps measured top tension onto the envelope's
+    ``tension_n`` input (an engine input, not a predicted output).
+
+The other two channels are ingested and typed but deliberately NOT consumed here,
+because doing so would fabricate capability the later children own:
+
+  * measured flex-joint angles (:class:`MeasuredResponse`) are *predicted outputs* of
+    the physics; the residual (measured − predicted) is twin B's ML seam (#1374);
+  * DP thruster / station-keeping state (:class:`DPState`) drives drift-off, which is
+    twin C's solver tier (#1375). The static envelope has no thruster term.
+
+SI internally (newtons, metres, degrees). A fixture may report kilonewtons; the
+conversion happens once, at the parse boundary. Public-provider / synthetic data
+only; no client telemetry, no vessel identity, no credentials are read here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Mapping, Optional, Sequence
+
+from digitalmodel.drilling_riser.operability import watch_circle_radius_m
+
+_KN_TO_N = 1000.0
+
+
+@dataclass(frozen=True)
+class DPState:
+    """DP thruster / station-keeping state (parked for twin C — drift-off)."""
+
+    thrusters_online: Optional[int] = None
+    total_available_thrust_n: Optional[float] = None
+    total_commanded_thrust_n: Optional[float] = None
+
+    @property
+    def station_keeping_margin(self) -> Optional[float]:
+        """``1 - commanded/available`` in [.., 1]; ``None`` when no capacity.
+
+        Guarded: returns ``None`` when available thrust is missing or <= 0 (e.g.
+        all thrusters offline) rather than dividing by zero. Not consumed by the
+        static envelope; twin C (#1375) uses it.
+        """
+        avail = self.total_available_thrust_n
+        cmd = self.total_commanded_thrust_n
+        if avail is None or cmd is None or avail <= 0:
+            return None
+        return 1.0 - cmd / avail
+
+
+@dataclass(frozen=True)
+class MeasuredResponse:
+    """Measured riser response (parked for twin B — ML residual-correction).
+
+    Flex-joint angle is a *predicted output* of the physics; the measured value
+    lives here so twin B (#1374) can form the measured − predicted residual. Twin A
+    ingests but does not consume it.
+    """
+
+    flexjoint_angle_upper_deg: Optional[float] = None
+    flexjoint_angle_lower_deg: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class TelemetrySnapshot:
+    """One atomic telemetry sample.
+
+    ``timestamp`` is a :class:`datetime` (mirrors the marine-ops MRUReading/buffer
+    idiom so a rolling window is well-defined for the twin-D monitoring surface).
+    ``vessel_offset_m`` (radial excursion, >= 0) and ``top_tension_n`` are the two
+    channels the envelope consumes; heading / ``dp`` / ``measured`` are ingested but
+    not consumed by the analytical tier.
+    """
+
+    vessel_offset_m: float
+    timestamp: Optional[datetime] = None
+    vessel_heading_deg: Optional[float] = None
+    top_tension_n: Optional[float] = None
+    dp: Optional[DPState] = None
+    measured: Optional[MeasuredResponse] = None
+
+
+def _parse_timestamp(value: object) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value)
+    return None
+
+
+def _kn_to_n(value: object) -> Optional[float]:
+    return None if value is None else float(value) * _KN_TO_N
+
+
+def _dp_from(rec: Mapping[str, object]) -> Optional[DPState]:
+    online = rec.get("thrusters_online")
+    avail = rec.get("total_available_thrust_kn")
+    cmd = rec.get("total_commanded_thrust_kn")
+    if online is None and avail is None and cmd is None:
+        return None
+    return DPState(
+        thrusters_online=None if online is None else int(online),
+        total_available_thrust_n=_kn_to_n(avail),
+        total_commanded_thrust_n=_kn_to_n(cmd),
+    )
+
+
+def _measured_from(rec: Mapping[str, object]) -> Optional[MeasuredResponse]:
+    upper = rec.get("flexjoint_angle_upper_deg")
+    lower = rec.get("flexjoint_angle_lower_deg")
+    if upper is None and lower is None:
+        return None
+    return MeasuredResponse(
+        flexjoint_angle_upper_deg=None if upper is None else float(upper),
+        flexjoint_angle_lower_deg=None if lower is None else float(lower),
+    )
+
+
+def parse_snapshots(records: Iterable[Mapping[str, object]]) -> list[TelemetrySnapshot]:
+    """Type a raw telemetry record stream into :class:`TelemetrySnapshot` objects.
+
+    Records missing ``vessel_offset_m`` (the one always-consumed channel) are
+    skipped; heading / tension / dp / measured are optional. ``timestamp`` is parsed
+    to :class:`datetime`. ``*_kn`` fields are converted to newtons at this boundary.
+    """
+    snapshots: list[TelemetrySnapshot] = []
+    for rec in records:
+        offset = rec.get("vessel_offset_m")
+        if offset is None:
+            continue
+        heading = rec.get("vessel_heading_deg")
+        snapshots.append(
+            TelemetrySnapshot(
+                vessel_offset_m=float(offset),
+                timestamp=_parse_timestamp(rec.get("timestamp")),
+                vessel_heading_deg=None if heading is None else float(heading),
+                top_tension_n=_kn_to_n(rec.get("top_tension_kn")),
+                dp=_dp_from(rec),
+                measured=_measured_from(rec),
+            )
+        )
+    return snapshots
+
+
+def snapshot_to_offset_pct(
+    snapshot: TelemetrySnapshot, *, water_depth_m: float
+) -> float:
+    """Measured vessel offset → envelope ``offset_pct`` (% of water depth).
+
+    Exact inverse of :func:`watch_circle_radius_m`. Raises ``ValueError`` on a
+    non-positive water depth or a negative offset (radial excursion is >= 0).
+    """
+    if water_depth_m <= 0:
+        raise ValueError(f"water_depth_m must be > 0, got {water_depth_m}")
+    if snapshot.vessel_offset_m < 0:
+        raise ValueError(
+            f"vessel_offset_m must be >= 0 (radial excursion), got {snapshot.vessel_offset_m}"
+        )
+    return 100.0 * snapshot.vessel_offset_m / water_depth_m
+
+
+def snapshot_to_tension_n(snapshot: TelemetrySnapshot) -> Optional[float]:
+    """Measured top tension [N] for the envelope's ``tension_n`` input.
+
+    ``None`` when no measured tension is present (caller falls back to the assembled
+    riser's design top tension).
+    """
+    return snapshot.top_tension_n
+
+
+def snapshots_to_offset_track(
+    records: Iterable[TelemetrySnapshot], *, water_depth_m: float
+) -> list[float]:
+    """``offset_pct`` time-series over a telemetry window (twin-D monitoring)."""
+    return [snapshot_to_offset_pct(s, water_depth_m=water_depth_m) for s in records]

--- a/tests/drilling_riser/fixtures/telemetry_snapshot_sample.json
+++ b/tests/drilling_riser/fixtures/telemetry_snapshot_sample.json
@@ -1,0 +1,14 @@
+{
+  "provenance": {
+    "source": "synthetic (generic DP-vessel telemetry record format); representative offline sample for CI",
+    "licence": "synthetic — no third-party or client data redistributed",
+    "note": "Offline fixture so the parse->reducer->envelope chain runs with no network. No client telemetry, no vessel identity, no authentication material of any kind. Values are round synthetic numbers chosen to exercise an operable->inoperable offset transition at a generic 1500 m water depth; they match no real vessel's rated capacity.",
+    "captured_offline": true
+  },
+  "records": [
+    {"timestamp": "2026-01-01T00:00:00", "vessel_offset_m": 15.0, "vessel_heading_deg": 172.0, "top_tension_kn": 3000.0, "thrusters_online": 6, "total_available_thrust_kn": 9000.0, "total_commanded_thrust_kn": 2400.0, "flexjoint_angle_upper_deg": 0.6, "flexjoint_angle_lower_deg": 0.9},
+    {"timestamp": "2026-01-01T00:01:00", "vessel_offset_m": 30.0, "vessel_heading_deg": 171.0, "top_tension_kn": 3000.0, "thrusters_online": 6, "total_available_thrust_kn": 9000.0, "total_commanded_thrust_kn": 2600.0, "flexjoint_angle_upper_deg": 1.1, "flexjoint_angle_lower_deg": 1.5},
+    {"timestamp": "2026-01-01T00:02:00", "vessel_offset_m": null, "vessel_heading_deg": 170.0, "top_tension_kn": 3000.0, "thrusters_online": 6, "total_available_thrust_kn": 9000.0, "total_commanded_thrust_kn": 2600.0, "flexjoint_angle_upper_deg": 1.2, "flexjoint_angle_lower_deg": 1.6},
+    {"timestamp": "2026-01-01T00:03:00", "vessel_offset_m": 225.0, "vessel_heading_deg": 168.0, "top_tension_kn": 3000.0, "thrusters_online": 4, "total_available_thrust_kn": 6000.0, "total_commanded_thrust_kn": 5700.0, "flexjoint_angle_upper_deg": 6.4, "flexjoint_angle_lower_deg": 7.8}
+  ]
+}

--- a/tests/drilling_riser/test_telemetry_inputs.py
+++ b/tests/drilling_riser/test_telemetry_inputs.py
@@ -1,0 +1,218 @@
+"""twin A #1373: telemetry ingestion → operating-envelope inputs.
+
+All offline — a synthetic DP-vessel telemetry fixture drives parse -> adapter ->
+compute_operating_envelope with no network. Verifies the two channels the envelope
+consumes today (measured offset -> offset_pct; measured tension -> tension_n), that
+the parked channels (DP state, measured flex-joint angle) do NOT couple into the
+engine, the offset-inversion guards, the reused netskip guard, and the fixture
+governance rule (provenance + no credentials + no vessel identity).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import requests
+from _pytest.outcomes import Skipped
+
+from digitalmodel.drilling_riser.envelope import (
+    EnvelopeCriteria,
+    RiserSection,
+    SeaState,
+    compute_operating_envelope,
+)
+from digitalmodel.drilling_riser.operability import watch_circle_radius_m
+from digitalmodel.drilling_riser.telemetry_inputs import (
+    DPState,
+    MeasuredResponse,
+    TelemetrySnapshot,
+    parse_snapshots,
+    snapshot_to_offset_pct,
+    snapshot_to_tension_n,
+    snapshots_to_offset_track,
+)
+from tests.metocean.netskip import skip_on_network_error
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "telemetry_snapshot_sample.json"
+
+
+def _fixture():
+    return json.loads(_FIXTURE.read_text())
+
+
+# -- parse ---------------------------------------------------------------------
+
+
+def test_parse_types_the_fixture_stream():
+    snaps = parse_snapshots(_fixture()["records"])
+    # 4 records, one has null vessel_offset_m -> 3 typed
+    assert len(snaps) == 3
+    s = snaps[0]
+    assert isinstance(s, TelemetrySnapshot)
+    assert isinstance(s.timestamp, datetime)
+    assert s.vessel_offset_m == 15.0
+    # kN -> N conversion at the parse boundary
+    assert s.top_tension_n == 3000.0 * 1000.0
+    assert isinstance(s.dp, DPState)
+    assert s.dp.total_available_thrust_n == 9000.0 * 1000.0
+    assert isinstance(s.measured, MeasuredResponse)
+    assert s.measured.flexjoint_angle_lower_deg == 0.9
+
+
+def test_parse_skips_only_on_missing_offset():
+    records = [
+        {"vessel_offset_m": None, "top_tension_kn": 3000.0},   # skipped
+        {"vessel_offset_m": 20.0},                             # kept; tension/dp optional
+        {"vessel_offset_m": 25.0, "vessel_heading_deg": 90.0},  # kept
+    ]
+    snaps = parse_snapshots(records)
+    assert [s.vessel_offset_m for s in snaps] == [20.0, 25.0]
+    assert snaps[0].top_tension_n is None and snaps[0].dp is None
+
+
+def test_dp_station_keeping_margin_is_guarded():
+    assert DPState(total_available_thrust_n=9e6, total_commanded_thrust_n=2.7e6).station_keeping_margin == pytest.approx(0.7)
+    # all thrusters offline / no capacity -> None, never a ZeroDivisionError
+    assert DPState(total_available_thrust_n=0.0, total_commanded_thrust_n=0.0).station_keeping_margin is None
+    assert DPState().station_keeping_margin is None
+
+
+# -- offset inversion ----------------------------------------------------------
+
+
+def test_offset_pct_is_exact_inverse_of_watch_circle():
+    snap = TelemetrySnapshot(vessel_offset_m=30.0)
+    pct = snapshot_to_offset_pct(snap, water_depth_m=1500.0)
+    assert pct == pytest.approx(2.0)
+    # round-trip: pct -> radius -> offset
+    assert watch_circle_radius_m(pct, 1500.0) == pytest.approx(30.0)
+
+
+def test_offset_pct_guards_degenerate_inputs():
+    with pytest.raises(ValueError):
+        snapshot_to_offset_pct(TelemetrySnapshot(vessel_offset_m=30.0), water_depth_m=0.0)
+    with pytest.raises(ValueError):
+        snapshot_to_offset_pct(TelemetrySnapshot(vessel_offset_m=-5.0), water_depth_m=1500.0)
+
+
+def test_offset_track_over_a_window():
+    snaps = parse_snapshots(_fixture()["records"])
+    track = snapshots_to_offset_track(snaps, water_depth_m=1500.0)
+    assert track == [pytest.approx(1.0), pytest.approx(2.0), pytest.approx(15.0)]
+
+
+# -- offline chain: telemetry -> envelope (non-vacuous) ------------------------
+
+
+def _section_and_criteria():
+    section = RiserSection(outer_diameter_m=0.5334, wall_thickness_m=0.0254)
+    # public standard factors (API RP 16Q 2°/4°; API STD 2RD 0.67) — the values the
+    # cited getters resolve to; used as literals for offline CI (no wiki), matching
+    # the merged metocean test.
+    criteria = EnvelopeCriteria(2.0, 4.0, 0.67)
+    return section, criteria
+
+
+def test_measured_offset_drives_operable_to_inoperable_boundary():
+    snaps = parse_snapshots(_fixture()["records"])
+    wd = 1500.0
+    small = snapshot_to_offset_pct(snaps[0], water_depth_m=wd)   # 15 m -> 1%
+    large = snapshot_to_offset_pct(snaps[2], water_depth_m=wd)   # 225 m -> 15%
+    section, criteria = _section_and_criteria()
+    tension = snapshot_to_tension_n(snaps[0])                    # 3.0e6 N
+    result = compute_operating_envelope(
+        section=section, water_depth_m=wd, length_m=1500.0, tension_n=tension,
+        criteria=criteria, offsets_pct=[small, large],
+        current_speeds_mps=[0.5], seastates=[SeaState(hs_m=1.5, tp_s=7.0)],
+    )
+    # the telemetry-derived offset actually discriminates: the boundary is crossed
+    small_row = result.allowable_mask[0]
+    large_row = result.allowable_mask[1]
+    assert small_row.all() and not large_row.any()
+    # governing utilisation rises monotonically with the measured offset
+    assert result.per_limit_utilisation["flexjoint_angle"][0].max() < \
+        result.per_limit_utilisation["flexjoint_angle"][1].max()
+
+
+def test_measured_tension_feeds_von_mises():
+    snaps = parse_snapshots(_fixture()["records"])
+    section, criteria = _section_and_criteria()
+    kwargs = dict(
+        section=section, water_depth_m=1500.0, length_m=1500.0, criteria=criteria,
+        offsets_pct=[5.0], current_speeds_mps=[0.5], seastates=[SeaState(1.5, 7.0)],
+    )
+    measured = compute_operating_envelope(tension_n=snapshot_to_tension_n(snaps[0]), **kwargs)
+    lower_tension = compute_operating_envelope(tension_n=2.0e6, **kwargs)
+    # the measured tension threads through to the von Mises utilisation surface
+    assert not np.array_equal(
+        measured.per_limit_utilisation["von_mises"],
+        lower_tension.per_limit_utilisation["von_mises"],
+    )
+
+
+# -- coupling guard: parked channels do NOT reach the engine -------------------
+
+
+def test_parked_channels_do_not_couple_into_the_envelope():
+    wd = 1500.0
+    section, criteria = _section_and_criteria()
+    with_parked = TelemetrySnapshot(
+        vessel_offset_m=30.0, top_tension_n=3.0e6,
+        dp=DPState(thrusters_online=6, total_available_thrust_n=9e6, total_commanded_thrust_n=2.6e6),
+        measured=MeasuredResponse(flexjoint_angle_upper_deg=1.1, flexjoint_angle_lower_deg=1.5),
+    )
+    without_parked = TelemetrySnapshot(vessel_offset_m=30.0, top_tension_n=3.0e6)
+    # the adapter surfaces only offset_pct + tension_n — identical regardless of the
+    # parked DP / measured-response fields
+    assert snapshot_to_offset_pct(with_parked, water_depth_m=wd) == \
+        snapshot_to_offset_pct(without_parked, water_depth_m=wd)
+    assert snapshot_to_tension_n(with_parked) == snapshot_to_tension_n(without_parked)
+
+    def run(snap):
+        return compute_operating_envelope(
+            section=section, water_depth_m=wd, length_m=1500.0,
+            tension_n=snapshot_to_tension_n(snap), criteria=criteria,
+            offsets_pct=[snapshot_to_offset_pct(snap, water_depth_m=wd)],
+            current_speeds_mps=[0.5], seastates=[SeaState(1.5, 7.0)],
+        )
+    assert np.array_equal(run(with_parked).allowable_mask, run(without_parked).allowable_mask)
+
+
+# -- reused netskip guard ------------------------------------------------------
+
+
+def test_netskip_skips_not_fails_on_stream_error():
+    """A live telemetry iterator's network error must SKIP, never fail CI.
+
+    Proves the reused ``tests/metocean/netskip`` guard converts a stream
+    ``RequestException`` (RetryError on retry exhaustion) into a pytest skip — with
+    the iterator consumed INSIDE the guard, per the guard's contract.
+    """
+    def raising_feed():
+        yield {"vessel_offset_m": 10.0}
+        raise requests.exceptions.RetryError("simulated retry exhaustion")
+
+    with pytest.raises(Skipped):
+        with skip_on_network_error("synthetic telemetry feed"):
+            parse_snapshots(list(raising_feed()))  # consume INSIDE the guard
+
+
+# -- governance: fixture provenance + no credentials + no vessel identity -------
+
+
+def test_fixture_provenance_no_credentials_no_identity():
+    fx = _fixture()
+    prov = fx["provenance"]
+    assert prov["source"] and prov["licence"]
+    raw = _FIXTURE.read_text().lower()
+    for forbidden in ("authorization", "x-api-key", "password", "token", "signature=", "aws"):
+        assert forbidden not in raw
+    # no vessel-identity keys anywhere in the records (fingerprinting surface)
+    identity_keys = {"vessel_name", "imo", "mmsi", "callsign", "field", "well", "rig"}
+    for rec in fx["records"]:
+        assert identity_keys.isdisjoint(rec.keys())
+    for tok in ("imo", "mmsi", "callsign", "vessel_name"):
+        assert f'"{tok}"' not in raw

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -62,6 +62,15 @@ _PUBLIC_ARTIFACTS = (
     REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "conductor_response.py",
     REPO_ROOT / "tests" / "drilling_riser" / "test_envelope.py",
     REPO_ROOT / "tests" / "drilling_riser" / "test_conductor_response.py",
+    # twin A #1373 telemetry ingestion: pure reducer over a synthetic fixture. It
+    # carries no provenance tokens by construction; gated (module + test + fixture)
+    # so any future edit that introduces one is caught. NOTE: the tripwire's tokens
+    # come from the private riser-projects registry, so it does NOT cover vessel /
+    # DP-vendor identifiers — that scrub is enforced by the fixture identity-key
+    # assertion in test_telemetry_inputs.py plus human review, not by this gate.
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "telemetry_inputs.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_telemetry_inputs.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "fixtures" / "telemetry_snapshot_sample.json",
 )
 
 
@@ -136,7 +145,8 @@ def test_new_analytical_code_is_gated():
     """#1345 [G-1]: the envelope + conductor analytical code must be inside the
     scanned artifact set (it reproduces wellhead/conductor engagements)."""
     scanned = {p.name for p in _PUBLIC_ARTIFACTS}
-    for required in ("envelope.py", "conductor_response.py", "riser_response.py"):
+    for required in ("envelope.py", "conductor_response.py", "riser_response.py",
+                     "telemetry_inputs.py"):
         assert required in scanned, f"{required} is not gated by the provenance tripwire"
 
 


### PR DESCRIPTION
## twin A: telemetry ingestion → operating-envelope inputs

Closes #1373 (epic #1372). Plan v2 approved (`status:plan-review` → approved) after T2 adversarial review (REJECT 2/2, findings folded).

### What
New **pure reducer** `src/digitalmodel/drilling_riser/telemetry_inputs.py`, mirroring the merged metocean-input pattern (#1282): a typed DP-vessel telemetry schema + synthetic offline fixture + the reused skip-on-network-error guard + adapters feeding the merged operating-envelope engine (#1279).

**Consumed by the physics tier today (two honest channels):**
- measured **vessel offset** → `offset_pct` (exact inverse of `watch_circle_radius_m`)
- measured **top tension** → the envelope's `tension_n` input

**Ingested + typed but parked** (consuming now would fabricate capability the later children own):
- measured **flex-joint angles** — a *predicted output*; the measured−predicted residual is **twin B** (#1374, ML correction)
- **DP thruster / station-keeping state** — drives drift-off, **twin C** (#1375)
- heading — ingested, not consumed (radial offset only)

SI internally (kN→N at the parse boundary). **No live client** committed — a vessel feed is session-specific with no public endpoint; the reused `netskip` guard is proven by a skip-not-fail unit test.

### Review findings folded
- **Correctness:** top tension is an engine *input* not a deferred response (now consumed); dropped the ill-fitting `BaseAPIClient` client seam (reducer-only); SI/units fixed; guarded offset inversion; `datetime` timestamps; non-vacuous tests.
- **Governance:** fixture forbids identity keys (vessel_name/imo/mmsi/callsign/field/well/rig) and asserts their absence; module + test + fixture gated in the provenance tripwire, with an explicit note that the tripwire (private-registry tokens) does **not** cover vessel/DP identifiers — that scrub is the fixture assertion + human review; no new cited getter.

### Evidence
- New suite **11/11 green**; full `drilling_riser` + `riser_database` regression **199/199 green** (LLM_WIKI_PATH set).
- Provenance tripwire **3/3 green** — `telemetry_inputs.py` gated, no provenance tokens.
- **Red-first / non-vacuity proof:** breaking the offset inversion turns the round-trip + operable→inoperable **boundary** tests red (they're load-bearing, not tautological).
- **legal-sanity-scan `--diff-only` over this delta: PASS** (the whole-tree scan's pre-existing baseline violations are all in unrelated files, none in this change).

No self-merge.
