### PR TITLE
feat(uncertainty): Monte Carlo UQ core (#1427 PR1)

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -73,6 +73,7 @@ of duplicating its detailed issue history.
 | `spectral_fatigue` | `src/digitalmodel/spectral_fatigue/` | `tests/` | `docs/domains/README.md` | Spectral (frequency-domain) fatigue calculation | fatigue standards, SciPy |
 | `synthetic_rope_mooring_fatigue` | `src/digitalmodel/synthetic_rope_mooring_fatigue/` | `tests/` | `docs/domains/README.md` | Synthetic-rope mooring fatigue analysis | fatigue standards, NumPy |
 | `tug` | `src/digitalmodel/tug/` | `tests/tug/` | `docs/domains/README.md` | Tug/towage analysis: bollard pull, fendering, girting stability, towline mechanics, emissions | NumPy, engineering standards |
+| `uncertainty` | `src/digitalmodel/uncertainty/` | `tests/uncertainty/` | `docs/domains/README.md` | Monte Carlo uncertainty quantification: priors, LHS DoE, evaluator harness, sensitivity ranking, percentile analytics | NumPy, pandas, SciPy, PyYAML, pydantic |
 | `usecase_registry` | `src/digitalmodel/usecase_registry/` | `tests/test_usecase_registry.py` | `docs/domains/README.md` | Registry of runnable use cases and routing metadata | PyYAML |
 | `vessel_seakeeping` | `src/digitalmodel/vessel_seakeeping/` | `tests/` | `docs/domains/README.md` | Vessel seakeeping response and operability analysis | hydrodynamics standards |
 | `weather_window` | `src/digitalmodel/weather_window/` | `tests/` | `docs/domains/README.md` | Weather-window/operability assessment for marine operations | metocean data, statistics |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -368,6 +368,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/tug/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#tug
+  - module: uncertainty
+    entry_point: src/digitalmodel/uncertainty/
+    maturity: development
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/uncertainty/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#uncertainty
   - module: workflow_api
     entry_point: src/digitalmodel/workflow_api/
     maturity: development

--- a/src/digitalmodel/uncertainty/__init__.py
+++ b/src/digitalmodel/uncertainty/__init__.py
@@ -1,0 +1,34 @@
+"""Monte Carlo uncertainty quantification harness for digitalmodel.
+
+This package implements the #1427 model-agnostic UQ core, motivated by the
+public RUNSPEC/Kostro Monte Carlo workflow pattern: distribution priors, Latin
+Hypercube and random designs, evaluator dispatch, and common post-processing
+metrics. It samples live evaluators under uncertainty; that is separate from
+:mod:`digitalmodel.parametric`, which interpolates deterministic responses
+from pre-computed grids.
+"""
+
+from digitalmodel.uncertainty.analytics import (
+    fan,
+    percentile_summary,
+    spearman_ranks,
+    tornado,
+)
+from digitalmodel.uncertainty.config import UncertaintyStudy, load_study
+from digitalmodel.uncertainty.distributions import Prior
+from digitalmodel.uncertainty.doe import sample_lhs, sample_random
+from digitalmodel.uncertainty.evaluator import Evaluator, run_matrix
+
+__all__ = [
+    "Evaluator",
+    "Prior",
+    "UncertaintyStudy",
+    "fan",
+    "load_study",
+    "percentile_summary",
+    "run_matrix",
+    "sample_lhs",
+    "sample_random",
+    "spearman_ranks",
+    "tornado",
+]

--- a/src/digitalmodel/uncertainty/analytics.py
+++ b/src/digitalmodel/uncertainty/analytics.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+
+
+def _zscore(values: pd.Series) -> np.ndarray:
+    array = values.to_numpy(dtype=float)
+    scale = array.std(ddof=0)
+    if scale == 0.0:
+        raise ValueError(f"{values.name} has zero variance")
+    return (array - array.mean()) / scale
+
+
+def tornado(run_df: pd.DataFrame, inputs: list[str], output: str) -> pd.DataFrame:
+    """Rank inputs by standardized regression coefficient magnitude."""
+    x = np.column_stack([_zscore(run_df[name]) for name in inputs])
+    y = _zscore(run_df[output])
+    coefficients, *_ = np.linalg.lstsq(x, y, rcond=None)
+    result = pd.DataFrame(
+        {
+            "input": inputs,
+            "coefficient": coefficients,
+            "abs_coefficient": np.abs(coefficients),
+        }
+    ).sort_values("abs_coefficient", ascending=False, ignore_index=True)
+    result["abs_rank"] = np.arange(1, len(result) + 1)
+    return result[["input", "coefficient", "abs_rank"]]
+
+
+def spearman_ranks(
+    run_df: pd.DataFrame, inputs: list[str], output: str
+) -> pd.DataFrame:
+    """Compute Spearman rank correlation from each input to one output."""
+    rows = []
+    for name in inputs:
+        coefficient, pvalue = spearmanr(run_df[name], run_df[output])
+        rows.append({"input": name, "coefficient": coefficient, "pvalue": pvalue})
+    return pd.DataFrame(rows)
+
+
+def percentile_summary(
+    run_df: pd.DataFrame,
+    output: str,
+    percentiles: tuple[int, ...] = (10, 50, 90),
+) -> dict[str, float]:
+    """Return percentile summary for a scalar output column."""
+    values = np.percentile(run_df[output].to_numpy(dtype=float), percentiles)
+    return {
+        f"p{percentile}": float(value) for percentile, value in zip(percentiles, values)
+    }
+
+
+def fan(
+    run_df: pd.DataFrame,
+    step_columns: list[str],
+    percentiles: tuple[int, int, int] = (10, 50, 90),
+) -> pd.DataFrame:
+    """Return P10/P50/P90 rows for output columns that encode a step axis."""
+    rows = []
+    for column in step_columns:
+        summary = percentile_summary(run_df, column, percentiles=percentiles)
+        rows.append({"step": column, **summary})
+    return pd.DataFrame(rows)

--- a/src/digitalmodel/uncertainty/config.py
+++ b/src/digitalmodel/uncertainty/config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FiniteFloat,
+    StringConstraints,
+    model_validator,
+)
+
+from digitalmodel.uncertainty.distributions import Prior
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class DoeConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    method: Literal["lhs", "random"]
+    n_samples: int = Field(gt=0)
+    seed: int
+
+
+class EvaluatorConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    builtin: NonEmptyStr | None = None
+    dotted_path: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_dispatch_path(self) -> EvaluatorConfig:
+        if (self.builtin is None) == (self.dotted_path is None):
+            raise ValueError("evaluator requires exactly one of builtin or dotted_path")
+        return self
+
+
+class ScreeningConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    metric: NonEmptyStr
+    operator: Literal["<=", "<", ">=", ">"]
+    threshold: FiniteFloat
+
+
+class OutputsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary: NonEmptyStr
+    screening: ScreeningConfig | None = None
+
+
+class UncertaintyStudy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    priors: list[Prior] = Field(min_length=1)
+    doe: DoeConfig
+    evaluator: EvaluatorConfig
+    outputs: OutputsConfig
+
+
+def load_study(path: str | Path) -> UncertaintyStudy:
+    """Load a YAML uncertainty-study config into the typed front door."""
+    with Path(path).open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    return UncertaintyStudy.model_validate(data)

--- a/src/digitalmodel/uncertainty/distributions.py
+++ b/src/digitalmodel/uncertainty/distributions.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import math
+from math import exp, log
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from scipy import stats
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class Prior(BaseModel):
+    """One scipy-backed distribution prior.
+
+    Distribution parameter mapping:
+    - ``uniform`` uses ``low`` and ``high`` as scipy ``loc`` and ``scale``.
+    - ``normal`` uses ``mean`` and ``std``.
+    - ``lognormal`` uses scipy ``lognorm`` with ``s=std_log`` and
+      ``scale=exp(mean_log)``; ``median`` is accepted as a front door for
+      ``mean_log=log(median)``.
+    - ``triangular`` uses scipy ``triang`` with
+      ``c=(mode-low)/(high-low)``, ``loc=low``, ``scale=high-low``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: NonEmptyStr
+    dist: Literal["uniform", "normal", "lognormal", "triangular"]
+    low: float | None = None
+    high: float | None = None
+    mean: float | None = None
+    std: float | None = Field(default=None, gt=0)
+    mean_log: float | None = None
+    median: float | None = Field(default=None, gt=0)
+    std_log: float | None = Field(default=None, gt=0)
+    mode: float | None = None
+
+    @model_validator(mode="after")
+    def _validate_params(self) -> Prior:
+        if not self.name:
+            raise ValueError("prior name is required")
+        numeric_params = {
+            "low": self.low,
+            "high": self.high,
+            "mean": self.mean,
+            "std": self.std,
+            "mean_log": self.mean_log,
+            "median": self.median,
+            "std_log": self.std_log,
+            "mode": self.mode,
+        }
+        if any(
+            value is not None and not math.isfinite(value)
+            for value in numeric_params.values()
+        ):
+            raise ValueError("prior numeric parameters must be finite")
+        allowed_params = {
+            "uniform": {"low", "high"},
+            "normal": {"mean", "std"},
+            "lognormal": {"mean_log", "median", "std_log"},
+            "triangular": {"low", "high", "mode"},
+        }[self.dist]
+        irrelevant_params = sorted(
+            name
+            for name, value in numeric_params.items()
+            if value is not None and name not in allowed_params
+        )
+        if irrelevant_params:
+            raise ValueError(
+                f"{self.dist} prior has irrelevant parameters: {', '.join(irrelevant_params)}"
+            )
+        if self.dist == "uniform":
+            if self.low is None or self.high is None or self.high <= self.low:
+                raise ValueError("uniform prior requires low < high")
+        elif self.dist == "normal":
+            if self.mean is None or self.std is None:
+                raise ValueError("normal prior requires mean and std")
+        elif self.dist == "lognormal":
+            if self.std_log is None:
+                raise ValueError("lognormal prior requires std_log")
+            if (self.mean_log is None) == (self.median is None):
+                raise ValueError(
+                    "lognormal prior requires exactly one of mean_log or median"
+                )
+        elif self.dist == "triangular":
+            if (
+                self.low is None
+                or self.mode is None
+                or self.high is None
+                or not (self.low <= self.mode <= self.high)
+                or self.high <= self.low
+            ):
+                raise ValueError("triangular prior requires low <= mode <= high")
+        return self
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Prior:
+        return cls.model_validate(data)
+
+    def frozen(self):
+        """Return the scipy frozen distribution for this prior."""
+        if self.dist == "uniform":
+            return stats.uniform(loc=self.low, scale=self.high - self.low)
+        if self.dist == "normal":
+            return stats.norm(loc=self.mean, scale=self.std)
+        if self.dist == "lognormal":
+            mean_log = self.mean_log if self.mean_log is not None else log(self.median)
+            return stats.lognorm(s=self.std_log, scale=exp(mean_log))
+        c = (self.mode - self.low) / (self.high - self.low)
+        return stats.triang(c=c, loc=self.low, scale=self.high - self.low)
+
+    def ppf(self, u):
+        """Map unit-cube quantiles through this prior."""
+        return self.frozen().ppf(u)

--- a/src/digitalmodel/uncertainty/doe.py
+++ b/src/digitalmodel/uncertainty/doe.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pandas as pd
+from scipy.stats import qmc
+
+from digitalmodel.uncertainty.distributions import Prior
+
+
+def _validate_priors(priors: list[Prior]) -> None:
+    if not priors:
+        raise ValueError("at least one prior is required")
+    names = [prior.name for prior in priors]
+    if len(names) != len(set(names)):
+        raise ValueError("prior names must be unique")
+
+
+def sample_lhs(priors: list[Prior], n_samples: int, seed: int) -> pd.DataFrame:
+    """Generate a Latin Hypercube design mapped through the configured priors."""
+    _validate_priors(priors)
+    if n_samples <= 0:
+        raise ValueError("n_samples must be positive")
+    unit_samples = qmc.LatinHypercube(d=len(priors), seed=seed).random(n_samples)
+    return pd.DataFrame(
+        {
+            prior.name: prior.ppf(unit_samples[:, index])
+            for index, prior in enumerate(priors)
+        }
+    )
+
+
+def sample_random(priors: list[Prior], n_samples: int, seed: int) -> pd.DataFrame:
+    """Generate a naive Monte Carlo sample matrix from the configured priors."""
+    _validate_priors(priors)
+    if n_samples <= 0:
+        raise ValueError("n_samples must be positive")
+    return pd.DataFrame(
+        {
+            prior.name: prior.frozen().rvs(size=n_samples, random_state=seed + index)
+            for index, prior in enumerate(priors)
+        }
+    )

--- a/src/digitalmodel/uncertainty/evaluator.py
+++ b/src/digitalmodel/uncertainty/evaluator.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from numbers import Real
+from typing import Protocol
+
+import pandas as pd
+
+
+class Evaluator(Protocol):
+    def run(self, sample: dict[str, float]) -> dict[str, float]:
+        """Evaluate one uncertainty sample and return scalar outputs."""
+
+
+def _call_evaluator(
+    evaluator: Evaluator | Callable[[dict[str, float]], Mapping[str, float]],
+    sample: dict[str, float],
+) -> Mapping[str, float]:
+    if hasattr(evaluator, "run"):
+        return evaluator.run(sample)
+    return evaluator(sample)
+
+
+def run_matrix(
+    evaluator: Evaluator | Callable[[dict[str, float]], Mapping[str, float]],
+    samples: pd.DataFrame,
+) -> pd.DataFrame:
+    """Run an evaluator over a sample matrix and return inputs plus outputs.
+
+    Output columns that collide with input names are prefixed with ``output_``.
+    Evaluator exceptions abort the batch and name the row index that failed.
+    """
+    rows: list[dict[str, float]] = []
+    input_columns = set(samples.columns)
+    for row_index, row in samples.iterrows():
+        sample = row.to_dict()
+        try:
+            outputs = _call_evaluator(evaluator, sample)
+        except Exception as exc:
+            raise RuntimeError(f"Evaluator failed at row {row_index}: {exc}") from exc
+        if not isinstance(outputs, Mapping):
+            raise TypeError(f"Evaluator row {row_index} did not return a mapping")
+        combined = dict(sample)
+        for key, value in outputs.items():
+            if not isinstance(value, Real) or not math.isfinite(float(value)):
+                raise ValueError(
+                    f"Evaluator output {key!r} at row {row_index} must be a finite scalar"
+                )
+            output_key = f"output_{key}" if key in input_columns else key
+            combined[output_key] = value
+        rows.append(combined)
+    return pd.DataFrame(rows)

--- a/tests/uncertainty/test_analytics.py
+++ b/tests/uncertainty/test_analytics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from digitalmodel.uncertainty import (
+    fan,
+    percentile_summary,
+    run_matrix,
+    spearman_ranks,
+    tornado,
+)
+
+
+def _run_df() -> pd.DataFrame:
+    x = np.repeat(np.linspace(0.0, 1.0, 8), 5)
+    y = np.tile(np.linspace(0.0, 1.0, 5), 8)
+    weak = np.sin(np.linspace(0.0, np.pi, 40))
+    output = 10.0 * x - 1.0 * y + 0.1 * weak
+    return pd.DataFrame(
+        {
+            "x": x,
+            "y": y,
+            "weak": weak,
+            "output": output,
+            "step_1": output,
+            "step_2": output + 5.0,
+        }
+    )
+
+
+def test_tornado_ranks_dominant_input_first():
+    result = tornado(_run_df(), inputs=["x", "y", "weak"], output="output")
+
+    assert result.iloc[0]["input"] == "x"
+    assert result.iloc[0]["abs_rank"] == 1
+
+
+def test_spearman_signs_and_percentiles_from_one_run_matrix():
+    run_df = _run_df()
+
+    ranks = spearman_ranks(run_df, inputs=["x", "y"], output="output")
+    summary = percentile_summary(run_df, output="output")
+
+    assert ranks.set_index("input").loc["x", "coefficient"] > 0
+    assert ranks.set_index("input").loc["y", "coefficient"] < 0
+    assert summary["p10"] < summary["p50"] < summary["p90"]
+
+
+def test_fan_returns_p10_p50_p90_per_step():
+    result = fan(_run_df(), step_columns=["step_1", "step_2"])
+
+    assert list(result.columns) == ["step", "p10", "p50", "p90"]
+    assert result["step"].tolist() == ["step_1", "step_2"]
+    assert (result["p10"] < result["p50"]).all()
+    assert (result["p50"] < result["p90"]).all()
+
+
+def test_analytics_share_one_run_matrix_result():
+    samples = pd.DataFrame(
+        {
+            "x": np.repeat(np.linspace(0.0, 1.0, 8), 5),
+            "y": np.tile(np.linspace(0.0, 1.0, 5), 8),
+        }
+    )
+
+    run_df = run_matrix(
+        lambda sample: {
+            "output": 8.0 * sample["x"] - sample["y"],
+            "step_1": sample["x"] + sample["y"],
+            "step_2": 2.0 * sample["x"] + sample["y"],
+        },
+        samples,
+    )
+
+    tornado_result = tornado(run_df, inputs=["x", "y"], output="output")
+    spearman_result = spearman_ranks(run_df, inputs=["x", "y"], output="output")
+    summary = percentile_summary(run_df, output="output")
+    fan_result = fan(run_df, step_columns=["step_1", "step_2"])
+
+    assert tornado_result.iloc[0]["input"] == "x"
+    assert spearman_result.set_index("input").loc["x", "coefficient"] > 0
+    assert summary["p10"] < summary["p50"] < summary["p90"]
+    assert fan_result["step"].tolist() == ["step_1", "step_2"]

--- a/tests/uncertainty/test_config.py
+++ b/tests/uncertainty/test_config.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from digitalmodel.uncertainty import UncertaintyStudy, load_study
+
+
+def _minimal_study_data():
+    return {
+        "priors": [{"name": "x", "dist": "uniform", "low": 0.0, "high": 1.0}],
+        "doe": {"method": "lhs", "n_samples": 4, "seed": 1},
+        "evaluator": {"builtin": "demo"},
+        "outputs": {
+            "primary": "y",
+            "screening": {"metric": "p90", "operator": "<=", "threshold": 1.0},
+        },
+    }
+
+
+def test_uncertainty_study_loads_yaml_front_door(tmp_path):
+    path = tmp_path / "study.yml"
+    path.write_text(
+        """
+priors:
+  - name: capacity_factor
+    dist: triangular
+    low: 0.42
+    mode: 0.50
+    high: 0.58
+doe:
+  method: lhs
+  n_samples: 25
+  seed: 42
+evaluator:
+  builtin: floating_wind_lcoe
+outputs:
+  primary: lcoe_usd_per_mwh
+  screening:
+    metric: p90
+    operator: "<="
+    threshold: 220.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    study = load_study(path)
+
+    assert isinstance(study, UncertaintyStudy)
+    assert study.priors[0].name == "capacity_factor"
+    assert study.doe.method == "lhs"
+    assert study.outputs.screening.threshold == 220.0
+
+
+def test_yaml_front_door_rejects_non_finite_prior_values(tmp_path):
+    path = tmp_path / "study.yml"
+    path.write_text(
+        """
+priors:
+  - name: x
+    dist: uniform
+    low: 0.0
+    high: .nan
+doe:
+  method: lhs
+  n_samples: 4
+  seed: 1
+evaluator:
+  builtin: demo
+outputs:
+  primary: y
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_study(path)
+
+
+@pytest.mark.parametrize("threshold", [".nan", ".inf"])
+def test_yaml_front_door_rejects_non_finite_screening_threshold(tmp_path, threshold):
+    path = tmp_path / "study.yml"
+    path.write_text(
+        f"""
+priors:
+  - name: x
+    dist: uniform
+    low: 0.0
+    high: 1.0
+doe:
+  method: lhs
+  n_samples: 4
+  seed: 1
+evaluator:
+  builtin: demo
+outputs:
+  primary: y
+  screening:
+    metric: p90
+    operator: "<="
+    threshold: {threshold}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_study(path)
+
+
+@pytest.mark.parametrize(
+    ("path_parts", "blank_value"),
+    [
+        (("evaluator", "builtin"), ""),
+        (("evaluator", "builtin"), "   "),
+        (("evaluator", "dotted_path"), ""),
+        (("evaluator", "dotted_path"), "   "),
+        (("outputs", "primary"), ""),
+        (("outputs", "primary"), "   "),
+        (("outputs", "screening", "metric"), ""),
+        (("outputs", "screening", "metric"), "   "),
+    ],
+)
+def test_yaml_front_door_rejects_blank_config_identifiers(
+    tmp_path, path_parts, blank_value
+):
+    data = _minimal_study_data()
+    if path_parts == ("evaluator", "dotted_path"):
+        data["evaluator"].pop("builtin")
+    target = data
+    for path_part in path_parts[:-1]:
+        target = target[path_part]
+    target[path_parts[-1]] = blank_value
+
+    path = tmp_path / "study.yml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        load_study(path)
+
+
+def test_unknown_distribution_is_rejected():
+    with pytest.raises(ValidationError):
+        UncertaintyStudy.model_validate(
+            {
+                "priors": [{"name": "x", "dist": "beta", "low": 0, "high": 1}],
+                "doe": {"method": "lhs", "n_samples": 4, "seed": 1},
+                "evaluator": {"builtin": "demo"},
+                "outputs": {"primary": "y"},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "evaluator",
+    [
+        {},
+        {"builtin": "demo", "dotted_path": "pkg.mod:func"},
+    ],
+)
+def test_evaluator_config_requires_exactly_one_dispatch_path(evaluator):
+    with pytest.raises(ValidationError):
+        UncertaintyStudy.model_validate(
+            {
+                "priors": [{"name": "x", "dist": "uniform", "low": 0.0, "high": 1.0}],
+                "doe": {"method": "lhs", "n_samples": 4, "seed": 1},
+                "evaluator": evaluator,
+                "outputs": {"primary": "y"},
+            }
+        )

--- a/tests/uncertainty/test_doe.py
+++ b/tests/uncertainty/test_doe.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+from scipy.stats import qmc
+
+from digitalmodel.uncertainty import Prior, sample_lhs, sample_random
+
+
+def test_lhs_matches_scipy_qmc_for_fixed_seed():
+    priors = [
+        Prior(name="x", dist="uniform", low=10.0, high=20.0),
+        Prior(name="y", dist="normal", mean=5.0, std=2.0),
+    ]
+
+    samples = sample_lhs(priors, n_samples=4, seed=123)
+    unit = qmc.LatinHypercube(d=2, seed=123).random(4)
+    expected = pd.DataFrame(
+        {
+            "x": priors[0].ppf(unit[:, 0]),
+            "y": priors[1].ppf(unit[:, 1]),
+        }
+    )
+
+    pd.testing.assert_frame_equal(samples, expected)
+
+
+def test_lhs_uniform_marginal_coverage_has_one_point_per_stratum():
+    prior = Prior(name="u", dist="uniform", low=0.0, high=1.0)
+
+    samples = sample_lhs([prior], n_samples=8, seed=7)
+    strata = np.floor(samples["u"].to_numpy() * 8).astype(int)
+
+    assert sorted(strata.tolist()) == list(range(8))
+
+
+def test_random_sampler_is_seeded_and_uses_prior_names():
+    prior = Prior(name="load", dist="triangular", low=1.0, mode=2.0, high=5.0)
+
+    first = sample_random([prior], n_samples=5, seed=42)
+    second = sample_random([prior], n_samples=5, seed=42)
+
+    pd.testing.assert_frame_equal(first, second)
+    assert list(first.columns) == ["load"]
+    assert first["load"].between(1.0, 5.0).all()
+
+
+def test_prior_rejects_incomplete_distribution_params():
+    with pytest.raises(ValueError, match="uniform"):
+        Prior(name="bad", dist="uniform", low=1.0)
+
+
+def test_prior_rejects_blank_name():
+    with pytest.raises(ValidationError):
+        Prior(name="   ", dist="uniform", low=0.0, high=1.0)
+
+
+@pytest.mark.parametrize(
+    "prior_spec",
+    [
+        {"name": "bad", "dist": "uniform", "low": 0.0, "high": float("nan")},
+        {"name": "bad", "dist": "normal", "mean": float("inf"), "std": 1.0},
+        {
+            "name": "bad",
+            "dist": "triangular",
+            "low": 0.0,
+            "mode": 1.0,
+            "high": float("inf"),
+        },
+        {"name": "bad", "dist": "lognormal", "mean_log": 0.0, "std_log": float("nan")},
+    ],
+)
+def test_prior_rejects_non_finite_numeric_params(prior_spec):
+    with pytest.raises(ValidationError):
+        Prior.model_validate(prior_spec)
+
+
+def test_lognormal_rejects_conflicting_mean_log_and_median_front_doors():
+    with pytest.raises(ValidationError):
+        Prior(
+            name="conflict",
+            dist="lognormal",
+            mean_log=0.0,
+            median=999.0,
+            std_log=0.2,
+        )
+
+
+@pytest.mark.parametrize(
+    "prior_spec",
+    [
+        {"name": "bad", "dist": "uniform", "low": 0.0, "high": 1.0, "mean": 999.0},
+        {"name": "bad", "dist": "normal", "mean": 0.0, "std": 1.0, "low": -1.0},
+        {
+            "name": "bad",
+            "dist": "lognormal",
+            "median": 1.0,
+            "std_log": 0.2,
+            "high": 2.0,
+        },
+        {
+            "name": "bad",
+            "dist": "triangular",
+            "low": 0.0,
+            "mode": 1.0,
+            "high": 2.0,
+            "std": 0.1,
+        },
+    ],
+)
+def test_prior_rejects_distribution_irrelevant_params(prior_spec):
+    with pytest.raises(ValidationError, match="irrelevant"):
+        Prior.model_validate(prior_spec)

--- a/tests/uncertainty/test_evaluator.py
+++ b/tests/uncertainty/test_evaluator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from digitalmodel.uncertainty import run_matrix
+
+
+class ObjectEvaluator:
+    def run(self, sample: dict[str, float]) -> dict[str, float]:
+        return {"y": sample["x"] * 2.0}
+
+
+def test_run_matrix_accepts_object_evaluator_and_preserves_inputs():
+    samples = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+
+    result = run_matrix(ObjectEvaluator(), samples)
+
+    assert list(result.columns) == ["x", "y"]
+    assert result["y"].tolist() == [2.0, 4.0, 6.0]
+
+
+def test_run_matrix_accepts_plain_callable_and_prefixes_output_collisions():
+    samples = pd.DataFrame({"x": [1.0, 2.0]})
+
+    result = run_matrix(lambda sample: {"x": sample["x"] + 10.0}, samples)
+
+    assert list(result.columns) == ["x", "output_x"]
+    assert result["output_x"].tolist() == [11.0, 12.0]
+
+
+def test_run_matrix_fails_closed_with_row_index_when_evaluator_raises():
+    samples = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+
+    def evaluator(sample: dict[str, float]) -> dict[str, float]:
+        if sample["x"] == 2.0:
+            raise RuntimeError("boom")
+        return {"y": sample["x"]}
+
+    with pytest.raises(RuntimeError, match="row 1"):
+        run_matrix(evaluator, samples)
+
+
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        {"y": [1.0, 2.0]},
+        {"y": float("nan")},
+        {"y": float("inf")},
+    ],
+)
+def test_run_matrix_rejects_non_scalar_or_non_finite_outputs(bad_output):
+    samples = pd.DataFrame({"x": [1.0]})
+
+    with pytest.raises((TypeError, ValueError), match="row 0"):
+        run_matrix(lambda sample: bad_output, samples)

--- a/tests/uncertainty/test_roundtrip.py
+++ b/tests/uncertainty/test_roundtrip.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+
+from digitalmodel.uncertainty import Prior, run_matrix, sample_lhs
+
+
+def test_linear_model_recovers_analytic_mean_and_variance():
+    x_value = 4.0
+    priors = [
+        Prior(name="a", dist="normal", mean=3.0, std=0.5),
+        Prior(name="b", dist="uniform", low=1.0, high=2.0),
+    ]
+    samples = sample_lhs(priors, n_samples=2000, seed=2026)
+
+    result = run_matrix(
+        lambda sample: {"y": sample["a"] * x_value + sample["b"]},
+        samples,
+    )
+
+    expected_mean = 3.0 * x_value + 1.5
+    expected_variance = (0.5**2) * (x_value**2) + ((2.0 - 1.0) ** 2) / 12.0
+    np.testing.assert_allclose(result["y"].mean(), expected_mean, rtol=0.02)
+    np.testing.assert_allclose(result["y"].var(ddof=0), expected_variance, rtol=0.05)


### PR DESCRIPTION
## Summary

Refs #1427.

Adds PR1 of the approved Monte Carlo UQ plan: the reusable `digitalmodel.uncertainty` core package, focused tests, and the required routing metadata for the new importable module.

Included:
- distribution priors for uniform, normal, lognormal, and triangular inputs
- Latin Hypercube and seeded random sampling
- evaluator protocol plus fail-closed `run_matrix`
- tornado, Spearman, percentile, and fan-chart data helpers
- YAML config front door with non-empty identifiers and finite numeric thresholds
- tests for sampler determinism, config validation, evaluator contracts, analytics from one run matrix, and analytic roundtrip
- `uncertainty` rows in the operator map and module-routing registry

Intentionally excluded from PR1:
- worked example wrapping an existing digitalmodel calc
- workflow/runtime registry integration
- report or HTML artifact generation

## Verification

Local:
- `uv run ruff format src/digitalmodel/uncertainty tests/uncertainty`
- `uv run ruff check src/digitalmodel/uncertainty tests/uncertainty`
- `uv run pytest tests/uncertainty -q` → 40 passed
- Targeted routing contract → 2 passed
- Exact failed CI contracts command with `--no-sources` → 133 passed, 61 skipped
- `git diff --cached --check`
- `scripts/enforcement/check-no-abs-paths.sh` on touched PR files
- `scripts/legal/legal-sanity-scan.sh --repo=../wt-dm-1427-pr1 --diff-only`
- staged leak/provenance grep for private-path/licensed-source terms: no matches

GitHub Actions:
- All PR checks passed on rerun after routing metadata fix, including `tests-contracts` and `Domain test aggregate`.

## Code-Stage Review

- Engineering review: APPROVE after TDD fixes for non-finite values, lognormal front-door conflicts, irrelevant distribution params, non-scalar/non-finite evaluator outputs, non-finite thresholds, and blank identifiers.
- Governance/scope/security review: APPROVE; scope remained PR1 core plus required routing metadata.
