### PR TITLE
docs: add #1182 PR1 exit handoff

### DIFF
--- a/docs/session-handoffs/2026-07-09-digitalmodel-1182-response-spectrum-pr1-exit-handoff.md
+++ b/docs/session-handoffs/2026-07-09-digitalmodel-1182-response-spectrum-pr1-exit-handoff.md
@@ -1,0 +1,36 @@
+# digitalmodel #1182 PR1 exit handoff - 2026-07-09
+
+## Active task
+
+- GitHub issue: vamseeachanta/digitalmodel#1182
+- PR merged: vamseeachanta/digitalmodel#1499
+- Scope completed: PR1 response-spectrum tracer, reader/baseline/workflow/report/registry coverage.
+- Scope not completed: elastic spectra, constant-ductility spectra, SDOF/Newmark solver work, and broader strong-motion measures remain follow-on work under the still-open issue.
+
+## Completed actions
+
+- Added the `digitalmodel.seismic` tracer package and response-spectrum workflow entrypoint.
+- Added public El Centro fixture provenance and pinned deterministic fixture statistics.
+- Added workflow registry, routing-map, domain, durable workflow, reader, baseline, and report coverage.
+- Ran adversarial review and fixed both accepted findings: no out-of-scope PGV/PGD reporting and no non-repo absolute source path leakage in generated HTML reports.
+- Merged PR #1499 into `main` by squash merge.
+- Deleted remote branch `feature/response-spectrum-tracer-1182`.
+
+## Verified state
+
+- PR #1499 state: `MERGED`
+- Merge commit on `origin/main`: `4e0ebd9e481f8911166528821c31d26e007f9ac8`
+- PR head before merge: `c76ae20438a067fa9fe03c47d6cc501d3100b1c5`
+- GitHub checks before merge: 30 completed successfully, 0 pending, 0 failing.
+- Issue #1182 state: open, labels include `status:pending`, `lane:codex`, and `lane:claude`.
+
+## Local disposition
+
+- The task worktree was reused only to write this handoff from `origin/main`.
+- The local `main` branch in this worktree was observed diverged and was not rebased or reset.
+- The primary checkout had pre-existing unrelated untracked files; those were not touched.
+
+## Next checkpoint
+
+- Continue #1182 with a follow-on plan/PR for Newmark/SDOF spectra and intensity measures.
+- Do not treat PR #1499 as closing the parent issue; it only completed the tracer/IO/report slice.


### PR DESCRIPTION
## Summary
- Documents the #1182 PR1 response-spectrum tracer closeout after PR #1499 was merged.
- Records merge evidence, issue state, local disposition, and next checkpoint.

## Verification
- git diff --check
- bash scripts/enforcement/check-no-abs-paths.sh --added origin/main

## Notes
Direct push to main was blocked by repository rules, so this handoff is carried as a narrow documentation PR.