### PR TITLE
docs(readme): add engineering ↔ asset circle section with 3 Mermaid flowcharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,54 @@ Engineering calculation library for offshore, subsea, and marine analysis. Singl
 
 **Dedicated to Mark Cerkovnik** -- Chief Engineer, mentor, and inspiration.
 
+## Why this exists — the engineering ↔ asset circle
+
+`digitalmodel` and `worldenergydata` are two halves of one loop.
+
+- **digitalmodel** is the engineering brain — deterministic, code-based analysis (mooring, riser, fitness-for-service, hydrodynamics, structural, tubulars, installation): *what is possible and safe via engineering*.
+- **worldenergydata** is the real-world asset ledger — public-source, reproducible field / well / facility data across the whole life cycle: *what was actually built, and how it performs*.
+
+Together they close a circle. Engineering designs an asset; it gets built and operated; operations feed back into engineering (inspection, fitness-for-service, fatigue re-assessment); at end of life it is decommissioned — itself an engineering problem — and the outcomes loop back as empirical priors for the next design. The **life-cycle timeline** is the shared spine: `worldenergydata` supplies each stage's real dates and assets, `digitalmodel` supplies each stage's engineering.
+
+```mermaid
+flowchart LR
+  E["Engineering<br/><i>digitalmodel</i><br/>design &amp; analysis"] -->|design &amp; size| A["Asset built<br/><i>worldenergydata</i><br/>field · well · facility"]
+  A -->|operate| O["Operations<br/>production · metocean · IMR"]
+  O -->|inspection · FFS · fatigue| E
+  O -->|end of life| D["Decommissioning<br/>late-life · P&amp;A · cost &amp; regs"]
+  D -->|lessons ground the next design| E
+```
+
+The same stage-gate timeline is **fractal** — one grammar that reads coherently from a whole region down to a single wellbore stage:
+
+```mermaid
+flowchart LR
+  R[Region] --> P[Play] --> F["Field<br/>Acquire→Abandon"] --> W["Well<br/>Spud→P&amp;A"] --> S["Stage<br/>drill · complete · workover"]
+```
+
+And the two repos meet at that timeline — each asset on a field page can show *what is possible via engineering*:
+
+```mermaid
+flowchart LR
+  subgraph DM["digitalmodel — engineering"]
+    direction TB
+    M1["mooring · riser · FFS"]
+    M2["hydrodynamics · structural"]
+    M3["tubulars · installation"]
+  end
+  subgraph WED["worldenergydata — assets &amp; data"]
+    direction TB
+    A1["field &amp; well registers"]
+    A2["facilities · components"]
+    A3["production · decommissioning"]
+  end
+  DM <-->|"life-cycle timeline"| WED
+```
+
+Live: [worldenergydata field life-cycle](https://vamseeachanta.github.io/worldenergydata/lifecycle/) · [digitalmodel engineering capabilities](https://vamseeachanta.github.io/digitalmodel/capabilities/)
+
+This repo is the **engineering** half of that loop — the solvers that size, analyse and re-assess the assets.
+
 ## What This Is
 
 A Python package of engineering calculations where every function traces to an international standard. Library-first: importable calculations with CLI convenience wrappers.


### PR DESCRIPTION
## What

Adds a shared **engineering ↔ asset circle** section near the top of the root README (right after the project title/description/dedication, before `## What This Is`).

The section frames `digitalmodel` and `worldenergydata` as two halves of one life-cycle loop and includes **3 Mermaid flowcharts** (GitHub renders them natively):

1. The engineering → asset → operations → decommissioning circle.
2. The fractal region→play→field→well→stage timeline.
3. The two repos meeting at the shared life-cycle timeline.

Closes with a repo-specific line: *"This repo is the engineering half of that loop — the solvers that size, analyse and re-assess the assets."*

## Scope

- Single file changed: `README.md` (+48 lines, insertion only).
- No other README content altered.