### PR TITLE
feat(cfd): headless cloud data-sync + topology for the CFD box (#1495)

### DIFF
--- a/scripts/setup/README-cfd-box.md
+++ b/scripts/setup/README-cfd-box.md
@@ -5,6 +5,12 @@ Bring a fresh Ubuntu 24.04 box to a working, **reproducible** CFD-execution stat
 the dedicated CFD node. interFoam is **CPU/MPI-bound**; "compute power" = cores +
 memory bandwidth, not GPU.
 
+## Topology
+The box is **headless** and reached by **SSH from ace-linux-1** (`ssh <cfdbox>` on
+a-l-1). Because it's headless: `gh` and cloud auth use **tokens, not browser
+flows**. Because CFD outputs must survive the box, **key data (inputs / reduced
+outputs / reports) is synced to a cloud remote** (see §5).
+
 ## 1. Provision (on the new box)
 ```bash
 # copy this repo's provisioner over, or clone first then run it:
@@ -36,6 +42,21 @@ repo). Compare:
 Matched case (cpb=60 / 216k cells, 0.30 s window, core ladder). Judge on **peak
 throughput AND wall-clock predictability** — a-l-2's real limit was contention on
 a shared box, not the solver.
+
+## 5. Data sync to the cloud (always-on)
+Key data survives the box via `rclone`. One-time (HITL — provides a cloud secret):
+```bash
+gh auth login --with-token < token.txt   # headless: PAT, not browser
+rclone config                             # create a remote (GDrive / S3 / Dropbox / …), e.g. "cfdcloud"
+```
+Then push (additive `copy` by default — never deletes cloud files):
+```bash
+RCLONE_REMOTE=cfdcloud:cfd-box scripts/setup/sync-cfd-data.sh
+# always-on (cron every 30 min):
+RCLONE_REMOTE=cfdcloud:cfd-box scripts/setup/sync-cfd-data.sh --install-timer 30m
+```
+Syncs the **small durable set** — input configs, result manifests, reports/HTML —
+**not** the multi-GB raw case trees (regenerable; opt in with `SYNC_RAW=1`).
 
 ## 4. Migrate (if the new box wins)
 - Commit the new box's benchmark manifest via PR (reference #1495).

--- a/scripts/setup/provision-cfd-box.sh
+++ b/scripts/setup/provision-cfd-box.sh
@@ -49,7 +49,8 @@ export DEBIAN_FRONTEND=noninteractive
 $SUDO apt-get update -qq
 $SUDO apt-get install -y -qq \
   build-essential git curl ca-certificates gnupg \
-  openmpi-bin libopenmpi-dev
+  openmpi-bin libopenmpi-dev \
+  rclone   # cloud data sync (inputs/outputs/reports) for the headless box
 
 # ---- OpenFOAM ESI v${OF_VERSION} ------------------------------------------- #
 if [[ -r "$OF_BASHRC" ]]; then
@@ -115,4 +116,9 @@ Next:
   cd $REPO_DIR
   scripts/setup/verify-cfd-box.sh                       # smoke + parallel MPI check
   scripts/setup/verify-cfd-box.sh --benchmark $WORK_DIR # + the 3D scaling benchmark (labelled for this box)
+
+HITL (secrets — not automated here):
+  gh auth login --with-token < token.txt   # headless: use a PAT, NOT the browser flow
+  rclone config                            # create the cloud remote for data sync
+  RCLONE_REMOTE=<remote:path> scripts/setup/sync-cfd-data.sh --install-timer 30m  # always-sync
 EOF

--- a/scripts/setup/sync-cfd-data.sh
+++ b/scripts/setup/sync-cfd-data.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# sync-cfd-data.sh — push key CFD data (inputs, reduced outputs, reports) from a
+# headless CFD box to a cloud remote via rclone, so results survive the box and
+# are reachable elsewhere (digitalmodel #1495).
+#
+# "Key data" = the small, durable derivatives (input configs, result manifests,
+# reports/HTML), NOT the multi-GB raw case trees (VTK / time dirs) — those are
+# regenerable and excluded by default (opt in with SYNC_RAW=1).
+#
+# Uses `rclone copy` (ADDITIVE — never deletes cloud files) by default; set
+# MODE=sync to mirror (deletes cloud files absent locally — use with care).
+#
+# Setup (one-time, HITL — provides a cloud secret):
+#   rclone config           # create a remote, e.g. name it "cfdcloud"
+#                           # (Google Drive, S3, Dropbox, … all supported)
+# Usage:
+#   RCLONE_REMOTE=cfdcloud:cfd-box scripts/setup/sync-cfd-data.sh
+#   RCLONE_REMOTE=cfdcloud:cfd-box SYNC_RAW=1 scripts/setup/sync-cfd-data.sh
+#   RCLONE_REMOTE=cfdcloud:cfd-box scripts/setup/sync-cfd-data.sh --install-timer 30m
+#
+# Env:
+#   RCLONE_REMOTE  cloud target (rclone remote:path)   [required]
+#   REPO_DIR       digitalmodel checkout                (default: $HOME/digitalmodel)
+#   WORK_DIR       CFD scratch (raw case trees)         (default: $HOME/cfd_work)
+#   MODE           copy | sync                          (default: copy)
+#   SYNC_RAW       1 to also sync raw case trees        (default: 0)
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$HOME/digitalmodel}"
+WORK_DIR="${WORK_DIR:-$HOME/cfd_work}"
+MODE="${MODE:-copy}"
+REMOTE="${RCLONE_REMOTE:-}"
+
+die() { printf '\033[1;31m[sync] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[1;34m[sync]\033[0m %s\n' "$*"; }
+
+command -v rclone >/dev/null 2>&1 || die "rclone not installed (provision-cfd-box.sh installs it; or 'sudo apt install rclone')."
+[[ -n "$REMOTE" ]] || die "set RCLONE_REMOTE=<remote:path> (configure once with 'rclone config')."
+rclone lsd "${REMOTE%%:*}:" >/dev/null 2>&1 || die "rclone remote '${REMOTE%%:*}' not configured/reachable — run 'rclone config'."
+
+# --- optional: install a periodic timer for "always sync" -------------------- #
+if [[ "${1:-}" == "--install-timer" ]]; then
+  every="${2:-30m}"
+  cron_min="*/30"
+  case "$every" in 15m) cron_min="*/15";; 30m) cron_min="*/30";; 1h) cron_min="0";; esac
+  line="$cron_min * * * * RCLONE_REMOTE=$REMOTE REPO_DIR=$REPO_DIR WORK_DIR=$WORK_DIR $(readlink -f "$0") >> \$HOME/.cfd-sync.log 2>&1"
+  ( crontab -l 2>/dev/null | grep -v 'sync-cfd-data.sh'; echo "$line" ) | crontab -
+  log "installed cron: sync every ${every} (RCLONE_REMOTE=$REMOTE). Log: \$HOME/.cfd-sync.log"
+  exit 0
+fi
+
+# --- the "key data" sync set (small, durable derivatives) -------------------- #
+RC=(rclone "$MODE" --create-empty-src-dirs --transfers 8 --checksum -v)
+sync_dir() {  # <local subdir> <remote subdir> [extra rclone args…]
+  local src="$1" dst="$2"; shift 2
+  [[ -e "$src" ]] || { log "skip (absent): $src"; return; }
+  log "$MODE  $src  ->  $REMOTE/$dst"
+  "${RC[@]}" "$@" "$src" "$REMOTE/$dst"
+}
+
+log "syncing key CFD data to $REMOTE (mode=$MODE, raw=${SYNC_RAW:-0})"
+# committed derivatives + inputs from the repo (small, the self-contained set)
+sync_dir "$REPO_DIR/docs/api/cfd"        "docs/api/cfd"          # manifests + study/report HTML
+sync_dir "$REPO_DIR/docs/api/structural" "docs/api/structural"   # backbone/EGA/tld manifests
+sync_dir "$REPO_DIR/config"              "config"                # input configs (yamls)
+# reduced result manifests written outside the repo, if any
+[[ -d "$WORK_DIR" ]] && sync_dir "$WORK_DIR" "work" --include '*_result.json' --include '*.json'
+
+# raw case trees only on request (large; regenerable)
+if [[ "${SYNC_RAW:-0}" == "1" && -d "$WORK_DIR" ]]; then
+  log "SYNC_RAW=1 — also copying raw case trees (large)…"
+  "${RC[@]}" "$WORK_DIR" "$REMOTE/work-raw"
+fi
+log "done."


### PR DESCRIPTION
Follow-up to [PR #1496](https://github.com/vamseeachanta/digitalmodel/pull/1496), addressing the owner-refined requirements: the CFD box is **headless** (SSH'd from ace-linux-1) and must **always sync key data (inputs/outputs/reports) to the cloud**.

- **`scripts/setup/sync-cfd-data.sh`** — `rclone` push of the **small durable set** (input configs, result manifests, reports/HTML) to a configurable cloud remote. Additive `copy` by default (never deletes cloud); `MODE=sync` to mirror; raw multi-GB case trees excluded unless `SYNC_RAW=1`; `--install-timer` sets an always-on cron.
- **`provision-cfd-box.sh`** — installs `rclone`; documents headless `gh auth` (PAT via `--with-token`, not browser) + the sync setup.
- **`README-cfd-box.md`** — Topology section (headless, SSH-from-a-l-1, token auth) + §5 cloud data-sync runbook.

Cloud target is deliberately generic (`RCLONE_REMOTE=<remote:path>`) — `rclone config` supports Google Drive / S3 / Dropbox / etc.; the specific remote is configured once on the box (HITL secret).

Part of #1495. Still pending to actually provision: the box hostname + a working SSH path + the chosen cloud remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)