### PR TITLE
refactor(brand): migrate capabilities pages onto brand.css + logo→index (#1474)

### DIFF
--- a/docs/api/capabilities/api/buckling-panel.html
+++ b/docs/api/capabilities/api/buckling-panel.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Stiffened-panel buckling explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Stiffened-panel buckling explorer</h1><div class="std">DNV-RP-C201</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/buckling-plate.html
+++ b/docs/api/capabilities/api/buckling-plate.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Ship plate buckling explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Ship plate buckling explorer</h1><div class="std">DNV-RP-C201</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/casing-design.html
+++ b/docs/api/capabilities/api/casing-design.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Casing design explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Casing design explorer</h1><div class="std">API 5C3 · API 5CT · NACE MR0175</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/cathodic-protection-explorer.html
+++ b/docs/api/capabilities/api/cathodic-protection-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cathodic-protection anode explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Cathodic-protection anode explorer</h1><div class="std">DNV-RP-B401</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/container-utilization.html
+++ b/docs/api/capabilities/api/container-utilization.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Offshore container utilization — DNV 2.7-1 — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Offshore container utilization — DNV 2.7-1</h1><div class="std">DNVGL-ST-E271 (2017)</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/diffraction-deck-prep.html
+++ b/docs/api/capabilities/api/diffraction-deck-prep.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Diffraction deck generation — spec to solver input — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Diffraction deck generation — spec to solver input</h1><div class="std">AQWA · OrcaWave · canonical spec</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/drilling-riser-operability-monitor.html
+++ b/docs/api/capabilities/api/drilling-riser-operability-monitor.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Operability &amp; integrity monitor — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Operability &amp; integrity monitor</h1><div class="std">API-RP-16Q · API-STD-2RD</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/drilling-riser-operability.html
+++ b/docs/api/capabilities/api/drilling-riser-operability.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Drilling-riser operability envelope explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Drilling-riser operability envelope explorer</h1><div class="std">API-RP-16Q · API-STD-2RD</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/dynacard-field-health.html
+++ b/docs/api/capabilities/api/dynacard-field-health.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Field-wide dynacard health rollup — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Field-wide dynacard health rollup</h1><div class="std">per-well diagnosis · fail-closed screening</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/dynacard-troubleshooting.html
+++ b/docs/api/capabilities/api/dynacard-troubleshooting.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Dynacard troubleshooting explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Dynacard troubleshooting explorer</h1><div class="std">Gibbs wave equation · Bezerra projections · 18 failure modes</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/ffs-field-dashboard.html
+++ b/docs/api/capabilities/api/ffs-field-dashboard.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>FFS inspector field dashboard — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>FFS inspector field dashboard</h1><div class="std">measurement sufficiency</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/ffs-showcase.html
+++ b/docs/api/capabilities/api/ffs-showcase.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>FFS decision-layer showcase — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>FFS decision-layer showcase</h1><div class="std">API 579-1 · ASME B31G · DNV-RP-F101</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/galvanic-explorer.html
+++ b/docs/api/capabilities/api/galvanic-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Galvanic compatibility explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Galvanic compatibility explorer</h1><div class="std">MIL-STD-889 anodic index</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/installation-bokalift.html
+++ b/docs/api/capabilities/api/installation-bokalift.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Installation vessel pamphlet — BokaLift 2 — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Installation vessel pamphlet — BokaLift 2</h1><div class="std">DNV-RP-H103 · DNV-ST-N001 · IMCA · HSE RR444</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/mooring-resilience.html
+++ b/docs/api/capabilities/api/mooring-resilience.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mooring resilience screen — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Mooring resilience screen</h1><div class="std">API RP 2SK · DNV-OS-E301</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/ocimf.html
+++ b/docs/api/capabilities/api/ocimf.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>OCIMF coefficient explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>OCIMF coefficient explorer</h1><div class="std">OCIMF MEG3 / MEG4</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/passing-ship.html
+++ b/docs/api/capabilities/api/passing-ship.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Passing-ship interaction benchmark — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Passing-ship interaction benchmark</h1><div class="std">Wang (1975)</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/rao-comparison.html
+++ b/docs/api/capabilities/api/rao-comparison.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AQWA vs OrcaWave RAO comparison — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>AQWA vs OrcaWave RAO comparison</h1><div class="std">cross-solver diffraction</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/riser-joint-acceptance.html
+++ b/docs/api/capabilities/api/riser-joint-acceptance.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Riser-joint flaw-acceptance explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Riser-joint flaw-acceptance explorer</h1><div class="std">API 579-1 · Modified B31G · API RP 1111</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/riser-mesh.html
+++ b/docs/api/capabilities/api/riser-mesh.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Riser mesh sensitivity report — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Riser mesh sensitivity report</h1><div class="std">OrcaFlex · convergence study</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/riser-validation.html
+++ b/docs/api/capabilities/api/riser-validation.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Riser validation report — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Riser validation report</h1><div class="std">OrcaFlex · tier-2 fast library</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/rudder-database.html
+++ b/docs/api/capabilities/api/rudder-database.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rudder-type database — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Rudder-type database</h1><div class="std">Molland &amp; Turnock · Brix · DNV/ABS</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/rudder-explorer.html
+++ b/docs/api/capabilities/api/rudder-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rudder &amp; low-speed manoeuvring explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Rudder &amp; low-speed manoeuvring explorer</h1><div class="std">IMO MSC.137(76) · Clarke 1983 · OCIMF</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/scale-si-explorer.html
+++ b/docs/api/capabilities/api/scale-si-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mineral-scale saturation explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Mineral-scale saturation explorer</h1><div class="std">Oddo–Tomson · SPE 21710</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/short-horizon-motion-forecast.html
+++ b/docs/api/capabilities/api/short-horizon-motion-forecast.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Short-horizon motion forecast — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Short-horizon motion forecast</h1><div class="std">MMS / MRU feed · DNV-ST-N001 · DNV-ST-0358 / Walk2Work · CAP 437</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/sloshing-explorer.html
+++ b/docs/api/capabilities/api/sloshing-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Tank sloshing natural-period &amp; resonance explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="700" height="220" viewBox="0 0 700 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="700" height="220" viewBox="0 0 700 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Tank sloshing natural-period &amp; resonance explorer</h1><div class="std">Faltinsen linear potential theory · McIver · API 650 Annex E</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/subsea-xsection.html
+++ b/docs/api/capabilities/api/subsea-xsection.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Offshore cross-section report — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Offshore cross-section report</h1><div class="std">cables · umbilicals · pipelines</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/unitbox-amplitude.html
+++ b/docs/api/capabilities/api/unitbox-amplitude.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>RAO amplitude overlay — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>RAO amplitude overlay</h1><div class="std">WAMIT · AQWA · OrcaWave</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/unitbox-combined.html
+++ b/docs/api/capabilities/api/unitbox-combined.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Combined solver comparison — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Combined solver comparison</h1><div class="std">WAMIT · AQWA · OrcaWave</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/unitbox-heatmap.html
+++ b/docs/api/capabilities/api/unitbox-heatmap.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Solver correlation heatmap — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Solver correlation heatmap</h1><div class="std">WAMIT · AQWA · OrcaWave</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/unitbox-phase.html
+++ b/docs/api/capabilities/api/unitbox-phase.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>RAO phase overlay — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>RAO phase overlay</h1><div class="std">WAMIT · AQWA · OrcaWave</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/unitbox-report.html
+++ b/docs/api/capabilities/api/unitbox-report.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Unit-box 3-way diffraction benchmark — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Unit-box 3-way diffraction benchmark</h1><div class="std">WAMIT · AQWA · OrcaWave</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/vessel-suitability.html
+++ b/docs/api/capabilities/api/vessel-suitability.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Installation vessel database &amp; suitability ranking — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Installation vessel database &amp; suitability ranking</h1><div class="std">DNV-RP-H103 · flag-don&#x27;t-fake provenance</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/wall-thickness-explorer.html
+++ b/docs/api/capabilities/api/wall-thickness-explorer.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Wall-thickness multi-code explorer — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <g transform="translate(20 10)">
       <path d="M0 10h130c58 0 100 42 100 100s-42 100-100 100H0z" fill="#0B3D91"/>
@@ -208,7 +209,7 @@
       <text x="0" y="56" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="60" font-weight="600" fill="#0B3D91" letter-spacing="0.5">Digital <tspan fill="#2BB2A6">Model</tspan></text>
     </g>
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Wall-thickness multi-code explorer</h1><div class="std">DNV-ST-F101 · API RP 1111 · ASME B31.4/8 · PD 8010-2 · ISO 13623</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/wind-economics.html
+++ b/docs/api/capabilities/api/wind-economics.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Floating-wind LCOE / TOTEX tradespace — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Floating-wind LCOE / TOTEX tradespace</h1><div class="std">LCOE · reliability · economies of scale</div>
 
   <div class="bigpanel">

--- a/docs/api/capabilities/api/wind-sizing.html
+++ b/docs/api/capabilities/api/wind-sizing.html
@@ -1,8 +1,9 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8">
+<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Floating-wind sizing &amp; concept screening — API call</title>
+<link rel="stylesheet" href="../../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--ink:#13233f;--muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:Arial,Helvetica,sans-serif;color:var(--ink);background:#eef3fa;line-height:1.5}
   .wrap{max-width:1000px;margin:0 auto;padding:22px}
@@ -31,7 +32,7 @@
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
 </style></head>
 <body><div class="wrap">
-  <div class="top"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip">
       <rect x="0" y="0" width="800" height="220" rx="16"/>
@@ -99,7 +100,7 @@
     </g>
 
   </g>
-</svg><div class="kind">Workflow-API · self-contained call</div></div>
+</svg></a><div class="kind">Workflow-API · self-contained call</div></div>
   <h1>Floating-wind sizing &amp; concept screening</h1><div class="std">semi-sub · spar · TLP · barge · IEA 15 MW</div>
 
   <div class="bigpanel">


### PR DESCRIPTION
Part of #1471 / #1474. 36 capabilities/api pages (navy/teal family).

- Drop redundant brand tokens from each `:root`; link `../../_assets/brand.css`; pin `data-theme="light"`.
- **Logo→capabilities:** wrap the `.top` SVG logo in `<a href="../">` (the capabilities index) with `display:contents` = zero layout change. Fulfils the explicit logo-routing request for the capabilities pages.
- Preserves `--soft`. **Verified pixel-identical** (before/after diff = 0 on 3 pages).

After this: navy/teal family remaining = ffs (3) + a few singles; then the cfd article family (real recolor).