### PR TITLE
feat(cfd): dispatch runs by benchmarked host

### DIFF
--- a/scripts/setup/README-cfd-box.md
+++ b/scripts/setup/README-cfd-box.md
@@ -43,6 +43,35 @@ Matched case (cpb=60 / 216k cells, 0.30 s window, core ladder). Judge on **peak
 throughput AND wall-clock predictability** — a-l-2's real limit was contention on
 a shared box, not the solver.
 
+## 4. Dispatch between CFD Linux hosts
+Use the dispatcher from `ace-linux-1` when both `gpu-claw` and `ace-linux-2` are
+available over SSH. It probes each host for reachability, core count, and current
+load, then selects the fastest eligible host from the benchmark manifests.
+
+```bash
+uv run python scripts/setup/dispatch-cfd-run.py --ranks 8 --dry-run -- \
+    echo run-on-{host}-np-{ranks}
+```
+
+Remove `--dry-run` to execute the command on the selected host. The remote
+command runs with OpenFOAM v2312 sourced, from `~/digitalmodel`, and receives:
+`CFD_DISPATCH_HOST`, `CFD_DISPATCH_RANKS`, and `CFD_DISPATCH_S_PER_STEP`.
+
+Host defaults:
+- `gpu-claw`: `CFD_GPU_CLAW_SSH` or `gpu-claw`; manifest
+  `docs/api/cfd/sloshing-3d-benchmark-gpu-claw.json`. For VPN-only addresses,
+  export `CFD_GPU_CLAW_SSH=user@<vpn-ip>` before dispatch.
+- `ace-linux-2`: `CFD_ACE_LINUX_2_SSH` or `ace-linux-2`;
+  manifest `docs/api/cfd/sloshing-3d-benchmark.json`.
+
+For offline planning or tests, bypass SSH probes:
+```bash
+uv run python scripts/setup/dispatch-cfd-run.py \
+    --assume-probe gpu-claw=8,0.5 \
+    --assume-probe ace-linux-2=32,8.0 \
+    --ranks 8 --dry-run -- echo run-on-{host}-np-{ranks}
+```
+
 ## 5. Data sync to the cloud (always-on)
 Key data survives the box via `rclone`. One-time (HITL — provides a cloud secret):
 ```bash
@@ -58,7 +87,7 @@ RCLONE_REMOTE=cfdcloud:cfd-box scripts/setup/sync-cfd-data.sh --install-timer 30
 Syncs the **small durable set** — input configs, result manifests, reports/HTML —
 **not** the multi-GB raw case trees (regenerable; opt in with `SYNC_RAW=1`).
 
-## 4. Migrate (if the new box wins)
+## 6. Migrate (if the new box wins)
 - Commit the new box's benchmark manifest via PR (reference #1495).
 - Update the CFD-execution routing: `workspace-hub` `routing-rules.yaml` (`domain:cfd`
   → new host) and the `cfd-execution-box` memory note.

--- a/scripts/setup/dispatch-cfd-run.py
+++ b/scripts/setup/dispatch-cfd-run.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+"""Dispatch CFD work using benchmark manifests plus live SSH probes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENFOAM_BASHRC = "/usr/lib/openfoam/openfoam2312/etc/bashrc"
+
+
+@dataclass(frozen=True)
+class HostConfig:
+    name: str
+    ssh_target: str
+    manifest: Path
+    dedicated: bool = False
+
+
+@dataclass(frozen=True)
+class HostProbe:
+    host: str
+    reachable: bool
+    hostname: str
+    cores: int
+    load1: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    ranks: int
+    s_per_step: float
+    cells_per_rank: int | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkProfile:
+    box: str
+    manifest: Path
+    cells: int | None
+    rows: tuple[BenchmarkRow, ...]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    host: HostConfig
+    probe: HostProbe
+    profile: BenchmarkProfile | None
+    row: BenchmarkRow | None
+    eligible: bool
+    reason: str
+    predicted_s_per_step: float | None
+
+
+def default_hosts() -> list[HostConfig]:
+    gpu_target = os.environ.get("CFD_GPU_CLAW_SSH", "gpu-claw")
+    ace_target = os.environ.get("CFD_ACE_LINUX_2_SSH", "ace-linux-2")
+    return [
+        HostConfig(
+            name="gpu-claw",
+            ssh_target=gpu_target,
+            manifest=REPO_ROOT / "docs/api/cfd/sloshing-3d-benchmark-gpu-claw.json",
+            dedicated=True,
+        ),
+        HostConfig(
+            name="ace-linux-2",
+            ssh_target=ace_target,
+            manifest=REPO_ROOT / "docs/api/cfd/sloshing-3d-benchmark.json",
+            dedicated=False,
+        ),
+    ]
+
+
+def _resolve_manifest(path: str) -> Path:
+    p = Path(path)
+    return p if p.is_absolute() else REPO_ROOT / p
+
+
+def parse_host(value: str) -> HostConfig:
+    """Parse name=ssh-target,manifest[,dedicated|shared]."""
+    try:
+        name, rest = value.split("=", 1)
+        ssh_target, manifest, *flags = rest.split(",")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "--host must be name=ssh-target,manifest[,dedicated|shared]"
+        ) from exc
+    if not name or not ssh_target or not manifest:
+        raise argparse.ArgumentTypeError(
+            "--host must include non-empty name, ssh target, and manifest"
+        )
+    dedicated = bool(flags and flags[0].strip().lower() == "dedicated")
+    return HostConfig(name, ssh_target, _resolve_manifest(manifest), dedicated)
+
+
+def parse_assume_probe(values: Sequence[str]) -> dict[str, HostProbe]:
+    """Parse repeated name=cores,load1[,hostname] test/offline probe overrides."""
+    probes: dict[str, HostProbe] = {}
+    for value in values:
+        try:
+            name, rest = value.split("=", 1)
+            cores_s, load_s, *hostname = rest.split(",")
+            cores = int(cores_s)
+            load1 = float(load_s)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                "--assume-probe must be name=cores,load1[,hostname]"
+            ) from exc
+        probes[name] = HostProbe(
+            host=name,
+            reachable=True,
+            hostname=hostname[0] if hostname else name,
+            cores=cores,
+            load1=load1,
+            reason="assumed",
+        )
+    return probes
+
+
+def load_benchmark(path: Path) -> BenchmarkProfile:
+    data = json.loads(path.read_text())
+    rows: list[BenchmarkRow] = []
+    for row in data.get("scaling", []):
+        if row.get("status") != "completed" or row.get("s_per_step") is None:
+            continue
+        rows.append(
+            BenchmarkRow(
+                ranks=int(row["ranks"]),
+                s_per_step=float(row["s_per_step"]),
+                cells_per_rank=row.get("cells_per_rank"),
+            )
+        )
+    return BenchmarkProfile(
+        box=data.get("meta", {}).get("box", path.stem),
+        manifest=path,
+        cells=data.get("case", {}).get("cells"),
+        rows=tuple(sorted(rows, key=lambda item: item.ranks)),
+    )
+
+
+def select_benchmark_row(
+    profile: BenchmarkProfile, requested_ranks: int | None, cores: int
+) -> BenchmarkRow | None:
+    eligible = [row for row in profile.rows if row.ranks <= cores]
+    if requested_ranks is not None:
+        exact = [row for row in eligible if row.ranks == requested_ranks]
+        return exact[0] if exact else None
+    return min(eligible, key=lambda row: row.s_per_step, default=None)
+
+
+def probe_host(
+    host: HostConfig,
+    *,
+    timeout: int = 8,
+    runner=subprocess.run,
+) -> HostProbe:
+    remote = (
+        "printf 'hostname=%s\\n' \"$(hostname -s)\"; "
+        "printf 'cores=%s\\n' \"$(nproc)\"; "
+        "awk '{print \"load1=\"$1}' /proc/loadavg"
+    )
+    result = runner(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            f"ConnectTimeout={timeout}",
+            host.ssh_target,
+            remote,
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        reason = (
+            result.stderr or result.stdout or f"ssh rc={result.returncode}"
+        ).strip()
+        return HostProbe(host.name, False, "", 0, 0.0, reason)
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, val = line.split("=", 1)
+            values[key.strip()] = val.strip()
+    try:
+        cores = int(values["cores"])
+        load1 = float(values["load1"])
+    except (KeyError, ValueError) as exc:
+        return HostProbe(host.name, False, "", 0, 0.0, f"bad probe output: {exc}")
+    return HostProbe(
+        host=host.name,
+        reachable=True,
+        hostname=values.get("hostname", host.name),
+        cores=cores,
+        load1=load1,
+        reason="ok",
+    )
+
+
+def evaluate_host(
+    host: HostConfig,
+    probe: HostProbe,
+    profile: BenchmarkProfile | None,
+    *,
+    requested_ranks: int | None,
+    max_load_per_core: float,
+) -> Candidate:
+    if not probe.reachable:
+        return Candidate(host, probe, profile, None, False, probe.reason, None)
+    if profile is None:
+        return Candidate(host, probe, None, None, False, "missing benchmark", None)
+    if probe.cores < 1:
+        return Candidate(host, probe, profile, None, False, "invalid core count", None)
+    row = select_benchmark_row(profile, requested_ranks, probe.cores)
+    if row is None:
+        rank_text = str(requested_ranks) if requested_ranks is not None else "any"
+        return Candidate(
+            host,
+            probe,
+            profile,
+            None,
+            False,
+            f"no valid row for ranks={rank_text}",
+            None,
+        )
+    projected_load_per_core = (probe.load1 + row.ranks) / probe.cores
+    if max_load_per_core > 0 and projected_load_per_core > max_load_per_core:
+        return Candidate(
+            host,
+            probe,
+            profile,
+            row,
+            False,
+            "projected load/core "
+            f"{projected_load_per_core:.2f} exceeds {max_load_per_core:.2f}",
+            row.s_per_step,
+        )
+    return Candidate(host, probe, profile, row, True, "ok", row.s_per_step)
+
+
+def select_candidate(candidates: Sequence[Candidate]) -> Candidate:
+    eligible = [candidate for candidate in candidates if candidate.eligible]
+    if not eligible:
+        raise RuntimeError("no eligible CFD host")
+    return min(
+        eligible, key=lambda candidate: candidate.predicted_s_per_step or float("inf")
+    )
+
+
+def _render_remote_command(args: Sequence[str], *, host: str, ranks: int) -> str:
+    tokens = {"{host}": host, "{ranks}": str(ranks)}
+    rendered = []
+    for arg in args:
+        for token, value in tokens.items():
+            arg = arg.replace(token, value)
+        rendered.append(arg)
+    return " ".join(shlex.quote(arg) for arg in rendered)
+
+
+def _quote_remote_path(path: str) -> str:
+    if path == "~":
+        return '"$HOME"'
+    if path.startswith("~/"):
+        return '"$HOME"/' + shlex.quote(path[2:])
+    return shlex.quote(path)
+
+
+def build_ssh_command(
+    candidate: Candidate,
+    *,
+    remote_command: Sequence[str],
+    repo_dir: str,
+    openfoam_bashrc: str = OPENFOAM_BASHRC,
+) -> list[str]:
+    if candidate.row is None or candidate.predicted_s_per_step is None:
+        raise ValueError("candidate must include a selected benchmark row")
+    command = _render_remote_command(
+        remote_command, host=candidate.host.name, ranks=candidate.row.ranks
+    )
+    remote_shell = (
+        "set -e; "
+        'export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"; '
+        f"source {shlex.quote(openfoam_bashrc)}; "
+        f"cd -- {_quote_remote_path(repo_dir)}; "
+        f"export CFD_DISPATCH_HOST={shlex.quote(candidate.host.name)}; "
+        f"export CFD_DISPATCH_RANKS={candidate.row.ranks}; "
+        f"export CFD_DISPATCH_S_PER_STEP={candidate.predicted_s_per_step}; "
+        f"{command}"
+    )
+    ssh_args = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=8"]
+    return [*ssh_args, candidate.host.ssh_target, remote_shell]
+
+
+def print_table(candidates: Sequence[Candidate], selected: Candidate | None) -> None:
+    print("CFD dispatch candidates:")
+    print(
+        f"{'host':<14} {'ok':<3} {'cores':>5} {'load/core':>9} {'ranks':>5} {'s/step':>8}  reason"
+    )
+    for candidate in candidates:
+        load = (
+            candidate.probe.load1 / candidate.probe.cores
+            if candidate.probe.cores
+            else None
+        )
+        s_step = candidate.predicted_s_per_step
+        print(
+            f"{candidate.host.name:<14} {str(candidate.eligible):<3} "
+            f"{candidate.probe.cores:>5} "
+            f"{(f'{load:.2f}' if isinstance(load, float) else '-'):>9} "
+            f"{(candidate.row.ranks if candidate.row else '-'):>5} "
+            f"{(f'{s_step:.4f}' if isinstance(s_step, float) else '-'):>8}  "
+            f"{candidate.reason}"
+        )
+    if selected:
+        print(
+            f"selected: {selected.host.name} "
+            f"ranks={selected.row.ranks if selected.row else '-'} "
+            f"s_per_step={selected.predicted_s_per_step}"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", action="append", type=parse_host)
+    parser.add_argument(
+        "--assume-probe",
+        action="append",
+        default=[],
+        help="name=cores,load1[,hostname]",
+    )
+    parser.add_argument(
+        "--ranks",
+        type=int,
+        default=None,
+        help="rank count to compare and dispatch",
+    )
+    parser.add_argument("--max-load-per-core", type=float, default=1.5)
+    parser.add_argument("--repo-dir", default="~/digitalmodel")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("remote_command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    remote_command = list(args.remote_command)
+    if remote_command and remote_command[0] == "--":
+        remote_command = remote_command[1:]
+    hosts = args.host or default_hosts()
+    assumed = parse_assume_probe(args.assume_probe)
+    candidates: list[Candidate] = []
+    for host in hosts:
+        probe = assumed.get(host.name) or probe_host(host)
+        try:
+            profile = load_benchmark(host.manifest)
+        except OSError as exc:
+            candidates.append(Candidate(host, probe, None, None, False, str(exc), None))
+            continue
+        candidates.append(
+            evaluate_host(
+                host,
+                probe,
+                profile,
+                requested_ranks=args.ranks,
+                max_load_per_core=args.max_load_per_core,
+            )
+        )
+    try:
+        selected = select_candidate(candidates)
+    except RuntimeError as exc:
+        print_table(candidates, None)
+        print(f"dispatch failed: {exc}", file=sys.stderr)
+        return 1
+    print_table(candidates, selected)
+    if not remote_command:
+        return 0
+    ssh_argv = build_ssh_command(
+        selected, remote_command=remote_command, repo_dir=args.repo_dir
+    )
+    if args.dry_run:
+        print("dry-run command:")
+        print(" ".join(shlex.quote(part) for part in ssh_argv))
+        return 0
+    return subprocess.run(ssh_argv, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_dispatch_cfd_run.py
+++ b/tests/scripts/test_dispatch_cfd_run.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/setup/dispatch-cfd-run.py"
+
+
+def load_dispatcher():
+    spec = importlib.util.spec_from_file_location("dispatch_cfd_run", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_manifest(path: Path, *, box: str, rows: list[dict]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "meta": {"box": box},
+                "case": {"cells": 216000},
+                "scaling": rows,
+            }
+        )
+    )
+
+
+def completed_row(ranks: int, s_per_step: float) -> dict:
+    return {
+        "ranks": ranks,
+        "status": "completed",
+        "s_per_step": s_per_step,
+        "cells_per_rank": round(216000 / ranks),
+    }
+
+
+def test_load_benchmark_skips_oversubscribed_rows(tmp_path: Path) -> None:
+    dispatcher = load_dispatcher()
+    manifest = tmp_path / "gpu.json"
+    write_manifest(
+        manifest,
+        box="gpu-claw",
+        rows=[
+            completed_row(4, 0.8821),
+            completed_row(8, 0.5899),
+            completed_row(16, 0.6945),
+        ],
+    )
+
+    profile = dispatcher.load_benchmark(manifest)
+    selected = dispatcher.select_benchmark_row(profile, requested_ranks=None, cores=8)
+
+    assert selected.ranks == 8
+    assert selected.s_per_step == 0.5899
+
+
+def test_load_gate_rejects_busy_shared_host(tmp_path: Path) -> None:
+    dispatcher = load_dispatcher()
+    manifest = tmp_path / "ace.json"
+    write_manifest(manifest, box="ace-linux-2", rows=[completed_row(8, 1.0582)])
+    host = dispatcher.HostConfig(
+        name="ace-linux-2",
+        ssh_target="ace-linux-2",
+        manifest=manifest,
+        dedicated=False,
+    )
+    probe = dispatcher.HostProbe(
+        host="ace-linux-2",
+        reachable=True,
+        hostname="ace-linux-2",
+        cores=8,
+        load1=24.0,
+        reason="ok",
+    )
+
+    candidate = dispatcher.evaluate_host(
+        host,
+        probe,
+        dispatcher.load_benchmark(manifest),
+        requested_ranks=8,
+        max_load_per_core=1.5,
+    )
+
+    assert not candidate.eligible
+    assert "load/core" in candidate.reason
+
+
+def test_projected_load_gate_rejects_rank_that_would_overcommit_host(
+    tmp_path: Path,
+) -> None:
+    dispatcher = load_dispatcher()
+    manifest = tmp_path / "gpu.json"
+    write_manifest(manifest, box="gpu-claw", rows=[completed_row(8, 0.5899)])
+    host = dispatcher.HostConfig("gpu-claw", "gpu-claw", manifest, True)
+    probe = dispatcher.HostProbe("gpu-claw", True, "gpu-claw", 8, 11.9, "ok")
+
+    candidate = dispatcher.evaluate_host(
+        host,
+        probe,
+        dispatcher.load_benchmark(manifest),
+        requested_ranks=8,
+        max_load_per_core=1.5,
+    )
+
+    assert not candidate.eligible
+    assert "projected load/core" in candidate.reason
+
+
+def test_select_host_prefers_fastest_eligible_candidate(tmp_path: Path) -> None:
+    dispatcher = load_dispatcher()
+    ace_manifest = tmp_path / "ace.json"
+    gpu_manifest = tmp_path / "gpu.json"
+    write_manifest(ace_manifest, box="ace-linux-2", rows=[completed_row(8, 1.0582)])
+    write_manifest(gpu_manifest, box="gpu-claw", rows=[completed_row(8, 0.5899)])
+    candidates = [
+        dispatcher.evaluate_host(
+            dispatcher.HostConfig("ace-linux-2", "ace-linux-2", ace_manifest, False),
+            dispatcher.HostProbe("ace-linux-2", True, "ace-linux-2", 32, 2.0, "ok"),
+            dispatcher.load_benchmark(ace_manifest),
+            requested_ranks=8,
+            max_load_per_core=1.5,
+        ),
+        dispatcher.evaluate_host(
+            dispatcher.HostConfig("gpu-claw", "gpu-claw", gpu_manifest, True),
+            dispatcher.HostProbe("gpu-claw", True, "gpu-claw", 8, 0.5, "ok"),
+            dispatcher.load_benchmark(gpu_manifest),
+            requested_ranks=8,
+            max_load_per_core=1.5,
+        ),
+    ]
+
+    selected = dispatcher.select_candidate(candidates)
+
+    assert selected.host.name == "gpu-claw"
+    assert selected.row.ranks == 8
+    assert selected.predicted_s_per_step == 0.5899
+
+
+def test_dispatch_dry_run_builds_openfoam_ssh_command(tmp_path: Path) -> None:
+    dispatcher = load_dispatcher()
+    manifest = tmp_path / "gpu.json"
+    write_manifest(manifest, box="gpu-claw", rows=[completed_row(8, 0.5899)])
+    candidate = dispatcher.evaluate_host(
+        dispatcher.HostConfig("gpu-claw", "gpu-claw", manifest, True),
+        dispatcher.HostProbe("gpu-claw", True, "gpu-claw", 8, 0.5, "ok"),
+        dispatcher.load_benchmark(manifest),
+        requested_ranks=8,
+        max_load_per_core=1.5,
+    )
+
+    argv = dispatcher.build_ssh_command(
+        candidate,
+        remote_command=["scripts/setup/verify-cfd-box.sh", "--benchmark", "~/cfd_work"],
+        repo_dir="~/digitalmodel",
+    )
+
+    assert argv[:4] == ["ssh", "-o", "BatchMode=yes", "-o"]
+    assert "gpu-claw" in argv
+    remote_shell = argv[-1]
+    assert "source /usr/lib/openfoam/openfoam2312/etc/bashrc" in remote_shell
+    assert 'cd -- "$HOME"/digitalmodel' in remote_shell
+    assert "CFD_DISPATCH_RANKS=8" in remote_shell
+    assert "scripts/setup/verify-cfd-box.sh --benchmark '~/cfd_work'" in remote_shell
+
+
+def test_remote_command_preserves_non_dispatch_braces() -> None:
+    dispatcher = load_dispatcher()
+
+    rendered = dispatcher._render_remote_command(
+        ["awk", "{print $1}", "run-on-{host}-np-{ranks}", '{"rank": 8}'],
+        host="gpu-claw",
+        ranks=8,
+    )
+
+    assert "'{print $1}'" in rendered
+    assert "run-on-gpu-claw-np-8" in rendered
+    assert "'{\"rank\": 8}'" in rendered
+
+
+def test_build_ssh_command_quotes_repo_dir_with_spaces(tmp_path: Path) -> None:
+    dispatcher = load_dispatcher()
+    manifest = tmp_path / "gpu.json"
+    write_manifest(manifest, box="gpu-claw", rows=[completed_row(8, 0.5899)])
+    candidate = dispatcher.evaluate_host(
+        dispatcher.HostConfig("gpu-claw", "gpu-claw", manifest, True),
+        dispatcher.HostProbe("gpu-claw", True, "gpu-claw", 8, 0.5, "ok"),
+        dispatcher.load_benchmark(manifest),
+        requested_ranks=8,
+        max_load_per_core=1.5,
+    )
+
+    argv = dispatcher.build_ssh_command(
+        candidate,
+        remote_command=["echo", "{host}"],
+        repo_dir="~/digital model",
+    )
+
+    assert "cd -- \"$HOME\"/'digital model';" in argv[-1]
+
+
+def test_default_hosts_use_neutral_gpu_claw_target(monkeypatch) -> None:
+    dispatcher = load_dispatcher()
+    monkeypatch.delenv("CFD_GPU_CLAW_SSH", raising=False)
+
+    gpu_host = dispatcher.default_hosts()[0]
+
+    assert gpu_host.name == "gpu-claw"
+    assert gpu_host.ssh_target == "gpu-claw"
+
+
+def test_cli_dry_run_does_not_invoke_ssh(tmp_path: Path) -> None:
+    manifest = tmp_path / "gpu.json"
+    write_manifest(manifest, box="gpu-claw", rows=[completed_row(8, 0.5899)])
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--host",
+            f"gpu-claw=gpu-claw,{manifest},dedicated",
+            "--assume-probe",
+            "gpu-claw=8,0.5",
+            "--ranks",
+            "8",
+            "--dry-run",
+            "--",
+            "echo",
+            "run",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "selected: gpu-claw" in result.stdout
+    assert "ssh " in result.stdout
+    assert "echo run" in result.stdout


### PR DESCRIPTION
## Summary
- Add `scripts/setup/dispatch-cfd-run.py` to choose between `gpu-claw` and `ace-linux-2` using SSH probes plus existing 3D CFD benchmark manifests.
- Reject unreachable, oversubscribed, or high-load hosts before dispatch.
- Source OpenFOAM v2312 on the selected host and export `CFD_DISPATCH_HOST`, `CFD_DISPATCH_RANKS`, and `CFD_DISPATCH_S_PER_STEP` for the remote command.
- Document usage in `scripts/setup/README-cfd-box.md`.

## Live Dry Run
```text
uv run python scripts/setup/dispatch-cfd-run.py --ranks 8 --dry-run -- echo run-on-{host}-np-{ranks}
selected: gpu-claw ranks=8 s_per_step=0.5899
```
Both `gpu-claw` and `ace-linux-2` were reachable from `ace-linux-1`; for 8 ranks the dispatcher selected `gpu-claw` over `ace-linux-2` based on the measured manifests.

## Verification
- RED first: `uv run python -m pytest tests/scripts/test_dispatch_cfd_run.py -q` failed before the dispatcher existed.
- GREEN: `uv run python -m pytest tests/scripts/test_dispatch_cfd_run.py -q`
- `uv run ruff check scripts/setup/dispatch-cfd-run.py tests/scripts/test_dispatch_cfd_run.py`
- `uv run ruff format --check scripts/setup/dispatch-cfd-run.py tests/scripts/test_dispatch_cfd_run.py`
- `python3 -m py_compile scripts/setup/dispatch-cfd-run.py`
- `scripts/enforcement/check-no-abs-paths.sh scripts/setup/dispatch-cfd-run.py tests/scripts/test_dispatch_cfd_run.py scripts/setup/README-cfd-box.md`
- `scripts/enforcement/check-no-conflict-markers.sh`
- `git diff --check`

Refs [digitalmodel #1495](https://github.com/vamseeachanta/digitalmodel/issues/1495).
