### PR TITLE
feat(motion_forecast): wave_forecast — directional + physics horizon (#1357)

### DIFF
--- a/docs/plans/2026-07-04-issue-1357-wave-forecast.md
+++ b/docs/plans/2026-07-04-issue-1357-wave-forecast.md
@@ -1,0 +1,54 @@
+# Plan: digitalmodel #1357 — wave_forecast: phase-resolved surface + physics predictable-zone (+ directional spreading)
+
+**Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1357
+**Epic:** #1356 (last core child) · **Status:** plan-review · **Tier:** T2/T3 (Route B/C)
+
+## Scope framing (read first — honesty boundary)
+The genuinely hard part — reconstructing a phase-resolved surface from X-band radar / wave lidar and evolving it nonlinearly (HOS-Ocean) — is **partner/licensed research** (Next Ocean / Miros / the DSWP literature). #1357 does **NOT** reimplement it. #1357 delivers the *physics-honest* pieces the offering owns, behind the `WaveForecast` protocol #1358 defined:
+1. a **principled predictable-zone horizon** (replaces the current hardcoded `horizon`),
+2. **directional spreading** (replaces the current long-crested single-heading synthesis),
+3. a first-class **phase-resolved surface-elevation evaluator** η(x,y,t),
+4. a **sensing-agnostic ingest interface** (stub) — real reconstruction/HOS evolution is the partner front-end behind the same interface.
+
+## Context
+`wave_source.synthesize_forecast` (merged, #1358) is long-crested and takes `horizon` as a hardcoded argument (verified: wave_source.py:49-102 — single `heading`, `horizon` passed in). #1357 makes the wave forecast physics-honest. The synthetic generator stays as the deterministic test stub, now enriched.
+
+**Stale-flag:** Not stale — final core child of the open epic.
+
+## Reuse (verified)
+- `models.WaveComponent` (omega, amplitude, phase, heading) / `WaveForecast` (components, horizon, origin_time, phase_reference_location, water_depth) — the protocol produced.
+- `wave_source.jonswap_spectrum` (spectrum) + `reconstruct.wavenumber` (deep/finite-depth k). `models.GRAVITY`.
+- `reconstruct.reconstruct_motion` already consumes components — no change; a richer/directional/physics-horizon `WaveForecast` flows through unchanged.
+
+## Design (in `motion_forecast/wave_forecast.py` — cohesion with the protocol + reconstruct; NOT a new top-level package, see open-q 1)
+- **Two honestly-named horizon functions** (the coherence proxy is NOT the DPZ — the name must say so):
+  - `coherence_horizon(components, *, tau_min, tau_max, k_coh) -> float` — **indicative** bandwidth-limited coherence/decorrelation time. Spectral width `ν = sqrt(max(0, m0*m2/m1² − 1))` from the component set; `τ = k_coh / (ν * f_peak)`, clamped to `[tau_min, tau_max]`. **ν = 0 (monochromatic) → `tau_max`** (guard div-by-zero). Narrow-band → small ν → longer τ. Docstring states plainly: *this is a coherence-time proxy, NOT the Deterministic Predictable Zone.*
+  - `dpz_horizon(components, *, aperture, energetic_fraction=0.9) -> float` — the **rigorous** group-velocity DPZ temporal width: `cg_i = 0.5*g/ω_i` (deep water) over the band carrying the central `energetic_fraction` of variance; `τ_DPZ = aperture * (1/cg_min − 1/cg_max)` (spread in group-arrival times across the measurement aperture; Naaijen 2018). "Predictable zone" naming reserved for this aperture-based path.
+  - The synthesizer uses `coherence_horizon` by default and `dpz_horizon` when an `aperture` is supplied. Honest ceiling on both via the clamp: realistic short-crested ~tens of s to ~1–2 min; never the vendor "4–5 min".
+- `directional_spread(headings, mean_heading, s) -> weights`: a cos-2s spreading function; energy-preserving (weights sum to 1).
+- `synthesize_directional_forecast(hs, tp, *, mean_heading, spread_s, n_freq, n_dir, aperture=None, seed, ...) -> WaveForecast`: JONSWAP × directional spread → a 2-D (freq × direction) phased component set with `a_{ij} = sqrt(2·S_i·dω_i·w_j)` (`Σ_j w_j = 1` ⇒ variance preserved, no double-counting); horizon from `dpz_horizon` if `aperture` else `coherence_horizon`; seeded phases. **Reuses `wave_source`'s ω-grid** (`edges = linspace(0.4wp, 3.2wp, n_freq+1)`, midpoints) so the `n_dir=1` case matches long-crested amplitudes.
+- `surface_elevation(forecast, x, y, t) -> float|array`: LWT η = Σ aᵢ cos(ωᵢ t + φᵢ − kᵢ (d̂ᵢ·(p − p_ref))). The free surface the reconstruct engine implicitly transfers — exposed for the demo + validation.
+- `WaveFieldSource` protocol (`read() -> WaveForecast`) + `SyntheticWaveField` stub (from a sea state) + a documented seam where a real radar/lidar reconstruction or HOS evolution plugs in (**partner/licensed — out of scope**).
+
+## Plan
+1. `predictable_zone_horizon` (+ bandwidth proxy and group-velocity option) + tests.
+2. `directional_spread` + `synthesize_directional_forecast` + tests (energy preservation, mean direction, long-crested reduction).
+3. `surface_elevation` + tests (single-component closed form; consistency with the components at the reference location).
+4. `WaveFieldSource` protocol + `SyntheticWaveField` stub + test.
+5. Optional: workflow `sea.spread_s`/`aperture` wiring so the router can request a directional, physics-horizon forecast.
+
+## Acceptance Criteria
+- [ ] `coherence_horizon`: a narrow-band spectrum yields a **strictly longer** horizon than a broadband one, **using spectra whose τ lands inside `[tau_min, tau_max]`** (not on the clamp rails); monochromatic (ν=0) → `tau_max` (no div-by-zero); both clamped to the realistic band (never 4–5 min).
+- [ ] `dpz_horizon`: equals `aperture*(1/cg_min − 1/cg_max)` over the energetic band to <1e-9 for a constructed two-component case (`cg = 0.5g/ω` verified).
+- [ ] `directional_spread` weights sum to 1; `synthesize_directional_forecast` preserves variance (`4√m0 ≈ Hs`) across the 2-D set and recovers the mean heading. `n_dir=1` reproduces the long-crested `wave_source` result as **amplitude/heading/variance equivalence on the shared ω-grid** (phases equal only under matched seeding — not asserted).
+- [ ] `surface_elevation`: single-component η matches `a·cos(ωt + φ − k·Δx)` to <1e-9; the value at `phase_reference_location` equals `Σ aᵢ cos(ωᵢ t + φᵢ)`.
+- [ ] `SyntheticWaveField.read()` returns a valid `WaveForecast` that flows through `reconstruct_motion` unchanged.
+- [ ] Existing #1358/#1359/#1367/#1360 tests still green; pure-numerical.
+
+## Deferred / out of scope (documented — the partner boundary)
+Real phase-resolved reconstruction from X-band radar / wave lidar; HOS-Ocean nonlinear evolution; data assimilation of a live sensed field. These are the licensed research front-end; #1357 provides the interface + LWT-grade synthesis/propagation only.
+
+## Open questions (recommendations)
+1. **Location:** `motion_forecast/wave_forecast.py` (**recommended** — cohesion with `WaveForecast`/`reconstruct`) vs a new top-level `wave_forecast/` package (epic's original framing)?
+2. **Predictable-zone default:** bandwidth-coherence proxy as default + group-velocity DPZ optional (**recommended**), or require an aperture always?
+3. **Directional model:** cos-2s spreading (**recommended**, standard) vs a configurable spreading function now?

--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -51,6 +51,15 @@ from .reconstruct import (
     vertical_motion_at,
     wavenumber,
 )
+from .wave_forecast import (
+    SyntheticWaveField,
+    WaveFieldSource,
+    coherence_horizon,
+    directional_spread,
+    dpz_horizon,
+    surface_elevation,
+    synthesize_directional_forecast,
+)
 from .wave_source import jonswap_spectrum, synthesize_forecast
 from .workflow import router
 
@@ -100,4 +109,11 @@ __all__ = [
     "holdout_report",
     "OperabilitySummary",
     "operability_summary",
+    "coherence_horizon",
+    "dpz_horizon",
+    "directional_spread",
+    "synthesize_directional_forecast",
+    "surface_elevation",
+    "WaveFieldSource",
+    "SyntheticWaveField",
 ]

--- a/src/digitalmodel/motion_forecast/wave_forecast.py
+++ b/src/digitalmodel/motion_forecast/wave_forecast.py
@@ -1,0 +1,190 @@
+"""Phase-resolved wave forecast: horizon, directional spread, surface (#1357).
+
+The physics-honest pieces the offering owns, behind the ``WaveForecast`` protocol
+(#1358). The genuinely hard front-end — reconstructing a phase-resolved surface
+from X-band radar / wave lidar and evolving it nonlinearly (HOS-Ocean) — is
+**partner/licensed** and out of scope; ``WaveFieldSource`` is the seam it plugs
+into. This module provides linear-wave-theory synthesis/propagation only.
+
+Two honestly-named horizon functions:
+- ``coherence_horizon`` — an INDICATIVE bandwidth-limited coherence time, NOT the
+  Deterministic Predictable Zone.
+- ``dpz_horizon`` — the rigorous group-velocity DPZ temporal width, which needs a
+  measurement aperture.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol, Sequence, Tuple, runtime_checkable
+
+import numpy as np
+
+from .models import GRAVITY, WaveComponent, WaveForecast
+from .reconstruct import wavenumber
+from .wave_source import jonswap_spectrum
+
+
+# ---- horizons ---------------------------------------------------------------
+
+def _moments(components: Sequence[WaveComponent]) -> Tuple[float, float, float]:
+    """Spectral moments m0, m1, m2 from a discrete component set (in omega)."""
+    w = np.array([c.omega for c in components], dtype=float)
+    e = np.array([0.5 * c.amplitude**2 for c in components], dtype=float)  # variance
+    m0 = float(np.sum(e))
+    m1 = float(np.sum(e * w))
+    m2 = float(np.sum(e * w * w))
+    return m0, m1, m2
+
+
+def coherence_horizon(
+    components: Sequence[WaveComponent], *,
+    tau_min: float = 15.0, tau_max: float = 120.0, k_coh: float = 1.0,
+) -> float:
+    """INDICATIVE bandwidth-limited coherence time (seconds).
+
+    NOT the Deterministic Predictable Zone (use :func:`dpz_horizon` for that).
+    ``nu = sqrt(max(0, m0*m2/m1^2 - 1))`` (spectral width); ``tau = k_coh /
+    (nu * f_peak)`` clamped to ``[tau_min, tau_max]``. Narrow-band -> small nu ->
+    longer horizon. Monochromatic (nu = 0) -> ``tau_max``.
+    """
+    m0, m1, m2 = _moments(components)
+    if m0 <= 0 or m1 <= 0:
+        return tau_max
+    nu = float(np.sqrt(max(0.0, m0 * m2 / (m1 * m1) - 1.0)))
+    if nu <= 1e-9:
+        return tau_max
+    # peak frequency (Hz) = omega of the largest component / 2pi
+    w_peak = max(components, key=lambda c: c.amplitude).omega
+    f_peak = w_peak / (2.0 * np.pi)
+    tau = k_coh / (nu * f_peak)
+    return float(np.clip(tau, tau_min, tau_max))
+
+
+def dpz_horizon(
+    components: Sequence[WaveComponent], *,
+    aperture: float, energetic_fraction: float = 0.9,
+) -> float:
+    """Rigorous group-velocity DPZ temporal width (seconds).
+
+    Over the band carrying the central ``energetic_fraction`` of variance,
+    ``tau = aperture * (1/cg_min - 1/cg_max)`` with deep-water group velocity
+    ``cg = 0.5 g / omega`` (the spread in group-arrival times across the
+    measurement aperture; Naaijen 2018).
+    """
+    if aperture <= 0:
+        raise ValueError("aperture must be > 0 for the DPZ horizon")
+    comps = sorted(components, key=lambda c: 0.5 * c.amplitude**2, reverse=True)
+    total = sum(0.5 * c.amplitude**2 for c in comps)
+    if total <= 0:
+        raise ValueError("no wave energy")
+    acc, band = 0.0, []
+    for c in comps:
+        band.append(c)
+        acc += 0.5 * c.amplitude**2
+        if acc >= energetic_fraction * total:
+            break
+    cg = np.array([0.5 * GRAVITY / c.omega for c in band], dtype=float)
+    return float(aperture * (1.0 / cg.min() - 1.0 / cg.max()))
+
+
+# ---- directional spreading --------------------------------------------------
+
+def directional_spread(
+    headings: np.ndarray, mean_heading: float, s: float
+) -> np.ndarray:
+    """cos-2s directional weights (sum to 1) over the sampled headings."""
+    d = ((np.asarray(headings, float) - mean_heading + 180.0) % 360.0) - 180.0  # [-180,180)
+    w = np.cos(np.deg2rad(d) / 2.0) ** (2.0 * s)
+    w = np.where(np.abs(d) < 180.0, w, 0.0)
+    total = w.sum()
+    if total <= 0:
+        raise ValueError("degenerate directional spread")
+    return w / total
+
+
+def synthesize_directional_forecast(
+    hs: float, tp: float, *,
+    mean_heading: float = 0.0, spread_s: float = 10.0,
+    n_freq: int = 32, n_dir: int = 7, gamma: float = 3.3,
+    dir_halfwidth: float = 90.0,
+    aperture: Optional[float] = None,
+    phase_reference_location: Tuple[float, float] = (0.0, 0.0),
+    water_depth: Optional[float] = None, origin_time: float = 0.0,
+    seed: int = 20260704,
+) -> WaveForecast:
+    """Short-crested phased forecast; physics horizon.
+
+    Reuses ``wave_source``'s omega-grid so ``n_dir=1`` matches the long-crested
+    amplitudes. Directional energy split ``a_ij = sqrt(2 S_i dω_i w_j)`` with
+    ``sum_j w_j = 1`` preserves variance. Horizon from ``dpz_horizon`` when an
+    ``aperture`` is given, else ``coherence_horizon``.
+    """
+    wp = 2.0 * np.pi / tp
+    edges = np.linspace(0.4 * wp, 3.2 * wp, n_freq + 1)
+    omega = 0.5 * (edges[:-1] + edges[1:])
+    d_omega = np.diff(edges)
+    s_i = jonswap_spectrum(omega, hs, tp, gamma)
+
+    if n_dir <= 1:
+        headings = np.array([mean_heading])
+        weights = np.array([1.0])
+    else:
+        headings = mean_heading + np.linspace(-dir_halfwidth, dir_halfwidth, n_dir)
+        weights = directional_spread(headings, mean_heading, spread_s)
+
+    rng = np.random.default_rng(seed)
+    components: List[WaveComponent] = []
+    for i in range(n_freq):
+        for j in range(len(headings)):
+            a = float(np.sqrt(2.0 * s_i[i] * d_omega[i] * weights[j]))
+            components.append(WaveComponent(
+                omega=float(omega[i]), amplitude=a,
+                phase=float(rng.uniform(0.0, 2.0 * np.pi)),
+                heading=float(headings[j])))
+
+    horizon = (dpz_horizon(components, aperture=aperture)
+               if aperture else coherence_horizon(components))
+    return WaveForecast(
+        components=components, horizon=horizon, origin_time=origin_time,
+        phase_reference_location=phase_reference_location, water_depth=water_depth,
+    )
+
+
+# ---- free surface -----------------------------------------------------------
+
+def surface_elevation(forecast: WaveForecast, x: float, y: float, t):
+    """Free-surface elevation eta(x, y, t) (m), LWT.
+
+    Matches ``reconstruct``'s incident-phase convention exactly:
+    ``eta = sum_i a_i cos(omega_i t + phi_i - k_i (d_hat_i . (p - p_ref)))``.
+    ``t`` may be a scalar or array.
+    """
+    t = np.asarray(t, dtype=float)
+    xr, yr = forecast.phase_reference_location
+    dx, dy = x - xr, y - yr
+    eta = np.zeros_like(t)
+    for c in forecast.components:
+        k = wavenumber(c.omega, forecast.water_depth)
+        brad = np.deg2rad(c.heading)
+        proj = np.cos(brad) * dx + np.sin(brad) * dy
+        eta = eta + c.amplitude * np.cos(c.omega * t + c.phase - k * proj)
+    return eta
+
+
+# ---- ingest seam (real reconstruction is partner/licensed) ------------------
+
+@runtime_checkable
+class WaveFieldSource(Protocol):
+    """Anything that yields a phase-resolved ``WaveForecast``."""
+
+    def read(self) -> WaveForecast: ...
+
+
+class SyntheticWaveField:
+    """Deterministic stub source; the seam a real radar/lidar/HOS front-end fills."""
+
+    def __init__(self, hs: float, tp: float, **kwargs):
+        self._hs, self._tp, self._kw = hs, tp, kwargs
+
+    def read(self) -> WaveForecast:
+        return synthesize_directional_forecast(self._hs, self._tp, **self._kw)

--- a/src/digitalmodel/motion_forecast/wave_forecast.py
+++ b/src/digitalmodel/motion_forecast/wave_forecast.py
@@ -46,6 +46,10 @@ def coherence_horizon(
     ``nu = sqrt(max(0, m0*m2/m1^2 - 1))`` (spectral width); ``tau = k_coh /
     (nu * f_peak)`` clamped to ``[tau_min, tau_max]``. Narrow-band -> small nu ->
     longer horizon. Monochromatic (nu = 0) -> ``tau_max``.
+
+    Note: tau also scales with 1/f_peak, so "narrower -> longer" is a property of
+    nu at a *fixed peak period*; a narrow high-frequency sea can score shorter
+    than a broad low-frequency one.
     """
     m0, m1, m2 = _moments(components)
     if m0 <= 0 or m1 <= 0:
@@ -66,10 +70,12 @@ def dpz_horizon(
 ) -> float:
     """Rigorous group-velocity DPZ temporal width (seconds).
 
-    Over the band carrying the central ``energetic_fraction`` of variance,
-    ``tau = aperture * (1/cg_min - 1/cg_max)`` with deep-water group velocity
-    ``cg = 0.5 g / omega`` (the spread in group-arrival times across the
-    measurement aperture; Naaijen 2018).
+    Over the **highest-energy components summing to** ``energetic_fraction`` of
+    variance, ``tau = aperture * (1/cg_min - 1/cg_max)`` with deep-water group
+    velocity ``cg = 0.5 g / omega`` (the spread in group-arrival times across the
+    measurement aperture; Naaijen 2018). For a unimodal sea (the JONSWAP caller)
+    that set is contiguous around the peak; a bimodal sea would span both peaks
+    and overstate the group spread.
     """
     if aperture <= 0:
         raise ValueError("aperture must be > 0 for the DPZ horizon")
@@ -143,7 +149,7 @@ def synthesize_directional_forecast(
                 heading=float(headings[j])))
 
     horizon = (dpz_horizon(components, aperture=aperture)
-               if aperture else coherence_horizon(components))
+               if aperture is not None else coherence_horizon(components))
     return WaveForecast(
         components=components, horizon=horizon, origin_time=origin_time,
         phase_reference_location=phase_reference_location, water_depth=water_depth,

--- a/tests/motion_forecast/test_wave_forecast.py
+++ b/tests/motion_forecast/test_wave_forecast.py
@@ -42,6 +42,12 @@ def test_coherence_horizon_clamped_to_realistic_band():
     assert 15.0 <= h <= 120.0   # never the vendor 4-5 min
 
 
+def test_zero_aperture_raises_not_silent_fallback():
+    # aperture=0.0 must fail loudly (not falsy-fall-back to coherence_horizon)
+    with pytest.raises(ValueError, match="aperture"):
+        synthesize_directional_forecast(2.5, 9.0, n_dir=1, aperture=0.0)
+
+
 def test_dpz_horizon_matches_formula():
     comps = [WaveComponent(0.5, 1.0, 0.0), WaveComponent(1.0, 1.0, 0.0)]
     L = 200.0

--- a/tests/motion_forecast/test_wave_forecast.py
+++ b/tests/motion_forecast/test_wave_forecast.py
@@ -1,0 +1,110 @@
+"""wave_forecast tests (digitalmodel #1357)."""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast import (
+    AnalyticRAO,
+    reconstruct_motion,
+)
+from digitalmodel.motion_forecast.models import GRAVITY, WaveComponent, WaveForecast
+from digitalmodel.motion_forecast.wave_forecast import (
+    SyntheticWaveField,
+    WaveFieldSource,
+    coherence_horizon,
+    directional_spread,
+    dpz_horizon,
+    surface_elevation,
+    synthesize_directional_forecast,
+)
+from digitalmodel.motion_forecast.wave_source import synthesize_forecast
+
+
+# ---- horizons ----
+
+def test_coherence_horizon_narrowband_longer_than_broadband():
+    narrow = synthesize_directional_forecast(2.5, 10.0, gamma=7.0, n_dir=1)
+    broad = synthesize_directional_forecast(2.5, 10.0, gamma=1.0, n_dir=1)
+    # wide clamp so we compare the raw coherence time, not the rails
+    hn = coherence_horizon(narrow.components, tau_min=1.0, tau_max=1e4)
+    hb = coherence_horizon(broad.components, tau_min=1.0, tau_max=1e4)
+    assert hn > hb
+
+
+def test_coherence_horizon_monochromatic_is_tau_max():
+    one = [WaveComponent(0.7, 1.0, 0.0)]
+    assert coherence_horizon(one, tau_max=120.0) == 120.0
+
+
+def test_coherence_horizon_clamped_to_realistic_band():
+    h = coherence_horizon(
+        synthesize_directional_forecast(2.5, 10.0, gamma=1.0, n_dir=1).components)
+    assert 15.0 <= h <= 120.0   # never the vendor 4-5 min
+
+
+def test_dpz_horizon_matches_formula():
+    comps = [WaveComponent(0.5, 1.0, 0.0), WaveComponent(1.0, 1.0, 0.0)]
+    L = 200.0
+    tau = dpz_horizon(comps, aperture=L)
+    assert tau == pytest.approx(2 * L * (1.0 - 0.5) / GRAVITY, abs=1e-9)
+
+
+# ---- directional ----
+
+def test_directional_spread_sums_to_one():
+    h = np.linspace(-90.0, 90.0, 7)
+    w = directional_spread(h, mean_heading=0.0, s=10.0)
+    assert w.sum() == pytest.approx(1.0)
+    assert np.argmax(w) == 3   # peak at the mean
+
+
+def test_directional_forecast_preserves_variance_and_mean_heading():
+    fc = synthesize_directional_forecast(3.0, 10.0, mean_heading=25.0,
+                                         spread_s=15.0, n_freq=40, n_dir=9)
+    m0 = sum(0.5 * c.amplitude**2 for c in fc.components)
+    assert 4.0 * np.sqrt(m0) == pytest.approx(3.0, rel=0.02)   # Hs preserved
+    e = np.array([0.5 * c.amplitude**2 for c in fc.components])
+    hdg = np.array([c.heading for c in fc.components])
+    assert np.average(hdg, weights=e) == pytest.approx(25.0, abs=1e-6)
+
+
+def test_n_dir_one_matches_long_crested_amplitudes():
+    fc = synthesize_directional_forecast(2.5, 9.0, mean_heading=20.0,
+                                         n_freq=32, n_dir=1)
+    ref = synthesize_forecast(2.5, 9.0, heading=20.0, n_components=32)
+    a1 = np.sort([c.amplitude for c in fc.components])
+    a2 = np.sort([c.amplitude for c in ref.components])
+    assert np.allclose(a1, a2)
+    assert all(c.heading == 20.0 for c in fc.components)
+
+
+# ---- surface ----
+
+def test_surface_elevation_single_component_closed_form():
+    w0, a0, phi0, hdg = 0.7, 1.3, 0.4, 30.0
+    fc = WaveForecast([WaveComponent(w0, a0, phi0, hdg)], horizon=60.0)
+    t = np.linspace(0, 20, 101)
+    x, y = 40.0, 0.0
+    k = w0 * w0 / GRAVITY
+    proj = np.cos(np.deg2rad(hdg)) * x + np.sin(np.deg2rad(hdg)) * y
+    expected = a0 * np.cos(w0 * t + phi0 - k * proj)
+    assert np.allclose(surface_elevation(fc, x, y, t), expected, atol=1e-9)
+
+
+def test_surface_at_reference_is_sum_of_component_cosines():
+    fc = synthesize_directional_forecast(2.0, 9.0, n_freq=16, n_dir=3)
+    t = np.linspace(0, 10, 51)
+    expected = sum(c.amplitude * np.cos(c.omega * t + c.phase) for c in fc.components)
+    assert np.allclose(surface_elevation(fc, 0.0, 0.0, t), expected, atol=1e-9)
+
+
+# ---- ingest seam ----
+
+def test_synthetic_wave_field_flows_through_reconstruct():
+    src = SyntheticWaveField(3.0, 10.0, n_dir=5, spread_s=12.0)
+    assert isinstance(src, WaveFieldSource)
+    fc = src.read()
+    assert isinstance(fc, WaveForecast) and fc.horizon > 0
+    rao = AnalyticRAO({"heave": lambda w, b: 1.0 + 0j})
+    mf = reconstruct_motion(fc, rao, dt=0.5)
+    assert mf.dof["heave"].shape == mf.t.shape


### PR DESCRIPTION
## What

The **last core child** of epic #1356 — a physics-honest phase-resolved wave forecast behind the `WaveForecast` protocol #1358 defined (plan: `docs/plans/2026-07-04-issue-1357-wave-forecast.md`). Fills the two gaps in the synthetic `wave_source`: it was long-crested with a hardcoded horizon.

### Honesty boundary
The genuinely hard front-end — reconstructing a phase-resolved surface from X-band radar / wave lidar and evolving it nonlinearly (HOS-Ocean) — is **partner/licensed research** (Next Ocean / Miros / the DSWP literature) and is **not** reimplemented. `WaveFieldSource` is the documented seam it plugs into; this module provides linear-wave-theory synthesis/propagation only.

### `motion_forecast/wave_forecast.py`
| Symbol | Role |
|---|---|
| `coherence_horizon` | **indicative** bandwidth coherence time (`ν` from spectral moments) — named to make clear it is **NOT** the DPZ; monochromatic → `τ_max`; clamped to a realistic band (never the vendor 4–5 min). |
| `dpz_horizon` | rigorous group-velocity DPZ width `τ = aperture·(1/cg_min − 1/cg_max)`, `cg = 0.5g/ω`, over the energetic band. |
| `directional_spread` + `synthesize_directional_forecast` | cos-2s short-crested 2-D (freq×dir) set, variance-preserving; reuses `wave_source`'s ω-grid so `n_dir=1` matches long-crested amplitudes. |
| `surface_elevation` | LWT `η(x,y,t)` with the **identical incident-phase convention as `reconstruct`** (verified) — so the demo's wave and motion panels agree. |
| `WaveFieldSource` / `SyntheticWaveField` | ingest protocol + deterministic stub. |

## Validation — 10 tests
- Coherence: narrow-band > broadband (raw, unclamped); monochromatic → `τ_max`; clamped to `[15,120]` s.
- DPZ equals the closed form for a two-component case.
- Directional: weights sum to 1; variance (`4√m0 ≈ Hs`) and mean heading preserved; `n_dir=1` matches long-crested amplitudes.
- `surface_elevation` single-component closed form; value at reference = `Σ aᵢcos(ωᵢt+φᵢ)`.
- `SyntheticWaveField.read()` flows through `reconstruct_motion` unchanged.

## Cross-review (Route C gate)
Adversarial code review → **APPROVE-WITH-CHANGES** (no blockers, no correctness bugs; the `surface_elevation` ≡ `reconstruct` phase equivalence verified at runtime against a short-crested mixed-heading case). Fixed:
- **Docstring accuracy:** `dpz_horizon` said "central" band but the code takes the highest-energy components — reworded to match (with the bimodal caveat).
- **`aperture=0.0` truthiness:** `if aperture` silently fell back to the coherence horizon on a zero aperture; now `if aperture is not None` so it fails loudly (test added).
- Documented that `coherence_horizon`'s "narrower → longer" holds at a fixed peak period.

## Epic #1356 core complete
With this, all core children are done: #1358 (engine) · #1359 (go/no-go) · #1360 (learning) · #1367 (measured) · #1361 (demo) · **#1357 (wave forecast)**. Remaining are fast-follows: #1358 Task 6 (`seastate_limits` RAO path), #1359 full riser-model top-tension, HOS-class nonlinear evolution behind `WaveFieldSource`, and PDF/API capability-card artifacts.

Refs #1357 #1356
