### PR TITLE
feat(motion_forecast): lumped SDOF top-tension screen (#1359 fast-follow)

### DIFF
--- a/src/digitalmodel/motion_forecast/__init__.py
+++ b/src/digitalmodel/motion_forecast/__init__.py
@@ -60,6 +60,13 @@ from .wave_forecast import (
     surface_elevation,
     synthesize_directional_forecast,
 )
+from .top_tension import (
+    LumpedLine,
+    TensionResult,
+    displacement_transmissibility,
+    dynamic_tension,
+    force_transmissibility,
+)
 from .wave_source import jonswap_spectrum, synthesize_forecast
 from .workflow import router
 
@@ -116,4 +123,9 @@ __all__ = [
     "surface_elevation",
     "WaveFieldSource",
     "SyntheticWaveField",
+    "LumpedLine",
+    "TensionResult",
+    "dynamic_tension",
+    "displacement_transmissibility",
+    "force_transmissibility",
 ]

--- a/src/digitalmodel/motion_forecast/top_tension.py
+++ b/src/digitalmodel/motion_forecast/top_tension.py
@@ -1,0 +1,173 @@
+"""Lumped SDOF dynamic top-tension screen (motion_forecast, #1359 fast-follow).
+
+Upgrades #1359's kinematic ``top_connection_vertical_velocity`` proxy to a
+force-based screen. The deployed payload (ROV/TMS or a lifted module) is modelled
+as a single mass on the lift-line axial stiffness, **base-excited** by the
+deployment-point vertical motion (the standard DNV-RP-N103 splash-zone lift
+screen)::
+
+    m*x'' + c*(x' - z_top') + k*(x - z_top) = 0       (deviations from equilibrium)
+    T(t) = static_tension + k*(z_top - x) + c*(z_top' - x')
+
+with ``m = payload + added mass``, ``k = EA/L``, ``c = 2*zeta*sqrt(k*m)``.
+
+HONESTY BOUNDARY: this is a lumped SDOF screen. It flags **slack onset**
+(``T <= 0``) but does NOT resolve the nonlinear snatch impact load, and is NOT a
+distributed riser/line dynamics model. Past first slack the linear model is
+invalid, so ``daf`` is flagged not-trustworthy. ``zeta`` linearizes the (really
+quadratic) hydrodynamic drag — acceptable for a screen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .reconstruct import time_derivative, vertical_motion_at
+
+
+@dataclass(frozen=True)
+class LumpedLine:
+    """Lumped lift-line + payload for the SDOF tension screen.
+
+    Parameters
+    ----------
+    payload_mass:
+        Deployed dry/structural mass [kg], > 0.
+    added_mass:
+        Hydrodynamic added mass [kg], >= 0.
+    ea:
+        Line axial stiffness product E*A [N], > 0.
+    length:
+        Deployed line length [m], > 0 (``k = ea/length``).
+    damping_ratio:
+        Linearized damping ratio ``zeta`` in (0, 1).
+    static_tension:
+        Still-water tension the line carries (submerged weight) [N], > 0.
+    """
+
+    payload_mass: float
+    added_mass: float
+    ea: float
+    length: float
+    damping_ratio: float
+    static_tension: float
+
+    def __post_init__(self):
+        if self.payload_mass <= 0 or self.ea <= 0 or self.length <= 0:
+            raise ValueError("payload_mass, ea, length must be > 0")
+        if self.added_mass < 0:
+            raise ValueError("added_mass must be >= 0")
+        if self.static_tension <= 0:
+            raise ValueError("static_tension must be > 0")
+        if not (0.0 < self.damping_ratio < 1.0):
+            raise ValueError("damping_ratio must be in (0, 1) (over-damped excluded)")
+
+    @property
+    def m(self) -> float:
+        return self.payload_mass + self.added_mass
+
+    @property
+    def k(self) -> float:
+        return self.ea / self.length
+
+    @property
+    def c(self) -> float:
+        return 2.0 * self.damping_ratio * np.sqrt(self.k * self.m)
+
+    @property
+    def wn(self) -> float:
+        return float(np.sqrt(self.k / self.m))
+
+
+def displacement_transmissibility(omega: float, line: LumpedLine) -> float:
+    """|X/Z_top| — payload displacement per unit base displacement (base excitation)."""
+    k, m, c = line.k, line.m, line.c
+    num = complex(k, omega * c)
+    den = complex(k - m * omega * omega, omega * c)
+    return float(abs(num / den))
+
+
+def force_transmissibility(omega: float, line: LumpedLine) -> float:
+    """Tension-oscillation amplitude per unit base displacement [N/m].
+
+    The dynamic tension is the payload inertia force ``m*x''``, so it carries an
+    extra ``(omega/wn)^2`` vs the displacement transmissibility:
+    ``m * omega^2 * |X/Z_top|``.
+    """
+    return line.m * omega * omega * displacement_transmissibility(omega, line)
+
+
+@dataclass
+class TensionResult:
+    """Dynamic top-tension screen result."""
+
+    t: np.ndarray
+    tension: np.ndarray
+    daf: float           # peak line load / static_tension (max(T), not max|T|)
+    min_tension: float
+    snatch: bool         # min_tension <= 0 -> line goes slack
+    daf_valid: bool      # False when snatch (linear model invalid past first slack)
+
+
+def _newmark(z: np.ndarray, zdot: np.ndarray, dt: float, line: LumpedLine):
+    """Newmark-beta (beta=1/4, gamma=1/2) base-excited SDOF -> payload x, x'."""
+    m, c, k = line.m, line.c, line.k
+    beta, gamma = 0.25, 0.5
+    f = c * zdot + k * z                       # absolute-coordinate forcing
+    n = z.size
+    x = np.zeros(n)
+    v = np.zeros(n)
+    a = np.zeros(n)
+    x[0] = z[0]                                 # start at quasi-equilibrium
+    v[0] = zdot[0]
+    a[0] = (f[0] - c * v[0] - k * x[0]) / m
+    a1 = 1.0 / (beta * dt * dt)
+    a2 = 1.0 / (beta * dt)
+    a3 = 1.0 / (2.0 * beta) - 1.0
+    a4 = gamma / (beta * dt)
+    a5 = gamma / beta - 1.0
+    a6 = dt * (gamma / (2.0 * beta) - 1.0)
+    keff = k + a4 * c + a1 * m
+    for i in range(n - 1):
+        feff = (f[i + 1]
+                + m * (a1 * x[i] + a2 * v[i] + a3 * a[i])
+                + c * (a4 * x[i] + a5 * v[i] + a6 * a[i]))
+        x[i + 1] = feff / keff
+        a[i + 1] = a1 * (x[i + 1] - x[i]) - a2 * v[i] - a3 * a[i]
+        v[i + 1] = v[i] + dt * ((1.0 - gamma) * a[i] + gamma * a[i + 1])
+    return x, v
+
+
+def dynamic_tension(motion, line: LumpedLine, *, top_offset=(0.0, 0.0, 0.0)) -> TensionResult:
+    """Dynamic line tension at the deployment point via the lumped SDOF screen.
+
+    The deployment-point vertical motion base-excites the payload; the line
+    tension is screened for dynamic amplification (``daf``) and slack onset
+    (``snatch``). Refines the time grid to ``<= Tn/20`` for integrator accuracy
+    near a short natural period.
+    """
+    z_coarse = vertical_motion_at(motion, top_offset)
+    zdot_coarse = time_derivative(motion.t, z_coarse)
+    t0, t1 = float(motion.t[0]), float(motion.t[-1])
+
+    tn = 2.0 * np.pi / line.wn
+    dt_grid = (t1 - t0) / max(1, motion.t.size - 1)
+    dt = min(dt_grid, tn / 20.0)
+    n = max(2, int(np.ceil((t1 - t0) / dt)) + 1)
+    t = np.linspace(t0, t1, n)
+    z = np.interp(t, motion.t, z_coarse)
+    zdot = np.interp(t, motion.t, zdot_coarse)
+
+    x, v = _newmark(z, zdot, t[1] - t[0], line)
+    tension = line.static_tension + line.k * (z - x) + line.c * (zdot - v)
+
+    tmax = float(np.max(tension))
+    tmin = float(np.min(tension))
+    snatch = tmin <= 0.0
+    return TensionResult(
+        t=t, tension=tension,
+        daf=tmax / line.static_tension,
+        min_tension=tmin, snatch=snatch, daf_valid=not snatch,
+    )

--- a/src/digitalmodel/motion_forecast/top_tension.py
+++ b/src/digitalmodel/motion_forecast/top_tension.py
@@ -148,16 +148,25 @@ def dynamic_tension(motion, line: LumpedLine, *, top_offset=(0.0, 0.0, 0.0)) -> 
     (``snatch``). Refines the time grid to ``<= Tn/20`` for integrator accuracy
     near a short natural period.
     """
+    if motion.t.size < 2 or not (float(motion.t[-1]) > float(motion.t[0])):
+        raise ValueError("dynamic_tension needs a motion with >= 2 samples spanning t1 > t0")
     z_coarse = vertical_motion_at(motion, top_offset)
     zdot_coarse = time_derivative(motion.t, z_coarse)
     t0, t1 = float(motion.t[0]), float(motion.t[-1])
 
     tn = 2.0 * np.pi / line.wn
-    dt_grid = (t1 - t0) / max(1, motion.t.size - 1)
+    dt_grid = (t1 - t0) / (motion.t.size - 1)
     dt = min(dt_grid, tn / 20.0)
     n = max(2, int(np.ceil((t1 - t0) / dt)) + 1)
+    if n > 2_000_000:
+        raise ValueError(
+            f"refined grid too large ({n} steps): line too stiff (Tn={tn:.3g}s) "
+            f"or record too long for this SDOF screen"
+        )
     t = np.linspace(t0, t1, n)
     z = np.interp(t, motion.t, z_coarse)
+    # Interpolate the coarse derivative (not re-differentiate the kinked interpolant);
+    # when refinement triggers, the screen's fidelity ceiling is the input sampling.
     zdot = np.interp(t, motion.t, zdot_coarse)
 
     x, v = _newmark(z, zdot, t[1] - t[0], line)

--- a/tests/motion_forecast/test_top_tension.py
+++ b/tests/motion_forecast/test_top_tension.py
@@ -1,0 +1,105 @@
+"""Lumped SDOF top-tension screen tests (digitalmodel #1359 fast-follow).
+
+The Newmark integrator is validated against the closed-form base-excitation
+transmissibilities (displacement and force/tension).
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.motion_forecast.models import DOF_NAMES, MotionForecast
+from digitalmodel.motion_forecast.top_tension import (
+    LumpedLine,
+    displacement_transmissibility,
+    dynamic_tension,
+    force_transmissibility,
+)
+from digitalmodel.motion_forecast.top_tension import _newmark
+
+
+def _line(static_tension=1.0e5, zeta=0.1):
+    # m = 10000 kg, k = 10000 N/m -> wn = 1.0 rad/s
+    return LumpedLine(payload_mass=5000.0, added_mass=5000.0, ea=1.0e6,
+                      length=100.0, damping_ratio=zeta, static_tension=static_tension)
+
+
+def _heave_motion(A, w, t):
+    dof = {d: np.zeros_like(t) for d in DOF_NAMES}
+    dof["heave"] = A * np.cos(w * t)
+    return MotionForecast(t=t, dof=dof, origin_time=float(t[0]),
+                          horizon=float(t[-1] - t[0]))
+
+
+def _tail_amp(x):
+    tail = x[x.size // 2:]
+    return 0.5 * (tail.max() - tail.min())
+
+
+def test_line_derived_properties():
+    ln = _line()
+    assert ln.m == 10000.0 and ln.k == pytest.approx(1.0e4)
+    assert ln.wn == pytest.approx(1.0)
+    assert ln.c == pytest.approx(2 * 0.1 * np.sqrt(1e4 * 1e4))
+
+
+def test_displacement_transmissibility_at_resonance():
+    ln = _line(zeta=0.1)
+    # base-excitation value sqrt(1+4 zeta^2)/(2 zeta), NOT 1/(2 zeta)
+    assert displacement_transmissibility(ln.wn, ln) == pytest.approx(
+        np.sqrt(1 + 4 * 0.1**2) / (2 * 0.1), rel=1e-9)
+
+
+def test_force_transmissibility_is_m_w2_times_displacement():
+    ln = _line()
+    w = 0.7
+    assert force_transmissibility(w, ln) == pytest.approx(
+        ln.m * w * w * displacement_transmissibility(w, ln), rel=1e-12)
+
+
+def test_newmark_matches_displacement_transmissibility():
+    ln = _line()
+    w, A = 0.5, 0.2
+    t = np.arange(0.0, 200.0, 0.05)
+    z = A * np.cos(w * t)
+    zdot = -A * w * np.sin(w * t)
+    x, _v = _newmark(z, zdot, t[1] - t[0], ln)
+    assert _tail_amp(x) == pytest.approx(displacement_transmissibility(w, ln) * A, rel=0.02)
+
+
+def test_tension_amplitude_matches_force_transmissibility():
+    ln = _line()
+    w, A = 0.5, 0.2
+    t = np.arange(0.0, 200.0, 0.1)
+    res = dynamic_tension(_heave_motion(A, w, t), ln)
+    amp = _tail_amp(res.tension)
+    assert amp == pytest.approx(force_transmissibility(w, ln) * A, rel=0.02)
+    assert not res.snatch and res.daf_valid
+    assert res.daf == pytest.approx(1.0 + amp / ln.static_tension, rel=0.02)
+
+
+def test_static_limit_daf_near_one_no_snatch():
+    ln = _line()
+    t = np.arange(0.0, 2000.0, 1.0)
+    res = dynamic_tension(_heave_motion(0.1, 0.01, t), ln)  # very slow base motion
+    assert res.daf == pytest.approx(1.0, abs=5e-3)
+    assert not res.snatch
+
+
+def test_large_near_resonance_triggers_snatch():
+    ln = _line(static_tension=1.0e5)
+    t = np.arange(0.0, 200.0, 0.1)
+    res = dynamic_tension(_heave_motion(3.0, 1.0, t), ln)  # A=3 at resonance
+    assert res.snatch and not res.daf_valid
+    assert res.min_tension <= 0.0
+
+
+@pytest.mark.parametrize("kw", [
+    {"payload_mass": 0.0}, {"ea": -1.0}, {"length": 0.0},
+    {"static_tension": 0.0}, {"damping_ratio": 1.0}, {"damping_ratio": 0.0},
+])
+def test_invalid_line_raises(kw):
+    base = dict(payload_mass=5000.0, added_mass=5000.0, ea=1.0e6,
+                length=100.0, damping_ratio=0.1, static_tension=1.0e5)
+    base.update(kw)
+    with pytest.raises(ValueError):
+        LumpedLine(**base)

--- a/tests/motion_forecast/test_top_tension.py
+++ b/tests/motion_forecast/test_top_tension.py
@@ -49,32 +49,47 @@ def test_displacement_transmissibility_at_resonance():
         np.sqrt(1 + 4 * 0.1**2) / (2 * 0.1), rel=1e-9)
 
 
-def test_force_transmissibility_is_m_w2_times_displacement():
-    ln = _line()
-    w = 0.7
-    assert force_transmissibility(w, ln) == pytest.approx(
-        ln.m * w * w * displacement_transmissibility(w, ln), rel=1e-12)
-
-
-def test_newmark_matches_displacement_transmissibility():
-    ln = _line()
-    w, A = 0.5, 0.2
-    t = np.arange(0.0, 200.0, 0.05)
+def _integrator_disp_amp(ln, w, A, dt=0.02, tmax=400.0):
+    t = np.arange(0.0, tmax, dt)
     z = A * np.cos(w * t)
     zdot = -A * w * np.sin(w * t)
-    x, _v = _newmark(z, zdot, t[1] - t[0], ln)
-    assert _tail_amp(x) == pytest.approx(displacement_transmissibility(w, ln) * A, rel=0.02)
+    x, _v = _newmark(z, zdot, dt, ln)
+    return _tail_amp(x)
+
+
+def test_newmark_matches_displacement_transmissibility_offresonance():
+    ln = _line()
+    w, A = 0.5, 0.2
+    assert _integrator_disp_amp(ln, w, A) == pytest.approx(
+        displacement_transmissibility(w, ln) * A, rel=5e-3)
+
+
+def test_newmark_matches_displacement_transmissibility_at_resonance():
+    # the hardest case for the integrator (largest amplitude/period error)
+    ln = _line(zeta=0.1)
+    A = 0.05
+    amp = _integrator_disp_amp(ln, ln.wn, A, dt=0.01, tmax=800.0)
+    assert amp == pytest.approx(displacement_transmissibility(ln.wn, ln) * A, rel=0.01)
 
 
 def test_tension_amplitude_matches_force_transmissibility():
     ln = _line()
     w, A = 0.5, 0.2
-    t = np.arange(0.0, 200.0, 0.1)
+    t = np.arange(0.0, 300.0, 0.1)
     res = dynamic_tension(_heave_motion(A, w, t), ln)
     amp = _tail_amp(res.tension)
-    assert amp == pytest.approx(force_transmissibility(w, ln) * A, rel=0.02)
+    assert amp == pytest.approx(force_transmissibility(w, ln) * A, rel=5e-3)
     assert not res.snatch and res.daf_valid
-    assert res.daf == pytest.approx(1.0 + amp / ln.static_tension, rel=0.02)
+    assert res.daf == pytest.approx(1.0 + amp / ln.static_tension, rel=5e-3)
+
+
+def test_single_sample_motion_raises():
+    ln = _line()
+    t = np.array([0.0])
+    dof = {d: np.zeros(1) for d in DOF_NAMES}
+    m = MotionForecast(t=t, dof=dof, origin_time=0.0, horizon=0.0)
+    with pytest.raises(ValueError, match=">= 2 samples"):
+        dynamic_tension(m, ln)
 
 
 def test_static_limit_daf_near_one_no_snatch():


### PR DESCRIPTION
## What

Upgrades #1359's **kinematic** top-tension proxy (`top_connection_vertical_velocity`, explicitly "not a tension") to a **force-based screen**: a lumped single-DOF dynamic model (`top_tension.py`).

The deployed payload (ROV/TMS or a lifted module) is modelled as a mass on the lift-line axial stiffness `k=EA/L`, **base-excited** by the deployment-point vertical motion — the standard DNV-RP-N103 splash-zone lift screen. `dynamic_tension` integrates the SDOF response (Newmark-β) and returns:
- **DAF** = `max(T)/static_tension` (peak line load),
- **`min_tension`** and a **slack/snatch flag** (`T ≤ 0`),
- with `daf_valid=False` past first slack.

### Honesty boundary
A lumped SDOF **screen** — it flags **slack onset**, it does **not** resolve the nonlinear snatch *impact load* or distributed riser/line dynamics (`daf` is flagged invalid once slack occurs). `ζ` linearizes the (quadratic) hydrodynamic drag. Full distributed line dynamics remain a riser-domain effort.

## Validation — 13 tests against closed forms
The Newmark integrator is checked against the **base-excitation** closed forms:
- **Displacement transmissibility** `|X/Z_top| = |(k+iωc)/(k−mω²+iωc)|` — integrator matches within 1–2%.
- **Force/tension transmissibility** `m·ω²·T_d` — the tension is the inertia force `m·ẍ`, so it carries the extra `(ω/ωₙ)²`; the tension amplitude matches this (not the displacement form).
- **Resonance:** `T_d(ωₙ) = √(1+4ζ²)/(2ζ)` (the base-excitation value, **not** the textbook `1/(2ζ)`).
- **Static limit** (ω→0): DAF≈1, no snatch; **snatch**: large near-resonant motion drives `min_tension ≤ 0`.
- LumpedLine guards (`m,k,static>0`, `ζ∈(0,1)`).

dt is internally refined to `≤ Tn/20` for integrator accuracy near a short natural period.

## Cross-review (Route C gate)
Adversarial physics + code review (the reviewer **algebraically re-derived the Newmark scheme** and confirmed the integrator constants, forcing, tension expression, and both transmissibilities are correct) → **APPROVE-WITH-CHANGES**, no blockers. Fixed:
- **Robustness:** `dynamic_tension` now raises on a single-sample / zero-span motion (was an opaque `int(nan)` crash) and caps the refined-grid size (a very stiff line over a long record could spin a multi-million-step loop).
- **Test honesty:** dropped a tautological `force_transmissibility` test (it re-asserted the implementation); added a **resonance-amplitude** integrator check (ω=ωₙ, the hardest case) against the closed form; tightened the off-resonance tolerances from 2% → 0.5% so a real ~1% integrator drift can't pass.
- Documented the input-sampling fidelity ceiling of the derivative interpolation.

Refs #1359 #1356
