### PR TITLE
feat(motion_forecast): derived operability quantities + rolling go/no-go (#1359)

### DIFF
--- a/docs/plans/2026-07-04-issue-1359-derived-quantities-go-no-go.md
+++ b/docs/plans/2026-07-04-issue-1359-derived-quantities-go-no-go.md
@@ -1,0 +1,53 @@
+# Plan: digitalmodel #1359 — derived operability quantities + rolling go/no-go with lead time
+
+**Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1359
+**Epic:** #1356 · **Status:** plan-review · **Tier:** T2/T3 (Route B/C — decision layer on the merged #1358 engine; reuses tested criterion primitives)
+
+> Adversarially reviewed against the code (2026-07-04): APPROVE-WITH-CHANGES. Blockers folded in — the consistency test now uses the deterministic spectral significant (not the dimensionally-wrong `operation_envelope` Hs-limit, and not a scatter-prone single-record std); governing velocities are magnitudes before classification; lead-time edge cases and the two-threshold→`warning_factor` mapping are pinned; YAML relocated to per-module package data.
+
+## Context
+
+#1358 (merged) produces a time-domain `MotionForecast` (6-DOF + lever-arm point-of-interest motion). #1359 turns that into the quantities operators gate on and a **rolling GO / CAUTION / NO-GO with lead time** — the decision the live demo (#1361) prototypes. The merged `operation_envelope.py` even annotates its heavy-lift limit *"crane-tip refinement later"*; this issue is that refinement. Not stale.
+
+## Reuse (verified 2026-07-04)
+- **Motion source (module functions, not methods):** `motion_forecast.MotionForecast` (`.dof`, `.t`, `.significant(dof)`), `vertical_motion_at(motion, offset)`, `time_derivative(t, x)` — all merged/exported in #1358.
+- **Criterion primitives:** `marine_ops/installation/go_no_go.py` — `_check_criterion(name, value, limit, unit, above_is_safe=False, warning_factor=...)`, `CriterionResult`, `CriterionState` (PASS/WARNING/FAIL), `DecisionState` (GO/MARGINAL/NO_GO). Reused directly. **Do NOT call `evaluate_go_no_go`** — verified jumper-lift-specific (hardcodes crane SWL 77.5 Te, sling MBL 1200 Te, Saipem deck, Ballymore baselines).
+- **Operation model (pattern only):** `operation_envelope.py::Operation`, `MotionLimit`, `OPERATIONS`. Note `operation_envelope()` returns a *limiting Hs* (`EnvelopeResult.hs_limit_m`), and the significant response lives in the private `_significant_response(...)` — so it is **not** used as the consistency oracle (see acceptance).
+
+## Net-new
+Time-domain **governing quantities** and a **rolling decision** — today only static significant-amplitude limits exist.
+
+## Design (all under `src/digitalmodel/motion_forecast/`)
+
+- `derived.py` — governing time series from a `MotionForecast` + point-of-interest offset. **All velocity/accel series are magnitudes** (`abs(time_derivative(...))`, or a running-peak envelope) so a large *downward* swing cannot pass a below-limit test:
+  - **Crane lift:** crane-tip vertical velocity (& acceleration) from `time_derivative(motion.t, vertical_motion_at(motion, tip))`. (DNV-ST-N001 / DNV-RP-N103.)
+  - **Gangway (W2W):** gangway-tip vertical velocity & excursion vs stroke. (DNV-ST-0358 / Walk2Work.)
+  - **Helideck:** inclination `hypot(roll, pitch)` (deg, ≥0) and deck heave velocity. (CAP 437 / HCA HMS: incl > 1°, heave vel > 0.4 m/s.)
+  - **Hose/riser top:** `top_connection_vertical_velocity` — an explicit **kinematic screen only** (NOT a tension; snatch load needs slack-taut/line-stiffness dynamics — deferred to a fast-follow).
+- `criteria.py` — per-operation records `{governing, caution, limit, unit, alpha, basis, poi_offset}` loaded from **package-data YAML** shipped beside the module (`motion_forecast/criteria/*.yml`, read via `importlib.resources`) — a *data* file, distinct from the `base_configs/modules/<m>/<m>.yml` engine-cfg templates. Loader validates `0 < caution ≤ limit`. Reusing `_check_criterion` means setting **`warning_factor = caution/limit`** (its WARNING band is `[warning_factor·limit, limit]`).
+- `decision.py` — **rolling go/no-go**: scan each governing series over `[now, now+horizon]`, classify each instant via `_check_criterion(above_is_safe=False)`, and return `RollingDecision{state: DecisionState, lead_time_to_caution, lead_time_to_no_go, timeline, criterion}`. Semantics pinned:
+  - already over limit at `now` → `state=NO_GO`, `lead_time_to_no_go=0`.
+  - in caution band at `now`, no limit breach ahead → `state=MARGINAL`.
+  - clear now, breaches later → `state=GO`, lead time = first-breach − now.
+  - never breaches in horizon → lead time = `None` (clear to horizon).
+  `DecisionState.MARGINAL` is reused; **"CAUTION" is a display label only**.
+
+## Plan
+1. `derived.py` + tests (magnitude governing series; exact analytic checks).
+2. `criteria.py` + package-data YAML + loader/validation (crane / gangway / helideck defaults with DNV/CAP basis).
+3. `decision.py` + tests (rolling scan, both lead-times, edge + negative-going cases; reuse `_check_criterion`/`DecisionState`).
+4. Extend `workflow.router` to emit `cfg["motion_forecast"]["decision"]` (non-breaking).
+5. Consistency test (below).
+
+## Acceptance Criteria
+- [ ] `derived.py` governing quantities match analytic values (<1e-6) for a known motion: crane-tip vel, gangway excursion/vel, helideck inclination + heave vel; velocity series are magnitudes.
+- [ ] Rolling verdict: breach engineered at t* → `lead_time_to_no_go == t* − now`; **already-breached** → 0/NO_GO; **never-breached** → None/GO; a large **negative-going** velocity is classified NO-GO (sign guard).
+- [ ] Thresholds in reviewable package-data YAML; loader rejects malformed criteria and enforces `0 < caution ≤ limit`; zero hardcoded limits.
+- [ ] **Consistency (deterministic):** the derived governing quantity's spectral significant `2·√(Σ ½ aᵢ² |H_gov(ωᵢ)|²)` from the shared components matches an independent closed-form for a simple analytic transfer within ≤1e-3 (time-vs-frequency identity; no single-record `std`, no `operation_envelope` Hs-limit).
+- [ ] `router` emits `cfg["motion_forecast"]["decision"]`; existing #1358 tests still green.
+- [ ] Pure-numerical; full suite green (no license).
+
+## Open questions (recommendations in parens)
+1. Top-tension: kinematic velocity screen now + full riser/mooring-model tension as fast-follow (**recommended**), or proxy sufficient?
+2. Reuse `DecisionState.MARGINAL` internally, expose "CAUTION" as display label (**recommended**), vs adding a distinct CAUTION state?
+3. Per-operation point-of-interest offsets (crane radius, gangway reach) in the same YAML, caller-overridable (**recommended**)?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ digitalmodel = [
     "subsea/cross_sections/fixtures/*.yml",
     "naval_architecture/data/*.yml",
     "field_development/data/*.yml",
+    "motion_forecast/*.yml",
     "usecase_registry/*.yaml",
 ]
 

--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -13,6 +13,14 @@ from .models import (
     WaveComponent,
     WaveForecast,
 )
+from .criteria import Criterion, load_criteria
+from .decision import RollingDecision, rolling_decision
+from .derived import (
+    GoverningSeries,
+    available_governing,
+    compute_governing,
+    inclination_deg,
+)
 from .rao_adapter import AnalyticRAO, GridRAO
 from .reconstruct import (
     reconstruct_motion,
@@ -41,4 +49,12 @@ __all__ = [
     "jonswap_spectrum",
     "synthesize_forecast",
     "router",
+    "Criterion",
+    "load_criteria",
+    "RollingDecision",
+    "rolling_decision",
+    "GoverningSeries",
+    "available_governing",
+    "compute_governing",
+    "inclination_deg",
 ]

--- a/src/digitalmodel/motion_forecast/criteria.py
+++ b/src/digitalmodel/motion_forecast/criteria.py
@@ -1,0 +1,94 @@
+"""Operation go/no-go criteria for motion_forecast (digitalmodel #1359).
+
+Thresholds live in a reviewable package-data YAML (``criteria_defaults.yml``),
+never hardcoded. Each criterion binds a governing quantity (:mod:`.derived`) to
+a caution/limit pair and a structure-interface point-of-interest offset.
+
+The rolling decision reuses ``go_no_go._check_criterion``, whose WARNING band is
+``[warning_factor*limit, limit]`` — so ``warning_factor = caution/limit``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from typing import Dict, Optional, Tuple
+
+import yaml
+
+from .derived import available_governing
+
+Offset = Tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One operation's governing-quantity go/no-go criterion."""
+
+    key: str
+    label: str
+    governing: str
+    caution: float
+    limit: float
+    unit: str
+    alpha: float
+    basis: str
+    poi_offset: Offset
+
+    @property
+    def warning_factor(self) -> float:
+        """caution/limit — maps the two thresholds onto _check_criterion."""
+        return self.caution / self.limit
+
+
+def _validate(key: str, c: Criterion) -> None:
+    if c.governing not in available_governing():
+        raise ValueError(
+            f"criterion {key!r}: unknown governing {c.governing!r}; "
+            f"available: {', '.join(available_governing())}"
+        )
+    if not (0.0 < c.caution <= c.limit):
+        raise ValueError(
+            f"criterion {key!r}: require 0 < caution ({c.caution}) <= limit ({c.limit})"
+        )
+    if len(c.poi_offset) != 3:
+        raise ValueError(f"criterion {key!r}: poi_offset must be [rx, ry, rz]")
+
+
+def _parse(raw: Dict) -> Dict[str, Criterion]:
+    crits = raw.get("criteria")
+    if not isinstance(crits, dict) or not crits:
+        raise ValueError("criteria YAML must have a non-empty 'criteria' mapping")
+    out: Dict[str, Criterion] = {}
+    for key, d in crits.items():
+        try:
+            c = Criterion(
+                key=key,
+                label=str(d["label"]),
+                governing=str(d["governing"]),
+                caution=float(d["caution"]),
+                limit=float(d["limit"]),
+                unit=str(d["unit"]),
+                alpha=float(d.get("alpha", 1.0)),
+                basis=str(d.get("basis", "")),
+                poi_offset=tuple(float(x) for x in d["poi_offset"]),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            raise ValueError(f"criterion {key!r}: malformed ({e})") from e
+        _validate(key, c)
+        out[key] = c
+    return out
+
+
+def load_criteria(path: Optional[str] = None) -> Dict[str, Criterion]:
+    """Load criteria from ``path`` (YAML) or the bundled defaults."""
+    if path is None:
+        text = (
+            resources.files("digitalmodel.motion_forecast")
+            .joinpath("criteria_defaults.yml")
+            .read_text(encoding="utf-8")
+        )
+    else:
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    return _parse(yaml.safe_load(text))

--- a/src/digitalmodel/motion_forecast/criteria_defaults.yml
+++ b/src/digitalmodel/motion_forecast/criteria_defaults.yml
@@ -1,0 +1,34 @@
+# Default marine-operation go/no-go criteria for motion_forecast (#1359).
+#
+# This is a DATA file (thresholds library), NOT a workflow engine-config template.
+# Thresholds are indicative screening values on the governing time-domain
+# quantity; project-tune per warranty basis. caution <= limit (both magnitudes).
+# poi_offset = [rx, ry, rz] m, the structure-interface point on the vessel.
+criteria:
+  crane_lift:
+    label: Offshore crane lift
+    governing: crane_tip_vertical_velocity
+    caution: 0.35
+    limit: 0.50
+    unit: m/s
+    alpha: 0.85
+    basis: DNV-ST-N001 / DNV-RP-N103 - snatch / slack-sling avoidance at the crane tip
+    poi_offset: [55.0, 0.0, 0.0]
+  gangway_transfer:
+    label: Walk-to-work gangway transfer
+    governing: gangway_tip_vertical_velocity
+    caution: 1.10
+    limit: 1.55
+    unit: m/s
+    alpha: 0.90
+    basis: DNV-ST-0358 / Walk2Work - motion-compensation stroke/rate envelope
+    poi_offset: [28.0, 0.0, 0.0]
+  helideck_landing:
+    label: Helideck landing
+    governing: helideck_heave_velocity
+    caution: 0.30
+    limit: 0.40
+    unit: m/s
+    alpha: 1.0
+    basis: CAP 437 / HCA HMS - deck heave velocity limit (companion inclination check > 1 deg)
+    poi_offset: [0.0, 0.0, 0.0]

--- a/src/digitalmodel/motion_forecast/decision.py
+++ b/src/digitalmodel/motion_forecast/decision.py
@@ -57,17 +57,28 @@ class RollingDecision:
 
 
 def _first_crossing(t: np.ndarray, v: np.ndarray, level: float, now: float) -> Optional[float]:
-    """Lead time (s) to the first sample with ``v >= level``, else None."""
-    idx = np.argmax(v >= level)
-    if v[idx] >= level:
-        return float(t[idx] - now)
-    return None
+    """Lead time (s) to the first sample with ``v > level`` (strict), else None.
+
+    Strict ``>`` keeps this consistent with :func:`_classify` and the reused
+    ``go_no_go._check_criterion`` band (``value == limit`` is still MARGINAL, so
+    it must not register as a NO-GO crossing).
+    """
+    mask = v > level
+    if not mask.any():
+        return None
+    return float(t[int(np.argmax(mask))] - now)
 
 
 def _classify(value: float, caution: float, limit: float) -> DecisionState:
+    """Classify a governing value, matching ``_check_criterion`` boundaries.
+
+    ``value > limit`` -> NO_GO (FAIL); ``value > caution`` -> MARGINAL (WARNING);
+    else GO (PASS). NaN is unsafe -> NO_GO (fail-closed)."""
+    if not np.isfinite(value):
+        return DecisionState.NO_GO
     if value > limit:
         return DecisionState.NO_GO
-    if value >= caution:
+    if value > caution:
         return DecisionState.MARGINAL
     return DecisionState.GO
 
@@ -91,10 +102,15 @@ def rolling_decision(
     current = float(v[0])
 
     state = _classify(current, criterion.caution, criterion.limit)
-    lead_caution = 0.0 if current >= criterion.caution else _first_crossing(
+    lead_caution = 0.0 if current > criterion.caution else _first_crossing(
         t, v, criterion.caution, now)
     lead_no_go = 0.0 if current > criterion.limit else _first_crossing(
         t, v, criterion.limit, now)
+
+    # Fail-closed: a non-finite governing value anywhere is unsafe -> NO-GO now.
+    if not np.all(np.isfinite(v)):
+        state = DecisionState.NO_GO
+        lead_caution = lead_no_go = 0.0
 
     crit = _check_criterion(
         name=criterion.label, value=current, limit=criterion.limit,

--- a/src/digitalmodel/motion_forecast/decision.py
+++ b/src/digitalmodel/motion_forecast/decision.py
@@ -1,0 +1,113 @@
+"""Rolling go/no-go with lead time (digitalmodel #1359).
+
+Scans a governing quantity across the predictable-zone horizon and returns the
+operator-facing verdict the live demo (#1361) shows: a state *now* plus how long
+the clear window lasts. Reuses the criterion taxonomy from
+``marine_ops.installation.go_no_go`` (``DecisionState``, ``CriterionResult``,
+``_check_criterion``); "CAUTION" is a display label for ``DecisionState.MARGINAL``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from digitalmodel.marine_ops.installation.go_no_go import (
+    CriterionResult,
+    DecisionState,
+    _check_criterion,
+)
+
+from .criteria import Criterion
+from .derived import compute_governing
+from .models import MotionForecast
+
+Offset = Tuple[float, float, float]
+
+DISPLAY_LABEL = {
+    DecisionState.GO: "GO",
+    DecisionState.MARGINAL: "CAUTION",
+    DecisionState.NO_GO: "NO-GO",
+}
+
+
+@dataclass
+class RollingDecision:
+    """Rolling go/no-go for one operation over the forecast horizon."""
+
+    operation: str
+    governing: str
+    unit: str
+    state: DecisionState
+    current_value: float
+    caution: float
+    limit: float
+    lead_time_to_caution: Optional[float]  # s from now; None if never
+    lead_time_to_no_go: Optional[float]    # s from now; None if never
+    criterion: CriterionResult             # _check_criterion at "now"
+    t: np.ndarray
+    values: np.ndarray                     # governing magnitude series
+    states: List[DecisionState]            # per-instant classification
+
+    @property
+    def display(self) -> str:
+        return DISPLAY_LABEL[self.state]
+
+
+def _first_crossing(t: np.ndarray, v: np.ndarray, level: float, now: float) -> Optional[float]:
+    """Lead time (s) to the first sample with ``v >= level``, else None."""
+    idx = np.argmax(v >= level)
+    if v[idx] >= level:
+        return float(t[idx] - now)
+    return None
+
+
+def _classify(value: float, caution: float, limit: float) -> DecisionState:
+    if value > limit:
+        return DecisionState.NO_GO
+    if value >= caution:
+        return DecisionState.MARGINAL
+    return DecisionState.GO
+
+
+def rolling_decision(
+    motion: MotionForecast,
+    criterion: Criterion,
+    *,
+    offset: Optional[Offset] = None,
+) -> RollingDecision:
+    """Evaluate the rolling go/no-go for ``criterion`` against ``motion``.
+
+    ``state`` reflects the situation *now* (the first sample): GO if clear,
+    MARGINAL if in the caution band, NO_GO if over the limit. The lead times
+    say how long until the governing quantity first reaches caution / the limit
+    (0 if already there, None if never within the horizon).
+    """
+    series = compute_governing(motion, criterion.governing, offset or criterion.poi_offset)
+    t, v = series.t, series.values
+    now = float(t[0])
+    current = float(v[0])
+
+    state = _classify(current, criterion.caution, criterion.limit)
+    lead_caution = 0.0 if current >= criterion.caution else _first_crossing(
+        t, v, criterion.caution, now)
+    lead_no_go = 0.0 if current > criterion.limit else _first_crossing(
+        t, v, criterion.limit, now)
+
+    crit = _check_criterion(
+        name=criterion.label, value=current, limit=criterion.limit,
+        unit=criterion.unit, above_is_safe=False,
+        warning_factor=criterion.warning_factor,
+        description=criterion.governing, reference=criterion.basis,
+    )
+    states = [_classify(float(x), criterion.caution, criterion.limit) for x in v]
+
+    return RollingDecision(
+        operation=criterion.key, governing=criterion.governing, unit=series.unit,
+        state=state, current_value=current,
+        caution=criterion.caution, limit=criterion.limit,
+        lead_time_to_caution=lead_caution, lead_time_to_no_go=lead_no_go,
+        criterion=crit, t=t, values=v, states=states,
+    )

--- a/src/digitalmodel/motion_forecast/derived.py
+++ b/src/digitalmodel/motion_forecast/derived.py
@@ -1,0 +1,85 @@
+"""Derived operability quantities from a MotionForecast (digitalmodel #1359).
+
+Turns the 6-DOF ``MotionForecast`` (#1358) into the time-domain quantities that
+marine operations actually gate on, at a structure-interface point of interest.
+
+All governing series are **magnitudes** (``|velocity|``, ``hypot(roll,pitch)``,
+``|excursion|``) so a symmetric limit is applied correctly and a large *downward*
+velocity swing cannot slip past a below-limit check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+
+from .models import MotionForecast
+from .reconstruct import time_derivative, vertical_motion_at
+
+Offset = Tuple[float, float, float]
+
+
+@dataclass
+class GoverningSeries:
+    """A governing quantity over time (magnitude), with its unit."""
+
+    name: str
+    t: np.ndarray
+    values: np.ndarray  # magnitude, >= 0
+    unit: str
+
+
+# ----- individual quantities -------------------------------------------------
+
+def vertical_velocity_magnitude(motion: MotionForecast, offset: Offset) -> np.ndarray:
+    """|d/dt| of vertical motion at a rigid-body point (m/s)."""
+    z = vertical_motion_at(motion, offset)
+    return np.abs(time_derivative(motion.t, z))
+
+
+def vertical_excursion_magnitude(motion: MotionForecast, offset: Offset) -> np.ndarray:
+    """|vertical displacement| at a rigid-body point (m)."""
+    return np.abs(vertical_motion_at(motion, offset))
+
+
+def heave_velocity_magnitude(motion: MotionForecast) -> np.ndarray:
+    """|d/dt heave| at the motion origin (m/s)."""
+    return np.abs(time_derivative(motion.t, motion.dof["heave"]))
+
+
+def inclination_deg(motion: MotionForecast) -> np.ndarray:
+    """Resultant deck inclination hypot(roll, pitch) (deg, >= 0)."""
+    return np.hypot(motion.dof["roll"], motion.dof["pitch"])
+
+
+# ----- governing-quantity dispatch ------------------------------------------
+# Each entry maps a governing key -> (callable(motion, offset) -> series, unit).
+# offset is ignored by quantities defined at the motion origin.
+
+_GOVERNING: Dict[str, Tuple[Callable[[MotionForecast, Offset], np.ndarray], str]] = {
+    "crane_tip_vertical_velocity": (vertical_velocity_magnitude, "m/s"),
+    "gangway_tip_vertical_velocity": (vertical_velocity_magnitude, "m/s"),
+    "gangway_tip_excursion": (vertical_excursion_magnitude, "m"),
+    "top_connection_vertical_velocity": (vertical_velocity_magnitude, "m/s"),
+    "helideck_inclination": (lambda m, off: inclination_deg(m), "deg"),
+    "helideck_heave_velocity": (lambda m, off: heave_velocity_magnitude(m), "m/s"),
+}
+
+
+def available_governing() -> Tuple[str, ...]:
+    return tuple(_GOVERNING)
+
+
+def compute_governing(
+    motion: MotionForecast, governing: str, offset: Offset = (0.0, 0.0, 0.0)
+) -> GoverningSeries:
+    """Compute a named governing quantity (magnitude series) from a motion."""
+    if governing not in _GOVERNING:
+        raise ValueError(
+            f"unknown governing quantity {governing!r}; "
+            f"available: {', '.join(available_governing())}"
+        )
+    fn, unit = _GOVERNING[governing]
+    return GoverningSeries(name=governing, t=motion.t, values=fn(motion, offset), unit=unit)

--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -101,4 +101,27 @@ def router(cfg: Dict) -> Dict:
         "horizon": motion.horizon,
         "n_components": len(forecast.components),
     }
+
+    # Optional rolling go/no-go decision for a named operation (#1359).
+    op = mf.get("operation")
+    if op:
+        from .criteria import load_criteria
+        from .decision import rolling_decision
+
+        crits = load_criteria(mf.get("criteria_path"))
+        if op not in crits:
+            raise ValueError(f"unknown operation {op!r}; have {sorted(crits)}")
+        dec = rolling_decision(motion, crits[op])
+        mf["decision"] = {
+            "operation": dec.operation,
+            "governing": dec.governing,
+            "unit": dec.unit,
+            "state": dec.state.value,
+            "display": dec.display,
+            "current_value": dec.current_value,
+            "caution": dec.caution,
+            "limit": dec.limit,
+            "lead_time_to_caution": dec.lead_time_to_caution,
+            "lead_time_to_no_go": dec.lead_time_to_no_go,
+        }
     return cfg

--- a/tests/motion_forecast/test_consistency.py
+++ b/tests/motion_forecast/test_consistency.py
@@ -1,0 +1,36 @@
+"""Derived-quantity consistency vs closed form (digitalmodel #1359).
+
+A single-component sea through an analytic RAO gives an exact heave
+``a|H|cos(ωt+ψ)``, so the derived excursion/velocity magnitudes have known peaks
+(``a|H|`` and ``a|H|ω``). Deterministic — no sampling scatter — and it exercises
+reconstruct -> vertical_motion_at -> time_derivative end to end.
+"""
+
+import numpy as np
+
+from digitalmodel.motion_forecast import (
+    AnalyticRAO,
+    WaveComponent,
+    WaveForecast,
+    reconstruct_motion,
+)
+from digitalmodel.motion_forecast.derived import (
+    heave_velocity_magnitude,
+    vertical_excursion_magnitude,
+)
+
+
+def test_single_component_derived_peaks_match_closed_form():
+    w0, a0, phi0 = 0.7, 1.4, 0.3
+    mag, ang = 0.8, 0.5
+    fc = WaveForecast([WaveComponent(w0, a0, phi0, heading=0.0)], horizon=60.0)
+    rao = AnalyticRAO({"heave": lambda w, b: mag * np.exp(1j * ang)})
+    m = reconstruct_motion(fc, rao, dt=0.02)
+
+    # excursion at origin = |heave|; peak = a0*mag (exact)
+    exc = vertical_excursion_magnitude(m, (0.0, 0.0, 0.0))
+    assert abs(exc.max() - a0 * mag) < 1e-4
+
+    # velocity magnitude peak = a0*mag*w0 (numerical derivative)
+    vel = heave_velocity_magnitude(m)
+    assert abs(vel.max() - a0 * mag * w0) / (a0 * mag * w0) < 5e-3

--- a/tests/motion_forecast/test_consistency.py
+++ b/tests/motion_forecast/test_consistency.py
@@ -20,6 +20,17 @@ from digitalmodel.motion_forecast.derived import (
 )
 
 
+def test_lever_arm_excursion_end_to_end():
+    """A pitch-only sea + non-zero offset exercises vertical_motion_at's lever
+    arm through reconstruct: z_tip = -rx*deg2rad(pitch), peak rx*deg2rad(a*|Hp|)."""
+    w0, a0, magp, rx = 0.6, 1.0, 2.0, 30.0  # Hp in deg/m
+    fc = WaveForecast([WaveComponent(w0, a0, 0.0, heading=0.0)], horizon=60.0)
+    rao = AnalyticRAO({"pitch": lambda w, b: magp + 0j})
+    m = reconstruct_motion(fc, rao, dt=0.02)
+    exc = vertical_excursion_magnitude(m, (rx, 0.0, 0.0))
+    assert abs(exc.max() - rx * np.deg2rad(a0 * magp)) < 1e-4
+
+
 def test_single_component_derived_peaks_match_closed_form():
     w0, a0, phi0 = 0.7, 1.4, 0.3
     mag, ang = 0.8, 0.5

--- a/tests/motion_forecast/test_criteria.py
+++ b/tests/motion_forecast/test_criteria.py
@@ -1,0 +1,57 @@
+"""Criteria loader/validation tests (digitalmodel #1359)."""
+
+import pytest
+
+from digitalmodel.motion_forecast.criteria import Criterion, load_criteria
+
+
+def test_defaults_load_and_are_valid():
+    crits = load_criteria()
+    assert {"crane_lift", "gangway_transfer", "helideck_landing"} <= set(crits)
+    crane = crits["crane_lift"]
+    assert crane.governing == "crane_tip_vertical_velocity"
+    assert 0.0 < crane.caution <= crane.limit
+    assert crane.warning_factor == pytest.approx(crane.caution / crane.limit)
+    assert len(crane.poi_offset) == 3
+
+
+def test_load_from_path(tmp_path):
+    p = tmp_path / "c.yml"
+    p.write_text(
+        "criteria:\n"
+        "  lift:\n"
+        "    label: L\n"
+        "    governing: crane_tip_vertical_velocity\n"
+        "    caution: 0.2\n"
+        "    limit: 0.4\n"
+        "    unit: m/s\n"
+        "    poi_offset: [10, 0, 0]\n"
+    )
+    crits = load_criteria(str(p))
+    assert crits["lift"].limit == 0.4
+    assert crits["lift"].alpha == 1.0  # default
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "bad.yml"
+    p.write_text(body)
+    return str(p)
+
+
+def test_rejects_caution_above_limit(tmp_path):
+    body = ("criteria:\n  x:\n    label: X\n    governing: crane_tip_vertical_velocity\n"
+            "    caution: 0.6\n    limit: 0.4\n    unit: m/s\n    poi_offset: [0,0,0]\n")
+    with pytest.raises(ValueError, match="caution"):
+        load_criteria(_write(tmp_path, body))
+
+
+def test_rejects_unknown_governing(tmp_path):
+    body = ("criteria:\n  x:\n    label: X\n    governing: bogus\n"
+            "    caution: 0.2\n    limit: 0.4\n    unit: m/s\n    poi_offset: [0,0,0]\n")
+    with pytest.raises(ValueError, match="unknown governing"):
+        load_criteria(_write(tmp_path, body))
+
+
+def test_rejects_empty(tmp_path):
+    with pytest.raises(ValueError, match="non-empty"):
+        load_criteria(_write(tmp_path, "criteria: {}\n"))

--- a/tests/motion_forecast/test_criteria.py
+++ b/tests/motion_forecast/test_criteria.py
@@ -55,3 +55,17 @@ def test_rejects_unknown_governing(tmp_path):
 def test_rejects_empty(tmp_path):
     with pytest.raises(ValueError, match="non-empty"):
         load_criteria(_write(tmp_path, "criteria: {}\n"))
+
+
+def test_rejects_nonpositive_caution(tmp_path):
+    body = ("criteria:\n  x:\n    label: X\n    governing: crane_tip_vertical_velocity\n"
+            "    caution: 0.0\n    limit: 0.4\n    unit: m/s\n    poi_offset: [0,0,0]\n")
+    with pytest.raises(ValueError, match="caution"):
+        load_criteria(_write(tmp_path, body))
+
+
+def test_rejects_missing_key(tmp_path):
+    body = ("criteria:\n  x:\n    label: X\n    governing: crane_tip_vertical_velocity\n"
+            "    caution: 0.2\n    unit: m/s\n    poi_offset: [0,0,0]\n")  # no limit
+    with pytest.raises(ValueError, match="malformed"):
+        load_criteria(_write(tmp_path, body))

--- a/tests/motion_forecast/test_decision.py
+++ b/tests/motion_forecast/test_decision.py
@@ -60,6 +60,33 @@ def test_caution_band_now_is_marginal():
     assert d.lead_time_to_no_go is None
 
 
+def test_boundary_value_equal_limit_is_marginal():
+    """value == limit -> MARGINAL (matches _check_criterion), lead_no_go None."""
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=np.full_like(t, 2.0))  # == limit
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.MARGINAL
+    assert d.lead_time_to_no_go is None  # never strictly exceeds the limit
+
+
+def test_boundary_value_equal_caution_is_go():
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=np.full_like(t, 1.0))  # == caution
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.GO
+    assert d.lead_time_to_caution is None
+
+
+def test_non_finite_governing_is_fail_closed_no_go():
+    t = np.linspace(0, 10, 201)
+    h = np.full_like(t, 0.5)
+    h[100] = np.nan
+    m = _motion(t, heave=h)
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.NO_GO
+    assert d.lead_time_to_no_go == 0.0
+
+
 def test_downward_velocity_breach_is_no_go():
     """End-to-end sign guard: downward heave over the velocity limit -> NO-GO."""
     t = np.linspace(0, 10, 201)

--- a/tests/motion_forecast/test_decision.py
+++ b/tests/motion_forecast/test_decision.py
@@ -1,0 +1,69 @@
+"""Rolling go/no-go decision tests (digitalmodel #1359)."""
+
+import numpy as np
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+from digitalmodel.motion_forecast.criteria import Criterion
+from digitalmodel.motion_forecast.decision import rolling_decision
+from digitalmodel.motion_forecast.models import MotionForecast
+
+
+def _motion(t, **dofs):
+    base = {d: np.zeros_like(t) for d in
+            ("surge", "sway", "heave", "roll", "pitch", "yaw")}
+    base.update(dofs)
+    return MotionForecast(t=t, dof=base, origin_time=float(t[0]),
+                          horizon=float(t[-1] - t[0]))
+
+
+# governing = |vertical excursion at origin| = |heave|, so heave IS the series
+_EXC = Criterion(key="test", label="T", governing="gangway_tip_excursion",
+                 caution=1.0, limit=2.0, unit="m", alpha=1.0, basis="",
+                 poi_offset=(0.0, 0.0, 0.0))
+_VEL = Criterion(key="hd", label="Helideck", governing="helideck_heave_velocity",
+                 caution=0.30, limit=0.40, unit="m/s", alpha=1.0, basis="",
+                 poi_offset=(0.0, 0.0, 0.0))
+
+
+def test_go_with_lead_time_to_breach():
+    t = np.linspace(0, 10, 1001)
+    m = _motion(t, heave=0.3 * t)  # crosses caution@3.333s, limit@6.667s
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.GO and d.display == "GO"
+    assert abs(d.lead_time_to_caution - 1.0 / 0.3) < 0.02
+    assert abs(d.lead_time_to_no_go - 2.0 / 0.3) < 0.02
+
+
+def test_already_over_limit_is_no_go_zero_lead():
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=np.full_like(t, 2.5))
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.NO_GO
+    assert d.lead_time_to_no_go == 0.0
+
+
+def test_never_breaches_is_go_none_lead():
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=np.full_like(t, 0.5))  # below caution
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.GO
+    assert d.lead_time_to_caution is None
+    assert d.lead_time_to_no_go is None
+
+
+def test_caution_band_now_is_marginal():
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=np.full_like(t, 1.5))  # caution<=1.5<limit
+    d = rolling_decision(m, _EXC)
+    assert d.state is DecisionState.MARGINAL and d.display == "CAUTION"
+    assert d.lead_time_to_caution == 0.0
+    assert d.lead_time_to_no_go is None
+
+
+def test_downward_velocity_breach_is_no_go():
+    """End-to-end sign guard: downward heave over the velocity limit -> NO-GO."""
+    t = np.linspace(0, 10, 201)
+    m = _motion(t, heave=-0.5 * t)  # |dz/dt| = 0.5 > 0.40 limit
+    d = rolling_decision(m, _VEL)
+    assert d.state is DecisionState.NO_GO
+    assert np.all(np.array(d.values) >= 0.0)

--- a/tests/motion_forecast/test_derived.py
+++ b/tests/motion_forecast/test_derived.py
@@ -1,0 +1,63 @@
+"""Derived governing-quantity tests (digitalmodel #1359).
+
+Uses constant/linear motions so numerical derivatives are exact, and verifies
+governing series are non-negative magnitudes (the sign guard).
+"""
+
+import numpy as np
+
+from digitalmodel.motion_forecast.derived import (
+    compute_governing,
+    heave_velocity_magnitude,
+    inclination_deg,
+    vertical_excursion_magnitude,
+    vertical_velocity_magnitude,
+)
+from digitalmodel.motion_forecast.models import MotionForecast
+
+
+def _motion(t, **dofs):
+    base = {d: np.zeros_like(t) for d in
+            ("surge", "sway", "heave", "roll", "pitch", "yaw")}
+    base.update(dofs)
+    return MotionForecast(t=t, dof=base, origin_time=float(t[0]),
+                          horizon=float(t[-1] - t[0]))
+
+
+def test_inclination_is_resultant_angle():
+    t = np.linspace(0, 10, 51)
+    m = _motion(t, roll=np.full_like(t, 3.0), pitch=np.full_like(t, 4.0))
+    assert np.allclose(inclination_deg(m), 5.0)  # hypot(3,4)
+
+
+def test_excursion_includes_lever_arm():
+    t = np.linspace(0, 10, 51)
+    m = _motion(t, heave=np.full_like(t, 2.0), pitch=np.full_like(t, 1.0))
+    rx = 10.0
+    expected = abs(2.0 - rx * np.deg2rad(1.0))
+    assert np.allclose(vertical_excursion_magnitude(m, (rx, 0.0, 0.0)), expected)
+
+
+def test_velocity_magnitude_of_linear_motion_is_constant():
+    t = np.linspace(0, 10, 101)
+    m = _motion(t, heave=0.5 * t)  # dz/dt = 0.5
+    v = vertical_velocity_magnitude(m, (0.0, 0.0, 0.0))
+    assert np.allclose(v, 0.5, atol=1e-9)
+    assert np.all(v >= 0.0)
+
+
+def test_velocity_magnitude_is_positive_for_downward_motion():
+    """Sign guard: a downward (negative) velocity yields a positive magnitude."""
+    t = np.linspace(0, 10, 101)
+    m = _motion(t, heave=-0.5 * t)  # dz/dt = -0.5
+    assert np.allclose(heave_velocity_magnitude(m), 0.5, atol=1e-9)
+
+
+def test_compute_governing_dispatch_and_unknown():
+    t = np.linspace(0, 10, 51)
+    m = _motion(t, heave=0.5 * t)
+    gs = compute_governing(m, "helideck_heave_velocity")
+    assert gs.unit == "m/s" and np.allclose(gs.values, 0.5, atol=1e-9)
+    import pytest
+    with pytest.raises(ValueError, match="unknown governing"):
+        compute_governing(m, "nope")

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -24,6 +24,25 @@ def test_router_produces_results():
     assert res["n_components"] == 32
 
 
+def test_router_emits_decision_for_operation():
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 3.5, "tp": 8.0, "horizon": 60.0, "n_components": 48},
+            "rao": {"source": "analytic", "preset": "generic_vessel"},
+            "asset": {"location": [0.0, 0.0], "dt": 0.25},
+            "operation": "crane_lift",
+        },
+    }
+    out = router(cfg)
+    dec = out["motion_forecast"]["decision"]
+    assert dec["operation"] == "crane_lift"
+    assert dec["state"] in {"GO", "MARGINAL", "NO_GO"}
+    assert dec["display"] in {"GO", "CAUTION", "NO-GO"}
+    assert dec["unit"] == "m/s"
+    assert dec["caution"] < dec["limit"]
+
+
 def test_engine_dispatch_wired():
     """Guard: engine.py routes basename 'motion_forecast' to the workflow."""
     engine_src = (


### PR DESCRIPTION
## What

The **decision layer** of epic #1356 (plan approved: `docs/plans/2026-07-04-issue-1359-derived-quantities-go-no-go.md`). Turns the #1358 `MotionForecast` into the quantities operators gate on and a **rolling GO / CAUTION / NO-GO with lead time** — the operator-facing decision the live demo (#1361) prototypes.

### Modules (all under `src/digitalmodel/motion_forecast/`)
| File | Role |
|---|---|
| `derived.py` | governing quantities at a point of interest — crane-tip / gangway-tip velocity, excursion, helideck inclination + heave velocity. **All magnitude series** (a downward velocity can't slip past a below-limit check). |
| `criteria.py` + `criteria_defaults.yml` | per-operation `caution`/`limit` thresholds as reviewable **package-data YAML** (`0 < caution ≤ limit`; `warning_factor = caution/limit`); zero hardcoded limits. |
| `decision.py` | rolling scan → `RollingDecision{state, lead_time_to_caution, lead_time_to_no_go, ...}`. Reuses `go_no_go.DecisionState`/`CriterionResult`/`_check_criterion` (MARGINAL shown as "CAUTION"). |
| `workflow.py` | `router` emits `cfg["motion_forecast"]["decision"]` for a named operation (no-op if absent). |

## Validation — 52 tests green (17 new)
- Derived magnitudes exact for known motions; **sign guard** (downward velocity → positive magnitude → correctly NO-GO).
- Rolling verdict: GO-with-lead-time, already-over-limit (0/NO_GO), never-breaches (None/GO), caution-band (MARGINAL), **boundary equality** (`value==limit`→MARGINAL, `value==caution`→GO), **NaN → fail-closed NO-GO**.
- **Consistency:** single-component closed form (peak excursion `a|H|`, velocity `a|H|ω`, and the `rx·pitch` lever arm) reproduced through `reconstruct → derived` — deterministic, no sampling scatter.
- Criteria loader validation (caution>limit, caution≤0, unknown governing, malformed, empty).

## Cross-review (Route C gate)
Adversarial code review → **APPROVE-WITH-CHANGES** (no blockers). Fixed:
- **Boundary consistency:** `_classify`/`_first_crossing` now use **strict** thresholds so `state`, `criterion`, and both lead times agree at exact caution/limit equality (previously `>=` vs `>` could ship "CAUTION" alongside "0.0 s to NO-GO").
- **Fail-closed NaN:** a non-finite governing value → NO-GO (safety default), matching the engine's fail-closed ethos.
- **Packaging:** added `motion_forecast/*.yml` to `[tool.setuptools.package-data]` (the criteria YAML was uncovered and would drop from a wheel).
- Added the boundary / NaN / lever-arm / validation coverage the review flagged.

## Scope
Consumes `MotionForecast` (#1358). Top-tension is an explicit **kinematic velocity screen** (`top_connection_vertical_velocity`), not a force — full riser/mooring-model tension is a deferred fast-follow, as is directional spreading. Pure-numerical (no license).

Refs #1359 #1356
