### PR TITLE
feat(cfd): CFD-execution-box provisioning + benchmark-compare toolchain (#1495)

### DIFF
--- a/scripts/cfd/run_sloshing_3d_benchmark.py
+++ b/scripts/cfd/run_sloshing_3d_benchmark.py
@@ -286,7 +286,8 @@ def run_at_ranks(work_dir: Path, cpb: int, end_time: float, dt: float,
     return row
 
 
-def collect(cpb: int, end_time: float, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+def collect(cpb: int, end_time: float, rows: List[Dict[str, Any]],
+            label: str | None = None) -> Dict[str, Any]:
     done = [r for r in rows if r["status"] == "completed" and r.get("s_per_step")]
     base = next((r for r in done if r["ranks"] == 1), None) or (
         min(done, key=lambda r: r["ranks"]) if done else None)
@@ -300,10 +301,13 @@ def collect(cpb: int, end_time: float, rows: List[Dict[str, Any]]) -> Dict[str, 
     # extrapolate a production estimate at the best-efficiency rank
     best = max((r for r in done if r["ranks"] > 1),
                key=lambda r: r.get("parallel_efficiency", 0), default=None)
+    import os
+    host = os.uname().nodename
     manifest = {
         "meta": {"generated_by": "scripts/cfd/run_sloshing_3d_benchmark.py",
                  "solver": "interFoam (VOF), OpenFOAM ESI v2312, Open MPI 4.1.6",
-                 "box": "a-l-2 / dev-secondary (32 cores)",
+                 "box": label or host,
+                 "hostname": host, "cores": os.cpu_count(),
                  "epic": "#1429", "issue": "#1433",
                  "purpose": "MPI strong-scaling of a representative 3D forced-roll sloshing case to size the 3D L-tank run (this box vs a heavier node)",
                  "geometry": "methodology near-square plan-form (NOT the real B1546 tank; real B_db/D_db from #640)",
@@ -315,8 +319,13 @@ def collect(cpb: int, end_time: float, rows: List[Dict[str, Any]]) -> Dict[str, 
         "scaling": sorted(rows, key=lambda r: r["ranks"]),
         "best_efficiency_rank": best,
     }
-    _MANIFEST.parent.mkdir(parents=True, exist_ok=True)
-    _MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    # A label writes a per-box manifest (…-<label>.json) so multiple boxes'
+    # results coexist for head-to-head comparison; no label keeps the base name.
+    out = (_MANIFEST.with_name(f"{_MANIFEST.stem}-{label}{_MANIFEST.suffix}")
+           if label else _MANIFEST)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(manifest, indent=2) + "\n")
+    manifest["_out_path"] = str(out.relative_to(_REPO))
     return manifest
 
 
@@ -327,6 +336,8 @@ def main(argv: List[str] | None = None) -> int:
     ap.add_argument("--end-time", type=float, default=0.30)
     ap.add_argument("--dt", type=float, default=0.001)
     ap.add_argument("--ranks", type=int, nargs="+", default=[1, 2, 4, 8, 16, 24, 32])
+    ap.add_argument("--label", default=None,
+                    help="per-box tag; writes sloshing-3d-benchmark-<label>.json so boxes coexist")
     args = ap.parse_args(argv)
     args.work_dir.mkdir(parents=True, exist_ok=True)
     print(f"3D benchmark: cpb={args.cpb}, end={args.end_time}s, ranks={args.ranks}")
@@ -337,7 +348,7 @@ def main(argv: List[str] | None = None) -> int:
         print(f"[np={n:>2}] {row['status']:<16} cells={row.get('cells','-')} "
               f"wall={row.get('wall_s','-')}s steps={row.get('steps','-')} "
               f"s/step={row.get('s_per_step','-')}")
-    m = collect(args.cpb, args.end_time, rows)
+    m = collect(args.cpb, args.end_time, rows, label=args.label)
     print("\n=== strong scaling ===")
     for r in m["scaling"]:
         if r["status"] == "completed":
@@ -345,7 +356,7 @@ def main(argv: List[str] | None = None) -> int:
                   f"speedup={r.get('speedup_vs_1rank','-')}x  "
                   f"eff={r.get('parallel_efficiency','-')}  "
                   f"cells/rank={r.get('cells_per_rank')}")
-    print(f"-> {_MANIFEST.relative_to(_REPO)}")
+    print(f"-> {m.get('_out_path', _MANIFEST.relative_to(_REPO))}")
     return 0
 
 

--- a/scripts/setup/README-cfd-box.md
+++ b/scripts/setup/README-cfd-box.md
@@ -1,0 +1,52 @@
+# CFD execution box — onboarding runbook (digitalmodel #1495)
+
+Bring a fresh Ubuntu 24.04 box to a working, **reproducible** CFD-execution state
+(matching `ace-linux-2`), benchmark it against a-l-2, and — if it wins — make it
+the dedicated CFD node. interFoam is **CPU/MPI-bound**; "compute power" = cores +
+memory bandwidth, not GPU.
+
+## 1. Provision (on the new box)
+```bash
+# copy this repo's provisioner over, or clone first then run it:
+curl -fsSL https://raw.githubusercontent.com/vamseeachanta/digitalmodel/main/scripts/setup/provision-cfd-box.sh -o provision-cfd-box.sh
+REPO_DIR=$HOME/digitalmodel WORK_DIR=$HOME/cfd_work bash provision-cfd-box.sh
+```
+Installs OpenFOAM ESI **v2312** (`dl.openfoam.com`), OpenMPI 4.1.x, uv, gh, git,
+clones `digitalmodel`, installs its Python deps. Idempotent — safe to re-run.
+
+## 2. Verify
+```bash
+source /usr/lib/openfoam/openfoam2312/etc/bashrc
+cd $HOME/digitalmodel
+scripts/setup/verify-cfd-box.sh                 # toolchain + tiny serial/2-rank MPI smoke
+```
+
+## 3. Benchmark vs a-l-2
+```bash
+scripts/setup/verify-cfd-box.sh --benchmark $HOME/cfd_work
+# → writes docs/api/cfd/sloshing-3d-benchmark-<hostname>.json (per-box, doesn't clobber a-l-2's)
+```
+`docs/api/cfd/sloshing-3d-benchmark.json` is the **a-l-2 baseline** (already in the
+repo). Compare:
+```bash
+.venv/bin/python scripts/setup/compare-cfd-benchmark.py \
+    docs/api/cfd/sloshing-3d-benchmark.json \
+    docs/api/cfd/sloshing-3d-benchmark-<hostname>.json
+```
+Matched case (cpb=60 / 216k cells, 0.30 s window, core ladder). Judge on **peak
+throughput AND wall-clock predictability** — a-l-2's real limit was contention on
+a shared box, not the solver.
+
+## 4. Migrate (if the new box wins)
+- Commit the new box's benchmark manifest via PR (reference #1495).
+- Update the CFD-execution routing: `workspace-hub` `routing-rules.yaml` (`domain:cfd`
+  → new host) and the `cfd-execution-box` memory note.
+- Re-calibrate the run-time estimator to the new box.
+- Move heavy sweeps (e.g. the gated 3D L-tank, #1433, once #640 geometry lands) here;
+  free a-l-2 for interactive/dev work.
+
+## Reproducibility notes
+- The benchmark is only comparable at the **same OpenFOAM build** (v2312 2312.260127-2)
+  and the **same mesh size**; the provisioner pins v2312 for exactly this reason.
+- Run the benchmark on an **idle** box for clean high-core numbers (that was the
+  a-l-2 failure mode).

--- a/scripts/setup/compare-cfd-benchmark.py
+++ b/scripts/setup/compare-cfd-benchmark.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""compare-cfd-benchmark.py — head-to-head of two 3D sloshing MPI benchmarks
+(digitalmodel #1495). Reads two manifests written by run_sloshing_3d_benchmark.py
+and prints a per-rank comparison + a verdict on which box is faster and scales
+better, so the CFD-execution-box decision is data-backed.
+
+    python scripts/setup/compare-cfd-benchmark.py \
+        docs/api/cfd/sloshing-3d-benchmark.json \            # baseline (a-l-2)
+        docs/api/cfd/sloshing-3d-benchmark-<newbox>.json     # candidate
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def load(p):
+    m = json.loads(Path(p).read_text())
+    box = m.get("meta", {}).get("box", Path(p).stem)
+    cells = m.get("case", {}).get("cells")
+    by = {r["ranks"]: r for r in m.get("scaling", [])
+          if r.get("status") == "completed" and r.get("s_per_step")}
+    return box, cells, by
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        return 2
+    a_box, a_cells, A = load(sys.argv[1])   # baseline
+    b_box, b_cells, B = load(sys.argv[2])   # candidate
+    print(f"Baseline : {a_box}  ({a_cells} cells)")
+    print(f"Candidate: {b_box}  ({b_cells} cells)")
+    if a_cells != b_cells:
+        print(f"⚠️  cell counts differ ({a_cells} vs {b_cells}) — per-step times "
+              f"are only comparable at matched mesh size; interpret with care.")
+    print()
+    print(f"{'cores':>5} | {'baseline s/step':>15} | {'candidate s/step':>16} | "
+          f"{'speed-up':>9} | {'cand eff':>8}")
+    print("-" * 66)
+    ratios = []
+    for n in sorted(set(A) | set(B)):
+        a = A.get(n); b = B.get(n)
+        asp = a["s_per_step"] if a else None
+        bsp = b["s_per_step"] if b else None
+        spd = (asp / bsp) if (asp and bsp) else None      # candidate speed-up vs baseline
+        eff = b.get("parallel_efficiency") if b else None
+        if spd:
+            ratios.append((n, spd))
+        print(f"{n:>5} | {('%.4f'%asp) if asp else '—':>15} | "
+              f"{('%.4f'%bsp) if bsp else '—':>16} | "
+              f"{('%.2fx'%spd) if spd else '—':>9} | {('%.2f'%eff) if eff else '—':>8}")
+    print()
+    if ratios:
+        # single-core (or lowest common) raw-speed ratio, and best throughput
+        lo = min(ratios, key=lambda x: x[0])
+        best_b = min(((n, r["s_per_step"]) for n, r in B.items()), key=lambda x: x[1])
+        best_a = min(((n, r["s_per_step"]) for n, r in A.items()), key=lambda x: x[1])
+        print(f"Per-core raw speed (np={lo[0]}): candidate is {lo[1]:.2f}x the baseline.")
+        print(f"Best throughput — baseline: {best_a[1]:.3f} s/step @np={best_a[0]}; "
+              f"candidate: {best_b[1]:.3f} s/step @np={best_b[0]} "
+              f"({best_a[1]/best_b[1]:.2f}x faster at each box's own best).")
+        verdict = ("candidate wins" if best_b[1] < best_a[1] else
+                   "baseline still faster" if best_b[1] > best_a[1] else "tie")
+        print(f"VERDICT: {verdict}. "
+              f"If the candidate is a dedicated (unshared) box, also weigh wall-clock "
+              f"PREDICTABILITY, not just peak speed — that was a-l-2's real limitation.")
+    else:
+        print("No overlapping completed ranks to compare.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup/provision-cfd-box.sh
+++ b/scripts/setup/provision-cfd-box.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# provision-cfd-box.sh — bring a fresh Ubuntu box to a working CFD-execution
+# state matching ace-linux-2, so benchmarks are reproducible (digitalmodel #1495).
+#
+# Installs (idempotent — safe to re-run):
+#   * OpenFOAM ESI v2312  (dl.openfoam.com apt repo; pkg openfoam2312-default)
+#   * OpenMPI 4.1.x       (Ubuntu openmpi-bin + libopenmpi-dev)
+#   * build tools, git, curl
+#   * uv                  (astral installer)
+#   * gh                  (GitHub CLI, optional — for issues/PRs/scheduled runs)
+#   * the digitalmodel repo + its Python deps (the CFD ecosystem)
+#
+# Usage:
+#   scripts/setup/provision-cfd-box.sh                 # full provision + clone + verify
+#   REPO_DIR=/data/digitalmodel WORK_DIR=/data/cfd_work scripts/setup/provision-cfd-box.sh
+#   SKIP_CLONE=1 scripts/setup/provision-cfd-box.sh    # toolchain only
+#
+# Env:
+#   REPO_DIR   where to clone digitalmodel   (default: $HOME/digitalmodel)
+#   WORK_DIR   scratch for CFD case trees    (default: $HOME/cfd_work)
+#   REPO_URL   git remote                    (default: https://github.com/vamseeachanta/digitalmodel.git)
+#   OF_VERSION OpenFOAM ESI version          (default: 2312 — MUST match a-l-2 for reproducible benchmarks)
+#   SKIP_CLONE / SKIP_GH   set to 1 to skip that stage
+set -euo pipefail
+
+OF_VERSION="${OF_VERSION:-2312}"
+REPO_URL="${REPO_URL:-https://github.com/vamseeachanta/digitalmodel.git}"
+REPO_DIR="${REPO_DIR:-$HOME/digitalmodel}"
+WORK_DIR="${WORK_DIR:-$HOME/cfd_work}"
+OF_BASHRC="/usr/lib/openfoam/openfoam${OF_VERSION}/etc/bashrc"
+
+log()  { printf '\033[1;34m[provision]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[provision] WARN:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[provision] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ---- preflight ------------------------------------------------------------- #
+[[ "$(uname -s)" == "Linux" ]] || die "Linux only (this box is $(uname -s))."
+if [[ -r /etc/os-release ]]; then . /etc/os-release; fi
+log "OS: ${PRETTY_NAME:-unknown}  kernel $(uname -r)  cores $(nproc)  mem $(free -g | awk 'NR==2{print $2}')GB"
+have apt-get || die "apt-get not found — this provisioner targets Ubuntu/Debian (a-l-2 is Ubuntu 24.04 'noble')."
+[[ "${VERSION_CODENAME:-}" == "noble" ]] || warn "Codename is '${VERSION_CODENAME:-?}', not 'noble' (24.04). The OpenFOAM ESI repo line is pinned to noble; adjust OF repo if this box differs."
+SUDO=""; [[ $EUID -ne 0 ]] && SUDO="sudo"
+$SUDO true 2>/dev/null || die "Need root or passwordless sudo for apt installs."
+
+# ---- base packages --------------------------------------------------------- #
+log "installing base packages (build tools, git, curl, OpenMPI)…"
+export DEBIAN_FRONTEND=noninteractive
+$SUDO apt-get update -qq
+$SUDO apt-get install -y -qq \
+  build-essential git curl ca-certificates gnupg \
+  openmpi-bin libopenmpi-dev
+
+# ---- OpenFOAM ESI v${OF_VERSION} ------------------------------------------- #
+if [[ -r "$OF_BASHRC" ]]; then
+  log "OpenFOAM v${OF_VERSION} already present ($OF_BASHRC) — skipping install."
+else
+  log "adding the OpenFOAM ESI apt repo (dl.openfoam.com) and installing openfoam${OF_VERSION}-default…"
+  # ESI's canonical repo installer (adds signed repo for the current codename).
+  curl -fsSL https://dl.openfoam.com/add-debian-repo.sh | $SUDO bash
+  $SUDO apt-get update -qq
+  $SUDO apt-get install -y -qq "openfoam${OF_VERSION}-default"
+  [[ -r "$OF_BASHRC" ]] || die "OpenFOAM install did not produce $OF_BASHRC — check apt output."
+fi
+
+# ---- uv (Python toolchain) ------------------------------------------------- #
+if have uv; then
+  log "uv present ($(uv --version))."
+else
+  log "installing uv (astral)…"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  have uv || warn "uv installed but not on PATH — add \$HOME/.local/bin to PATH."
+fi
+
+# ---- gh (optional) --------------------------------------------------------- #
+if [[ "${SKIP_GH:-0}" != "1" ]] && ! have gh; then
+  log "installing gh (GitHub CLI)…"
+  $SUDO mkdir -p -m 755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | $SUDO tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  $SUDO chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | $SUDO tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  $SUDO apt-get update -qq && $SUDO apt-get install -y -qq gh || warn "gh install failed (non-fatal)."
+fi
+
+# ---- clone the CFD ecosystem + install deps -------------------------------- #
+if [[ "${SKIP_CLONE:-0}" != "1" ]]; then
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    log "digitalmodel already at $REPO_DIR — fetching latest main…"
+    git -C "$REPO_DIR" fetch origin -q && git -C "$REPO_DIR" checkout main -q \
+      && git -C "$REPO_DIR" pull --ff-only origin main -q || warn "could not fast-forward main (local changes?)."
+  else
+    log "cloning digitalmodel → $REPO_DIR…"
+    git clone -q "$REPO_URL" "$REPO_DIR"
+  fi
+  log "installing Python deps (uv venv + editable install)…"
+  ( cd "$REPO_DIR" && uv venv -q && UV_NO_SOURCES=true uv pip install -q -e . \
+      && uv pip install -q pytest pyyaml loguru click matplotlib )
+  mkdir -p "$WORK_DIR"
+fi
+
+# ---- summary --------------------------------------------------------------- #
+log "DONE. Toolchain summary:"
+printf '  OpenFOAM : %s\n' "$(dpkg -l 2>/dev/null | awk '/openfoam'"$OF_VERSION"'-default/{print $3; exit}' || echo '?')"
+printf '  OpenMPI  : %s\n' "$(mpirun --version 2>/dev/null | head -1 || echo '?')"
+printf '  uv       : %s\n' "$(uv --version 2>/dev/null || echo '?')"
+printf '  repo     : %s @ %s\n' "$REPO_DIR" "$(git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo 'not cloned')"
+printf '  work dir : %s\n' "$WORK_DIR"
+cat <<EOF
+
+Next:
+  source $OF_BASHRC
+  cd $REPO_DIR
+  scripts/setup/verify-cfd-box.sh                       # smoke + parallel MPI check
+  scripts/setup/verify-cfd-box.sh --benchmark $WORK_DIR # + the 3D scaling benchmark (labelled for this box)
+EOF

--- a/scripts/setup/verify-cfd-box.sh
+++ b/scripts/setup/verify-cfd-box.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# verify-cfd-box.sh — confirm a provisioned box can run interFoam + MPI, then
+# (optionally) run the 3D scaling benchmark labelled for this host so it can be
+# compared head-to-head with ace-linux-2 (digitalmodel #1495).
+#
+# Run AFTER provisioning, with OpenFOAM sourced:
+#   source /usr/lib/openfoam/openfoam2312/etc/bashrc
+#   scripts/setup/verify-cfd-box.sh                        # smoke + 2-rank MPI
+#   scripts/setup/verify-cfd-box.sh --benchmark WORKDIR    # + full scaling sweep
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+WORK_DIR="${2:-${WORK_DIR:-$HOME/cfd_work}}"
+PY="$REPO_ROOT/.venv/bin/python"; [[ -x "$PY" ]] || PY="python"
+
+ok()  { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
+bad() { printf '  \033[1;31m✗\033[0m %s\n' "$*" >&2; FAIL=1; }
+FAIL=0
+
+echo "== toolchain =="
+for t in blockMesh interFoam decomposePar reconstructPar mpirun; do
+  if command -v "$t" >/dev/null 2>&1; then ok "$t ($(command -v "$t"))"; else bad "$t NOT on PATH — did you 'source .../etc/bashrc'?"; fi
+done
+[[ -x "$PY" || "$PY" == python ]] && ok "python: $($PY --version 2>&1)"
+(( FAIL )) && { echo "toolchain incomplete — fix before benchmarking."; exit 1; }
+
+echo "== smoke: tiny 3D interFoam, serial + 2-rank MPI =="
+# reuse the benchmark harness at a trivial size + window (fast machinery check)
+if $PY scripts/cfd/run_sloshing_3d_benchmark.py --work-dir "$WORK_DIR" \
+     --cpb 24 --end-time 0.02 --dt 0.001 --ranks 1 2 --label "$(hostname -s)-smoke" >/tmp/cfdsmoke.log 2>&1; then
+  if grep -q "np= 2.*completed" /tmp/cfdsmoke.log && grep -q "np= 1.*completed" /tmp/cfdsmoke.log; then
+    ok "serial + 2-rank (decomposePar + mpirun -parallel) both completed"
+    grep -E "np=[[:space:]]*[12]" /tmp/cfdsmoke.log | sed 's/^/    /'
+  else
+    bad "smoke run did not complete both ranks — see /tmp/cfdsmoke.log"; tail -15 /tmp/cfdsmoke.log
+  fi
+else
+  bad "smoke run failed — see /tmp/cfdsmoke.log"; tail -20 /tmp/cfdsmoke.log
+fi
+(( FAIL )) && exit 1
+
+if [[ "${1:-}" == "--benchmark" ]]; then
+  echo "== full 3D scaling benchmark (labelled '$(hostname -s)') =="
+  echo "   (matches the a-l-2 case: cpb=60/216k cells, 0.30s window, core ladder)"
+  ranks=$(nproc); ladder="1 2 4 8 16"; (( ranks >= 24 )) && ladder="$ladder 24"; (( ranks >= 32 )) && ladder="$ladder 32"
+  $PY scripts/cfd/run_sloshing_3d_benchmark.py --work-dir "$WORK_DIR" \
+      --cpb 60 --end-time 0.30 --dt 0.001 --ranks $ladder --label "$(hostname -s)"
+  echo ""
+  echo "Compare vs a-l-2 baseline:"
+  echo "  $PY scripts/setup/compare-cfd-benchmark.py \\"
+  echo "      docs/api/cfd/sloshing-3d-benchmark.json \\"
+  echo "      docs/api/cfd/sloshing-3d-benchmark-$(hostname -s).json"
+fi
+echo "verify-cfd-box: OK"


### PR DESCRIPTION
Closes the P0 of #1495 — the scripts to onboard a dedicated CFD compute box and benchmark it against ace-linux-2. (The actual provision + benchmark run needs the new box's access details.)

## What's here
- **`scripts/setup/provision-cfd-box.sh`** — idempotent provisioner: OpenFOAM ESI **v2312** (pinned to match a-l-2 for reproducible benchmarks), OpenMPI 4.1.x, uv, gh, git; clones `digitalmodel` + installs deps. Fail-closed preflight.
- **`scripts/setup/verify-cfd-box.sh`** — toolchain check + tiny serial/2-rank MPI smoke; `--benchmark` runs the full scaling sweep labelled for the host.
- **`scripts/setup/compare-cfd-benchmark.py`** — head-to-head of two benchmark manifests (per-rank s/step, speed-up, efficiency, verdict; warns on mismatched mesh size).
- **`scripts/setup/README-cfd-box.md`** — the runbook (provision → verify → benchmark vs a-l-2 → migrate).
- **`run_sloshing_3d_benchmark.py --label`** — per-box manifest (`…-<label>.json`) + records hostname/cores, so a-l-2's existing baseline (`sloshing-3d-benchmark.json`) is preserved and boxes compare cleanly.

## Validated locally
- `bash -n` + `py_compile` clean.
- `--label` writes the per-box manifest with correct meta (host/cores); compare script reads both, produces a verdict, and correctly warns on mismatched cell counts.
- (Provisioning itself runs on the target box — not exercised here.)

## Next (needs the box)
Run `provision-cfd-box.sh` on the new box, then `verify-cfd-box.sh --benchmark`, then `compare-cfd-benchmark.py` vs the a-l-2 baseline. If it wins, migrate routing (`cfd-execution-box`) + docs and move heavy sweeps off a-l-2.

Part of #1495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)