### PR TITLE
Field-development onshore tracer: YAML layout + terrain routing + screening + plot + API (#1508)

### DIFF
--- a/scripts/field_development/onshore_flythrough_bpy.py
+++ b/scripts/field_development/onshore_flythrough_bpy.py
@@ -1,0 +1,209 @@
+# ABOUTME: Blender (bpy) fly-through of the onshore tracer scene JSON (#1508).
+# ABOUTME: REQUIRES BLENDER — run inside blender, not plain python; stdlib-only imports.
+"""Render a short fly-through of an onshore field layout scene in Blender.
+
+REQUIRES BLENDER (tested API target: Blender >= 3.6). This script imports
+``bpy`` and therefore CANNOT run under a plain Python interpreter — it must be
+executed by Blender itself, headless:
+
+    # 1. produce the scene JSON with the tracer API
+    .venv/bin/python -c "
+    from digitalmodel.field_development import screen_layout
+    screen_layout(
+        'src/digitalmodel/field_development/data/onshore_demo_field.yml',
+        output_dir='outputs/field_development',
+    )"
+
+    # 2. render the ~4 s fly-through (96 frames @ 24 fps, MPEG-4)
+    blender --background --python \
+        scripts/field_development/onshore_flythrough_bpy.py -- \
+        --scene outputs/field_development/onshore_demo_scene.json \
+        --out outputs/field_development/onshore_demo_flythrough.mp4
+
+The scene JSON is produced by
+``digitalmodel.field_development.onshore_layout.export_scene_json`` (JSON so
+Blender's bundled Python needs no third-party packages). The rendered video is
+NOT committed to the repo (see .gitignore) — re-render it locally with the
+command above.
+
+Scene contents: terrain mesh built from the elevation grid, a cube for the
+host/processing pad, cylinders for wells, bevelled curves for flowlines, a sun
+lamp, and a camera orbiting the field centre with a slow descent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import bpy  # noqa: F401  (only available inside Blender)
+
+FPS = 24
+DURATION_S = 4.0
+FRAME_COUNT = int(FPS * DURATION_S)
+# Vertical exaggeration makes gentle onshore relief readable in the clip.
+Z_EXAGGERATION = 2.0
+FLOWLINE_BEVEL_M = 8.0
+WELL_RADIUS_M = 25.0
+WELL_HEIGHT_M = 60.0
+HOST_SIZE_M = 120.0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scene", required=True, help="scene JSON from export_scene_json"
+    )
+    parser.add_argument("--out", required=True, help="output video path (.mp4)")
+    return parser.parse_args(argv)
+
+
+def _clear_default_scene() -> None:
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+
+
+def _add_terrain(terrain: dict) -> tuple[float, float, float]:
+    """Build the terrain mesh; return the scene centre (x, y, z)."""
+    xs, ys, zs = terrain["x_m"], terrain["y_m"], terrain["z_m"]
+    nx, ny = len(xs), len(ys)
+    z0 = min(min(row) for row in zs)
+    verts = [
+        (xs[i], ys[j], (zs[j][i] - z0) * Z_EXAGGERATION)
+        for j in range(ny)
+        for i in range(nx)
+    ]
+    faces = [
+        (j * nx + i, j * nx + i + 1, (j + 1) * nx + i + 1, (j + 1) * nx + i)
+        for j in range(ny - 1)
+        for i in range(nx - 1)
+    ]
+    mesh = bpy.data.meshes.new("terrain")
+    mesh.from_pydata(verts, [], faces)
+    mesh.update()
+    obj = bpy.data.objects.new("terrain", mesh)
+    bpy.context.collection.objects.link(obj)
+
+    material = bpy.data.materials.new("terrain_mat")
+    material.diffuse_color = (0.35, 0.45, 0.25, 1.0)
+    obj.data.materials.append(material)
+
+    cx = 0.5 * (xs[0] + xs[-1])
+    cy = 0.5 * (ys[0] + ys[-1])
+    cz = (max(max(row) for row in zs) - z0) * Z_EXAGGERATION * 0.5
+    return cx, cy, cz
+
+
+def _scene_z(z_m: float, z0: float) -> float:
+    return (z_m - z0) * Z_EXAGGERATION
+
+
+def _add_assets(scene: dict, z0: float) -> None:
+    for asset in scene["assets"]:
+        z = _scene_z(asset["z_m"], z0)
+        if asset["kind"] == "host":
+            bpy.ops.mesh.primitive_cube_add(
+                size=HOST_SIZE_M,
+                location=(asset["x_m"], asset["y_m"], z + HOST_SIZE_M / 2),
+            )
+        else:
+            bpy.ops.mesh.primitive_cylinder_add(
+                radius=WELL_RADIUS_M,
+                depth=WELL_HEIGHT_M,
+                location=(asset["x_m"], asset["y_m"], z + WELL_HEIGHT_M / 2),
+            )
+        bpy.context.active_object.name = f"asset_{asset['id']}"
+
+
+def _add_flowlines(scene: dict, z0: float) -> None:
+    for flowline in scene["flowlines"]:
+        curve = bpy.data.curves.new(f"fl_{flowline['id']}", type="CURVE")
+        curve.dimensions = "3D"
+        curve.bevel_depth = FLOWLINE_BEVEL_M
+        spline = curve.splines.new("POLY")
+        path = flowline["path_xyz_m"]
+        spline.points.add(len(path) - 1)
+        for point, (x, y, z) in zip(spline.points, path):
+            point.co = (x, y, _scene_z(z, z0) + FLOWLINE_BEVEL_M, 1.0)
+        obj = bpy.data.objects.new(f"fl_{flowline['id']}", curve)
+        bpy.context.collection.objects.link(obj)
+
+
+def _add_camera_flythrough(centre: tuple[float, float, float], radius: float) -> None:
+    cx, cy, cz = centre
+    target = bpy.data.objects.new("cam_target", None)
+    target.location = (cx, cy, cz)
+    bpy.context.collection.objects.link(target)
+
+    camera_data = bpy.data.cameras.new("camera")
+    camera = bpy.data.objects.new("camera", camera_data)
+    bpy.context.collection.objects.link(camera)
+    bpy.context.scene.camera = camera
+    track = camera.constraints.new(type="TRACK_TO")
+    track.target = target
+
+    scene = bpy.context.scene
+    scene.frame_start, scene.frame_end = 1, FRAME_COUNT
+    scene.render.fps = FPS
+    for frame in range(1, FRAME_COUNT + 1):
+        t = (frame - 1) / (FRAME_COUNT - 1)
+        angle = math.radians(200.0) * t
+        height = radius * (0.9 - 0.45 * t)
+        camera.location = (
+            cx + radius * math.cos(angle),
+            cy + radius * math.sin(angle),
+            cz + height,
+        )
+        camera.keyframe_insert(data_path="location", frame=frame)
+
+    sun_data = bpy.data.lights.new("sun", type="SUN")
+    sun = bpy.data.objects.new("sun", sun_data)
+    sun.location = (cx, cy, cz + 2 * radius)
+    sun.rotation_euler = (math.radians(30), 0.0, math.radians(45))
+    bpy.context.collection.objects.link(sun)
+
+
+def _configure_render(out_path: str) -> None:
+    scene = bpy.context.scene
+    render = scene.render
+    render.resolution_x, render.resolution_y = 1280, 720
+    render.image_settings.file_format = "FFMPEG"
+    render.ffmpeg.format = "MPEG4"
+    render.ffmpeg.codec = "H264"
+    render.filepath = out_path
+    # Prefer EEVEE (fast); engine id differs across Blender versions.
+    for engine in ("BLENDER_EEVEE_NEXT", "BLENDER_EEVEE", "BLENDER_WORKBENCH"):
+        try:
+            render.engine = engine
+            break
+        except TypeError:
+            continue
+
+
+def main() -> None:
+    argv = sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else []
+    args = _parse_args(argv)
+    with open(args.scene, "r", encoding="utf-8") as fh:
+        scene_data = json.load(fh)
+
+    _clear_default_scene()
+    terrain = scene_data["terrain"]
+    z0 = min(min(row) for row in terrain["z_m"])
+    centre = _add_terrain(terrain)
+    _add_assets(scene_data, z0)
+    _add_flowlines(scene_data, z0)
+    span_x = terrain["x_m"][-1] - terrain["x_m"][0]
+    span_y = terrain["y_m"][-1] - terrain["y_m"][0]
+    _add_camera_flythrough(centre, radius=0.85 * math.hypot(span_x, span_y))
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    _configure_render(args.out)
+    bpy.ops.render.render(animation=True)
+    print(f"fly-through rendered to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/field_development/__init__.py
+++ b/src/digitalmodel/field_development/__init__.py
@@ -12,6 +12,7 @@ Modules:
 - benchmarks:          SubseaIQ concept-selection and architecture benchmarks — #1861/#2053
 - timeline:            Milestone-based schedule benchmark analytics — #2060
 - workflow:            End-to-end FDP screening orchestrator — #1858/#1848
+- onshore_layout:      Onshore tracer — YAML layout + terrain routing + screening — #1508
 """
 
 from .schematic_generator import generate_field_schematic, SOLVEIG_PHASE2_CONFIG
@@ -75,6 +76,15 @@ from .concept_comparison_note import (
     render_comparison_note,
     build_comparison_note,
 )
+from .onshore_layout import (
+    FieldLayout,
+    TerrainGrid,
+    build_layout,
+    darcy_weisbach_pressure_drop,
+    load_field_config,
+    screen_layout,
+    swamee_jain_friction_factor,
+)
 
 __all__ = [
     # Schematics (WRK-192)
@@ -137,4 +147,12 @@ __all__ = [
     "weight_sensitivity_sweep",
     "render_comparison_note",
     "build_comparison_note",
+    # Onshore layout tracer (#1508)
+    "FieldLayout",
+    "TerrainGrid",
+    "build_layout",
+    "darcy_weisbach_pressure_drop",
+    "load_field_config",
+    "screen_layout",
+    "swamee_jain_friction_factor",
 ]

--- a/src/digitalmodel/field_development/data/onshore_demo_field.yml
+++ b/src/digitalmodel/field_development/data/onshore_demo_field.yml
@@ -1,0 +1,83 @@
+# ABOUTME: Demo onshore field for the field-development tracer (#1508, epic #1507).
+# ABOUTME: ALL layout/fluid/output constants live here — nothing hardcoded in code.
+#
+# Synthetic demo field. Coordinates are a local Cartesian grid in metres
+# (easting/northing from an arbitrary field datum). The terrain is a small
+# deterministic synthetic elevation grid standing in for a real DEM; USGS 3DEP
+# ingestion is worldenergydata#930's deliverable, not this tracer's.
+
+field:
+  name: Demo Onshore Field
+  coordinate_note: local Cartesian metres from field datum (synthetic demo)
+
+terrain:
+  kind: synthetic          # synthetic | csv_grid
+  x_min_m: 0.0
+  x_max_m: 3000.0
+  y_min_m: 0.0
+  y_max_m: 3000.0
+  nx: 61
+  ny: 61
+  base_elevation_m: 350.0
+  amplitude_m: 40.0
+  x_wavelength_m: 2400.0
+  y_wavelength_m: 1800.0
+
+host:
+  id: CPF-1
+  name: Central processing facility
+  x_m: 1500.0
+  y_m: 1500.0
+
+wells:
+  - id: W-1
+    name: Demo well 1
+    x_m: 400.0
+    y_m: 2600.0
+    rate_m3_per_day: 280.0   # gross liquid rate (demo value)
+  - id: W-2
+    name: Demo well 2
+    x_m: 2600.0
+    y_m: 2400.0
+    rate_m3_per_day: 320.0
+  - id: W-3
+    name: Demo well 3
+    x_m: 2200.0
+    y_m: 500.0
+    rate_m3_per_day: 260.0
+
+flowlines:
+  - id: FL-1
+    from_well: W-1
+    to: CPF-1
+    inner_diameter_m: 0.1524   # 6-inch nominal bore (demo)
+    roughness_m: 4.5e-05       # commercial steel absolute roughness (Moody chart)
+  - id: FL-2
+    from_well: W-2
+    to: CPF-1
+    inner_diameter_m: 0.1524
+    roughness_m: 4.5e-05
+  - id: FL-3
+    from_well: W-3
+    to: CPF-1
+    inner_diameter_m: 0.1016   # 4-inch nominal bore (demo)
+    roughness_m: 4.5e-05
+
+fluid:
+  name: stabilised crude (demo properties)
+  density_kg_per_m3: 850.0
+  viscosity_pa_s: 0.005        # 5 cP
+
+routing:
+  sample_spacing_m: 25.0       # terrain sampling step along each flowline
+
+screening:
+  max_velocity_m_per_s: 4.0    # simple velocity screen threshold
+
+plot:
+  output_path: outputs/field_development/onshore_demo_layout.png
+  format: png
+  dpi: 150
+
+scene_export:
+  output_path: outputs/field_development/onshore_demo_scene.json

--- a/src/digitalmodel/field_development/onshore_layout.py
+++ b/src/digitalmodel/field_development/onshore_layout.py
@@ -1,0 +1,610 @@
+# ABOUTME: Onshore field-development tracer — YAML layout + terrain routing + screening + plot.
+# ABOUTME: Issue #1508 (tracer slice of epic #1507). Synthetic DEM stands in for USGS 3DEP.
+"""
+digitalmodel.field_development.onshore_layout
+==============================================
+
+Tracer slice (#1508) of the onshore field-development epic (#1507): ONE demo
+onshore field taken end-to-end —
+
+  1. **YAML config**  — terrain grid spec, wells, flowlines, host pad, fluid
+     properties, plot/scene output paths. ALL constants live in the YAML
+     (see ``data/onshore_demo_field.yml``); nothing is hardcoded here.
+  2. **Terrain**      — a small deterministic elevation grid. Either a
+     ``synthetic`` analytic surface sampled onto a grid, or a ``csv_grid``
+     bundled elevation table. Real USGS 3DEP DEM ingestion is deliberately
+     OUT of this slice (that wiring is worldenergydata#930's deliverable).
+  3. **Layout model** — typed asset/flowline objects placed on the terrain
+     surface; straight-line plan routing with the flowline length computed
+     OVER the terrain (3D length, not plan length).
+  4. **Screening**    — Darcy-Weisbach frictional pressure drop per flowline
+     with the Swamee-Jain explicit friction factor (laminar: f = 64/Re),
+     plus the hydrostatic elevation term. See
+     :func:`darcy_weisbach_pressure_drop` for the citation.
+  5. **2D plot**      — deterministic matplotlib figure (terrain contours +
+     assets + flowlines) saved to the path given in the config.
+  6. **Scene export** — a JSON scene file consumed by the Blender fly-through
+     script (``scripts/field_development/onshore_flythrough_bpy.py``); JSON so
+     Blender's bundled Python needs no third-party packages.
+  7. **API**          — :func:`screen_layout` is the single entry point:
+     ``screen_layout(config_path) -> dict`` (layout summary + screening
+     results + artifact paths).
+
+Scope honesty
+-------------
+Screening-grade only: straight-line routing (no obstacle avoidance, no
+least-cost path), single-phase incompressible pressure drop (no multiphase
+flow assurance), synthetic terrain. Each of those is a follow-on workstream
+of epic #1507, not this tracer.
+
+Usage
+-----
+>>> from digitalmodel.field_development import screen_layout
+>>> result = screen_layout(
+...     "src/digitalmodel/field_development/data/onshore_demo_field.yml",
+...     output_dir="outputs/field_development",
+... )  # doctest: +SKIP
+>>> result["flowlines"][0]["screening"]["dp_total_kpa"]  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import matplotlib
+import numpy as np
+import yaml
+
+matplotlib.use("Agg")  # non-interactive backend for file output
+import matplotlib.pyplot as plt  # noqa: E402
+
+from .schematics.renderer import render_figure  # noqa: E402
+
+# --- physical constants ------------------------------------------------------
+GRAVITY_M_PER_S2 = 9.80665
+SECONDS_PER_DAY = 86_400.0
+# Below this Reynolds number the laminar friction factor f = 64/Re applies.
+LAMINAR_REYNOLDS_LIMIT = 2_300.0
+
+_REQUIRED_SECTIONS = ("field", "terrain", "host", "wells", "flowlines", "fluid", "plot")
+
+
+# ---------------------------------------------------------------------------
+# Terrain
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TerrainGrid:
+    """A small DEM-like elevation grid over a rectangular domain.
+
+    ``z_m`` has shape ``(ny, nx)``; ``z_m[j, i]`` is the elevation at
+    ``(x_m[i], y_m[j])``. Elevation queries use bilinear interpolation, the
+    standard treatment of a gridded DEM between posts.
+    """
+
+    x_m: np.ndarray
+    y_m: np.ndarray
+    z_m: np.ndarray
+    source: str = "synthetic"
+
+    def elevation_at(self, x: float, y: float) -> float:
+        """Bilinear-interpolated elevation at plan position (x, y) [m]."""
+        xg, yg = self.x_m, self.y_m
+        if not (xg[0] <= x <= xg[-1] and yg[0] <= y <= yg[-1]):
+            raise ValueError(
+                f"point ({x}, {y}) lies outside the terrain domain "
+                f"x=[{xg[0]}, {xg[-1]}], y=[{yg[0]}, {yg[-1]}]"
+            )
+        i = int(np.clip(np.searchsorted(xg, x) - 1, 0, len(xg) - 2))
+        j = int(np.clip(np.searchsorted(yg, y) - 1, 0, len(yg) - 2))
+        tx = (x - xg[i]) / (xg[i + 1] - xg[i])
+        ty = (y - yg[j]) / (yg[j + 1] - yg[j])
+        z = self.z_m
+        return float(
+            z[j, i] * (1 - tx) * (1 - ty)
+            + z[j, i + 1] * tx * (1 - ty)
+            + z[j + 1, i] * (1 - tx) * ty
+            + z[j + 1, i + 1] * tx * ty
+        )
+
+
+def _build_synthetic_terrain(spec: dict[str, Any]) -> TerrainGrid:
+    """Deterministic analytic surface sampled onto a grid (DEM stand-in).
+
+    z(x, y) = base + amplitude * sin(2*pi*x / x_wavelength) * cos(2*pi*y / y_wavelength)
+    """
+    x = np.linspace(float(spec["x_min_m"]), float(spec["x_max_m"]), int(spec["nx"]))
+    y = np.linspace(float(spec["y_min_m"]), float(spec["y_max_m"]), int(spec["ny"]))
+    xx, yy = np.meshgrid(x, y)
+    z = float(spec["base_elevation_m"]) + float(spec["amplitude_m"]) * np.sin(
+        2.0 * math.pi * xx / float(spec["x_wavelength_m"])
+    ) * np.cos(2.0 * math.pi * yy / float(spec["y_wavelength_m"]))
+    return TerrainGrid(x_m=x, y_m=y, z_m=z, source="synthetic")
+
+
+def _build_csv_terrain(spec: dict[str, Any], base_dir: Path) -> TerrainGrid:
+    """Elevation grid from a bundled CSV table of z values (row = one y line)."""
+    csv_path = Path(spec["csv_path"])
+    if not csv_path.is_absolute():
+        csv_path = base_dir / csv_path
+    z = np.loadtxt(csv_path, delimiter=",", ndmin=2)
+    ny, nx = z.shape
+    x = np.linspace(float(spec["x_min_m"]), float(spec["x_max_m"]), nx)
+    y = np.linspace(float(spec["y_min_m"]), float(spec["y_max_m"]), ny)
+    return TerrainGrid(x_m=x, y_m=y, z_m=z, source=f"csv_grid:{csv_path.name}")
+
+
+def build_terrain(spec: dict[str, Any], base_dir: Path) -> TerrainGrid:
+    """Build the terrain grid described by the config ``terrain`` section."""
+    kind = spec.get("kind")
+    if kind == "synthetic":
+        return _build_synthetic_terrain(spec)
+    if kind == "csv_grid":
+        return _build_csv_terrain(spec, base_dir)
+    raise ValueError(f"terrain.kind must be 'synthetic' or 'csv_grid', got {kind!r}")
+
+
+# ---------------------------------------------------------------------------
+# Layout model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Asset:
+    """A surface asset placed on the terrain (well pad or host/processing pad)."""
+
+    asset_id: str
+    name: str
+    kind: str  # "well" | "host"
+    x_m: float
+    y_m: float
+    z_m: float
+    rate_m3_per_day: float = 0.0
+
+
+@dataclass
+class FlowlineRoute:
+    """A routed flowline: straight in plan, draped over the terrain surface."""
+
+    flowline_id: str
+    from_id: str
+    to_id: str
+    inner_diameter_m: float
+    roughness_m: float
+    rate_m3_per_day: float
+    path_xyz_m: np.ndarray = field(repr=False)  # (n, 3) sampled polyline
+    plan_length_m: float = 0.0
+    terrain_length_m: float = 0.0
+    elevation_change_m: float = 0.0  # z_to - z_from
+
+
+@dataclass
+class FieldLayout:
+    """Typed layout of one onshore field on its terrain."""
+
+    name: str
+    terrain: TerrainGrid
+    host: Asset
+    wells: list[Asset]
+    flowlines: list[FlowlineRoute]
+
+
+def load_field_config(config_path: str | Path) -> dict[str, Any]:
+    """Load and validate the onshore field YAML config."""
+    path = Path(config_path)
+    with open(path, "r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+    if not isinstance(config, dict):
+        raise ValueError(f"config {path} did not parse to a mapping")
+    missing = [key for key in _REQUIRED_SECTIONS if key not in config]
+    if missing:
+        raise ValueError(f"config {path} missing required sections: {missing}")
+    if not config["wells"]:
+        raise ValueError("config must define at least one well")
+    if not config["flowlines"]:
+        raise ValueError("config must define at least one flowline")
+    return config
+
+
+def _route_flowline(
+    spec: dict[str, Any],
+    assets: dict[str, Asset],
+    terrain: TerrainGrid,
+    sample_spacing_m: float,
+) -> FlowlineRoute:
+    """Straight-line plan route, sampled and draped over the terrain."""
+    from_id, to_id = str(spec["from_well"]), str(spec["to"])
+    for asset_id in (from_id, to_id):
+        if asset_id not in assets:
+            raise ValueError(
+                f"flowline {spec.get('id')!r} references unknown asset {asset_id!r}"
+            )
+    a, b = assets[from_id], assets[to_id]
+    plan_length = math.hypot(b.x_m - a.x_m, b.y_m - a.y_m)
+    n_segments = max(1, int(math.ceil(plan_length / sample_spacing_m)))
+    t = np.linspace(0.0, 1.0, n_segments + 1)
+    xs = a.x_m + t * (b.x_m - a.x_m)
+    ys = a.y_m + t * (b.y_m - a.y_m)
+    zs = np.array([terrain.elevation_at(x, y) for x, y in zip(xs, ys)])
+    path = np.column_stack([xs, ys, zs])
+    seg = np.diff(path, axis=0)
+    terrain_length = float(np.sum(np.sqrt(np.sum(seg**2, axis=1))))
+    return FlowlineRoute(
+        flowline_id=str(spec["id"]),
+        from_id=from_id,
+        to_id=to_id,
+        inner_diameter_m=float(spec["inner_diameter_m"]),
+        roughness_m=float(spec["roughness_m"]),
+        rate_m3_per_day=a.rate_m3_per_day,
+        path_xyz_m=path,
+        plan_length_m=plan_length,
+        terrain_length_m=terrain_length,
+        elevation_change_m=float(zs[-1] - zs[0]),
+    )
+
+
+def build_layout(config: dict[str, Any], base_dir: str | Path = ".") -> FieldLayout:
+    """Build the typed field layout from a validated config mapping.
+
+    ``base_dir`` resolves relative data paths inside the config (e.g. a
+    ``csv_grid`` terrain file) — pass the config file's parent directory.
+    """
+    base = Path(base_dir)
+    terrain = build_terrain(config["terrain"], base)
+
+    host_spec = config["host"]
+    host = Asset(
+        asset_id=str(host_spec["id"]),
+        name=str(host_spec.get("name", host_spec["id"])),
+        kind="host",
+        x_m=float(host_spec["x_m"]),
+        y_m=float(host_spec["y_m"]),
+        z_m=terrain.elevation_at(float(host_spec["x_m"]), float(host_spec["y_m"])),
+    )
+    wells = [
+        Asset(
+            asset_id=str(w["id"]),
+            name=str(w.get("name", w["id"])),
+            kind="well",
+            x_m=float(w["x_m"]),
+            y_m=float(w["y_m"]),
+            z_m=terrain.elevation_at(float(w["x_m"]), float(w["y_m"])),
+            rate_m3_per_day=float(w["rate_m3_per_day"]),
+        )
+        for w in config["wells"]
+    ]
+    assets = {host.asset_id: host, **{w.asset_id: w for w in wells}}
+    if len(assets) != 1 + len(wells):
+        raise ValueError("asset ids must be unique across host and wells")
+
+    routing = config.get("routing", {})
+    sample_spacing = float(routing.get("sample_spacing_m", 25.0))
+    flowlines = [
+        _route_flowline(fl, assets, terrain, sample_spacing)
+        for fl in config["flowlines"]
+    ]
+    return FieldLayout(
+        name=str(config["field"]["name"]),
+        terrain=terrain,
+        host=host,
+        wells=wells,
+        flowlines=flowlines,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Screening calc — Darcy-Weisbach + Swamee-Jain
+# ---------------------------------------------------------------------------
+
+
+def swamee_jain_friction_factor(reynolds: float, relative_roughness: float) -> float:
+    """Darcy friction factor.
+
+    Laminar (Re < 2300): f = 64/Re (exact, Hagen-Poiseuille).
+    Turbulent: Swamee-Jain explicit approximation to the Colebrook-White
+    equation —
+
+        f = 0.25 / [log10(eps/(3.7 D) + 5.74 / Re^0.9)]^2
+
+    Reference: Swamee, P.K. & Jain, A.K. (1976), "Explicit equations for
+    pipe-flow problems", Journal of the Hydraulics Division, ASCE, 102(5),
+    657-664. Stated validity 5e3 <= Re <= 3e8, 1e-6 <= eps/D <= 1e-2; within
+    ~1% of Colebrook-White there. In the transition band 2300 < Re < 5000 it
+    is used here as a screening-grade approximation.
+    """
+    if reynolds <= 0:
+        raise ValueError(f"reynolds must be > 0, got {reynolds!r}")
+    if reynolds < LAMINAR_REYNOLDS_LIMIT:
+        return 64.0 / reynolds
+    return 0.25 / math.log10(relative_roughness / 3.7 + 5.74 / reynolds**0.9) ** 2
+
+
+def darcy_weisbach_pressure_drop(
+    rate_m3_per_s: float,
+    length_m: float,
+    inner_diameter_m: float,
+    roughness_m: float,
+    density_kg_per_m3: float,
+    viscosity_pa_s: float,
+    elevation_change_m: float = 0.0,
+) -> dict[str, float]:
+    """Single-phase incompressible flowline pressure drop (screening grade).
+
+    Frictional term: Darcy-Weisbach, dp = f (L/D) (rho v^2 / 2), with the
+    friction factor from :func:`swamee_jain_friction_factor` (citation there).
+    Elevation term: hydrostatic, dp = rho g dz (positive uphill).
+
+    Reference for Darcy-Weisbach: e.g. White, F.M., "Fluid Mechanics",
+    McGraw-Hill, ch. 6 (viscous flow in ducts).
+    """
+    if inner_diameter_m <= 0 or length_m < 0:
+        raise ValueError("inner_diameter_m must be > 0 and length_m >= 0")
+    if rate_m3_per_s <= 0:
+        raise ValueError(f"rate_m3_per_s must be > 0, got {rate_m3_per_s!r}")
+    area = math.pi * inner_diameter_m**2 / 4.0
+    velocity = rate_m3_per_s / area
+    reynolds = density_kg_per_m3 * velocity * inner_diameter_m / viscosity_pa_s
+    friction = swamee_jain_friction_factor(reynolds, roughness_m / inner_diameter_m)
+    dp_friction = (
+        friction * (length_m / inner_diameter_m) * density_kg_per_m3 * velocity**2 / 2.0
+    )
+    dp_elevation = density_kg_per_m3 * GRAVITY_M_PER_S2 * elevation_change_m
+    return {
+        "velocity_m_per_s": velocity,
+        "reynolds": reynolds,
+        "friction_factor": friction,
+        "flow_regime": "laminar" if reynolds < LAMINAR_REYNOLDS_LIMIT else "turbulent",
+        "dp_friction_kpa": dp_friction / 1_000.0,
+        "dp_elevation_kpa": dp_elevation / 1_000.0,
+        "dp_total_kpa": (dp_friction + dp_elevation) / 1_000.0,
+    }
+
+
+def screen_flowline(
+    flowline: FlowlineRoute,
+    fluid: dict[str, Any],
+    screening: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Apply the pressure-drop screen to one routed flowline.
+
+    Uses the TERRAIN length (3D) as the hydraulic length and the endpoint
+    elevation difference for the hydrostatic term. Adds a pass/fail velocity
+    flag against ``screening.max_velocity_m_per_s`` when configured.
+    """
+    result = darcy_weisbach_pressure_drop(
+        rate_m3_per_s=flowline.rate_m3_per_day / SECONDS_PER_DAY,
+        length_m=flowline.terrain_length_m,
+        inner_diameter_m=flowline.inner_diameter_m,
+        roughness_m=flowline.roughness_m,
+        density_kg_per_m3=float(fluid["density_kg_per_m3"]),
+        viscosity_pa_s=float(fluid["viscosity_pa_s"]),
+        elevation_change_m=flowline.elevation_change_m,
+    )
+    max_velocity = (screening or {}).get("max_velocity_m_per_s")
+    if max_velocity is not None:
+        result["velocity_ok"] = result["velocity_m_per_s"] <= float(max_velocity)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 2D layout plot
+# ---------------------------------------------------------------------------
+
+
+def plot_layout(
+    layout: FieldLayout,
+    output_path: str | Path,
+    output_format: str = "png",
+    dpi: int = 150,
+) -> str:
+    """Deterministic 2D layout figure: terrain contours + assets + flowlines."""
+    fig, ax = plt.subplots(figsize=(9, 8))
+    terrain = layout.terrain
+    filled = ax.contourf(
+        terrain.x_m, terrain.y_m, terrain.z_m, levels=12, cmap="terrain", alpha=0.75
+    )
+    contours = ax.contour(
+        terrain.x_m,
+        terrain.y_m,
+        terrain.z_m,
+        levels=12,
+        colors="dimgray",
+        linewidths=0.5,
+    )
+    ax.clabel(contours, inline=True, fontsize=7, fmt="%.0f")
+    fig.colorbar(filled, ax=ax, label="Elevation [m]")
+
+    for fl in layout.flowlines:
+        ax.plot(
+            fl.path_xyz_m[:, 0],
+            fl.path_xyz_m[:, 1],
+            color="firebrick",
+            linewidth=2.0,
+            zorder=3,
+        )
+        mid = fl.path_xyz_m[len(fl.path_xyz_m) // 2]
+        ax.annotate(
+            f"{fl.flowline_id}: {fl.terrain_length_m:,.0f} m",
+            (mid[0], mid[1]),
+            textcoords="offset points",
+            xytext=(6, 6),
+            fontsize=8,
+        )
+    for well in layout.wells:
+        ax.plot(well.x_m, well.y_m, "o", color="black", markersize=8, zorder=4)
+        ax.annotate(
+            well.asset_id,
+            (well.x_m, well.y_m),
+            textcoords="offset points",
+            xytext=(8, -12),
+            fontsize=9,
+        )
+    host = layout.host
+    ax.plot(host.x_m, host.y_m, "s", color="navy", markersize=12, zorder=4)
+    ax.annotate(
+        host.asset_id,
+        (host.x_m, host.y_m),
+        textcoords="offset points",
+        xytext=(10, 8),
+        fontsize=10,
+        weight="bold",
+    )
+
+    ax.set_xlabel("Easting [m]")
+    ax.set_ylabel("Northing [m]")
+    ax.set_title(f"{layout.name} — onshore layout (screening)")
+    ax.set_aspect("equal")
+    saved = render_figure(fig, str(output_path), output_format, dpi=dpi)
+    plt.close(fig)
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# Scene export (Blender fly-through input)
+# ---------------------------------------------------------------------------
+
+
+def export_scene_json(layout: FieldLayout, output_path: str | Path) -> str:
+    """Write the layout as a JSON scene for the bpy fly-through script.
+
+    JSON (not YAML/pickle) so Blender's bundled Python can read it with the
+    standard library only. Consumed by
+    ``scripts/field_development/onshore_flythrough_bpy.py``.
+    """
+    scene = {
+        "field_name": layout.name,
+        "terrain": {
+            "x_m": layout.terrain.x_m.tolist(),
+            "y_m": layout.terrain.y_m.tolist(),
+            "z_m": layout.terrain.z_m.tolist(),
+            "source": layout.terrain.source,
+        },
+        "assets": [
+            {
+                "id": a.asset_id,
+                "name": a.name,
+                "kind": a.kind,
+                "x_m": a.x_m,
+                "y_m": a.y_m,
+                "z_m": a.z_m,
+            }
+            for a in [layout.host, *layout.wells]
+        ],
+        "flowlines": [
+            {
+                "id": fl.flowline_id,
+                "from": fl.from_id,
+                "to": fl.to_id,
+                "path_xyz_m": fl.path_xyz_m.tolist(),
+            }
+            for fl in layout.flowlines
+        ],
+    }
+    dest = Path(output_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "w", encoding="utf-8") as fh:
+        json.dump(scene, fh)
+    return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# API entry point
+# ---------------------------------------------------------------------------
+
+
+def _resolve_output(configured: str, output_dir: Optional[str | Path]) -> Path:
+    """Configured output path, optionally redirected into ``output_dir``."""
+    path = Path(configured)
+    if output_dir is not None:
+        return Path(output_dir) / path.name
+    return path
+
+
+def screen_layout(
+    config_path: str | Path, output_dir: Optional[str | Path] = None
+) -> dict[str, Any]:
+    """Run the onshore layout tracer end-to-end from a YAML config.
+
+    Loads the config, builds terrain + layout, screens every flowline
+    (Darcy-Weisbach + Swamee-Jain, see :func:`darcy_weisbach_pressure_drop`),
+    renders the 2D layout plot, and exports the Blender scene JSON.
+
+    Parameters
+    ----------
+    config_path : str | Path
+        Field YAML (schema: ``data/onshore_demo_field.yml``).
+    output_dir : str | Path, optional
+        Redirect all output artifacts (plot, scene JSON) into this directory,
+        keeping the configured file names. Default: use the config paths as-is
+        (relative paths resolve against the current working directory).
+
+    Returns
+    -------
+    dict
+        Layout summary + per-flowline screening results + artifact paths.
+    """
+    config_file = Path(config_path)
+    config = load_field_config(config_file)
+    layout = build_layout(config, base_dir=config_file.parent)
+
+    fluid = config["fluid"]
+    screening_cfg = config.get("screening", {})
+    flowline_rows = []
+    for fl in layout.flowlines:
+        flowline_rows.append(
+            {
+                "id": fl.flowline_id,
+                "from": fl.from_id,
+                "to": fl.to_id,
+                "rate_m3_per_day": fl.rate_m3_per_day,
+                "inner_diameter_m": fl.inner_diameter_m,
+                "plan_length_m": round(fl.plan_length_m, 2),
+                "terrain_length_m": round(fl.terrain_length_m, 2),
+                "elevation_change_m": round(fl.elevation_change_m, 2),
+                "screening": screen_flowline(fl, fluid, screening_cfg),
+            }
+        )
+
+    plot_cfg = config["plot"]
+    plot_path = plot_layout(
+        layout,
+        _resolve_output(plot_cfg["output_path"], output_dir),
+        output_format=str(plot_cfg.get("format", "png")),
+        dpi=int(plot_cfg.get("dpi", 150)),
+    )
+    scene_cfg = config.get("scene_export", {})
+    scene_path: Optional[str] = None
+    if scene_cfg.get("output_path"):
+        scene_path = export_scene_json(
+            layout, _resolve_output(scene_cfg["output_path"], output_dir)
+        )
+
+    terrain = layout.terrain
+    return {
+        "field": layout.name,
+        "terrain": {
+            "source": terrain.source,
+            "x_range_m": [float(terrain.x_m[0]), float(terrain.x_m[-1])],
+            "y_range_m": [float(terrain.y_m[0]), float(terrain.y_m[-1])],
+            "z_range_m": [float(terrain.z_m.min()), float(terrain.z_m.max())],
+        },
+        "host": {"id": layout.host.asset_id, "z_m": round(layout.host.z_m, 2)},
+        "wells": [
+            {
+                "id": w.asset_id,
+                "x_m": w.x_m,
+                "y_m": w.y_m,
+                "z_m": round(w.z_m, 2),
+                "rate_m3_per_day": w.rate_m3_per_day,
+            }
+            for w in layout.wells
+        ],
+        "flowlines": flowline_rows,
+        "plot_path": plot_path,
+        "scene_path": scene_path,
+    }

--- a/tests/field_development/test_onshore_layout.py
+++ b/tests/field_development/test_onshore_layout.py
@@ -1,0 +1,341 @@
+# ABOUTME: Tests for onshore_layout — field-development tracer (#1508, epic #1507).
+# ABOUTME: Loader, terrain, 3D routing, Darcy-Weisbach screening, plot, API end-to-end.
+"""Tests for digitalmodel.field_development.onshore_layout."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.field_development.onshore_layout import (
+    LAMINAR_REYNOLDS_LIMIT,
+    build_layout,
+    build_terrain,
+    darcy_weisbach_pressure_drop,
+    load_field_config,
+    screen_layout,
+    swamee_jain_friction_factor,
+)
+
+DEMO_CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+    / "onshore_demo_field.yml"
+)
+
+
+def _minimal_layout_config(terrain: dict, host_xy=(0.0, 0.0), well_xy=(300.0, 0.0)):
+    """Smallest config build_layout accepts — one well, one flowline."""
+    return {
+        "field": {"name": "T"},
+        "terrain": terrain,
+        "host": {"id": "H", "x_m": host_xy[0], "y_m": host_xy[1]},
+        "wells": [
+            {"id": "W", "x_m": well_xy[0], "y_m": well_xy[1], "rate_m3_per_day": 100.0}
+        ],
+        "flowlines": [
+            {
+                "id": "FL",
+                "from_well": "W",
+                "to": "H",
+                "inner_diameter_m": 0.1524,
+                "roughness_m": 4.5e-5,
+            }
+        ],
+        "routing": {"sample_spacing_m": 10.0},
+    }
+
+
+# --- config loader -----------------------------------------------------------
+class TestLoadFieldConfig:
+    def test_bundled_demo_config_loads(self):
+        config = load_field_config(DEMO_CONFIG)
+        assert config["field"]["name"] == "Demo Onshore Field"
+        assert len(config["wells"]) == 3
+        assert len(config["flowlines"]) == 3
+        assert config["terrain"]["kind"] == "synthetic"
+
+    def test_missing_section_raises(self, tmp_path):
+        config = load_field_config(DEMO_CONFIG)
+        del config["fluid"]
+        bad = tmp_path / "bad.yml"
+        bad.write_text(yaml.safe_dump(config), encoding="utf-8")
+        with pytest.raises(ValueError, match="missing required sections.*fluid"):
+            load_field_config(bad)
+
+    def test_unknown_flowline_endpoint_raises(self):
+        config = _minimal_layout_config(
+            {
+                "kind": "synthetic",
+                "x_min_m": 0,
+                "x_max_m": 1000,
+                "y_min_m": 0,
+                "y_max_m": 1000,
+                "nx": 11,
+                "ny": 11,
+                "base_elevation_m": 100.0,
+                "amplitude_m": 0.0,
+                "x_wavelength_m": 500.0,
+                "y_wavelength_m": 500.0,
+            }
+        )
+        config["flowlines"][0]["from_well"] = "NOPE"
+        with pytest.raises(ValueError, match="unknown asset 'NOPE'"):
+            build_layout(config)
+
+
+# --- terrain -----------------------------------------------------------------
+class TestTerrain:
+    def test_synthetic_grid_matches_analytic_at_nodes(self):
+        spec = {
+            "kind": "synthetic",
+            "x_min_m": 0,
+            "x_max_m": 3000,
+            "y_min_m": 0,
+            "y_max_m": 3000,
+            "nx": 61,
+            "ny": 61,
+            "base_elevation_m": 350.0,
+            "amplitude_m": 40.0,
+            "x_wavelength_m": 2400.0,
+            "y_wavelength_m": 1800.0,
+        }
+        terrain = build_terrain(spec, Path("."))
+        # node (0, 0): sin(0) = 0 -> base elevation
+        assert terrain.elevation_at(0.0, 0.0) == pytest.approx(350.0)
+        # node (600, 0): x = wavelength/4 -> sin = 1, cos(0) = 1 -> base + amplitude
+        assert terrain.elevation_at(600.0, 0.0) == pytest.approx(390.0)
+
+    def test_csv_grid_bilinear_is_exact_on_a_plane(self, tmp_path):
+        # plane z = x/10 + y/10 sampled on a 2x2 grid
+        (tmp_path / "dem.csv").write_text("0,30\n40,70\n", encoding="utf-8")
+        spec = {
+            "kind": "csv_grid",
+            "csv_path": "dem.csv",
+            "x_min_m": 0,
+            "x_max_m": 300,
+            "y_min_m": 0,
+            "y_max_m": 400,
+        }
+        terrain = build_terrain(spec, tmp_path)
+        assert terrain.elevation_at(150.0, 200.0) == pytest.approx(35.0)
+        assert terrain.elevation_at(300.0, 400.0) == pytest.approx(70.0)
+
+    def test_out_of_domain_query_raises(self):
+        spec = {
+            "kind": "synthetic",
+            "x_min_m": 0,
+            "x_max_m": 100,
+            "y_min_m": 0,
+            "y_max_m": 100,
+            "nx": 3,
+            "ny": 3,
+            "base_elevation_m": 0.0,
+            "amplitude_m": 0.0,
+            "x_wavelength_m": 100.0,
+            "y_wavelength_m": 100.0,
+        }
+        terrain = build_terrain(spec, Path("."))
+        with pytest.raises(ValueError, match="outside the terrain domain"):
+            terrain.elevation_at(101.0, 50.0)
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="terrain.kind"):
+            build_terrain({"kind": "usgs_3dep"}, Path("."))
+
+
+# --- routing over terrain ----------------------------------------------------
+class TestRouting:
+    def test_flat_terrain_3d_length_equals_plan_length(self):
+        config = _minimal_layout_config(
+            {
+                "kind": "synthetic",
+                "x_min_m": 0,
+                "x_max_m": 1000,
+                "y_min_m": 0,
+                "y_max_m": 1000,
+                "nx": 11,
+                "ny": 11,
+                "base_elevation_m": 200.0,
+                "amplitude_m": 0.0,
+                "x_wavelength_m": 500.0,
+                "y_wavelength_m": 500.0,
+            },
+            host_xy=(0.0, 0.0),
+            well_xy=(300.0, 400.0),
+        )
+        layout = build_layout(config)
+        fl = layout.flowlines[0]
+        assert fl.plan_length_m == pytest.approx(500.0)
+        assert fl.terrain_length_m == pytest.approx(500.0)
+        assert fl.elevation_change_m == pytest.approx(0.0)
+
+    def test_planar_slope_3d_length_is_hypotenuse(self, tmp_path):
+        # uniform slope in x only: z rises 0 -> 30 m over 300 m
+        (tmp_path / "slope.csv").write_text("0,30\n0,30\n", encoding="utf-8")
+        config = _minimal_layout_config(
+            {
+                "kind": "csv_grid",
+                "csv_path": "slope.csv",
+                "x_min_m": 0,
+                "x_max_m": 300,
+                "y_min_m": 0,
+                "y_max_m": 100,
+            },
+            host_xy=(0.0, 50.0),
+            well_xy=(300.0, 50.0),
+        )
+        layout = build_layout(config, base_dir=tmp_path)
+        fl = layout.flowlines[0]
+        assert fl.plan_length_m == pytest.approx(300.0)
+        # straight line on a plane: L3d = sqrt(plan^2 + dz^2)
+        assert fl.terrain_length_m == pytest.approx(math.hypot(300.0, 30.0))
+        # flowline runs well -> host, i.e. downhill: dz = z_host - z_well = -30
+        assert fl.elevation_change_m == pytest.approx(-30.0)
+
+    def test_assets_sit_on_terrain_surface(self):
+        config = load_field_config(DEMO_CONFIG)
+        layout = build_layout(config, base_dir=DEMO_CONFIG.parent)
+        for asset in [layout.host, *layout.wells]:
+            assert asset.z_m == pytest.approx(
+                layout.terrain.elevation_at(asset.x_m, asset.y_m)
+            )
+
+
+# --- screening calc ----------------------------------------------------------
+class TestScreeningCalc:
+    def test_turbulent_darcy_weisbach_hand_calc(self):
+        """Hand-computed: rho=850, mu=5 cP, D=0.1524 m, eps=45 um, v=1 m/s, L=1 km.
+
+        A  = pi 0.1524^2/4          = 0.0182415 m^2
+        Re = 850*1*0.1524/0.005     = 25,908
+        f  (Swamee-Jain)            = 0.02504
+        dp = f (L/D) rho v^2/2      = 0.02504 * 6561.7 * 425 = 69.8 kPa
+        """
+        area = math.pi * 0.1524**2 / 4.0
+        result = darcy_weisbach_pressure_drop(
+            rate_m3_per_s=area * 1.0,  # v = 1 m/s exactly
+            length_m=1_000.0,
+            inner_diameter_m=0.1524,
+            roughness_m=4.5e-5,
+            density_kg_per_m3=850.0,
+            viscosity_pa_s=0.005,
+        )
+        assert result["velocity_m_per_s"] == pytest.approx(1.0)
+        assert result["reynolds"] == pytest.approx(25_908.0)
+        assert result["flow_regime"] == "turbulent"
+        assert result["friction_factor"] == pytest.approx(0.02504, rel=1e-3)
+        assert result["dp_friction_kpa"] == pytest.approx(69.8, rel=5e-3)
+        assert result["dp_elevation_kpa"] == pytest.approx(0.0)
+
+    def test_laminar_matches_hagen_poiseuille(self):
+        # Re = 850*0.5*0.1524/0.05 = 1295 < 2300 -> laminar
+        d, v, rho, mu, length = 0.1524, 0.5, 850.0, 0.05, 500.0
+        area = math.pi * d**2 / 4.0
+        result = darcy_weisbach_pressure_drop(
+            rate_m3_per_s=area * v,
+            length_m=length,
+            inner_diameter_m=d,
+            roughness_m=4.5e-5,
+            density_kg_per_m3=rho,
+            viscosity_pa_s=mu,
+        )
+        assert result["flow_regime"] == "laminar"
+        assert result["reynolds"] < LAMINAR_REYNOLDS_LIMIT
+        # laminar Darcy-Weisbach reduces to Hagen-Poiseuille: dp = 32 mu L v / D^2
+        expected_kpa = 32.0 * mu * length * v / d**2 / 1_000.0
+        assert result["dp_friction_kpa"] == pytest.approx(expected_kpa, rel=1e-9)
+
+    def test_elevation_term_is_rho_g_dz(self):
+        area = math.pi * 0.1524**2 / 4.0
+        result = darcy_weisbach_pressure_drop(
+            rate_m3_per_s=area * 1.0,
+            length_m=100.0,
+            inner_diameter_m=0.1524,
+            roughness_m=4.5e-5,
+            density_kg_per_m3=850.0,
+            viscosity_pa_s=0.005,
+            elevation_change_m=10.0,
+        )
+        assert result["dp_elevation_kpa"] == pytest.approx(
+            850.0 * 9.80665 * 10.0 / 1_000.0
+        )
+        assert result["dp_total_kpa"] == pytest.approx(
+            result["dp_friction_kpa"] + result["dp_elevation_kpa"]
+        )
+
+    def test_laminar_friction_factor_is_64_over_re(self):
+        assert swamee_jain_friction_factor(1_000.0, 3e-4) == pytest.approx(0.064)
+
+    def test_invalid_inputs_raise(self):
+        with pytest.raises(ValueError):
+            swamee_jain_friction_factor(0.0, 3e-4)
+        with pytest.raises(ValueError):
+            darcy_weisbach_pressure_drop(
+                rate_m3_per_s=0.0,
+                length_m=100.0,
+                inner_diameter_m=0.1524,
+                roughness_m=4.5e-5,
+                density_kg_per_m3=850.0,
+                viscosity_pa_s=0.005,
+            )
+
+
+# --- API end-to-end ----------------------------------------------------------
+class TestScreenLayoutApi:
+    def test_end_to_end_on_bundled_demo_field(self, tmp_path):
+        result = screen_layout(DEMO_CONFIG, output_dir=tmp_path)
+
+        assert result["field"] == "Demo Onshore Field"
+        assert len(result["wells"]) == 3
+        assert len(result["flowlines"]) == 3
+
+        for row in result["flowlines"]:
+            assert row["plan_length_m"] > 0
+            # 3D length over terrain can never be shorter than plan length
+            assert row["terrain_length_m"] >= row["plan_length_m"]
+            screening = row["screening"]
+            assert screening["velocity_m_per_s"] > 0
+            assert screening["reynolds"] > 0
+            assert 0 < screening["friction_factor"] < 0.1
+            assert math.isfinite(screening["dp_total_kpa"])
+            assert screening["velocity_ok"] is True  # demo rates are well below 4 m/s
+
+        plot_path = Path(result["plot_path"])
+        assert plot_path.parent == tmp_path
+        assert plot_path.exists() and plot_path.stat().st_size > 0
+
+        scene_path = Path(result["scene_path"])
+        assert scene_path.exists()
+        scene = json.loads(scene_path.read_text(encoding="utf-8"))
+        assert scene["field_name"] == "Demo Onshore Field"
+        assert len(scene["assets"]) == 4  # host + 3 wells
+        assert len(scene["flowlines"]) == 3
+        assert len(scene["terrain"]["z_m"]) == 61
+        assert len(scene["terrain"]["z_m"][0]) == 61
+
+    def test_results_are_deterministic(self, tmp_path):
+        first = screen_layout(DEMO_CONFIG, output_dir=tmp_path / "a")
+        second = screen_layout(DEMO_CONFIG, output_dir=tmp_path / "b")
+        assert first["flowlines"] == second["flowlines"]
+        assert first["terrain"] == second["terrain"]
+
+    def test_velocity_flag_trips_when_threshold_tightened(self, tmp_path):
+        config = load_field_config(DEMO_CONFIG)
+        config["screening"]["max_velocity_m_per_s"] = 0.01
+        # keep the synthetic terrain; only outputs + threshold change
+        config["plot"]["output_path"] = "layout.png"
+        config["scene_export"]["output_path"] = "scene.json"
+        tight = tmp_path / "tight.yml"
+        tight.write_text(yaml.safe_dump(config), encoding="utf-8")
+        result = screen_layout(tight, output_dir=tmp_path)
+        assert all(
+            row["screening"]["velocity_ok"] is False for row in result["flowlines"]
+        )


### PR DESCRIPTION
Closes #1508. Tracer slice of epic #1507 — ONE onshore demo field end-to-end, proving the whole spine (config -> terrain -> layout -> screening -> plot -> 3D scene -> API) before any workstream widens.

## What's in the slice

| Piece | Where |
|---|---|
| YAML demo field (ALL constants externalized: terrain spec, 3 wells, 3 flowlines, host pad, fluid, outputs) | `src/digitalmodel/field_development/data/onshore_demo_field.yml` |
| Loader + typed layout model + terrain (synthetic grid or bundled CSV grid, bilinear elevation queries) | `src/digitalmodel/field_development/onshore_layout.py` |
| Straight-line flowline routing with **3D length over the terrain** (not plan length) | same module |
| ONE screening calc: Darcy-Weisbach pressure drop, Swamee-Jain friction factor (Swamee & Jain 1976, J. Hydraulics Div. ASCE 102(5); laminar f = 64/Re), plus hydrostatic elevation term | `darcy_weisbach_pressure_drop()` |
| Deterministic 2D layout plot (terrain contours + assets + flowlines + lengths) | `plot_layout()` via the existing `schematics.renderer.render_figure` |
| Blender fly-through script (bpy, ~4 s orbit; consumes the exported scene JSON) | `scripts/field_development/onshore_flythrough_bpy.py` |
| Representative API call: `screen_layout(config_path) -> dict` (layout summary + screening + artifact paths) | exported from `digitalmodel.field_development` |
| Tests: loader, terrain, routing geometry (flat + planar-slope hand checks), screening vs hand-computed value + Hagen-Poiseuille cross-check, API end-to-end in tmp_path | `tests/field_development/test_onshore_layout.py` |

## Deliberate tracer-scope limits (follow-ons of #1507, not bugs)

- **Terrain is a small synthetic/bundled grid.** Real USGS 3DEP DEM ingestion is worldenergydata#930's deliverable; this module's `TerrainGrid` + `csv_grid` path is the seam it will plug into.
- Straight-line plan routing only (no obstacle avoidance / least-cost path).
- Single-phase incompressible screening only (no multiphase flow assurance).
- **Blender was NOT installed on the dev box** — the bpy script is committed with a "requires Blender" docstring and the exact headless render invocation, but no clip was rendered (per the issue: script + invocation docs; no faked render). The rendered video lands under `outputs/`, which is already gitignored.

## Verification

- `.venv/bin/python -m pytest tests/field_development/test_onshore_layout.py -v` — **18 passed**.
- Full package regression: `pytest tests/field_development/` — **545 passed, 32 skipped** (no existing test broken).
- Lint: repo venv `ruff check` / `black --check` / `isort --check` clean on all new files (`__init__.py` keeps its pre-existing import order — already not isort-sorted on main — and stays ruff- and black-clean).
- Screening hand-check in-test: rho=850 kg/m3, mu=5 cP, D=0.1524 m, eps=45 um, v=1 m/s, L=1 km -> Re=25,908, f=0.02504 (Swamee-Jain), dp=69.8 kPa.
- Demo field numbers are clearly-labelled generic demo values; the only physical constants are textbook (g, laminar limit, commercial-steel roughness in the YAML).
