### PR TITLE
feat(motion_forecast): measured-motion (MMS) ingest + reconciliation (#1367)

### DIFF
--- a/docs/plans/2026-07-04-issue-1367-mms-ingest-measured-mode.md
+++ b/docs/plans/2026-07-04-issue-1367-mms-ingest-measured-mode.md
@@ -1,0 +1,51 @@
+# Plan: digitalmodel #1367 — real-time MMS / measurement-system ingest (measured-motion mode + reconciliation)
+
+**Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1367
+**Epic:** #1356 · **Status:** plan-review · **Tier:** T2/T3 (Route B/C — ingest + measured mode reusing #1358/#1359; time-alignment is the real work)
+
+> Adversarially reviewed (2026-07-04): APPROVE-WITH-CHANGES. Reuse claims all verified. Blockers folded in — a **shared wall-clock time base** and an explicit **resampling contract** for reconciliation; `measured_status` uses `decision._classify` (DecisionState + NaN fail-close), not `_check_criterion`; router gates reconciliation on a real forecast; a rich `MeasuredDecision` mirrors `RollingDecision`.
+
+## Context
+
+Two data modes (owner): *Predicted* (#1358 forecast) and **Measured** — live vessel & structure motions from an onboard MMS / MRU as the "now" ground truth (the demo #1361 splits every panel `MMS MEASURED | FORECAST`). This issue builds the measured half: ingest, a measured representation, **measured-mode go/no-go** on real motion, and **reconciliation** of measured vs forecast — the signal #1360 consumes. Not stale (nothing exists).
+
+## Reuse (verified against merged code)
+- **Derived layer duck-types on `.t` + `.dof` only** — confirmed: `derived.compute_governing` and its targets (`vertical_motion_at`, `time_derivative`, `heave_velocity_magnitude`, `inclination_deg`) touch **no** `.origin_time`/`.horizon`/methods. A `MeasuredMotion` with `.t` + `.dof` flows through unchanged.
+- **Classification:** reuse `decision._classify` (DecisionState; strict `>` boundaries + NaN→NO_GO fail-close) — **not** `_check_criterion` (which yields CriterionState). Guarantees measured & forecast classify identically. `criteria.load_criteria`/`Criterion` reused.
+- **Router pattern:** `router` mutates + returns cfg; a `mf.get("measured")` branch is non-breaking.
+
+## Time base (blocker fix — the load-bearing decision)
+`MotionForecast.t` is **absolute** (reconstruct builds `t = linspace(origin_time, origin_time+horizon)`). `MeasuredMotion.t` is likewise **absolute seconds on the same wall-clock**; `now = t[-1]`. All alignment is on this shared clock. Overlap of two records = `[max(starts), min(ends)]`.
+
+## Design (under `src/digitalmodel/motion_forecast/`)
+
+- `measured.py` — `MeasuredMotion{t (absolute s), dof}`; `now` property = `t[-1]`; `at_now()` (latest 6-DOF), `window(seconds)` (trailing slice). Docstring warns: **do not** pass to `rolling_decision` (which treats `t[0]` as now — see footgun note); `measured_status` is the sanctioned entry.
+- `measured_source.py` — `MeasuredMotionSource` protocol (`read() -> MeasuredMotion`); `SyntheticMMS` (deterministic, seeded, from a reference motion + optional sensor noise); `from_csv(path)` reading columns `t, surge, sway, heave, roll, pitch, yaw` with **rotations in degrees** (model convention). Real MMS/MRU protocols (NMEA/network) are partner/deployment.
+- `reconcile.py`:
+  - `_resample(forecast, t_query)` — per-DOF `np.interp` of the forecast onto query timestamps **within the forecast's absolute range** (raise if out of range; no extrapolation).
+  - `seam_offset(measured, forecast)` — per-DOF `measured(now) − forecast(now)`, where `forecast(now)` = forecast interpolated at `measured.now`; require `measured.now` within the forecast's `[t0, t1]` (else raise). Anchoring/continuity check.
+  - `overlap_error(measured, forecast)` — on the absolute-time overlap: interpolate the forecast onto the measured timestamps in-overlap, then per-DOF **RMSE, bias, correlation**. Require a minimum overlap length; correlation is `None` on a zero-variance/too-short window (RMSE/bias still defined). Metrics only — recalibration is #1360.
+  - `measured_status(measured, criterion, offset=None) -> MeasuredDecision` — instantaneous classify of the **latest** governing value via `derived.compute_governing` + `decision._classify`.
+- `MeasuredDecision` dataclass — mirrors `RollingDecision` **minus lead times**: `state, display, current_value, caution, limit, governing, unit, t, values, states` — so the demo (#1361) and #1360 consume measured & forecast uniformly.
+- `workflow.router` — optional `mf["measured"]` (a source spec / CSV path): emit `mf["measured_status"]`. Emit `mf["reconciliation"]` **only** when a genuine forecast for the same scenario is present (explicit `sea`/forecast), never against the default synthetic sea.
+
+## Plan
+1. `measured.py` + tests (representation, `now`, `window`, duck-type through `compute_governing`).
+2. `measured_source.py` + tests (SyntheticMMS deterministic; CSV round-trip w/ tolerance; protocol conformance; rotations-in-deg).
+3. `reconcile.py` + tests — **including a deliberately different forecast/measured grid** scored vs closed form (exercises resampling); seam alignment + out-of-range raise; correlation zero-variance guard; `measured_status` vs `_classify` at `t[-1]`; NaN → NO_GO.
+4. Workflow wiring + tests (measured_status emitted; reconciliation gated on real forecast).
+
+## Acceptance Criteria
+- [ ] `MeasuredMotion` flows through `derived.compute_governing` unchanged (test).
+- [ ] `SyntheticMMS` deterministic (seeded); `from_csv` round-trips a 6-DOF series within float tolerance; rotations documented as degrees.
+- [ ] `seam_offset` = 0 (per DOF) when measured equals forecast at the same instant; raises when `measured.now` is outside the forecast range.
+- [ ] `overlap_error`: RMSE/bias = 0 on identical overlap; **matches a closed-form value when forecast & measured are on DIFFERENT grids** (resampling path); correlation guarded on zero-variance/short overlap.
+- [ ] `measured_status` returns a `MeasuredDecision` equal to `_classify` at `t[-1]`; NaN → fail-closed NO-GO; unit/thresholds from the #1359 criteria YAML.
+- [ ] `router` emits `measured_status` when a feed is supplied and `reconciliation` **only** with a real forecast; existing #1358/#1359 tests still green.
+- [ ] Pure-numerical; zero hardcoded thresholds.
+
+## Deferred / out of scope (documented)
+Real MMS/MRU wire protocols + hardware time-sync; recalibration & skill-tracking-over-time (**#1360**, which inherits this issue's resampling + metric definitions).
+
+## Open questions — all resolved to recommended defaults (owner 2026-07-04)
+Distinct `MeasuredMotion` type · reconciliation metrics here / recalibration in #1360 · CSV reader.

--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -15,6 +15,15 @@ from .models import (
 )
 from .criteria import Criterion, load_criteria
 from .decision import RollingDecision, rolling_decision
+from .measured import MeasuredMotion
+from .measured_source import MeasuredMotionSource, SyntheticMMS, from_csv
+from .reconcile import (
+    DofError,
+    MeasuredDecision,
+    measured_status,
+    overlap_error,
+    seam_offset,
+)
 from .derived import (
     GoverningSeries,
     available_governing,
@@ -57,4 +66,13 @@ __all__ = [
     "available_governing",
     "compute_governing",
     "inclination_deg",
+    "MeasuredMotion",
+    "MeasuredMotionSource",
+    "SyntheticMMS",
+    "from_csv",
+    "seam_offset",
+    "overlap_error",
+    "measured_status",
+    "MeasuredDecision",
+    "DofError",
 ]

--- a/src/digitalmodel/motion_forecast/measured.py
+++ b/src/digitalmodel/motion_forecast/measured.py
@@ -1,0 +1,69 @@
+"""Measured-motion representation (digitalmodel #1367).
+
+The *measured* data mode: live vessel & structure motions from an onboard MMS /
+MRU, the "now" ground truth the forecast is anchored to and scored against.
+
+``MeasuredMotion`` shares the ``.t`` / ``.dof`` field contract with
+``MotionForecast`` (so it flows through the #1359 ``derived`` layer unchanged),
+but its "now" is the **last** sample ``t[-1]`` (the past up to now), whereas a
+forecast's now is ``t[0]``. ``t`` is **absolute seconds on a shared wall-clock**
+with ``MotionForecast.t`` so the two can be reconciled.
+
+WARNING: do not pass a ``MeasuredMotion`` to ``decision.rolling_decision`` — it
+treats ``t[0]`` as "now" and scans forward, which for a measured record classifies
+the *oldest* sample and computes lead times into the past. Use
+``reconcile.measured_status`` (the sanctioned measured entry point).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+import numpy as np
+
+from .models import DOF_NAMES
+
+
+@dataclass
+class MeasuredMotion:
+    """Measured 6-DOF motion up to "now" (= ``t[-1]``).
+
+    ``t``: absolute seconds (shared clock with ``MotionForecast.t``), ascending.
+    ``dof``: name -> series; translations m, rotations deg.
+    """
+
+    t: np.ndarray
+    dof: Dict[str, np.ndarray]
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.t = np.asarray(self.t, dtype=float)
+        if self.t.ndim != 1 or self.t.size < 1:
+            raise ValueError("MeasuredMotion.t must be a non-empty 1-D array")
+        missing = [d for d in DOF_NAMES if d not in self.dof]
+        if missing:
+            raise ValueError(f"MeasuredMotion.dof missing DOFs: {missing}")
+        for d in DOF_NAMES:
+            self.dof[d] = np.asarray(self.dof[d], dtype=float)
+            if self.dof[d].shape != self.t.shape:
+                raise ValueError(f"dof[{d!r}] shape {self.dof[d].shape} != t {self.t.shape}")
+
+    @property
+    def now(self) -> float:
+        return float(self.t[-1])
+
+    def at_now(self) -> Dict[str, float]:
+        """Latest 6-DOF values (the current measured motion)."""
+        return {d: float(self.dof[d][-1]) for d in DOF_NAMES}
+
+    def window(self, seconds: float) -> "MeasuredMotion":
+        """Trailing slice of the last ``seconds`` up to now."""
+        if seconds <= 0:
+            raise ValueError("window seconds must be > 0")
+        mask = self.t >= (self.now - seconds)
+        return MeasuredMotion(
+            t=self.t[mask],
+            dof={d: self.dof[d][mask] for d in DOF_NAMES},
+            metadata=dict(self.metadata),
+        )

--- a/src/digitalmodel/motion_forecast/measured.py
+++ b/src/digitalmodel/motion_forecast/measured.py
@@ -41,6 +41,8 @@ class MeasuredMotion:
         self.t = np.asarray(self.t, dtype=float)
         if self.t.ndim != 1 or self.t.size < 1:
             raise ValueError("MeasuredMotion.t must be a non-empty 1-D array")
+        if self.t.size >= 2 and not np.all(np.diff(self.t) > 0):
+            raise ValueError("MeasuredMotion.t must be strictly ascending (shared clock)")
         missing = [d for d in DOF_NAMES if d not in self.dof]
         if missing:
             raise ValueError(f"MeasuredMotion.dof missing DOFs: {missing}")

--- a/src/digitalmodel/motion_forecast/measured_source.py
+++ b/src/digitalmodel/motion_forecast/measured_source.py
@@ -1,0 +1,72 @@
+"""Measured-motion ingest (digitalmodel #1367).
+
+Sensing-agnostic sources that yield a :class:`MeasuredMotion`. A
+``MeasuredMotionSource`` is anything with ``read() -> MeasuredMotion``; two
+concrete implementations ship:
+
+- :class:`SyntheticMMS` — a deterministic stub: a "truth" motion plus optional
+  seeded sensor noise, standing in for a live feed in tests/demos.
+- :func:`from_csv` — read a 6-DOF time series file.
+
+Real MMS/MRU wire protocols (NMEA / network) and hardware time-sync are
+partner/deployment integrations, out of scope here.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from .measured import MeasuredMotion
+from .models import DOF_NAMES
+
+
+@runtime_checkable
+class MeasuredMotionSource(Protocol):
+    """Anything that yields a measured motion record."""
+
+    def read(self) -> MeasuredMotion: ...
+
+
+class SyntheticMMS:
+    """Deterministic measured-motion stub: truth + seeded per-DOF noise.
+
+    ``truth`` is any object exposing ``.t`` and ``.dof`` (e.g. a reconstructed
+    ``MotionForecast`` used as ground truth). ``noise_std`` (same units as each
+    DOF) adds seeded Gaussian sensor noise; 0 reproduces the truth exactly.
+    """
+
+    def __init__(self, truth, noise_std: float = 0.0, seed: int = 20260704):
+        self._t = np.asarray(truth.t, dtype=float)
+        self._dof = {d: np.asarray(truth.dof[d], dtype=float) for d in DOF_NAMES}
+        self._noise = float(noise_std)
+        self._seed = int(seed)
+
+    def read(self) -> MeasuredMotion:
+        rng = np.random.default_rng(self._seed)
+        dof = {}
+        for d in DOF_NAMES:
+            base = self._dof[d]
+            dof[d] = base + (rng.normal(0.0, self._noise, size=base.shape)
+                             if self._noise > 0 else 0.0)
+        return MeasuredMotion(t=self._t.copy(), dof=dof,
+                              metadata={"source": "SyntheticMMS", "noise_std": self._noise})
+
+
+def from_csv(path: str) -> MeasuredMotion:
+    """Read a measured 6-DOF record from CSV.
+
+    Columns (header required): ``t, surge, sway, heave, roll, pitch, yaw``.
+    ``t`` is absolute seconds; rotations (roll/pitch/yaw) are **degrees** to
+    match the model convention. Extra columns are ignored.
+    """
+    data = np.genfromtxt(path, delimiter=",", names=True)
+    cols = data.dtype.names or ()
+    required = ("t",) + DOF_NAMES
+    missing = [c for c in required if c not in cols]
+    if missing:
+        raise ValueError(f"CSV missing columns: {missing} (have {list(cols)})")
+    t = np.atleast_1d(data["t"]).astype(float)
+    dof = {d: np.atleast_1d(data[d]).astype(float) for d in DOF_NAMES}
+    return MeasuredMotion(t=t, dof=dof, metadata={"source": f"csv:{path}"})

--- a/src/digitalmodel/motion_forecast/reconcile.py
+++ b/src/digitalmodel/motion_forecast/reconcile.py
@@ -1,0 +1,134 @@
+"""Reconcile measured motion against a forecast (digitalmodel #1367).
+
+All alignment is on the shared absolute wall-clock (``MotionForecast.t`` and
+``MeasuredMotion.t`` are both absolute seconds). The forecast is **resampled**
+onto the measured timestamps before any metric is taken. Metrics only — the
+#1360 learning loop consumes these; recalibration lives there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+
+from .criteria import Criterion
+from .decision import DISPLAY_LABEL, _classify
+from .derived import compute_governing
+from .measured import MeasuredMotion
+from .models import DOF_NAMES
+
+Offset = Tuple[float, float, float]
+
+
+def _resample(forecast, t_query: np.ndarray) -> Dict[str, np.ndarray]:
+    """Per-DOF interpolate the forecast onto ``t_query`` (absolute s).
+
+    Fail-closed: raises if any query time is outside the forecast's range
+    (no extrapolation beyond the predictable zone).
+    """
+    ft = np.asarray(forecast.t, dtype=float)
+    tq = np.asarray(t_query, dtype=float)
+    if tq.size and (tq.min() < ft[0] - 1e-9 or tq.max() > ft[-1] + 1e-9):
+        raise ValueError(
+            f"query times [{tq.min():.3f}, {tq.max():.3f}] outside forecast "
+            f"range [{ft[0]:.3f}, {ft[-1]:.3f}] (no extrapolation)"
+        )
+    return {d: np.interp(tq, ft, np.asarray(forecast.dof[d], dtype=float))
+            for d in DOF_NAMES}
+
+
+def seam_offset(measured: MeasuredMotion, forecast) -> Dict[str, float]:
+    """Per-DOF ``measured(now) - forecast(now)`` at the measured "now".
+
+    Raises if ``measured.now`` is outside the forecast range.
+    """
+    now = measured.now
+    fc = _resample(forecast, np.array([now]))
+    return {d: float(measured.dof[d][-1] - fc[d][0]) for d in DOF_NAMES}
+
+
+@dataclass
+class DofError:
+    rmse: float
+    bias: float
+    correlation: Optional[float]
+
+
+def overlap_error(
+    measured: MeasuredMotion, forecast, *, min_overlap_samples: int = 3
+) -> Dict[str, DofError]:
+    """Per-DOF RMSE / bias / correlation of forecast vs measured on their overlap.
+
+    The forecast is interpolated onto the measured timestamps within the
+    absolute-time overlap ``[max(starts), min(ends)]``. Correlation is ``None``
+    on a zero-variance or too-short window (RMSE/bias remain defined).
+    """
+    mt = measured.t
+    lo = max(mt[0], forecast.t[0])
+    hi = min(mt[-1], forecast.t[-1])
+    if hi <= lo:
+        raise ValueError("no time overlap between measured and forecast")
+    mask = (mt >= lo) & (mt <= hi)
+    tq = mt[mask]
+    if tq.size < min_overlap_samples:
+        raise ValueError(
+            f"overlap has {tq.size} samples (< min_overlap_samples={min_overlap_samples})"
+        )
+    fc = _resample(forecast, tq)
+    out: Dict[str, DofError] = {}
+    for d in DOF_NAMES:
+        m = measured.dof[d][mask]
+        err = m - fc[d]
+        rmse = float(np.sqrt(np.mean(err**2)))
+        bias = float(np.mean(err))
+        if tq.size >= 2 and np.std(m) > 0 and np.std(fc[d]) > 0:
+            corr = float(np.corrcoef(m, fc[d])[0, 1])
+        else:
+            corr = None
+        out[d] = DofError(rmse=rmse, bias=bias, correlation=corr)
+    return out
+
+
+@dataclass
+class MeasuredDecision:
+    """Instantaneous measured-mode go/no-go (mirrors RollingDecision, no lead time)."""
+
+    operation: str
+    governing: str
+    unit: str
+    state: DecisionState
+    current_value: float
+    caution: float
+    limit: float
+    t: np.ndarray
+    values: np.ndarray
+    states: List[DecisionState]
+
+    @property
+    def display(self) -> str:
+        return DISPLAY_LABEL[self.state]
+
+
+def measured_status(
+    measured: MeasuredMotion, criterion: Criterion, *, offset: Optional[Offset] = None
+) -> MeasuredDecision:
+    """Classify the **latest** measured governing value (now = ``t[-1]``).
+
+    Uses the same ``decision._classify`` as the forecast mode, so measured and
+    forecast classify identically (strict boundaries + NaN -> NO-GO).
+    """
+    series = compute_governing(measured, criterion.governing, offset or criterion.poi_offset)
+    v = series.values
+    current = float(v[-1])
+    state = _classify(current, criterion.caution, criterion.limit)
+    states = [_classify(float(x), criterion.caution, criterion.limit) for x in v]
+    return MeasuredDecision(
+        operation=criterion.key, governing=criterion.governing, unit=series.unit,
+        state=state, current_value=current,
+        caution=criterion.caution, limit=criterion.limit,
+        t=series.t, values=v, states=states,
+    )

--- a/src/digitalmodel/motion_forecast/reconcile.py
+++ b/src/digitalmodel/motion_forecast/reconcile.py
@@ -85,7 +85,8 @@ def overlap_error(
         err = m - fc[d]
         rmse = float(np.sqrt(np.mean(err**2)))
         bias = float(np.mean(err))
-        if tq.size >= 2 and np.std(m) > 0 and np.std(fc[d]) > 0:
+        # tq.size >= min_overlap_samples already guaranteed above
+        if np.std(m) > 0 and np.std(fc[d]) > 0:
             corr = float(np.corrcoef(m, fc[d])[0, 1])
         else:
             corr = None
@@ -121,6 +122,10 @@ def measured_status(
     Uses the same ``decision._classify`` as the forecast mode, so measured and
     forecast classify identically (strict boundaries + NaN -> NO-GO).
     """
+    if measured.t.size < 2:
+        raise ValueError(
+            "measured_status requires >= 2 samples (a velocity governing needs a time base)"
+        )
     series = compute_governing(measured, criterion.governing, offset or criterion.poi_offset)
     v = series.values
     current = float(v[-1])

--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -102,15 +102,21 @@ def router(cfg: Dict) -> Dict:
         "n_components": len(forecast.components),
     }
 
-    # Optional rolling go/no-go decision for a named operation (#1359).
+    # Criteria loaded once when a named operation is set; reused by the forecast
+    # decision (#1359) and the measured status (#1367).
     op = mf.get("operation")
+    crits = None
     if op:
         from .criteria import load_criteria
-        from .decision import rolling_decision
 
         crits = load_criteria(mf.get("criteria_path"))
         if op not in crits:
             raise ValueError(f"unknown operation {op!r}; have {sorted(crits)}")
+
+    # Optional rolling go/no-go decision for a named operation (#1359).
+    if op:
+        from .decision import rolling_decision
+
         dec = rolling_decision(motion, crits[op])
         mf["decision"] = {
             "operation": dec.operation,
@@ -141,7 +147,6 @@ def router(cfg: Dict) -> Dict:
                 "motion_forecast.measured must be a MeasuredMotion or {'csv': <path>}"
             )
         if op:
-            crits = load_criteria(mf.get("criteria_path"))
             md = measured_status(measured, crits[op])
             mf["measured_status"] = {
                 "operation": md.operation, "governing": md.governing,

--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -124,4 +124,33 @@ def router(cfg: Dict) -> Dict:
             "lead_time_to_caution": dec.lead_time_to_caution,
             "lead_time_to_no_go": dec.lead_time_to_no_go,
         }
+
+    # Optional measured-motion mode: ingest an MMS/MRU feed (#1367).
+    meas_cfg = mf.get("measured")
+    if meas_cfg:
+        from .measured import MeasuredMotion
+        from .measured_source import from_csv
+        from .reconcile import measured_status, seam_offset
+
+        if isinstance(meas_cfg, MeasuredMotion):
+            measured = meas_cfg
+        elif isinstance(meas_cfg, dict) and meas_cfg.get("csv"):
+            measured = from_csv(meas_cfg["csv"])
+        else:
+            raise ValueError(
+                "motion_forecast.measured must be a MeasuredMotion or {'csv': <path>}"
+            )
+        if op:
+            crits = load_criteria(mf.get("criteria_path"))
+            md = measured_status(measured, crits[op])
+            mf["measured_status"] = {
+                "operation": md.operation, "governing": md.governing,
+                "unit": md.unit, "state": md.state.value, "display": md.display,
+                "current_value": md.current_value,
+                "caution": md.caution, "limit": md.limit,
+            }
+        # Reconcile only against the just-built forecast when "now" is inside it
+        # (never against an unrelated default sea).
+        if float(motion.t[0]) <= measured.now <= float(motion.t[-1]):
+            mf["reconciliation"] = {"seam_offset": seam_offset(measured, motion)}
     return cfg

--- a/tests/motion_forecast/test_measured.py
+++ b/tests/motion_forecast/test_measured.py
@@ -37,6 +37,12 @@ def test_duck_types_through_derived():
     assert np.allclose(gs.values, 0.5, atol=1e-9)
 
 
+def test_non_monotonic_t_raises():
+    t = np.array([0.0, 3.0, 1.0, 2.0, 4.0])  # scrambled clock
+    with pytest.raises(ValueError, match="ascending"):
+        _measured(t, heave=t)
+
+
 def test_validation_missing_dof_and_shape():
     t = np.linspace(0, 10, 11)
     with pytest.raises(ValueError, match="missing DOFs"):

--- a/tests/motion_forecast/test_measured.py
+++ b/tests/motion_forecast/test_measured.py
@@ -1,0 +1,48 @@
+"""MeasuredMotion representation tests (digitalmodel #1367)."""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast.derived import compute_governing
+from digitalmodel.motion_forecast.measured import MeasuredMotion
+
+
+def _measured(t, **dofs):
+    base = {d: np.zeros_like(t) for d in
+            ("surge", "sway", "heave", "roll", "pitch", "yaw")}
+    base.update(dofs)
+    return MeasuredMotion(t=t, dof=base)
+
+
+def test_now_is_last_sample():
+    t = np.linspace(100.0, 160.0, 61)  # absolute seconds
+    m = _measured(t, heave=np.sin(t))
+    assert m.now == 160.0
+    assert m.at_now()["heave"] == pytest.approx(np.sin(160.0))
+
+
+def test_window_is_trailing_slice():
+    t = np.linspace(100.0, 160.0, 61)
+    m = _measured(t, heave=t)
+    w = m.window(20.0)
+    assert w.t[0] == pytest.approx(140.0) and w.now == 160.0
+    assert w.dof["heave"][0] == pytest.approx(140.0)
+
+
+def test_duck_types_through_derived():
+    t = np.linspace(100.0, 160.0, 121)
+    m = _measured(t, heave=0.5 * (t - 100.0))  # dz/dt = 0.5
+    gs = compute_governing(m, "helideck_heave_velocity")
+    assert gs.unit == "m/s"
+    assert np.allclose(gs.values, 0.5, atol=1e-9)
+
+
+def test_validation_missing_dof_and_shape():
+    t = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match="missing DOFs"):
+        MeasuredMotion(t=t, dof={"heave": np.zeros_like(t)})
+    bad = {d: np.zeros_like(t) for d in
+           ("surge", "sway", "heave", "roll", "pitch", "yaw")}
+    bad["heave"] = np.zeros(5)
+    with pytest.raises(ValueError, match="shape"):
+        MeasuredMotion(t=t, dof=bad)

--- a/tests/motion_forecast/test_measured_source.py
+++ b/tests/motion_forecast/test_measured_source.py
@@ -50,6 +50,13 @@ def test_csv_round_trip(tmp_path):
     assert np.allclose(m.dof["heave"], truth.dof["heave"], atol=1e-6)
 
 
+def test_csv_single_row(tmp_path):
+    p = tmp_path / "one.csv"
+    p.write_text("t," + ",".join(DOF_NAMES) + "\n5.0," + ",".join(["0.0"] * 6) + "\n")
+    m = from_csv(str(p))
+    assert m.t.shape == (1,) and m.now == 5.0  # atleast_1d guard on 0-d genfromtxt
+
+
 def test_csv_missing_column_raises(tmp_path):
     p = tmp_path / "bad.csv"
     p.write_text("t,heave\n0,0\n1,1\n")

--- a/tests/motion_forecast/test_measured_source.py
+++ b/tests/motion_forecast/test_measured_source.py
@@ -1,0 +1,57 @@
+"""Measured-motion ingest tests (digitalmodel #1367)."""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast.measured import MeasuredMotion
+from digitalmodel.motion_forecast.measured_source import (
+    MeasuredMotionSource,
+    SyntheticMMS,
+    from_csv,
+)
+from digitalmodel.motion_forecast.models import DOF_NAMES
+
+
+def _truth(t):
+    return MeasuredMotion(
+        t=t, dof={d: (np.sin(t) if d == "heave" else np.zeros_like(t))
+                  for d in DOF_NAMES})
+
+
+def test_synthetic_noiseless_reproduces_truth_and_is_source():
+    t = np.linspace(0.0, 30.0, 121)
+    src = SyntheticMMS(_truth(t), noise_std=0.0)
+    assert isinstance(src, MeasuredMotionSource)  # runtime Protocol
+    m = src.read()
+    assert np.allclose(m.dof["heave"], np.sin(t))
+
+
+def test_synthetic_noise_is_deterministic():
+    t = np.linspace(0.0, 30.0, 121)
+    a = SyntheticMMS(_truth(t), noise_std=0.05, seed=7).read()
+    b = SyntheticMMS(_truth(t), noise_std=0.05, seed=7).read()
+    assert np.array_equal(a.dof["heave"], b.dof["heave"])  # same seed -> identical
+    assert not np.allclose(a.dof["heave"], np.sin(t))       # noise applied
+
+
+def test_csv_round_trip(tmp_path):
+    t = np.linspace(0.0, 5.0, 26)
+    truth = _truth(t)
+    p = tmp_path / "mms.csv"
+    header = "t," + ",".join(DOF_NAMES)
+    rows = [header]
+    for i in range(t.size):
+        rows.append(",".join(
+            [f"{t[i]:.6f}"] + [f"{truth.dof[d][i]:.6f}" for d in DOF_NAMES]))
+    p.write_text("\n".join(rows) + "\n")
+
+    m = from_csv(str(p))
+    assert np.allclose(m.t, t, atol=1e-6)
+    assert np.allclose(m.dof["heave"], truth.dof["heave"], atol=1e-6)
+
+
+def test_csv_missing_column_raises(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text("t,heave\n0,0\n1,1\n")
+    with pytest.raises(ValueError, match="missing columns"):
+        from_csv(str(p))

--- a/tests/motion_forecast/test_reconcile.py
+++ b/tests/motion_forecast/test_reconcile.py
@@ -1,0 +1,105 @@
+"""Reconciliation tests (digitalmodel #1367).
+
+Covers the resampling path explicitly: forecast and measured on DIFFERENT grids,
+scored against a closed-form value.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+from digitalmodel.motion_forecast.criteria import Criterion
+from digitalmodel.motion_forecast.decision import _classify
+from digitalmodel.motion_forecast.measured import MeasuredMotion
+from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
+from digitalmodel.motion_forecast.reconcile import (
+    measured_status,
+    overlap_error,
+    seam_offset,
+)
+
+
+def _forecast(t, **dofs):
+    base = {d: np.zeros(len(t)) for d in DOF_NAMES}
+    base.update(dofs)
+    return MotionForecast(t=np.asarray(t, float), dof=base,
+                          origin_time=float(t[0]), horizon=float(t[-1] - t[0]))
+
+
+def _measured(t, **dofs):
+    base = {d: np.zeros(len(t)) for d in DOF_NAMES}
+    base.update(dofs)
+    return MeasuredMotion(t=np.asarray(t, float), dof=base)
+
+
+def test_seam_offset_zero_when_identical_at_now():
+    t = np.linspace(100.0, 160.0, 61)
+    fc = _forecast(t, heave=0.1 * (t - 100.0))
+    m = _measured(t, heave=0.1 * (t - 100.0))
+    off = seam_offset(m, fc)
+    assert off["heave"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_seam_offset_raises_when_now_outside_forecast():
+    fc = _forecast(np.linspace(100.0, 160.0, 61), heave=np.zeros(61))
+    m = _measured(np.linspace(100.0, 200.0, 51), heave=np.zeros(51))  # now=200
+    with pytest.raises(ValueError, match="no extrapolation|outside"):
+        seam_offset(m, fc)
+
+
+def test_overlap_error_zero_on_identical():
+    t = np.linspace(100.0, 160.0, 61)
+    fc = _forecast(t, heave=np.sin(t))
+    m = _measured(t, heave=np.sin(t))
+    err = overlap_error(m, fc)
+    assert err["heave"].rmse == pytest.approx(0.0, abs=1e-12)
+    assert err["heave"].bias == pytest.approx(0.0, abs=1e-12)
+
+
+def test_overlap_error_resamples_across_different_grids():
+    """Forecast (coarse) vs measured (fine) linear signals offset by b:
+    linear interp is exact, so err == b everywhere -> rmse=|b|, bias=b, corr=1."""
+    tf = np.linspace(100.0, 160.0, 7)     # coarse forecast grid
+    tm = np.linspace(100.0, 160.0, 121)   # fine measured grid
+    b = 0.25
+
+    def line(t):
+        return 0.1 * (t - 100.0)
+
+    fc = _forecast(tf, heave=line(tf))
+    m = _measured(tm, heave=line(tm) + b)
+    err = overlap_error(m, fc)
+    assert err["heave"].rmse == pytest.approx(b, abs=1e-9)
+    assert err["heave"].bias == pytest.approx(b, abs=1e-9)
+    assert err["heave"].correlation == pytest.approx(1.0, abs=1e-9)
+
+
+def test_overlap_error_correlation_none_on_zero_variance():
+    t = np.linspace(100.0, 160.0, 61)
+    fc = _forecast(t, heave=np.full_like(t, 2.0))  # constant -> zero variance
+    m = _measured(t, heave=np.full_like(t, 2.0))
+    err = overlap_error(m, fc)
+    assert err["heave"].correlation is None
+    assert err["heave"].rmse == pytest.approx(0.0)
+
+
+_VEL = Criterion(key="hd", label="Helideck", governing="helideck_heave_velocity",
+                 caution=0.30, limit=0.40, unit="m/s", alpha=1.0, basis="",
+                 poi_offset=(0.0, 0.0, 0.0))
+
+
+def test_measured_status_classifies_latest_and_matches_classify():
+    t = np.linspace(0.0, 20.0, 201)
+    m = _measured(t, heave=0.6 * t)  # |dz/dt|=0.6 > 0.40 -> NO_GO
+    md = measured_status(m, _VEL)
+    assert md.state is DecisionState.NO_GO and md.display == "NO-GO"
+    assert md.state is _classify(md.current_value, _VEL.caution, _VEL.limit)
+
+
+def test_measured_status_nan_is_fail_closed():
+    t = np.linspace(0.0, 20.0, 201)
+    h = 0.1 * t
+    h[-1] = np.nan  # latest sample bad
+    m = _measured(t, heave=h)
+    md = measured_status(m, _VEL)
+    assert md.state is DecisionState.NO_GO

--- a/tests/motion_forecast/test_reconcile.py
+++ b/tests/motion_forecast/test_reconcile.py
@@ -96,6 +96,26 @@ def test_measured_status_classifies_latest_and_matches_classify():
     assert md.state is _classify(md.current_value, _VEL.caution, _VEL.limit)
 
 
+def test_overlap_error_no_overlap_raises():
+    fc = _forecast(np.linspace(100.0, 160.0, 61), heave=np.zeros(61))
+    m = _measured(np.linspace(200.0, 260.0, 61), heave=np.zeros(61))  # disjoint
+    with pytest.raises(ValueError, match="no time overlap"):
+        overlap_error(m, fc)
+
+
+def test_overlap_error_too_short_raises():
+    fc = _forecast(np.linspace(100.0, 160.0, 61), heave=np.zeros(61))
+    m = _measured(np.array([158.0, 159.5, 160.5, 162.0]), heave=np.zeros(4))  # 2 in overlap
+    with pytest.raises(ValueError, match="min_overlap"):
+        overlap_error(m, fc)
+
+
+def test_measured_status_single_sample_raises():
+    m = _measured(np.array([5.0]), heave=np.array([0.1]))
+    with pytest.raises(ValueError, match=">= 2 samples"):
+        measured_status(m, _VEL)
+
+
 def test_measured_status_nan_is_fail_closed():
     t = np.linspace(0.0, 20.0, 201)
     h = 0.1 * t

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -43,6 +43,30 @@ def test_router_emits_decision_for_operation():
     assert dec["caution"] < dec["limit"]
 
 
+def test_router_measured_mode_emits_status_and_reconciliation():
+    import numpy as np
+    from digitalmodel.motion_forecast.measured import MeasuredMotion
+    from digitalmodel.motion_forecast.models import DOF_NAMES
+
+    tm = np.linspace(0.0, 30.0, 121)  # now=30 lies within the forecast horizon
+    measured = MeasuredMotion(
+        t=tm, dof={d: (0.2 * np.sin(tm) if d == "heave" else np.zeros_like(tm))
+                   for d in DOF_NAMES})
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.0, "tp": 9.0, "horizon": 60.0, "n_components": 32},
+            "rao": {"source": "analytic", "preset": "generic_vessel"},
+            "operation": "crane_lift",
+            "measured": measured,
+        },
+    }
+    out = router(cfg)["motion_forecast"]
+    assert out["measured_status"]["operation"] == "crane_lift"
+    assert out["measured_status"]["display"] in {"GO", "CAUTION", "NO-GO"}
+    assert set(out["reconciliation"]["seam_offset"]) == set(DOF_NAMES)
+
+
 def test_engine_dispatch_wired():
     """Guard: engine.py routes basename 'motion_forecast' to the workflow."""
     engine_src = (

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -67,6 +67,40 @@ def test_router_measured_mode_emits_status_and_reconciliation():
     assert set(out["reconciliation"]["seam_offset"]) == set(DOF_NAMES)
 
 
+def test_router_measured_without_operation_emits_reconciliation_only():
+    import numpy as np
+    from digitalmodel.motion_forecast.measured import MeasuredMotion
+    from digitalmodel.motion_forecast.models import DOF_NAMES
+
+    tm = np.linspace(0.0, 30.0, 121)
+    measured = MeasuredMotion(t=tm, dof={d: np.zeros_like(tm) for d in DOF_NAMES})
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.0, "tp": 9.0, "horizon": 60.0, "n_components": 24},
+            "rao": {"source": "analytic"},
+            "measured": measured,  # no "operation"
+        },
+    }
+    out = router(cfg)["motion_forecast"]
+    assert "measured_status" not in out          # needs an operation
+    assert "seam_offset" in out["reconciliation"]  # reconciliation still emitted
+
+
+def test_router_measured_bad_type_raises():
+    import pytest
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.0, "tp": 9.0, "horizon": 60.0, "n_components": 24},
+            "rao": {"source": "analytic"},
+            "measured": 123,  # neither MeasuredMotion nor {'csv': ...}
+        },
+    }
+    with pytest.raises(ValueError, match="must be a MeasuredMotion"):
+        router(cfg)
+
+
 def test_engine_dispatch_wired():
     """Guard: engine.py routes basename 'motion_forecast' to the workflow."""
     engine_src = (


### PR DESCRIPTION
## What

The **measured data mode** of epic #1356 (plan approved: `docs/plans/2026-07-04-issue-1367-mms-ingest-measured-mode.md`). Ingests live vessel & structure motions from an onboard MMS / MRU as the "now" ground truth, runs go/no-go on real motion, and reconciles measured vs forecast — the signal the #1360 learning loop will consume. Together with the #1358 forecast, this completes the two data modes the live demo (#1361) already shows as `MMS MEASURED | FORECAST`.

### Modules (under `src/digitalmodel/motion_forecast/`)
| File | Role |
|---|---|
| `measured.py` | `MeasuredMotion` — `.t`/`.dof` contract shared with `MotionForecast` (so it flows through the #1359 `derived` layer), but **now = t[-1]** (the past). `t` is absolute seconds on the **shared wall-clock**, enforced strictly ascending. |
| `measured_source.py` | `MeasuredMotionSource` protocol + `SyntheticMMS` (deterministic seeded stub) + `from_csv` (6-DOF, rotations in deg). Real MMS/MRU wire protocols are partner/deployment. |
| `reconcile.py` | `_resample` (fail-closed forecast interp onto measured timestamps), `seam_offset`, `overlap_error` (RMSE/bias/correlation across **different grids**), and `measured_status → MeasuredDecision` via `decision._classify`. |
| `workflow.py` | `router` emits `measured_status` for a named operation and `reconciliation` **only** when "now" lies inside the just-built forecast (never vs a default sea). |

Measured and forecast classify through the **same** `decision._classify`, so both halves of the demo agree at every boundary (strict thresholds + NaN → fail-closed NO-GO).

## Validation — 26 new tests green
- Representation (`now`, `window`, duck-type through `derived`), **strictly-ascending `t` enforced**.
- `SyntheticMMS` deterministic; `from_csv` round-trip incl. single-row.
- **Reconciliation resamples across different forecast/measured grids** scored against a closed form; `seam_offset` zero when aligned, raises out of range; `overlap_error` no-overlap / too-short raises; correlation guarded on zero-variance.
- `measured_status` matches `_classify` at `t[-1]`; NaN → NO-GO; single-sample raises a clear domain error.
- Workflow: measured_status + reconciliation emitted; reconciliation-only (no op); bad-type raise; existing #1358/#1359 tests still green.

## Cross-review (Route C gate)
Adversarial code review → **APPROVE-WITH-CHANGES** (no blockers; reconcile math confirmed correct). Fixed:
- **Strictly-ascending `t` now enforced** (the shared-clock invariant `np.interp` relies on — was documented, not guarded).
- **Single-sample measured** now raises a clear `ValueError` instead of an opaque `np.gradient` `IndexError`.
- Criteria loaded once in the router (was re-reading the YAML); dead correlation sub-guard removed; added the missing edge-case coverage.

## Scope
Pure-numerical (no license). Deferred (documented): real MMS/MRU wire protocols + hardware time-sync; recalibration & skill-tracking-over-time = **#1360** (which inherits this issue's resampling + metric definitions).

Refs #1367 #1356
