### PR TITLE
refactor(brand): migrate remaining navy/teal pages onto brand.css (#1474)

### DIFF
--- a/docs/api/artificial-lift/dynacard-troubleshooting.html
+++ b/docs/api/artificial-lift/dynacard-troubleshooting.html
@@ -1,14 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Dynacard troubleshooting explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#ffffff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;
-        --series-card:#2563C4;--series-ref:#0B8F80;
-        --st-normal:#1f9d57;--st-warning:#b7791f;--st-critical:#c2410c;--st-failure:#b91c1c}
+  :root{--soft:#f4f8fc;--series-card:#2563C4;--series-ref:#0B8F80;--st-normal:#1f9d57;--st-warning:#b7791f;--st-critical:#c2410c;--st-failure:#b91c1c}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
        color:var(--ink);line-height:1.5;padding:26px 22px 60px}

--- a/docs/api/cfd/cfd-runtime-estimator.html
+++ b/docs/api/cfd/cfd-runtime-estimator.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD run-time estimator — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;--mut:#5b6b86;
-       --line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b8860b;--bad:#c0392b}
+ :root{--mut:#5b6b86;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b8860b;--bad:#c0392b}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);color:var(--ink);
       line-height:1.55;padding:26px 20px 60px;max-width:1000px;margin:0 auto}

--- a/docs/api/corrosion/galvanic-compatibility-explorer.html
+++ b/docs/api/corrosion/galvanic-compatibility-explorer.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Galvanic Compatibility Explorer — dissimilar-metal screening</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
        color:var(--ink);line-height:1.5;padding:26px 30px 60px;max-width:1180px;margin:0 auto}

--- a/docs/api/ffs/riser-joint-acceptance-explorer.html
+++ b/docs/api/ffs/riser-joint-acceptance-explorer.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Riser-Joint Flaw-Acceptance Explorer — drilling riser FFS</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#fff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc}
+  :root{--soft:#f4f8fc}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
        color:var(--ink);line-height:1.5;padding:26px 30px 60px;max-width:1180px;margin:0 auto}

--- a/docs/api/hydro/rudder-maneuvering-explorer.html
+++ b/docs/api/hydro/rudder-maneuvering-explorer.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rudder &amp; low-speed manoeuvring explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" charset="utf-8"></script>
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#ffffff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b7791f;--bad:#d1242f;--side:330px}
+  :root{--soft:#f4f8fc;--ok:#1f9d57;--warn:#b7791f;--bad:#d1242f;--side:330px}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
        color:var(--ink);line-height:1.45}

--- a/docs/api/well/casing-design-explorer.html
+++ b/docs/api/well/casing-design-explorer.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Casing design explorer — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" charset="utf-8"></script>
 <style>
-  :root{--navy:#0B3D91;--teal:#0f8a7e;--bg:#eef3fa;--panel:#ffffff;--ink:#13233f;
-        --muted:#5b6b86;--line:#dbe4f0;--soft:#f4f8fc;
-        --ok:#1f9d57;--bad:#b91c1c}
+  :root{--soft:#f4f8fc;--ok:#1f9d57;--bad:#b91c1c}
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);
        color:var(--ink);line-height:1.5;padding:26px 22px 60px}


### PR DESCRIPTION
Part of #1471 / #1474. 6 scattered navy/teal pages (hydro, ffs, cfd, well, corrosion, artificial-lift). Same value-checked transform (drop redundant brand tokens, link brand.css, pin data-theme=light, keep page-specific). Verified pixel-identical. cfd article family untouched (separate recolor). This completes the safe navy/teal family (~66 pages migrated across #1483/#1484/this).