### PR TITLE
twin E: integration + live demo loop (#1377)

### DIFF
--- a/docs/api/drilling/operability-monitor.html
+++ b/docs/api/drilling/operability-monitor.html
@@ -74,7 +74,10 @@
       <button class="pb" id="play" aria-label="Play or pause">&#9654; Play</button>
       <input id="scrub" type="range" min="0" value="0" step="1" aria-label="Scrub the telemetry track">
       <span class="tstamp" id="tlab">t = 0 s</span>
+      <span class="chip" id="verdict" style="font-size:13px;padding:4px 12px" aria-live="polite">
+        <span class="ic" id="vic"></span><span id="vlt"></span></span>
     </div>
+    <canvas id="vs" width="360" height="26" role="img" aria-label="Rolling GO / CAUTION / NO-GO verdict over the track" style="margin-top:4px"></canvas>
     <div class="row">
       <div>
         <div class="lab" style="font-size:11.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);font-weight:600;margin-bottom:6px">Watch circle</div>
@@ -340,7 +343,9 @@ const DATA = {
       "time_to_limit_s": 81.49,
       "lead_time_margin_s": 21.49,
       "point_of_disconnect_m": 4.095,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 21.49
     },
     {
       "t": 300.0,
@@ -359,7 +364,9 @@ const DATA = {
       "time_to_limit_s": 73.319,
       "lead_time_margin_s": 13.319,
       "point_of_disconnect_m": 6.421,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 13.319
     },
     {
       "t": 600.0,
@@ -378,7 +385,9 @@ const DATA = {
       "time_to_limit_s": 64.116,
       "lead_time_margin_s": 4.116,
       "point_of_disconnect_m": 9.04,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 4.116
     },
     {
       "t": 900.0,
@@ -397,7 +406,9 @@ const DATA = {
       "time_to_limit_s": 53.348,
       "lead_time_margin_s": -6.652,
       "point_of_disconnect_m": 12.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -6.652
     },
     {
       "t": 1200.0,
@@ -416,7 +427,9 @@ const DATA = {
       "time_to_limit_s": 39.763,
       "lead_time_margin_s": -20.237,
       "point_of_disconnect_m": 15.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -20.237
     },
     {
       "t": 1500.0,
@@ -435,7 +448,9 @@ const DATA = {
       "time_to_limit_s": 0.0,
       "lead_time_margin_s": -60.0,
       "point_of_disconnect_m": 24.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -60.0
     },
     {
       "t": 1800.0,
@@ -454,7 +469,9 @@ const DATA = {
       "time_to_limit_s": 53.348,
       "lead_time_margin_s": -6.652,
       "point_of_disconnect_m": 12.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -6.652
     },
     {
       "t": 2100.0,
@@ -473,10 +490,12 @@ const DATA = {
       "time_to_limit_s": 73.319,
       "lead_time_margin_s": 13.319,
       "point_of_disconnect_m": 6.421,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 13.319
     }
   ],
-  "fingerprint": "86ddf18d48f98f86"
+  "fingerprint": "8b998b9900aeda2a"
 };
 const TRACK = DATA.track, OFF = DATA.offset_pct, CUR = DATA.current_speed_mps;
 const CFG = DATA.scenario.config, GRID = DATA.configs[CFG];
@@ -492,6 +511,21 @@ function driftColor(st){
   if(st==='station_held') return css('--good');
   if(st==='escalate') return css('--escalate');
   return css('--warn'); // drift_off
+}
+function verdictColor(v){
+  if(v==='GO') return css('--good');
+  if(v==='CAUTION') return css('--warn');
+  return css('--serious'); // NO-GO
+}
+// rolling verdict strip — one cell per track point, coloured by the SERVED go_no_go
+// label (no recompute). This is the "traffic light" over the whole scenario.
+const vs=document.getElementById('vs'), vsx=vs.getContext('2d');
+function drawVS(){
+  const dpr=window.devicePixelRatio||1, W=vs.clientWidth||360, H=26;
+  vs.width=W*dpr; vs.height=H*dpr; vsx.setTransform(dpr,0,0,dpr,0,0); vsx.clearRect(0,0,W,H);
+  const n=TRACK.length, w=W/n;
+  TRACK.forEach((p,i)=>{ vsx.fillStyle=verdictColor(p.go_no_go); vsx.fillRect(i*w+1,0,w-2,H-8); });
+  vsx.fillStyle=css('--dot'); vsx.fillRect(idx*w+w/2-1,H-6,2,6);
 }
 function fmtT(s){ if(s===null) return '&infin;'; const m=Math.floor(s/60), r=Math.round(s%60); return m+':'+String(r).padStart(2,'0'); }
 
@@ -535,7 +569,11 @@ function render(){
   const p=TRACK[idx];
   document.getElementById('scrub').value=idx;
   document.getElementById('tlab').innerHTML='t = '+p.t+' s';
-  drawWC(p); drawTL();
+  drawWC(p); drawTL(); drawVS();
+  const vcol=verdictColor(p.go_no_go);
+  document.getElementById('vic').style.background=vcol;
+  document.getElementById('vlt').textContent='verdict '+p.go_no_go+
+    (p.lead_time_s!==null?' · '+Math.round(p.lead_time_s)+' s lead':'');
   document.getElementById('wcnote').innerHTML='Vessel offset <b>'+p.offset_m.toFixed(0)+' m</b> ('+
     p.offset_pct.toFixed(1)+'% WD) of allowable <b>'+p.r_watch_m.toFixed(0)+' m</b>'+
     (p.watch_frac!==null?' &middot; '+(p.watch_frac*100).toFixed(0)+'% of watch circle':'');

--- a/docs/api/drilling/operability-monitor.results.json
+++ b/docs/api/drilling/operability-monitor.results.json
@@ -219,7 +219,9 @@
       "time_to_limit_s": 81.49,
       "lead_time_margin_s": 21.49,
       "point_of_disconnect_m": 4.095,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 21.49
     },
     {
       "t": 300.0,
@@ -238,7 +240,9 @@
       "time_to_limit_s": 73.319,
       "lead_time_margin_s": 13.319,
       "point_of_disconnect_m": 6.421,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 13.319
     },
     {
       "t": 600.0,
@@ -257,7 +261,9 @@
       "time_to_limit_s": 64.116,
       "lead_time_margin_s": 4.116,
       "point_of_disconnect_m": 9.04,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 4.116
     },
     {
       "t": 900.0,
@@ -276,7 +282,9 @@
       "time_to_limit_s": 53.348,
       "lead_time_margin_s": -6.652,
       "point_of_disconnect_m": 12.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -6.652
     },
     {
       "t": 1200.0,
@@ -295,7 +303,9 @@
       "time_to_limit_s": 39.763,
       "lead_time_margin_s": -20.237,
       "point_of_disconnect_m": 15.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -20.237
     },
     {
       "t": 1500.0,
@@ -314,7 +324,9 @@
       "time_to_limit_s": 0.0,
       "lead_time_margin_s": -60.0,
       "point_of_disconnect_m": 24.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -60.0
     },
     {
       "t": 1800.0,
@@ -333,7 +345,9 @@
       "time_to_limit_s": 53.348,
       "lead_time_margin_s": -6.652,
       "point_of_disconnect_m": 12.0,
-      "drift_status": "escalate"
+      "drift_status": "escalate",
+      "go_no_go": "NO-GO",
+      "lead_time_s": -6.652
     },
     {
       "t": 2100.0,
@@ -352,8 +366,10 @@
       "time_to_limit_s": 73.319,
       "lead_time_margin_s": 13.319,
       "point_of_disconnect_m": 6.421,
-      "drift_status": "drift_off"
+      "drift_status": "drift_off",
+      "go_no_go": "CAUTION",
+      "lead_time_s": 13.319
     }
   ],
-  "fingerprint": "86ddf18d48f98f86"
+  "fingerprint": "8b998b9900aeda2a"
 }

--- a/scripts/drilling_riser/build_operability_monitor.py
+++ b/scripts/drilling_riser/build_operability_monitor.py
@@ -26,29 +26,27 @@ from __future__ import annotations
 
 import hashlib
 import json
-import math
 from pathlib import Path
 
 import yaml
 
 from digitalmodel.drilling_riser import operability_atlas as oa
-from digitalmodel.drilling_riser.conductor_response import solve_conductor_moment
-from digitalmodel.drilling_riser.drift_off import drift_off_screen
 from digitalmodel.drilling_riser.drift_off import load_config as load_drift_config
 from digitalmodel.drilling_riser.envelope import (
     ConductorInput,
-    CurrentProfile,
     EnvelopeCriteria,
     RiserSection,
 )
 from digitalmodel.drilling_riser.operability_screening import screen_operability
-from digitalmodel.drilling_riser.response_correction import (
-    correct_flexjoint_response,
-    fit_flexjoint_models,
-    flexjoint_utilisation,
+from digitalmodel.drilling_riser.response_correction import fit_flexjoint_models
+from digitalmodel.decision_spine import DISPLAY_LABEL
+from digitalmodel.drilling_riser.telemetry_inputs import parse_snapshots
+from digitalmodel.drilling_riser.twin_loop import (
+    STATIC_SCREEN_HS_CEILING_M,
+    _num,
+    _roll_verdict,
+    evaluate_point,
 )
-from digitalmodel.drilling_riser.riser_response import solve_static_response
-from digitalmodel.drilling_riser.telemetry_inputs import parse_snapshots, snapshot_to_offset_pct
 from digitalmodel.parametric.atlas import Atlas
 from digitalmodel.subsea.mooring_analysis.models import EnvironmentalConditions
 
@@ -81,13 +79,6 @@ _COND_BAND = {"soil_modulus_n_per_m2": 1_000_000.0, "stand_off_m": 5.0}
 
 def _sha(obj) -> str:
     return hashlib.sha256(json.dumps(obj, sort_keys=True).encode()).hexdigest()
-
-
-def _num(x):
-    """JSON-safe number: inf/nan -> None (station-held time-to-limit is 'no drift')."""
-    if x is None or (isinstance(x, float) and (math.isinf(x) or math.isnan(x))):
-        return None
-    return round(float(x), 3)
 
 
 def _criteria_from_atlas_config() -> tuple[EnvelopeCriteria, list[dict]]:
@@ -136,49 +127,19 @@ def build_results(atlas_root: Path | None = None) -> dict:
     t0 = snaps[0].timestamp
     track = []
     for snap in snaps:
-        off_pct = snapshot_to_offset_pct(snap, water_depth_m=wd)
-        # -- operability (twin A offset -> #1283 atlas) --
-        scr = screen_operability(token, off_pct, cur, atlas_root=root)
-        # -- physics prediction at the live point (for twin B + wellhead) --
-        drag = CurrentProfile(surface_speed_mps=cur).drag_load_n_per_m(section.outer_diameter_m)
-        pred = solve_static_response(length_m=length, top_offset_m=snap.vessel_offset_m,
-                                     tension_n=tension, ei_nm2=section.ei_nm2, current_load_n_per_m=drag)
-        pred_angle = max(abs(pred.angle_upper_deg), abs(pred.angle_lower_deg))
-        # -- flex-joint (twin B: correct the prediction; decision = max(corrected, raw)) --
-        corr = correct_flexjoint_response(pred, models)
-        fj_uc = flexjoint_utilisation(corr.decision_static_angle_deg, criteria)
-        meas = snap.measured
-        meas_angle = None
-        if meas is not None:
-            vals = [abs(v) for v in (meas.flexjoint_angle_upper_deg, meas.flexjoint_angle_lower_deg) if v is not None]
-            meas_angle = max(vals) if vals else None
-        # -- wellhead bending-moment INDICATOR (kN·m only; no capacity, no UC) --
-        wh = solve_conductor_moment(shear_n=pred.shear_lower_n, stand_off_m=conductor.stand_off_m,
-                                    soil_modulus_n_per_m2=conductor.soil_modulus_n_per_m2, ei_nm2=conductor.ei_nm2)
-        wh_moment_knm = wh.max_moment_nm / 1000.0
-        # -- drift-off (twin C: watch-circle + time-to-limit) --
-        dr = drift_off_screen(snap.dp, condition, section=section, water_depth_m=wd, length_m=length,
-                              tension_n=tension, criteria=criteria, config=drift_cfg, x0_m=snap.vessel_offset_m)
-        watch_frac = snap.vessel_offset_m / dr.r_watch_m if dr.r_watch_m > 0 else None
-        track.append({
-            "t": round((snap.timestamp - t0).total_seconds(), 1),
-            "offset_m": round(snap.vessel_offset_m, 3),
-            "offset_pct": round(off_pct, 4),
-            "operability_uc": round(float(scr.governing_utilisation), 6) if scr.governing_utilisation is not None else None,
-            "light": scr.light,
-            "flexjoint_uc": round(float(fj_uc), 6),
-            "measured_angle_deg": None if meas_angle is None else round(meas_angle, 3),
-            "predicted_angle_deg": round(pred_angle, 3),
-            "corrected_angle_deg": round(corr.corrected_static_angle_deg, 3),
-            "decision_angle_deg": round(corr.decision_static_angle_deg, 3),
-            "wh_moment_knm": round(wh_moment_knm, 3),
-            "r_watch_m": round(dr.r_watch_m, 3),
-            "watch_frac": None if watch_frac is None else round(watch_frac, 4),
-            "time_to_limit_s": _num(dr.time_to_limit_s),
-            "lead_time_margin_s": _num(dr.lead_time_margin_s),
-            "point_of_disconnect_m": _num(dr.point_of_disconnect_m),
-            "drift_status": dr.status,
-        })
+        p = evaluate_point(
+            snap, token=token, section=section, conductor=conductor, condition=condition,
+            cur=cur, water_depth_m=wd, length_m=length, tension_n=tension, criteria=criteria,
+            models=models, drift_cfg=drift_cfg, atlas_root=root, t0=t0,
+        )
+        # twin E #1377: the rolled conservative verdict for THIS demo point (fixed sea =
+        # the atlas static-screen ceiling, so the seastate-domain guard is in-domain here;
+        # the rolling-metocean guard is exercised by twin_loop.run_twin_loop + its test).
+        state, lead = _roll_verdict(p, wave_hs_m=float(condition.wave_hs),
+                                    hs_ceiling_m=STATIC_SCREEN_HS_CEILING_M)
+        p["go_no_go"] = DISPLAY_LABEL[state]
+        p["lead_time_s"] = _num(lead)
+        track.append(p)
 
     # scenario config's atlas grid (the heatmap backdrop for the watch-circle-in-envelope view)
     offset_axis = [ax for ax in atlas.axes if ax.name == "offset_pct"][0].grid
@@ -312,7 +273,10 @@ _TEMPLATE = r"""<!DOCTYPE html>
       <button class="pb" id="play" aria-label="Play or pause">&#9654; Play</button>
       <input id="scrub" type="range" min="0" value="0" step="1" aria-label="Scrub the telemetry track">
       <span class="tstamp" id="tlab">t = 0 s</span>
+      <span class="chip" id="verdict" style="font-size:13px;padding:4px 12px" aria-live="polite">
+        <span class="ic" id="vic"></span><span id="vlt"></span></span>
     </div>
+    <canvas id="vs" width="360" height="26" role="img" aria-label="Rolling GO / CAUTION / NO-GO verdict over the track" style="margin-top:4px"></canvas>
     <div class="row">
       <div>
         <div class="lab" style="font-size:11.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--muted);font-weight:600;margin-bottom:6px">Watch circle</div>
@@ -373,6 +337,21 @@ function driftColor(st){
   if(st==='escalate') return css('--escalate');
   return css('--warn'); // drift_off
 }
+function verdictColor(v){
+  if(v==='GO') return css('--good');
+  if(v==='CAUTION') return css('--warn');
+  return css('--serious'); // NO-GO
+}
+// rolling verdict strip — one cell per track point, coloured by the SERVED go_no_go
+// label (no recompute). This is the "traffic light" over the whole scenario.
+const vs=document.getElementById('vs'), vsx=vs.getContext('2d');
+function drawVS(){
+  const dpr=window.devicePixelRatio||1, W=vs.clientWidth||360, H=26;
+  vs.width=W*dpr; vs.height=H*dpr; vsx.setTransform(dpr,0,0,dpr,0,0); vsx.clearRect(0,0,W,H);
+  const n=TRACK.length, w=W/n;
+  TRACK.forEach((p,i)=>{ vsx.fillStyle=verdictColor(p.go_no_go); vsx.fillRect(i*w+1,0,w-2,H-8); });
+  vsx.fillStyle=css('--dot'); vsx.fillRect(idx*w+w/2-1,H-6,2,6);
+}
 function fmtT(s){ if(s===null) return '&infin;'; const m=Math.floor(s/60), r=Math.round(s%60); return m+':'+String(r).padStart(2,'0'); }
 
 // --- watch-circle plan: allowable radius ring + vessel-offset dot (linear scale, no physics) ---
@@ -415,7 +394,11 @@ function render(){
   const p=TRACK[idx];
   document.getElementById('scrub').value=idx;
   document.getElementById('tlab').innerHTML='t = '+p.t+' s';
-  drawWC(p); drawTL();
+  drawWC(p); drawTL(); drawVS();
+  const vcol=verdictColor(p.go_no_go);
+  document.getElementById('vic').style.background=vcol;
+  document.getElementById('vlt').textContent='verdict '+p.go_no_go+
+    (p.lead_time_s!==null?' · '+Math.round(p.lead_time_s)+' s lead':'');
   document.getElementById('wcnote').innerHTML='Vessel offset <b>'+p.offset_m.toFixed(0)+' m</b> ('+
     p.offset_pct.toFixed(1)+'% WD) of allowable <b>'+p.r_watch_m.toFixed(0)+' m</b>'+
     (p.watch_frac!==null?' &middot; '+(p.watch_frac*100).toFixed(0)+'% of watch circle':'');

--- a/src/digitalmodel/decision_spine.py
+++ b/src/digitalmodel/decision_spine.py
@@ -1,0 +1,54 @@
+"""Shared rolling go/no-go spine (#1377).
+
+The classifier + lead-time mechanics that BOTH the motion-forecast rolling decision
+(#1359, ``motion_forecast.decision``) and the drilling-riser twin loop (#1377,
+``drilling_riser.twin_loop``) roll their verdicts with — the single "one rolling-verdict
+spine" the two domains share. Generic over any ``(t, magnitude-series, caution, limit)``;
+imports only numpy + the ``DecisionState`` taxonomy from
+``marine_ops.installation.go_no_go`` (no motion / riser domain imports, no cycles).
+
+``motion_forecast.decision`` RE-EXPORTS these names, so ``decision._classify`` /
+``decision._first_crossing`` / ``decision.DISPLAY_LABEL`` keep resolving for existing
+consumers (e.g. ``motion_forecast.reconcile``).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+
+#: "CAUTION" is the operator-facing display label for ``DecisionState.MARGINAL``.
+DISPLAY_LABEL = {
+    DecisionState.GO: "GO",
+    DecisionState.MARGINAL: "CAUTION",
+    DecisionState.NO_GO: "NO-GO",
+}
+
+
+def _first_crossing(t: np.ndarray, v: np.ndarray, level: float, now: float) -> Optional[float]:
+    """Lead time (s) to the first sample with ``v > level`` (strict), else None.
+
+    Strict ``>`` keeps this consistent with :func:`_classify` and the reused
+    ``go_no_go._check_criterion`` band (``value == limit`` is still MARGINAL, so
+    it must not register as a NO-GO crossing).
+    """
+    mask = v > level
+    if not mask.any():
+        return None
+    return float(t[int(np.argmax(mask))] - now)
+
+
+def _classify(value: float, caution: float, limit: float) -> DecisionState:
+    """Classify a governing value, matching ``_check_criterion`` boundaries.
+
+    ``value > limit`` -> NO_GO (FAIL); ``value > caution`` -> MARGINAL (WARNING);
+    else GO (PASS). NaN is unsafe -> NO_GO (fail-closed)."""
+    if not np.isfinite(value):
+        return DecisionState.NO_GO
+    if value > limit:
+        return DecisionState.NO_GO
+    if value > caution:
+        return DecisionState.MARGINAL
+    return DecisionState.GO

--- a/src/digitalmodel/drilling_riser/twin_loop.py
+++ b/src/digitalmodel/drilling_riser/twin_loop.py
@@ -211,7 +211,7 @@ class _Context(NamedTuple):
     conductor: ConductorInput
     wd: float
     length: float
-    tension: float
+    tension_n: float
     criteria: EnvelopeCriteria
     models: FlexjointModels
     drift_cfg: dict
@@ -250,7 +250,7 @@ def _load_context(atlas_root: Path | None = None) -> _Context:
     )
     return _Context(
         token=sc["config"], section=section, conductor=conductor,
-        wd=float(sc["water_depth_m"]), length=float(sc["length_m"]), tension=float(sc["tension_n"]),
+        wd=float(sc["water_depth_m"]), length=float(sc["length_m"]), tension_n=float(sc["tension_n"]),
         criteria=criteria, models=models, drift_cfg=load_drift_config(),
         root=(atlas_root or (repo / "atlases")),
     )
@@ -287,7 +287,7 @@ def run_twin_loop(
         point = evaluate_point(
             snap, token=ctx.token, section=ctx.section, conductor=ctx.conductor,
             condition=condition, cur=cur, water_depth_m=ctx.wd, length_m=ctx.length,
-            tension_n=ctx.tension, criteria=ctx.criteria, models=ctx.models,
+            tension_n=ctx.tension_n, criteria=ctx.criteria, models=ctx.models,
             drift_cfg=ctx.drift_cfg, atlas_root=ctx.root, t0=t0,
         )
         state, lead = _roll_verdict(point, wave_hs_m=hs, hs_ceiling_m=hs_ceiling_m)

--- a/src/digitalmodel/drilling_riser/twin_loop.py
+++ b/src/digitalmodel/drilling_riser/twin_loop.py
@@ -1,0 +1,291 @@
+"""Drilling-riser twin loop — the shared per-point composition engine + the rolling
+GO/CAUTION/NO-GO integration (twin E #1377, epic #1372; the end-to-end proof).
+
+``evaluate_point`` is the per-telemetry-point composition extracted verbatim from the
+twin D monitor build (#1376) so the monitor page and this loop share ONE engine (DRY):
+for a single snapshot + environmental condition it composes the five merged seams —
+operability (#1283 atlas), flex-joint with the twin-B measured-tracking correction
+(decision = max(corrected, raw)), a wellhead bending-MOMENT indicator (kN·m only, no
+capacity/UC), and the twin-C drift-off screen — into one allow-listed track dict.
+
+``run_twin_loop`` wires the metocean feed (#1282) into a ROLLING loop and rolls the
+composed gauges into ONE conservative, fail-closed verdict per timestep:
+
+  * the verdict is the WORST DecisionState across the gauges (NO_GO > MARGINAL > GO);
+  * the operability gauge is consumed via the atlas's own ``light`` (OPERABLE / ESCALATE
+    / INOPERABLE) — a missing / out-of-range operability value fails closed to NO_GO
+    BEFORE any classify (never a silent GO); ESCALATE is indeterminate, never a clean
+    CAUTION;
+  * the atlas is FROZEN at its build seastate — a rolling ``wave_hs`` above the build Hs
+    puts the operability gauge OUT OF ITS DOMAIN, so the verdict fails closed (the
+    seastate-domain guard) rather than trusting a frozen operability call;
+  * drift-off is gated on the lead-time MAGNITUDE (a negative EDS window is NO_GO), not
+    the categorical status alone;
+  * ``lead_time_s`` is the drift-off physics projection only (``lead_time_margin_s``) —
+    this is a replay of recorded telemetry, not a forecast, so no retrospective
+    first-crossing is claimed.
+
+Limits stay the cited getters (via the atlas config's criteria); the verdict carries the
+screening-tier disclaimer. Deterministic + offline (committed atlas + synthetic fixtures).
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Iterable, Mapping, NamedTuple
+
+import yaml
+
+from digitalmodel.decision_spine import DISPLAY_LABEL, _classify
+from digitalmodel.drilling_riser import operability_atlas as oa
+from digitalmodel.drilling_riser.conductor_response import solve_conductor_moment
+from digitalmodel.drilling_riser.drift_off import drift_off_screen
+from digitalmodel.drilling_riser.drift_off import load_config as load_drift_config
+from digitalmodel.drilling_riser.envelope import (
+    ConductorInput,
+    CurrentProfile,
+    EnvelopeCriteria,
+    RiserSection,
+)
+from digitalmodel.drilling_riser.operability_screening import screen_operability
+from digitalmodel.drilling_riser.response_correction import (
+    FlexjointModels,
+    correct_flexjoint_response,
+    fit_flexjoint_models,
+    flexjoint_utilisation,
+)
+from digitalmodel.drilling_riser.riser_response import solve_static_response
+from digitalmodel.drilling_riser.telemetry_inputs import (
+    TelemetrySnapshot,
+    parse_snapshots,
+    snapshot_to_offset_pct,
+)
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+from digitalmodel.parametric.atlas import Atlas
+from digitalmodel.subsea.mooring_analysis.models import EnvironmentalConditions
+
+#: Severity ordering for the worst-of roll-up.
+_SEVERITY = {DecisionState.GO: 0, DecisionState.MARGINAL: 1, DecisionState.NO_GO: 2}
+
+
+def _num(x):
+    """JSON-safe number: inf/nan -> None (station-held time-to-limit is 'no drift')."""
+    if x is None or (isinstance(x, float) and (math.isinf(x) or math.isnan(x))):
+        return None
+    return round(float(x), 3)
+
+
+def evaluate_point(
+    snap: TelemetrySnapshot,
+    *,
+    token: str,
+    section: RiserSection,
+    conductor: ConductorInput,
+    condition,
+    cur: float,
+    water_depth_m: float,
+    length_m: float,
+    tension_n: float,
+    criteria: EnvelopeCriteria,
+    models: FlexjointModels,
+    drift_cfg: dict,
+    atlas_root,
+    t0,
+) -> dict:
+    """Compose the five gauges for one telemetry snapshot into the allow-listed track dict.
+
+    This is twin D's per-point loop body verbatim (byte-identical serving); the only
+    parameterisation is the environmental ``condition`` / ``cur`` (fixed for the monitor
+    demo, rolling for :func:`run_twin_loop`).
+    """
+    off_pct = snapshot_to_offset_pct(snap, water_depth_m=water_depth_m)
+    # -- operability (twin A offset -> #1283 atlas) --
+    scr = screen_operability(token, off_pct, cur, atlas_root=atlas_root)
+    # -- physics prediction at the live point (for twin B + wellhead) --
+    drag = CurrentProfile(surface_speed_mps=cur).drag_load_n_per_m(section.outer_diameter_m)
+    pred = solve_static_response(length_m=length_m, top_offset_m=snap.vessel_offset_m,
+                                 tension_n=tension_n, ei_nm2=section.ei_nm2, current_load_n_per_m=drag)
+    pred_angle = max(abs(pred.angle_upper_deg), abs(pred.angle_lower_deg))
+    # -- flex-joint (twin B: correct the prediction; decision = max(corrected, raw)) --
+    corr = correct_flexjoint_response(pred, models)
+    fj_uc = flexjoint_utilisation(corr.decision_static_angle_deg, criteria)
+    meas = snap.measured
+    meas_angle = None
+    if meas is not None:
+        vals = [abs(v) for v in (meas.flexjoint_angle_upper_deg, meas.flexjoint_angle_lower_deg) if v is not None]
+        meas_angle = max(vals) if vals else None
+    # -- wellhead bending-moment INDICATOR (kN·m only; no capacity, no UC) --
+    wh = solve_conductor_moment(shear_n=pred.shear_lower_n, stand_off_m=conductor.stand_off_m,
+                                soil_modulus_n_per_m2=conductor.soil_modulus_n_per_m2, ei_nm2=conductor.ei_nm2)
+    wh_moment_knm = wh.max_moment_nm / 1000.0
+    # -- drift-off (twin C: watch-circle + time-to-limit) --
+    dr = drift_off_screen(snap.dp, condition, section=section, water_depth_m=water_depth_m, length_m=length_m,
+                          tension_n=tension_n, criteria=criteria, config=drift_cfg, x0_m=snap.vessel_offset_m)
+    watch_frac = snap.vessel_offset_m / dr.r_watch_m if dr.r_watch_m > 0 else None
+    return {
+        "t": round((snap.timestamp - t0).total_seconds(), 1),
+        "offset_m": round(snap.vessel_offset_m, 3),
+        "offset_pct": round(off_pct, 4),
+        "operability_uc": round(float(scr.governing_utilisation), 6) if scr.governing_utilisation is not None else None,
+        "light": scr.light,
+        "flexjoint_uc": round(float(fj_uc), 6),
+        "measured_angle_deg": None if meas_angle is None else round(meas_angle, 3),
+        "predicted_angle_deg": round(pred_angle, 3),
+        "corrected_angle_deg": round(corr.corrected_static_angle_deg, 3),
+        "decision_angle_deg": round(corr.decision_static_angle_deg, 3),
+        "wh_moment_knm": round(wh_moment_knm, 3),
+        "r_watch_m": round(dr.r_watch_m, 3),
+        "watch_frac": None if watch_frac is None else round(watch_frac, 4),
+        "time_to_limit_s": _num(dr.time_to_limit_s),
+        "lead_time_margin_s": _num(dr.lead_time_margin_s),
+        "point_of_disconnect_m": _num(dr.point_of_disconnect_m),
+        "drift_status": dr.status,
+    }
+
+
+# --- rolling GO/CAUTION/NO-GO integration -----------------------------------------
+
+#: The #1283 operability atlas is a STATIC screen (built at zero-Hs — waves enter only
+#: via the zero RAO term), so it does not see wave-induced flex-joint loading. This is
+#: the Hs (m) up to which that static operability screen is treated as valid; a rolling
+#: ``wave_hs`` above it puts the operability gauge OUT OF ITS DOMAIN and the verdict fails
+#: closed (the seastate-domain guard) rather than trusting a wave-blind operability call.
+STATIC_SCREEN_HS_CEILING_M = 1.0
+
+
+def _roll_verdict(point: Mapping, *, wave_hs_m: float, hs_ceiling_m: float):
+    """Roll the composed gauges into ONE conservative DecisionState + physics lead time.
+
+    The verdict is the WORST DecisionState across the gauges (fail-closed):
+      * operability — the atlas ``light`` directly (OPERABLE->GO, INOPERABLE->NO_GO,
+        ESCALATE->NO_GO when the value is missing/out-of-range else MARGINAL). None is
+        normalised to fail-closed BEFORE any classify (never ``_classify(None, ...)``).
+      * seastate-domain guard — a rolling Hs above the static-screen ceiling -> NO_GO.
+      * flex-joint — the twin-B decision UC via the shared ``_classify`` (caution 0.9).
+      * drift-off — magnitude-gated: escalate or a non-positive EDS window -> NO_GO;
+        an open window -> MARGINAL; station held -> GO.
+    ``lead_time_s`` is the drift-off physics projection only (``lead_time_margin_s``);
+    no retrospective first-crossing over the replay is claimed.
+    """
+    states = []
+
+    light = point["light"]
+    uc = point["operability_uc"]
+    if light == "OPERABLE":
+        states.append(DecisionState.GO)
+    elif light == "INOPERABLE":
+        states.append(DecisionState.NO_GO)
+    else:  # ESCALATE — indeterminate; fail closed when there is no in-range value
+        states.append(DecisionState.NO_GO if uc is None else DecisionState.MARGINAL)
+
+    # seastate-domain guard: the wave-blind static operability screen is out of its
+    # validated domain above the ceiling -> the verdict cannot be a trusted GO.
+    if wave_hs_m > hs_ceiling_m + 1e-9:
+        states.append(DecisionState.NO_GO)
+
+    # flex-joint (twin-B decision UC = max(corrected, raw); trips before the raw atlas)
+    states.append(_classify(float(point["flexjoint_uc"]), 0.9, 1.0))
+
+    # drift-off, gated on the EDS lead-time MAGNITUDE, not the categorical status alone
+    st = point["drift_status"]
+    lm = point["lead_time_margin_s"]
+    if st == "escalate":
+        states.append(DecisionState.NO_GO)
+    elif st == "station_held":
+        states.append(DecisionState.GO)
+    else:  # drift_off
+        states.append(DecisionState.NO_GO if (lm is not None and lm <= 0.0) else DecisionState.MARGINAL)
+
+    worst = max(states, key=lambda s: _SEVERITY[s])
+    return worst, point["lead_time_margin_s"]
+
+
+class _Context(NamedTuple):
+    token: str
+    section: RiserSection
+    conductor: ConductorInput
+    wd: float
+    length: float
+    tension: float
+    criteria: EnvelopeCriteria
+    models: FlexjointModels
+    drift_cfg: dict
+    root: Path
+
+
+def _load_context(atlas_root: Path | None = None) -> _Context:
+    """Load the fixed composition inputs from the committed config + fixtures (offline).
+
+    Criteria are SOURCED from the atlas's own config (not re-invented), so the drift-off
+    watch-circle boundary can never disagree with the operability boundary.
+    """
+    repo = oa.REPO_ROOT
+    src = repo / "src" / "digitalmodel" / "drilling_riser"
+    fix = repo / "tests" / "drilling_riser" / "fixtures"
+    mon = yaml.safe_load((src / "monitor_config.yml").read_text())
+    atlas_cfg = yaml.safe_load((src / "operability_configs.yml").read_text())
+    c = atlas_cfg["criteria"]
+    criteria = EnvelopeCriteria(
+        float(c["flexjoint_angle_mean_deg"]),
+        float(c["flexjoint_angle_max_deg"]),
+        float(c["von_mises_design_factor"]),
+    )
+    sc = mon["scenario"]
+    cd = mon["conductor"]
+    section = RiserSection(outer_diameter_m=float(sc["outer_diameter_m"]),
+                           wall_thickness_m=float(sc["wall_thickness_m"]))
+    conductor = ConductorInput(
+        outer_diameter_m=float(cd["outer_diameter_m"]), wall_thickness_m=float(cd["wall_thickness_m"]),
+        soil_modulus_n_per_m2=float(cd["soil_modulus_n_per_m2"]), stand_off_m=float(cd["stand_off_m"]),
+    )
+    train = json.loads((fix / "monitor_flexjoint_training.json").read_text())
+    models = fit_flexjoint_models(
+        measured_upper_deg=train["measured_upper_deg"], predicted_upper_deg=train["predicted_upper_deg"],
+        measured_lower_deg=train["measured_lower_deg"], predicted_lower_deg=train["predicted_lower_deg"],
+    )
+    return _Context(
+        token=sc["config"], section=section, conductor=conductor,
+        wd=float(sc["water_depth_m"]), length=float(sc["length_m"]), tension=float(sc["tension_n"]),
+        criteria=criteria, models=models, drift_cfg=load_drift_config(),
+        root=(atlas_root or (repo / "atlases")),
+    )
+
+
+def run_twin_loop(
+    metocean_records: Iterable[Mapping],
+    telemetry_records: Iterable[Mapping],
+    *,
+    atlas_root: Path | None = None,
+    hs_ceiling_m: float = STATIC_SCREEN_HS_CEILING_M,
+) -> list[dict]:
+    """Replay a telemetry track against a ROLLING metocean stream -> per-step verdicts.
+
+    Deterministic + offline. ``metocean_records`` and ``telemetry_records`` are aligned by
+    index (one metocean condition per telemetry snapshot). Each returned dict is the
+    allow-listed track point plus ``go_no_go`` (the DISPLAY_LABEL string) + ``lead_time_s``
+    (drift-off physics lead time, rounded). No physics is re-derived downstream — a page
+    just plays these back.
+    """
+    ctx = _load_context(atlas_root)
+    snaps = parse_snapshots(list(telemetry_records))
+    mets = list(metocean_records)
+    t0 = snaps[0].timestamp
+    out = []
+    for snap, met in zip(snaps, mets):
+        hs = float(met["wave_hs_m"])
+        cur = float(met["current_speed_mps"])
+        condition = EnvironmentalConditions(
+            wave_hs=hs, wave_tp=float(met["wave_tp_s"]), wave_direction=180.0,
+            current_speed=cur, current_direction=180.0,
+            wind_speed=float(met.get("wind_speed_mps", 8.0)), wind_direction=180.0,
+        )
+        point = evaluate_point(
+            snap, token=ctx.token, section=ctx.section, conductor=ctx.conductor,
+            condition=condition, cur=cur, water_depth_m=ctx.wd, length_m=ctx.length,
+            tension_n=ctx.tension, criteria=ctx.criteria, models=ctx.models,
+            drift_cfg=ctx.drift_cfg, atlas_root=ctx.root, t0=t0,
+        )
+        state, lead = _roll_verdict(point, wave_hs_m=hs, hs_ceiling_m=hs_ceiling_m)
+        out.append({**point, "go_no_go": DISPLAY_LABEL[state], "lead_time_s": _num(lead)})
+    return out

--- a/src/digitalmodel/drilling_riser/twin_loop.py
+++ b/src/digitalmodel/drilling_riser/twin_loop.py
@@ -161,10 +161,11 @@ def _roll_verdict(point: Mapping, *, wave_hs_m: float, hs_ceiling_m: float):
       * operability — the atlas ``light`` directly (OPERABLE->GO, INOPERABLE->NO_GO,
         ESCALATE->NO_GO when the value is missing/out-of-range else MARGINAL). None is
         normalised to fail-closed BEFORE any classify (never ``_classify(None, ...)``).
-      * seastate-domain guard — a rolling Hs above the static-screen ceiling -> NO_GO.
+      * seastate-domain guard — a rolling Hs above the static-screen ceiling (or a
+        missing / NaN Hs) -> NO_GO.
       * flex-joint — the twin-B decision UC via the shared ``_classify`` (caution 0.9).
-      * drift-off — magnitude-gated: escalate or a non-positive EDS window -> NO_GO;
-        an open window -> MARGINAL; station held -> GO.
+      * drift-off — magnitude-gated: escalate, a non-positive OR a missing EDS window
+        -> NO_GO; an open (finite, positive) window -> MARGINAL; station held -> GO.
     ``lead_time_s`` is the drift-off physics projection only (``lead_time_margin_s``);
     no retrospective first-crossing over the replay is claimed.
     """
@@ -180,8 +181,10 @@ def _roll_verdict(point: Mapping, *, wave_hs_m: float, hs_ceiling_m: float):
         states.append(DecisionState.NO_GO if uc is None else DecisionState.MARGINAL)
 
     # seastate-domain guard: the wave-blind static operability screen is out of its
-    # validated domain above the ceiling -> the verdict cannot be a trusted GO.
-    if wave_hs_m > hs_ceiling_m + 1e-9:
+    # validated domain above the ceiling -> the verdict cannot be a trusted GO. A
+    # missing / NaN rolling Hs (a dropped metocean sample) is treated as out-of-domain
+    # too (fail-closed), never silently skipped.
+    if not math.isfinite(wave_hs_m) or wave_hs_m > hs_ceiling_m + 1e-9:
         states.append(DecisionState.NO_GO)
 
     # flex-joint (twin-B decision UC = max(corrected, raw); trips before the raw atlas)
@@ -194,8 +197,9 @@ def _roll_verdict(point: Mapping, *, wave_hs_m: float, hs_ceiling_m: float):
         states.append(DecisionState.NO_GO)
     elif st == "station_held":
         states.append(DecisionState.GO)
-    else:  # drift_off
-        states.append(DecisionState.NO_GO if (lm is not None and lm <= 0.0) else DecisionState.MARGINAL)
+    else:  # drift_off — fail-closed: only an OPEN (finite, positive) EDS window is
+        # MARGINAL; a missing or non-positive window cannot be a trusted CAUTION.
+        states.append(DecisionState.MARGINAL if (lm is not None and lm > 0.0) else DecisionState.NO_GO)
 
     worst = max(states, key=lambda s: _SEVERITY[s])
     return worst, point["lead_time_margin_s"]

--- a/src/digitalmodel/motion_forecast/decision.py
+++ b/src/digitalmodel/motion_forecast/decision.py
@@ -20,17 +20,21 @@ from digitalmodel.marine_ops.installation.go_no_go import (
     _check_criterion,
 )
 
+# The classifier + lead-time mechanics moved to the shared spine (#1377) so the
+# drilling-riser twin loop and this motion loop share ONE copy. Re-exported here so
+# ``decision._classify`` / ``decision._first_crossing`` / ``decision.DISPLAY_LABEL``
+# keep resolving for existing consumers (e.g. ``motion_forecast.reconcile``).
+from digitalmodel.decision_spine import (  # noqa: F401
+    DISPLAY_LABEL,
+    _classify,
+    _first_crossing,
+)
+
 from .criteria import Criterion
 from .derived import compute_governing
 from .models import MotionForecast
 
 Offset = Tuple[float, float, float]
-
-DISPLAY_LABEL = {
-    DecisionState.GO: "GO",
-    DecisionState.MARGINAL: "CAUTION",
-    DecisionState.NO_GO: "NO-GO",
-}
 
 
 @dataclass
@@ -54,33 +58,6 @@ class RollingDecision:
     @property
     def display(self) -> str:
         return DISPLAY_LABEL[self.state]
-
-
-def _first_crossing(t: np.ndarray, v: np.ndarray, level: float, now: float) -> Optional[float]:
-    """Lead time (s) to the first sample with ``v > level`` (strict), else None.
-
-    Strict ``>`` keeps this consistent with :func:`_classify` and the reused
-    ``go_no_go._check_criterion`` band (``value == limit`` is still MARGINAL, so
-    it must not register as a NO-GO crossing).
-    """
-    mask = v > level
-    if not mask.any():
-        return None
-    return float(t[int(np.argmax(mask))] - now)
-
-
-def _classify(value: float, caution: float, limit: float) -> DecisionState:
-    """Classify a governing value, matching ``_check_criterion`` boundaries.
-
-    ``value > limit`` -> NO_GO (FAIL); ``value > caution`` -> MARGINAL (WARNING);
-    else GO (PASS). NaN is unsafe -> NO_GO (fail-closed)."""
-    if not np.isfinite(value):
-        return DecisionState.NO_GO
-    if value > limit:
-        return DecisionState.NO_GO
-    if value > caution:
-        return DecisionState.MARGINAL
-    return DecisionState.GO
 
 
 def rolling_decision(

--- a/tests/drilling_riser/fixtures/monitor_metocean_track.json
+++ b/tests/drilling_riser/fixtures/monitor_metocean_track.json
@@ -1,0 +1,18 @@
+{
+  "provenance": {
+    "source": "synthetic (generic instantaneous metocean sequence); representative offline sample for CI",
+    "licence": "synthetic — no third-party, client, or real hindcast data redistributed",
+    "note": "Fully synthetic illustrative metocean track for the twin E rolling loop (#1377), aligned index-for-index with monitor_demo_track.json. Round numbers only. No real metocean station, no station id, no latitude/longitude, no basin name, no vessel identity, no credentials. wave_hs rises above the static operability screen's validity ceiling (1.0 m) mid-track to exercise the seastate-domain guard; current stays on an atlas current knot (0.5 m/s).",
+    "captured_offline": true
+  },
+  "records": [
+    {"t": 0.0,   "current_speed_mps": 0.5, "wave_hs_m": 0.8, "wave_tp_s": 8.0, "wind_speed_mps": 8.0},
+    {"t": 300.0, "current_speed_mps": 0.5, "wave_hs_m": 0.9, "wave_tp_s": 8.0, "wind_speed_mps": 8.0},
+    {"t": 600.0, "current_speed_mps": 0.5, "wave_hs_m": 1.0, "wave_tp_s": 8.0, "wind_speed_mps": 8.0},
+    {"t": 900.0, "current_speed_mps": 0.5, "wave_hs_m": 1.0, "wave_tp_s": 8.0, "wind_speed_mps": 8.0},
+    {"t": 1200.0,"current_speed_mps": 0.5, "wave_hs_m": 1.5, "wave_tp_s": 9.0, "wind_speed_mps": 12.0},
+    {"t": 1500.0,"current_speed_mps": 0.5, "wave_hs_m": 2.0, "wave_tp_s": 10.0,"wind_speed_mps": 14.0},
+    {"t": 1800.0,"current_speed_mps": 0.5, "wave_hs_m": 1.0, "wave_tp_s": 8.0, "wind_speed_mps": 9.0},
+    {"t": 2100.0,"current_speed_mps": 0.5, "wave_hs_m": 0.8, "wave_tp_s": 8.0, "wind_speed_mps": 8.0}
+  ]
+}

--- a/tests/drilling_riser/test_operability_monitor.py
+++ b/tests/drilling_riser/test_operability_monitor.py
@@ -179,6 +179,9 @@ _ALLOWED_POINT_KEYS = {
     "measured_angle_deg", "predicted_angle_deg", "corrected_angle_deg", "decision_angle_deg",
     "wh_moment_knm", "r_watch_m", "watch_frac", "time_to_limit_s", "lead_time_margin_s",
     "point_of_disconnect_m", "drift_status",
+    # twin E #1377: the rolled verdict (label) + physics lead time (seconds) — a label
+    # and a time, no absolute force / mass / capacity.
+    "go_no_go", "lead_time_s",
 }
 _FORBIDDEN = ("provenance", "validation", "source_sha256", "SOURCE_FILES", "samples",
               "m_eff", "thrust_efficiency", "environmental_force", "f_env_n", "f_net_n",

--- a/tests/drilling_riser/test_twin_loop.py
+++ b/tests/drilling_riser/test_twin_loop.py
@@ -59,6 +59,13 @@ def test_seastate_domain_guard_forces_no_go_above_ceiling():
     assert st is DecisionState.NO_GO
 
 
+def test_nan_seastate_fails_closed():
+    # a dropped / NaN metocean sample must NOT bypass the domain guard (NaN > ceiling is
+    # False) — it fails closed to NO-GO rather than being silently trusted as in-domain
+    st, _ = _roll_verdict(_point(), wave_hs_m=float("nan"), hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+
+
 def test_drift_off_is_magnitude_gated():
     # an OPEN EDS window is CAUTION ...
     st, _ = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=120.0), wave_hs_m=0.8, hs_ceiling_m=1.0)
@@ -67,6 +74,9 @@ def test_drift_off_is_magnitude_gated():
     st, _ = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=-5.0), wave_hs_m=0.8, hs_ceiling_m=1.0)
     assert st is DecisionState.NO_GO
     st, _ = _roll_verdict(_point(drift_status="escalate"), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+    # ... and a drift-off with NO reported EDS margin fails closed (never a trusted CAUTION)
+    st, _ = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=None), wave_hs_m=0.8, hs_ceiling_m=1.0)
     assert st is DecisionState.NO_GO
 
 

--- a/tests/drilling_riser/test_twin_loop.py
+++ b/tests/drilling_riser/test_twin_loop.py
@@ -1,0 +1,120 @@
+"""twin E #1377 — the integration + demo loop (end-to-end proof of the twin).
+
+Replays the synthetic demo telemetry track against a rolling metocean stream through the
+composed seams and rolls ONE conservative GO/CAUTION/NO-GO verdict per step. Offline,
+deterministic, no wiki. The heavy end-to-end replay (which recomputes envelope sweeps per
+point) runs once; the conservative-roll-up logic is unit-tested directly (fast).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.decision_spine import DISPLAY_LABEL
+from digitalmodel.drilling_riser import twin_loop
+from digitalmodel.drilling_riser.twin_loop import _roll_verdict, run_twin_loop
+from digitalmodel.marine_ops.installation.go_no_go import DecisionState
+
+_FIX = Path(__file__).parent / "fixtures"
+_TRACK = json.loads((_FIX / "monitor_demo_track.json").read_text())["records"]
+_MET = json.loads((_FIX / "monitor_metocean_track.json").read_text())["records"]
+
+
+def _point(**over):
+    """A minimal composed-point dict for the roll-up unit tests."""
+    p = dict(light="OPERABLE", operability_uc=0.5, flexjoint_uc=0.5,
+             drift_status="station_held", lead_time_margin_s=None)
+    p.update(over)
+    return p
+
+
+# -- conservative worst-of roll-up (fast, no envelope recompute) ----------------
+
+def test_all_clear_is_go():
+    st, _ = _roll_verdict(_point(), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.GO
+
+
+def test_inoperable_is_no_go():
+    st, _ = _roll_verdict(_point(light="INOPERABLE", operability_uc=1.4), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+
+
+def test_none_operability_fails_closed_without_crashing():
+    # out-of-range operability -> light ESCALATE, uc None. Must NOT call _classify(None).
+    st, _ = _roll_verdict(_point(light="ESCALATE", operability_uc=None), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+
+
+def test_escalate_with_value_is_at_least_caution_not_go():
+    st, _ = _roll_verdict(_point(light="ESCALATE", operability_uc=0.98), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.MARGINAL  # never a clean GO
+
+
+def test_seastate_domain_guard_forces_no_go_above_ceiling():
+    # everything else clear, but a rolling Hs beyond the static-screen ceiling is out of domain
+    st, _ = _roll_verdict(_point(), wave_hs_m=1.6, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+
+
+def test_drift_off_is_magnitude_gated():
+    # an OPEN EDS window is CAUTION ...
+    st, _ = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=120.0), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.MARGINAL
+    # ... a non-positive window (cannot disconnect in time) is NO-GO, not CAUTION
+    st, _ = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=-5.0), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+    st, _ = _roll_verdict(_point(drift_status="escalate"), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+
+
+def test_flexjoint_decision_uc_gates_the_verdict():
+    st, _ = _roll_verdict(_point(flexjoint_uc=1.2), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.NO_GO
+    st, _ = _roll_verdict(_point(flexjoint_uc=0.95), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert st is DecisionState.MARGINAL
+
+
+def test_lead_time_is_the_drift_off_physics_margin():
+    st, lead = _roll_verdict(_point(drift_status="drift_off", lead_time_margin_s=90.0), wave_hs_m=0.8, hs_ceiling_m=1.0)
+    assert lead == 90.0  # the physics EDS margin, not a retrospective crossing
+
+
+# -- end-to-end replay (the proof; slow — recomputes envelope sweeps) -----------
+
+@pytest.fixture(scope="module")
+def loop():
+    return run_twin_loop(_MET, _TRACK)
+
+
+def test_loop_covers_the_track(loop):
+    assert len(loop) == len(_TRACK)
+    for p in loop:
+        assert p["go_no_go"] in ("GO", "CAUTION", "NO-GO")
+        assert "lead_time_s" in p
+
+
+def test_rolling_transition_go_to_nogo(loop):
+    labels = [p["go_no_go"] for p in loop]
+    assert labels[0] == "GO", labels                 # calm, on station
+    assert "NO-GO" in labels, labels                 # the drift-off / high-sea excursion
+    # the vessel recovers by the end of the drift-then-recover scenario
+    assert labels[-1] in ("GO", "CAUTION"), labels
+    # the peak-sea step (Hs 2.0 > ceiling, index 5) must be NO-GO (seastate-domain guard)
+    assert labels[5] == "NO-GO", labels
+
+
+def test_loop_is_deterministic(loop):
+    again = run_twin_loop(_MET, _TRACK)
+    assert [p["go_no_go"] for p in again] == [p["go_no_go"] for p in loop]
+    assert again == loop
+
+
+def test_verdict_is_worst_of_the_served_gauges(loop):
+    # composition fidelity: the served verdict equals the roll-up of the served gauges
+    for p, met in zip(loop, _MET):
+        expect, _ = _roll_verdict(p, wave_hs_m=float(met["wave_hs_m"]),
+                                  hs_ceiling_m=twin_loop.STATIC_SCREEN_HS_CEILING_M)
+        assert p["go_no_go"] == DISPLAY_LABEL[expect]

--- a/tests/drilling_riser/test_twin_loop.py
+++ b/tests/drilling_riser/test_twin_loop.py
@@ -106,12 +106,20 @@ def test_loop_covers_the_track(loop):
         assert "lead_time_s" in p
 
 
-def test_rolling_transition_go_to_nogo(loop):
+def test_rolling_transition_caution_to_nogo_and_back(loop):
+    # NOTE: under the twin-C zero-thrust-credit screen (drift_off_config.yml
+    # ``thrust_efficiency: 0.0`` — a scalar DPState cannot be shown to OPPOSE the
+    # drift, so surviving thrust is reported as a margin, never credited), the
+    # drift gauge can never say station_held with the default config. The composed
+    # verdict is therefore CAUTION at best — GO is deliberately unreachable in the
+    # served demo. This matches the committed monitor artifact and the reviewed
+    # twin-C conservatism; do NOT "fix" it by crediting thrust in the served loop.
     labels = [p["go_no_go"] for p in loop]
-    assert labels[0] == "GO", labels                 # calm, on station
+    assert labels[0] == "CAUTION", labels            # calm: best achievable verdict
+    assert "GO" not in labels, labels                # GO unreachable under zero credit
     assert "NO-GO" in labels, labels                 # the drift-off / high-sea excursion
     # the vessel recovers by the end of the drift-then-recover scenario
-    assert labels[-1] in ("GO", "CAUTION"), labels
+    assert labels[-1] == "CAUTION", labels
     # the peak-sea step (Hs 2.0 > ceiling, index 5) must be NO-GO (seastate-domain guard)
     assert labels[5] == "NO-GO", labels
 

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -91,6 +91,12 @@ _PUBLIC_ARTIFACTS = (
     REPO_ROOT / "scripts" / "parametric" / "build_drilling_riser_drift_off_library.py",
     REPO_ROOT / "tests" / "drilling_riser" / "test_drift_off.py",
     REPO_ROOT / "tests" / "drilling_riser" / "fixtures" / "drift_off_sample.json",
+    # #1377 twin E: the shared per-point composition engine + the rolling GO/CAUTION/
+    # NO-GO integration, the shared decision spine, and the synthetic metocean fixture.
+    REPO_ROOT / "src" / "digitalmodel" / "drilling_riser" / "twin_loop.py",
+    REPO_ROOT / "src" / "digitalmodel" / "decision_spine.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "test_twin_loop.py",
+    REPO_ROOT / "tests" / "drilling_riser" / "fixtures" / "monitor_metocean_track.json",
 )
 
 
@@ -167,7 +173,7 @@ def test_new_analytical_code_is_gated():
     scanned = {p.name for p in _PUBLIC_ARTIFACTS}
     for required in ("envelope.py", "conductor_response.py", "riser_response.py",
                      "telemetry_inputs.py", "response_correction.py", "model.py",
-                     "skill.py", "drift_off.py"):
+                     "skill.py", "drift_off.py", "twin_loop.py", "decision_spine.py"):
         assert required in scanned, f"{required} is not gated by the provenance tripwire"
 
 


### PR DESCRIPTION
Closes #1377 — the LAST child of the hybrid physics+ML digital-twin epic #1372 (six of seven already merged: #1379, #1393, #1397, #1403, #1410, #1422). **Merging this completes the epic.**

## What it is
`twin_loop.py`: composes the merged seams (telemetry ingest → operability monitor → twin-C drift-off screen → shared `decision_spine`) into one deterministic, offline, allow-listed demo loop with a conservative worst-of GO/CAUTION/NO-GO roll-up per track point, serving `docs/api/drilling/operability-monitor.{html,results.json}`.

## Verification (this session, all on the pushed branch)
- **Suites 44/44 green** (`test_twin_loop`, `test_operability_monitor`, motion-forecast `test_decision` + `test_reconcile`) — offline, no wiki.
- **Determinism:** monitor rebuilt from scratch → **byte-identical** to the committed artifact (fp `8b998b9900aeda2a`, atlas `b5a542c49bf7`, 8 track points; empty scoped git diff).
- **Legal sanity scan `--diff-only`: PASS** (served-JSON allow-list previously verified: 19 keys, zero thrust/tension/force/kn keys served; 0 external URLs; no JS physics).
- **T2 adversarial reviews** (prior session, 2 reject-seeking lenses): governance CLEAN, correctness ACCEPT; both latent fail-open paths folded (NaN Hs fails closed; missing EDS window → NO-GO) with red-first tests.

## One substantive finding this session
`test_rolling_transition_go_to_nogo` asserted a GO start that the merged twin-C screen **deliberately forbids**: `drift_off_config.yml` ships `thrust_efficiency: 0.0` (scalar DPState thrust is reported as a margin, never credited against drift — per the #1375 T2 review), so `station_held` is unreachable and the composed verdict is CAUTION at best. The twice-T2-cleared committed artifact already tells the honest CAUTION → NO-GO → CAUTION story. Fixed the stale test expectation (commit 937ed888) and documented why GO is unreachable — the screen's conservatism was kept, not weakened.

## Invariants preserved (spot-checked green)
Worst-of roll-up; None/NaN fail-closed before `_classify`; ESCALATE never a clean CAUTION; seastate-domain guard (Hs > 1.0 m ceiling or NaN → NO-GO); drift-off gated on EDS lead-time magnitude; `lead_time_s` = drift physics only; cited getters (API RP 16Q / STD 2RD); wellhead = kN·m indicator only; page self-contained.

Epic: #1372