### PR TITLE
feat(artificial-lift): uplift dynacard diagnostic report

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/diagnostics.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/diagnostics.py
@@ -181,13 +181,17 @@ class PumpDiagnostics:
             model_version="legacy",
         )
 
-    def generate_troubleshooting_report(self, results: AnalysisResults) -> str:
+    def generate_troubleshooting_report(
+        self,
+        results: AnalysisResults,
+        diag: DiagnosticResult | None = None,
+    ) -> str:
         """Generate a natural language troubleshooting report.
 
         Backward-compatible method. Now uses ML classifier internally
         for richer diagnostics.
         """
-        diag = self.classify_with_context(results)
+        diag = diag or self.classify_with_context(results)
         mode = diag.classification
         description = self.FAILURE_MODES.get(mode, "Unknown failure mode.")
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/report_sections.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/report_sections.py
@@ -1,0 +1,350 @@
+# ABOUTME: HTML report sections and verdict helpers for dynacard diagnostics.
+# ABOUTME: Keeps report rendering separate from the dynacard solver workflow.
+
+from html import escape
+from pathlib import Path
+from typing import Any
+
+from .models import AnalysisResults, DynacardAnalysisContext
+from .poc_settings import evaluate_alarms, recommend_setpoints
+from .troubleshooting import guide_for
+
+
+FAIL_SEVERITIES = {"critical", "failure"}
+TROUBLESHOOTING_ALIASES = {"VALVE_LEAK": "VALVE_LEAK_TV"}
+
+
+def _classification_verdict(classification: str) -> dict[str, str]:
+    """Map a dynacard classification to report severity and pass/fail status."""
+    try:
+        severity = guide_for(_guide_key(classification)).severity
+    except KeyError:
+        severity = "warning"
+    return {
+        "classification": classification,
+        "severity": severity,
+        "screening_status": "fail" if severity in FAIL_SEVERITIES else "pass",
+    }
+
+
+def _build_alarm_block(
+    ctx: DynacardAnalysisContext,
+    classification: str,
+) -> dict[str, Any]:
+    """Build POC setpoints and single-card alarm events for report output."""
+    peak = max(ctx.surface_card.load)
+    minimum = min(ctx.surface_card.load)
+    structure_rating = ctx.surface_unit.beam_rating or None
+    stroke = ctx.surface_unit.stroke_length or None
+    setpoints = recommend_setpoints(
+        peak,
+        minimum,
+        structure_rating_lbs=structure_rating,
+        stroke_length_in=stroke,
+        gassy_well=classification == "GAS_INTERFERENCE",
+    )
+    events = evaluate_alarms(ctx.surface_card, setpoints)
+    return {
+        "reference": "current_card",
+        "note": (
+            "Setpoints use the current card as the reference; a field "
+            "controller should use a known-normal card."
+        ),
+        "setpoints": setpoints.model_dump(),
+        "alarms": [event.model_dump() for event in events],
+    }
+
+
+def build_diagnostic_report_html(
+    cfg: dict[str, Any],
+    results: AnalysisResults,
+    svg: str,
+    verdict: dict[str, str],
+    alarm_block: dict[str, Any],
+) -> str:
+    """Build the self-contained dynacard diagnostic report document."""
+    ctx = results.ctx
+    lines = _report_header()
+    lines.extend(["    <h1>Dynacard Diagnostic Report</h1>"])
+    lines.extend(_verdict_section(verdict))
+    if ctx is not None:
+        lines.extend(_input_section(cfg, ctx, results.solver_method))
+        lines.extend(_input_checks_section(cfg, ctx))
+    lines.extend(_kpi_section(results))
+    lines.extend(_setpoints_section(alarm_block))
+    lines.extend(_troubleshooting_section(verdict["classification"]))
+    lines.extend([svg, "  </main>", "</body>", "</html>"])
+    return "\n".join(lines)
+
+
+def _esc(value: Any) -> str:
+    return escape(str(value), quote=True)
+
+
+def _fmt(value: Any, places: int = 3) -> str:
+    if value is None:
+        return ""
+    try:
+        return f"{float(value):.{places}f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _input_stem(cfg: dict[str, Any]) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(str(cfg["_config_file_path"])).stem
+    analysis = cfg.get("Analysis", {})
+    if analysis.get("file_name"):
+        return Path(str(analysis["file_name"])).stem
+    return "input"
+
+
+def _rod_configs(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    well_cfg = cfg.get("well", {})
+    if "rod_string" in well_cfg:
+        return list(well_cfg["rod_string"])
+    if "rods" in well_cfg:
+        return list(well_cfg["rods"])
+    if "rod" in well_cfg:
+        return [well_cfg["rod"]]
+    well_data = cfg.get("well_data", {})
+    return list(well_data.get("rod_string", []))
+
+
+def _input_warnings(
+    cfg: dict[str, Any],
+    ctx: DynacardAnalysisContext,
+) -> list[str]:
+    warnings: list[str] = []
+    for index, rod in enumerate(_rod_configs(cfg), start=1):
+        if float(rod.get("damping_factor", 0.0) or 0.0) == 0.0:
+            warnings.append(
+                f"Rod section {index}: no damping specified; higher damping "
+                "shrinks the downhole card."
+            )
+        if float(rod.get("weight_per_foot", 0.0) or 0.0) == 0.0:
+            warnings.append(
+                f"Rod section {index}: weight_per_foot computed from diameter."
+            )
+    if ctx.surface_unit.stroke_length == 0.0:
+        warnings.append(
+            "Surface unit stroke_length is 0; stroke-speed checks are not applied."
+        )
+    if ctx.surface_unit.beam_rating == 0.0:
+        warnings.append(
+            "Surface unit beam_rating is 0; structure-rating cap not applied."
+        )
+    return warnings
+
+
+def _dl_row(label: str, value: Any, suffix: str = "") -> str:
+    return f"      <dt>{_esc(label)}</dt><dd>{_esc(value)}{_esc(suffix)}</dd>"
+
+
+def _report_header() -> list[str]:
+    return [
+        "<!doctype html>",
+        "<html lang=\"en\">",
+        "<head>",
+        "  <meta charset=\"utf-8\">",
+        "  <title>Dynacard Diagnostic Report</title>",
+        "  <style>",
+        "    body { font-family: Arial, sans-serif; margin: 24px; color: #202124; }",
+        "    main { max-width: 1080px; margin: 0 auto; }",
+        "    section { margin: 24px 0; }",
+        "    dl { display: grid; grid-template-columns: 220px 1fr; gap: 8px; }",
+        "    dt { font-weight: 700; }",
+        "    table { border-collapse: collapse; width: 100%; margin: 8px 0; }",
+        "    th, td { border: 1px solid #d0d7de; padding: 6px 8px; text-align: left; }",
+        "    th { background: #f6f8fa; }",
+        "    .verdict { border-left: 6px solid #6a737d; padding: 12px 16px; background: #f6f8fa; }",
+        "    .verdict.pass { border-left-color: #1a7f37; }",
+        "    .verdict.fail { border-left-color: #cf222e; }",
+        "    .warning { color: #8a4600; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        "  <main>",
+    ]
+
+
+def _verdict_section(verdict: dict[str, str]) -> list[str]:
+    status = verdict["screening_status"]
+    return [
+        f"    <section class=\"verdict {_esc(status)}\">",
+        "      <h2>Verdict</h2>",
+        "      <dl>",
+        _dl_row("screening_status", status),
+        _dl_row("Classification", verdict["classification"]),
+        _dl_row("Severity", verdict["severity"]),
+        "      </dl>",
+        "    </section>",
+    ]
+
+
+def _input_section(
+    cfg: dict[str, Any],
+    ctx: DynacardAnalysisContext,
+    solver_method: str,
+) -> list[str]:
+    synthetic = cfg.get("synthetic_card", {})
+    lines = [
+        "    <section>",
+        "      <h2>Inputs</h2>",
+        "      <dl>",
+        _dl_row("Input stem", _input_stem(cfg)),
+        _dl_row("Well", ctx.api14),
+        _dl_row("SPM", _fmt(ctx.spm, 3)),
+        _dl_row("Solver method", solver_method),
+    ]
+    if synthetic:
+        lines.extend([
+            _dl_row("Synthetic mode", synthetic.get("mode", "")),
+            _dl_row("Synthetic seed", synthetic.get("seed", "")),
+        ])
+    lines.extend([
+        _dl_row("Pump diameter", _fmt(ctx.pump.diameter, 3), " in"),
+        _dl_row("Pump depth", _fmt(ctx.pump.depth, 3), " ft"),
+        _dl_row("Stroke length", _fmt(ctx.surface_unit.stroke_length, 3), " in"),
+        _dl_row("Beam rating", _fmt(ctx.surface_unit.beam_rating, 0), " lb"),
+        "      </dl>",
+        "      <h3>Rod string</h3>",
+        "      <table>",
+        "        <tr><th>#</th><th>Diameter</th><th>Length</th><th>Count</th><th>Damping</th><th>Weight/ft</th></tr>",
+    ])
+    for index, rod in enumerate(ctx.rod_string, start=1):
+        lines.append(
+            "        <tr>"
+            f"<td>{index}</td>"
+            f"<td>{_esc(_fmt(rod.diameter, 3))} in</td>"
+            f"<td>{_esc(_fmt(rod.length, 3))} ft</td>"
+            f"<td>{_esc(rod.count)}</td>"
+            f"<td>{_esc(_fmt(rod.damping_factor, 4))}</td>"
+            f"<td>{_esc(_fmt(rod.weight_per_foot, 4))} lb/ft</td>"
+            "</tr>"
+        )
+    lines.extend(["      </table>", "    </section>"])
+    return lines
+
+
+def _input_checks_section(
+    cfg: dict[str, Any],
+    ctx: DynacardAnalysisContext,
+) -> list[str]:
+    warnings = _input_warnings(cfg, ctx)
+    lines = ["    <section>", "      <h2>Input checks</h2>"]
+    if warnings:
+        lines.append("      <ul>")
+        lines.extend(
+            f"        <li class=\"warning\">{_esc(warning)}</li>"
+            for warning in warnings
+        )
+        lines.append("      </ul>")
+    else:
+        lines.append("      <p>No input lint warnings.</p>")
+    lines.append("    </section>")
+    return lines
+
+
+def _kpi_section(results: AnalysisResults) -> list[str]:
+    fluid_load = None
+    if results.fluid_load is not None:
+        fluid_load = results.fluid_load.fluid_load
+    load_span = results.peak_polished_rod_load - results.minimum_polished_rod_load
+    rows = [
+        _dl_row("Diagnostic", results.diagnostic_message),
+        _dl_row("Pump fillage", _fmt(results.pump_fillage, 6)),
+        _dl_row("Production", _fmt(results.inferred_production, 6), " bbl/day"),
+        _dl_row("Buckling detected", results.buckling_detected),
+        _dl_row("PPRL", _fmt(results.peak_polished_rod_load, 3), " lb"),
+        _dl_row("MPRL", _fmt(results.minimum_polished_rod_load, 3), " lb"),
+        _dl_row("Load span", _fmt(load_span, 3), " lb"),
+    ]
+    if fluid_load is not None:
+        rows.append(_dl_row("Fluid load", _fmt(fluid_load, 3), " lb"))
+    return [
+        "    <section>",
+        "      <h2>KPIs</h2>",
+        "      <dl>",
+        *rows,
+        "      </dl>",
+        "    </section>",
+    ]
+
+
+def _setpoints_section(alarm_block: dict[str, Any]) -> list[str]:
+    setpoints = alarm_block["setpoints"]
+    lines = [
+        "    <section>",
+        "      <h2>POC setpoints &amp; alarms</h2>",
+        f"      <p>{_esc(alarm_block['note'])}</p>",
+        "      <table>",
+        "        <tr><th>Setpoint</th><th>Value</th></tr>",
+    ]
+    for key, value in setpoints.items():
+        if key == "notes":
+            continue
+        lines.append(f"        <tr><td>{_esc(key)}</td><td>{_esc(value)}</td></tr>")
+    lines.extend(["      </table>", "      <h3>Tripped alarms</h3>"])
+    return [*lines, *_alarm_rows(alarm_block), *_setpoint_notes(setpoints), "    </section>"]
+
+
+def _alarm_rows(alarm_block: dict[str, Any]) -> list[str]:
+    alarms = alarm_block["alarms"]
+    if not alarms:
+        return ["      <p>No alarms tripped.</p>"]
+    lines = [
+        "      <table>",
+        "        <tr><th>Name</th><th>Severity</th><th>Observed</th><th>Threshold</th><th>Message</th></tr>",
+    ]
+    for event in alarms:
+        lines.append(
+            "        <tr>"
+            f"<td>{_esc(event['name'])}</td>"
+            f"<td>{_esc(event['severity'])}</td>"
+            f"<td>{_esc(_fmt(event['observed'], 3))}</td>"
+            f"<td>{_esc(_fmt(event['threshold'], 3))}</td>"
+            f"<td>{_esc(event['message'])}</td>"
+            "</tr>"
+        )
+    lines.append("      </table>")
+    return lines
+
+
+def _setpoint_notes(setpoints: dict[str, Any]) -> list[str]:
+    notes = setpoints.get("notes") or []
+    if not notes:
+        return []
+    return [
+        "      <h3>Notes</h3>",
+        "      <ul>",
+        *(f"        <li>{_esc(note)}</li>" for note in notes),
+        "      </ul>",
+    ]
+
+
+def _troubleshooting_section(classification: str) -> list[str]:
+    try:
+        entry = guide_for(_guide_key(classification))
+    except KeyError:
+        return [
+            "    <section>",
+            "      <h2>Troubleshooting</h2>",
+            f"      <p>No troubleshooting catalog entry for {_esc(classification)}.</p>",
+            "    </section>",
+        ]
+    return [
+        "    <section>",
+        "      <h2>Troubleshooting</h2>",
+        f"      <h3>{_esc(entry.title)}</h3>",
+        f"      <p><strong>Symptom:</strong> {_esc(entry.symptom)}</p>",
+        f"      <p><strong>Mechanism:</strong> {_esc(entry.mechanism)}</p>",
+        "      <ol>",
+        *(f"        <li>{_esc(action)}</li>" for action in entry.actions),
+        "      </ol>",
+        "    </section>",
+    ]
+
+
+def _guide_key(classification: str) -> str:
+    return TROUBLESHOOTING_ALIASES.get(classification, classification)

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/solver.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/solver.py
@@ -1,15 +1,19 @@
 # ABOUTME: Main orchestrator for Dynacard analysis in digitalmodel.
 # ABOUTME: Integrates physics solvers, calculations, and diagnostics into unified workflow.
 
-from html import escape
 from pathlib import Path
-from typing import Optional, Literal
+from typing import Any, Literal
 
 from .models import DynacardAnalysisContext, AnalysisResults
 from .physics import DynacardPhysicsSolver
 from .finite_difference import FiniteDifferenceSolver
 from .diagnostics import PumpDiagnostics
 from .calculations import run_p1_calculations
+from .report_sections import (
+    _build_alarm_block,
+    _classification_verdict,
+    build_diagnostic_report_html,
+)
 
 
 class DynacardWorkflow:
@@ -39,6 +43,7 @@ class DynacardWorkflow:
         self.solver_method = solver_method
         self.solver = None
         self.diagnostics = PumpDiagnostics()
+        self._last_diagnostic_result = None
 
         if context:
             self._init_solver()
@@ -68,11 +73,32 @@ class DynacardWorkflow:
 
         # 2. Run Analysis
         results = self.run_full_analysis()
+        diag = self._last_diagnostic_result
+        if diag is None:
+            diag = self.diagnostics.classify_with_context(results)
+        verdict = _classification_verdict(diag.classification)
+        alarm_block = _build_alarm_block(self.ctx, diag.classification)
 
         # 3. Update cfg with results
+        cfg['screening_status'] = verdict['screening_status']
+        cfg['artificial_lift'] = {
+            'screening_status': verdict['screening_status'],
+            'classification': verdict['classification'],
+            'severity': verdict['severity'],
+            'setpoint_reference': alarm_block['reference'],
+            'alarm_note': alarm_block['note'],
+            'setpoints': alarm_block['setpoints'],
+            'alarms': alarm_block['alarms'],
+        }
         cfg['results'] = results.model_dump()
         if cfg.get('report', {}).get('html', False):
-            html_report = self._write_html_report(cfg, results)
+            html_report = self._write_html_report(
+                cfg,
+                results,
+                diag,
+                verdict,
+                alarm_block,
+            )
             cfg.setdefault('outputs', {})['html_report'] = str(html_report)
         return cfg
 
@@ -104,6 +130,9 @@ class DynacardWorkflow:
         self,
         cfg: dict,
         results: AnalysisResults,
+        diag: Any,
+        verdict: dict[str, str],
+        alarm_block: dict[str, Any],
     ) -> Path:
         """Write a standalone diagnostic report beside the saved cfg."""
         from .visualization.diagnostic_annotator import DiagnosticAnnotator
@@ -113,14 +142,13 @@ class DynacardWorkflow:
         file_base = self._result_file_base(cfg)
         report_path = result_folder / f'{file_base}_diagnostic_report.html'
 
-        diag = self.diagnostics.classify_with_context(results)
         svg = DiagnosticAnnotator().render(
             results.downhole_card,
             diag.classification,
             diag.confidence,
             diag.differential,
         )
-        html = self._html_document(results, svg)
+        html = build_diagnostic_report_html(cfg, results, svg, verdict, alarm_block)
         report_path.write_text(html)
         return report_path
 
@@ -140,42 +168,6 @@ class DynacardWorkflow:
         if cfg.get('_config_file_path'):
             return Path(str(cfg['_config_file_path'])).stem
         return 'input'
-
-    def _html_document(
-        self,
-        results: AnalysisResults,
-        svg: str,
-    ) -> str:
-        ctx = results.ctx
-        well_id = ctx.api14 if ctx else 'unknown'
-        return "\n".join([
-            "<!doctype html>",
-            "<html lang=\"en\">",
-            "<head>",
-            "  <meta charset=\"utf-8\">",
-            "  <title>Dynacard Diagnostic Report</title>",
-            "  <style>",
-            "    body { font-family: Arial, sans-serif; margin: 24px; }",
-            "    main { max-width: 960px; margin: 0 auto; }",
-            "    dl { display: grid; grid-template-columns: 180px 1fr; gap: 8px; }",
-            "    dt { font-weight: 700; }",
-            "  </style>",
-            "</head>",
-            "<body>",
-            "  <main>",
-            "    <h1>Dynacard Diagnostic Report</h1>",
-            f"    <p><strong>Well:</strong> {escape(well_id)}</p>",
-            "    <dl>",
-            f"      <dt>Diagnostic</dt><dd>{escape(results.diagnostic_message)}</dd>",
-            f"      <dt>Pump fillage</dt><dd>{results.pump_fillage:.6f}</dd>",
-            f"      <dt>Production</dt><dd>{results.inferred_production:.6f} bbl/day</dd>",
-            f"      <dt>Buckling detected</dt><dd>{results.buckling_detected}</dd>",
-            "    </dl>",
-            svg,
-            "  </main>",
-            "</body>",
-            "</html>",
-        ])
 
     def run_full_analysis(self) -> AnalysisResults:
         """
@@ -213,7 +205,9 @@ class DynacardWorkflow:
             results.inferred_production = p1_results['production'].theoretical_production
 
         # 4. AI Diagnostics: Troubleshooting
-        self.diagnostics.generate_troubleshooting_report(results)
+        diag = self.diagnostics.classify_with_context(results)
+        self.diagnostics.generate_troubleshooting_report(results, diag=diag)
+        self._last_diagnostic_result = diag
 
         return results
 

--- a/tests/marine_ops/artificial_lift/dynacard/test_report_sections.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_report_sections.py
@@ -1,0 +1,114 @@
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.models import (
+    AnalysisResults,
+    CardData,
+    DynacardAnalysisContext,
+    PumpProperties,
+    RodSection,
+    SurfaceUnit,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.diagnostics import (
+    PumpDiagnostics,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.solver import (
+    DynacardWorkflow,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.report_sections import (
+    _build_alarm_block,
+    _classification_verdict,
+    build_diagnostic_report_html,
+)
+
+
+@pytest.mark.parametrize(
+    ("classification", "severity", "screening_status"),
+    [
+        ("NORMAL", "normal", "pass"),
+        ("PUMP_TAGGING", "critical", "fail"),
+        ("VALVE_LEAK", "warning", "pass"),
+    ],
+)
+def test_classification_verdict_maps_severity_to_screening_status(
+    classification,
+    severity,
+    screening_status,
+):
+    verdict = _classification_verdict(classification)
+
+    assert verdict["classification"] == classification
+    assert verdict["severity"] == severity
+    assert verdict["screening_status"] == screening_status
+
+
+def test_alarm_block_treats_zero_beam_rating_as_no_structure_cap():
+    ctx = DynacardAnalysisContext(
+        api14="SIM-REPORT-UNIT",
+        surface_card=CardData(
+            position=[0.0, 144.0, 144.0, 0.0],
+            load=[1000.0, 1200.0, 1100.0, 900.0],
+        ),
+        rod_string=[RodSection(diameter=1.0, length=5000.0)],
+        pump=PumpProperties(diameter=1.75, depth=5000.0),
+        surface_unit=SurfaceUnit(stroke_length=144.0, beam_rating=0.0),
+        spm=10.0,
+    )
+
+    alarm_block = _build_alarm_block(ctx, "NORMAL")
+
+    assert alarm_block["setpoints"]["structure_rating_capped"] is False
+    assert alarm_block["setpoints"]["high_load_shutdown_lbs"] == pytest.approx(1440.0)
+
+
+def test_legacy_valve_leak_report_renders_troubleshooting_actions():
+    html = build_diagnostic_report_html(
+        cfg={},
+        results=AnalysisResults(diagnostic_message="Classification: VALVE_LEAK."),
+        svg="",
+        verdict={
+            "classification": "VALVE_LEAK",
+            "severity": "warning",
+            "screening_status": "pass",
+        },
+        alarm_block={"note": "single-card report", "setpoints": {}, "alarms": []},
+    )
+
+    assert "Traveling valve leak" in html
+    assert "Symptom:" in html
+    assert "Mechanism:" in html
+    assert "Confirm with a traveling valve test" in html
+
+
+def test_router_reuses_one_diagnostic_classification(monkeypatch):
+    calls = 0
+    original = PumpDiagnostics.classify_with_context
+
+    def counting_classifier(self, results):
+        nonlocal calls
+        calls += 1
+        return original(self, results)
+
+    monkeypatch.setattr(
+        PumpDiagnostics,
+        "classify_with_context",
+        counting_classifier,
+    )
+    cfg = {
+        "synthetic_card": {"mode": "PUMP_TAGGING", "seed": 711},
+        "well": {
+            "api14": "SIM-PUMP-TAGGING-711",
+            "rod": {"diameter": 1.0, "length": 5000.0},
+            "pump": {"diameter": 1.75, "depth": 5000.0},
+            "surface_unit": {"stroke_length": 144.0},
+            "spm": 10.0,
+        },
+        "report": {"html": False},
+    }
+
+    result = DynacardWorkflow().router(cfg)
+
+    assert calls == 1
+    assert result["results"]["diagnostic_message"].startswith(
+        "Classification: PUMP_TAGGING."
+    )
+    assert result["artificial_lift"]["classification"] == "PUMP_TAGGING"

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -818,13 +818,28 @@ def test_workflow_registry(workflow, monkeypatch):
         assert results["diagnostic_message"].startswith("Classification: PUMP_TAGGING.")
         assert results["pump_fillage"] == pytest.approx(75.909653)
         assert results["inferred_production"] == pytest.approx(338.041470)
+        assert cfg["screening_status"] == "fail"
+        assert cfg["artificial_lift"]["screening_status"] == "fail"
+        assert cfg["artificial_lift"]["classification"] == "PUMP_TAGGING"
+        assert cfg["artificial_lift"]["severity"] == "critical"
+        assert cfg["artificial_lift"]["setpoints"]["structure_rating_capped"] is False
 
         html_report = Path(cfg["outputs"]["html_report"])
         if not html_report.is_absolute():
             html_report = REPO_ROOT / html_report
         html = html_report.read_text()
+        assert "screening_status" in html
+        assert "POC setpoints" in html
+        assert "Troubleshooting" in html
+        assert "structure-rating cap not applied" in html
+        assert "Synthetic seed</dt><dd>711" in html
+        assert "PPRL" in html
+        assert "MPRL" in html
+        assert "Load span" in html
+        assert "Fluid load" in html
         assert "Pump Tagging" in html
         assert "SIM-PUMP-TAGGING-711" in html
+        assert "711" in html
     elif workflow["id"] == "artificial-lift-field-health":
         summary = cfg["artificial_lift_field_health"]
         statuses = {row["api14"]: row["health_status"] for row in summary["wells"]}


### PR DESCRIPTION
## Summary
- Adds dynacard PR-A report verdict plumbing for #1299: `screening_status`, classification severity, POC setpoints, and alarm events in cfg.
- Moves self-contained HTML report sections into a focused report module with escaped verdict, inputs/provenance, input checks, KPIs, setpoints/alarms, and troubleshooting sections.
- Reuses one diagnostic classification through router/report generation and aliases the legacy `VALVE_LEAK` label to the valve-leak troubleshooting section.
- Extends durable workflow coverage and adds unit tests for severity mapping, zero beam-rating no-cap behavior, single-classification reuse, and legacy valve-leak troubleshooting output.

## Scope
PR-A only from the approved #1299 re-plan. PR-B surveillance and PR-C valve-check workflows remain queued after this lands.

## Verification
- RED observed first:
  - unit test import failed on missing `_build_alarm_block` / `_classification_verdict`
  - durable workflow failed on missing `cfg["screening_status"]`
  - classifier-call regression failed with `calls == 2`
  - legacy `VALVE_LEAK` report test failed on the no-entry placeholder
- `uv run ruff check src/digitalmodel/marine_ops/artificial_lift/dynacard/diagnostics.py src/digitalmodel/marine_ops/artificial_lift/dynacard/solver.py src/digitalmodel/marine_ops/artificial_lift/dynacard/report_sections.py tests/marine_ops/artificial_lift/dynacard/test_report_sections.py tests/workflows/test_durable_workflows.py`
- `uv run python -m pytest tests/marine_ops/artificial_lift/dynacard/test_report_sections.py -q` (6 passed)
- `uv run python -m pytest "tests/workflows/test_durable_workflows.py::test_workflow_registry[dynacard-diagnostics]" -q` (1 passed)
- `uv run python -m pytest tests/marine_ops/artificial_lift/ -q` (745 passed, 1 skipped)
- `uv run python -m digitalmodel examples/workflows/dynacard-diagnostics/input.yml`
- `rg "screening_status|POC setpoints|Troubleshooting|structure-rating cap not applied|Synthetic seed|PPRL|MPRL|Load span|Fluid load" examples/workflows/dynacard-diagnostics/results/input_diagnostic_report.html`
- `rg "screening_status|artificial_lift:|classification:|severity:" examples/workflows/dynacard-diagnostics/results/input.yml`
- `bash scripts/enforcement/check-no-abs-paths.sh --added origin/main`
- GitHub Actions on head `1abc4b94`: all checks passed, including docs, quality gates, GitGuardian, `tests-workflows`, `tests-orcaflex-solver`, and Domain test aggregate.
- Code-stage adversarial review: initial Important finding fixed; focused re-review found no remaining issues.

## Notes
- `scripts/legal/legal-sanity-scan.sh` is not present in this repo checkout, so that gate could not be run locally.
- The example command emits existing OrcaFlex license/import warnings during startup, then completes the `artificial_lift` workflow successfully.
