### PR TITLE
feat(subsea/rov): RAO-based LARS operability path (#1358 Task 6)

### DIFF
--- a/src/digitalmodel/subsea/rov/seastate_limits.py
+++ b/src/digitalmodel/subsea/rov/seastate_limits.py
@@ -229,7 +229,8 @@ class RaoOperabilityResult:
     Attributes
     ----------
     v_significant:
-        Significant (2*std) vertical velocity at the deployment point [m/s].
+        Significant *single* amplitude (2*sigma) of the vertical velocity at the
+        deployment point [m/s]. ``velocity_limit`` must be in the same convention.
     v_oplim:
         Operational velocity limit ``alpha * velocity_limit`` [m/s].
     utilisation:
@@ -251,7 +252,7 @@ def rao_based_operability(
     forecast,
     rao,
     *,
-    deployment_offset: tuple = (0.0, 0.0, 0.0),
+    deployment_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
     velocity_limit: float,
     alpha: float = 1.0,
     dt: float = 0.2,
@@ -274,11 +275,17 @@ def rao_based_operability(
     deployment_offset:
         ``(rx, ry, rz)`` [m] of the deployment point on the vessel.
     velocity_limit:
-        Rated limiting significant vertical velocity [m/s], must be > 0.
+        Rated limiting vertical velocity [m/s], must be > 0, expressed as a
+        **significant single amplitude (2*sigma)** to match ``v_significant``.
     alpha:
-        Weather-forecast allowance (0 < alpha <= 1, default 1.0).
+        Weather-forecast allowance (0 < alpha <= 1, default 1.0), applied as
+        ``v_oplim = alpha * velocity_limit`` (same semantics as the Hs path).
     dt:
         Reconstruction time step [s].
+
+    Returns
+    -------
+    RaoOperabilityResult
 
     Raises
     ------

--- a/src/digitalmodel/subsea/rov/seastate_limits.py
+++ b/src/digitalmodel/subsea/rov/seastate_limits.py
@@ -9,10 +9,16 @@ publish a *limiting significant wave height* ``Hs_limit`` for launch and recover
 (IMCA R 004 / IMCA R 015 LARS operability practice; consistent with the workability
 concept used throughout DNV-RP / API 17H intervention planning).
 
-This module provides the deterministic, public-standard core of that check. It does
-not model spectral vessel motion (deferred to ``hydrodynamics/seakeeping`` and an
-RAO-based response solver); it works on the bounding parameter the standards and
-operability tables are written in: significant wave height.
+This module provides the deterministic, public-standard core of that check on the
+bounding parameter the standards and operability tables are written in:
+significant wave height (the ``seastate_operability`` / ``scatter_operability``
+screens below).
+
+An optional **RAO-based response path** (``rao_based_operability``) refines the
+screen to the *actual* motion at the ROV deployment point: it reuses the
+``motion_forecast`` engine (#1358) to transfer a phased wave forecast through the
+vessel RAO and evaluate the vertical velocity at the splash-zone / A-frame point.
+It is additive and independent — the Hs screens do not require it.
 
 Single sea-state operability (deterministic screening)
 ------------------------------------------------------
@@ -213,4 +219,93 @@ def scatter_operability(
         hs_oplim=hs_oplim,
         n_operable=n_operable,
         n_total=n_total,
+    )
+
+
+@dataclass(frozen=True)
+class RaoOperabilityResult:
+    """RAO-based LARS operability at the ROV deployment point.
+
+    Attributes
+    ----------
+    v_significant:
+        Significant (2*std) vertical velocity at the deployment point [m/s].
+    v_oplim:
+        Operational velocity limit ``alpha * velocity_limit`` [m/s].
+    utilisation:
+        ``v_significant / v_oplim`` (<= 1.0 means operable).
+    margin:
+        ``v_oplim - v_significant`` [m/s] (positive = margin remaining).
+    operable:
+        ``True`` when ``v_significant <= v_oplim``.
+    """
+
+    v_significant: float
+    v_oplim: float
+    utilisation: float
+    margin: float
+    operable: bool
+
+
+def rao_based_operability(
+    forecast,
+    rao,
+    *,
+    deployment_offset: tuple = (0.0, 0.0, 0.0),
+    velocity_limit: float,
+    alpha: float = 1.0,
+    dt: float = 0.2,
+) -> RaoOperabilityResult:
+    """RAO-based LARS operability at the ROV deployment point (response-solver path).
+
+    The refinement the Hs screens above defer to: reuses the ``motion_forecast``
+    engine (#1358) to reconstruct vessel motion from a phased ``WaveForecast`` and
+    the vessel ``rao``, evaluates the **vertical velocity at the ROV splash-zone /
+    A-frame deployment point** (rigid-body lever arm), and compares its significant
+    amplitude to the rated velocity limit (snatch-load avoidance at the splash
+    zone; IMCA R 004 / R 015). Additive to and independent of the Hs screens.
+
+    Parameters
+    ----------
+    forecast:
+        A phased ``motion_forecast.WaveForecast`` (or duck-typed equivalent).
+    rao:
+        A ``motion_forecast`` RAO provider (``AnalyticRAO`` / ``GridRAO``).
+    deployment_offset:
+        ``(rx, ry, rz)`` [m] of the deployment point on the vessel.
+    velocity_limit:
+        Rated limiting significant vertical velocity [m/s], must be > 0.
+    alpha:
+        Weather-forecast allowance (0 < alpha <= 1, default 1.0).
+    dt:
+        Reconstruction time step [s].
+
+    Raises
+    ------
+    ValueError
+        On non-positive ``velocity_limit`` or ``alpha`` outside (0, 1].
+    """
+    if velocity_limit <= 0.0:
+        raise ValueError(f"velocity_limit must be > 0, got {velocity_limit!r}")
+    if not (0.0 < alpha <= 1.0):
+        raise ValueError(f"alpha must be in (0, 1], got {alpha!r}")
+
+    import numpy as np
+    from digitalmodel.motion_forecast import (
+        reconstruct_motion,
+        time_derivative,
+        vertical_motion_at,
+    )
+
+    motion = reconstruct_motion(forecast, rao, dt=dt)
+    z = vertical_motion_at(motion, deployment_offset)
+    v = time_derivative(motion.t, z)                 # signed vertical velocity
+    v_significant = 2.0 * float(np.std(v))
+    v_oplim = alpha * velocity_limit
+    return RaoOperabilityResult(
+        v_significant=v_significant,
+        v_oplim=v_oplim,
+        utilisation=v_significant / v_oplim,
+        margin=v_oplim - v_significant,
+        operable=v_significant <= v_oplim,
     )

--- a/tests/subsea/rov/test_seastate_limits.py
+++ b/tests/subsea/rov/test_seastate_limits.py
@@ -165,7 +165,9 @@ def test_rao_operability_lever_arm_increases_velocity():
 
 @pytest.mark.parametrize("kwargs", [
     {"velocity_limit": 0.0},
+    {"velocity_limit": -0.4},
     {"velocity_limit": 0.4, "alpha": 1.5},
+    {"velocity_limit": 0.4, "alpha": 0.0},
 ])
 def test_rao_operability_invalid_inputs_raise(kwargs):
     fc, rao = _forecast_and_rao()

--- a/tests/subsea/rov/test_seastate_limits.py
+++ b/tests/subsea/rov/test_seastate_limits.py
@@ -122,3 +122,52 @@ def test_scatter_operability_alpha_excludes_more_cells():
 def test_scatter_invalid_inputs_raise(scatter, kwargs):
     with pytest.raises(ValueError):
         scatter_operability(scatter, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# RAO-based response path (#1358 Task 6) — reuses the motion_forecast engine
+# --------------------------------------------------------------------------- #
+from digitalmodel.subsea.rov.seastate_limits import rao_based_operability  # noqa: E402
+
+
+def _forecast_and_rao():
+    from digitalmodel.motion_forecast import AnalyticRAO, synthesize_forecast
+
+    fc = synthesize_forecast(2.5, 9.0, n_components=48, horizon=90.0, seed=3)
+    rao = AnalyticRAO({"heave": lambda w, b: 0.9 + 0j})  # near wave-following heave
+    return fc, rao
+
+
+def test_rao_operability_operable_and_not():
+    fc, rao = _forecast_and_rao()
+    # measure the significant velocity, then bracket it with two limits
+    res = rao_based_operability(fc, rao, velocity_limit=100.0)  # huge -> operable
+    v = res.v_significant
+    assert v > 0.0 and res.operable
+    tight = rao_based_operability(fc, rao, velocity_limit=v * 0.5)
+    assert not tight.operable and tight.utilisation > 1.0
+
+
+def test_rao_operability_lever_arm_increases_velocity():
+    from digitalmodel.motion_forecast import AnalyticRAO, synthesize_forecast
+
+    fc = synthesize_forecast(2.5, 9.0, n_components=48, horizon=90.0, seed=3)
+    rao = AnalyticRAO({
+        "heave": lambda w, b: 0.5 + 0j,
+        "pitch": lambda w, b: (w * w / 9.80665) * 40.0 + 0j,  # deg/m
+    })
+    at_cog = rao_based_operability(fc, rao, deployment_offset=(0.0, 0.0, 0.0),
+                                   velocity_limit=100.0).v_significant
+    far = rao_based_operability(fc, rao, deployment_offset=(60.0, 0.0, 0.0),
+                                velocity_limit=100.0).v_significant
+    assert far > at_cog  # lever arm adds pitch-induced vertical velocity
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"velocity_limit": 0.0},
+    {"velocity_limit": 0.4, "alpha": 1.5},
+])
+def test_rao_operability_invalid_inputs_raise(kwargs):
+    fc, rao = _forecast_and_rao()
+    with pytest.raises(ValueError):
+        rao_based_operability(fc, rao, **kwargs)


### PR DESCRIPTION
## What

Fast-follow closing **#1358 Task 6** — the RAO-based response path that `subsea/rov/seastate_limits.py` documented as *"deferred to an RAO-based response solver."* Now that the `motion_forecast` engine exists, this wires it in.

`rao_based_operability(forecast, rao, *, deployment_offset, velocity_limit, alpha, dt)` reuses the engine: `reconstruct_motion` (phased `WaveForecast` × vessel RAO) → `vertical_motion_at` (rigid-body lever arm to the ROV splash-zone / A-frame deployment point) → `time_derivative` → significant vertical velocity, screened against a rated limit (IMCA R 004 / R 015 snatch-load avoidance). Returns `RaoOperabilityResult{v_significant, v_oplim, utilisation, margin, operable}` mirroring the existing `SeaStateResult` conventions.

- **Additive & feature-flagged:** the existing `seastate_operability` / `scatter_operability` Hs screens are untouched; `motion_forecast`/`numpy` are lazy-imported inside the function so the module stays import-light.
- Module docstring updated (the path is no longer "deferred").

## Validation — 20 tests (16 existing Hs + 4 new)
- Operable vs not-operable bracketed around the measured significant velocity.
- Lever arm at a non-zero offset increases the deployment-point velocity (pitch-induced).
- Invalid inputs (`velocity_limit ≤ 0`, `alpha` out of range) raise; existing Hs screens still green.

Refs #1358 #1356
