### PR TITLE
feat(brand): brand.css back-compat alias layer (unblocks #1474)

### DIFF
--- a/docs/api/_assets/brand.css
+++ b/docs/api/_assets/brand.css
@@ -60,6 +60,19 @@
   --shadow:0 1px 0 rgba(255,255,255,.03), 0 12px 30px rgba(0,0,0,.4);
 }
 
+/* ---- back-compat aliases -------------------------------------------------
+   Legacy pages used different NAMES for the same brand roles. Aliasing them to
+   the canonical vars lets a migrated page drop its own :root and inherit brand
+   values (light/dark aware) unchanged. New pages: use the canonical names. #1474
+   NOTE: linking brand.css also enables dark-mode via @media; a light-only legacy
+   page should pin <html data-theme="light"> during migration unless it tokenises
+   every colour. */
+:root{
+  --navy:var(--brand);  --teal:var(--accent);
+  --line:var(--edge);   --soft:var(--panel-2);  --bg:var(--ground);
+  --mut:var(--muted);   --good:var(--go);  --warn:var(--caution);  --red:var(--nogo);
+}
+
 /* ---- shared primitives -------------------------------------------------- */
 *{box-sizing:border-box}
 body{


### PR DESCRIPTION
Part of #1471 / #1474. Additive-only — no page links these aliases yet, so nothing changes today; the exemplar doesn't use aliases.

Adds an alias layer mapping legacy token names to the canonical brand vars:
`--navy→--brand · --teal→--accent · --line→--edge · --soft→--panel-2 · --bg→--ground · --mut→--muted · --good→--go · --warn→--caution · --red→--nogo`.

**Why:** audit (see #1474 comments) shows the 52-page navy/teal family already uses the *exact* brand values under these names, so with the aliases those pages can drop their own `:root` and inherit brand tokens **pixel-identical**. The alias comment also flags the dark-mode caveat (link brand.css enables `@media prefers-dark`; light-only legacy pages must pin `data-theme=light`).

Keystone for the family-by-family migration; no client page recolored in this PR.