### PR TITLE
fix(docs): sync operator map + registry with motion_forecast & residual domains (green main)

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -33,6 +33,7 @@ of duplicating its detailed issue history.
 | `floating_wind` | `src/digitalmodel/floating_wind/` | `tests/floating_wind/` | `docs/domains/README.md` | Floating-wind global sizing & concept screening (semi/spar/TLP/barge); `floating_wind_sizing` workflow | hydrostatics, parametric sweeps, OrcaWave/OrcaFlex (solver tier) |
 | `hydrostatics` | `src/digitalmodel/hydrostatics/` | `tests/hydrostatics/` | `docs/domains/README.md` | Fluid-column hydrostatics; seabed/hydrostatic pressure and offshore pressure-unit conversions | NumPy |
 | `mooring_resilience` | `src/digitalmodel/mooring_resilience/` | `tests/` | `docs/domains/README.md` | Mooring-system resilience screening (intact/damaged tension, foundation, fatigue) over pre-computed atlases | mooring atlases, API RP 2SK / DNV-OS-E301 |
+| `motion_forecast` | `src/digitalmodel/motion_forecast/` | `tests/motion_forecast/` | `docs/domains/README.md` | Short-horizon vessel/structure motion forecast, operability go/no-go (#1358) | NumPy, RAO/hydrodynamics |
 | `naval_architecture` | `src/digitalmodel/naval_architecture/` | `tests/naval_architecture/` | `docs/domains/README.md` | Stability, hull form, compliance, gyradius calculations; loading computer (#1035) | naval architecture standards |
 | `reporting` | `src/digitalmodel/reporting/` | `tests/reporting/` | `docs/domains/README.md` | Shared report block library / backbone (report-as-backbone, #1018) | pydantic, HTML rendering |
 | `nde` | `src/digitalmodel/nde/` | `tests/nde/` | `docs/domains/README.md` | Non-destructive examination workflows and checks | inspection standards |
@@ -42,6 +43,7 @@ of duplicating its detailed issue history.
 | `production_chemistry` | `src/digitalmodel/production_chemistry/` | `tests/production_chemistry/` | `docs/domains/README.md` | Mineral-scale saturation indices (Oddo-Tomson), brine mixing/waterflood compatibility | NumPy, pandas |
 | `production_engineering` | `src/digitalmodel/production_engineering/` | `tests/production_engineering/` | `docs/domains/README.md` | Well testing, nodal analysis, production quality scoring | petroleum engineering models |
 | `reservoir` | `src/digitalmodel/reservoir/` | `tests/reservoir/` | `docs/domains/reservoir/` | Reservoir engineering and production-support calculations | reservoir engineering models |
+| `residual` | `src/digitalmodel/residual/` | `tests/residual/` | `docs/domains/README.md` | Transparent, bounded residual-correction spine for the hybrid digital twin (#1374) | NumPy |
 | `signal_processing` | `src/digitalmodel/signal_processing/` | `tests/signal_processing/` | `docs/domains/signal_processing/` | Signal analysis, filters, time-series utilities | NumPy, SciPy |
 | `solvers` | `src/digitalmodel/solvers/` | `tests/solvers/` | `docs/domains/solvers/` | Solver adapters, OrcaFlex/OrcaWave/AQWA workflows, batch execution | solver-specific APIs |
 | `specialized` | `src/digitalmodel/specialized/` | `tests/specialized/` | `docs/domains/specialized/` | Specialized/non-core modules pending routing cleanup | mixed utilities |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -116,6 +116,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#mooring_resilience
+  - module: motion_forecast
+    entry_point: src/digitalmodel/motion_forecast/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/motion_forecast/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#motion_forecast
   - module: naval_architecture
     entry_point: src/digitalmodel/naval_architecture/
     maturity: beta
@@ -170,6 +176,12 @@ modules:
     owner_wiki: docs/domains/reservoir/
     key_tests: [tests/reservoir/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#reservoir
+  - module: residual
+    entry_point: src/digitalmodel/residual/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/residual/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#residual
   - module: signal_processing
     entry_point: src/digitalmodel/signal_processing/
     maturity: beta


### PR DESCRIPTION
## Problem — main is red

`tests/docs/test_digitalmodel_routing_contract.py::test_operator_map_rows_match_live_source_tree` (and its registry-coverage companion) is **failing on main**. `src/digitalmodel/` has **62** packages but the operator map + routing registry list only **60** — the recently-merged **`motion_forecast`** (#1358) and **`residual`** (#1374, twin B) domains were added to `src/` without their routing rows.

This surfaced as the `tests-contracts` / `Domain test aggregate` failure on the open PR **#1403** (drilling-riser explorer) — which is **not #1403's fault**; it inherits main's breakage.

## Fix
Add both domains to:
- `docs/maps/digitalmodel-operator-map.md` (2 table rows)
- `docs/registry/module-routing.yaml` (2 entries; `maturity: beta`, `key_tests` → the existing `tests/motion_forecast/` [15 files] and `tests/residual/` [2 files])

**Verified locally:** `package_domains() == operator_map_domains() == registry_domains()` = 62, all set-diffs empty → both contract tests pass.

## Notes
- **Not caused by the capabilities-page work** — that added scripts + docs only, no new `src/` domain.
- Owning lanes (motion_forecast / twin) can refine the maturity/description later; this just restores green.
- Unblocks the contract gate cosmetically failing on every open PR.