### PR TITLE
feat(asset-integrity): add composite repair screening for #1296

### DIFF
--- a/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py
@@ -26,11 +26,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import numpy as np
 import pandas as pd
 
+from digitalmodel.asset_integrity.composite_repair import (
+    CompositeRepairParameters,
+    recommend_from_ffs_result,
+)
 from digitalmodel.codes import API_579
 from .ffs_decision import FFSDecision
 from .ffs_router import FFSRouter
@@ -52,14 +56,14 @@ class FFSComponent:
     """The component under assessment (geometry, code, material, condition)."""
 
     component_id: str
-    design_code: str               # e.g. "B31.8", "B31.4", "ASME_VIII_DIV1"
+    design_code: str  # e.g. "B31.8", "B31.4", "ASME_VIII_DIV1"
     nominal_od_in: float
     nominal_wt_in: float
     design_pressure_psi: float
     smys_psi: Optional[float] = None
     corrosion_rate_in_per_yr: float = 0.0
-    fca_in: float = 0.0            # future corrosion allowance
-    rsf_a: float = 0.90            # allowable remaining strength factor
+    fca_in: float = 0.0  # future corrosion allowance
+    rsf_a: float = 0.90  # allowable remaining strength factor
     component_type: str = "pipe"
 
 
@@ -68,8 +72,8 @@ class FFSAssessmentResult:
     """Unified FFS result — the canonical record for downstream consumers."""
 
     component_id: str
-    assessment_type: str           # "GML" | "LML" | "PITTING"
-    level_reached: int             # 1 (screening sufficed) or 2 (RSF needed)
+    assessment_type: str  # "GML" | "LML" | "PITTING"
+    level_reached: int  # 1 (screening sufficed) or 2 (RSF needed)
     t_nominal_in: float
     t_min_in: float
     t_measured_min_in: float
@@ -79,10 +83,11 @@ class FFSAssessmentResult:
     rsf_a: float
     folias_factor: float
     remaining_life_yr: float
-    verdict: str                   # ACCEPT/MONITOR/RE_RATE/REPAIR/REPLACE
-    rerated_pressure_psi: float    # screening re-rate = P_design * min(1, rsf/rsf_a)
-    sufficiency_status: str        # SUFFICIENT/TAKE_MORE/ESCALATE
-    sufficiency: Any = None        # SufficiencyResult
+    verdict: str  # ACCEPT/MONITOR/RE_RATE/REPAIR/REPLACE
+    rerated_pressure_psi: float  # screening re-rate = P_design * min(1, rsf/rsf_a)
+    sufficiency_status: str  # SUFFICIENT/TAKE_MORE/ESCALATE
+    repair_recommendation: Optional[dict[str, Any]] = None
+    sufficiency: Any = None  # SufficiencyResult
     level1: dict = field(default_factory=dict)
     level2: dict = field(default_factory=dict)
     decision: dict = field(default_factory=dict)
@@ -96,7 +101,7 @@ class FFSAssessmentResult:
 
     def to_dict(self) -> dict:
         """JSON-serialisable summary (for lookup tables / the Deckhand API)."""
-        return {
+        payload = {
             "component_id": self.component_id,
             "assessment_type": self.assessment_type,
             "level_reached": self.level_reached,
@@ -115,6 +120,9 @@ class FFSAssessmentResult:
             "passes": self.passes,
             "code_reference": self.code_reference,
         }
+        if self.repair_recommendation is not None:
+            payload["repair_recommendation"] = self.repair_recommendation
+        return payload
 
 
 def assess_component(
@@ -123,6 +131,7 @@ def assess_component(
     *,
     input_units: str = "in",
     force_type: Optional[str] = None,
+    repair_context: Optional[Mapping[str, Any]] = None,
 ) -> FFSAssessmentResult:
     """Run the full Phase-1 FFS chain and return one unified result.
 
@@ -133,6 +142,8 @@ def assess_component(
         input_units: ``"in"`` (default) or ``"mm"`` — passed to GridParser.
         force_type: override the auto-classification
             ("GML"/"LML"/"PITTING").
+        repair_context: optional composite-repair screening context. Used only
+            for REPAIR verdicts.
     """
     df = _to_grid_df(grid, input_units)
 
@@ -209,7 +220,7 @@ def assess_component(
     rerated = float(_rr) if _rr is not None else float("nan")
     level_reached = 1 if l1["verdict"] == "ACCEPT" else 2
 
-    return FFSAssessmentResult(
+    result = FFSAssessmentResult(
         component_id=component.component_id,
         assessment_type=atype,
         level_reached=level_reached,
@@ -242,6 +253,12 @@ def assess_component(
             ),
         },
     )
+    params = CompositeRepairParameters()
+    context = _repair_context_from_component(component, atype, repair_context, params)
+    recommendation = recommend_from_ffs_result(result, context, params=params)
+    if recommendation is not None:
+        result.repair_recommendation = recommendation.to_dict()
+    return result
 
 
 def _to_grid_df(grid: GridLike, input_units: str) -> pd.DataFrame:
@@ -255,3 +272,35 @@ def _to_grid_df(grid: GridLike, input_units: str) -> pd.DataFrame:
     raise TypeError(
         f"grid must be a DataFrame, numpy array, or CSV path; got {type(grid)!r}."
     )
+
+
+def _repair_context_from_component(
+    component: FFSComponent,
+    assessment_type: str,
+    repair_context: Optional[Mapping[str, Any]],
+    params: CompositeRepairParameters,
+) -> dict[str, Any]:
+    """Build default repair context from FFS fields, then overlay caller data."""
+    context: dict[str, Any] = {
+        "active_leak": False,
+        "through_wall_now": False,
+        "through_wall_within_repair_life": False,
+        "defect_type": _repair_defect_type(assessment_type),
+        "service": "oil",
+        "pressure_psi": component.design_pressure_psi,
+        "temperature_f": params.default_temperature_f,
+        "repair_life_yr": params.default_repair_life_yr,
+        "axial_load": False,
+    }
+    if repair_context:
+        context.update(repair_context)
+    return context
+
+
+def _repair_defect_type(assessment_type: str) -> str:
+    mapping = {
+        "GML": "external_metal_loss",
+        "LML": "external_metal_loss",
+        "PITTING": "pitting",
+    }
+    return mapping.get(assessment_type.upper(), assessment_type.lower())

--- a/src/digitalmodel/asset_integrity/assessment/ffs_report.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_report.py
@@ -10,6 +10,7 @@ The report includes:
   5. Remaining Life — simple linear projection.
   6. Methodology & References — API 579 clause references.
   7. Appendix — raw grid data table (first 20 rows × 10 cols).
+  Optional: composite repair recommendation for REPAIR verdicts.
 
 Plotly CDN is referenced for interactive charts (if Plotly heatmap data is
 supplied via the optional ``plotly_heatmap_json`` parameter).  The report
@@ -24,15 +25,15 @@ from __future__ import annotations
 import html
 import math
 from datetime import datetime
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import pandas as pd
 
 _VERDICT_COLORS = {
-    "ACCEPT": "#2e7d32",   # green
+    "ACCEPT": "#2e7d32",  # green
     "MONITOR": "#f57c00",  # amber
     "RE_RATE": "#e65100",  # deep orange
-    "REPAIR": "#c62828",   # red
+    "REPAIR": "#c62828",  # red
     "REPLACE": "#4a148c",  # purple
     "FAIL_LEVEL_1": "#c62828",
     "FAIL_LEVEL_2": "#c62828",
@@ -78,6 +79,7 @@ class FFSReport:
         corrosion_rate_in_per_yr: Optional[float] = None,
         plotly_heatmap_json: Optional[str] = None,
         sufficiency: Optional[object] = None,
+        repair_recommendation: Optional[Mapping[str, Any]] = None,
     ) -> str:
         """Render the full FFS assessment as a self-contained HTML string.
 
@@ -96,18 +98,28 @@ class FFSReport:
             corrosion_rate_in_per_yr: Future corrosion rate; optional metadata.
             plotly_heatmap_json: Pre-serialised Plotly figure JSON for
                 interactive heatmap embedding; omitted when None.
+            repair_recommendation: optional composite-repair screening payload
+                for REPAIR verdicts.
 
         Returns:
             Complete HTML document as a string.
         """
         today = assessment_date or datetime.utcnow().strftime("%Y-%m-%d")
-        nominal_id = nominal_id_in if nominal_id_in else nominal_od_in - 2.0 * nominal_wt_in
+        nominal_id = (
+            nominal_id_in if nominal_id_in else nominal_od_in - 2.0 * nominal_wt_in
+        )
 
         verdict = decision.get("verdict", "UNKNOWN")
         rsf = decision.get("rsf", float("nan"))
         rsf_a = decision.get("rsf_a", 0.9)
         remaining_life = decision.get("remaining_life_yr", float("nan"))
         criterion = decision.get("governing_criterion", "")
+        if verdict == "REPAIR" and repair_recommendation:
+            repair_summary = str(repair_recommendation.get("summary", "")).strip()
+            if repair_summary:
+                criterion = (
+                    f"{criterion}; {repair_summary}" if criterion else repair_summary
+                )
 
         # Derive t_mm from grid
         t_mm = float(grid_df.min(skipna=True).min())
@@ -118,13 +130,27 @@ class FFSReport:
         sections = [
             FFSReport._html_head(component_id, today),
             FFSReport._section_executive_summary(
-                component_id, today, verdict, verdict_color, criterion,
-                remaining_life, design_code, rsf, rsf_a,
+                component_id,
+                today,
+                verdict,
+                verdict_color,
+                criterion,
+                remaining_life,
+                design_code,
+                rsf,
+                rsf_a,
                 rerated_mawp_psi=decision.get("rerated_mawp_psi"),
             ),
             FFSReport._section_component_data(
-                component_id, today, nominal_od_in, nominal_id, nominal_wt_in,
-                design_pressure_psi, design_code, smys_psi, corrosion_rate_in_per_yr
+                component_id,
+                today,
+                nominal_od_in,
+                nominal_id,
+                nominal_wt_in,
+                design_pressure_psi,
+                design_code,
+                smys_psi,
+                corrosion_rate_in_per_yr,
             ),
             FFSReport._section_level1(t_mm, t_min_in, design_code),
             FFSReport._section_level2(rsf, rsf_a, t_am, t_mm, decision),
@@ -139,6 +165,11 @@ class FFSReport:
         if sufficiency is not None:
             # Field measurement-sufficiency guidance, prominent near the top.
             sections.insert(2, FFSReport._section_sufficiency(sufficiency))
+
+        if verdict == "REPAIR" and repair_recommendation is not None:
+            sections.insert(
+                2, FFSReport._section_repair_recommendation(repair_recommendation)
+            )
 
         if plotly_heatmap_json:
             # Insert after executive summary
@@ -158,15 +189,15 @@ class FFSReport:
         status = html.escape(str(getattr(result, "status", "UNKNOWN")))
         confidence = html.escape(str(getattr(result, "confidence", "")))
         colors = {
-            "SUFFICIENT": "#38a169", "TAKE_MORE": "#dd6b20", "ESCALATE": "#e53e3e",
+            "SUFFICIENT": "#38a169",
+            "TAKE_MORE": "#dd6b20",
+            "ESCALATE": "#e53e3e",
         }
         color = colors.get(status, _DEFAULT_COLOR)
         reasons = getattr(result, "reasons", []) or []
         actions = getattr(result, "actions", []) or []
 
-        reason_items = "".join(
-            f"<li>{html.escape(str(r))}</li>" for r in reasons
-        )
+        reason_items = "".join(f"<li>{html.escape(str(r))}</li>" for r in reasons)
         action_rows = ""
         for a in actions:
             act = html.escape(str(getattr(a, "action", "")))
@@ -181,7 +212,8 @@ class FFSReport:
         action_table = (
             "<table><thead><tr><th>Action</th><th>Where</th><th>Why</th></tr>"
             f"</thead><tbody>{action_rows}</tbody></table>"
-            if action_rows else "<p>No further field action required.</p>"
+            if action_rows
+            else "<p>No further field action required.</p>"
         )
 
         return (
@@ -194,6 +226,50 @@ class FFSReport:
             f"{action_table}\n"
             "<p><em>Field screening only — does not replace a detailed Level 2/3 "
             "assessment.</em></p>\n"
+            "</div>"
+        )
+
+    @staticmethod
+    def _section_repair_recommendation(recommendation: Mapping[str, Any]) -> str:
+        """Render composite-repair class screening for REPAIR verdict reports."""
+        candidates = recommendation.get("candidate_classes", []) or []
+        candidate_text = ", ".join(str(c) for c in candidates) or "none"
+        excluded = recommendation.get("excluded", {}) or {}
+        basis = recommendation.get("standards_basis", []) or []
+        interval = recommendation.get("reinspection_interval_yr")
+        interval_row = (
+            "<tr><td>Re-inspection interval</td>"
+            f"<td>{float(interval):.1f} yr</td></tr>\n"
+            if interval is not None
+            else ""
+        )
+        excluded_rows = "".join(
+            "<tr>"
+            f"<td>{html.escape(str(cls))}</td>"
+            f"<td>{html.escape(str(reason))}</td>"
+            "</tr>"
+            for cls, reason in excluded.items()
+        )
+        basis_items = "".join(f"<li>{html.escape(str(item))}</li>" for item in basis)
+        summary = html.escape(str(recommendation.get("summary", "")))
+        iso_type = html.escape(str(recommendation.get("iso_defect_type", "")))
+        return (
+            "<div class='section'>\n"
+            "<h2>Composite Repair Recommendation</h2>\n"
+            f"<p><strong>{summary}</strong></p>\n"
+            "<table>\n"
+            "<tr><th>Parameter</th><th>Value</th></tr>\n"
+            f"<tr><td>ISO 24817 defect type</td><td>{iso_type}</td></tr>\n"
+            f"<tr><td>Candidate repair class(es)</td><td>"
+            f"{html.escape(candidate_text)}</td></tr>\n"
+            f"{interval_row}"
+            "</table>\n"
+            "<h3>Excluded classes</h3>\n"
+            "<table><tr><th>Class</th><th>Reason</th></tr>"
+            f"{excluded_rows}</table>\n"
+            f"<h3>Basis</h3><ul>{basis_items}</ul>\n"
+            "<p class='disclaimer'>Screening only; quantitative laminate design, "
+            "installation procedure, and competent-person review remain required.</p>\n"
             "</div>"
         )
 
@@ -311,7 +387,9 @@ class FFSReport:
     def _section_level1(t_mm: float, t_min: float, code: str) -> str:
         margin = t_mm - t_min
         verdict = "ACCEPT" if t_mm >= t_min else "FAIL"
-        color = _VERDICT_COLORS.get("ACCEPT" if t_mm >= t_min else "REPAIR", _DEFAULT_COLOR)
+        color = _VERDICT_COLORS.get(
+            "ACCEPT" if t_mm >= t_min else "REPAIR", _DEFAULT_COLOR
+        )
         return (
             "<div class='section'>\n"
             "<h2>3. Level 1 Assessment (API 579 Part 4/5 §4.3 / §5.3)</h2>\n"
@@ -336,7 +414,9 @@ class FFSReport:
     ) -> str:
         rsf_str = f"{rsf:.4f}" if math.isfinite(rsf) else "N/A"
         verdict = "ACCEPT" if rsf >= rsf_a else "FAIL"
-        color = _VERDICT_COLORS.get("ACCEPT" if rsf >= rsf_a else "REPAIR", _DEFAULT_COLOR)
+        color = _VERDICT_COLORS.get(
+            "ACCEPT" if rsf >= rsf_a else "REPAIR", _DEFAULT_COLOR
+        )
         folias = decision.get("folias_factor", 1.0)
         l2_verdict = decision.get("verdict", "")
         return (
@@ -395,22 +475,44 @@ class FFSReport:
             (html.escape(design_code), "Current", "t_min calculation"),
         ]
         eq_rows = [
-            ("t_min B31.8", "t=P&#183;D/(2&#183;SMYS&#183;F&#183;E&#183;T)", "B31.8 §841.1.1"),
+            (
+                "t_min B31.8",
+                "t=P&#183;D/(2&#183;SMYS&#183;F&#183;E&#183;T)",
+                "B31.8 §841.1.1",
+            ),
             ("t_min B31.4", "t=P&#183;D/(2&#183;SMYS&#183;F&#183;E)", "B31.4 §403.2.1"),
-            ("t_min ASME VIII", "t=P&#183;R/(S&#183;E&#8722;0.6P)", "BPVC VIII UG-27(c)(1)"),
-            ("Folias M_t", "&#8730;(1+0.48&#955;&#178;), &#955;=1.285L_a/&#8730;(Dt_c)", "API 579 Tbl 4.4"),
+            (
+                "t_min ASME VIII",
+                "t=P&#183;R/(S&#183;E&#8722;0.6P)",
+                "BPVC VIII UG-27(c)(1)",
+            ),
+            (
+                "Folias M_t",
+                "&#8730;(1+0.48&#955;&#178;), &#955;=1.285L_a/&#8730;(Dt_c)",
+                "API 579 Tbl 4.4",
+            ),
             ("RSF LML", "R_t/(1&#8722;(1&#8722;R_t)/M_t)", "API 579 §5.4.2.2"),
         ]
-        std_table = ("<table><tr><th>Standard</th><th>Edition</th><th>Application</th></tr>"
-                     + "".join(f"<tr><td>{a}</td><td>{b}</td><td>{c}</td></tr>" for a, b, c in rows)
-                     + "</table>")
-        eq_table = ("<table><tr><th>Parameter</th><th>Equation</th><th>Reference</th></tr>"
-                    + "".join(f"<tr><td>{a}</td><td>{b}</td><td>{c}</td></tr>" for a, b, c in eq_rows)
-                    + "</table>")
-        limits = ("<ul><li>Calculations in US Customary units (inches, psi).</li>"
-                  "<li>Remaining life: linear extrapolation only.</li>"
-                  "<li>Part 6 pitting and Part 7 HIC out of scope.</li>"
-                  "<li>Results near limits require certified engineering review.</li></ul>")
+        std_table = (
+            "<table><tr><th>Standard</th><th>Edition</th><th>Application</th></tr>"
+            + "".join(
+                f"<tr><td>{a}</td><td>{b}</td><td>{c}</td></tr>" for a, b, c in rows
+            )
+            + "</table>"
+        )
+        eq_table = (
+            "<table><tr><th>Parameter</th><th>Equation</th><th>Reference</th></tr>"
+            + "".join(
+                f"<tr><td>{a}</td><td>{b}</td><td>{c}</td></tr>" for a, b, c in eq_rows
+            )
+            + "</table>"
+        )
+        limits = (
+            "<ul><li>Calculations in US Customary units (inches, psi).</li>"
+            "<li>Remaining life: linear extrapolation only.</li>"
+            "<li>Part 6 pitting and Part 7 HIC out of scope.</li>"
+            "<li>Results near limits require certified engineering review.</li></ul>"
+        )
         return (
             "<div class='section'>\n<h2>6. Methodology &amp; References</h2>\n"
             f"<h3>Standards</h3>{std_table}"
@@ -435,13 +537,22 @@ class FFSReport:
         display_df = grid_df.iloc[:20, :10].round(4)
         nr, nc = display_df.shape
         tr, tc = grid_df.shape
-        hdr = "<tr><th>Row\\Col</th>" + "".join(f"<th>{c}</th>" for c in display_df.columns) + "</tr>"
+        hdr = (
+            "<tr><th>Row\\Col</th>"
+            + "".join(f"<th>{c}</th>" for c in display_df.columns)
+            + "</tr>"
+        )
         rows = "".join(
-            f"<tr><td>{idx}</td>" + "".join(f"<td>{v:.4f}</td>" for v in row.values) + "</tr>"
+            f"<tr><td>{idx}</td>"
+            + "".join(f"<td>{v:.4f}</td>" for v in row.values)
+            + "</tr>"
             for idx, row in display_df.iterrows()
         )
-        note = (f"<p class='disclaimer'>Showing {nr} of {tr} rows, {nc} of {tc} cols.</p>"
-                if tr > nr or tc > nc else "")
+        note = (
+            f"<p class='disclaimer'>Showing {nr} of {tr} rows, {nc} of {tc} cols.</p>"
+            if tr > nr or tc > nc
+            else ""
+        )
         return (
             "<div class='section'>\n<h2>Appendix — Grid Data (inches)</h2>\n"
             f"<table>{hdr}{rows}</table>{note}\n</div>\n"

--- a/src/digitalmodel/asset_integrity/assessment/ffs_workflow.py
+++ b/src/digitalmodel/asset_integrity/assessment/ffs_workflow.py
@@ -45,6 +45,7 @@ class FFSWorkflow:
             grid,
             input_units=ffs_cfg.get("input_units", "in"),
             force_type=ffs_cfg.get("force_type"),
+            repair_context=ffs_cfg.get("repair_context"),
         )
 
         # in-memory locator target: cfg[basename] == cfg["ffs"] (the 16-key

--- a/src/digitalmodel/asset_integrity/composite_repair.py
+++ b/src/digitalmodel/asset_integrity/composite_repair.py
@@ -1,0 +1,266 @@
+# ABOUTME: Composite repair candidate screening for FFS REPAIR verdicts.
+# ABOUTME: Maps service/defect context to ISO 24817 / ASME PCC-2 repair classes.
+"""Composite repair recommendation helper.
+
+This module screens candidate composite repair classes for an FFS result that
+already requires physical repair. It intentionally does not perform laminate
+sizing or installation-provider selection; those remain project-specific
+engineering tasks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+BASIS_NOTES = (
+    "ISO 24817 (composite repairs for pipework)",
+    "ASME PCC-2, non-metallic composite repair articles",
+)
+EM_DASH = "\u2014"
+REPAIR_CLASSES: dict[str, str] = {
+    "A": "through-wall capable",
+    "B": "axial reinforcement",
+    "C": "hoop/pressure reinforcement",
+    "D": "axial and structural reinforcement",
+    "E": "structural-only reinforcement",
+}
+REPAIR_CLASS_ORDER = tuple(REPAIR_CLASSES)
+
+
+@dataclass(frozen=True)
+class CompositeRepairParameters:
+    """Practice defaults for conservative candidate screening.
+
+    These are operator-practice screening defaults, not values claimed from
+    ISO 24817 or ASME PCC-2 tables.
+    """
+
+    default_temperature_f: float = 100.0
+    default_repair_life_yr: float = 20.0
+    reinspection_fraction_of_repair_life: float = 0.5
+    max_pressure_psi_by_class: Mapping[str, float] = field(
+        default_factory=lambda: {
+            "A": 2500.0,
+            "B": 2500.0,
+            "C": 2500.0,
+            "D": 2500.0,
+            "E": 0.0,
+        }
+    )
+    max_temperature_f_by_class: Mapping[str, float] = field(
+        default_factory=lambda: {klass: 180.0 for klass in REPAIR_CLASS_ORDER}
+    )
+    allow_steam_service: bool = False
+
+    def __post_init__(self) -> None:
+        for name in (
+            "default_temperature_f",
+            "default_repair_life_yr",
+            "reinspection_fraction_of_repair_life",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.reinspection_fraction_of_repair_life > 1.0:
+            raise ValueError("reinspection_fraction_of_repair_life must be <= 1")
+        _validate_class_limits(
+            "max_pressure_psi_by_class", self.max_pressure_psi_by_class
+        )
+        _validate_class_limits(
+            "max_temperature_f_by_class", self.max_temperature_f_by_class
+        )
+
+    def basis_notes(self) -> list[str]:
+        """Document-level standards basis for public payloads."""
+        return list(BASIS_NOTES)
+
+
+@dataclass(frozen=True)
+class RepairContext:
+    """Operating and defect context used to screen repair classes."""
+
+    active_leak: bool = False
+    through_wall_now: bool = False
+    through_wall_within_repair_life: bool = False
+    defect_type: str = "external_metal_loss"
+    service: str = "oil"
+    pressure_psi: float = 0.0
+    temperature_f: float = 100.0
+    repair_life_yr: float = 20.0
+    axial_load: bool = False
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: "RepairContext | Mapping[str, Any] | None",
+        params: CompositeRepairParameters,
+    ) -> "RepairContext":
+        """Build a context from optional caller overrides."""
+        if isinstance(value, cls):
+            return value
+        data = dict(value or {})
+        data.setdefault("temperature_f", params.default_temperature_f)
+        data.setdefault("repair_life_yr", params.default_repair_life_yr)
+        return cls(**data)
+
+    def __post_init__(self) -> None:
+        if self.service.lower() not in {"water", "oil", "gas", "steam"}:
+            raise ValueError(f"unsupported service {self.service!r}")
+        if self.pressure_psi < 0:
+            raise ValueError("pressure_psi must be non-negative")
+        if self.temperature_f <= 0:
+            raise ValueError("temperature_f must be positive")
+        if self.repair_life_yr <= 0:
+            raise ValueError("repair_life_yr must be positive")
+
+
+@dataclass(frozen=True)
+class CompositeRepairRecommendation:
+    """Candidate classes and screening reasons for a composite repair."""
+
+    candidate_classes: list[str]
+    excluded: dict[str, str]
+    iso_defect_type: str
+    standards_basis: list[str]
+    reinspection_interval_yr: float
+    summary: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly payload for FFS reports and APIs."""
+        return {
+            "candidate_classes": list(self.candidate_classes),
+            "excluded": dict(self.excluded),
+            "iso_defect_type": self.iso_defect_type,
+            "standards_basis": list(self.standards_basis),
+            "reinspection_interval_yr": float(self.reinspection_interval_yr),
+            "summary": self.summary,
+        }
+
+
+def recommend_from_ffs_result(
+    result: Any,
+    repair_context: RepairContext | Mapping[str, Any] | None = None,
+    *,
+    params: CompositeRepairParameters | None = None,
+) -> CompositeRepairRecommendation | None:
+    """Return a recommendation only when the FFS verdict is ``REPAIR``."""
+    if str(getattr(result, "verdict", "")).upper() != "REPAIR":
+        return None
+    params = params or CompositeRepairParameters()
+    return recommend_composite_repair(repair_context, params=params)
+
+
+def recommend_composite_repair(
+    repair_context: RepairContext | Mapping[str, Any] | None = None,
+    *,
+    params: CompositeRepairParameters | None = None,
+) -> CompositeRepairRecommendation:
+    """Screen candidate repair classes from defect and operating context."""
+    params = params or CompositeRepairParameters()
+    context = RepairContext.from_mapping(repair_context, params)
+    iso_type = _iso_defect_type(context)
+    pool, excluded = _class_pool(context)
+    candidates: list[str] = []
+
+    for repair_class in pool:
+        reason = _screening_exclusion(repair_class, context, params)
+        if reason:
+            excluded[repair_class] = reason
+        else:
+            candidates.append(repair_class)
+
+    reinspection_interval = (
+        context.repair_life_yr * params.reinspection_fraction_of_repair_life
+    )
+    summary = _summary(candidates, reinspection_interval)
+    return CompositeRepairRecommendation(
+        candidate_classes=candidates,
+        excluded={k: excluded[k] for k in REPAIR_CLASS_ORDER if k in excluded},
+        iso_defect_type=iso_type,
+        standards_basis=params.basis_notes(),
+        reinspection_interval_yr=reinspection_interval,
+        summary=summary,
+    )
+
+
+def _iso_defect_type(context: RepairContext) -> str:
+    if (
+        context.active_leak
+        or context.through_wall_now
+        or context.through_wall_within_repair_life
+    ):
+        return "Type B"
+    return "Type A"
+
+
+def _class_pool(context: RepairContext) -> tuple[list[str], dict[str, str]]:
+    if _is_through_wall(context):
+        return ["A"], {
+            "B": "load-transfer class does not seal active through-wall loss",
+            "C": "pressure-only class does not seal active through-wall loss",
+            "D": "load-transfer class does not seal active through-wall loss",
+            "E": "structural class does not seal pressure boundary leaks",
+        }
+    if context.defect_type.lower() == "structural_only":
+        return ["E"], {
+            "A": "through-wall leak repair class not required",
+            "B": "axial pressure-boundary reinforcement not required",
+            "C": "pressure-only reinforcement not required",
+            "D": "combined pressure/axial reinforcement not required",
+        }
+    if context.axial_load:
+        return ["B", "D"], {
+            "A": "through-wall leak repair class not required",
+            "C": "pressure-only class does not address axial load",
+            "E": "structural-only class does not restore pressure boundary",
+        }
+    return ["C", "D"], {
+        "A": "through-wall leak repair class not required",
+        "B": "axial load-transfer class not required",
+        "E": "structural-only class does not restore pressure boundary",
+    }
+
+
+def _is_through_wall(context: RepairContext) -> bool:
+    return (
+        context.active_leak
+        or context.through_wall_now
+        or context.through_wall_within_repair_life
+    )
+
+
+def _screening_exclusion(
+    repair_class: str,
+    context: RepairContext,
+    params: CompositeRepairParameters,
+) -> str | None:
+    service = context.service.lower()
+    if service == "steam" and not params.allow_steam_service:
+        return "steam service requires project-specific laminate design"
+    max_pressure = params.max_pressure_psi_by_class[repair_class]
+    max_temperature = params.max_temperature_f_by_class[repair_class]
+    if context.pressure_psi > max_pressure:
+        return f"pressure {context.pressure_psi:g} psi exceeds screening default"
+    if context.temperature_f > max_temperature:
+        return f"temperature {context.temperature_f:g} F exceeds screening default"
+    return None
+
+
+def _summary(candidates: list[str], reinspection_interval_yr: float) -> str:
+    classes = ", ".join(candidates) if candidates else "none"
+    return (
+        f"REPAIR {EM_DASH} candidate repair class(es): {classes}, "
+        f"re-inspection interval {reinspection_interval_yr:.1f} yr "
+        "per repair-life design"
+    )
+
+
+def _validate_class_limits(name: str, values: Mapping[str, float]) -> None:
+    missing = set(REPAIR_CLASS_ORDER) - set(values)
+    if missing:
+        raise ValueError(f"{name} missing classes: {sorted(missing)}")
+    for repair_class, value in values.items():
+        if repair_class not in REPAIR_CLASSES:
+            raise ValueError(f"{name} has unknown class {repair_class!r}")
+        if value < 0:
+            raise ValueError(f"{name}[{repair_class!r}] must be non-negative")

--- a/tests/asset_integrity/test_composite_repair.py
+++ b/tests/asset_integrity/test_composite_repair.py
@@ -1,0 +1,212 @@
+# ABOUTME: Tests for composite repair candidate screening and FFS repair joins.
+# ABOUTME: Covers ISO 24817 / ASME PCC-2 class filtering without design sizing.
+"""Composite repair recommendation tests for issue #1296."""
+
+import json
+
+import pandas as pd
+
+from digitalmodel.asset_integrity.assessment.ffs_decision import FFSDecision
+from digitalmodel.asset_integrity.assessment.ffs_coordinator import FFSAssessmentResult
+from digitalmodel.asset_integrity.assessment.ffs_report import FFSReport
+from digitalmodel.asset_integrity.composite_repair import (
+    CompositeRepairParameters,
+    RepairContext,
+    recommend_composite_repair,
+    recommend_from_ffs_result,
+)
+
+
+def _repair_context(**overrides):
+    base = {
+        "active_leak": False,
+        "through_wall_now": False,
+        "through_wall_within_repair_life": False,
+        "defect_type": "external_metal_loss",
+        "service": "oil",
+        "pressure_psi": 900.0,
+        "temperature_f": 120.0,
+        "repair_life_yr": 5.0,
+        "axial_load": False,
+    }
+    base.update(overrides)
+    return RepairContext(**base)
+
+
+def _ffs_result(**overrides):
+    base = dict(
+        component_id="FFS-REPAIR-1",
+        assessment_type="GML",
+        level_reached=2,
+        t_nominal_in=0.875,
+        t_min_in=0.761,
+        t_measured_min_in=0.720,
+        t_measured_avg_in=0.745,
+        fca_in=0.0,
+        rsf=0.91,
+        rsf_a=0.90,
+        folias_factor=1.1,
+        remaining_life_yr=1.0,
+        verdict="REPAIR",
+        rerated_pressure_psi=1480.0,
+        sufficiency_status="SUFFICIENT",
+    )
+    base.update(overrides)
+    return FFSAssessmentResult(**base)
+
+
+def _report_inputs():
+    df = pd.DataFrame([[0.420] * 5 for _ in range(5)])
+    decision = FFSDecision.decide(
+        level1_verdict="ACCEPT",
+        level2_verdict="ACCEPT",
+        rsf=0.93,
+        rsf_a=0.9,
+        t_mm_in=0.420,
+        t_min_in=0.300,
+        corrosion_rate_in_per_yr=0.006,
+    )
+    return df, decision
+
+
+def test_through_wall_leak_uses_type_b_and_class_a_only():
+    recommendation = recommend_composite_repair(
+        _repair_context(active_leak=True, through_wall_now=True)
+    )
+
+    assert recommendation.iso_defect_type == "Type B"
+    assert recommendation.candidate_classes == ["A"]
+    assert set(recommendation.excluded) == {"B", "C", "D", "E"}
+    assert recommendation.excluded["C"]
+    assert recommendation.reinspection_interval_yr == 2.5
+    assert recommendation.summary == (
+        "REPAIR \u2014 candidate repair class(es): A, "
+        "re-inspection interval 2.5 yr per repair-life design"
+    )
+
+
+def test_non_leaking_axial_metal_loss_candidates_b_and_d():
+    recommendation = recommend_composite_repair(_repair_context(axial_load=True))
+
+    assert recommendation.iso_defect_type == "Type A"
+    assert recommendation.candidate_classes == ["B", "D"]
+    assert "C" in recommendation.excluded
+    assert "axial" in recommendation.excluded["C"].lower()
+
+
+def test_structural_only_defect_candidates_class_e():
+    recommendation = recommend_composite_repair(
+        _repair_context(
+            defect_type="structural_only",
+            pressure_psi=0.0,
+            axial_load=False,
+        )
+    )
+
+    assert recommendation.candidate_classes == ["E"]
+    assert recommendation.iso_defect_type == "Type A"
+
+
+def test_steam_service_screens_out_by_default():
+    recommendation = recommend_composite_repair(_repair_context(service="steam"))
+
+    assert recommendation.candidate_classes == []
+    assert set(recommendation.excluded) == {"A", "B", "C", "D", "E"}
+    assert "steam" in recommendation.excluded["C"].lower()
+    assert "steam" in recommendation.excluded["D"].lower()
+    assert "candidate repair class(es): none" in recommendation.summary
+
+
+def test_to_dict_is_json_friendly_and_contains_document_level_basis():
+    recommendation = recommend_composite_repair(
+        _repair_context(active_leak=True, through_wall_within_repair_life=True)
+    )
+    payload = recommendation.to_dict()
+
+    json.dumps(payload)
+    assert payload["candidate_classes"] == ["A"]
+    assert payload["standards_basis"] == [
+        "ISO 24817 (composite repairs for pipework)",
+        "ASME PCC-2, non-metallic composite repair articles",
+    ]
+    assert payload["reinspection_interval_yr"] == 2.5
+    assert "excluded" in payload
+    assert "basis" not in payload
+    assert sorted(payload) == [
+        "candidate_classes",
+        "excluded",
+        "iso_defect_type",
+        "reinspection_interval_yr",
+        "standards_basis",
+        "summary",
+    ]
+
+
+def test_recommend_from_ffs_result_is_fail_closed_to_repair_verdicts():
+    params = CompositeRepairParameters(default_temperature_f=100.0)
+    accept = recommend_from_ffs_result(
+        _ffs_result(verdict="ACCEPT"),
+        _repair_context(),
+        params=params,
+    )
+    repair = recommend_from_ffs_result(
+        _ffs_result(verdict="REPAIR"),
+        _repair_context(active_leak=True, through_wall_now=True),
+        params=params,
+    )
+
+    assert accept is None
+    assert repair is not None
+    assert repair.candidate_classes == ["A"]
+
+
+def test_repair_recommendation_report_section_is_optional():
+    df, decision = _report_inputs()
+    stale_recommendation = recommend_composite_repair(
+        _repair_context(active_leak=True, through_wall_now=True)
+    ).to_dict()
+    html = FFSReport.generate_html(
+        grid_df=df,
+        decision=decision,
+        component_id="PIPE-001",
+        nominal_od_in=16.0,
+        nominal_wt_in=0.500,
+        t_min_in=0.300,
+        design_code="B31.8",
+        design_pressure_psi=1000.0,
+        repair_recommendation=stale_recommendation,
+    )
+
+    assert "Composite Repair Recommendation" not in html
+    assert stale_recommendation["summary"] not in html
+
+
+def test_repair_recommendation_report_section_and_summary_are_rendered():
+    df, decision = _report_inputs()
+    recommendation = recommend_composite_repair(
+        _repair_context(active_leak=True, through_wall_now=True)
+    ).to_dict()
+    decision = {
+        **decision,
+        "verdict": "REPAIR",
+        "governing_criterion": "Level 1 FAIL; repair recommended.",
+    }
+
+    html = FFSReport.generate_html(
+        grid_df=df,
+        decision=decision,
+        component_id="PIPE-001",
+        nominal_od_in=16.0,
+        nominal_wt_in=0.500,
+        t_min_in=0.300,
+        design_code="B31.8",
+        design_pressure_psi=1000.0,
+        repair_recommendation=recommendation,
+    )
+
+    assert "Composite Repair Recommendation" in html
+    assert recommendation["summary"] in html
+    assert (f"Level 1 FAIL; repair recommended.; {recommendation['summary']}") in html
+    assert "2.5 yr" in html
+    assert "ISO 24817 (composite repairs for pipework)" in html
+    assert "ASME PCC-2, non-metallic composite repair articles" in html

--- a/tests/asset_integrity/test_ffs_coordinator.py
+++ b/tests/asset_integrity/test_ffs_coordinator.py
@@ -38,6 +38,12 @@ def _local_thin_grid():
     return g
 
 
+def _repair_grid():
+    g = np.full((6, 6), 0.50)
+    g[2, 3] = 0.12
+    return g
+
+
 # --- end-to-end chain ------------------------------------------------------
 def test_assess_returns_unified_result():
     res = assess_component(_pipe(), _healthy_grid())
@@ -78,7 +84,9 @@ def test_accepts_numpy_dataframe_and_csv(tmp_path):
     csv = tmp_path / "grid.csv"
     pd.DataFrame(arr).to_csv(csv, index=False, header=False)
     res_csv = assess_component(_pipe(), str(csv))
-    assert res_csv.t_measured_min_in == pytest.approx(res_np.t_measured_min_in, rel=1e-6)
+    assert res_csv.t_measured_min_in == pytest.approx(
+        res_np.t_measured_min_in, rel=1e-6
+    )
 
 
 def test_mm_units_converted():
@@ -101,14 +109,81 @@ def test_rerated_pressure_bounded():
 
 def test_to_dict_is_json_friendly():
     import json
+
     res = assess_component(_pipe(), _healthy_grid())
     d = res.to_dict()
     json.dumps(d)  # must not raise
     assert d["component_id"] == "LINE-001"
     assert d["passes"] is True
     assert isinstance(d["rsf"], float)
+    assert "repair_recommendation" not in d
+
+
+def test_repair_context_adds_recommendation_only_for_repair_verdict():
+    res = assess_component(
+        _pipe(),
+        _repair_grid(),
+        repair_context={
+            "active_leak": True,
+            "through_wall_now": True,
+            "defect_type": "external_metal_loss",
+            "service": "oil",
+            "pressure_psi": 1000.0,
+            "temperature_f": 120.0,
+            "repair_life_yr": 5.0,
+        },
+    )
+
+    payload = res.to_dict()
+    assert res.assessment_type == "LML"
+    assert payload["verdict"] == "REPAIR"
+    assert payload["repair_recommendation"]["candidate_classes"] == ["A"]
+    assert payload["repair_recommendation"]["reinspection_interval_yr"] == 2.5
+    assert payload["repair_recommendation"]["summary"] == (
+        "REPAIR \u2014 candidate repair class(es): A, "
+        "re-inspection interval 2.5 yr per repair-life design"
+    )
 
 
 def test_invalid_grid_type_raises():
     with pytest.raises(TypeError):
         assess_component(_pipe(), 42)
+
+
+def test_ffs_workflow_passes_repair_context_to_assess_component(monkeypatch):
+    from digitalmodel.asset_integrity.assessment.ffs_workflow import FFSWorkflow
+    import digitalmodel.asset_integrity.assessment.ffs_workflow as ffs_workflow
+
+    captured = {}
+
+    class Result:
+        def to_dict(self):
+            return {"component_id": "LINE-001", "verdict": "REPAIR"}
+
+    def _fake_assess(component, grid, **kwargs):
+        captured.update(kwargs)
+        return Result()
+
+    monkeypatch.setattr(ffs_workflow, "assess_component", _fake_assess)
+
+    cfg = {
+        "basename": "ffs",
+        "ffs_assessment": {
+            "component": {
+                "component_id": "LINE-001",
+                "design_code": "B31.8",
+                "nominal_od_in": 12.75,
+                "nominal_wt_in": 0.500,
+                "design_pressure_psi": 1000.0,
+                "smys_psi": 52_000.0,
+                "corrosion_rate_in_per_yr": 0.005,
+            },
+            "grid": [[0.48, 0.48], [0.48, 0.48]],
+            "repair_context": {"active_leak": True, "through_wall_now": True},
+        },
+    }
+
+    out = FFSWorkflow().router(cfg)
+
+    assert out["ffs"]["verdict"] == "REPAIR"
+    assert captured["repair_context"] == {"active_leak": True, "through_wall_now": True}


### PR DESCRIPTION
Part of #1296. This is PR1 from the approved two-PR plan; it does not close the issue because the durable-workflow repair row and capability-page mention remain PR2 scope.

## Summary
- Added `digitalmodel.asset_integrity.composite_repair` for qualitative ISO 24817 / ASME PCC-2 composite repair class screening behind FFS `REPAIR` verdicts.
- Added conditional `repair_recommendation` attachment to `FFSAssessmentResult.to_dict()` only when a recommendation exists, preserving the existing ACCEPT 17-key payload.
- Added optional FFS report rendering for REPAIR recommendations, fail-closed so stale recommendation data is ignored on non-REPAIR reports.
- Added tests for A-E class filtering, Type A/B mapping, excluded-class reasons, derived re-inspection interval, real FFS REPAIR coordinator attachment, and workflow context forwarding.

## Scope Notes
- No quantitative ISO 24817 laminate sizing, thickness, lap-length, or table values. Numeric limits are operator-practice screening parameters.
- No vendor, product, installer, contact, client, or private-source data.
- Deliberate deviation from original issue wording: this cites ISO 24817 and ASME PCC-2 at document/article level, not fabricated clause numbers.
- PR2 remains out of scope: `ffs-metal-loss-repair` durable workflow row/example and capability-page mention.

## Verification
- `./.venv/bin/ruff check src/digitalmodel/asset_integrity/composite_repair.py src/digitalmodel/asset_integrity/assessment/ffs_coordinator.py src/digitalmodel/asset_integrity/assessment/ffs_report.py src/digitalmodel/asset_integrity/assessment/ffs_workflow.py tests/asset_integrity/test_composite_repair.py tests/asset_integrity/test_ffs_coordinator.py`
- `./.venv/bin/python -m pytest tests/asset_integrity/test_composite_repair.py tests/asset_integrity/test_rbi_screening.py tests/asset_integrity/test_ffs_coordinator.py tests/asset_integrity/test_ffs_assessment.py "tests/workflows/test_durable_workflows.py::test_workflow_registry[ffs-metal-loss]" -q` — 117 passed
- `bash scripts/enforcement/check-no-abs-paths.sh --added origin/main`
- `scripts/legal/legal-sanity-scan.sh` could not be run because that script is not present in this repository.

## Review
Two adversarial Codex re-reviews reported no blocking/major findings after fixes.

No self-merge.