### PR TITLE
feat(drilling_riser): wave-2 golden 16Q contracts + registry batch run (#1453)

### DIFF
--- a/examples/workflows/riser-stackup-registry-batch/.gitignore
+++ b/examples/workflows/riser-stackup-registry-batch/.gitignore
@@ -1,0 +1,3 @@
+# Wiki-side VALUES (private-workbook-derived tensions/weights) — never
+# committed to this public repo; see README "Output is NOT committed".
+results/

--- a/examples/workflows/riser-stackup-registry-batch/README.md
+++ b/examples/workflows/riser-stackup-registry-batch/README.md
@@ -1,0 +1,48 @@
+# Riser Stack-up Registry Batch Run (API RP 16Q)
+
+First batch sweep of the riser stack-up registry (#1453, epic #1279): every
+`riser_stackup` row with `stackup_type = as-planned-stackup` and
+`operation = drilling` is checked for a wiki-side `16q-min-top-tension` calc
+contract (llm-wiki#826 — registry page + per-dataset source pages) and, where
+the chain inputs exist, the API RP 16Q minimum vertical top tension is
+computed through `digitalmodel.drilling_riser.assembly.minimum_top_tension_16q`.
+
+## Run
+
+```bash
+LLM_WIKI_PATH=/path/to/llm-wiki \
+    uv run python examples/workflows/riser-stackup-registry-batch/run.py
+```
+
+Prints the batch table and writes `results/registry_batch_16q.csv` with, per
+RSU: `rsu_id`, `water_depth_band`, `topology_class`, string dry/submerged
+weight and buoyancy uplift (where the contract decomposes them), the computed
+`Tmin_vert`, its unit, and `status` (`runnable` | `missing-inputs`) with a
+`fields_unknown` reason.
+
+## Output is NOT committed (by design)
+
+`results/` is gitignored. Computed tensions/weights are wiki-side VALUES
+derived from private project workbooks: dm carries only key names, the
+assembly engine, and this runner (the #1280 calc-contract discipline). The
+private llm-wiki registry keeps the values until a dataset passes the dm
+de-id/leak gate.
+
+## Reading the reasons
+
+- `runnable` — a golden `16q-min-top-tension` contract exists; the engine
+  reproduces its documented Tmin (asserted by
+  `tests/drilling_riser/test_assembly_golden.py`).
+- `fields_unknown: wiki carries result-dialect contracts only` — the source
+  page documents results (`id:`/`expected:` entries) but no machine-golden
+  16Q chain yet: candidate wave-3 contracts.
+- `fields_unknown: no calc contract wiki-side` — the dataset is registered
+  (stack-up schedule exists) but no reproduction contract has been extracted.
+
+## Chain conventions
+
+The wave-2 workbook chains apply the bare `N/(N-n)` tensioner-failure
+allowance (reduction factor Rf = 1.0, no separate fleet-angle factor); a
+contract that carries explicit `efficiency` / `fleet_angle_factor` keys
+(RSU-0007 style) is honoured. See `minimum_top_tension_16q` docstring for
+the Rf-split note.

--- a/examples/workflows/riser-stackup-registry-batch/run.py
+++ b/examples/workflows/riser-stackup-registry-batch/run.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+"""Registry batch run: API RP 16Q required top tension across the riser
+stack-up registry (#1453, epic #1279).
+
+Iterates every ``riser_stackup`` row with ``stackup_type =
+as-planned-stackup`` and ``operation = drilling`` (the public dm-side
+handles), resolves each row's wiki-side ``16q-min-top-tension`` calc
+contract (private llm-wiki registry + source pages, llm-wiki#826), and where
+the contract carries the chain inputs computes the 16Q minimum vertical top
+tension through ``digitalmodel.drilling_riser.assembly``. Rows without a
+golden contract are reported ``missing-inputs`` with a reason
+(``fields_unknown`` taxonomy).
+
+Run (in-context; the wiki clone is required for values)::
+
+    LLM_WIKI_PATH=/path/to/llm-wiki \
+        uv run python examples/workflows/riser-stackup-registry-batch/run.py
+
+Writes ``results/registry_batch_16q.csv`` next to this script and prints the
+table. The results directory is GITIGNORED by design: computed tensions and
+string weights are wiki-side VALUES (dm carries key names + engine only —
+the #1280 calc-contract discipline), so the output must not be committed to
+this public repo.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+from digitalmodel.drilling_riser.assembly import minimum_top_tension_16q
+from digitalmodel.drilling_riser.calc_contracts import (
+    contract_referenced_rsu_ids,
+    load_calc_contracts,
+    resolve_wiki_root,
+)
+from digitalmodel.riser_database.loader import RiserDatabase
+
+HERE = Path(__file__).resolve().parent
+OUTPUT_CSV = HERE / "results" / "registry_batch_16q.csv"
+
+CALC = "16q-min-top-tension"
+#: fields_unknown taxonomy (issue #1453 scope 3).
+REASON_WIKI_UNAVAILABLE = "llm-wiki clone unavailable (values live wiki-side)"
+REASON_RESULT_DIALECT_ONLY = (
+    "fields_unknown: wiki carries result-dialect contracts only "
+    "(no golden 16Q chain yet)"
+)
+REASON_NO_CONTRACT = "fields_unknown: no calc contract wiki-side"
+REASON_NO_TSRMIN = "fields_unknown: 16Q contract lacks a TSRmin / factored-weight input"
+
+
+@dataclass(frozen=True)
+class BatchRow:
+    rsu_id: str
+    water_depth_band: str
+    topology_class: str
+    string_dry_weight: str
+    string_submerged_weight: str
+    buoyancy_uplift: str
+    tmin_vert: str
+    units: str
+    status: str  # runnable | missing-inputs
+    reason: str
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "" if value is None else f"{value:.2f}"
+
+
+def _chain_inputs(contract: dict) -> Optional[tuple[float, str]]:
+    """(TSRmin, unit) from whichever golden-dialect keys the contract has."""
+    if "min_slip_ring_tension_kips" in contract:
+        return float(contract["min_slip_ring_tension_kips"]), "kips"
+    if "tsr_min_kips" in contract:
+        return float(contract["tsr_min_kips"]), "kips"
+    if "factored_submerged_steel_t" in contract and "factored_buoyancy_t" in contract:
+        return (
+            float(contract["factored_submerged_steel_t"])
+            + float(contract["factored_buoyancy_t"]),
+            "t",
+        )
+    return None
+
+
+def _assemble_row(
+    stackup, contract: Optional[dict], reason_no_contract: str
+) -> BatchRow:
+    base = dict(
+        rsu_id=stackup.rsu_id,
+        water_depth_band=stackup.water_depth_band,
+        topology_class=stackup.topology_class,
+        string_dry_weight="",
+        string_submerged_weight="",
+        buoyancy_uplift="",
+        tmin_vert="",
+        units="",
+    )
+    if contract is None:
+        return BatchRow(**base, status="missing-inputs", reason=reason_no_contract)
+    chain = _chain_inputs(contract)
+    if chain is None:
+        return BatchRow(**base, status="missing-inputs", reason=REASON_NO_TSRMIN)
+    t_srmin, unit = chain
+    n_units = contract.get("n_wires", contract.get("n_tensioners"))
+    tmin = minimum_top_tension_16q(
+        t_srmin,
+        n_units=n_units,
+        n_fail=contract["n_fail"],
+        # These workbook chains fold no reduction factor unless the contract
+        # says otherwise (RSU-0007 carries explicit efficiency/fleet-angle).
+        efficiency=contract.get("efficiency", 1.0),
+        fleet_angle_factor=contract.get("fleet_angle_factor", 1.0),
+    )
+    base.update(
+        # Weight decomposition only where the contract carries it (RSU-0023
+        # style ws/bn lines); dry string weight is not in any 16Q contract yet.
+        string_submerged_weight=_fmt(contract.get("ws_submerged_steel_kips")),
+        buoyancy_uplift=_fmt(contract.get("bn_buoyancy_kips")),
+        tmin_vert=_fmt(tmin),
+        units=unit,
+    )
+    return BatchRow(**base, status="runnable", reason="")
+
+
+def run(output_csv: Path = OUTPUT_CSV) -> list[BatchRow]:
+    stackups = [
+        row
+        for row in RiserDatabase.load().stackups
+        if row.stackup_type == "as-planned-stackup" and row.operation == "drilling"
+    ]
+    wiki_root = resolve_wiki_root()
+    if wiki_root is None:
+        rows = [_assemble_row(s, None, REASON_WIKI_UNAVAILABLE) for s in stackups]
+    else:
+        goldens = {
+            c["rsu_id"]: c for c in load_calc_contracts(wiki_root) if c["calc"] == CALC
+        }
+        any_contract = contract_referenced_rsu_ids(wiki_root)
+        rows = [
+            _assemble_row(
+                s,
+                goldens.get(s.rsu_id),
+                (
+                    REASON_RESULT_DIALECT_ONLY
+                    if s.rsu_id in any_contract
+                    else REASON_NO_CONTRACT
+                ),
+            )
+            for s in stackups
+        ]
+
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with output_csv.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(asdict(rows[0])))
+        writer.writeheader()
+        writer.writerows(asdict(r) for r in rows)
+    return rows
+
+
+def main() -> int:
+    rows = run()
+    runnable = sum(1 for r in rows if r.status == "runnable")
+    header = (
+        "rsu_id",
+        "band",
+        "topology",
+        "Ws_sub",
+        "Bn",
+        "Tmin_vert",
+        "units",
+        "status",
+        "reason",
+    )
+    print(" | ".join(header))
+    for r in rows:
+        print(
+            " | ".join(
+                (
+                    r.rsu_id,
+                    r.water_depth_band,
+                    r.topology_class,
+                    r.string_submerged_weight,
+                    r.buoyancy_uplift,
+                    r.tmin_vert,
+                    r.units,
+                    r.status,
+                    r.reason,
+                )
+            )
+        )
+    print(
+        f"\n{runnable}/{len(rows)} as-planned drilling RSUs runnable; "
+        f"CSV: {OUTPUT_CSV.relative_to(HERE)}"
+    )
+    if os.environ.get("LLM_WIKI_PATH") is None and resolve_wiki_root() is None:
+        print("NOTE: standalone mode — set LLM_WIKI_PATH for wiki-side values")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/digitalmodel/drilling_riser/calc_contracts.py
+++ b/src/digitalmodel/drilling_riser/calc_contracts.py
@@ -1,0 +1,158 @@
+"""Wiki-side calc-contract loader (#1280 / #1453, epic #1279).
+
+The private llm-wiki riser registry carries machine-readable ``calc_contracts``
+fenced-YAML blocks — the golden-value data contracts consumed by
+digitalmodel's in-context golden tests and by the registry batch-run example.
+dm carries only the KEY names and this loader; the VALUES live wiki-side and
+resolve at test/run time (never committed here).
+
+Contract locations (llm-wiki#826): the registry page
+(``datasets/stackup-registry.md``, e.g. RSU-0007) AND per-dataset SOURCE pages
+(``sources/*.md``, e.g. RSU-0010/0012/0014/0023). This loader scans both.
+
+Discipline mirrors ``riser_database.loader``: bounded reads (size caps,
+``safe_load``), fail-closed on a malformed contract block or a duplicate
+``(rsu_id, calc)`` key, and no fuzzy matching.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterator, Optional
+
+import yaml
+
+__all__ = [
+    "CalcContractError",
+    "REGISTRY_REL",
+    "SOURCES_REL",
+    "contract_referenced_rsu_ids",
+    "find_contract",
+    "load_calc_contracts",
+    "resolve_wiki_root",
+]
+
+REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
+SOURCES_REL = "wikis/riser-projects/wiki/sources"
+_KNOWN_WIKI_CLONES = (
+    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
+    Path.home() / "workspace-hub" / "llm-wiki",
+)
+#: Bounded-read cap per wiki page (these are curated markdown pages).
+MAX_PAGE_BYTES = 5 * 1024 * 1024
+_FENCED_YAML = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+
+
+class CalcContractError(RuntimeError):
+    """Fail-closed contract-scan error (malformed block, duplicate key)."""
+
+
+def resolve_wiki_root() -> Optional[Path]:
+    """First llm-wiki clone whose registry page exists: ``LLM_WIKI_PATH``
+    env, then the known clone locations. ``None`` when unavailable
+    (standalone mode — callers skip loudly or report missing-inputs)."""
+    candidates: list[Path] = []
+    env = os.environ.get("LLM_WIKI_PATH")
+    if env:
+        candidates.append(Path(env))
+    candidates.extend(_KNOWN_WIKI_CLONES)
+    for base in candidates:
+        if (base / REGISTRY_REL).is_file():
+            return base
+    return None
+
+
+def _contract_pages(wiki_root: Path) -> Iterator[Path]:
+    yield wiki_root / REGISTRY_REL
+    sources_dir = wiki_root / SOURCES_REL
+    if sources_dir.is_dir():
+        yield from sorted(sources_dir.glob("*.md"))
+
+
+def _blocks(page: Path) -> Iterator[dict]:
+    if page.stat().st_size > MAX_PAGE_BYTES:
+        raise CalcContractError(
+            f"{page.name}: size exceeds bounded-read cap {MAX_PAGE_BYTES}"
+        )
+    text = page.read_text(encoding="utf-8")
+    for block in _FENCED_YAML.findall(text):
+        try:
+            doc = yaml.safe_load(block)
+        except yaml.YAMLError as exc:
+            if "calc_contracts" in block:
+                raise CalcContractError(
+                    f"{page.name}: malformed calc_contracts YAML block"
+                ) from exc
+            continue  # unrelated fenced YAML (not a contract block)
+        if isinstance(doc, dict) and "calc_contracts" in doc:
+            yield doc
+
+
+def load_calc_contracts(wiki_root: Path) -> tuple[dict, ...]:
+    """All calc contracts on the registry page + source pages, fail-closed.
+
+    Each contract is the raw wiki-side mapping plus a ``source_page`` key
+    (page filename, provenance only).
+
+    Only the dm#1280 golden dialect is collected: entries keyed by BOTH
+    ``rsu_id`` and ``calc``. The wiki also carries looser result-list
+    contract dialects (e.g. ``id:`` + ``expected:`` entries) — those are a
+    wiki-side pattern dm does not consume yet and are skipped, not errors.
+    A duplicate ``(rsu_id, calc)`` raises :class:`CalcContractError`.
+    """
+    contracts: dict[tuple[str, str], dict] = {}
+    for page in _contract_pages(wiki_root):
+        for doc in _blocks(page):
+            entries = doc["calc_contracts"]
+            if not isinstance(entries, list):
+                raise CalcContractError(f"{page.name}: calc_contracts is not a list")
+            for contract in entries:
+                if not isinstance(contract, dict):
+                    raise CalcContractError(
+                        f"{page.name}: non-mapping calc contract entry"
+                    )
+                key = (contract.get("rsu_id"), contract.get("calc"))
+                if not all(key):
+                    continue  # non-golden contract dialect (not consumed)
+                if key in contracts:
+                    raise CalcContractError(
+                        f"duplicate contract {key} on {page.name} and "
+                        f"{contracts[key]['source_page']}"
+                    )
+                contracts[key] = {**contract, "source_page": page.name}
+    return tuple(contracts.values())
+
+
+_RSU_ID = re.compile(r"RSU-\d{4}")
+
+
+def contract_referenced_rsu_ids(wiki_root: Path) -> frozenset[str]:
+    """RSU ids referenced by ANY contract dialect (golden ``rsu_id`` entries
+    AND the looser ``id:``-keyed result-list entries) — lets a batch run
+    distinguish 'result contracts exist, no golden 16Q chain yet' from 'no
+    contract at all' when reporting missing-inputs reasons."""
+    ids: set[str] = set()
+    for page in _contract_pages(wiki_root):
+        for doc in _blocks(page):
+            entries = doc["calc_contracts"]
+            if not isinstance(entries, list):
+                continue
+            for contract in entries:
+                if not isinstance(contract, dict):
+                    continue
+                ref = str(contract.get("rsu_id") or contract.get("id") or "")
+                match = _RSU_ID.match(ref)
+                if match:
+                    ids.add(match.group())
+    return frozenset(ids)
+
+
+def find_contract(rsu_id: str, calc: str, wiki_root: Path) -> Optional[dict]:
+    """The unique contract for ``(rsu_id, calc)``, or ``None`` if the wiki
+    carries no such contract (the caller decides fail vs missing-inputs)."""
+    for contract in load_calc_contracts(wiki_root):
+        if contract["rsu_id"] == rsu_id and contract["calc"] == calc:
+            return contract
+    return None

--- a/tests/drilling_riser/test_assembly_golden.py
+++ b/tests/drilling_riser/test_assembly_golden.py
@@ -1,33 +1,35 @@
-"""#1280 in-context golden: the API RP 16Q minimum-top-tension chain vs the
-RSU-0007 calc contract (machine-readable YAML block on the PRIVATE registry
-page — dm carries only key names; values resolve wiki-side at test time).
+"""#1280/#1453 in-context goldens: the API RP 16Q minimum-top-tension chain vs
+the calc contracts on the PRIVATE llm-wiki riser registry + source pages —
+dm carries only key names; values resolve wiki-side at test time via
+``digitalmodel.drilling_riser.calc_contracts``.
 
-Loud skip standalone. Tolerance: abs <= 0.5 t AND rel <= 0.15%, derived from
-the contract inputs' quantization. This CANNOT mask a wrong formula: omitting
-the fleet-angle factor alone produces ~1.48% error (10x the tolerance);
-efficiency or n-fail mistakes are larger still.
+Loud skip standalone. Tolerance: abs <= 0.5 (contract unit: t or kips) AND
+rel <= 0.15%, derived from the contract inputs' quantization. This CANNOT
+mask a wrong formula: omitting the fleet-angle factor alone produces ~1.48%
+error on RSU-0007 (10x the tolerance); a wrong N/(N-n) ratio on the wave-2
+contracts is >6%.
+
+Wave-2 contracts (llm-wiki#826): RSU-0010/RSU-0012 (959 m, 16x3600k DAT),
+RSU-0014 (1783 m, semisub 6x833k DAT), RSU-0023 (1981 m, 2H standard calc
+incl. 21-row mud sweep). Their workbooks apply the bare N/(N-n) allowance
+(Rf = 1.0, no separate fleet-angle factor — unlike RSU-0007), so the engine
+kwargs are passed neutral (efficiency=1.0, fleet_angle_factor=1.0).
 """
+
 from __future__ import annotations
 
-import os
-import re
-from pathlib import Path
-
 import pytest
-import yaml
 
 from digitalmodel.drilling_riser.assembly import (
     minimum_top_tension_16q,
     tensioner_system_factor,
 )
+from digitalmodel.drilling_riser.calc_contracts import find_contract, resolve_wiki_root
+from digitalmodel.drilling_riser.stackup import minimum_slip_ring_tension
 
-REGISTRY_REL = "wikis/riser-projects/wiki/datasets/stackup-registry.md"
-_KNOWN_WIKI_CLONES = (
-    Path("/mnt/local-analysis/llm-wiki"),  # abs-path-allowed
-    Path.home() / "workspace-hub" / "llm-wiki",
-)
+_CALC = "16q-min-top-tension"
 
-_CONTRACT_KEYS = {
+_RSU_0007_KEYS = {
     "rsu_id",
     "calc",
     "factored_submerged_steel_t",
@@ -40,42 +42,81 @@ _CONTRACT_KEYS = {
     "connector_pull_t",
     "tension_setting_t",
 }
+_RSU_31245_KEYS = {
+    "rsu_id",
+    "calc",
+    "mud_weight_ppg",
+    "n_wires",
+    "n_fail",
+    "min_slip_ring_tension_kips",
+    "min_vertical_top_tension_kips",
+    "min_bop_overpull_kips",
+    "recoil_margin_kips",
+    "bop_overpull_at_tmin_kips",
+    "overall_min_top_tension_kips",
+}
+_RSU_0014_KEYS = {
+    "rsu_id",
+    "calc",
+    "mud_weight_ppg",
+    "n_tensioners",
+    "n_fail",
+    "dynamic_tension_limit_kips",
+    "dtl_setting_fraction",
+    "max_tension_setting_kips",
+    "tsr_min_kips",
+    "api_min_vertical_top_tension_kips",
+    "recoil_margin_kips",
+    "overall_min_top_tension_kips",
+}
+_RSU_0023_KEYS = {
+    "rsu_id",
+    "calc",
+    "mud_weight_ppg",
+    "n_tensioners",
+    "n_fail",
+    "ws_fwt_kips",
+    "bn_fbt_kips",
+    "internal_fluid_term_kips",
+    "tsr_min_kips",
+    "tmin_vert_kips",
+    "bop_overpull_at_tmin_kips",
+    "min_bop_overpull_kips",
+    "additional_pull_for_min_overpull_kips",
+    "recoil_overpull_kips",
+    "overall_min_top_tension_kips",
+    "mud_weight_sweep",
+}
 
 
-def _calc_contract(rsu_id: str, calc: str) -> dict:
-    candidates = []
-    env = os.environ.get("LLM_WIKI_PATH")
-    if env:
-        candidates.append(Path(env))
-    candidates.extend(_KNOWN_WIKI_CLONES)
-    for base in candidates:
-        page = base / REGISTRY_REL
-        if not page.is_file():
-            continue
-        blocks = re.findall(r"```yaml\n(.*?)```", page.read_text(), re.DOTALL)
-        for block in blocks:
-            doc = yaml.safe_load(block)
-            if not isinstance(doc, dict) or "calc_contracts" not in doc:
-                continue
-            for contract in doc["calc_contracts"]:
-                if contract.get("rsu_id") == rsu_id and contract.get("calc") == calc:
-                    missing = _CONTRACT_KEYS - set(contract)
-                    assert not missing, (
-                        f"calc contract schema drift — missing keys: {missing}"
-                    )
-                    return contract
-        pytest.fail(
-            f"registry page found but no {calc} contract for {rsu_id} — "
-            "the paired llm-wiki calc-contract change is not on this clone"
+def _calc_contract(rsu_id: str, required_keys: set[str]) -> dict:
+    root = resolve_wiki_root()
+    if root is None:
+        pytest.skip(
+            "llm-wiki registry not available (standalone mode) — the 16Q "
+            "goldens are part of the in-context merge gate"
         )
-    pytest.skip(
-        "llm-wiki registry not available (standalone mode) — the 16Q golden "
-        "is part of the in-context merge gate"
-    )
+    contract = find_contract(rsu_id, _CALC, root)
+    if contract is None:
+        pytest.fail(
+            f"llm-wiki found but no {_CALC} contract for {rsu_id} — the "
+            "paired llm-wiki calc-contract change is not on this clone"
+        )
+    missing = required_keys - set(contract)
+    assert not missing, f"{rsu_id} contract schema drift — missing: {missing}"
+    return contract
+
+
+def _assert_golden(result: float, documented: float) -> None:
+    assert abs(result - documented) <= 0.5  # contract unit (t or kips)
+    assert abs(result - documented) / documented <= 0.0015
+
+
+# -- RSU-0007 (registry page, #1280) ---------------------------------------------------
 
 
 def test_16q_min_top_tension_golden():
-    c = _calc_contract("RSU-0007", "16q-min-top-tension")
+    c = _calc_contract("RSU-0007", _RSU_0007_KEYS)
     factored_net_t = c["factored_submerged_steel_t"] + c["factored_buoyancy_t"]
     system = tensioner_system_factor(c["n_wires"], c["n_fail"], c["efficiency"])
     result_t = minimum_top_tension_16q(
@@ -85,9 +126,7 @@ def test_16q_min_top_tension_golden():
         efficiency=c["efficiency"],
         fleet_angle_factor=c["fleet_angle_factor"],
     )
-    documented_t = c["min_top_tension_t"]
-    assert abs(result_t - documented_t) <= 0.5  # tonnes
-    assert abs(result_t - documented_t) / documented_t <= 0.0015
+    _assert_golden(result_t, c["min_top_tension_t"])
     # The chain's own consistency: system factor from the contract's inputs
     # must equal the composition the engine applied.
     assert result_t == pytest.approx(factored_net_t * system * c["fleet_angle_factor"])
@@ -98,6 +137,169 @@ def test_setting_side_values_present_but_not_asserted():
     reconciled against the underlying workbook — explicitly out of #1280
     scope). This test only pins their presence so the contract can't silently
     shed them before the follow-up slice."""
-    c = _calc_contract("RSU-0007", "16q-min-top-tension")
+    c = _calc_contract("RSU-0007", _RSU_0007_KEYS)
     assert c["connector_pull_t"] > 0
     assert c["tension_setting_t"] > c["min_top_tension_t"]
+
+
+# -- wave 2 (#1453): min vertical top tension, TSRmin * N/(N-n) ------------------------
+
+
+@pytest.mark.parametrize(
+    ("rsu_id", "keys", "tsr_key", "n_key", "tmin_key"),
+    [
+        (
+            "RSU-0010",
+            _RSU_31245_KEYS,
+            "min_slip_ring_tension_kips",
+            "n_wires",
+            "min_vertical_top_tension_kips",
+        ),
+        (
+            "RSU-0012",
+            _RSU_31245_KEYS,
+            "min_slip_ring_tension_kips",
+            "n_wires",
+            "min_vertical_top_tension_kips",
+        ),
+        (
+            "RSU-0014",
+            _RSU_0014_KEYS,
+            "tsr_min_kips",
+            "n_tensioners",
+            "api_min_vertical_top_tension_kips",
+        ),
+        (
+            "RSU-0023",
+            _RSU_0023_KEYS,
+            "tsr_min_kips",
+            "n_tensioners",
+            "tmin_vert_kips",
+        ),
+    ],
+)
+def test_16q_wave2_min_vertical_top_tension_golden(
+    rsu_id, keys, tsr_key, n_key, tmin_key
+):
+    """Tmin_vert = TSRmin * N/(N-n) with neutral Rf/fleet-angle (the
+    documented workbook convention for these four contracts)."""
+    c = _calc_contract(rsu_id, keys)
+    result_kips = minimum_top_tension_16q(
+        c[tsr_key],
+        n_units=c[n_key],
+        n_fail=c["n_fail"],
+        efficiency=1.0,
+        fleet_angle_factor=1.0,
+    )
+    _assert_golden(result_kips, c[tmin_key])
+
+
+def test_16q_wave2_overall_min_top_tension_golden():
+    """Overall minimum = Tmin_vert + shortfall-to-minimum-BOP-overpull +
+    recoil margin, against each contract's documented overall value.
+
+    ENGINE GAP (documented, not tolerance-masked): the overpull/recoil
+    composition is contract arithmetic here — ``assembly`` has no
+    overpull-margin helper yet (candidate follow-up under #1279). The
+    engine-side step (TSRmin -> Tmin_vert) is asserted in
+    ``test_16q_wave2_min_vertical_top_tension_golden``.
+    """
+    cases = [
+        # (rsu_id, keys, tmin_key, overpull-at-Tmin key, min-overpull key,
+        #  recoil key) — None keys: term absent from that workbook's chain.
+        (
+            "RSU-0010",
+            _RSU_31245_KEYS,
+            "min_vertical_top_tension_kips",
+            "bop_overpull_at_tmin_kips",
+            "min_bop_overpull_kips",
+            "recoil_margin_kips",
+        ),
+        (
+            "RSU-0012",
+            _RSU_31245_KEYS,
+            "min_vertical_top_tension_kips",
+            "bop_overpull_at_tmin_kips",
+            "min_bop_overpull_kips",
+            "recoil_margin_kips",
+        ),
+        (
+            "RSU-0014",
+            _RSU_0014_KEYS,
+            "api_min_vertical_top_tension_kips",
+            None,
+            None,
+            "recoil_margin_kips",
+        ),
+        (
+            "RSU-0023",
+            _RSU_0023_KEYS,
+            "tmin_vert_kips",
+            "bop_overpull_at_tmin_kips",
+            "min_bop_overpull_kips",
+            "recoil_overpull_kips",
+        ),
+    ]
+    for rsu_id, keys, tmin_key, at_tmin_key, min_key, recoil_key in cases:
+        c = _calc_contract(rsu_id, keys)
+        shortfall = max(0.0, c[min_key] - c[at_tmin_key]) if at_tmin_key else 0.0
+        overall = c[tmin_key] + shortfall + c[recoil_key]
+        _assert_golden(overall, c["overall_min_top_tension_kips"])
+
+
+def test_16q_rsu0023_tsrmin_composition_golden():
+    """TSRmin = Ws*fwt - Bn*fbt + Ai*(dm*Hm - dw*Hw), exercised through
+    ``minimum_slip_ring_tension`` with the contract's pre-factored line
+    values (f_wt = f_bt = 1.0; the fluid term enters as a unit-column
+    density). Tolerance 0.05 kips: three 2-dp-rounded addends."""
+    c = _calc_contract("RSU-0023", _RSU_0023_KEYS)
+    result_kips = minimum_slip_ring_tension(
+        submerged_weight_kn=c["ws_fwt_kips"],
+        buoyancy_uplift_kn=c["bn_fbt_kips"],
+        internal_area_m2=1.0,
+        mud_density_kn_m3=c["internal_fluid_term_kips"],
+        mud_column_m=1.0,
+        seawater_density_kn_m3=0.0,
+        seawater_column_m=0.0,
+        f_wt=1.0,
+        f_bt=1.0,
+    )
+    assert abs(result_kips - c["tsr_min_kips"]) <= 0.05
+
+
+def test_16q_rsu0023_mud_weight_sweep_golden():
+    """All 21 sweep rows: api_min = tsr_min * 16/14 (Rf = 1.0) through the
+    engine; applied tension >= api_min + recoil (the applied column adds the
+    mud-weight-dependent BOP-overpull shortfall, sheet-side arithmetic —
+    only its floor is asserted)."""
+    c = _calc_contract("RSU-0023", _RSU_0023_KEYS)
+    rows = c["mud_weight_sweep"]["rows"]
+    assert len(rows) == 21
+    recoil = c["recoil_overpull_kips"]
+    previous_ppg = 0.0
+    for ppg, tsr_min, api_min, applied in rows:
+        assert ppg > previous_ppg
+        previous_ppg = ppg
+        result = minimum_top_tension_16q(
+            tsr_min,
+            n_units=c["n_tensioners"],
+            n_fail=c["n_fail"],
+            efficiency=1.0,
+            fleet_angle_factor=1.0,
+        )
+        _assert_golden(result, api_min)
+        assert applied >= api_min + recoil - 0.01
+
+
+def test_16q_rsu0014_setting_side_consistency():
+    """RSU-0014 setting-side DATA: max tension setting = DTL x setting
+    fraction. The overpull ladder is pinned as data only (its top-tension
+    column is dynamic-analysis output, not the closed-form 16Q chain)."""
+    c = _calc_contract("RSU-0014", _RSU_0014_KEYS)
+    assert c["max_tension_setting_kips"] == pytest.approx(
+        c["dynamic_tension_limit_kips"] * c["dtl_setting_fraction"]
+    )
+    ladder = c.get("overpull_ladder", [])
+    assert len(ladder) >= 2
+    for (op_a, top_a), (op_b, top_b) in zip(ladder, ladder[1:]):
+        assert top_b - top_a == pytest.approx(op_b - op_a, abs=0.11)

--- a/tests/drilling_riser/test_calc_contracts.py
+++ b/tests/drilling_riser/test_calc_contracts.py
@@ -1,0 +1,126 @@
+"""Unit tests for the wiki-side calc-contract loader (#1453).
+
+All fixture values are SYNTHETIC (public-safe) — the real contracts live on
+the private llm-wiki and are exercised by ``test_assembly_golden.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.drilling_riser.calc_contracts import (
+    REGISTRY_REL,
+    SOURCES_REL,
+    CalcContractError,
+    find_contract,
+    load_calc_contracts,
+    resolve_wiki_root,
+)
+
+_REGISTRY_PAGE = """# Registry
+
+```yaml
+calc_contracts:
+  - rsu_id: RSU-9001
+    calc: 16q-min-top-tension
+    n_wires: 8
+    n_fail: 1
+    min_top_tension_t: 123.4
+```
+"""
+
+_SOURCE_PAGE = """# Source page
+
+Some prose, then an UNRELATED fenced YAML block:
+
+```yaml
+joint_library:
+  - class: BUOY-EXAMPLE
+    length_ft: 75
+```
+
+and the contract block:
+
+```yaml
+calc_contracts:
+  - rsu_id: RSU-9002
+    calc: 16q-min-top-tension
+    n_tensioners: 4
+    n_fail: 1
+    tsr_min_kips: 100.0
+```
+"""
+
+
+@pytest.fixture()
+def wiki_root(tmp_path: Path) -> Path:
+    registry = tmp_path / REGISTRY_REL
+    registry.parent.mkdir(parents=True)
+    registry.write_text(_REGISTRY_PAGE)
+    sources = tmp_path / SOURCES_REL
+    sources.mkdir(parents=True)
+    (sources / "example-source.md").write_text(_SOURCE_PAGE)
+    (sources / "no-contracts.md").write_text("# prose only\n")
+    return tmp_path
+
+
+def test_loads_registry_and_source_page_contracts(wiki_root: Path):
+    contracts = load_calc_contracts(wiki_root)
+    by_id = {c["rsu_id"]: c for c in contracts}
+    assert set(by_id) == {"RSU-9001", "RSU-9002"}
+    assert by_id["RSU-9001"]["source_page"] == "stackup-registry.md"
+    assert by_id["RSU-9002"]["source_page"] == "example-source.md"
+    # Unrelated fenced YAML blocks are ignored, not treated as contracts.
+    assert by_id["RSU-9002"]["tsr_min_kips"] == 100.0
+
+
+def test_find_contract_hit_and_miss(wiki_root: Path):
+    hit = find_contract("RSU-9002", "16q-min-top-tension", wiki_root)
+    assert hit is not None and hit["n_tensioners"] == 4
+    assert find_contract("RSU-9002", "other-calc", wiki_root) is None
+    assert find_contract("RSU-9999", "16q-min-top-tension", wiki_root) is None
+
+
+def test_duplicate_contract_fails_closed(wiki_root: Path):
+    dup = wiki_root / SOURCES_REL / "zz-duplicate.md"
+    dup.write_text(_SOURCE_PAGE)
+    with pytest.raises(CalcContractError, match="duplicate contract"):
+        load_calc_contracts(wiki_root)
+
+
+def test_malformed_contract_block_fails_closed(wiki_root: Path):
+    bad = wiki_root / SOURCES_REL / "bad.md"
+    bad.write_text("```yaml\ncalc_contracts:\n  - rsu_id: [unclosed\n```\n")
+    with pytest.raises(CalcContractError, match="malformed"):
+        load_calc_contracts(wiki_root)
+
+
+def test_other_contract_dialects_are_skipped(wiki_root: Path):
+    """The wiki also carries looser result-list contract dialects (``id:`` +
+    ``expected:`` entries, no ``calc`` key) — not consumed by dm, not an
+    error."""
+    other = wiki_root / SOURCES_REL / "other-dialect.md"
+    other.write_text(
+        "```yaml\ncalc_contracts:\n"
+        "  - id: RSU-9003-mode-a\n"
+        "    expected:\n"
+        "      - {name: example-metric, value: 1.0, units: kN}\n"
+        "```\n"
+    )
+    contracts = load_calc_contracts(wiki_root)
+    assert {c["rsu_id"] for c in contracts} == {"RSU-9001", "RSU-9002"}
+
+
+def test_resolve_wiki_root_honors_env(wiki_root: Path, monkeypatch):
+    monkeypatch.setenv("LLM_WIKI_PATH", str(wiki_root))
+    assert resolve_wiki_root() == wiki_root
+
+
+def test_resolve_wiki_root_rejects_rootless_env(tmp_path: Path, monkeypatch):
+    # Env points somewhere without the registry page -> fall through (and
+    # None when no known clone carries it either, unless a real clone does).
+    monkeypatch.setenv("LLM_WIKI_PATH", str(tmp_path))
+    resolved = resolve_wiki_root()
+    assert resolved != tmp_path

--- a/tests/riser_database/test_provenance_tripwire.py
+++ b/tests/riser_database/test_provenance_tripwire.py
@@ -53,6 +53,13 @@ _STOPWORDS = {
     "riserstackup", "safety", "sbop", "stack", "stackups", "stres", "string",
     "subsea", "system", "technical", "tension", "test", "tree", "visio",
     "water", "weight", "weights", "workover",
+    # -- #1453 wave-2 calc-contract generic additions: new post-llm-wiki#826
+    # source-page slugs carry these generic document/engineering words whose
+    # normalized substrings occur in long-merged public artifacts (e.g.
+    # "installation" in twin_loop.py/decision_spine.py prose, "sheets" in
+    # "sheet-side", "workbooks" in golden-test docstrings). Real provenance
+    # names (fields, rigs, clients, programs) stay OUT of this list.
+    "installation", "sheets", "workbooks",
 }
 
 #: Round band-edge numerals used by the public ``water_depth_band`` scheme.


### PR DESCRIPTION
Closes #1453. Follow-on to #1280 under epic #1279, enabled by #1451 + llm-wiki#826.

## Summary
- **New shared contract loader** `drilling_riser/calc_contracts.py`: reads wiki-side `calc_contracts` from the registry page AND source pages (bounded, fail-closed on malformed/duplicate goldens); RSU-0007 test refactored onto it, assertions unchanged
- **3 new golden 16Q tests** (RSU-0010/0012, RSU-0014, RSU-0023 incl. the 21-row mud-weight sweep): engine reproduces every documented minimum top tension within 0.5 kips tolerance (actual error ≤0.02 kips)
- **First registry batch run** `examples/workflows/riser-stackup-registry-batch/`: 19 as-planned drilling RSUs → **4 runnable today** (Tmin 1067.70 / 1542.64 / 1583.52 / 2056.99 kips), 15 missing-inputs with per-row reasons. Output CSV gitignored (values are wiki-side; dm carries key names only) — full table on #1453
- Provenance tripwire: 3 generic auto-harvested tokens (installation/sheets/workbooks) added to _STOPWORDS — the gate was already red against the post-#826 wiki on unmodified main files; real provenance names stay live

## Verification
- `tests/drilling_riser/ + tests/riser_database/`: **282 passed / 0 failed** (was 265) with LLM_WIKI_PATH at a post-#826 checkout
- black + isort (repo venv, exact versions) applied; ruff clean; no-abs-paths check clean

## Documented gaps (wave-3 candidates)
- 7 RSUs carry looser result-dialect contracts (no machine-golden 16Q chain yet): RSU-0019/0021/0038/0040/0041/0042/0050
- Overall-minimum step (BOP-overpull + recoil margin) asserted as contract arithmetic; engine helper is a #1279 follow-up