### PR TITLE
chore: ignore output_610 run output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,8 +370,8 @@ src/digitalmodel/base_configs/modules/*/logs/
 # epic #3084: keep repo-scoped agent memory tracked despite blanket memory/ rule
 !.claude/memory/
 !.claude/memory/**
-
 # Local-only agent config + ecosystem-propagated markers (machine/user-specific)
 CLAUDE.local.md
 .claude/skills/.ecosystem-propagated
 .claude/skills/guidelines
+output_610/


### PR DESCRIPTION
## Summary
- ignore generated output_610 run output directory

## Verification
- git diff --check
- conflict markers removed from .gitignore

No issue: machine-equivalence cleanup from ace-win-2.