### PR TITLE
docs(capability-map): capabilities IA spec — 7 clusters + reference index

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -22,6 +22,13 @@ gates:
     failure_action: "block"
     warning_action: "report"
 
+  tests-capabilities:
+    enabled: true
+    order: 1
+    description: "Domain tests for capabilities IA inventory (#1444)"
+    domain: "capabilities"
+    test_roots: ["tests/capabilities/"]
+    command: "uv run --no-sources --with 'assetutilities @ git+https://github.com/vamseeachanta/assetutilities.git@main' --with-editable . python -m pytest tests/capabilities/ -rfE -p no:asyncio -p no:randomly -p no:sugar --no-header -q --tb=line"
   tests-cathodic-protection:
     enabled: true
     order: 1

--- a/docs/capability-map/capabilities-added.yml
+++ b/docs/capability-map/capabilities-added.yml
@@ -1,0 +1,36 @@
+# ABOUTME: Explicit recency metadata for capabilities sections (issue #1444).
+# ABOUTME: Git-derived dating is IMPOSSIBLE here — sections live inside one
+# ABOUTME: index.html AND repo history was truncated by the 2026-07 git slim —
+# ABOUTME: so recency is frozen PR evidence, maintained by hand on each merge.
+#
+# Format: sections.<id>: {date: YYYY-MM-DD, pr: NNNN} | "unknown"
+# Entries without evidence stay "unknown" (rendered honestly, never dated).
+
+schema_version: "1.0"
+recent_n: 8
+
+sections:
+  # 2026-07-04 restoration + expansion waves (PR evidence from gh, 2026-07-06)
+  wall-thickness: {date: "2026-07-04", pr: 1389}
+  cathodic: {date: "2026-07-04", pr: 1389}
+  naval-architecture: {date: "2026-07-04", pr: 1394}
+  geotechnical: {date: "2026-07-04", pr: 1394}
+  viv: {date: "2026-07-04", pr: 1396}
+  fatigue: {date: "2026-07-04", pr: 1396}
+  production-engineering: {date: "2026-07-04", pr: 1396}
+  drilling-engineering: {date: "2026-07-04", pr: 1396}
+  field-development: {date: "2026-07-04", pr: 1396}
+  cfd: {date: "2026-07-06", pr: 1442}
+  # pre-slim sections — no recoverable evidence (history truncated)
+  ffs: unknown
+  structural: unknown
+  hydro: unknown
+  risers: unknown
+  subsea: unknown
+  installation: unknown
+  wind: unknown
+  manoeuvring: unknown
+  artificial-lift: unknown
+  well: unknown
+  corrosion-production: unknown
+  validation: unknown

--- a/docs/capability-map/capabilities-clusters.yml
+++ b/docs/capability-map/capabilities-clusters.yml
@@ -1,0 +1,69 @@
+# ABOUTME: Machine source-of-truth for the capabilities-page cluster taxonomy
+# ABOUTME: (issue #1444). The IA spec + inventory render FROM this file.
+#
+# Contract: every <section id> on docs/api/capabilities/index.html appears in
+# EXACTLY one cluster (totality + disjointness are test-enforced against the
+# live page census — a new section that skips this file fails CI).
+# Labels/membership are the owner's review surface: edit here, regenerate.
+
+schema_version: "1.0"
+
+clusters:
+  - key: structures-ffs
+    label: Structures & Fitness-for-Service
+    value_statement: >-
+      Strength, fatigue and remaining-life decisions for plates, panels and
+      aging assets — field measurement to code verdict, with the validation
+      table anchoring every engine to a published golden case.
+    sections: [structural, fatigue, ffs, cathodic, validation]
+
+  - key: pipelines-risers
+    label: Pipelines & Risers
+    value_statement: >-
+      Wall sizing, code checks and vortex-induced-vibration screening for
+      flowlines, pipelines and riser systems across 10+ design codes.
+    sections: [risers, wall-thickness, viv]
+
+  - key: moorings-stationkeeping
+    label: Moorings, Anchors & Subsea
+    value_statement: >-
+      Stationkeeping design and subsea hardware — mooring strength and
+      fatigue, anchor holding capacity, and foundation geotechnics.
+    sections: [subsea, geotechnical]
+
+  - key: hydro-naval
+    label: Hydrodynamics & Naval Architecture
+    value_statement: >-
+      Vessel and floating-body behaviour — diffraction, seakeeping, CFD,
+      manoeuvring and ship-form performance from hull lines to RAOs.
+    sections: [hydro, cfd, manoeuvring, naval-architecture]
+
+  - key: wells-drilling-production
+    label: Wells, Drilling & Production
+    value_statement: >-
+      The well axis end-to-end — casing and drilling engineering, pore
+      pressure, artificial lift, production chemistry and flow assurance.
+    sections:
+      [well, drilling-engineering, artificial-lift, production-engineering,
+       corrosion-production]
+
+  - key: field-dev-economics
+    label: Field Development & Economics
+    value_statement: >-
+      Concept-to-cashflow screening — field development options, floating
+      wind TOTEX/LCOE and NPV levers over real project structures.
+    sections: [field-development, wind]
+
+  - key: installation-ops
+    label: Installation & Marine Operations
+    value_statement: >-
+      Getting hardware to the seabed safely — installability screening,
+      lifting/lowering dynamics and weather-windowed marine operations.
+    sections: [installation]
+
+# explorer relpath -> section id, for explorers not hyperlinked from any
+# section block (residual joins are declared here, reviewed, never guessed).
+explorer_aliases:
+  # tank-sloshing lives in the CFD-study family (PRs #1424/#1428/#1443) but
+  # the index's cfd section does not hyperlink it — owner may re-home it.
+  docs/api/structural/sloshing-explorer.html: cfd

--- a/docs/capability-map/capabilities-ia-spec-1444.md
+++ b/docs/capability-map/capabilities-ia-spec-1444.md
@@ -1,0 +1,111 @@
+# Capabilities page — information-architecture spec (issue #1444)
+
+> GENERATED tables (source of truth: `capabilities-clusters.yml`, `capabilities-added.yml`, the live page census). Regenerate with:
+> `.venv/bin/python scripts/capabilities/build_capabilities_inventory.py`
+> Presentation is owned by the capabilities revamp lane (PR #1389 coordination note) — this spec is its input; `index.html` is not edited here.
+
+Sections on the live page: **22** · clusters: **7** · PDF coverage gaps: **10** · unlinked explorers: **0**
+
+## Cluster taxonomy
+
+### Structures & Fitness-for-Service (`structures-ffs`)
+*Strength, fatigue and remaining-life decisions for plates, panels and aging assets — field measurement to code verdict, with the validation table anchoring every engine to a published golden case.*
+
+- [`#structural`](../api/capabilities/index.html#structural) — Ship structural strength
+- [`#fatigue`](../api/capabilities/index.html#fatigue) — Fatigue &amp; fracture &mdash; S-N life and crack growth
+- [`#ffs`](../api/capabilities/index.html#ffs) — Fitness-for-service
+- [`#cathodic`](../api/capabilities/index.html#cathodic) — Cathodic protection
+- [`#validation`](../api/capabilities/index.html#validation) — Validated against published references
+
+### Pipelines & Risers (`pipelines-risers`)
+*Wall sizing, code checks and vortex-induced-vibration screening for flowlines, pipelines and riser systems across 10+ design codes.*
+
+- [`#risers`](../api/capabilities/index.html#risers) — Risers &amp; pipelines
+- [`#wall-thickness`](../api/capabilities/index.html#wall-thickness) — Wall thickness &mdash; sizing &amp; code checks
+- [`#viv`](../api/capabilities/index.html#viv) — Vortex-induced vibration &mdash; screening, frequency &amp; fatigue
+
+### Moorings, Anchors & Subsea (`moorings-stationkeeping`)
+*Stationkeeping design and subsea hardware — mooring strength and fatigue, anchor holding capacity, and foundation geotechnics.*
+
+- [`#subsea`](../api/capabilities/index.html#subsea) — Subsea
+- [`#geotechnical`](../api/capabilities/index.html#geotechnical) — Geotechnical &mdash; pile, anchor &amp; foundation capacity
+
+### Hydrodynamics & Naval Architecture (`hydro-naval`)
+*Vessel and floating-body behaviour — diffraction, seakeeping, CFD, manoeuvring and ship-form performance from hull lines to RAOs.*
+
+- [`#hydro`](../api/capabilities/index.html#hydro) — Hydrodynamics &amp; diffraction
+- [`#cfd`](../api/capabilities/index.html#cfd) — Computational fluid dynamics (CFD)
+- [`#manoeuvring`](../api/capabilities/index.html#manoeuvring) — Manoeuvring &amp; station-keeping
+- [`#naval-architecture`](../api/capabilities/index.html#naval-architecture) — Naval architecture &mdash; stability, resistance &amp; hull strength
+
+### Wells, Drilling & Production (`wells-drilling-production`)
+*The well axis end-to-end — casing and drilling engineering, pore pressure, artificial lift, production chemistry and flow assurance.*
+
+- [`#well`](../api/capabilities/index.html#well) — Well construction &mdash; casing &amp; tubulars
+- [`#drilling-engineering`](../api/capabilities/index.html#drilling-engineering) — Drilling engineering &mdash; pore pressure, hydraulics &amp; well control
+- [`#artificial-lift`](../api/capabilities/index.html#artificial-lift) — Artificial lift &mdash; rod-pump diagnostics
+- [`#production-engineering`](../api/capabilities/index.html#production-engineering) — Production engineering &mdash; nodal analysis &amp; well deliverability
+- [`#corrosion-production`](../api/capabilities/index.html#corrosion-production) — Corrosion &amp; production chemistry
+
+### Field Development & Economics (`field-dev-economics`)
+*Concept-to-cashflow screening — field development options, floating wind TOTEX/LCOE and NPV levers over real project structures.*
+
+- [`#field-development`](../api/capabilities/index.html#field-development) — Field development &mdash; concept screening, cost &amp; economics
+- [`#wind`](../api/capabilities/index.html#wind) — Floating wind
+
+### Installation & Marine Operations (`installation-ops`)
+*Getting hardware to the seabed safely — installability screening, lifting/lowering dynamics and weather-windowed marine operations.*
+
+- [`#installation`](../api/capabilities/index.html#installation) — Installation
+
+## Reference index (citable front doors)
+
+| Section | Cluster | Live explorer(s) | 1-pager PDF | Added |
+|---|---|---|---|---|
+| [`#ffs`](../api/capabilities/index.html#ffs) | structures-ffs | `docs/api/ffs/riser-joint-acceptance-explorer.html` | `docs/api/capabilities/pdf/sec-ffs.pdf` | unknown |
+| [`#structural`](../api/capabilities/index.html#structural) | structures-ffs | *gap* | `docs/api/capabilities/pdf/sec-structural.pdf` | unknown |
+| [`#fatigue`](../api/capabilities/index.html#fatigue) | structures-ffs | *gap* | *gap* | 2026-07-04 (#1396) |
+| [`#hydro`](../api/capabilities/index.html#hydro) | hydro-naval | `docs/api/hydro/ocimf-coefficient-explorer.html` | `docs/api/capabilities/pdf/sec-hydro.pdf` | unknown |
+| [`#cfd`](../api/capabilities/index.html#cfd) | hydro-naval | `docs/api/structural/sloshing-explorer.html` | *gap* | 2026-07-06 (#1442) |
+| [`#risers`](../api/capabilities/index.html#risers) | pipelines-risers | `docs/api/drilling/drilling-riser-operability-explorer.html` | `docs/api/capabilities/pdf/sec-risers.pdf` | unknown |
+| [`#wall-thickness`](../api/capabilities/index.html#wall-thickness) | pipelines-risers | `docs/api/structural/wall-thickness-explorer.html` | *gap* | 2026-07-04 (#1389) |
+| [`#subsea`](../api/capabilities/index.html#subsea) | moorings-stationkeeping | *gap* | `docs/api/capabilities/pdf/sec-subsea.pdf` | unknown |
+| [`#viv`](../api/capabilities/index.html#viv) | pipelines-risers | `docs/api/structural/viv-explorer.html` | *gap* | 2026-07-04 (#1396) |
+| [`#installation`](../api/capabilities/index.html#installation) | installation-ops | *gap* | `docs/api/capabilities/pdf/sec-installation.pdf` | unknown |
+| [`#wind`](../api/capabilities/index.html#wind) | field-dev-economics | *gap* | `docs/api/capabilities/pdf/sec-wind.pdf` | unknown |
+| [`#field-development`](../api/capabilities/index.html#field-development) | field-dev-economics | `docs/api/structural/field-economics-explorer.html` | *gap* | 2026-07-04 (#1396) |
+| [`#manoeuvring`](../api/capabilities/index.html#manoeuvring) | hydro-naval | `docs/api/hydro/rudder-maneuvering-explorer.html` | `docs/api/capabilities/pdf/sec-manoeuvring.pdf` | unknown |
+| [`#naval-architecture`](../api/capabilities/index.html#naval-architecture) | hydro-naval | `docs/api/structural/ship-resistance-explorer.html` | *gap* | 2026-07-04 (#1394) |
+| [`#geotechnical`](../api/capabilities/index.html#geotechnical) | moorings-stationkeeping | `docs/api/structural/anchor-holding-explorer.html` | *gap* | 2026-07-04 (#1394) |
+| [`#artificial-lift`](../api/capabilities/index.html#artificial-lift) | wells-drilling-production | *gap* | `docs/api/capabilities/pdf/sec-artificial-lift.pdf` | unknown |
+| [`#production-engineering`](../api/capabilities/index.html#production-engineering) | wells-drilling-production | `docs/api/structural/ipr-explorer.html` | *gap* | 2026-07-04 (#1396) |
+| [`#well`](../api/capabilities/index.html#well) | wells-drilling-production | `docs/api/well/casing-design-explorer.html` | `docs/api/capabilities/pdf/sec-well.pdf` | unknown |
+| [`#drilling-engineering`](../api/capabilities/index.html#drilling-engineering) | wells-drilling-production | `docs/api/structural/pore-pressure-explorer.html` | *gap* | 2026-07-04 (#1396) |
+| [`#cathodic`](../api/capabilities/index.html#cathodic) | structures-ffs | `docs/api/structural/cathodic-protection-explorer.html` | *gap* | 2026-07-04 (#1389) |
+| [`#corrosion-production`](../api/capabilities/index.html#corrosion-production) | wells-drilling-production | `docs/api/corrosion/galvanic-compatibility-explorer.html`<br>`docs/api/production/scale-si-explorer.html` | `docs/api/capabilities/pdf/sec-corrosion-production.pdf` | unknown |
+| [`#validation`](../api/capabilities/index.html#validation) | structures-ffs | *gap* | `docs/api/capabilities/pdf/sec-validation.pdf` | unknown |
+
+**PDF gap set (10):** `fatigue`, `cfd`, `wall-thickness`, `viv`, `field-development`, `naval-architecture`, `geotechnical`, `production-engineering`, `drilling-engineering`, `cathodic`
+
+**Unlinked explorers:** none
+
+## Recently added (strip content model)
+
+Display contract: top-N below (N from `capabilities-added.yml:recent_n`), newest first; entries without PR evidence stay off the strip (honest `unknown`, never a fabricated date — repo history was truncated by the 2026-07 git slim, so recency is explicit metadata).
+
+- `#cfd` — 2026-07-06 (PR #1442)
+- `#fatigue` — 2026-07-04 (PR #1396)
+- `#wall-thickness` — 2026-07-04 (PR #1389)
+- `#viv` — 2026-07-04 (PR #1396)
+- `#field-development` — 2026-07-04 (PR #1396)
+- `#naval-architecture` — 2026-07-04 (PR #1394)
+- `#geotechnical` — 2026-07-04 (PR #1394)
+- `#production-engineering` — 2026-07-04 (PR #1396)
+
+## Anchor-stability contract
+
+The revamp MUST preserve every anchor below (external links already cite them). Enforcement pattern: route manifest + link-graph CI gate (see worldenergydata #850).
+
+```
+ffs structural fatigue hydro cfd risers wall-thickness subsea viv installation wind field-development manoeuvring naval-architecture geotechnical artificial-lift production-engineering well drilling-engineering cathodic corrosion-production validation
+```

--- a/docs/capability-map/capabilities-inventory.json
+++ b/docs/capability-map/capabilities-inventory.json
@@ -1,0 +1,371 @@
+{
+  "clusters": [
+    {
+      "key": "structures-ffs",
+      "label": "Structures & Fitness-for-Service",
+      "sections": [
+        "structural",
+        "fatigue",
+        "ffs",
+        "cathodic",
+        "validation"
+      ],
+      "value_statement": "Strength, fatigue and remaining-life decisions for plates, panels and aging assets — field measurement to code verdict, with the validation table anchoring every engine to a published golden case."
+    },
+    {
+      "key": "pipelines-risers",
+      "label": "Pipelines & Risers",
+      "sections": [
+        "risers",
+        "wall-thickness",
+        "viv"
+      ],
+      "value_statement": "Wall sizing, code checks and vortex-induced-vibration screening for flowlines, pipelines and riser systems across 10+ design codes."
+    },
+    {
+      "key": "moorings-stationkeeping",
+      "label": "Moorings, Anchors & Subsea",
+      "sections": [
+        "subsea",
+        "geotechnical"
+      ],
+      "value_statement": "Stationkeeping design and subsea hardware — mooring strength and fatigue, anchor holding capacity, and foundation geotechnics."
+    },
+    {
+      "key": "hydro-naval",
+      "label": "Hydrodynamics & Naval Architecture",
+      "sections": [
+        "hydro",
+        "cfd",
+        "manoeuvring",
+        "naval-architecture"
+      ],
+      "value_statement": "Vessel and floating-body behaviour — diffraction, seakeeping, CFD, manoeuvring and ship-form performance from hull lines to RAOs."
+    },
+    {
+      "key": "wells-drilling-production",
+      "label": "Wells, Drilling & Production",
+      "sections": [
+        "well",
+        "drilling-engineering",
+        "artificial-lift",
+        "production-engineering",
+        "corrosion-production"
+      ],
+      "value_statement": "The well axis end-to-end — casing and drilling engineering, pore pressure, artificial lift, production chemistry and flow assurance."
+    },
+    {
+      "key": "field-dev-economics",
+      "label": "Field Development & Economics",
+      "sections": [
+        "field-development",
+        "wind"
+      ],
+      "value_statement": "Concept-to-cashflow screening — field development options, floating wind TOTEX/LCOE and NPV levers over real project structures."
+    },
+    {
+      "key": "installation-ops",
+      "label": "Installation & Marine Operations",
+      "sections": [
+        "installation"
+      ],
+      "value_statement": "Getting hardware to the seabed safely — installability screening, lifting/lowering dynamics and weather-windowed marine operations."
+    }
+  ],
+  "pdf_gaps": [
+    "fatigue",
+    "cfd",
+    "wall-thickness",
+    "viv",
+    "field-development",
+    "naval-architecture",
+    "geotechnical",
+    "production-engineering",
+    "drilling-engineering",
+    "cathodic"
+  ],
+  "recent": [
+    {
+      "date": "2026-07-06",
+      "id": "cfd",
+      "pr": 1442
+    },
+    {
+      "date": "2026-07-04",
+      "id": "fatigue",
+      "pr": 1396
+    },
+    {
+      "date": "2026-07-04",
+      "id": "wall-thickness",
+      "pr": 1389
+    },
+    {
+      "date": "2026-07-04",
+      "id": "viv",
+      "pr": 1396
+    },
+    {
+      "date": "2026-07-04",
+      "id": "field-development",
+      "pr": 1396
+    },
+    {
+      "date": "2026-07-04",
+      "id": "naval-architecture",
+      "pr": 1394
+    },
+    {
+      "date": "2026-07-04",
+      "id": "geotechnical",
+      "pr": 1394
+    },
+    {
+      "date": "2026-07-04",
+      "id": "production-engineering",
+      "pr": 1396
+    }
+  ],
+  "schema_version": "1.0",
+  "sections": [
+    {
+      "added": "unknown",
+      "cluster": "structures-ffs",
+      "explorers": [
+        "docs/api/ffs/riser-joint-acceptance-explorer.html"
+      ],
+      "id": "ffs",
+      "pdf": "docs/api/capabilities/pdf/sec-ffs.pdf",
+      "title": "Fitness-for-service"
+    },
+    {
+      "added": "unknown",
+      "cluster": "structures-ffs",
+      "explorers": [],
+      "id": "structural",
+      "pdf": "docs/api/capabilities/pdf/sec-structural.pdf",
+      "title": "Ship structural strength"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1396
+      },
+      "cluster": "structures-ffs",
+      "explorers": [],
+      "id": "fatigue",
+      "pdf": null,
+      "title": "Fatigue &amp; fracture &mdash; S-N life and crack growth"
+    },
+    {
+      "added": "unknown",
+      "cluster": "hydro-naval",
+      "explorers": [
+        "docs/api/hydro/ocimf-coefficient-explorer.html"
+      ],
+      "id": "hydro",
+      "pdf": "docs/api/capabilities/pdf/sec-hydro.pdf",
+      "title": "Hydrodynamics &amp; diffraction"
+    },
+    {
+      "added": {
+        "date": "2026-07-06",
+        "pr": 1442
+      },
+      "cluster": "hydro-naval",
+      "explorers": [
+        "docs/api/structural/sloshing-explorer.html"
+      ],
+      "id": "cfd",
+      "pdf": null,
+      "title": "Computational fluid dynamics (CFD)"
+    },
+    {
+      "added": "unknown",
+      "cluster": "pipelines-risers",
+      "explorers": [
+        "docs/api/drilling/drilling-riser-operability-explorer.html"
+      ],
+      "id": "risers",
+      "pdf": "docs/api/capabilities/pdf/sec-risers.pdf",
+      "title": "Risers &amp; pipelines"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1389
+      },
+      "cluster": "pipelines-risers",
+      "explorers": [
+        "docs/api/structural/wall-thickness-explorer.html"
+      ],
+      "id": "wall-thickness",
+      "pdf": null,
+      "title": "Wall thickness &mdash; sizing &amp; code checks"
+    },
+    {
+      "added": "unknown",
+      "cluster": "moorings-stationkeeping",
+      "explorers": [],
+      "id": "subsea",
+      "pdf": "docs/api/capabilities/pdf/sec-subsea.pdf",
+      "title": "Subsea"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1396
+      },
+      "cluster": "pipelines-risers",
+      "explorers": [
+        "docs/api/structural/viv-explorer.html"
+      ],
+      "id": "viv",
+      "pdf": null,
+      "title": "Vortex-induced vibration &mdash; screening, frequency &amp; fatigue"
+    },
+    {
+      "added": "unknown",
+      "cluster": "installation-ops",
+      "explorers": [],
+      "id": "installation",
+      "pdf": "docs/api/capabilities/pdf/sec-installation.pdf",
+      "title": "Installation"
+    },
+    {
+      "added": "unknown",
+      "cluster": "field-dev-economics",
+      "explorers": [],
+      "id": "wind",
+      "pdf": "docs/api/capabilities/pdf/sec-wind.pdf",
+      "title": "Floating wind"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1396
+      },
+      "cluster": "field-dev-economics",
+      "explorers": [
+        "docs/api/structural/field-economics-explorer.html"
+      ],
+      "id": "field-development",
+      "pdf": null,
+      "title": "Field development &mdash; concept screening, cost &amp; economics"
+    },
+    {
+      "added": "unknown",
+      "cluster": "hydro-naval",
+      "explorers": [
+        "docs/api/hydro/rudder-maneuvering-explorer.html"
+      ],
+      "id": "manoeuvring",
+      "pdf": "docs/api/capabilities/pdf/sec-manoeuvring.pdf",
+      "title": "Manoeuvring &amp; station-keeping"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1394
+      },
+      "cluster": "hydro-naval",
+      "explorers": [
+        "docs/api/structural/ship-resistance-explorer.html"
+      ],
+      "id": "naval-architecture",
+      "pdf": null,
+      "title": "Naval architecture &mdash; stability, resistance &amp; hull strength"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1394
+      },
+      "cluster": "moorings-stationkeeping",
+      "explorers": [
+        "docs/api/structural/anchor-holding-explorer.html"
+      ],
+      "id": "geotechnical",
+      "pdf": null,
+      "title": "Geotechnical &mdash; pile, anchor &amp; foundation capacity"
+    },
+    {
+      "added": "unknown",
+      "cluster": "wells-drilling-production",
+      "explorers": [],
+      "id": "artificial-lift",
+      "pdf": "docs/api/capabilities/pdf/sec-artificial-lift.pdf",
+      "title": "Artificial lift &mdash; rod-pump diagnostics"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1396
+      },
+      "cluster": "wells-drilling-production",
+      "explorers": [
+        "docs/api/structural/ipr-explorer.html"
+      ],
+      "id": "production-engineering",
+      "pdf": null,
+      "title": "Production engineering &mdash; nodal analysis &amp; well deliverability"
+    },
+    {
+      "added": "unknown",
+      "cluster": "wells-drilling-production",
+      "explorers": [
+        "docs/api/well/casing-design-explorer.html"
+      ],
+      "id": "well",
+      "pdf": "docs/api/capabilities/pdf/sec-well.pdf",
+      "title": "Well construction &mdash; casing &amp; tubulars"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1396
+      },
+      "cluster": "wells-drilling-production",
+      "explorers": [
+        "docs/api/structural/pore-pressure-explorer.html"
+      ],
+      "id": "drilling-engineering",
+      "pdf": null,
+      "title": "Drilling engineering &mdash; pore pressure, hydraulics &amp; well control"
+    },
+    {
+      "added": {
+        "date": "2026-07-04",
+        "pr": 1389
+      },
+      "cluster": "structures-ffs",
+      "explorers": [
+        "docs/api/structural/cathodic-protection-explorer.html"
+      ],
+      "id": "cathodic",
+      "pdf": null,
+      "title": "Cathodic protection"
+    },
+    {
+      "added": "unknown",
+      "cluster": "wells-drilling-production",
+      "explorers": [
+        "docs/api/corrosion/galvanic-compatibility-explorer.html",
+        "docs/api/production/scale-si-explorer.html"
+      ],
+      "id": "corrosion-production",
+      "pdf": "docs/api/capabilities/pdf/sec-corrosion-production.pdf",
+      "title": "Corrosion &amp; production chemistry"
+    },
+    {
+      "added": "unknown",
+      "cluster": "structures-ffs",
+      "explorers": [],
+      "id": "validation",
+      "pdf": "docs/api/capabilities/pdf/sec-validation.pdf",
+      "title": "Validated against published references"
+    }
+  ],
+  "source": "docs/api/capabilities/index.html",
+  "unlinked_explorers": []
+}

--- a/scripts/capabilities/build_capabilities_inventory.py
+++ b/scripts/capabilities/build_capabilities_inventory.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""ABOUTME: Capabilities IA inventory builder (issue #1444) — census, clusters,
+ABOUTME: reference-index joins, recency, spec rendering, and --check freshness.
+
+Reads (never edits) docs/api/capabilities/index.html plus the machine
+source-of-truth files under docs/capability-map/, and emits:
+
+  docs/capability-map/capabilities-inventory.json   (machine contract)
+  docs/capability-map/capabilities-ia-spec-1444.md  (rendered spec; tables are
+                                                     generated, never hand-typed)
+
+``--check`` regenerates in memory and exits non-zero if the committed
+inventory drifted (CI freshness gate via the tests/DOMAINS.md capabilities row).
+
+Recency comes ONLY from capabilities-added.yml (explicit, PR-evidenced
+metadata): the repo's git history was truncated by the 2026-07 slim and
+sections live inside one HTML file, so no git-derived dating is valid.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+SCHEMA_VERSION = "1.0"
+HERE = Path(__file__).resolve()
+REPO_DEFAULT = HERE.parents[2]
+
+CAP_MAP = "docs/capability-map"
+INDEX_HTML = "docs/api/capabilities/index.html"
+FROZEN_DIR = "capabilities/api"  # frozen work-item assets — excluded from discovery
+
+
+class CensusError(RuntimeError):
+    """Census failures fail closed with an actionable message."""
+
+
+# ---------------------------------------------------------------------------
+# parsing
+# ---------------------------------------------------------------------------
+
+_SECTION_RE = re.compile(r'<section[^>]*\bid="([a-z0-9-]+)"')
+_NAV_BLOCK_RE = re.compile(r"<nav>.*?</nav>", re.S)
+_NAV_HREF_RE = re.compile(r'href="#([a-z0-9-]+)"')
+_H2_RE = re.compile(r"<h2[^>]*>([^<]{1,120})<")
+_HREF_RE = re.compile(r'href="([^"#]+)"')
+
+
+def parse_nav(html: str) -> list[str]:
+    m = _NAV_BLOCK_RE.search(html)
+    if not m:
+        raise CensusError("no <nav> block found")
+    return _NAV_HREF_RE.findall(m.group(0))
+
+
+def parse_sections(html: str) -> list[dict]:
+    """Section id, title (first h2), and the hrefs inside each section block."""
+    out = []
+    matches = list(_SECTION_RE.finditer(html))
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(html)
+        block = html[start:end]
+        h2 = _H2_RE.search(block)
+        out.append(
+            {
+                "id": m.group(1),
+                "title": (h2.group(1).strip() if h2 else ""),
+                "hrefs": _HREF_RE.findall(block),
+            }
+        )
+    return out
+
+
+def census(html: str) -> list[dict]:
+    """Bijection-checked census: nav <-> sections, no duplicates. Fail closed."""
+    sections = parse_sections(html)
+    ids = [s["id"] for s in sections]
+    dupes = {i for i in ids if ids.count(i) > 1}
+    if dupes:
+        raise CensusError(f"duplicate section ids: {sorted(dupes)}")
+    nav = parse_nav(html)
+    ghosts = set(nav) - set(ids)
+    if ghosts:
+        raise CensusError(f"nav links to missing sections: {sorted(ghosts)}")
+    unlisted = set(ids) - set(nav)
+    if unlisted:
+        raise CensusError(f"sections absent from nav: {sorted(unlisted)}")
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# discovery + joins
+# ---------------------------------------------------------------------------
+
+
+def discover_explorers(repo: Path) -> list[str]:
+    """Live explorer pages across docs/api/**, excluding the frozen
+    capabilities/api work-item assets."""
+    root = repo / "docs" / "api"
+    return sorted(
+        str(p.relative_to(repo))
+        for p in root.rglob("*-explorer.html")
+        if FROZEN_DIR not in str(p)
+    )
+
+
+def load_pdf_specs(repo: Path) -> dict[str, str]:
+    """section id -> pdf relpath, from build_onepagers SPECS (importlib on the
+    real path — the module builds dict()s, so AST parsing will not work)."""
+    script = repo / "scripts" / "capabilities" / "build_onepagers.py"
+    spec = importlib.util.spec_from_file_location("build_onepagers_ro", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    out = {}
+    for entry in mod.SPECS:
+        if entry.get("kind") == "section" and entry["id"].startswith("sec-"):
+            sec = entry["id"][len("sec-") :]
+            out[sec] = f"docs/api/capabilities/pdf/{entry['id']}.pdf"
+    return out
+
+
+def load_clusters(repo: Path) -> dict:
+    return yaml.safe_load((repo / CAP_MAP / "capabilities-clusters.yml").read_text())
+
+
+def load_added(repo: Path) -> dict:
+    return yaml.safe_load((repo / CAP_MAP / "capabilities-added.yml").read_text())
+
+
+def build_inventory(repo: Path | str = REPO_DEFAULT) -> dict:
+    repo = Path(repo)
+    html = (repo / INDEX_HTML).read_text()
+    sections = census(html)
+    clusters_doc = load_clusters(repo)
+    added_doc = load_added(repo)
+
+    cluster_of: dict[str, str] = {}
+    for c in clusters_doc["clusters"]:
+        for sid in c["sections"]:
+            if sid in cluster_of:
+                raise CensusError(f"section {sid} assigned to two clusters")
+            cluster_of[sid] = c["key"]
+
+    explorers = discover_explorers(repo)
+    aliases = clusters_doc.get("explorer_aliases", {})  # explorer relpath -> section id
+    pdf_by_section = load_pdf_specs(repo)
+    added = added_doc.get("sections", {})
+
+    # explorer -> section: in-section href match first, then alias map
+    by_name = {Path(e).name: e for e in explorers}
+    owner: dict[str, str] = {}
+    for s in sections:
+        for href in s["hrefs"]:
+            name = Path(href).name
+            if name in by_name:
+                e = by_name[name]
+                if e in owner and owner[e] != s["id"]:
+                    raise CensusError(
+                        f"explorer {e} linked from two sections "
+                        f"({owner[e]}, {s['id']}) — add an explorer_aliases entry"
+                    )
+                owner[e] = s["id"]
+    for e, sid in aliases.items():
+        owner.setdefault(e, sid)
+
+    inv_sections = []
+    for s in sections:
+        sid = s["id"]
+        if sid not in cluster_of:
+            raise CensusError(f"section {sid} missing from capabilities-clusters.yml")
+        inv_sections.append(
+            {
+                "id": sid,
+                "title": s["title"],
+                "cluster": cluster_of[sid],
+                "explorers": sorted(e for e, o in owner.items() if o == sid),
+                "pdf": pdf_by_section.get(sid),
+                "added": added.get(sid, "unknown"),
+            }
+        )
+
+    stale_clusters = set(cluster_of) - {s["id"] for s in sections}
+    if stale_clusters:
+        raise CensusError(
+            f"cluster map lists unknown sections: {sorted(stale_clusters)}"
+        )
+
+    known = [
+        s
+        for s in inv_sections
+        if s["added"] != "unknown" and isinstance(s["added"], dict)
+    ]
+    recent = sorted(known, key=lambda s: s["added"]["date"], reverse=True)
+    n = added_doc.get("recent_n", 8)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": INDEX_HTML,
+        "sections": inv_sections,
+        "clusters": [
+            {k: c[k] for k in ("key", "label", "value_statement", "sections")}
+            for c in clusters_doc["clusters"]
+        ],
+        "pdf_gaps": [s["id"] for s in inv_sections if s["pdf"] is None],
+        "unlinked_explorers": sorted(set(explorers) - set(owner)),
+        "recent": [
+            {"id": s["id"], "date": s["added"]["date"], "pr": s["added"]["pr"]}
+            for s in recent[:n]
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# outputs
+# ---------------------------------------------------------------------------
+
+
+def _canon(doc: dict) -> str:
+    return json.dumps(doc, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def write_inventory(inv: dict, out_path: Path) -> None:
+    Path(out_path).write_text(_canon(inv))
+
+
+def check(repo: Path | str, committed_path: Path | str) -> int:
+    """0 when the committed inventory matches a fresh regeneration."""
+    fresh = _canon(build_inventory(repo))
+    committed = Path(committed_path).read_text()
+    return 0 if fresh == committed else 1
+
+
+def render_spec(inv: dict) -> str:
+    lines = [
+        "# Capabilities page — information-architecture spec (issue #1444)",
+        "",
+        "> GENERATED tables (source of truth: `capabilities-clusters.yml`, "
+        "`capabilities-added.yml`, the live page census). Regenerate with:",
+        "> `.venv/bin/python scripts/capabilities/build_capabilities_inventory.py`",
+        "> Presentation is owned by the capabilities revamp lane (PR #1389 "
+        "coordination note) — this spec is its input; `index.html` is not "
+        "edited here.",
+        "",
+        f"Sections on the live page: **{len(inv['sections'])}** · clusters: "
+        f"**{len(inv['clusters'])}** · PDF coverage gaps: "
+        f"**{len(inv['pdf_gaps'])}** · unlinked explorers: "
+        f"**{len(inv['unlinked_explorers'])}**",
+        "",
+        "## Cluster taxonomy",
+        "",
+    ]
+    by_id = {s["id"]: s for s in inv["sections"]}
+    for c in inv["clusters"]:
+        lines.append(f"### {c['label']} (`{c['key']}`)")
+        lines.append(f"*{c['value_statement']}*")
+        lines.append("")
+        for sid in c["sections"]:
+            s = by_id[sid]
+            lines.append(
+                f"- [`#{sid}`](../api/capabilities/index.html#{sid}) — {s['title']}"
+            )
+        lines.append("")
+    lines += [
+        "## Reference index (citable front doors)",
+        "",
+        "| Section | Cluster | Live explorer(s) | 1-pager PDF | Added |",
+        "|---|---|---|---|---|",
+    ]
+    for s in inv["sections"]:
+        exp = "<br>".join(f"`{e}`" for e in s["explorers"]) or "*gap*"
+        pdf = f"`{s['pdf']}`" if s["pdf"] else "*gap*"
+        if isinstance(s["added"], dict):
+            added = f"{s['added']['date']} (#{s['added']['pr']})"
+        else:
+            added = "unknown"
+        lines.append(
+            f"| [`#{s['id']}`](../api/capabilities/index.html#{s['id']}) "
+            f"| {s['cluster']} | {exp} | {pdf} | {added} |"
+        )
+    lines += [
+        "",
+        f"**PDF gap set ({len(inv['pdf_gaps'])}):** "
+        + ", ".join(f"`{g}`" for g in inv["pdf_gaps"]),
+        "",
+        "**Unlinked explorers:** "
+        + (", ".join(f"`{e}`" for e in inv["unlinked_explorers"]) or "none"),
+        "",
+        "## Recently added (strip content model)",
+        "",
+        "Display contract: top-N below (N from `capabilities-added.yml:recent_n`),"
+        " newest first; entries without PR evidence stay off the strip (honest"
+        " `unknown`, never a fabricated date — repo history was truncated by the"
+        " 2026-07 git slim, so recency is explicit metadata).",
+        "",
+    ]
+    for r in inv["recent"]:
+        lines.append(f"- `#{r['id']}` — {r['date']} (PR #{r['pr']})")
+    lines += [
+        "",
+        "## Anchor-stability contract",
+        "",
+        "The revamp MUST preserve every anchor below (external links already "
+        "cite them). Enforcement pattern: route manifest + link-graph CI gate "
+        "(see worldenergydata #850).",
+        "",
+        "```",
+        " ".join(s["id"] for s in inv["sections"]),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--repo", default=str(REPO_DEFAULT))
+    args = ap.parse_args()
+    repo = Path(args.repo)
+    committed = repo / CAP_MAP / "capabilities-inventory.json"
+    if args.check:
+        rc = check(repo, committed)
+        print("fresh" if rc == 0 else "DRIFTED — regenerate and commit")
+        return rc
+    inv = build_inventory(repo)
+    write_inventory(inv, committed)
+    (repo / CAP_MAP / "capabilities-ia-spec-1444.md").write_text(render_spec(inv))
+    print(
+        f"  wrote capabilities-inventory.json ({len(inv['sections'])} sections, "
+        f"{len(inv['pdf_gaps'])} pdf gaps, "
+        f"{len(inv['unlinked_explorers'])} unlinked explorers)"
+    )
+    print("  wrote capabilities-ia-spec-1444.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/DOMAINS.md
+++ b/tests/DOMAINS.md
@@ -7,6 +7,7 @@ backtick-wrapped so `scripts/ci/detect_touched_domains.py` can parse them.
 | Domain | Test roots | Purpose/deps/notes |
 | --- | --- | --- |
 | asset-integrity | `tests/asset_integrity/`, `tests/engineering_validation/`, `tests/test_wall_thickness.py`, `tests/test_wall_thickness_api_rp_2rd.py`, `tests/test_wall_thickness_api_std_2rd.py`, `tests/test_wall_thickness_codes/`, `tests/test_wall_thickness_comparison.py`, `tests/test_wall_thickness_dnv_editions.py`, `tests/test_wall_thickness_editions.py`, `tests/test_wall_thickness_interactive_report.py`, `tests/test_wall_thickness_lookup.py`, `tests/test_wall_thickness_mt_report.py`, `tests/test_wall_thickness_parametric.py`, `tests/test_wall_thickness_phases.py`, `tests/materials/` | Fitness-for-service, pipe sizing, wall thickness, material grade matrix, and integrity calculations. |
+| capabilities | `tests/capabilities/` | Capabilities-page IA inventory: section census bijection, cluster totality, reference-index joins, freshness gate (#1444). |
 | cathodic-protection | `tests/cathodic_protection/` | Cathodic protection design, monitoring, surveys, standards, and reports. |
 | citations | `tests/citations/` | Citation registry and schema validation. |
 | contracts | `tests/contracts/`, `tests/compat/`, `tests/cross_repo/`, `tests/docs/`, `tests/test_apistd2rd_migration.py`, `tests/test_module_reorganization.py`, `tests/test_restructure_compat.py`, `tests/test_units.py`, `tests/test_validation_utils.py` | External package contracts, routing/docs contracts, compatibility, and migration guards. |

--- a/tests/capabilities/test_capabilities_inventory.py
+++ b/tests/capabilities/test_capabilities_inventory.py
@@ -1,0 +1,161 @@
+# ABOUTME: TDD suite for the capabilities IA inventory (issue #1444) — section
+# ABOUTME: census bijection, cluster totality, joins with gaps, freshness gate.
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "capabilities" / "build_capabilities_inventory.py"
+
+spec = importlib.util.spec_from_file_location("capinv", SCRIPT)
+ci = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ci)
+
+INDEX = REPO / "docs" / "api" / "capabilities" / "index.html"
+CLUSTERS = REPO / "docs" / "capability-map" / "capabilities-clusters.yml"
+ADDED = REPO / "docs" / "capability-map" / "capabilities-added.yml"
+
+
+# 1 — census bijection on the LIVE page: nav hrefs <-> section ids, 1:1
+
+
+def test_section_census_bijection_live_page():
+    sections = ci.parse_sections(INDEX.read_text())
+    ids = [s["id"] for s in sections]
+    assert len(ids) == len(set(ids))
+    nav = ci.parse_nav(INDEX.read_text())
+    assert set(nav) == set(ids)
+    assert len(nav) == len(ids)
+    for s in sections:
+        assert s["title"]
+
+
+# 2 — parser failure fixtures fail closed with diagnostics
+
+
+def test_parser_failure_fixtures():
+    dup = '<nav><a href="#a">A</a></nav><section id="a"></section><section id="a"></section>'
+    with pytest.raises(ci.CensusError, match="duplicate"):
+        ci.census(dup)
+    nav_only = '<nav><a href="#a">A</a><a href="#ghost">G</a></nav><section id="a"><h2>A</h2></section>'
+    with pytest.raises(ci.CensusError, match="ghost"):
+        ci.census(nav_only)
+    sec_only = '<nav><a href="#a">A</a></nav><section id="a"><h2>A</h2></section><section id="b"><h2>B</h2></section>'
+    with pytest.raises(ci.CensusError, match="b"):
+        ci.census(sec_only)
+
+
+# 3 — cluster map: schema, totality, disjointness vs the live census
+
+
+def test_cluster_mapping_total_disjoint_and_schema():
+    doc = yaml.safe_load(CLUSTERS.read_text())
+    assert doc["schema_version"]
+    assigned = []
+    for c in doc["clusters"]:
+        assert c["key"] and c["label"] and c["value_statement"]
+        assigned += c["sections"]
+    assert len(assigned) == len(set(assigned)), "section in two clusters"
+    live = {s["id"] for s in ci.parse_sections(INDEX.read_text())}
+    assert set(assigned) == live, (
+        f"cluster map out of sync: missing={live - set(assigned)} "
+        f"stale={set(assigned) - live}"
+    )
+
+
+# 4 — explorer discovery excludes the frozen capabilities/api duplicates
+
+
+def test_explorer_discovery_excludes_frozen_dupes():
+    found = ci.discover_explorers(REPO)
+    assert found, "no explorers discovered"
+    assert all("capabilities/api" not in p for p in found)
+    live = {
+        str(p.relative_to(REPO))
+        for p in (REPO / "docs" / "api").rglob("*-explorer.html")
+        if "capabilities/api" not in str(p)
+    }
+    assert set(found) == live
+
+
+# 5 — joins one-to-one; gaps and unlinked explicit; PDF joins via sec-<anchor>
+
+
+def test_joins_one_to_one_with_gaps_and_unlinked():
+    inv = ci.build_inventory(REPO)
+    by_id = {s["id"]: s for s in inv["sections"]}
+    assert len(by_id) == len(inv["sections"])
+    for s in inv["sections"]:
+        assert s["cluster"]
+        assert isinstance(s["explorers"], list)
+        assert s["pdf"] is None or s["pdf"].startswith("sec-") is False
+    gaps = [s["id"] for s in inv["sections"] if s["pdf"] is None]
+    assert gaps == inv["pdf_gaps"]
+    # every discovered explorer either linked to exactly one section or listed
+    linked = [e for s in inv["sections"] for e in s["explorers"]]
+    assert len(linked) == len(set(linked)), "explorer joined to two sections"
+    assert set(linked) | set(inv["unlinked_explorers"]) == set(
+        ci.discover_explorers(REPO)
+    )
+
+
+# 6 — recency from metadata only; no git calls; unknown honest
+
+
+def test_recency_from_metadata_only():
+    # guard: no git INVOCATION mechanism (prose mentions of git are fine —
+    # the docstring explains why git-derived dating is invalid here)
+    src = SCRIPT.read_text()
+    for needle in ("subprocess", "os.system", "os.popen", "from git", "import git"):
+        assert needle not in src, f"extractor must not shell out / use git: {needle}"
+    added = yaml.safe_load(ADDED.read_text())
+    inv = ci.build_inventory(REPO)
+    for s in inv["sections"]:
+        assert "added" in s
+        if s["added"] != "unknown":
+            assert s["added"]["date"] and s["added"]["pr"]
+    known = [s for s in inv["sections"] if s["added"] != "unknown"]
+    assert known, "recency seed empty — expected PR-evidenced entries"
+    assert len(inv["recent"]) <= added.get("recent_n", 8)
+
+
+# 7 — --check mode fails on drift
+
+
+def test_check_mode_fails_on_drift(tmp_path):
+    out = tmp_path / "inv.json"
+    ci.write_inventory(ci.build_inventory(REPO), out)
+    assert ci.check(REPO, out) == 0
+    doc = json.loads(out.read_text())
+    doc["sections"][0]["cluster"] = "tampered"
+    out.write_text(json.dumps(doc, indent=2, sort_keys=True))
+    assert ci.check(REPO, out) != 0
+
+
+# 8 — rendered spec tables match the generated JSON
+
+
+def test_md_tables_match_inventory_json(tmp_path):
+    inv = ci.build_inventory(REPO)
+    md = ci.render_spec(inv)
+    for s in inv["sections"]:
+        assert f"#{s['id']}" in md, f"section {s['id']} missing from spec tables"
+    for gap in inv["pdf_gaps"]:
+        assert gap in md
+    assert str(len(inv["sections"])) in md
+
+
+# 9 — committed artifacts are fresh (the real CI gate)
+
+
+def test_committed_inventory_is_fresh():
+    committed = REPO / "docs" / "capability-map" / "capabilities-inventory.json"
+    assert committed.exists(), "run build_capabilities_inventory.py and commit"
+    assert ci.check(REPO, committed) == 0, (
+        "committed inventory drifted — regenerate: "
+        ".venv/bin/python scripts/capabilities/build_capabilities_inventory.py"
+    )


### PR DESCRIPTION
## Capabilities IA spec — 7 clusters, recency metadata, citable reference index

Closes #1444. Implements the owner-approved r3 plan (workspace-hub `docs/plans/2026-07-06-issue-dm-1444-capabilities-ia-spec.md`; r1 MAJOR/8 repo-verified + r2 Codex MAJOR/10 pre-approval). **SPEC-ONLY: `index.html` untouched** — this is the revamp lane's input (PR #1389 coordination note).

### What ships (7 files)
- **`capabilities-clusters.yml`** — machine SoT: all 22 sections in exactly one of 7 discipline clusters with value statements; totality/disjointness test-enforced against the live page census, so a future section that skips the map **fails CI**.
- **`capabilities-added.yml`** — explicit PR-evidenced recency (10 dated entries from PRs #1389/#1394/#1396/#1442; 12 honest `unknown`s). Git-derived dating is structurally impossible here: sections live inside one HTML file AND history was truncated to 19 commits by the 2026-07 slim.
- **`build_capabilities_inventory.py`** — fail-closed census (nav↔section bijection with actionable diagnostics), explorer discovery across `docs/api/**` excluding the frozen `capabilities/api` duplicates, joins via in-section hrefs + SPECS `sec-<anchor>` + one reviewed alias (`sloshing-explorer → cfd`), and a **`--check` freshness gate** so the committed inventory can't drift silently.
- **Generated**: `capabilities-inventory.json` + `capabilities-ia-spec-1444.md` — reference index (22 sections × explorer/PDF/recency; **10 PDF gaps explicit** = the #1388-style follow-on backlog), recently-added strip model, and the **anchor-stability contract** enumerating all 22 anchors the revamp must preserve.
- **`tests/capabilities/` (9 tests) + `tests/DOMAINS.md` row** — without the row, dm CI would never run the suite (review finding).

### Owner acceptance (AC)
Per the plan's governance AC: please review the cluster taxonomy + labels in `capabilities-clusters.yml` (that YAML is the adjustment surface) and leave an acceptance comment on #1444 before/at merge.
