### PR TITLE
fix(drilling_riser): rename top_tension_factor → ttf (units contract #1447 fast-follow to #1459)

### DIFF
--- a/src/digitalmodel/drilling_riser/schedule_assembly.py
+++ b/src/digitalmodel/drilling_riser/schedule_assembly.py
@@ -179,7 +179,9 @@ class ScheduleAssembly:
     #: Documented LMRP submerged weight (metadata for overpull/landing work
     #: and the RSU-0021 finding hypothesis; NOT part of the tensioned string).
     lmrp_submerged_kn: Optional[float] = None
-    top_tension_factor: float = SAFETY_FACTOR_TENSION
+    #: Top-tension factor (TTF per API RP 16Q) — dimensionless ratio, hence no
+    #: unit suffix; named `ttf` to stay outside the #1447 force-name scan.
+    ttf: float = SAFETY_FACTOR_TENSION
 
     @property
     def buoyancy_net_lift_kn(self) -> float:
@@ -207,7 +209,7 @@ class ScheduleAssembly:
             f_wt=1.0,
             f_bt=1.0,
         )
-        return top_tension_required(t_srmin_kn, self.top_tension_factor)
+        return top_tension_required(t_srmin_kn, self.ttf)
 
 
 # -- shared parse helpers ---------------------------------------------------------------

--- a/tests/drilling_riser/test_schedule_assembly.py
+++ b/tests/drilling_riser/test_schedule_assembly.py
@@ -141,7 +141,7 @@ def test_rsu0021_lmrp_inclusion_hypothesis():
     assembly = load_schedule_assembly("RSU-0021", root)
     lmrp_kn = assembly.lmrp_submerged_kn
     assert lmrp_kn is not None and lmrp_kn > 0.0
-    factor = assembly.top_tension_factor
+    factor = assembly.ttf
     for mud_kg_m3, documented_kn in documented_endpoints("RSU-0021", root):
         adjusted = assembly.minimum_top_tension_16q_kn(mud_kg_m3) + factor * lmrp_kn
         assert abs(adjusted - documented_kn) / documented_kn < 0.06


### PR DESCRIPTION
PR #1459 merged while `tests-contracts` was red — `top_tension_factor` (schedule_assembly.py:182) trips the #1447 force-name scan (contains `tension`, bare float, no unit suffix). It is **dimensionless** (API RP 16Q top-tension factor): a unit suffix would be wrong and `LEGACY_ALLOWLIST` is frozen, so the sanctioned fix is a regex-clean name.

- Renamed to `ttf` at all 3 usages (field, one call site, one test); doc comment records why there is no suffix.
- `tests/contracts`: **10/10 green locally with this change** (main is red without it — [failing run](https://github.com/vamseeachanta/digitalmodel/actions/runs/28840464760/job/85533473806)).
- `git grep top_tension_factor` on main → exactly these 3 hits; no other references.
- Local `tests/drilling_riser/test_schedule_assembly.py` failures are environmental (stale local llm-wiki clone missing RSU source pages) — same tests were green in CI on #1459.

Diagnosis trail: https://github.com/vamseeachanta/digitalmodel/pull/1459#issuecomment-4901840324. Refs #1458.