### PR TITLE
feat(motion_forecast): wire directional wave_forecast into router (#1357)

### DIFF
--- a/src/digitalmodel/motion_forecast/workflow.py
+++ b/src/digitalmodel/motion_forecast/workflow.py
@@ -72,6 +72,43 @@ def _build_rao(rao_cfg: Dict):
     return generic_vessel_rao()
 
 
+def _build_forecast(sea: Dict):
+    """Build the incident-wave forecast per ``sea['forecaster']``.
+
+    ``"synthetic"`` (default) — long-crested JONSWAP with a caller-set horizon
+    (``wave_source``, unchanged / backward-compatible). ``"directional"`` — the
+    #1357 short-crested forecaster with a physics predictable-zone horizon
+    (``coherence_horizon``, or ``dpz_horizon`` when a measurement ``aperture`` is
+    given).
+    """
+    kind = sea.get("forecaster", "synthetic")
+    if kind == "synthetic":
+        return synthesize_forecast(
+            hs=float(sea.get("hs", 2.5)),
+            tp=float(sea.get("tp", 9.0)),
+            gamma=float(sea.get("gamma", 3.3)),
+            heading=float(sea.get("heading", 0.0)),
+            n_components=int(sea.get("n_components", 48)),
+            horizon=float(sea.get("horizon", 90.0)),
+            seed=int(sea.get("seed", 20260704)),
+        )
+    if kind == "directional":
+        from .wave_forecast import synthesize_directional_forecast
+
+        aperture = sea.get("aperture")
+        return synthesize_directional_forecast(
+            float(sea.get("hs", 2.5)), float(sea.get("tp", 9.0)),
+            gamma=float(sea.get("gamma", 3.3)),
+            mean_heading=float(sea.get("mean_heading", sea.get("heading", 0.0))),
+            spread_s=float(sea.get("spread_s", 10.0)),
+            n_freq=int(sea.get("n_freq", sea.get("n_components", 32))),
+            n_dir=int(sea.get("n_dir", 7)),
+            aperture=(float(aperture) if aperture is not None else None),
+            seed=int(sea.get("seed", 20260704)),
+        )
+    raise ValueError(f"unknown forecaster {kind!r}; use 'synthetic' or 'directional'")
+
+
 def router(cfg: Dict) -> Dict:
     """Run a motion forecast and write results back into ``cfg``."""
     mf = cfg.setdefault("motion_forecast", {})
@@ -79,15 +116,7 @@ def router(cfg: Dict) -> Dict:
     rao_cfg = mf.get("rao", {})
     asset = mf.get("asset", {})
 
-    forecast = synthesize_forecast(
-        hs=float(sea.get("hs", 2.5)),
-        tp=float(sea.get("tp", 9.0)),
-        gamma=float(sea.get("gamma", 3.3)),
-        heading=float(sea.get("heading", 0.0)),
-        n_components=int(sea.get("n_components", 48)),
-        horizon=float(sea.get("horizon", 90.0)),
-        seed=int(sea.get("seed", 20260704)),
-    )
+    forecast = _build_forecast(sea)
     rao = _build_rao(rao_cfg)
     location = tuple(asset.get("location", (0.0, 0.0)))
     motion = reconstruct_motion(

--- a/tests/motion_forecast/test_workflow.py
+++ b/tests/motion_forecast/test_workflow.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from digitalmodel.motion_forecast import DOF_NAMES
 from digitalmodel.motion_forecast.workflow import router
 
@@ -129,6 +131,40 @@ def test_router_emits_skill_summary():
     assert set(out["skill_summary"]) == set(DOF_NAMES)
     assert out["skill_summary"]["heave"]["rmse"] > 0.0
     assert out["skill_summary"]["heave"]["n_samples"] == 161 * 2
+
+
+def test_router_directional_forecaster():
+    cfg = {
+        "basename": "motion_forecast",
+        "motion_forecast": {
+            "sea": {"hs": 2.5, "tp": 9.0, "forecaster": "directional",
+                    "n_freq": 24, "n_dir": 5, "spread_s": 12.0},
+            "rao": {"source": "analytic"},
+            "asset": {"dt": 0.5},
+        },
+    }
+    res = router(cfg)["motion_forecast"]["results"]
+    assert res["n_components"] == 24 * 5              # freq x dir set
+    assert 15.0 <= res["horizon"] <= 120.0           # physics predictable-zone
+    assert len(res["t"]) == len(res["dof"]["heave"])
+
+
+def test_router_synthetic_default_unchanged():
+    # no 'forecaster' key -> long-crested synthetic with the caller's horizon
+    cfg = {"basename": "motion_forecast",
+           "motion_forecast": {"sea": {"hs": 2.0, "tp": 9.0, "horizon": 70.0,
+                                       "n_components": 32},
+                               "rao": {"source": "analytic"}}}
+    res = router(cfg)["motion_forecast"]["results"]
+    assert res["n_components"] == 32 and res["horizon"] == 70.0
+
+
+def test_router_unknown_forecaster_raises():
+    cfg = {"basename": "motion_forecast",
+           "motion_forecast": {"sea": {"forecaster": "bogus"},
+                               "rao": {"source": "analytic"}}}
+    with pytest.raises(ValueError, match="unknown forecaster"):
+        router(cfg)
 
 
 def test_engine_dispatch_wired():


### PR DESCRIPTION
## What

Wires the #1357 `wave_forecast` module into `motion_forecast.workflow.router` so the full pipeline runs from one config. The router now dispatches on `sea['forecaster']`:
- **`synthetic`** (default, unchanged) — long-crested `wave_source` with the caller's horizon. **Fully backward compatible.**
- **`directional`** — the #1357 short-crested forecaster with a **physics predictable-zone horizon** (`coherence_horizon`, or `dpz_horizon` when an `aperture` is given), driven by `n_freq / n_dir / spread_s / mean_heading / aperture`.

Makes the whole offering (physics forecast → motion → decision → measured reconcile → skill) runnable from a single `motion_forecast` config.

## Validation — 10 workflow tests
- New directional path: `n_components = n_freq×n_dir`, horizon within the realistic physics band.
- **Synthetic default unchanged** (explicit regression test).
- Unknown forecaster raises.

Small, additive, backward-compatible; reuses the already-reviewed #1357 functions.

Refs #1357 #1356