### PR TITLE
feat(motion_forecast): learning loop — skill, recalibration, feedback (#1360)

### DIFF
--- a/docs/plans/2026-07-04-issue-1360-learning-loop.md
+++ b/docs/plans/2026-07-04-issue-1360-learning-loop.md
@@ -1,0 +1,52 @@
+# Plan: digitalmodel #1360 — learning loop (forecast-vs-measured skill + recalibration + engineering feedback)
+
+**Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1360
+**Epic:** #1356 · **Status:** plan-review · **Tier:** T3 (Route C — analytics + a fitted correction; extends #1367's reconcile)
+
+> Adversarially reviewed (2026-07-04): APPROVE-WITH-CHANGES. Blocker folded in — `overlap_error` discards residuals, so #1360 **adds `overlap_residuals` to `reconcile.py`** (edits #1367's module ⇒ #1367 must be merged first) and refactors `overlap_error` onto it. Statistical should-fixes (pooled residuals vs correlation, noise-only/identity, phase-vs-amplitude caveat, zero-variance guard) folded in.
+
+## Context
+
+#1367 (merged) reconciles one forecast vs one measured record. #1360 closes the loop across **many** pairs: aggregate skill (how it degrades with lead time), fit a correction that provably reduces held-out error, and roll up an operability-fraction feedback number. Makes the offering *improve*. Not stale.
+
+**Depends on #1367 merged** — imports (and extends) `reconcile.py`; uses `MotionForecast`/`MeasuredMotion`.
+
+## Reuse + the one edit to #1367's module
+- Reuse `MotionForecast` (`.t` absolute, `.origin_time == t[0]` by construction, `.dof`), `MeasuredMotion` (`.now = t[-1]`), `models.DOF_NAMES`, `decision.DecisionState`.
+- **Add `reconcile.overlap_residuals(measured, forecast, *, min_overlap_samples=3) -> (tq_abs, {dof: residual = measured − forecast_resampled})`** and refactor `overlap_error` to compute `rmse=sqrt(mean(err²))`, `bias=mean(err)` from it (behaviour unchanged; residuals now recoverable). This is the blocker fix — `error_vs_lead_time`/`aggregate_skill` are impossible on the current aggregate-only return.
+
+## Design (under `src/digitalmodel/motion_forecast/`)
+- `skill.py`:
+  - `SkillRecord{forecast, measured}` — validator enforces a non-empty overlap on the shared clock.
+  - `error_vs_lead_time(records, dof, n_bins) -> {lead_bin_center: rmse}` — for each record, `lead = tq − forecast.origin_time` (≥0, verified); **pool residuals** across records into lead bins; RMSE per bin (the honest skill-decay curve).
+  - `aggregate_skill(records) -> Dict[dof, {rmse, bias, correlation}]` — **RMSE & bias pool** residuals across records (correct for unequal-length overlaps; not a mean-of-RMSEs). **Correlation does NOT pool** (concatenating records with different DC offsets is a Simpson artifact): demean each record before pooling *or* report the per-record correlation distribution (median + IQR). Plan chooses: report pooled RMSE/bias + per-record correlation median/IQR.
+- `recalibrate.py`:
+  - `@dataclass Correction{gain: Dict[dof,float], bias: Dict[dof,float]}`; `apply(forecast) -> MotionForecast` (`x_corr = gain·x + bias`).
+  - `fit_correction(records) -> Correction` — per-DOF least squares `gain = cov(fc,m)/var(fc)`, `bias = mean(m) − gain·mean(fc)` over pooled overlap residuals. **Zero-variance guard:** when `var(fc) ≈ 0`, fall back to bias-only (`gain=1`), mirroring `overlap_error`'s `std>0` guard.
+  - Before/after report on a **held-out split** returns **both RMSE and correlation** per DOF.
+  - **Caveat (documented):** an affine correction captures only systematic **amplitude scaling + DC bias**, NOT the phase decorrelation that dominates lead-time skill decay. RMSE↓ alone is *not* evidence of a better forecast (a shrinking `gain` regresses toward the mean); that is why correlation is reported alongside. This is an **output-space** correction, explicitly NOT RAO-model recalibration (deferred).
+- `feedback.py`:
+  - `operability_summary(states: Sequence[DecisionState], *, marginal_operable=False) -> {operable_fraction, downtime_fraction, longest_operable_run, waiting_on_weather_fraction}`. `operable = (state is GO)` (or GO+MARGINAL when `marginal_operable`); `waiting_on_weather_fraction = 1 − operable_fraction`; `longest_operable_run` in samples. Feeds field-development economics.
+- `workflow.router` — optional `cfg['motion_forecast']['skill']['records']` (in-memory `SkillRecord`/pairs) → emit aggregate skill (+ optional fitted-correction before/after summary). Additive; existing workflow tests stay green.
+
+## Plan
+1. `reconcile.overlap_residuals` + refactor `overlap_error`; assert `overlap_error` outputs unchanged (regression).
+2. `skill.py` + tests (pooled-residual RMSE ≠ mean-of-RMSE on unequal overlaps; lead-time bins recover an injected lead-dependent error; correlation reported per-record not pooled-naively).
+3. `recalibrate.py` + tests (recover injected affine gain/bias <1e-6; held-out RMSE reduced *on affine-structured* error; near-identity + not-worsened on noise-only; zero-variance DOF → bias-only; correlation reported).
+4. `feedback.py` + tests (operable fraction, WoW, longest run on a known state sequence; marginal handling).
+5. Workflow wiring + test.
+
+## Acceptance Criteria
+- [ ] `overlap_error` outputs byte-for-byte unchanged after the `overlap_residuals` refactor (regression test).
+- [ ] `error_vs_lead_time` recovers a known injected lead-dependent error curve (bins increase as designed).
+- [ ] `aggregate_skill`: RMSE/bias pool correctly (differs from mean-of-per-record-RMSE on unequal overlaps — tested); correlation reported per-record (median/IQR), not a naive pooled scalar.
+- [ ] `fit_correction` recovers injected `gain,bias` <1e-6; **on affine-structured error** held-out RMSE is reduced; **on noise-only** correction ≈ identity and held-out RMSE not worsened beyond tolerance; **zero-variance forecast DOF** → `gain=1` bias-only (no blow-up). Before/after reports RMSE **and** correlation.
+- [ ] `operability_summary` returns correct operable/downtime/WoW/longest-run on a known `DecisionState` sequence, with `marginal_operable` honoured.
+- [ ] `router` emits `skill` when records supplied; existing #1358/#1359/#1367 tests still green.
+- [ ] Pure-numerical; no hardcoded thresholds.
+
+## Deferred / out of scope (documented)
+Online data assimilation (EnKF live re-anchoring) — seam only. RAO-model (hydrodynamic-coefficient) recalibration — this fits output space, not coefficients. Deep weather-downtime stats beyond the operable/WoW proxy. Frequency-dependent correction (fast-follow to the affine one).
+
+## Open questions — resolved to recommended defaults (owner pattern)
+Per-DOF affine correction · operable-fraction/WoW proxy now · in-memory `SkillRecord` batch.

--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -17,12 +17,26 @@ from .criteria import Criterion, load_criteria
 from .decision import RollingDecision, rolling_decision
 from .measured import MeasuredMotion
 from .measured_source import MeasuredMotionSource, SyntheticMMS, from_csv
+from .feedback import OperabilitySummary, operability_summary
 from .reconcile import (
     DofError,
     MeasuredDecision,
     measured_status,
     overlap_error,
+    overlap_residuals,
     seam_offset,
+)
+from .recalibrate import (
+    Correction,
+    HoldoutResult,
+    fit_correction,
+    holdout_report,
+)
+from .skill import (
+    AggregateSkill,
+    SkillRecord,
+    aggregate_skill,
+    error_vs_lead_time,
 )
 from .derived import (
     GoverningSeries,
@@ -75,4 +89,15 @@ __all__ = [
     "measured_status",
     "MeasuredDecision",
     "DofError",
+    "overlap_residuals",
+    "SkillRecord",
+    "AggregateSkill",
+    "aggregate_skill",
+    "error_vs_lead_time",
+    "Correction",
+    "HoldoutResult",
+    "fit_correction",
+    "holdout_report",
+    "OperabilitySummary",
+    "operability_summary",
 ]

--- a/src/digitalmodel/motion_forecast/feedback.py
+++ b/src/digitalmodel/motion_forecast/feedback.py
@@ -1,0 +1,56 @@
+"""Engineering-feedback rollup (digitalmodel #1360).
+
+Rolls a sequence of go/no-go states (measured or forecast) into an operability
+summary — the number that feeds field-development economics. A proxy for full
+weather-downtime statistics (deferred).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+
+
+@dataclass
+class OperabilitySummary:
+    operable_fraction: float
+    downtime_fraction: float
+    waiting_on_weather_fraction: float
+    longest_operable_run: int  # samples
+    n: int
+
+
+def operability_summary(
+    states: Sequence[DecisionState], *, marginal_operable: bool = False
+) -> OperabilitySummary:
+    """Summarise operability over a state sequence.
+
+    ``operable`` = ``DecisionState.GO`` (or GO + MARGINAL when
+    ``marginal_operable``). ``waiting_on_weather_fraction`` = the not-operable
+    fraction (a downtime proxy). ``longest_operable_run`` counts the longest
+    consecutive operable stretch, in samples.
+    """
+    n = len(states)
+    if n == 0:
+        raise ValueError("operability_summary needs a non-empty state sequence")
+
+    def _operable(s: DecisionState) -> bool:
+        return s is DecisionState.GO or (marginal_operable and s is DecisionState.MARGINAL)
+
+    flags = [_operable(s) for s in states]
+    operable_fraction = sum(flags) / n
+
+    longest = cur = 0
+    for f in flags:
+        cur = cur + 1 if f else 0
+        longest = max(longest, cur)
+
+    return OperabilitySummary(
+        operable_fraction=operable_fraction,
+        downtime_fraction=1.0 - operable_fraction,
+        waiting_on_weather_fraction=1.0 - operable_fraction,
+        longest_operable_run=longest,
+        n=n,
+    )

--- a/src/digitalmodel/motion_forecast/feedback.py
+++ b/src/digitalmodel/motion_forecast/feedback.py
@@ -16,7 +16,8 @@ from digitalmodel.marine_ops.installation.go_no_go import DecisionState
 @dataclass
 class OperabilitySummary:
     operable_fraction: float
-    downtime_fraction: float
+    # weather/motion-driven downtime only (from go/no-go state); this is a subset
+    # of total downtime, which also covers equipment/logistics not modelled here.
     waiting_on_weather_fraction: float
     longest_operable_run: int  # samples
     n: int
@@ -49,7 +50,6 @@ def operability_summary(
 
     return OperabilitySummary(
         operable_fraction=operable_fraction,
-        downtime_fraction=1.0 - operable_fraction,
         waiting_on_weather_fraction=1.0 - operable_fraction,
         longest_operable_run=longest,
         n=n,

--- a/src/digitalmodel/motion_forecast/recalibrate.py
+++ b/src/digitalmodel/motion_forecast/recalibrate.py
@@ -50,7 +50,9 @@ def _pooled_m_fc(records: Sequence[SkillRecord], dof: str) -> Tuple[np.ndarray, 
         m, fc, _ = res[dof]
         ms.append(m)
         fcs.append(fc)
-    return np.concatenate(ms), np.concatenate(fcs)
+    m_arr, fc_arr = np.concatenate(ms), np.concatenate(fcs)
+    finite = np.isfinite(m_arr) & np.isfinite(fc_arr)  # drop MRU dropouts
+    return m_arr[finite], fc_arr[finite]
 
 
 def fit_correction(records: Sequence[SkillRecord], *, var_eps: float = 1e-12) -> Correction:

--- a/src/digitalmodel/motion_forecast/recalibrate.py
+++ b/src/digitalmodel/motion_forecast/recalibrate.py
@@ -1,0 +1,118 @@
+"""Output-space recalibration of a forecast (digitalmodel #1360).
+
+Fits a per-DOF affine correction ``x_corr = gain*x + bias`` (least squares of
+forecast -> measured over pooled overlaps) that reduces systematic amplitude
+scaling + DC bias.
+
+CAVEAT (by construction): an affine correction is **invariant in correlation**
+(a positive-gain scale + shift does not change ``corrcoef``), so it cannot fix
+the **phase decorrelation** that dominates lead-time skill decay. RMSE going
+down is therefore NOT evidence of a better forecast — a shrinking ``gain``
+regresses toward the mean. ``holdout_report`` reports correlation alongside RMSE
+so this is visible. This is an OUTPUT-space correction, explicitly not an
+RAO-model (hydrodynamic-coefficient) recalibration (deferred).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .models import DOF_NAMES, MotionForecast
+from .reconcile import overlap_residuals
+from .skill import SkillRecord
+
+
+@dataclass
+class Correction:
+    """Per-DOF affine output correction ``x_corr = gain*x + bias``."""
+
+    gain: Dict[str, float]
+    bias: Dict[str, float]
+
+    def apply(self, forecast) -> MotionForecast:
+        dof = {d: self.gain[d] * np.asarray(forecast.dof[d], dtype=float) + self.bias[d]
+               for d in DOF_NAMES}
+        return MotionForecast(
+            t=np.asarray(forecast.t, dtype=float), dof=dof,
+            origin_time=forecast.origin_time, horizon=forecast.horizon,
+            metadata={"correction": "affine"},
+        )
+
+
+def _pooled_m_fc(records: Sequence[SkillRecord], dof: str) -> Tuple[np.ndarray, np.ndarray]:
+    ms: List[np.ndarray] = []
+    fcs: List[np.ndarray] = []
+    for r in records:
+        _tq, res = overlap_residuals(r.measured, r.forecast)
+        m, fc, _ = res[dof]
+        ms.append(m)
+        fcs.append(fc)
+    return np.concatenate(ms), np.concatenate(fcs)
+
+
+def fit_correction(records: Sequence[SkillRecord], *, var_eps: float = 1e-12) -> Correction:
+    """Least-squares per-DOF ``gain, bias`` of forecast -> measured.
+
+    Zero-variance guard: when the forecast DOF is ~constant over the overlap,
+    fall back to bias-only (``gain = 1``) instead of dividing by ~0.
+    """
+    gain: Dict[str, float] = {}
+    bias: Dict[str, float] = {}
+    for d in DOF_NAMES:
+        m, fc = _pooled_m_fc(records, d)
+        vfc = float(np.var(fc))
+        if vfc <= var_eps:
+            g = 1.0
+            b = float(np.mean(m) - np.mean(fc))
+        else:
+            cov = float(np.mean((fc - fc.mean()) * (m - m.mean())))
+            g = cov / vfc
+            b = float(np.mean(m) - g * np.mean(fc))
+        gain[d] = g
+        bias[d] = b
+    return Correction(gain=gain, bias=bias)
+
+
+def _corr(a: np.ndarray, b: np.ndarray) -> Optional[float]:
+    if a.size >= 2 and np.std(a) > 0 and np.std(b) > 0:
+        return float(np.corrcoef(a, b)[0, 1])
+    return None
+
+
+@dataclass
+class HoldoutResult:
+    rmse_before: float
+    rmse_after: float
+    correlation_before: Optional[float]
+    correlation_after: Optional[float]
+
+
+def holdout_report(
+    records: Sequence[SkillRecord], *, test_fraction: float = 0.5
+) -> Dict[str, HoldoutResult]:
+    """Fit on a train split, report before/after RMSE + correlation on the test split.
+
+    Generalisation, not memorisation: the correction is fit only on train.
+    """
+    n = len(records)
+    if n < 2:
+        raise ValueError("holdout_report needs >= 2 records")
+    k = max(1, int(round(n * (1.0 - test_fraction))))
+    k = min(k, n - 1)  # keep at least one test record
+    train, test = records[:k], records[k:]
+    corr = fit_correction(train)
+
+    out: Dict[str, HoldoutResult] = {}
+    for d in DOF_NAMES:
+        m, fc = _pooled_m_fc(test, d)
+        fc_c = corr.gain[d] * fc + corr.bias[d]
+        out[d] = HoldoutResult(
+            rmse_before=float(np.sqrt(np.mean((m - fc) ** 2))),
+            rmse_after=float(np.sqrt(np.mean((m - fc_c) ** 2))),
+            correlation_before=_corr(m, fc),
+            correlation_after=_corr(m, fc_c),
+        )
+    return out

--- a/src/digitalmodel/motion_forecast/reconcile.py
+++ b/src/digitalmodel/motion_forecast/reconcile.py
@@ -58,14 +58,16 @@ class DofError:
     correlation: Optional[float]
 
 
-def overlap_error(
+def overlap_residuals(
     measured: MeasuredMotion, forecast, *, min_overlap_samples: int = 3
-) -> Dict[str, DofError]:
-    """Per-DOF RMSE / bias / correlation of forecast vs measured on their overlap.
+) -> Tuple[np.ndarray, Dict[str, Tuple[np.ndarray, np.ndarray, np.ndarray]]]:
+    """Per-DOF ``(measured, forecast_resampled, residual)`` on the time overlap.
 
     The forecast is interpolated onto the measured timestamps within the
-    absolute-time overlap ``[max(starts), min(ends)]``. Correlation is ``None``
-    on a zero-variance or too-short window (RMSE/bias remain defined).
+    absolute-time overlap ``[max(starts), min(ends)]``. Returns the absolute
+    query times ``tq`` and, per DOF, the aligned ``(m, fc, m - fc)`` arrays.
+    Raises on no overlap or fewer than ``min_overlap_samples``. This is the
+    primitive the #1360 skill layer pools across records.
     """
     mt = measured.t
     lo = max(mt[0], forecast.t[0])
@@ -79,15 +81,29 @@ def overlap_error(
             f"overlap has {tq.size} samples (< min_overlap_samples={min_overlap_samples})"
         )
     fc = _resample(forecast, tq)
-    out: Dict[str, DofError] = {}
+    res: Dict[str, Tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
     for d in DOF_NAMES:
         m = measured.dof[d][mask]
-        err = m - fc[d]
+        res[d] = (m, fc[d], m - fc[d])
+    return tq, res
+
+
+def overlap_error(
+    measured: MeasuredMotion, forecast, *, min_overlap_samples: int = 3
+) -> Dict[str, DofError]:
+    """Per-DOF RMSE / bias / correlation of forecast vs measured on their overlap.
+
+    Correlation is ``None`` on a zero-variance window (RMSE/bias remain defined).
+    Thin wrapper over :func:`overlap_residuals`.
+    """
+    _tq, res = overlap_residuals(measured, forecast, min_overlap_samples=min_overlap_samples)
+    out: Dict[str, DofError] = {}
+    for d in DOF_NAMES:
+        m, fc, err = res[d]
         rmse = float(np.sqrt(np.mean(err**2)))
         bias = float(np.mean(err))
-        # tq.size >= min_overlap_samples already guaranteed above
-        if np.std(m) > 0 and np.std(fc[d]) > 0:
-            corr = float(np.corrcoef(m, fc[d])[0, 1])
+        if np.std(m) > 0 and np.std(fc) > 0:
+            corr = float(np.corrcoef(m, fc)[0, 1])
         else:
             corr = None
         out[d] = DofError(rmse=rmse, bias=bias, correlation=corr)

--- a/src/digitalmodel/motion_forecast/skill.py
+++ b/src/digitalmodel/motion_forecast/skill.py
@@ -4,8 +4,11 @@ Pools forecast-vs-measured residuals across a batch of ``SkillRecord`` pairs to
 show how skill degrades with lead time and to summarise aggregate error.
 
 Statistical care (per review):
-- RMSE and bias **pool** residuals across records (equal weight per sample —
-  correct for unequal-length overlaps; not a mean of per-record RMSEs).
+- RMSE and bias **pool** residuals across records (sample-weighted — not a mean
+  of per-record RMSEs; note denser-sampled records carry more weight, and
+  autocorrelated residuals reduce the effective sample count).
+- Non-finite residuals (e.g. MRU dropouts) are masked out before pooling, so one
+  bad sample cannot poison the batch.
 - Correlation does **not** pool (concatenating records with different DC offsets
   is a Simpson artifact) — it is reported as the per-record distribution
   (median + IQR).
@@ -37,6 +40,10 @@ class SkillRecord:
         hi = min(self.measured.t[-1], self.forecast.t[-1])
         if hi <= lo:
             raise ValueError("SkillRecord: forecast and measured do not overlap in time")
+        if self.forecast.origin_time > self.forecast.t[0] + 1e-9:
+            raise ValueError(
+                "SkillRecord: forecast.origin_time must be <= forecast.t[0] (lead >= 0)"
+            )
 
 
 def _pooled(records: Sequence[SkillRecord], dof: str) -> Tuple[np.ndarray, np.ndarray]:
@@ -49,7 +56,10 @@ def _pooled(records: Sequence[SkillRecord], dof: str) -> Tuple[np.ndarray, np.nd
         resid.append(res[dof][2])
     if not leads:
         return np.array([]), np.array([])
-    return np.concatenate(leads), np.concatenate(resid)
+    lead_arr = np.concatenate(leads)
+    resid_arr = np.concatenate(resid)
+    finite = np.isfinite(resid_arr) & np.isfinite(lead_arr)  # drop MRU dropouts
+    return lead_arr[finite], resid_arr[finite]
 
 
 def error_vs_lead_time(
@@ -83,6 +93,8 @@ class AggregateSkill:
 
 def aggregate_skill(records: Sequence[SkillRecord]) -> Dict[str, AggregateSkill]:
     """Pooled RMSE/bias + per-record correlation distribution, per DOF."""
+    if not records:
+        raise ValueError("aggregate_skill needs at least one record")
     out: Dict[str, AggregateSkill] = {}
     for d in DOF_NAMES:
         _leads, resid = _pooled(records, d)

--- a/src/digitalmodel/motion_forecast/skill.py
+++ b/src/digitalmodel/motion_forecast/skill.py
@@ -1,0 +1,103 @@
+"""Forecast skill across many measured records (digitalmodel #1360).
+
+Pools forecast-vs-measured residuals across a batch of ``SkillRecord`` pairs to
+show how skill degrades with lead time and to summarise aggregate error.
+
+Statistical care (per review):
+- RMSE and bias **pool** residuals across records (equal weight per sample —
+  correct for unequal-length overlaps; not a mean of per-record RMSEs).
+- Correlation does **not** pool (concatenating records with different DC offsets
+  is a Simpson artifact) — it is reported as the per-record distribution
+  (median + IQR).
+- Lead time uses ``lead = t_measured - forecast.origin_time`` (>= 0, since
+  ``origin_time == forecast.t[0]`` and the overlap starts at ``max(starts)``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+
+from .measured import MeasuredMotion
+from .models import DOF_NAMES
+from .reconcile import overlap_error, overlap_residuals
+
+
+@dataclass
+class SkillRecord:
+    """A forecast paired with the motion later measured on the shared clock."""
+
+    forecast: object      # MotionForecast (or duck-typed .t/.dof/.origin_time)
+    measured: MeasuredMotion
+
+    def __post_init__(self):
+        lo = max(self.measured.t[0], self.forecast.t[0])
+        hi = min(self.measured.t[-1], self.forecast.t[-1])
+        if hi <= lo:
+            raise ValueError("SkillRecord: forecast and measured do not overlap in time")
+
+
+def _pooled(records: Sequence[SkillRecord], dof: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Concatenate (lead_time, residual) across records for one DOF."""
+    leads: List[np.ndarray] = []
+    resid: List[np.ndarray] = []
+    for r in records:
+        tq, res = overlap_residuals(r.measured, r.forecast)
+        leads.append(tq - float(r.forecast.origin_time))
+        resid.append(res[dof][2])
+    if not leads:
+        return np.array([]), np.array([])
+    return np.concatenate(leads), np.concatenate(resid)
+
+
+def error_vs_lead_time(
+    records: Sequence[SkillRecord], dof: str, *, n_bins: int = 10
+) -> Dict[float, float]:
+    """RMSE of the pooled residual binned by lead time (the skill-decay curve).
+
+    Returns ``{bin_center: rmse}`` for non-empty bins.
+    """
+    leads, resid = _pooled(records, dof)
+    if leads.size == 0:
+        return {}
+    edges = np.linspace(leads.min(), leads.max() + 1e-12, n_bins + 1)
+    out: Dict[float, float] = {}
+    for i in range(n_bins):
+        m = (leads >= edges[i]) & (leads < edges[i + 1])
+        if np.any(m):
+            center = 0.5 * (edges[i] + edges[i + 1])
+            out[float(center)] = float(np.sqrt(np.mean(resid[m] ** 2)))
+    return out
+
+
+@dataclass
+class AggregateSkill:
+    rmse: float
+    bias: float
+    n_samples: int
+    correlation_median: float | None
+    correlation_iqr: float | None
+
+
+def aggregate_skill(records: Sequence[SkillRecord]) -> Dict[str, AggregateSkill]:
+    """Pooled RMSE/bias + per-record correlation distribution, per DOF."""
+    out: Dict[str, AggregateSkill] = {}
+    for d in DOF_NAMES:
+        _leads, resid = _pooled(records, d)
+        corrs = [c for c in
+                 (overlap_error(r.measured, r.forecast)[d].correlation for r in records)
+                 if c is not None]
+        if corrs:
+            cmed = float(np.median(corrs))
+            ciqr = float(np.percentile(corrs, 75) - np.percentile(corrs, 25))
+        else:
+            cmed = ciqr = None
+        out[d] = AggregateSkill(
+            rmse=float(np.sqrt(np.mean(resid**2))) if resid.size else 0.0,
+            bias=float(np.mean(resid)) if resid.size else 0.0,
+            n_samples=int(resid.size),
+            correlation_median=cmed, correlation_iqr=ciqr,
+        )
+    return out

--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -158,4 +158,18 @@ def router(cfg: Dict) -> Dict:
         # (never against an unrelated default sea).
         if float(motion.t[0]) <= measured.now <= float(motion.t[-1]):
             mf["reconciliation"] = {"seam_offset": seam_offset(measured, motion)}
+
+    # Optional forecast-skill aggregation over a batch of records (#1360).
+    skill_cfg = mf.get("skill")
+    if skill_cfg and skill_cfg.get("records"):
+        from .skill import SkillRecord, aggregate_skill
+
+        recs = [r if isinstance(r, SkillRecord) else SkillRecord(*r)
+                for r in skill_cfg["records"]]
+        agg = aggregate_skill(recs)
+        mf["skill_summary"] = {
+            d: {"rmse": a.rmse, "bias": a.bias, "n_samples": a.n_samples,
+                "correlation_median": a.correlation_median}
+            for d, a in agg.items()
+        }
     return cfg

--- a/tests/motion_forecast/test_feedback.py
+++ b/tests/motion_forecast/test_feedback.py
@@ -1,0 +1,30 @@
+"""Operability-feedback tests (digitalmodel #1360)."""
+
+import pytest
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+from digitalmodel.motion_forecast.feedback import operability_summary
+
+GO, MARG, NOGO = DecisionState.GO, DecisionState.MARGINAL, DecisionState.NO_GO
+
+
+def test_operable_fraction_and_longest_run_go_only():
+    states = [GO, GO, NOGO, GO, MARG, GO]
+    s = operability_summary(states)
+    assert s.operable_fraction == pytest.approx(4 / 6)   # GO only
+    assert s.downtime_fraction == pytest.approx(2 / 6)
+    assert s.waiting_on_weather_fraction == pytest.approx(2 / 6)
+    assert s.longest_operable_run == 2                   # GO,GO
+    assert s.n == 6
+
+
+def test_marginal_operable_flag():
+    states = [GO, GO, NOGO, GO, MARG, GO]
+    s = operability_summary(states, marginal_operable=True)
+    assert s.operable_fraction == pytest.approx(5 / 6)   # GO + MARGINAL
+    assert s.longest_operable_run == 3                   # GO,MARG,GO
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        operability_summary([])

--- a/tests/motion_forecast/test_feedback.py
+++ b/tests/motion_forecast/test_feedback.py
@@ -12,7 +12,6 @@ def test_operable_fraction_and_longest_run_go_only():
     states = [GO, GO, NOGO, GO, MARG, GO]
     s = operability_summary(states)
     assert s.operable_fraction == pytest.approx(4 / 6)   # GO only
-    assert s.downtime_fraction == pytest.approx(2 / 6)
     assert s.waiting_on_weather_fraction == pytest.approx(2 / 6)
     assert s.longest_operable_run == 2                   # GO,GO
     assert s.n == 6

--- a/tests/motion_forecast/test_recalibrate.py
+++ b/tests/motion_forecast/test_recalibrate.py
@@ -1,0 +1,67 @@
+"""Recalibration tests (digitalmodel #1360)."""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast.measured import MeasuredMotion
+from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
+from digitalmodel.motion_forecast.recalibrate import fit_correction, holdout_report
+from digitalmodel.motion_forecast.skill import SkillRecord
+
+
+def _fc(t, **d):
+    base = {k: np.zeros(len(t)) for k in DOF_NAMES}
+    base.update(d)
+    return MotionForecast(t=np.asarray(t, float), dof=base,
+                          origin_time=float(t[0]), horizon=float(t[-1] - t[0]))
+
+
+def _meas(t, **d):
+    base = {k: np.zeros(len(t)) for k in DOF_NAMES}
+    base.update(d)
+    return MeasuredMotion(t=np.asarray(t, float), dof=base)
+
+
+def _affine_record(t, gain, bias, seed=None, noise=0.0):
+    fc_heave = np.sin(0.5 * t)
+    m_heave = gain * fc_heave + bias
+    if noise:
+        m_heave = m_heave + np.random.default_rng(seed).normal(0, noise, size=t.shape)
+    return SkillRecord(_fc(t, heave=fc_heave), _meas(t, heave=m_heave))
+
+
+def test_fit_recovers_injected_gain_bias():
+    t = np.linspace(0.0, 50.0, 501)
+    rec = _affine_record(t, gain=2.0, bias=0.5)
+    corr = fit_correction([rec])
+    assert corr.gain["heave"] == pytest.approx(2.0, abs=1e-9)
+    assert corr.bias["heave"] == pytest.approx(0.5, abs=1e-9)
+
+
+def test_holdout_reduces_rmse_on_affine_structure():
+    ts = [np.linspace(0.0, 50.0, 251) + 100 * i for i in range(4)]
+    recs = [_affine_record(t, gain=2.0, bias=0.5) for t in ts]
+    rep = holdout_report(recs)["heave"]
+    assert rep.rmse_after < rep.rmse_before          # affine error is removable
+    assert rep.rmse_after == pytest.approx(0.0, abs=1e-9)
+    # correlation is invariant under a positive-gain affine correction
+    assert rep.correlation_after == pytest.approx(rep.correlation_before, abs=1e-9)
+
+
+def test_noise_only_is_near_identity_and_not_worsened():
+    ts = [np.linspace(0.0, 50.0, 251) + 100 * i for i in range(4)]
+    recs = [_affine_record(t, gain=1.0, bias=0.0, seed=i, noise=0.2)
+            for i, t in enumerate(ts)]
+    corr = fit_correction(recs)
+    assert corr.gain["heave"] == pytest.approx(1.0, abs=0.05)   # ~identity
+    rep = holdout_report(recs)["heave"]
+    assert rep.rmse_after <= rep.rmse_before * 1.2             # not worsened
+
+
+def test_zero_variance_dof_falls_back_to_bias_only():
+    t = np.linspace(0.0, 50.0, 201)
+    # sway forecast constant 0, measured constant 0.3 -> gain=1, bias=0.3
+    rec = SkillRecord(_fc(t, sway=np.zeros_like(t)), _meas(t, sway=np.full_like(t, 0.3)))
+    corr = fit_correction([rec])
+    assert corr.gain["sway"] == 1.0
+    assert corr.bias["sway"] == pytest.approx(0.3)

--- a/tests/motion_forecast/test_recalibrate.py
+++ b/tests/motion_forecast/test_recalibrate.py
@@ -38,13 +38,25 @@ def test_fit_recovers_injected_gain_bias():
     assert corr.bias["heave"] == pytest.approx(0.5, abs=1e-9)
 
 
-def test_holdout_reduces_rmse_on_affine_structure():
+def test_holdout_removes_exact_affine():
     ts = [np.linspace(0.0, 50.0, 251) + 100 * i for i in range(4)]
     recs = [_affine_record(t, gain=2.0, bias=0.5) for t in ts]
     rep = holdout_report(recs)["heave"]
-    assert rep.rmse_after < rep.rmse_before          # affine error is removable
-    assert rep.rmse_after == pytest.approx(0.0, abs=1e-9)
-    # correlation is invariant under a positive-gain affine correction
+    assert rep.rmse_after == pytest.approx(0.0, abs=1e-9)  # exact affine removable
+
+
+def test_holdout_generalises_to_noise_floor():
+    """Fit on train, apply to HELD-OUT test with independent noise realisations:
+    rmse_after lands at the noise floor (NOT ~0), so a fit-on-test bug (memorising
+    the test split) could not satisfy it. Correlation is invariant (affine)."""
+    noise = 0.1
+    ts = [np.linspace(0.0, 50.0, 251) + 100 * i for i in range(6)]
+    recs = [_affine_record(t, gain=2.0, bias=0.5, seed=i, noise=noise)
+            for i, t in enumerate(ts)]
+    rep = holdout_report(recs)["heave"]
+    assert rep.rmse_before > 0.5                          # uncorrected: gain 2 + bias
+    assert rep.rmse_after == pytest.approx(noise, rel=0.3)  # ~ injected noise floor
+    assert rep.rmse_after < 0.3 * rep.rmse_before
     assert rep.correlation_after == pytest.approx(rep.correlation_before, abs=1e-9)
 
 

--- a/tests/motion_forecast/test_reconcile.py
+++ b/tests/motion_forecast/test_reconcile.py
@@ -15,6 +15,7 @@ from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
 from digitalmodel.motion_forecast.reconcile import (
     measured_status,
     overlap_error,
+    overlap_residuals,
     seam_offset,
 )
 
@@ -30,6 +31,19 @@ def _measured(t, **dofs):
     base = {d: np.zeros(len(t)) for d in DOF_NAMES}
     base.update(dofs)
     return MeasuredMotion(t=np.asarray(t, float), dof=base)
+
+
+def test_overlap_residuals_backs_overlap_error():
+    """overlap_error is a thin wrapper over overlap_residuals (regression)."""
+    t = np.linspace(100.0, 160.0, 61)
+    fc = _forecast(t, heave=np.sin(t))
+    m = _measured(t, heave=np.sin(t) + 0.1)
+    tq, res = overlap_residuals(m, fc)
+    _mm, _fcd, err = res["heave"]
+    assert np.allclose(err, 0.1, atol=1e-9)
+    assert tq.shape == err.shape
+    e = overlap_error(m, fc)["heave"]
+    assert e.rmse == pytest.approx(0.1) and e.bias == pytest.approx(0.1)
 
 
 def test_seam_offset_zero_when_identical_at_now():

--- a/tests/motion_forecast/test_skill.py
+++ b/tests/motion_forecast/test_skill.py
@@ -1,0 +1,58 @@
+"""Forecast-skill tests (digitalmodel #1360)."""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast.measured import MeasuredMotion
+from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
+from digitalmodel.motion_forecast.skill import (
+    SkillRecord,
+    aggregate_skill,
+    error_vs_lead_time,
+)
+
+
+def _fc(t, **d):
+    base = {k: np.zeros(len(t)) for k in DOF_NAMES}
+    base.update(d)
+    return MotionForecast(t=np.asarray(t, float), dof=base,
+                          origin_time=float(t[0]), horizon=float(t[-1] - t[0]))
+
+
+def _meas(t, **d):
+    base = {k: np.zeros(len(t)) for k in DOF_NAMES}
+    base.update(d)
+    return MeasuredMotion(t=np.asarray(t, float), dof=base)
+
+
+def test_record_requires_overlap():
+    fc = _fc(np.linspace(0, 50, 51), heave=np.zeros(51))
+    m = _meas(np.linspace(100, 150, 51), heave=np.zeros(51))
+    with pytest.raises(ValueError, match="overlap"):
+        SkillRecord(fc, m)
+
+
+def test_error_vs_lead_time_recovers_injected_growth():
+    t = np.linspace(0.0, 100.0, 201)
+    fc = _fc(t, heave=np.zeros_like(t))          # forecast predicts 0
+    m = _meas(t, heave=0.01 * t)                 # drift grows with lead (= t)
+    curve = error_vs_lead_time([SkillRecord(fc, m)], "heave", n_bins=5)
+    centers = sorted(curve)
+    rmses = [curve[c] for c in centers]
+    assert rmses == sorted(rmses)                # monotonic increase with lead
+    assert rmses[-1] > rmses[0]
+
+
+def test_aggregate_skill_pools_residuals_not_mean_of_rmse():
+    # record A: 10 samples, residual 1 ; record B: 90 samples, residual 3
+    tA = np.linspace(0.0, 9.0, 10)
+    tB = np.linspace(0.0, 89.0, 90)
+    recs = [
+        SkillRecord(_fc(tA, heave=np.zeros_like(tA)), _meas(tA, heave=np.ones_like(tA))),
+        SkillRecord(_fc(tB, heave=np.zeros_like(tB)), _meas(tB, heave=np.full_like(tB, 3.0))),
+    ]
+    agg = aggregate_skill(recs)["heave"]
+    pooled = np.sqrt((10 * 1.0 + 90 * 9.0) / 100.0)   # 2.863...
+    assert agg.rmse == pytest.approx(pooled, rel=1e-9)
+    assert agg.rmse != pytest.approx(2.0)             # != mean-of-rmse (1+3)/2
+    assert agg.n_samples == 100

--- a/tests/motion_forecast/test_skill.py
+++ b/tests/motion_forecast/test_skill.py
@@ -56,3 +56,18 @@ def test_aggregate_skill_pools_residuals_not_mean_of_rmse():
     assert agg.rmse == pytest.approx(pooled, rel=1e-9)
     assert agg.rmse != pytest.approx(2.0)             # != mean-of-rmse (1+3)/2
     assert agg.n_samples == 100
+
+
+def test_nan_residual_is_masked_not_poisoning():
+    t = np.linspace(0.0, 40.0, 81)
+    mh = np.ones_like(t)   # residual 1 vs a zero forecast
+    mh[10] = np.nan        # one MRU dropout
+    agg = aggregate_skill([SkillRecord(_fc(t, heave=np.zeros_like(t)),
+                                       _meas(t, heave=mh))])["heave"]
+    assert agg.rmse == pytest.approx(1.0)  # NaN masked, not poisoning the batch
+    assert agg.n_samples == 80             # the dropout dropped
+
+
+def test_aggregate_skill_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        aggregate_skill([])

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -101,6 +101,36 @@ def test_router_measured_bad_type_raises():
         router(cfg)
 
 
+def test_router_emits_skill_summary():
+    import numpy as np
+    from digitalmodel.motion_forecast.measured import MeasuredMotion
+    from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
+
+    def _pair(offset):
+        t = np.linspace(0.0, 40.0, 161)
+        fc = MotionForecast(
+            t=t, dof={d: (np.sin(t) if d == "heave" else np.zeros_like(t))
+                      for d in DOF_NAMES},
+            origin_time=0.0, horizon=40.0)
+        meas = MeasuredMotion(
+            t=t, dof={d: (np.sin(t) + offset if d == "heave" else np.zeros_like(t))
+                      for d in DOF_NAMES})
+        return (fc, meas)
+
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.0, "tp": 9.0, "horizon": 60.0, "n_components": 24},
+            "rao": {"source": "analytic"},
+            "skill": {"records": [_pair(0.1), _pair(0.2)]},
+        },
+    }
+    out = router(cfg)["motion_forecast"]
+    assert set(out["skill_summary"]) == set(DOF_NAMES)
+    assert out["skill_summary"]["heave"]["rmse"] > 0.0
+    assert out["skill_summary"]["heave"]["n_samples"] == 161 * 2
+
+
 def test_engine_dispatch_wired():
     """Guard: engine.py routes basename 'motion_forecast' to the workflow."""
     engine_src = (


### PR DESCRIPTION
## What

The **learning loop** of epic #1356 — the capstone that makes the offering *improve* rather than emit one-shot forecasts (plan: `docs/plans/2026-07-04-issue-1360-learning-loop.md`). Aggregates forecast-vs-measured error across many pairs, fits a recalibration correction proven on held-out data, and rolls results into an operability feedback number.

### Modules (under `src/digitalmodel/motion_forecast/`)
| File | Role |
|---|---|
| `reconcile.py` | **new `overlap_residuals`** exposing per-sample `(measured, forecast_resampled, residual)` + timestamps; `overlap_error` refactored onto it (output unchanged, regression-tested). |
| `skill.py` | `SkillRecord` (validates overlap); `error_vs_lead_time` (pooled residuals binned by `lead = t_measured − origin_time` — the skill-decay curve); `aggregate_skill` (RMSE/bias pool; correlation reported per-record median/IQR). |
| `recalibrate.py` | per-DOF affine `gain·x+bias` fit + zero-variance guard; `holdout_report` (train/test) reports RMSE **and** correlation. |
| `feedback.py` | `operability_summary(states)` → operable / downtime / waiting-on-weather / longest-run. |
| `workflow.py` | optional skill batch → `skill_summary`. |

### Statistical honesty (baked into design + tests)
- RMSE/bias **pool** residuals across records; **correlation does not** (concatenating records with different DC offsets is a Simpson artifact → per-record median/IQR).
- Recalibration proves itself on a **held-out** split, not fit-and-eval on the same data.
- **Documented caveat:** an affine correction is *correlation-invariant*, so it captures amplitude scaling + DC bias only — **not** the phase decorrelation that dominates lead-time skill decay. RMSE↓ alone is *not* a better forecast (a shrinking gain regresses to the mean); `holdout_report` shows correlation alongside so this is visible. This is an **output-space** correction, explicitly not RAO-model recalibration (deferred).

## Validation — 28 new tests green
- `overlap_error` output unchanged after the residuals refactor (regression).
- `error_vs_lead_time` recovers an injected lead-dependent error; `aggregate_skill` pooling distinguished from mean-of-RMSE on unequal overlaps.
- `fit_correction` recovers injected gain/bias <1e-6; held-out RMSE reduced on affine structure; **noise-only → near-identity, not worsened**; zero-variance DOF → bias-only; correlation invariance shown.
- `operability_summary` operable/WoW/longest-run incl. `marginal_operable`.
- Router emits `skill_summary`; existing #1358/#1359/#1367 tests still green.

## Cross-review (Route C gate)
Adversarial code review → **APPROVE-WITH-CHANGES** (no blockers; reconcile refactor confirmed behavior-preserving, OLS/pooling math confirmed correct). Fixed:
- **NaN masking:** an MRU-dropout NaN previously poisoned the whole batch's pooled RMSE/bias — now masked before pooling (consistent with the fail-closed decision path); `aggregate_skill([])` raises instead of fabricating a zero result.
- **Generalisation test strengthened:** the held-out test now uses independent per-record noise and asserts `rmse_after` lands at the **noise floor** (not ~0), so a fit-on-test bug can't pass — plus a separate exact-affine-removable test.
- **Feedback contract:** dropped `downtime_fraction` (it equalled WoW, which is only a *subset* of downtime; with state-only input only the weather-driven fraction is honest).
- `SkillRecord` enforces `origin_time ≤ t[0]` (the `lead ≥ 0` guarantee); softened the "sample-weighted" pooling docstring.

## Scope
Deferred (documented): online data assimilation (EnKF live re-anchoring); RAO-model (coefficient) recalibration; deep weather-downtime stats beyond the operable/WoW proxy; frequency-dependent correction. Pure-numerical (no license).

With this, the two data modes (forecast #1358 + measured #1367) close into a system that measurably improves — leaving **#1357 (real phased wave-forecast front-end)** as the last core child.

Refs #1360 #1356
