### PR TITLE
chore: gitignore dynacard client-data staging intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,8 @@ CLAUDE.local.md
 .claude/skills/.ecosystem-propagated
 .claude/skills/guidelines
 output_610/
+
+# Dynacard capability staging intermediates — derived from PRIVATE client card
+# archives (reference client production-data paths); must stay uncommitted.
+scripts/capabilities/_*_stage.json
+scripts/capabilities/_*_manifest.json


### PR DESCRIPTION
Two untracked dynacard staging side files (`scripts/capabilities/_digitized_cards_stage.json`, `_measured_cards_manifest.json`) are derived from **private client card archives**. They were showing as untracked; these directory-anchored ignore patterns prevent them from ever being staged into this public repo. Verified zero tracked files shadowed (all tracked entries under `scripts/capabilities/` are `.py`).

Surfaced by a client-data hygiene sweep. That sweep also flagged some pre-existing client-referencing content already committed elsewhere in the repo — escalated privately to the owner under the public-repo-PII epic; not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)