### PR TITLE
refactor(brand): migrate structural pages onto brand.css (#1474)

### DIFF
--- a/docs/api/structural/anchor-holding-explorer.html
+++ b/docs/api/structural/anchor-holding-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Drag-anchor holding-capacity explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+ :root{--soft:#f4f8fc}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/cathodic-protection-explorer.html
+++ b/docs/api/structural/cathodic-protection-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cathodic-protection anode explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--teal2:#12A6B0}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--teal2:#12A6B0}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/field-economics-explorer.html
+++ b/docs/api/structural/field-economics-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Field-development economics explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/ipr-explorer.html
+++ b/docs/api/structural/ipr-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Well inflow-performance (IPR) explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+ :root{--soft:#f4f8fc}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/pore-pressure-explorer.html
+++ b/docs/api/structural/pore-pressure-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Pore-pressure / mud-weight explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--mw:#7c3aed}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--mw:#7c3aed}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/ship-resistance-explorer.html
+++ b/docs/api/structural/ship-resistance-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Ship resistance &amp; powering explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+ :root{--soft:#f4f8fc}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/sloshing-explorer.html
+++ b/docs/api/structural/sloshing-explorer.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Tank sloshing — natural-period & resonance explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--roll:#7c3aed;
-       --c0:#0B3D91;--c1:#0f8a7e;--c2:#b8860b;--c3:#c0392b}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--roll:#7c3aed;--c0:#0B3D91;--c1:#0f8a7e;--c2:#b8860b;--c3:#c0392b}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/viv-explorer.html
+++ b/docs/api/structural/viv-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>VIV lock-in screening explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b7791f;--bad:#c0392b}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--warn:#b7791f;--bad:#c0392b}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}

--- a/docs/api/structural/wall-thickness-explorer.html
+++ b/docs/api/structural/wall-thickness-explorer.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Wall-thickness multi-code explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-       --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--warn:#b7791f}
+ :root{--soft:#f4f8fc;--ok:#1f9d57;--bad:#c0392b;--warn:#b7791f}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
       color:var(--ink);line-height:1.5;padding:26px 20px 60px;max-width:1080px;margin:0 auto}


### PR DESCRIPTION
Part of #1471 / #1474 — first migrated family (navy/teal). 9 structural explorer pages.

- Drops the redundant brand tokens from each `:root` (they already equalled brand values); brand.css now provides them via canonical names + aliases.
- Links `../_assets/brand.css`; pins `data-theme="light"` (these pages are light-only and don't tokenise every colour — the pin stops brand.css's `@media prefers-dark` from imposing a broken dark theme; `[data-theme]` outranks the media rule).
- Preserves page-specific tokens (`--c0..c3`, `--roll`, `--ok/--bad`, `--soft`).
- **Verified pixel-identical** (headless before/after diff = 0 differing pixels on anchor-holding + sloshing).

Pattern for the remaining navy/teal pages (capabilities 37, ffs 3, singles).