### PR TITLE
refactor(brand): recolor cfd article pages onto brand palette (#1474)

### DIFF
--- a/docs/api/cfd/cfd-runtime-estimator.html
+++ b/docs/api/cfd/cfd-runtime-estimator.html
@@ -4,7 +4,7 @@
 <title>CFD run-time estimator — digitalmodel</title>
 <link rel="stylesheet" href="../_assets/brand.css">
 <style>
- :root{--mut:#5b6b86;--soft:#f4f8fc;--ok:#1f9d57;--warn:#b8860b;--bad:#c0392b}
+ :root{--ok:#1f9d57;--bad:#c0392b}
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);color:var(--ink);
       line-height:1.55;padding:26px 20px 60px;max-width:1000px;margin:0 auto}

--- a/docs/api/cfd/cylinder-re100-verification.html
+++ b/docs/api/cfd/cylinder-re100-verification.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Laminar Vortex Shedding behind a Cylinder (Re=100)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
 color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}

--- a/docs/api/cfd/dam-break-verification.html
+++ b/docs/api/cfd/dam-break-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Dam Break (Martin & Moyce 1952)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/flat-plate-blasius-verification.html
+++ b/docs/api/cfd/flat-plate-blasius-verification.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en" data-theme="light"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Laminar Flat-Plate Boundary Layer (Blasius)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
 color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}

--- a/docs/api/cfd/floating-body-decay-verification.html
+++ b/docs/api/cfd/floating-body-decay-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Floating-Body Heave Free Decay</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/kleefsman-impact-verification.html
+++ b/docs/api/cfd/kleefsman-impact-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Green-Water Impact (Kleefsman/MARIN)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/maccamy-fuchs-cylinder-verification.html
+++ b/docs/api/cfd/maccamy-fuchs-cylinder-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — MacCamy-Fuchs Cylinder Wave Loading</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/naca0012-airfoil-verification.html
+++ b/docs/api/cfd/naca0012-airfoil-verification.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<!DOCTYPE html><html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — NACA0012 Airfoil Lift Curve</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/sloshing-cfd-study.html
+++ b/docs/api/cfd/sloshing-cfd-study.html
@@ -1,5 +1,6 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ballast-tank sloshing — the 2D CFD study — digitalmodel</title><style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--red:#c0392b;--bg:#f7f9fb;}
+<!DOCTYPE html><html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ballast-tank sloshing — the 2D CFD study — digitalmodel</title>
+<link rel="stylesheet" href="../_assets/brand.css"><style>
+
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:940px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/tank-sloshing-verification.html
+++ b/docs/api/cfd/tank-sloshing-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — 2D Tank Sloshing (forced roll) &amp; ballast-tank roll damper</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/turbulent-flat-plate-verification.html
+++ b/docs/api/cfd/turbulent-flat-plate-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Turbulent Flat Plate (k-omega SST)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/wave-excited-body-decay-verification.html
+++ b/docs/api/cfd/wave-excited-body-decay-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Overset Body Free-Decay Heave Damping</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/wave-excited-body-rao-verification.html
+++ b/docs/api/cfd/wave-excited-body-rao-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Wave-Excited Body Heave-RAO Curve</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/wave-excited-body-verification.html
+++ b/docs/api/cfd/wave-excited-body-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Wave-Excited Floating Body (Overset)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}

--- a/docs/api/cfd/wave-tank-verification.html
+++ b/docs/api/cfd/wave-tank-verification.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en" data-theme="light"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CFD Verification — Numerical Wave Tank (StokesII)</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <style>
-:root{--ink:#1a2332;--mut:#5a6b7b;--line:#dde3ea;--accent:#0b6e99;--good:#1a7a3f;--warn:#b06f00;--bg:#f7f9fb;}
+
 *{box-sizing:border-box} body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:var(--ink);line-height:1.6;margin:0;background:var(--bg);}
 .wrap{max-width:920px;margin:0 auto;padding:0 24px 80px;background:#fff;box-shadow:0 0 40px rgba(0,0,0,.04);}
 header{border-bottom:3px solid var(--accent);padding:38px 0 22px;margin-bottom:8px}


### PR DESCRIPTION
Part of #1471 / #1474 — the one **intentional recolor** family. 15 cfd verification/article pages move from their local blue palette to the brand palette (accent blue #0b6e99 → brand teal #0f8a7e; bg grey → brand ground; ink/line/good/warn → brand). Link brand.css, pin data-theme=light, preserve page-specific series colours.

Canonical accent = teal was your call. Before/after screenshots confirm a clean on-brand recolor (kicker + header rule now teal, panels pick up brand ground) with no breakage. This clears the cfd family; remaining tail = 3 ffs dashboards + 2 index/landing pages + ocimf (bespoke, per-page).