### PR TITLE
fix: set camera clip range in onshore fly-through bpy script

### DIFF
--- a/scripts/field_development/onshore_flythrough_bpy.py
+++ b/scripts/field_development/onshore_flythrough_bpy.py
@@ -139,6 +139,10 @@ def _add_camera_flythrough(centre: tuple[float, float, float], radius: float) ->
     bpy.context.collection.objects.link(target)
 
     camera_data = bpy.data.cameras.new("camera")
+    # Field spans are km-scale; Blender's default clip_end (100 m) would cull
+    # the entire scene and render only the world background.
+    camera_data.clip_start = max(0.1, 0.001 * radius)
+    camera_data.clip_end = 10.0 * radius
     camera = bpy.data.objects.new("camera", camera_data)
     bpy.context.collection.objects.link(camera)
     bpy.context.scene.camera = camera


### PR DESCRIPTION
Follow-up to #1515 (epic #1507). First real headless render of the #1508 fly-through produced blank gray frames: Blender's default camera `clip_end` (100 m) culled the entire km-scale field scene, so only the world background rendered.

Fix: scale the camera clip range to the orbit radius (`clip_start = max(0.1, 0.001·r)`, `clip_end = 10·r`).

Verified end-to-end on Blender 4.0.2 headless: 96-frame 1280×720 MPEG-4 renders with terrain, host pad, wells, and flowlines visible (frame-48 spot check via ffmpeg).