### PR TITLE
Field-development layout model: full asset schema + offshore-ready surfaces + waypoint routing (#1509)

### DIFF
--- a/src/digitalmodel/field_development/data/offshore_demo_field.yml
+++ b/src/digitalmodel/field_development/data/offshore_demo_field.yml
@@ -1,0 +1,122 @@
+# ABOUTME: Demo offshore field for the full layout model (#1509, epic #1507).
+# ABOUTME: Synthetic bathymetry (negative elevation) + subsea asset taxonomy demo.
+#
+# Synthetic demo field. Coordinates are a local Cartesian grid in metres
+# (easting/northing from an arbitrary field datum). Elevation is signed
+# relative to the sea surface: NEGATIVE values are water depth (bathymetry).
+# The synthetic surface stands in for a real bathymetry grid (e.g. GEBCO /
+# NOAA); real-source ingestion is the worldenergydata data-foundation epic's
+# deliverable (worldenergydata#929), not this model's.
+
+field:
+  name: Demo Offshore Field
+  coordinate_note: local Cartesian metres from field datum; z negative below sea surface
+
+surface:
+  kind: synthetic          # synthetic | csv_grid
+  x_min_m: 0.0
+  x_max_m: 8000.0
+  y_min_m: 0.0
+  y_max_m: 8000.0
+  nx: 81
+  ny: 81
+  base_elevation_m: -1450.0   # nominal water depth 1450 m
+  amplitude_m: 60.0
+  x_wavelength_m: 6000.0
+  y_wavelength_m: 5000.0
+
+assets:
+  - id: FPSO-1
+    kind: vessel
+    subtype: fpso
+    name: Demo FPSO
+    x_m: 4000.0
+    y_m: 4000.0
+    z_m: 0.0                 # floats at the sea surface (explicit override)
+  - id: MAN-1
+    kind: manifold
+    subtype: 4-slot cluster manifold
+    name: Drill-centre manifold
+    x_m: 2500.0
+    y_m: 2500.0
+  - id: W-1
+    kind: well
+    name: Demo subsea well 1
+    x_m: 2000.0
+    y_m: 2000.0
+    rate_m3_per_day: 950.0   # gross liquid rate (demo value)
+  - id: W-2
+    kind: well
+    name: Demo subsea well 2
+    x_m: 2900.0
+    y_m: 1900.0
+    rate_m3_per_day: 820.0
+  - id: W-3
+    kind: well
+    name: Demo subsea well 3
+    x_m: 1900.0
+    y_m: 3000.0
+    rate_m3_per_day: 780.0
+  - id: XT-1                 # trees are co-located with their wells
+    kind: tree
+    subtype: vertical
+    x_m: 2000.0
+    y_m: 2000.0
+  - id: XT-2
+    kind: tree
+    subtype: vertical
+    x_m: 2900.0
+    y_m: 1900.0
+  - id: XT-3
+    kind: tree
+    subtype: vertical
+    x_m: 1900.0
+    y_m: 3000.0
+  - id: EXP-1
+    kind: host
+    subtype: export tie-in
+    name: Export pipeline tie-in
+    x_m: 7500.0
+    y_m: 4000.0
+
+connections:
+  - id: JMP-1
+    kind: jumper
+    from: XT-1
+    to: MAN-1
+    inner_diameter_m: 0.1524   # 6-inch nominal bore (demo)
+    roughness_m: 4.5e-05       # commercial steel absolute roughness (Moody chart)
+  - id: JMP-2
+    kind: jumper
+    from: XT-2
+    to: MAN-1
+    inner_diameter_m: 0.1524
+    roughness_m: 4.5e-05
+  - id: JMP-3
+    kind: jumper
+    from: XT-3
+    to: MAN-1
+    inner_diameter_m: 0.1524
+    roughness_m: 4.5e-05
+  - id: FL-1                   # production flowline, routed via a waypoint
+    kind: flowline
+    from: MAN-1
+    to: FPSO-1
+    inner_diameter_m: 0.254    # 10-inch nominal bore (demo)
+    roughness_m: 4.5e-05
+    waypoints:
+      - x_m: 3200.0
+        y_m: 3600.0
+  - id: UMB-1                  # controls/chemicals umbilical (no bore hydraulics)
+    kind: umbilical
+    from: FPSO-1
+    to: MAN-1
+  - id: PL-1                   # export pipeline
+    kind: pipeline
+    from: FPSO-1
+    to: EXP-1
+    inner_diameter_m: 0.4064   # 16-inch nominal bore (demo)
+    roughness_m: 4.5e-05
+
+routing:
+  sample_spacing_m: 50.0       # surface sampling step along each routed leg

--- a/src/digitalmodel/field_development/layout_model.py
+++ b/src/digitalmodel/field_development/layout_model.py
@@ -1,0 +1,517 @@
+# ABOUTME: Full field-layout model — YAML asset schema + layout engine over terrain/bathymetry.
+# ABOUTME: Issue #1509 (workstream B of epic #1507). Generalizes the #1508 onshore tracer.
+"""
+digitalmodel.field_development.layout_model
+============================================
+
+Workstream B (#1509) of the field-development epic (#1507): the FULL
+field-layout model, generalizing the onshore tracer
+(:mod:`digitalmodel.field_development.onshore_layout`, #1508) —
+
+1. **Full asset schema (YAML-first)** — beyond the tracer's host/wells the
+   schema covers the subsea/onshore taxonomy: ``host``, ``vessel``, ``well``,
+   ``tree``, ``manifold`` assets connected by ``jumper``, ``flowline``,
+   ``pipeline``, ``umbilical`` links. ALL configuration is externalized to
+   YAML (see ``data/offshore_demo_field.yml``); nothing is hardcoded here.
+2. **Offshore-ready surface** — the surface is the tracer's
+   :class:`~digitalmodel.field_development.onshore_layout.TerrainGrid`
+   (bilinear DEM queries). Elevation is signed relative to the field datum
+   (sea level offshore), so bathymetry is simply NEGATIVE elevation — the
+   later offshore data slice swaps the surface DATA, not this model.
+3. **Layout engine** — assets are draped onto the surface (optional explicit
+   ``z_m`` override for floating hosts/vessels at the waterline); connections
+   route through optional intermediate plan waypoints as piecewise straight
+   legs, each leg sampled and draped over the surface, with TRUE 3D lengths.
+4. **Back-compat** — the tracer schema (``host``/``wells``/``flowlines`` with
+   ``from_well``) still loads: :func:`load_layout_config` normalizes it into
+   the generalized ``assets``/``connections`` form.
+
+Scope honesty
+-------------
+Routing is piecewise straight in plan (no pathfinding, no obstacle avoidance,
+no least-cost optimization — follow-on workstreams of #1507). A floating
+host's riser is approximated by the straight final segment from the last
+draped sample up to the host's explicit ``z_m`` (screening-grade geometry,
+not a catenary). Hydraulic screening lives in workstream D and in the tracer's
+:func:`~digitalmodel.field_development.onshore_layout.screen_flowline`.
+
+Usage
+-----
+>>> from digitalmodel.field_development.layout_model import (
+...     build_layout_model, load_layout_config,
+... )
+>>> config = load_layout_config(
+...     "src/digitalmodel/field_development/data/offshore_demo_field.yml"
+... )  # doctest: +SKIP
+>>> model = build_layout_model(config, base_dir="...")  # doctest: +SKIP
+>>> model.connections[0].route_length_m  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import yaml
+
+from .onshore_layout import TerrainGrid, build_terrain
+
+# --- schema vocabulary -------------------------------------------------------
+#: Recognized asset kinds (surface-placed field infrastructure).
+ASSET_KINDS = frozenset({"host", "vessel", "well", "tree", "manifold"})
+#: Recognized connection kinds (routed links between assets).
+CONNECTION_KINDS = frozenset({"jumper", "flowline", "pipeline", "umbilical"})
+
+_REQUIRED_SECTIONS = ("field", "assets", "connections")
+_TRACER_SECTIONS = ("host", "wells", "flowlines")
+
+_ASSET_KNOWN_KEYS = frozenset(
+    {"id", "kind", "subtype", "name", "x_m", "y_m", "z_m", "rate_m3_per_day"}
+)
+_CONNECTION_KNOWN_KEYS = frozenset(
+    {"id", "kind", "from", "to", "waypoints", "inner_diameter_m", "roughness_m"}
+)
+
+_DEFAULT_SAMPLE_SPACING_M = 25.0
+
+
+# ---------------------------------------------------------------------------
+# Typed model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LayoutAsset:
+    """A field asset placed on (or above) the terrain/bathymetry surface.
+
+    ``on_surface`` is True when ``z_m`` was draped from the surface; False
+    when the config gave an explicit ``z_m`` (e.g. a floating host at the
+    waterline, ``z_m: 0.0``, above negative-elevation bathymetry).
+    """
+
+    asset_id: str
+    kind: str  # one of ASSET_KINDS
+    x_m: float
+    y_m: float
+    z_m: float
+    name: str = ""
+    subtype: str = ""
+    on_surface: bool = True
+    rate_m3_per_day: Optional[float] = None
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RoutedConnection:
+    """A routed connection: piecewise straight plan legs draped over the surface.
+
+    ``route_length_m`` is the TRUE 3D polyline length (sum of straight-segment
+    lengths of the sampled, draped path) — never shorter than
+    ``plan_length_m``. ``elevation_change_m`` is ``z_to - z_from``.
+    """
+
+    connection_id: str
+    kind: str  # one of CONNECTION_KINDS
+    from_id: str
+    to_id: str
+    path_xyz_m: np.ndarray = field(repr=False)  # (n, 3) sampled polyline
+    waypoints_plan_m: list[tuple[float, float]] = field(default_factory=list)
+    plan_length_m: float = 0.0
+    route_length_m: float = 0.0
+    elevation_change_m: float = 0.0
+    inner_diameter_m: Optional[float] = None
+    roughness_m: Optional[float] = None
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FieldLayoutModel:
+    """Typed layout of one field: surface + placed assets + routed connections."""
+
+    name: str
+    surface: TerrainGrid
+    surface_spec: dict[str, Any]
+    assets: list[LayoutAsset]
+    connections: list[RoutedConnection]
+    sample_spacing_m: float = _DEFAULT_SAMPLE_SPACING_M
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def asset(self, asset_id: str) -> LayoutAsset:
+        """Return the asset with ``asset_id`` (KeyError if absent)."""
+        for a in self.assets:
+            if a.asset_id == asset_id:
+                return a
+        raise KeyError(asset_id)
+
+    def assets_of_kind(self, kind: str) -> list[LayoutAsset]:
+        """All assets of one kind (e.g. ``\"well\"``)."""
+        return [a for a in self.assets if a.kind == kind]
+
+    def connections_of_kind(self, kind: str) -> list[RoutedConnection]:
+        """All connections of one kind (e.g. ``\"flowline\"``)."""
+        return [c for c in self.connections if c.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Config loading + normalization (tracer schema back-compat)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_tracer_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Map the #1508 tracer schema onto the generalized assets/connections form.
+
+    Tracer: ``host`` (single mapping) + ``wells`` + ``flowlines`` (with
+    ``from_well``/``to``). Generalized: ``assets`` + ``connections``.
+    Unrelated sections (fluid, screening, plot, scene_export, ...) pass
+    through untouched.
+    """
+    normalized = {k: v for k, v in config.items() if k not in _TRACER_SECTIONS}
+    host = dict(config["host"])
+    host["kind"] = "host"
+    assets: list[dict[str, Any]] = [host]
+    for well in config["wells"]:
+        w = dict(well)
+        w["kind"] = "well"
+        assets.append(w)
+    connections: list[dict[str, Any]] = []
+    for fl in config["flowlines"]:
+        c = dict(fl)
+        c["kind"] = "flowline"
+        c["from"] = c.pop("from_well")
+        connections.append(c)
+    normalized["assets"] = assets
+    normalized["connections"] = connections
+    return normalized
+
+
+def load_layout_config(config_path: str | Path) -> dict[str, Any]:
+    """Load + validate a field-layout YAML config, normalized to the full schema.
+
+    Accepts either the generalized schema (``assets`` + ``connections`` +
+    ``surface``) or the #1508 tracer schema (``host`` + ``wells`` +
+    ``flowlines`` + ``terrain``), which is normalized into the generalized
+    form. The returned mapping always has ``field``, ``surface``, ``assets``,
+    ``connections``.
+    """
+    path = Path(config_path)
+    with open(path, "r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+    if not isinstance(config, dict):
+        raise ValueError(f"config {path} did not parse to a mapping")
+    return normalize_layout_config(config, source=str(path))
+
+
+def normalize_layout_config(
+    config: dict[str, Any], source: str = "<config>"
+) -> dict[str, Any]:
+    """Validate a parsed config mapping and normalize it to the full schema."""
+    if "assets" not in config and all(k in config for k in _TRACER_SECTIONS):
+        config = _normalize_tracer_config(config)
+    # `surface` is the canonical section name; `terrain` (tracer) is an alias.
+    if "surface" not in config and "terrain" in config:
+        config = dict(config)
+        config["surface"] = config.pop("terrain")
+    missing = [k for k in (*_REQUIRED_SECTIONS, "surface") if k not in config]
+    if missing:
+        raise ValueError(f"config {source} missing required sections: {missing}")
+    if not config["assets"]:
+        raise ValueError(f"config {source} must define at least one asset")
+    if config["connections"] is None:
+        config = dict(config)
+        config["connections"] = []
+    _validate_schema(config, source)
+    return config
+
+
+def _validate_schema(config: dict[str, Any], source: str) -> None:
+    """Schema-level checks: kinds, unique ids, connectivity (no dangling refs)."""
+    asset_ids: set[str] = set()
+    for spec in config["assets"]:
+        asset_id = str(spec.get("id"))
+        kind = spec.get("kind")
+        if kind not in ASSET_KINDS:
+            raise ValueError(
+                f"{source}: asset {asset_id!r} has unknown kind {kind!r}; "
+                f"expected one of {sorted(ASSET_KINDS)}"
+            )
+        if asset_id in asset_ids:
+            raise ValueError(f"{source}: duplicate asset id {asset_id!r}")
+        asset_ids.add(asset_id)
+        for key in ("x_m", "y_m"):
+            if key not in spec:
+                raise ValueError(f"{source}: asset {asset_id!r} missing {key!r}")
+    connection_ids: set[str] = set()
+    for spec in config["connections"]:
+        conn_id = str(spec.get("id"))
+        kind = spec.get("kind")
+        if kind not in CONNECTION_KINDS:
+            raise ValueError(
+                f"{source}: connection {conn_id!r} has unknown kind {kind!r}; "
+                f"expected one of {sorted(CONNECTION_KINDS)}"
+            )
+        if conn_id in connection_ids:
+            raise ValueError(f"{source}: duplicate connection id {conn_id!r}")
+        connection_ids.add(conn_id)
+        for end in ("from", "to"):
+            ref = str(spec.get(end))
+            if ref not in asset_ids:
+                raise ValueError(
+                    f"{source}: connection {conn_id!r} references unknown "
+                    f"asset {ref!r} (dangling {end!r} reference)"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Layout engine: placement + waypoint routing
+# ---------------------------------------------------------------------------
+
+
+def _place_asset(spec: dict[str, Any], surface: TerrainGrid) -> LayoutAsset:
+    """Place one asset: drape onto the surface unless an explicit z_m is given."""
+    x, y = float(spec["x_m"]), float(spec["y_m"])
+    if "z_m" in spec:
+        z, on_surface = float(spec["z_m"]), False
+    else:
+        z, on_surface = surface.elevation_at(x, y), True
+    rate = spec.get("rate_m3_per_day")
+    extras = {k: v for k, v in spec.items() if k not in _ASSET_KNOWN_KEYS}
+    return LayoutAsset(
+        asset_id=str(spec["id"]),
+        kind=str(spec["kind"]),
+        x_m=x,
+        y_m=y,
+        z_m=z,
+        name=str(spec.get("name", spec["id"])),
+        subtype=str(spec.get("subtype", "")),
+        on_surface=on_surface,
+        rate_m3_per_day=None if rate is None else float(rate),
+        properties=extras,
+    )
+
+
+def _drape_leg(
+    surface: TerrainGrid,
+    p0: tuple[float, float],
+    p1: tuple[float, float],
+    sample_spacing_m: float,
+) -> np.ndarray:
+    """One straight plan leg p0 -> p1, sampled and draped over the surface.
+
+    Returns an (n+1, 3) array including both endpoints; z is the bilinear
+    surface elevation at each sample.
+    """
+    plan_length = math.hypot(p1[0] - p0[0], p1[1] - p0[1])
+    n_segments = max(1, int(math.ceil(plan_length / sample_spacing_m)))
+    t = np.linspace(0.0, 1.0, n_segments + 1)
+    xs = p0[0] + t * (p1[0] - p0[0])
+    ys = p0[1] + t * (p1[1] - p0[1])
+    zs = np.array([surface.elevation_at(x, y) for x, y in zip(xs, ys)])
+    return np.column_stack([xs, ys, zs])
+
+
+def route_connection(
+    spec: dict[str, Any],
+    assets: dict[str, LayoutAsset],
+    surface: TerrainGrid,
+    sample_spacing_m: float = _DEFAULT_SAMPLE_SPACING_M,
+) -> RoutedConnection:
+    """Route one connection: from-asset -> waypoints... -> to-asset.
+
+    Piecewise straight in plan; every leg is sampled and draped over the
+    surface. If an endpoint asset has an explicit (off-surface) ``z_m`` —
+    e.g. a floating host at the waterline — the endpoint sample takes that
+    elevation, so the final segment rises straight from the last draped
+    sample to the asset (screening-grade riser stand-in). Lengths are true
+    3D polyline lengths.
+    """
+    from_id, to_id = str(spec["from"]), str(spec["to"])
+    for ref in (from_id, to_id):
+        if ref not in assets:
+            raise ValueError(
+                f"connection {spec.get('id')!r} references unknown asset {ref!r}"
+            )
+    a, b = assets[from_id], assets[to_id]
+    waypoints = [
+        (float(w["x_m"]), float(w["y_m"])) for w in (spec.get("waypoints") or [])
+    ]
+    plan_points = [(a.x_m, a.y_m), *waypoints, (b.x_m, b.y_m)]
+
+    legs = []
+    for p0, p1 in zip(plan_points[:-1], plan_points[1:]):
+        leg = _drape_leg(surface, p0, p1, sample_spacing_m)
+        legs.append(leg if not legs else leg[1:])  # drop duplicate joint point
+    path = np.vstack(legs)
+
+    # Endpoint elevation overrides (off-surface assets, e.g. floating hosts).
+    if not a.on_surface:
+        path[0, 2] = a.z_m
+    if not b.on_surface:
+        path[-1, 2] = b.z_m
+
+    plan_length = sum(
+        math.hypot(p1[0] - p0[0], p1[1] - p0[1])
+        for p0, p1 in zip(plan_points[:-1], plan_points[1:])
+    )
+    seg = np.diff(path, axis=0)
+    route_length = float(np.sum(np.sqrt(np.sum(seg**2, axis=1))))
+
+    diameter = spec.get("inner_diameter_m")
+    roughness = spec.get("roughness_m")
+    extras = {k: v for k, v in spec.items() if k not in _CONNECTION_KNOWN_KEYS}
+    return RoutedConnection(
+        connection_id=str(spec["id"]),
+        kind=str(spec["kind"]),
+        from_id=from_id,
+        to_id=to_id,
+        path_xyz_m=path,
+        waypoints_plan_m=waypoints,
+        plan_length_m=plan_length,
+        route_length_m=route_length,
+        elevation_change_m=float(path[-1, 2] - path[0, 2]),
+        inner_diameter_m=None if diameter is None else float(diameter),
+        roughness_m=None if roughness is None else float(roughness),
+        properties=extras,
+    )
+
+
+def build_layout_model(
+    config: dict[str, Any], base_dir: str | Path = "."
+) -> FieldLayoutModel:
+    """Build the typed field-layout model from a normalized config mapping.
+
+    ``base_dir`` resolves relative data paths inside the config (e.g. a
+    ``csv_grid`` surface file) — pass the config file's parent directory.
+    """
+    config = normalize_layout_config(config)
+    surface_spec = config["surface"]
+    surface = build_terrain(surface_spec, Path(base_dir))
+
+    assets = [_place_asset(spec, surface) for spec in config["assets"]]
+    asset_map = {a.asset_id: a for a in assets}
+
+    routing = config.get("routing") or {}
+    sample_spacing = float(routing.get("sample_spacing_m", _DEFAULT_SAMPLE_SPACING_M))
+    connections = [
+        route_connection(spec, asset_map, surface, sample_spacing)
+        for spec in config["connections"]
+    ]
+
+    field_section = dict(config["field"])
+    name = str(field_section.pop("name"))
+    return FieldLayoutModel(
+        name=name,
+        surface=surface,
+        surface_spec=dict(surface_spec),
+        assets=assets,
+        connections=connections,
+        sample_spacing_m=sample_spacing,
+        metadata=field_section,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip export + summary
+# ---------------------------------------------------------------------------
+
+
+def layout_model_to_config(model: FieldLayoutModel) -> dict[str, Any]:
+    """Emit the model back as a normalized, YAML-serializable config mapping.
+
+    Round-trip property: ``build_layout_model(layout_model_to_config(m))``
+    rebuilds an equivalent model (same ids, kinds, coordinates, routes).
+    """
+    assets = []
+    for a in model.assets:
+        spec: dict[str, Any] = {
+            "id": a.asset_id,
+            "kind": a.kind,
+            "x_m": a.x_m,
+            "y_m": a.y_m,
+        }
+        if a.name and a.name != a.asset_id:
+            spec["name"] = a.name
+        if a.subtype:
+            spec["subtype"] = a.subtype
+        if not a.on_surface:
+            spec["z_m"] = a.z_m
+        if a.rate_m3_per_day is not None:
+            spec["rate_m3_per_day"] = a.rate_m3_per_day
+        spec.update(a.properties)
+        assets.append(spec)
+    connections = []
+    for c in model.connections:
+        cspec: dict[str, Any] = {
+            "id": c.connection_id,
+            "kind": c.kind,
+            "from": c.from_id,
+            "to": c.to_id,
+        }
+        if c.waypoints_plan_m:
+            cspec["waypoints"] = [{"x_m": x, "y_m": y} for x, y in c.waypoints_plan_m]
+        if c.inner_diameter_m is not None:
+            cspec["inner_diameter_m"] = c.inner_diameter_m
+        if c.roughness_m is not None:
+            cspec["roughness_m"] = c.roughness_m
+        cspec.update(c.properties)
+        connections.append(cspec)
+    return {
+        "field": {"name": model.name, **model.metadata},
+        "surface": dict(model.surface_spec),
+        "assets": assets,
+        "connections": connections,
+        "routing": {"sample_spacing_m": model.sample_spacing_m},
+    }
+
+
+def layout_summary(model: FieldLayoutModel) -> dict[str, Any]:
+    """JSON-able summary: surface ranges, assets by kind, per-connection lengths."""
+    surface = model.surface
+    by_kind: dict[str, int] = {}
+    for a in model.assets:
+        by_kind[a.kind] = by_kind.get(a.kind, 0) + 1
+    return {
+        "field": model.name,
+        "surface": {
+            "source": surface.source,
+            "x_range_m": [float(surface.x_m[0]), float(surface.x_m[-1])],
+            "y_range_m": [float(surface.y_m[0]), float(surface.y_m[-1])],
+            "z_range_m": [float(surface.z_m.min()), float(surface.z_m.max())],
+            "is_subsea": bool(surface.z_m.max() <= 0.0),
+        },
+        "assets_by_kind": by_kind,
+        "assets": [
+            {
+                "id": a.asset_id,
+                "kind": a.kind,
+                "x_m": a.x_m,
+                "y_m": a.y_m,
+                "z_m": round(a.z_m, 3),
+                "on_surface": a.on_surface,
+            }
+            for a in model.assets
+        ],
+        "connections": [
+            {
+                "id": c.connection_id,
+                "kind": c.kind,
+                "from": c.from_id,
+                "to": c.to_id,
+                "n_waypoints": len(c.waypoints_plan_m),
+                "plan_length_m": round(c.plan_length_m, 2),
+                "route_length_m": round(c.route_length_m, 2),
+                "elevation_change_m": round(c.elevation_change_m, 2),
+            }
+            for c in model.connections
+        ],
+    }
+
+
+def build_layout_model_from_file(config_path: str | Path) -> FieldLayoutModel:
+    """Convenience: load + normalize + build in one call (paths resolve
+    against the config file's directory)."""
+    path = Path(config_path)
+    config = load_layout_config(path)
+    return build_layout_model(config, base_dir=path.parent)

--- a/tests/field_development/test_layout_model.py
+++ b/tests/field_development/test_layout_model.py
@@ -1,0 +1,354 @@
+# ABOUTME: Tests for layout_model — full field-layout model (#1509, epic #1507).
+# ABOUTME: Schema round-trip, connectivity validation, waypoint routing, offshore e2e, tracer back-compat.
+"""Tests for digitalmodel.field_development.layout_model."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.field_development.layout_model import (
+    ASSET_KINDS,
+    CONNECTION_KINDS,
+    build_layout_model,
+    build_layout_model_from_file,
+    layout_model_to_config,
+    layout_summary,
+    load_layout_config,
+)
+from digitalmodel.field_development.onshore_layout import build_layout
+
+DATA_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+)
+OFFSHORE_CONFIG = DATA_DIR / "offshore_demo_field.yml"
+ONSHORE_CONFIG = DATA_DIR / "onshore_demo_field.yml"
+
+
+def _flat_surface(base_elevation_m: float, extent_m: float = 1000.0) -> dict:
+    """Flat synthetic surface spec (amplitude 0) at a fixed elevation."""
+    return {
+        "kind": "synthetic",
+        "x_min_m": 0.0,
+        "x_max_m": extent_m,
+        "y_min_m": 0.0,
+        "y_max_m": extent_m,
+        "nx": 11,
+        "ny": 11,
+        "base_elevation_m": base_elevation_m,
+        "amplitude_m": 0.0,
+        "x_wavelength_m": extent_m / 2.0,
+        "y_wavelength_m": extent_m / 2.0,
+    }
+
+
+def _minimal_config(surface: dict, assets: list, connections: list) -> dict:
+    return {
+        "field": {"name": "T"},
+        "surface": surface,
+        "assets": assets,
+        "connections": connections,
+        "routing": {"sample_spacing_m": 10.0},
+    }
+
+
+# --- schema + validation -----------------------------------------------------
+class TestSchema:
+    def test_offshore_demo_config_loads(self):
+        config = load_layout_config(OFFSHORE_CONFIG)
+        assert config["field"]["name"] == "Demo Offshore Field"
+        kinds = {a["kind"] for a in config["assets"]}
+        assert kinds == {"vessel", "manifold", "well", "tree", "host"}
+        assert {c["kind"] for c in config["connections"]} == {
+            "jumper",
+            "flowline",
+            "umbilical",
+            "pipeline",
+        }
+        assert kinds <= ASSET_KINDS
+
+    def test_unknown_asset_kind_rejected(self):
+        config = _minimal_config(
+            _flat_surface(100.0),
+            [{"id": "A", "kind": "spaceship", "x_m": 0.0, "y_m": 0.0}],
+            [],
+        )
+        with pytest.raises(ValueError, match="unknown kind 'spaceship'"):
+            build_layout_model(config)
+
+    def test_unknown_connection_kind_rejected(self):
+        config = _minimal_config(
+            _flat_surface(100.0),
+            [
+                {"id": "A", "kind": "well", "x_m": 0.0, "y_m": 0.0},
+                {"id": "B", "kind": "host", "x_m": 100.0, "y_m": 0.0},
+            ],
+            [{"id": "C-1", "kind": "teleporter", "from": "A", "to": "B"}],
+        )
+        with pytest.raises(ValueError, match="unknown kind 'teleporter'"):
+            build_layout_model(config)
+
+    def test_dangling_connection_reference_rejected(self):
+        config = _minimal_config(
+            _flat_surface(100.0),
+            [{"id": "A", "kind": "well", "x_m": 0.0, "y_m": 0.0}],
+            [{"id": "C-1", "kind": "flowline", "from": "A", "to": "GHOST"}],
+        )
+        with pytest.raises(ValueError, match="unknown asset 'GHOST'.*dangling"):
+            build_layout_model(config)
+
+    def test_duplicate_asset_id_rejected(self):
+        config = _minimal_config(
+            _flat_surface(100.0),
+            [
+                {"id": "A", "kind": "well", "x_m": 0.0, "y_m": 0.0},
+                {"id": "A", "kind": "manifold", "x_m": 50.0, "y_m": 0.0},
+            ],
+            [],
+        )
+        with pytest.raises(ValueError, match="duplicate asset id 'A'"):
+            build_layout_model(config)
+
+    def test_duplicate_connection_id_rejected(self):
+        assets = [
+            {"id": "A", "kind": "well", "x_m": 0.0, "y_m": 0.0},
+            {"id": "B", "kind": "host", "x_m": 100.0, "y_m": 0.0},
+        ]
+        conns = [
+            {"id": "C-1", "kind": "flowline", "from": "A", "to": "B"},
+            {"id": "C-1", "kind": "umbilical", "from": "B", "to": "A"},
+        ]
+        config = _minimal_config(_flat_surface(100.0), assets, conns)
+        with pytest.raises(ValueError, match="duplicate connection id 'C-1'"):
+            build_layout_model(config)
+
+    def test_missing_section_rejected(self):
+        with pytest.raises(ValueError, match="missing required sections"):
+            build_layout_model(
+                {"field": {"name": "T"}, "assets": [], "connections": []}
+            )
+
+
+# --- schema round-trip -------------------------------------------------------
+class TestRoundTrip:
+    def test_offshore_demo_round_trips_through_yaml(self, tmp_path):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        config = layout_model_to_config(model)
+        dumped = tmp_path / "roundtrip.yml"
+        dumped.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+        rebuilt = build_layout_model_from_file(dumped)
+        assert layout_summary(rebuilt) == layout_summary(model)
+        # typed equivalence, not just summary equality
+        assert [a.asset_id for a in rebuilt.assets] == [
+            a.asset_id for a in model.assets
+        ]
+        for c0, c1 in zip(model.connections, rebuilt.connections):
+            assert c1.kind == c0.kind
+            assert c1.route_length_m == pytest.approx(c0.route_length_m)
+            assert c1.waypoints_plan_m == c0.waypoints_plan_m
+
+    def test_off_surface_flag_survives_round_trip(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        config = layout_model_to_config(model)
+        fpso = next(a for a in config["assets"] if a["id"] == "FPSO-1")
+        assert fpso["z_m"] == pytest.approx(0.0)  # explicit override re-emitted
+        manifold = next(a for a in config["assets"] if a["id"] == "MAN-1")
+        assert "z_m" not in manifold  # draped assets stay schema-draped
+
+
+# --- waypoint routing over the surface ---------------------------------------
+class TestWaypointRouting:
+    def test_flat_surface_waypoint_lengths(self):
+        # L-shaped route: (0,0) -> waypoint (300,0) -> (300,400); flat surface
+        config = _minimal_config(
+            _flat_surface(-100.0),
+            [
+                {"id": "M", "kind": "manifold", "x_m": 0.0, "y_m": 0.0},
+                {"id": "H", "kind": "host", "x_m": 300.0, "y_m": 400.0},
+            ],
+            [
+                {
+                    "id": "FL",
+                    "kind": "flowline",
+                    "from": "M",
+                    "to": "H",
+                    "waypoints": [{"x_m": 300.0, "y_m": 0.0}],
+                }
+            ],
+        )
+        model = build_layout_model(config)
+        conn = model.connections[0]
+        assert conn.plan_length_m == pytest.approx(700.0)  # 300 + 400
+        assert conn.route_length_m == pytest.approx(700.0)  # flat: 3D == plan
+        assert conn.elevation_change_m == pytest.approx(0.0)
+        # path passes exactly through the waypoint
+        waypoint_hits = [p for p in conn.path_xyz_m if p[0] == 300.0 and p[1] == 0.0]
+        assert len(waypoint_hits) == 1
+
+    def test_sloped_surface_route_length_is_sum_of_hypotenuses(self, tmp_path):
+        # uniform slope in x only: z rises 0 -> 30 m over 300 m (plane)
+        (tmp_path / "slope.csv").write_text("0,30\n0,30\n", encoding="utf-8")
+        surface = {
+            "kind": "csv_grid",
+            "csv_path": "slope.csv",
+            "x_min_m": 0,
+            "x_max_m": 300,
+            "y_min_m": 0,
+            "y_max_m": 100,
+        }
+        config = _minimal_config(
+            surface,
+            [
+                {"id": "W", "kind": "well", "x_m": 0.0, "y_m": 50.0},
+                {"id": "H", "kind": "host", "x_m": 300.0, "y_m": 50.0},
+            ],
+            [
+                {
+                    "id": "FL",
+                    "kind": "flowline",
+                    "from": "W",
+                    "to": "H",
+                    "waypoints": [{"x_m": 150.0, "y_m": 50.0}],
+                }
+            ],
+        )
+        model = build_layout_model(config, base_dir=tmp_path)
+        conn = model.connections[0]
+        assert conn.plan_length_m == pytest.approx(300.0)
+        # two collinear legs on a plane: each hypot(150, 15); sum = hypot(300, 30)
+        assert conn.route_length_m == pytest.approx(math.hypot(300.0, 30.0))
+        assert conn.elevation_change_m == pytest.approx(30.0)
+
+    def test_off_surface_endpoint_rises_from_seabed(self):
+        # flat bathymetry at -100 m; vessel floats at z = 0 (explicit override)
+        config = _minimal_config(
+            _flat_surface(-100.0),
+            [
+                {"id": "M", "kind": "manifold", "x_m": 0.0, "y_m": 0.0},
+                {"id": "V", "kind": "vessel", "x_m": 300.0, "y_m": 0.0, "z_m": 0.0},
+            ],
+            [{"id": "FL", "kind": "flowline", "from": "M", "to": "V"}],
+        )
+        config["routing"]["sample_spacing_m"] = 300.0  # single straight segment
+        model = build_layout_model(config)
+        conn = model.connections[0]
+        assert model.asset("M").z_m == pytest.approx(-100.0)
+        assert model.asset("V").z_m == pytest.approx(0.0)
+        assert model.asset("V").on_surface is False
+        assert conn.plan_length_m == pytest.approx(300.0)
+        # one segment from (0,0,-100) to (300,0,0): true 3D hypotenuse
+        assert conn.route_length_m == pytest.approx(math.hypot(300.0, 100.0))
+        assert conn.elevation_change_m == pytest.approx(100.0)
+
+    def test_bathymetry_negative_elevations_supported(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        assert float(model.surface.z_m.max()) < 0.0  # everything under water
+        for asset in model.assets:
+            if asset.on_surface:
+                assert asset.z_m < 0.0
+                assert asset.z_m == pytest.approx(
+                    model.surface.elevation_at(asset.x_m, asset.y_m)
+                )
+
+
+# --- offshore demo end-to-end ------------------------------------------------
+class TestOffshoreDemoEndToEnd:
+    def test_asset_taxonomy_counts(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        assert len(model.assets_of_kind("well")) == 3
+        assert len(model.assets_of_kind("tree")) == 3
+        assert len(model.assets_of_kind("manifold")) == 1
+        assert len(model.assets_of_kind("vessel")) == 1
+        assert len(model.assets_of_kind("host")) == 1
+        assert len(model.connections_of_kind("jumper")) == 3
+        assert len(model.connections_of_kind("flowline")) == 1
+        assert len(model.connections_of_kind("umbilical")) == 1
+        assert len(model.connections_of_kind("pipeline")) == 1
+        assert {c.kind for c in model.connections} <= CONNECTION_KINDS
+
+    def test_flowline_waypoint_plan_length_hand_computed(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        fl = next(c for c in model.connections if c.connection_id == "FL-1")
+        # MAN-1 (2500,2500) -> WP (3200,3600) -> FPSO-1 (4000,4000)
+        expected = math.hypot(700.0, 1100.0) + math.hypot(800.0, 400.0)
+        assert fl.plan_length_m == pytest.approx(expected)
+        # route drapes ~1400 m-deep seabed then rises to the FPSO at z = 0
+        assert fl.route_length_m > fl.plan_length_m
+        assert fl.elevation_change_m > 1000.0  # seabed up to waterline
+
+    def test_route_lengths_never_shorter_than_plan(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        for conn in model.connections:
+            assert conn.route_length_m >= conn.plan_length_m > 0.0
+
+    def test_umbilical_has_no_bore_hydraulics(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        umb = next(c for c in model.connections if c.kind == "umbilical")
+        assert umb.inner_diameter_m is None
+        assert umb.roughness_m is None
+
+    def test_summary_is_json_able_and_flags_subsea(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        summary = layout_summary(model)
+        assert summary["field"] == "Demo Offshore Field"
+        assert summary["surface"]["is_subsea"] is True
+        assert summary["assets_by_kind"] == {
+            "vessel": 1,
+            "manifold": 1,
+            "well": 3,
+            "tree": 3,
+            "host": 1,
+        }
+        assert len(summary["connections"]) == 6
+        import json
+
+        json.dumps(summary)  # must not raise
+
+
+# --- tracer schema back-compat (#1508) ----------------------------------------
+class TestTracerBackCompat:
+    def test_onshore_demo_loads_through_generalized_loader(self):
+        config = load_layout_config(ONSHORE_CONFIG)
+        assert "assets" in config and "connections" in config
+        assert "surface" in config  # terrain alias normalized
+        kinds = [a["kind"] for a in config["assets"]]
+        assert kinds.count("host") == 1
+        assert kinds.count("well") == 3
+        assert all(c["kind"] == "flowline" for c in config["connections"])
+        assert all("from" in c for c in config["connections"])
+
+    def test_tracer_route_lengths_match_onshore_layout(self):
+        """The generalized engine reproduces the tracer's 3D flowline lengths."""
+        model = build_layout_model_from_file(ONSHORE_CONFIG)
+
+        tracer_config = yaml.safe_load(ONSHORE_CONFIG.read_text(encoding="utf-8"))
+        tracer_layout = build_layout(tracer_config, base_dir=ONSHORE_CONFIG.parent)
+
+        tracer_by_id = {fl.flowline_id: fl for fl in tracer_layout.flowlines}
+        assert len(model.connections) == len(tracer_by_id) == 3
+        for conn in model.connections:
+            tracer_fl = tracer_by_id[conn.connection_id]
+            assert conn.plan_length_m == pytest.approx(tracer_fl.plan_length_m)
+            assert conn.route_length_m == pytest.approx(tracer_fl.terrain_length_m)
+            assert conn.elevation_change_m == pytest.approx(
+                tracer_fl.elevation_change_m
+            )
+
+    def test_tracer_asset_placement_matches(self):
+        model = build_layout_model_from_file(ONSHORE_CONFIG)
+        tracer_config = yaml.safe_load(ONSHORE_CONFIG.read_text(encoding="utf-8"))
+        tracer_layout = build_layout(tracer_config, base_dir=ONSHORE_CONFIG.parent)
+        assert model.asset("CPF-1").z_m == pytest.approx(tracer_layout.host.z_m)
+        for well in tracer_layout.wells:
+            assert model.asset(well.asset_id).z_m == pytest.approx(well.z_m)
+            assert model.asset(well.asset_id).rate_m3_per_day == pytest.approx(
+                well.rate_m3_per_day
+            )


### PR DESCRIPTION
Closes #1509. Workstream B of epic #1507, building on the merged #1508 tracer (`onshore_layout.py` is untouched).

## What

**New module `src/digitalmodel/field_development/layout_model.py`** (new code only; `field_development/__init__.py` deliberately NOT touched — exports get wired in the follow-up integration PR, per the parallel-lane rule):

- **Full YAML-first asset schema** — asset kinds `host`, `vessel`, `well`, `tree`, `manifold`; connection kinds `jumper`, `flowline`, `pipeline`, `umbilical`. All config externalized to YAML; unknown keys pass through as `properties` for round-trip fidelity.
- **Schema validation** — unique asset/connection ids, known kinds, dangling `from`/`to` references rejected with clear errors.
- **Offshore-ready surfaces** — reuses the tracer's `TerrainGrid` (bilinear DEM queries); elevation is signed relative to datum, so bathymetry is simply negative elevation. The later offshore slice swaps surface DATA, not the model. `surface:` is the canonical section; `terrain:` (tracer) is an accepted alias.
- **Layout engine** — assets draped onto the surface, with optional explicit `z_m` override (e.g. FPSO at the waterline, `z_m: 0.0`); connections route through optional intermediate plan waypoints as piecewise-straight legs, each sampled and draped, with true 3D lengths (never shorter than plan length). No pathfinding/optimization in this slice (follow-on workstreams of #1507).
- **Round-trip** — `layout_model_to_config(model)` re-emits a normalized YAML-serializable config that rebuilds an equivalent model; `layout_summary(model)` gives a JSON-able summary (incl. `is_subsea` flag).
- **Tracer back-compat** — the #1508 schema (`host`/`wells`/`flowlines` with `from_well`) normalizes into the generalized form; the generalized engine reproduces the tracer's 3D flowline lengths exactly (asserted in tests against `onshore_layout.build_layout`).

**New demo data `data/offshore_demo_field.yml`** — synthetic bathymetry (~1450 m water depth, negative elevations), 3 subsea wells + co-located trees, cluster manifold, FPSO at the waterline, export tie-in; 3 jumpers, a waypointed production flowline, an umbilical, an export pipeline.

## Tests

`tests/field_development/test_layout_model.py` — 21 new tests: schema load + validation (unknown kinds, duplicates, dangling refs), YAML round-trip, waypoint routing lengths vs hand-computed values (flat, sloped-plane hypotenuse, off-surface riser rise), offshore demo end-to-end, tracer back-compat.

```
39 passed (21 new + 18 existing onshore_layout tests, unchanged)
```

ruff / black / isort clean on the new files (repo toolchain versions).