### PR TITLE
feat(brand): a11y baseline in brand.css — focus-visible + sr-only (#1475)

### DIFF
--- a/docs/api/_assets/brand.css
+++ b/docs/api/_assets/brand.css
@@ -88,3 +88,18 @@ body{
 a.brandmark{text-decoration:none; color:inherit; display:inline-flex; align-items:center; border-radius:6px}
 a.brandmark:hover .lbl{color:var(--ink)}
 a.brandmark:focus-visible{outline:2px solid var(--accent); outline-offset:3px}
+
+/* ---- accessibility baseline (#1475) --------------------------------------
+   Purely additive: every page that links brand.css gets a consistent, visible
+   keyboard-focus indicator (many pages strip the native ring via all:unset) and
+   a .sr-only helper for text alternatives. :where() keeps specificity 0 so a
+   page's own focus styles always win. No effect on the default (unfocused) render. */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible{
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+.sr-only{
+  position:absolute !important; width:1px; height:1px; padding:0; margin:-1px;
+  overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0;
+}


### PR DESCRIPTION
Part of #1471 / #1475. Purely additive a11y layer in the shared `brand.css`, so all 72 linked pages benefit at once — no per-page edits, no visual change to default render.

- **Consistent keyboard focus ring** via `:where(a,button,input,select,textarea,summary,[tabindex]):focus-visible` (0 specificity → a page's own focus styles still win). Fixes the pages that strip the native ring with `all:unset`.
- **`.sr-only`** helper for text alternatives.

Scope check: only 3 pages use `<canvas>` and all already carry `role="img"`+`aria-label`; the exemplar already meets the full baseline (LAYOUT.md §5). This closes the systemic gap; any remaining page-specific a11y (live regions, per-control labels) is already handled on the interactive pages that need it.