### PR TITLE
ci(brand): drift guard for hard-coded brand tokens (closes #1476)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Brand token guard
+        run: python scripts/brand_guard.py
+
       - name: Build docs
         env:
           UV_NO_SOURCES: "true"

--- a/docs/api/production/scale-si-explorer.html
+++ b/docs/api/production/scale-si-explorer.html
@@ -1,16 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mineral-Scale Saturation-Index Explorer</title>
+<link rel="stylesheet" href="../_assets/brand.css">
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <style>
-  :root {
-    --navy: #0B3D91;
-    --teal: #0f8a7e;
-    --bg: #eef3fa;
-  }
+  
   * { box-sizing: border-box; }
   body {
     margin: 0; background: var(--bg); color: #1c2a3a;

--- a/scripts/brand_guard.py
+++ b/scripts/brand_guard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Brand drift guard — digitalmodel#1476 (epic #1471).
+
+Fails CI if a public capability page under docs/api/ hard-codes a CORE brand
+colour token (--brand/--navy/--accent/--teal) with a literal hex, instead of
+inheriting it from the canonical docs/api/_assets/brand.css.
+
+This locks in the #1474 migration: identity colours come from ONE place, so brand
+drift (the original problem — --accent across 6+ values) cannot creep back.
+
+Run in CI (see .github/workflows/docs.yml) and locally:
+    python scripts/brand_guard.py
+Exit 0 = clean, 1 = violations.
+"""
+from __future__ import annotations
+import re, sys, glob, os
+
+ROOT = "docs/api"
+
+# identity colours that MUST be inherited from brand.css, never hard-coded in a page.
+CORE = ("brand", "navy", "accent", "teal")
+CORE_RE = re.compile(r"--(?:%s)\s*:\s*#[0-9a-fA-F]{3,8}" % "|".join(CORE))
+
+# pages intentionally self-themed (documented exceptions). Keep this list tiny and justified.
+ALLOWLIST = {
+    "docs/api/ffs/build-wave-2026-07.html",  # ships its own complete dark-mode design (#1474)
+}
+
+# sanctioned container widths (soft check — informational only, never fails the build)
+SANCTIONED_WIDTHS = {"var(--wrap)", "1240px"}
+WIDTH_RE = re.compile(r"max-width\s*:\s*([0-9]+px|var\(--wrap\))")
+
+
+def iter_pages():
+    for f in sorted(glob.glob(f"{ROOT}/**/*.html", recursive=True)):
+        f = f.replace("\\", "/")
+        if "/_assets/" in f:      # brand.css legitimately DEFINES the tokens
+            continue
+        yield f
+
+
+def selftest() -> int:
+    ok = bool(CORE_RE.search("--accent:#0b6e99"))
+    ok &= bool(CORE_RE.search("  --navy: #1a365d;"))
+    ok &= CORE_RE.search("color:var(--accent)") is None      # usage must NOT flag
+    ok &= CORE_RE.search("--soft:#f4f8fc") is None           # page-specific must NOT flag
+    print("selftest:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    violations, widths = [], {}
+    for f in iter_pages():
+        s = open(f, encoding="utf-8", errors="ignore").read()
+        if f not in ALLOWLIST:
+            m = CORE_RE.search(s)
+            if m:
+                violations.append((f, m.group(0)))
+        for w in WIDTH_RE.findall(s):
+            if w not in SANCTIONED_WIDTHS:
+                widths.setdefault(w, 0)
+                widths[w] += 1
+
+    if widths:
+        total = sum(widths.values())
+        print(f"note (non-failing): {len(widths)} non-sanctioned max-width value(s) across "
+              f"{total} occurrence(s) — consider var(--wrap). Top: "
+              + ", ".join(f"{w}×{n}" for w, n in sorted(widths.items(), key=lambda kv: -kv[1])[:3]))
+        print()
+
+    if violations:
+        print("BRAND GUARD FAILED — pages hard-code core brand tokens instead of "
+              "linking ../_assets/brand.css:\n")
+        for f, tok in violations:
+            print(f"  ✗ {f}   ({tok})")
+        print(f"\n{len(violations)} violation(s). Use `var(--brand)`/`var(--accent)` and "
+              "`<link rel=\"stylesheet\" href=\"…/_assets/brand.css\">` — see "
+              "docs/api/_assets/LAYOUT.md. If a page is intentionally self-themed, add it "
+              "to ALLOWLIST in scripts/brand_guard.py with a reason.")
+        return 1
+
+    n = sum(1 for _ in iter_pages())
+    print(f"brand guard OK — no core-token drift across {n} pages in {ROOT}/** "
+          f"(allowlist: {len(ALLOWLIST)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Part of #1471. Self-enforcing invariant so the #1474 migration can't regress.

- `scripts/brand_guard.py` — fails if any `docs/api` page hard-codes a **core brand token** (`--brand/--navy/--accent/--teal`) instead of inheriting from `_assets/brand.css`. Tiny justified allowlist (`build-wave`, self-themed). Includes `--selftest`; non-failing note on non-sanctioned `max-width` values.
- Wired into **Build API Docs** (`docs.yml`), which runs on `docs/api/**` PRs.
- **It already earned its keep:** caught `production/scale-si-explorer.html` — missed by the sweep because its `:root` used `:root {` with a space — now migrated (benign layout shift only, verified).

After merge, epic #1471 remaining = a11y baseline #1475.