### PR TITLE
feat(drilling_riser): schedule-assembly path + endpoint validation (#1458)

### DIFF
--- a/examples/workflows/riser-stackup-registry-batch/README.md
+++ b/examples/workflows/riser-stackup-registry-batch/README.md
@@ -1,11 +1,17 @@
 # Riser Stack-up Registry Batch Run (API RP 16Q)
 
-First batch sweep of the riser stack-up registry (#1453, epic #1279): every
+Batch sweep of the riser stack-up registry (#1453/#1458, epic #1279): every
 `riser_stackup` row with `stackup_type = as-planned-stackup` and
 `operation = drilling` is checked for a wiki-side `16q-min-top-tension` calc
 contract (llm-wiki#826 — registry page + per-dataset source pages) and, where
 the chain inputs exist, the API RP 16Q minimum vertical top tension is
 computed through `digitalmodel.drilling_riser.assembly.minimum_top_tension_16q`.
+Rows without a golden chain contract but WITH a text-extractable wiki joint
+schedule + joint library run the #1458 schedule-assembly path instead
+(`digitalmodel.drilling_riser.schedule_assembly`): the string weight is
+assembled from the schedule, the 16Q minimum is computed at the heaviest
+documented mud weight, and the row reports the validation delta band against
+the wave-3 `16q-min-tension-endpoints` contract (llm-wiki#828).
 
 ## Run
 
@@ -16,9 +22,9 @@ LLM_WIKI_PATH=/path/to/llm-wiki \
 
 Prints the batch table and writes `results/registry_batch_16q.csv` with, per
 RSU: `rsu_id`, `water_depth_band`, `topology_class`, string dry/submerged
-weight and buoyancy uplift (where the contract decomposes them), the computed
-`Tmin_vert`, its unit, and `status` (`runnable` | `missing-inputs`) with a
-`fields_unknown` reason.
+weight and buoyancy uplift/net-lift (where the source decomposes them), the
+computed `Tmin_vert`, its unit, and `status` (`runnable` |
+`runnable-schedule` | `missing-inputs`) with a `fields_unknown` reason.
 
 ## Output is NOT committed (by design)
 
@@ -33,6 +39,19 @@ de-id/leak gate.
 - `runnable` — a golden `16q-min-top-tension` contract exists; the engine
   reproduces its documented Tmin (asserted by
   `tests/drilling_riser/test_assembly_golden.py`).
+- `runnable-schedule` — no golden chain contract, but the source page carries
+  a text-extractable joint schedule + joint library: the string is assembled
+  bottom-up (#1458) and validated against the `16q-min-tension-endpoints`
+  contract. The reason column carries the per-RSU delta band and a
+  PASS (<= 3 %) / FINDING verdict — findings are characterized (delta bands
+  pinned) in `tests/drilling_riser/test_schedule_assembly.py`, never
+  tolerance-masked. The modelling assumptions (net-weight basis, mud in main
+  bore + C&K + boost, 1.25 top-tension factor, pup/termination joints at the
+  slick per-foot rate, ...) are documented in
+  `digitalmodel.drilling_riser.schedule_assembly`.
+- `fields_unknown: 16Q endpoint contract exists but the joint schedule is
+  not text-extractable` — e.g. RSU-0038, whose per-class joint counts are
+  raster-only in the source document.
 - `fields_unknown: wiki carries result-dialect contracts only` — the source
   page documents results (`id:`/`expected:` entries) but no machine-golden
   16Q chain yet: candidate wave-3 contracts.

--- a/examples/workflows/riser-stackup-registry-batch/run.py
+++ b/examples/workflows/riser-stackup-registry-batch/run.py
@@ -7,9 +7,14 @@ as-planned-stackup`` and ``operation = drilling`` (the public dm-side
 handles), resolves each row's wiki-side ``16q-min-top-tension`` calc
 contract (private llm-wiki registry + source pages, llm-wiki#826), and where
 the contract carries the chain inputs computes the 16Q minimum vertical top
-tension through ``digitalmodel.drilling_riser.assembly``. Rows without a
-golden contract are reported ``missing-inputs`` with a reason
-(``fields_unknown`` taxonomy).
+tension through ``digitalmodel.drilling_riser.assembly``. Rows whose source
+page carries a text-extractable joint schedule + joint library instead run
+the #1458 schedule-assembly path (``drilling_riser.schedule_assembly``):
+string weight assembled from the wiki schedule, 16Q minimum computed at the
+heaviest documented mud weight, and the reason column reports the delta
+band against the wave-3 ``16q-min-tension-endpoints`` contract
+(llm-wiki#828) — status ``runnable-schedule``. Remaining rows are
+``missing-inputs`` with a reason (``fields_unknown`` taxonomy).
 
 Run (in-context; the wiki clone is required for values)::
 
@@ -31,11 +36,18 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
+from digitalmodel.drilling_riser.adapter import KIPS_TO_KN
 from digitalmodel.drilling_riser.assembly import minimum_top_tension_16q
 from digitalmodel.drilling_riser.calc_contracts import (
     contract_referenced_rsu_ids,
     load_calc_contracts,
     resolve_wiki_root,
+)
+from digitalmodel.drilling_riser.schedule_assembly import (
+    SCHEDULE_RSU_IDS,
+    ScheduleAssemblyError,
+    documented_endpoints,
+    load_schedule_assembly,
 )
 from digitalmodel.riser_database.loader import RiserDatabase
 
@@ -51,6 +63,11 @@ REASON_RESULT_DIALECT_ONLY = (
 )
 REASON_NO_CONTRACT = "fields_unknown: no calc contract wiki-side"
 REASON_NO_TSRMIN = "fields_unknown: 16Q contract lacks a TSRmin / factored-weight input"
+REASON_ENDPOINTS_NO_SCHEDULE = (
+    "fields_unknown: 16Q endpoint contract exists but the joint schedule is "
+    "not text-extractable (raster-only counts)"
+)
+ENDPOINT_CALC = "16q-min-tension-endpoints"
 
 
 @dataclass(frozen=True)
@@ -63,7 +80,7 @@ class BatchRow:
     buoyancy_uplift: str
     tmin_vert: str
     units: str
-    status: str  # runnable | missing-inputs
+    status: str  # runnable | runnable-schedule | missing-inputs
     reason: str
 
 
@@ -84,6 +101,48 @@ def _chain_inputs(contract: dict) -> Optional[tuple[float, str]]:
             "t",
         )
     return None
+
+
+def _schedule_row(stackup, wiki_root) -> Optional[BatchRow]:
+    """#1458 schedule-assembly path: assemble the string from the wiki joint
+    schedule + library, compute the 16Q minimum at the heaviest documented
+    mud weight, and report the validation delta band against the wave-3
+    endpoint contract. ``None`` when this RSU has no text-extractable
+    schedule (the caller falls back to missing-inputs)."""
+    if stackup.rsu_id not in SCHEDULE_RSU_IDS:
+        return None
+    try:
+        assembly = load_schedule_assembly(stackup.rsu_id, wiki_root)
+        endpoints = documented_endpoints(stackup.rsu_id, wiki_root)
+    except ScheduleAssemblyError:
+        return None
+    mud_kg_m3, documented_kn = max(endpoints)
+    tmin_kn = assembly.minimum_top_tension_16q_kn(mud_kg_m3)
+    deltas = [
+        (assembly.minimum_top_tension_16q_kn(mud) - doc_kn) / doc_kn
+        for mud, doc_kn in endpoints
+    ]
+    band = f"{min(deltas):+.1%}..{max(deltas):+.1%}"
+    verdict = "PASS" if max(abs(d) for d in deltas) <= 0.03 else "FINDING"
+    return BatchRow(
+        rsu_id=stackup.rsu_id,
+        water_depth_band=stackup.water_depth_band,
+        topology_class=stackup.topology_class,
+        string_dry_weight=_fmt(assembly.model.total_dry_weight_kn() / KIPS_TO_KN),
+        # NET submerged steel weight + net lift of buoyed joints (the sources
+        # document no gross-Ws/uplift split — see schedule_assembly header).
+        string_submerged_weight=_fmt(
+            assembly.model.total_submerged_weight_kn() / KIPS_TO_KN
+        ),
+        buoyancy_uplift=_fmt(assembly.buoyancy_net_lift_kn / KIPS_TO_KN),
+        tmin_vert=_fmt(tmin_kn / KIPS_TO_KN),
+        units="kips",
+        status="runnable-schedule",
+        reason=(
+            f"schedule-assembly at heaviest documented mud; vs "
+            f"16q-min-tension-endpoints: {verdict} (delta {band})"
+        ),
+    )
 
 
 def _assemble_row(
@@ -136,22 +195,21 @@ def run(output_csv: Path = OUTPUT_CSV) -> list[BatchRow]:
     if wiki_root is None:
         rows = [_assemble_row(s, None, REASON_WIKI_UNAVAILABLE) for s in stackups]
     else:
-        goldens = {
-            c["rsu_id"]: c for c in load_calc_contracts(wiki_root) if c["calc"] == CALC
-        }
+        contracts = load_calc_contracts(wiki_root)
+        goldens = {c["rsu_id"]: c for c in contracts if c["calc"] == CALC}
+        endpoint_ids = {c["rsu_id"] for c in contracts if c["calc"] == ENDPOINT_CALC}
         any_contract = contract_referenced_rsu_ids(wiki_root)
-        rows = [
-            _assemble_row(
-                s,
-                goldens.get(s.rsu_id),
-                (
-                    REASON_RESULT_DIALECT_ONLY
-                    if s.rsu_id in any_contract
-                    else REASON_NO_CONTRACT
-                ),
-            )
-            for s in stackups
-        ]
+        rows = []
+        for s in stackups:
+            golden = goldens.get(s.rsu_id)
+            schedule = None if golden else _schedule_row(s, wiki_root)
+            if s.rsu_id in endpoint_ids:
+                reason = REASON_ENDPOINTS_NO_SCHEDULE
+            elif s.rsu_id in any_contract:
+                reason = REASON_RESULT_DIALECT_ONLY
+            else:
+                reason = REASON_NO_CONTRACT
+            rows.append(schedule or _assemble_row(s, golden, reason))
 
     output_csv.parent.mkdir(parents=True, exist_ok=True)
     with output_csv.open("w", newline="") as handle:
@@ -163,7 +221,11 @@ def run(output_csv: Path = OUTPUT_CSV) -> list[BatchRow]:
 
 def main() -> int:
     rows = run()
-    runnable = sum(1 for r in rows if r.status == "runnable")
+    runnable = sum(1 for r in rows if r.status.startswith("runnable"))
+    by_status = {
+        status: sum(1 for r in rows if r.status == status)
+        for status in ("runnable", "runnable-schedule", "missing-inputs")
+    }
     header = (
         "rsu_id",
         "band",
@@ -193,7 +255,10 @@ def main() -> int:
             )
         )
     print(
-        f"\n{runnable}/{len(rows)} as-planned drilling RSUs runnable; "
+        f"\n{runnable}/{len(rows)} as-planned drilling RSUs runnable "
+        f"({by_status['runnable']} contract-chain + "
+        f"{by_status['runnable-schedule']} schedule-assembly; "
+        f"{by_status['missing-inputs']} missing-inputs); "
         f"CSV: {OUTPUT_CSV.relative_to(HERE)}"
     )
     if os.environ.get("LLM_WIKI_PATH") is None and resolve_wiki_root() is None:

--- a/src/digitalmodel/drilling_riser/schedule_assembly.py
+++ b/src/digitalmodel/drilling_riser/schedule_assembly.py
@@ -1,0 +1,775 @@
+"""Schedule-assembly path (#1458, epic #1279; follows #1453/#1454).
+
+Builds a rig-specific riser string FROM the wiki-side joint schedule + joint
+library on a private llm-wiki source page (never from a transcribed factored
+chain), normalizes each component into the ``adapter`` SI vocabulary, and
+assembles it through :class:`~digitalmodel.drilling_riser.assembly.RiserStackupModel`.
+The result feeds the API RP 16Q minimum-top-tension chain
+(:func:`~digitalmodel.drilling_riser.stackup.minimum_slip_ring_tension` +
+the 2H methodology 1.25 top-tension factor) for validation against the
+wave-3 ``16q-min-tension-endpoints`` contracts (llm-wiki#828).
+
+Discipline mirrors ``calc_contracts``: dm carries only PAGE NAMES, component
+class labels and parse shapes; schedule counts, joint weights and geometry
+VALUES live wiki-side and resolve at run/test time. Bounded reads,
+fail-closed on any unparsed field, no fuzzy matching.
+
+Documented modelling assumptions (issue #1458 scope 4 — fields the wiki
+schedules do NOT carry, encoded once here and echoed per-assembly in
+:attr:`ScheduleAssembly.assumptions`):
+
+* Tensioned string = outer barrel down to and including the lower flexjoint
+  (LMRP/BOP/wellhead/conductor excluded; overpull is not part of the API
+  minimum).
+* Weight basis is the library's NET submerged weights (f_wt = f_bt = 1.0):
+  the sources document no gross-steel/uplift split for buoyed joints.
+* Pup/termination joints without library weights take the slick-joint
+  per-foot rate (their 21.63 x 1.188 in walls are heavier than the slick
+  21 x 0.875 in tube but carry the same aux-line cluster).
+* Flexjoint / outer-barrel submerged weight = dry weight x (1 - rho_sw /
+  rho_steel) — only dry values are documented.
+* Internal fluid columns: mud fills the main bore + both choke/kill lines +
+  the mud-boost line from the string base (lower-flexjoint datum) to the
+  drill floor; seawater backpressure acts on the same area to the
+  waterline. Seawater at 1025 kg/m3.
+* Minimum top tension = 1.25 x TSRmin (2H-TNE-0050-03 §3.1 project factor,
+  ``stackup.SAFETY_FACTOR_TENSION`` — numerically identical to the 16Q
+  N/(Rf(N-n)) allowance with N=6, n=1, Rf=0.96). Validated to <=1.7 % on
+  the RSU-0019 endpoints; see ``tests/drilling_riser/test_schedule_assembly.py``
+  for the per-RSU pass/finding stance.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from digitalmodel.drilling_riser.assembly import RiserStackupModel
+from digitalmodel.drilling_riser.calc_contracts import (
+    MAX_PAGE_BYTES,
+    SOURCES_REL,
+    find_contract,
+)
+from digitalmodel.drilling_riser.stackup import (
+    SAFETY_FACTOR_TENSION,
+    minimum_slip_ring_tension,
+    top_tension_required,
+)
+
+__all__ = [
+    "SCHEDULE_RSU_IDS",
+    "ScheduleAssembly",
+    "ScheduleAssemblyError",
+    "StringGeometry",
+    "documented_endpoints",
+    "load_schedule_assembly",
+]
+
+_G = 9.80665  # [m/s2]
+_FT_TO_M = 0.3048
+_IN_TO_M = 0.0254
+_LB_TO_KN = 4.4482216152605e-3  # weight values quoted in lb (force)
+_KG_TO_KN = _G / 1000.0  # mass values quoted in kg
+_KIPS_TO_KN = 4.4482216152605
+_PPG_TO_KG_M3 = 119.82642731689663
+SEAWATER_DENSITY_KG_M3 = 1025.0
+STEEL_DENSITY_KG_M3 = 7850.0
+#: dry -> submerged factor for bare-steel components documented dry-only.
+_STEEL_WET_FRACTION = 1.0 - SEAWATER_DENSITY_KG_M3 / STEEL_DENSITY_KG_M3
+
+#: Source pages carrying a text-extractable joint schedule (+ the page that
+#: tabulates the joint library — RSU-0040's library RSU-0039 is primary on
+#: the sister Das Bump page). RSU-0038 is deliberately ABSENT: its joint
+#: counts are raster-only in the source (wiki page caveat) and the loader
+#: must fail closed rather than guess.
+_SCHEDULE_PAGES: dict[str, tuple[str, str]] = {
+    "RSU-0019": (
+        "31072-rpt-0001-3-ahawbil-1-drilling-riser-analysis.md",
+        "31072-rpt-0001-3-ahawbil-1-drilling-riser-analysis.md",
+    ),
+    "RSU-0021": (
+        "3914-rpt-0001-2-centenario-nen-1-drilling-riser-analysis.md",
+        "3914-rpt-0001-2-centenario-nen-1-drilling-riser-analysis.md",
+    ),
+    "RSU-0040": (
+        "3248-rpt-0001-3-mad-dog-deep-drilling-riser-report.md",
+        "3191-rpt-0001-1-das-bump-drilling-riser-report.md",
+    ),
+}
+SCHEDULE_RSU_IDS = frozenset(_SCHEDULE_PAGES)
+
+_ENDPOINT_CALC = "16q-min-tension-endpoints"
+#: (contract key, mud unit, tension unit, mud column, tension column) per
+#: endpoint-row dialect — the wave-3 pages tabulate mud in three units.
+_ENDPOINT_DIALECTS: dict[str, dict[str, tuple[str, str, str, int, int]]] = {
+    "RSU-0019": {"primary": ("api_min_top_tension", "kg_m3", "kips", 0, 2)},
+    "RSU-0021": {"primary": ("api_min_top_tension", "g_cm3", "kips", 0, 1)},
+    "RSU-0038": {"primary": ("api_min_top_tension", "ppg", "Mlbs", 0, 1)},
+    "RSU-0040": {
+        "primary": ("api_16q_stability_tension_15_bare_joints", "ppg", "kips", 0, 1),
+        "5-bare": ("api_16q_stability_tension_5_bare_joints", "ppg", "kips", 0, 1),
+    },
+}
+_MUD_TO_KG_M3 = {"kg_m3": 1.0, "g_cm3": 1000.0, "ppg": _PPG_TO_KG_M3}
+_TENSION_TO_KN = {"kips": _KIPS_TO_KN, "Mlbs": 1000.0 * _KIPS_TO_KN}
+
+
+class ScheduleAssemblyError(RuntimeError):
+    """Fail-closed schedule/library extraction error (missing page, unparsed
+    field, schedule-integrity mismatch)."""
+
+
+def _num(text: str) -> float:
+    """Parse a wiki numeric token (thousands commas, unicode minus, +)."""
+    return float(text.replace(",", "").replace("−", "-").lstrip("+"))
+
+
+def _search(pattern: str, text: str, *, page: str, field: str) -> re.Match:
+    match = re.search(pattern, text)
+    if match is None:
+        raise ScheduleAssemblyError(f"{page}: cannot extract {field}")
+    return match
+
+
+def _page_text(wiki_root: Path, page_name: str) -> str:
+    page = Path(wiki_root) / SOURCES_REL / page_name
+    if not page.is_file():
+        raise ScheduleAssemblyError(f"missing wiki source page: {page}")
+    if page.stat().st_size > MAX_PAGE_BYTES:
+        raise ScheduleAssemblyError(
+            f"{page_name}: size exceeds bounded-read cap {MAX_PAGE_BYTES}"
+        )
+    return page.read_text(encoding="utf-8")
+
+
+def _circle_area_m2(diameter_in: float) -> float:
+    return math.pi / 4.0 * (diameter_in * _IN_TO_M) ** 2
+
+
+@dataclass(frozen=True)
+class StringGeometry:
+    """Fluid-column geometry for the 16Q internal-fluid term. Elevations are
+    metres above mudline (the schedule tables' datum)."""
+
+    water_depth_m: float
+    drill_floor_above_mudline_m: float
+    string_base_above_mudline_m: float
+    internal_area_m2: float
+
+    @property
+    def mud_column_m(self) -> float:
+        return self.drill_floor_above_mudline_m - self.string_base_above_mudline_m
+
+    @property
+    def seawater_column_m(self) -> float:
+        return self.water_depth_m - self.string_base_above_mudline_m
+
+
+@dataclass(frozen=True)
+class ScheduleAssembly:
+    """A wiki-schedule-assembled tensioned string + its 16Q chain inputs."""
+
+    rsu_id: str
+    model: RiserStackupModel
+    geometry: StringGeometry
+    assumptions: tuple[str, ...]
+    #: Documented LMRP submerged weight (metadata for overpull/landing work
+    #: and the RSU-0021 finding hypothesis; NOT part of the tensioned string).
+    lmrp_submerged_kn: Optional[float] = None
+    top_tension_factor: float = SAFETY_FACTOR_TENSION
+
+    @property
+    def buoyancy_net_lift_kn(self) -> float:
+        """Net lift of the buoyed joints (positive up). The sources document
+        net wet weights only — this is NOT the gross foam uplift Bn."""
+        return -sum(
+            float(item.component["submerged_weight_kn"]) * item.count
+            for item in self.model.items
+            if float(item.component["submerged_weight_kn"]) < 0.0
+        )
+
+    def minimum_top_tension_16q_kn(self, mud_density_kg_m3: float) -> float:
+        """API RP 16Q minimum top tension [kN] at ``mud_density_kg_m3``:
+        1.25 x (net Ws + Ai(dm.Hm - dw.Hw)) — see the module header for the
+        factor provenance and the net-weight (f_wt = f_bt = 1) basis."""
+        geometry = self.geometry
+        t_srmin_kn = minimum_slip_ring_tension(
+            submerged_weight_kn=self.model.total_submerged_weight_kn(),
+            buoyancy_uplift_kn=0.0,
+            internal_area_m2=geometry.internal_area_m2,
+            mud_density_kn_m3=mud_density_kg_m3 * _KG_TO_KN,
+            mud_column_m=geometry.mud_column_m,
+            seawater_density_kn_m3=SEAWATER_DENSITY_KG_M3 * _KG_TO_KN,
+            seawater_column_m=geometry.seawater_column_m,
+            f_wt=1.0,
+            f_bt=1.0,
+        )
+        return top_tension_required(t_srmin_kn, self.top_tension_factor)
+
+
+# -- shared parse helpers ---------------------------------------------------------------
+
+
+def _record(
+    rsu_id: str,
+    slug: str,
+    component_type: str,
+    *,
+    dry_kn: float,
+    wet_kn: float,
+    count: int,
+    length_m: Optional[float] = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "component_id": f"{rsu_id}/{slug}",
+        "component_type": component_type,
+        "weight_air_kn": dry_kn,
+        "submerged_weight_kn": wet_kn,
+        "count": count,
+    }
+    if length_m is not None:
+        entry["length_m"] = length_m
+    return entry
+
+
+def _internal_area_m2(
+    text: str, *, page: str, od_wt_pattern: str, ck_pattern: str, boost_pattern: str
+) -> float:
+    od_wt = _search(od_wt_pattern, text, page=page, field="main tube OD x WT")
+    bore_in = _num(od_wt.group(1)) - 2.0 * _num(od_wt.group(2))
+    ck_id_in = _num(
+        _search(ck_pattern, text, page=page, field="choke/kill line ID").group(1)
+    )
+    boost_id_in = _num(
+        _search(boost_pattern, text, page=page, field="mud-boost line ID").group(1)
+    )
+    return (
+        _circle_area_m2(bore_in)
+        + 2.0 * _circle_area_m2(ck_id_in)
+        + _circle_area_m2(boost_id_in)
+    )
+
+
+_ASSUMPTIONS_COMMON = (
+    "tensioned string = outer barrel .. lower flexjoint (LMRP/BOP excluded)",
+    "net submerged weights, f_wt = f_bt = 1.0 (no gross/uplift split documented)",
+    "flexjoint/outer-barrel submerged weight = dry x (1 - rho_sw/rho_steel)",
+    "mud in main bore + 2x choke/kill + mud boost, columns to drill floor",
+    "seawater at 1025 kg/m3",
+    "Tmin = 1.25 x TSRmin (2H-TNE-0050-03 s3.1; = 16Q N/(Rf(N-n)), N=6, n=1, Rf=0.96)",
+)
+
+
+# -- Grupo-R sister pages (RSU-0019 / RSU-0021): table + prose library ------------------
+
+_GRUPO_SCHEDULE_ROW = re.compile(
+    r"^\|\s*([^|]+?)\s*\|\s*([\d,.]+)\s*\|\s*(\d+)\s*\|\s*([−\-\d,.]+)\s*\|\s*$",
+    re.MULTILINE,
+)
+_GRUPO_BUOYANT_CLASS = re.compile(
+    r"(\d{4})'(?:\s+rating)?\s+([\d,]+\.?\d*)\s*/\s*([−+]?[\d,]+\.?\d*)\s*kg"
+)
+_BUOYANT_ROW_NAME = re.compile(r"Buoyancy joint (\d{4})' rating")
+
+
+def _grupo_library(text: str, *, page: str) -> dict[str, tuple[float, float]]:
+    """{class: (dry_kn, wet_kn)} for the slick + buoyancy-joint families."""
+    slick = _search(
+        r"slick 75 ft [\d.]+ in x [\d.]+ in,\s+([\d,]+\.?\d*) kg air / "
+        r"([\d,]+\.?\d*) kg\s+water",
+        text,
+        page=page,
+        field="slick-joint library weights",
+    )
+    library = {
+        "slick": (_num(slick.group(1)) * _KG_TO_KN, _num(slick.group(2)) * _KG_TO_KN)
+    }
+    for match in _GRUPO_BUOYANT_CLASS.finditer(text):
+        rating, dry_kg, net_kg = match.groups()
+        # The library quotes buoyed-joint NET wet values as "net lift" where
+        # negative; keep sign convention: submerged weight, positive down.
+        library[rating] = (_num(dry_kg) * _KG_TO_KN, _num(net_kg) * _KG_TO_KN)
+    if len(library) < 3:
+        raise ScheduleAssemblyError(f"{page}: buoyancy-joint library not extracted")
+    return library
+
+
+def _load_grupo_assembly(rsu_id: str, wiki_root: Path) -> ScheduleAssembly:
+    page = _SCHEDULE_PAGES[rsu_id][0]
+    text = _page_text(wiki_root, page)
+    library = _grupo_library(text, page=page)
+    slick_dry_kn, slick_wet_kn = library["slick"]
+    lfj_dry_kn = (
+        _num(
+            _search(
+                r"lower [\d,]+ lb-ft/deg \([\d,]+ N-m/deg\), ±10 deg, ([\d,]+) kg",
+                text,
+                page=page,
+                field="lower flexjoint dry mass",
+            ).group(1)
+        )
+        * _KG_TO_KN
+    )
+    ob_lb = re.search(r"outer barrel [\d.]+ x [\d.]+ in x \d+ ft, ([\d,]+) lb", text)
+    ob_kg = re.search(r"outer barrel [\d.]+ x [\d.]+ in, ([\d,]+) kg", text)
+    if ob_lb is not None:
+        ob_dry_kn = _num(ob_lb.group(1)) * _LB_TO_KN
+    elif ob_kg is not None:
+        ob_dry_kn = _num(ob_kg.group(1)) * _KG_TO_KN
+    else:
+        raise ScheduleAssemblyError(f"{page}: cannot extract outer-barrel dry weight")
+
+    # -- schedule table (between the RSU heading and the next section) ------------
+    heading = re.search(rf"^## Riser stack-up — {rsu_id}([^\n]*)$", text, re.MULTILINE)
+    if heading is None:
+        raise ScheduleAssemblyError(f"{page}: no schedule heading for {rsu_id}")
+    section = text[heading.end() :].split("\n## ", 1)[0]
+    unit_to_m = _FT_TO_M if "ft units" in heading.group(1) else 1.0
+    rows = [
+        (name, _num(length) * unit_to_m, int(count), _num(elev) * unit_to_m)
+        for name, length, count, elev in _GRUPO_SCHEDULE_ROW.findall(section)
+    ]
+    names = [row[0] for row in rows]
+    if "Outer barrel" not in names or "Lower flexjoint" not in names:
+        raise ScheduleAssemblyError(f"{page}: schedule table rows not extracted")
+    lo = min(names.index("Outer barrel"), names.index("Lower flexjoint"))
+    hi = max(names.index("Outer barrel"), names.index("Lower flexjoint"))
+    string_rows = rows[lo : hi + 1]
+
+    records: list[dict[str, Any]] = []
+    slick_seq = 0
+    for name, length_m, count, _elev in string_rows:
+        buoyant = _BUOYANT_ROW_NAME.fullmatch(name)
+        if name == "Slick joint":
+            slick_seq += 1
+            records.append(
+                _record(
+                    rsu_id,
+                    f"slick-joint-run{slick_seq}",
+                    "riser_joint",
+                    dry_kn=slick_dry_kn,
+                    wet_kn=slick_wet_kn,
+                    count=count,
+                    length_m=length_m,
+                )
+            )
+        elif buoyant is not None:
+            rating = buoyant.group(1)
+            if rating not in library:
+                raise ScheduleAssemblyError(
+                    f"{page}: schedule uses buoyancy class {rating}' with no "
+                    "library weights (buoyancy class mapping gap)"
+                )
+            dry_kn, wet_kn = library[rating]
+            records.append(
+                _record(
+                    rsu_id,
+                    f"buoyancy-joint-{rating}ft",
+                    "riser_joint_buoyant",
+                    dry_kn=dry_kn,
+                    wet_kn=wet_kn,
+                    count=count,
+                    length_m=length_m,
+                )
+            )
+        elif name == "Lower flexjoint":
+            records.append(
+                _record(
+                    rsu_id,
+                    "lower-flexjoint",
+                    "flexjoint",
+                    dry_kn=lfj_dry_kn,
+                    wet_kn=lfj_dry_kn * _STEEL_WET_FRACTION,
+                    count=count,
+                    length_m=length_m,
+                )
+            )
+        elif name == "Outer barrel":
+            records.append(
+                _record(
+                    rsu_id,
+                    "telescopic-outer-barrel",
+                    "telescopic_joint",
+                    dry_kn=ob_dry_kn,
+                    wet_kn=ob_dry_kn * _STEEL_WET_FRACTION,
+                    count=count,
+                    length_m=length_m,
+                )
+            )
+        elif name.endswith("pup") or name == "Termination joint":
+            # [ASSUMED] slick per-foot rate — no pup/termination weights in
+            # the library prose.
+            dry_kn = slick_dry_kn * length_m / (75.0 * _FT_TO_M)
+            records.append(
+                _record(
+                    rsu_id,
+                    name.lower().replace(" ", "-"),
+                    "pup_joint",
+                    dry_kn=dry_kn,
+                    wet_kn=dry_kn * (slick_wet_kn / slick_dry_kn),
+                    count=count,
+                    length_m=length_m,
+                )
+            )
+        else:
+            raise ScheduleAssemblyError(
+                f"{page}: unmapped tensioned-string schedule row {name!r}"
+            )
+
+    # -- schedule integrity: joint tally + elevation-span cross-checks -------------
+    tally = _search(
+        r"(\d+) x 75-ft riser joints \((\d+) slick \+ (\d+) buoyant\)",
+        text,
+        page=page,
+        field="riser joint tally",
+    )
+    slick_count = sum(
+        r["count"] for r in records if r["component_type"] == "riser_joint"
+    )
+    buoyant_count = sum(
+        r["count"] for r in records if r["component_type"] == "riser_joint_buoyant"
+    )
+    if (slick_count, buoyant_count) != (int(tally.group(2)), int(tally.group(3))):
+        raise ScheduleAssemblyError(
+            f"{page}: schedule joint tally mismatch — parsed "
+            f"{slick_count} slick + {buoyant_count} buoyant vs documented "
+            f"{tally.group(2)} + {tally.group(3)}"
+        )
+    elevations = [row[3] for row in string_rows] + [
+        string_rows[0][3] + string_rows[0][1],
+        string_rows[-1][3] + string_rows[-1][1],
+    ]
+    span_m = max(elevations) - min(elevations)
+    summed_m = sum(row[1] * row[2] for row in string_rows)
+    if abs(span_m - summed_m) / summed_m > 0.005:
+        raise ScheduleAssemblyError(
+            f"{page}: schedule span {span_m:.1f} m != summed lengths "
+            f"{summed_m:.1f} m"
+        )
+    datum_m = next(row[3] for row in string_rows if row[0] == "Lower flexjoint")
+
+    geometry = StringGeometry(
+        water_depth_m=_num(
+            _search(
+                r"\*\*([\d,]+(?:\.\d+)?) m water depth\*\*",
+                text,
+                page=page,
+                field="water depth",
+            ).group(1)
+        ),
+        drill_floor_above_mudline_m=_num(
+            _search(
+                r"\(([\d,]+\.?\d*) m above\s+mudline",
+                text,
+                page=page,
+                field="drill-floor elevation",
+            ).group(1)
+        ),
+        string_base_above_mudline_m=datum_m,
+        internal_area_m2=_internal_area_m2(
+            text,
+            page=page,
+            od_wt_pattern=r"slick 75 ft ([\d.]+) in x ([\d.]+) in",
+            ck_pattern=r"C&K [\d.]+ x ([\d.]+) in",
+            boost_pattern=r"mud boost [\d.]+ x ([\d.]+) in",
+        ),
+    )
+    lmrp = _search(
+        r"LMRP [\d.]+ ft, ([\d,]+) lb air / ([\d,]+) lb\s+water",
+        text,
+        page=page,
+        field="LMRP masses",
+    )
+    return ScheduleAssembly(
+        rsu_id=rsu_id,
+        model=RiserStackupModel.from_records(records, rsu_id=rsu_id),
+        geometry=geometry,
+        assumptions=_ASSUMPTIONS_COMMON
+        + ("pup/termination joints at the slick per-foot weight rate",),
+        lmrp_submerged_kn=_num(lmrp.group(2)) * _LB_TO_KN,
+    )
+
+
+# -- Ocean Confidence (RSU-0040 schedule + RSU-0039 library on the sister page) ---------
+
+_OC_LIBRARY_LABELS = {
+    "Slick joint": "slick",
+    "25 ft pup joint": "pup-25ft",
+    "35 ft termination joint": "termination-35ft",
+    "2000 ft buoyancy joint": "2000",
+    "3000 ft buoyancy joint": "3000",
+    "5000 ft buoyancy joint": "5000",
+    "6600 ft buoyancy joint": "6600",
+}
+
+
+def _oc_library(text: str, *, page: str) -> dict[str, tuple[float, float]]:
+    """{class: (dry_kn, wet_kn)} from the RSU-0039 markdown weight table."""
+    library: dict[str, tuple[float, float]] = {}
+    for line in text.splitlines():
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 5:
+            continue
+        key = _OC_LIBRARY_LABELS.get(cells[0])
+        if key is None and cells[0].startswith("Telescopic joint"):
+            key = "telescopic-joint"
+        if key is None:
+            continue
+        library[key] = (_num(cells[2]) * _LB_TO_KN, _num(cells[3]) * _LB_TO_KN)
+    missing = (set(_OC_LIBRARY_LABELS.values()) | {"telescopic-joint"}) - set(library)
+    if missing:
+        raise ScheduleAssemblyError(
+            f"{page}: joint-library rows not extracted: {sorted(missing)}"
+        )
+    return library
+
+
+def _load_oc_assembly(rsu_id: str, wiki_root: Path) -> ScheduleAssembly:
+    schedule_page, library_page = _SCHEDULE_PAGES[rsu_id]
+    text = _page_text(wiki_root, schedule_page)
+    lib_text = _page_text(wiki_root, library_page)
+    library = _oc_library(lib_text, page=library_page)
+    lfj_dry_kn = (
+        _num(
+            _search(
+                r"lower [\d,]+ ft-lb/deg, ([\d,]+) lb dry",
+                lib_text,
+                page=library_page,
+                field="lower flexjoint dry weight",
+            ).group(1)
+        )
+        * _LB_TO_KN
+    )
+
+    buoyant_row = _search(
+        r"\| Buoyant joints, 75 ft \| \*\*(\d+) total: ([^*]+)\*\* \| "
+        r"([\d,.]+) → ([\d,.]+) \|",
+        text,
+        page=schedule_page,
+        field="buoyant-joint schedule row",
+    )
+    class_counts = re.findall(r"(\d+)x (\d{4}) ft", buoyant_row.group(2))
+    if sum(int(count) for count, _ in class_counts) != int(buoyant_row.group(1)):
+        raise ScheduleAssemblyError(
+            f"{schedule_page}: buoyant class counts do not sum to the "
+            f"documented total {buoyant_row.group(1)}"
+        )
+    slick_row = _search(
+        r"\| Slick joints, 75 ft \| (\d+) \| ([\d,.]+) → ([\d,.]+) \|",
+        text,
+        page=schedule_page,
+        field="slick-joint schedule row",
+    )
+    # Elevation-span integrity: both 75-ft joint runs vs their m-ASB spans.
+    for count, top_m, base_m, label in (
+        (
+            int(buoyant_row.group(1)),
+            buoyant_row.group(3),
+            buoyant_row.group(4),
+            "buoyant",
+        ),
+        (int(slick_row.group(1)), slick_row.group(2), slick_row.group(3), "slick"),
+    ):
+        span_m = _num(top_m) - _num(base_m)
+        summed_m = count * 75.0 * _FT_TO_M
+        if abs(span_m - summed_m) / summed_m > 0.005:
+            raise ScheduleAssemblyError(
+                f"{schedule_page}: {label} run span {span_m:.1f} m != "
+                f"{count} x 75 ft"
+            )
+    lfj_row = _search(
+        r"\| Lower flex joint \| 1 x ([\d.]+) ft \| ([\d,.]+) \|",
+        text,
+        page=schedule_page,
+        field="lower flexjoint schedule row",
+    )
+    _search(
+        r"\| Pup joints 50 ft \+ 25 ft \| 2 \|",
+        text,
+        page=schedule_page,
+        field="pup-joint schedule row",
+    )
+    _search(
+        r"\| Lower termination joint, 35 ft \| 1 \|",
+        text,
+        page=schedule_page,
+        field="termination-joint schedule row",
+    )
+
+    pup25_dry_kn, pup25_wet_kn = library["pup-25ft"]
+    records = [
+        # [ASSUMED] the tensioners carry the full telescopic-joint weight
+        # (the library tabulates it as one item; no IB/OB split documented).
+        _record(
+            rsu_id,
+            "telescopic-joint",
+            "telescopic_joint",
+            dry_kn=library["telescopic-joint"][0],
+            wet_kn=library["telescopic-joint"][1],
+            count=1,
+        ),
+        # [ASSUMED] 50 ft pup at twice the 25 ft pup weight (same family).
+        _record(
+            rsu_id,
+            "pup-50ft",
+            "pup_joint",
+            dry_kn=2.0 * pup25_dry_kn,
+            wet_kn=2.0 * pup25_wet_kn,
+            count=1,
+            length_m=50.0 * _FT_TO_M,
+        ),
+        _record(
+            rsu_id,
+            "pup-25ft",
+            "pup_joint",
+            dry_kn=pup25_dry_kn,
+            wet_kn=pup25_wet_kn,
+            count=1,
+            length_m=25.0 * _FT_TO_M,
+        ),
+        _record(
+            rsu_id,
+            "slick-joint",
+            "riser_joint",
+            dry_kn=library["slick"][0],
+            wet_kn=library["slick"][1],
+            count=int(slick_row.group(1)),
+            length_m=75.0 * _FT_TO_M,
+        ),
+        _record(
+            rsu_id,
+            "termination-joint-35ft",
+            "termination_joint",
+            dry_kn=library["termination-35ft"][0],
+            wet_kn=library["termination-35ft"][1],
+            count=1,
+            length_m=35.0 * _FT_TO_M,
+        ),
+        _record(
+            rsu_id,
+            "lower-flexjoint",
+            "flexjoint",
+            dry_kn=lfj_dry_kn,
+            wet_kn=lfj_dry_kn * _STEEL_WET_FRACTION,
+            count=1,
+            length_m=_num(lfj_row.group(1)) * _FT_TO_M,
+        ),
+    ]
+    for count, rating in class_counts:
+        if rating not in library:
+            raise ScheduleAssemblyError(
+                f"{schedule_page}: schedule uses buoyancy class {rating} ft "
+                "with no library weights (buoyancy class mapping gap)"
+            )
+        records.append(
+            _record(
+                rsu_id,
+                f"buoyancy-joint-{rating}ft",
+                "riser_joint_buoyant",
+                dry_kn=library[rating][0],
+                wet_kn=library[rating][1],
+                count=int(count),
+                length_m=75.0 * _FT_TO_M,
+            )
+        )
+
+    datum_m = _num(lfj_row.group(2)) - _num(lfj_row.group(1)) * _FT_TO_M
+    geometry = StringGeometry(
+        water_depth_m=_num(
+            _search(
+                r"\(([\d,]+\.\d+) m\)\*\* water depth",
+                text,
+                page=schedule_page,
+                field="water depth",
+            ).group(1)
+        ),
+        drill_floor_above_mudline_m=_num(
+            _search(
+                r"drill floor =\s+([\d,]+\.?\d*) m",
+                text,
+                page=schedule_page,
+                field="drill-floor elevation",
+            ).group(1)
+        ),
+        string_base_above_mudline_m=datum_m,
+        internal_area_m2=_internal_area_m2(
+            lib_text,
+            page=library_page,
+            od_wt_pattern=r"([\d.]+) in OD x ([\d.]+) in WT",
+            ck_pattern=r"choke/kill\s+[\d.]+ x ([\d.]+) in",
+            boost_pattern=r"mud booster [\d.]+ x ([\d.]+) in",
+        ),
+    )
+    lmrp = _search(
+        r"LMRP ([\d,]+) / ([\d,]+) lb",
+        lib_text,
+        page=library_page,
+        field="LMRP masses",
+    )
+    return ScheduleAssembly(
+        rsu_id=rsu_id,
+        model=RiserStackupModel.from_records(records, rsu_id=rsu_id),
+        geometry=geometry,
+        assumptions=_ASSUMPTIONS_COMMON
+        + (
+            "50 ft pup at twice the 25 ft pup library weight",
+            "full telescopic-joint weight tensioner-carried (no IB/OB split)",
+        ),
+        lmrp_submerged_kn=_num(lmrp.group(2)) * _LB_TO_KN,
+    )
+
+
+# -- public API -------------------------------------------------------------------------
+
+
+def load_schedule_assembly(rsu_id: str, wiki_root: Path) -> ScheduleAssembly:
+    """Assemble the tensioned riser string for ``rsu_id`` from its wiki-side
+    joint schedule + joint library. Fail-closed: RSUs without a
+    text-extractable schedule (e.g. RSU-0038, raster-only counts) raise
+    :class:`ScheduleAssemblyError`."""
+    if rsu_id not in _SCHEDULE_PAGES:
+        raise ScheduleAssemblyError(
+            f"{rsu_id}: no text-extractable wiki joint schedule "
+            "(RSU-0038 counts are raster-only; other RSUs are not "
+            "schedule-assembly candidates yet)"
+        )
+    if rsu_id == "RSU-0040":
+        return _load_oc_assembly(rsu_id, Path(wiki_root))
+    return _load_grupo_assembly(rsu_id, Path(wiki_root))
+
+
+def documented_endpoints(
+    rsu_id: str, wiki_root: Path, *, variant: str = "primary"
+) -> tuple[tuple[float, float], ...]:
+    """Documented ``16q-min-tension-endpoints`` rows for ``rsu_id`` as
+    ``(mud_density_kg_m3, tension_kn)`` tuples — mud/tension units normalized
+    across the per-page dialects. ``variant="5-bare"`` selects RSU-0040's
+    second stability sweep."""
+    dialects = _ENDPOINT_DIALECTS.get(rsu_id)
+    if dialects is None or variant not in dialects:
+        raise ScheduleAssemblyError(
+            f"{rsu_id}: no known endpoint dialect (variant {variant!r})"
+        )
+    key, mud_unit, tension_unit, mud_col, tension_col = dialects[variant]
+    contract = find_contract(rsu_id, _ENDPOINT_CALC, Path(wiki_root))
+    if contract is None:
+        raise ScheduleAssemblyError(
+            f"{rsu_id}: wiki carries no {_ENDPOINT_CALC} contract"
+        )
+    rows = (
+        contract.get(key, {}).get("rows")
+        if isinstance(contract.get(key), dict)
+        else None
+    )
+    if not rows:
+        raise ScheduleAssemblyError(f"{rsu_id}: endpoint contract lacks {key}.rows")
+    return tuple(
+        (
+            float(row[mud_col]) * _MUD_TO_KG_M3[mud_unit],
+            float(row[tension_col]) * _TENSION_TO_KN[tension_unit],
+        )
+        for row in rows
+    )

--- a/tests/drilling_riser/test_schedule_assembly.py
+++ b/tests/drilling_riser/test_schedule_assembly.py
@@ -1,0 +1,181 @@
+"""#1458 schedule-assembly goldens: string weight assembled FROM the wiki
+joint schedules + joint libraries, validated against the wave-3
+``16q-min-tension-endpoints`` contracts (llm-wiki#828).
+
+dm carries only page/key names, parse shapes and the engine; the schedule
+counts, joint weights and documented tensions live wiki-side and resolve at
+test time via ``digitalmodel.drilling_riser.schedule_assembly``. Loud skip
+standalone (same discipline as ``test_assembly_golden``).
+
+Validation stance (issue #1458 scope 2 — tolerances stated per RSU, misses
+are FINDINGS, never masked by loosening):
+
+* RSU-0019 — PASS at 3 %: the assembled chain reproduces all three Sec 5.2
+  endpoints (observed max |delta| ~1.7 %). Tolerance basis: the documented
+  assumption stack (pup/termination joints at the slick per-ft rate,
+  flexjoint/outer-barrel submerged weight from steel displacement, seawater
+  at 1025 kg/m3, mud in main bore + C&K + boost) each contribute <=~1 %.
+* RSU-0021 — FINDING: the sister-well formulation that passes RSU-0019
+  under-predicts all three Table 2.2 endpoints by 20-40 % (observed
+  -35/-27/-23 %). The contract's own figure caveats (tension-ring datum,
+  fleet angle excluded) cannot explain that magnitude. Adding the documented
+  LMRP submerged weight brings all three within ~6 % — recorded here as a
+  quantified hypothesis, NOT adopted (undocumented in the source).
+* RSU-0040 — FINDING: the SES "API 16Q stability" 15-bare sweep is
+  under-predicted by 3-15 % (largest at light mud). BUT the documented
+  15-bare minus 5-bare offset equals the UNfactored 10-joint
+  slick-for-5000ft-class swap from the RSU-0039 library to <1 % — the
+  schedule + library assembly itself is validated; the SES line carries
+  additional (undocumented) dead load / a different factor treatment.
+* RSU-0038 — no schedule-assembly: the joint counts are raster-only in the
+  source (wiki page caveat), so the loader must fail closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.drilling_riser.calc_contracts import resolve_wiki_root
+from digitalmodel.drilling_riser.schedule_assembly import (
+    SCHEDULE_RSU_IDS,
+    ScheduleAssemblyError,
+    documented_endpoints,
+    load_schedule_assembly,
+)
+
+
+def _wiki_root():
+    root = resolve_wiki_root()
+    if root is None:
+        pytest.skip(
+            "llm-wiki registry not available (standalone mode) — the "
+            "schedule-assembly goldens are part of the in-context merge gate"
+        )
+    return root
+
+
+def _deltas(rsu_id: str, *, variant: str = "primary") -> list[float]:
+    """Relative (computed - documented) / documented per endpoint row."""
+    root = _wiki_root()
+    assembly = load_schedule_assembly(rsu_id, root)
+    rows = documented_endpoints(rsu_id, root, variant=variant)
+    assert len(rows) >= 3
+    return [
+        (assembly.minimum_top_tension_16q_kn(mud_kg_m3) - documented_kn) / documented_kn
+        for mud_kg_m3, documented_kn in rows
+    ]
+
+
+# -- loader structure / fail-closed ----------------------------------------------------
+
+
+@pytest.mark.parametrize("rsu_id", sorted(SCHEDULE_RSU_IDS))
+def test_schedule_assembly_structure(rsu_id):
+    """Every schedule-assembly RSU yields a physically coherent string:
+    positive dry weight, net submerged below dry, positive net buoyancy lift
+    (all three strings carry buoyed joints), and a mud column longer than
+    the seawater column (drill floor above waterline)."""
+    assembly = load_schedule_assembly(rsu_id, _wiki_root())
+    assert len(assembly.model.items) >= 5
+    dry = assembly.model.total_dry_weight_kn()
+    net = assembly.model.total_submerged_weight_kn()
+    assert 0.0 < net < dry
+    assert assembly.buoyancy_net_lift_kn > 0.0
+    geo = assembly.geometry
+    assert geo.mud_column_m > geo.seawater_column_m > 0.0
+    assert geo.internal_area_m2 > 0.0
+
+
+def test_rsu0038_schedule_is_raster_only():
+    """RSU-0038's joint counts are raster-only in the source — the loader
+    must fail closed, never guess a schedule."""
+    with pytest.raises(ScheduleAssemblyError, match="RSU-0038"):
+        load_schedule_assembly("RSU-0038", _wiki_root())
+
+
+def test_unknown_rsu_fails_closed():
+    with pytest.raises(ScheduleAssemblyError, match="RSU-9999"):
+        load_schedule_assembly("RSU-9999", _wiki_root())
+
+
+def test_missing_wiki_page_fails_closed(tmp_path):
+    with pytest.raises(ScheduleAssemblyError, match="missing"):
+        load_schedule_assembly("RSU-0019", tmp_path)
+
+
+def test_tension_is_mud_linear_increasing():
+    """The 16Q chain is linear and increasing in mud density (fixed
+    geometry) — a slope/sign regression fails loudly here."""
+    assembly = load_schedule_assembly("RSU-0019", _wiki_root())
+    t1 = assembly.minimum_top_tension_16q_kn(1000.0)
+    t2 = assembly.minimum_top_tension_16q_kn(1500.0)
+    t3 = assembly.minimum_top_tension_16q_kn(2000.0)
+    assert t1 < t2 < t3
+    assert (t3 - t2) == pytest.approx(t2 - t1, rel=1e-9)
+
+
+# -- RSU-0019: endpoint validation PASS at 3 % ------------------------------------------
+
+
+def test_rsu0019_endpoints_within_3_percent():
+    deltas = _deltas("RSU-0019")
+    assert max(abs(d) for d in deltas) <= 0.03, deltas
+
+
+# -- RSU-0021: documented FINDING (delta band pinned, not masked) -----------------------
+
+
+def test_rsu0021_endpoints_finding_band():
+    """Characterization: all endpoints under-predicted by 20-40 %. If this
+    band ever shifts (physics or wiki-side contract change), re-investigate
+    rather than silently re-baseline."""
+    deltas = _deltas("RSU-0021")
+    assert all(-0.40 < d < -0.20 for d in deltas), deltas
+
+
+def test_rsu0021_lmrp_inclusion_hypothesis():
+    """Quantified hypothesis (NOT adopted): adding the documented LMRP
+    submerged weight to the tensioned string brings all three endpoints
+    within ~6 %."""
+    root = _wiki_root()
+    assembly = load_schedule_assembly("RSU-0021", root)
+    lmrp_kn = assembly.lmrp_submerged_kn
+    assert lmrp_kn is not None and lmrp_kn > 0.0
+    factor = assembly.top_tension_factor
+    for mud_kg_m3, documented_kn in documented_endpoints("RSU-0021", root):
+        adjusted = assembly.minimum_top_tension_16q_kn(mud_kg_m3) + factor * lmrp_kn
+        assert abs(adjusted - documented_kn) / documented_kn < 0.06
+
+
+# -- RSU-0040: documented FINDING + positive swap-consistency validation ----------------
+
+
+def test_rsu0040_endpoints_finding_band():
+    """Characterization of the 15-bare SES stability sweep: under-predicted
+    by 3-15 %, monotonically shrinking with mud weight (constant absolute
+    weight-side shortfall + slightly steeper model mud slope)."""
+    deltas = _deltas("RSU-0040")
+    assert all(-0.15 < d < -0.03 for d in deltas), deltas
+    # shrinking magnitude with increasing mud weight
+    magnitudes = [abs(d) for d in deltas]
+    assert magnitudes == sorted(magnitudes, reverse=True)
+
+
+def test_rsu0040_five_bare_swap_consistency():
+    """Positive validation of the schedule + RSU-0039 library: the
+    documented 15-bare minus 5-bare tension offset equals the UNfactored
+    10-joint slick-for-5000ft-class swap to <1 % on every sweep row."""
+    root = _wiki_root()
+    assembly = load_schedule_assembly("RSU-0040", root)
+    items = {item.component_id: item.component for item in assembly.model.items}
+    slick = items["RSU-0040/slick-joint"]
+    b5000 = items["RSU-0040/buoyancy-joint-5000ft"]
+    swap_kn = 10.0 * (
+        float(slick["submerged_weight_kn"]) - float(b5000["submerged_weight_kn"])
+    )
+    rows_15 = documented_endpoints("RSU-0040", root)
+    rows_5 = documented_endpoints("RSU-0040", root, variant="5-bare")
+    assert len(rows_15) == len(rows_5) == 9
+    for (mud_15, t15), (mud_5, t5) in zip(rows_15, rows_5):
+        assert mud_15 == mud_5
+        assert abs((t15 - t5) - swap_kn) / swap_kn < 0.01


### PR DESCRIPTION
Closes #1458. Follow-on to #1453/#1454 under epic #1279, enabled by llm-wiki#828.

## Summary
- **New `schedule_assembly.py`**: assembles the tensioned riser string FROM wiki joint schedules + joint libraries (markdown table + prose parsing, bounded reads, fail-closed, built-in schedule-integrity cross-checks: joint tallies + elevation spans ≤0.5%)
- **16Q chain** through the existing `minimum_slip_ring_tension`/`top_tension_required` (2H-TNE-0050-03 §3.1 factor ≡ 16Q N/(Rf(N−n)), N=6/n=1/Rf=0.96); mud in main bore + C&K + boost from lower-FJ datum
- **Batch: 4 → 7 of 19 runnable** (4 contract-chain + 3 schedule-assembly), new `runnable-schedule` status with per-RSU delta band + PASS/FINDING verdict

## Validation (no tolerances loosened — finding bands pinned in tests)
- **RSU-0019 (1933 m): PASS ≤1.7%** on all three documented endpoints — first fully schedule-assembled 16Q reproduction in the repo
- **RSU-0021 (1495 m): FINDING −23..−35%** — sister-well formulation that passes RSU-0019 under-predicts; the documented-LMRP-weight hypothesis closes it to ±4.9% but is undocumented source-side (wiki-note candidate)
- **RSU-0040 (2053 m): FINDING −4.8..−13.5%**, but the 15-vs-5-bare offset reproduces the RSU-0039 library swap to <1% on all 9 rows — assembly validated; residual attributable to the SES stability line's undocumented dead-load/factor composition
- RSU-0038: fails closed (schedule is raster-only in the source; documented on-page)

## Tests / lint
- **294 passed** (was 282; +12 schedule-assembly tests) with LLM_WIKI_PATH at post-#828 wiki
- black/isort/ruff (repo venv, exact versions) clean

Refs: epic #1279, #1454, llm-wiki#828