### PR TITLE
Field-development screening layer: cable + flowline sizing sweeps + screening report (#1511)

### DIFF
--- a/src/digitalmodel/field_development/data/screening_defaults.yml
+++ b/src/digitalmodel/field_development/data/screening_defaults.yml
@@ -1,0 +1,55 @@
+# ABOUTME: Screening-layer defaults for field-development sizing sweeps (#1511).
+# ABOUTME: ALL correlation constants live here — nothing hardcoded in screening.py.
+#
+# Every value below is a SCREENING-TIER default with a cited source. Override
+# any of them per-study by passing a modified mapping to the screening
+# functions; the code never hardcodes these numbers.
+
+erosional:
+  # API RP 14E (5th ed., 1991), section 2.5a: Ve = C / sqrt(rho_m) with Ve in
+  # ft/s and rho_m in lb/ft3. C = 100 is the RP 14E value for continuous,
+  # non-corrosive service in solids-free systems; use lower C for corrosive or
+  # sandy service per the RP.
+  c_factor: 100.0
+
+conductors:
+  # DC resistivity at 20 degC and temperature coefficient per IEC 60228
+  # (Conductors of insulated cables) / standard tables, e.g. IEC 60287-1-1
+  # Table 1. rho in ohm-m, alpha in 1/K.
+  materials:
+    copper:
+      resistivity_20c_ohm_m: 1.7241e-8
+      temp_coefficient_per_k: 3.93e-3
+    aluminium:
+      resistivity_20c_ohm_m: 2.8264e-8
+      temp_coefficient_per_k: 4.03e-3
+  # IEC 60228 standard nominal conductor cross-sections (mm2).
+  standard_sizes_mm2:
+    [1.5, 2.5, 4.0, 6.0, 10.0, 16.0, 25.0, 35.0, 50.0, 70.0, 95.0,
+     120.0, 150.0, 185.0, 240.0, 300.0, 400.0, 500.0, 630.0, 800.0, 1000.0]
+
+cable_screening:
+  material: copper
+  # XLPE-insulated cable continuous conductor temperature limit (IEC 60502).
+  max_conductor_temp_c: 90.0
+  ambient_temp_c: 30.0
+  # LUMPED total thermal resistance conductor -> ambient (K.m/W), standing in
+  # for T1 + n(T2 + T3 + T4) of IEC 60287-1-1. Screening-tier single number;
+  # replace with the per-layer IEC 60287 build-up for a rated design.
+  thermal_resistance_k_m_per_w: 3.5
+  # Cable series reactance per metre (ohm/m). 1.0e-4 ohm/m (= 0.1 ohm/km) is
+  # the common textbook screening value for three-core MV cable; replace with
+  # vendor data for a rated design.
+  reactance_ohm_per_m: 1.0e-4
+  # Steady-state voltage-drop limit, percent of nominal (typical planning
+  # limit, cf. IEC 60364-5-52 Annex G guidance of 3-5 %).
+  voltage_drop_limit_pct: 5.0
+
+flowline_sweep:
+  # Candidate Nominal Pipe Sizes (inches) swept smallest-first. IDs come from
+  # the ASME B36.10M catalog in digitalmodel.materials.line_pipe.
+  candidate_nps: [2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 12.0]
+  schedule: STD
+  # API 5L grade for the catalog lookup (affects the product reference only;
+  # the hydraulic screen uses geometry alone).
+  grade: B

--- a/src/digitalmodel/field_development/screening.py
+++ b/src/digitalmodel/field_development/screening.py
@@ -1,0 +1,530 @@
+# ABOUTME: Engineering screening layer — cable sizing, flowline diameter sweep,
+# ABOUTME: and deterministic markdown screening report. Issue #1511 (epic #1507).
+"""
+digitalmodel.field_development.screening
+=========================================
+
+Workstream D of the field-development epic (#1507): screening-tier sizing
+correlations layered on top of the #1508 tracer, plus a one-page deterministic
+markdown report per layout iteration.
+
+What this module does
+---------------------
+1. **Cable sizing screen** — conductor DC resistance (IEC 60228 material
+   constants), a conductor-loss-only IEC 60287-1-1 ampacity estimate, the
+   standard three-phase voltage-drop formula, and a smallest-passing-size
+   sweep over the IEC 60228 standard cross-sections.
+2. **Flowline diameter sweep** — REUSES the tracer's Darcy-Weisbach +
+   Swamee-Jain pressure-drop screen
+   (:func:`digitalmodel.field_development.onshore_layout.darcy_weisbach_pressure_drop`)
+   and the ASME B36.10M pipe catalog
+   (:mod:`digitalmodel.materials.line_pipe`) to find the smallest standard
+   nominal size that meets a target arrival pressure AND the API RP 14E
+   erosional-velocity limit.
+3. **Screening report** — :func:`screening_report` writes a deterministic
+   one-page markdown summary (assumptions, inputs, per-line results,
+   pass/fail flags). No timestamps, fixed number formatting: identical inputs
+   give byte-identical output.
+
+ALL correlation constants (C-factor, resistivities, thermal resistance,
+candidate sizes, ...) live in ``data/screening_defaults.yml``; nothing is
+hardcoded here. Pass an edited copy of that mapping to override any default.
+
+Scope honesty
+-------------
+Screening grade only. The ampacity estimate zeroes dielectric and
+sheath/armour losses and lumps the IEC 60287 thermal-resistance build-up into
+one number; the hydraulic screen is single-phase incompressible. Rated cable
+and multiphase flow-assurance design are downstream workstreams of #1507, not
+this slice.
+
+This module CONSUMES the tracer's public layout objects (it reads
+``FlowlineRoute`` attributes) and deliberately does not modify or re-route
+them — layout-schema work is a parallel lane (#1509).
+
+Usage
+-----
+>>> from digitalmodel.field_development.screening import (
+...     flowline_diameter_sweep, size_cable, screening_report)
+>>> sweep = flowline_diameter_sweep(
+...     rate_m3_per_day=300.0, length_m=2000.0, elevation_change_m=15.0,
+...     roughness_m=4.5e-5, density_kg_per_m3=850.0, viscosity_pa_s=2.0e-3,
+...     inlet_pressure_kpa=2000.0, target_arrival_pressure_kpa=1500.0)
+>>> sweep["selected"]["nps"]  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from digitalmodel.materials.line_pipe import line_pipe
+
+from .onshore_layout import SECONDS_PER_DAY, FieldLayout, darcy_weisbach_pressure_drop
+
+# --- unit conversions (exact definitions) ------------------------------------
+_M_PER_FT = 0.3048
+# 1 kg/m^3 in lb/ft^3 (= 0.45359237 kg/lb / 0.3048^3 m^3/ft^3, inverted).
+_LB_PER_FT3_PER_KG_PER_M3 = 0.3048**3 / 0.45359237
+
+_DEFAULTS_PATH = Path(__file__).parent / "data" / "screening_defaults.yml"
+
+
+def load_screening_defaults(path: Optional[str | Path] = None) -> dict[str, Any]:
+    """Load the screening-defaults YAML (bundled file unless ``path`` given)."""
+    with open(path or _DEFAULTS_PATH, "r", encoding="utf-8") as fh:
+        defaults = yaml.safe_load(fh)
+    if not isinstance(defaults, dict):
+        raise ValueError("screening defaults did not parse to a mapping")
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# Erosional velocity — API RP 14E
+# ---------------------------------------------------------------------------
+
+
+def erosional_velocity_api_rp_14e(density_kg_per_m3: float, c_factor: float) -> float:
+    """Erosional velocity limit [m/s] per API RP 14E.
+
+    API RP 14E (Recommended Practice for Design and Installation of Offshore
+    Production Platform Piping Systems, 5th ed., 1991), section 2.5a:
+
+        Ve = C / sqrt(rho_m)   [Ve in ft/s, rho_m in lb/ft^3]
+
+    with C = 100 for continuous, non-corrosive, solids-free service (lower C
+    for corrosive or sandy service per the RP). This function converts the
+    field-unit correlation to SI exactly; the C-factor keeps its RP 14E
+    field-unit definition and comes from config, never hardcoded.
+    """
+    if density_kg_per_m3 <= 0:
+        raise ValueError(f"density must be > 0, got {density_kg_per_m3!r}")
+    if c_factor <= 0:
+        raise ValueError(f"c_factor must be > 0, got {c_factor!r}")
+    density_lb_ft3 = density_kg_per_m3 * _LB_PER_FT3_PER_KG_PER_M3
+    return _M_PER_FT * c_factor / math.sqrt(density_lb_ft3)
+
+
+# ---------------------------------------------------------------------------
+# Cable screening — resistance, ampacity, voltage drop, sizing sweep
+# ---------------------------------------------------------------------------
+
+
+def conductor_resistance_ohm_per_m(
+    area_mm2: float,
+    temperature_c: float,
+    material: str = "copper",
+    materials: Optional[dict[str, Any]] = None,
+) -> float:
+    """Conductor DC resistance per metre at operating temperature.
+
+    R(theta) = rho_20 * (1 + alpha_20 * (theta - 20)) / A — the standard
+    linear temperature correction used by IEC 60287-1-1 (section 2.1.1, with
+    the AC skin/proximity increments neglected at screening fidelity).
+    Material constants (rho_20, alpha_20) per IEC 60228 come from the
+    ``conductors.materials`` config section.
+    """
+    if area_mm2 <= 0:
+        raise ValueError(f"area_mm2 must be > 0, got {area_mm2!r}")
+    if materials is None:
+        materials = load_screening_defaults()["conductors"]["materials"]
+    if material not in materials:
+        raise KeyError(
+            f"material {material!r} not in config; available: {sorted(materials)}"
+        )
+    props = materials[material]
+    rho20 = float(props["resistivity_20c_ohm_m"])
+    alpha = float(props["temp_coefficient_per_k"])
+    area_m2 = area_mm2 * 1.0e-6
+    return rho20 * (1.0 + alpha * (temperature_c - 20.0)) / area_m2
+
+
+def cable_ampacity_screening(
+    resistance_ohm_per_m: float,
+    max_conductor_temp_c: float,
+    ambient_temp_c: float,
+    thermal_resistance_k_m_per_w: float,
+) -> float:
+    """Continuous current rating [A] — conductor-loss-only IEC 60287 form.
+
+    IEC 60287-1-1 (Electric cables — Calculation of the current rating)
+    gives, for the permissible current, I = [dTheta / (R*T_total)]^0.5 once
+    dielectric losses and sheath/armour loss factors are set to zero and the
+    thermal-resistance build-up T1 + n(T2 + T3 + T4) is lumped into a single
+    total ``thermal_resistance_k_m_per_w``. Screening tier only: real ratings
+    need the full per-layer IEC 60287 (or vendor) calculation.
+    """
+    delta_theta = max_conductor_temp_c - ambient_temp_c
+    if delta_theta <= 0:
+        raise ValueError(
+            "max_conductor_temp_c must exceed ambient_temp_c "
+            f"(got {max_conductor_temp_c} <= {ambient_temp_c})"
+        )
+    if resistance_ohm_per_m <= 0 or thermal_resistance_k_m_per_w <= 0:
+        raise ValueError("resistance and thermal resistance must be > 0")
+    return math.sqrt(
+        delta_theta / (resistance_ohm_per_m * thermal_resistance_k_m_per_w)
+    )
+
+
+def voltage_drop_three_phase_v(
+    current_a: float,
+    length_m: float,
+    resistance_ohm_per_m: float,
+    reactance_ohm_per_m: float,
+    power_factor: float,
+) -> float:
+    """Three-phase line-to-line voltage drop [V].
+
+    dU = sqrt(3) * I * L * (R' cos(phi) + X' sin(phi)) — the standard
+    steady-state formula (cf. IEC 60364-5-52 Annex G; any power-distribution
+    textbook). Lagging power factor assumed (sin(phi) >= 0).
+    """
+    if not 0.0 < power_factor <= 1.0:
+        raise ValueError(f"power_factor must be in (0, 1], got {power_factor!r}")
+    if current_a <= 0 or length_m < 0:
+        raise ValueError("current_a must be > 0 and length_m >= 0")
+    sin_phi = math.sqrt(1.0 - power_factor**2)
+    return (
+        math.sqrt(3.0)
+        * current_a
+        * length_m
+        * (resistance_ohm_per_m * power_factor + reactance_ohm_per_m * sin_phi)
+    )
+
+
+def size_cable(
+    load_kw: float,
+    line_voltage_v: float,
+    length_m: float,
+    power_factor: float,
+    defaults: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Smallest IEC 60228 conductor size passing ampacity + voltage-drop screens.
+
+    Load current: I = P / (sqrt(3) * U_LL * pf) (three-phase). Each standard
+    cross-section is screened for (a) ampacity >= load current
+    (:func:`cable_ampacity_screening`) and (b) voltage drop within the
+    configured percent limit (:func:`voltage_drop_three_phase_v`). Candidates
+    are swept ascending; ``selected`` is the smallest passing size (``None``
+    if none passes).
+    """
+    if load_kw <= 0 or line_voltage_v <= 0:
+        raise ValueError("load_kw and line_voltage_v must be > 0")
+    cfg = defaults or load_screening_defaults()
+    cable_cfg = cfg["cable_screening"]
+    materials = cfg["conductors"]["materials"]
+    sizes = [float(s) for s in cfg["conductors"]["standard_sizes_mm2"]]
+    material = str(cable_cfg["material"])
+    temp_max = float(cable_cfg["max_conductor_temp_c"])
+    temp_amb = float(cable_cfg["ambient_temp_c"])
+    thermal_res = float(cable_cfg["thermal_resistance_k_m_per_w"])
+    reactance = float(cable_cfg["reactance_ohm_per_m"])
+    vdrop_limit_pct = float(cable_cfg["voltage_drop_limit_pct"])
+
+    current = load_kw * 1.0e3 / (math.sqrt(3.0) * line_voltage_v * power_factor)
+
+    candidates: list[dict[str, Any]] = []
+    selected: Optional[dict[str, Any]] = None
+    for size in sorted(sizes):
+        resistance = conductor_resistance_ohm_per_m(
+            size, temp_max, material=material, materials=materials
+        )
+        ampacity = cable_ampacity_screening(resistance, temp_max, temp_amb, thermal_res)
+        vdrop = voltage_drop_three_phase_v(
+            current, length_m, resistance, reactance, power_factor
+        )
+        vdrop_pct = 100.0 * vdrop / line_voltage_v
+        row = {
+            "size_mm2": size,
+            "resistance_ohm_per_m": resistance,
+            "ampacity_a": ampacity,
+            "ampacity_ok": ampacity >= current,
+            "voltage_drop_v": vdrop,
+            "voltage_drop_pct": vdrop_pct,
+            "voltage_drop_ok": vdrop_pct <= vdrop_limit_pct,
+        }
+        row["passes"] = bool(row["ampacity_ok"] and row["voltage_drop_ok"])
+        candidates.append(row)
+        if selected is None and row["passes"]:
+            selected = row
+
+    return {
+        "load_kw": load_kw,
+        "line_voltage_v": line_voltage_v,
+        "length_m": length_m,
+        "power_factor": power_factor,
+        "current_a": current,
+        "material": material,
+        "max_conductor_temp_c": temp_max,
+        "ambient_temp_c": temp_amb,
+        "thermal_resistance_k_m_per_w": thermal_res,
+        "voltage_drop_limit_pct": vdrop_limit_pct,
+        "candidates": candidates,
+        "selected": selected,
+        "passes": selected is not None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Flowline diameter sweep — reuses the tracer's Darcy-Weisbach screen
+# ---------------------------------------------------------------------------
+
+
+def flowline_diameter_sweep(
+    rate_m3_per_day: float,
+    length_m: float,
+    elevation_change_m: float,
+    roughness_m: float,
+    density_kg_per_m3: float,
+    viscosity_pa_s: float,
+    inlet_pressure_kpa: float,
+    target_arrival_pressure_kpa: float,
+    defaults: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Smallest standard pipe size meeting arrival pressure + erosional limit.
+
+    Sweeps the configured candidate NPS list (ascending) with inner diameters
+    from the ASME B36.10M catalog (:mod:`digitalmodel.materials.line_pipe`,
+    REUSED). Per candidate:
+
+    - pressure drop via the tracer's Darcy-Weisbach + Swamee-Jain screen
+      (:func:`~digitalmodel.field_development.onshore_layout.darcy_weisbach_pressure_drop`,
+      REUSED — citations there);
+    - arrival pressure = inlet - dp_total, screened against the target;
+    - velocity screened against the API RP 14E erosional limit
+      (:func:`erosional_velocity_api_rp_14e`, C-factor from config).
+
+    ``selected`` is the smallest passing size (``None`` if none passes).
+    """
+    if inlet_pressure_kpa <= target_arrival_pressure_kpa:
+        raise ValueError(
+            "inlet_pressure_kpa must exceed target_arrival_pressure_kpa "
+            f"(got {inlet_pressure_kpa} <= {target_arrival_pressure_kpa})"
+        )
+    cfg = defaults or load_screening_defaults()
+    sweep_cfg = cfg["flowline_sweep"]
+    c_factor = float(cfg["erosional"]["c_factor"])
+    schedule = str(sweep_cfg["schedule"])
+    grade = str(sweep_cfg["grade"])
+    v_erosional = erosional_velocity_api_rp_14e(density_kg_per_m3, c_factor)
+
+    candidates: list[dict[str, Any]] = []
+    selected: Optional[dict[str, Any]] = None
+    for nps in sorted(float(n) for n in sweep_cfg["candidate_nps"]):
+        pipe = line_pipe(grade, nps=nps, schedule=schedule)
+        inner_diameter_m = pipe.id_mm / 1.0e3
+        drop = darcy_weisbach_pressure_drop(
+            rate_m3_per_s=rate_m3_per_day / SECONDS_PER_DAY,
+            length_m=length_m,
+            inner_diameter_m=inner_diameter_m,
+            roughness_m=roughness_m,
+            density_kg_per_m3=density_kg_per_m3,
+            viscosity_pa_s=viscosity_pa_s,
+            elevation_change_m=elevation_change_m,
+        )
+        arrival = inlet_pressure_kpa - drop["dp_total_kpa"]
+        row = {
+            "nps": nps,
+            "schedule": schedule,
+            "inner_diameter_m": inner_diameter_m,
+            "product": pipe.api_5l_reference,
+            "velocity_m_per_s": drop["velocity_m_per_s"],
+            "erosional_velocity_m_per_s": v_erosional,
+            "velocity_ok": drop["velocity_m_per_s"] <= v_erosional,
+            "dp_friction_kpa": drop["dp_friction_kpa"],
+            "dp_elevation_kpa": drop["dp_elevation_kpa"],
+            "dp_total_kpa": drop["dp_total_kpa"],
+            "arrival_pressure_kpa": arrival,
+            "arrival_ok": arrival >= target_arrival_pressure_kpa,
+        }
+        row["passes"] = bool(row["velocity_ok"] and row["arrival_ok"])
+        candidates.append(row)
+        if selected is None and row["passes"]:
+            selected = row
+
+    return {
+        "rate_m3_per_day": rate_m3_per_day,
+        "length_m": length_m,
+        "elevation_change_m": elevation_change_m,
+        "roughness_m": roughness_m,
+        "density_kg_per_m3": density_kg_per_m3,
+        "viscosity_pa_s": viscosity_pa_s,
+        "inlet_pressure_kpa": inlet_pressure_kpa,
+        "target_arrival_pressure_kpa": target_arrival_pressure_kpa,
+        "erosional_c_factor": c_factor,
+        "erosional_velocity_m_per_s": v_erosional,
+        "candidates": candidates,
+        "selected": selected,
+        "passes": selected is not None,
+    }
+
+
+def sweep_layout_flowlines(
+    layout: FieldLayout,
+    fluid: dict[str, Any],
+    inlet_pressure_kpa: float,
+    target_arrival_pressure_kpa: float,
+    defaults: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
+    """Run the diameter sweep for every routed flowline of a tracer layout.
+
+    Consumes the PUBLIC attributes of the #1508 tracer's
+    :class:`~digitalmodel.field_development.onshore_layout.FlowlineRoute`
+    objects (terrain length, endpoint elevation change, rate, roughness) —
+    read-only, so this stays decoupled from the parallel layout-schema lane
+    (#1509). Each returned sweep dict gains ``id``/``from``/``to`` keys.
+    """
+    results: list[dict[str, Any]] = []
+    for fl in layout.flowlines:
+        sweep = flowline_diameter_sweep(
+            rate_m3_per_day=fl.rate_m3_per_day,
+            length_m=fl.terrain_length_m,
+            elevation_change_m=fl.elevation_change_m,
+            roughness_m=fl.roughness_m,
+            density_kg_per_m3=float(fluid["density_kg_per_m3"]),
+            viscosity_pa_s=float(fluid["viscosity_pa_s"]),
+            inlet_pressure_kpa=inlet_pressure_kpa,
+            target_arrival_pressure_kpa=target_arrival_pressure_kpa,
+            defaults=defaults,
+        )
+        sweep["id"] = fl.flowline_id
+        sweep["from"] = fl.from_id
+        sweep["to"] = fl.to_id
+        results.append(sweep)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Screening report — one-page deterministic markdown
+# ---------------------------------------------------------------------------
+
+_CORRELATION_NOTES = (
+    "Flowline hydraulics: Darcy-Weisbach with Swamee-Jain friction factor "
+    "(Swamee & Jain 1976, J. Hydraulics Div. ASCE 102(5); laminar f = 64/Re). "
+    "Single-phase incompressible, screening grade.",
+    "Erosional velocity: API RP 14E section 2.5a, Ve = C/sqrt(rho_m) "
+    "(field units), C-factor from config.",
+    "Pipe inner diameters: ASME B36.10M catalog " "(digitalmodel.materials.line_pipe).",
+    "Cable ampacity: IEC 60287-1-1 permissible-current equation reduced to "
+    "its conductor-loss-only form with a lumped total thermal resistance. "
+    "Screening grade — not a rated design.",
+    "Voltage drop: dU = sqrt(3) I L (R' cos(phi) + X' sin(phi)) "
+    "(cf. IEC 60364-5-52 Annex G). Conductor constants per IEC 60228.",
+)
+
+
+def _flag(ok: bool) -> str:
+    return "PASS" if ok else "FAIL"
+
+
+def _flowline_section(flowlines: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "## Flowline diameter sweep",
+        "",
+        "| Line | Rate [m3/d] | Length [m] | Selected | ID [mm] | v [m/s] "
+        "| Ve 14E [m/s] | dP [kPa] | Arrival [kPa] | Result |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for fl in flowlines:
+        sel = fl.get("selected")
+        if sel is not None:
+            selected_txt = f"NPS {sel['nps']:g} {sel['schedule']}"
+            detail = (
+                f"{sel['inner_diameter_m'] * 1e3:.1f} | "
+                f"{sel['velocity_m_per_s']:.3f} | "
+                f"{sel['erosional_velocity_m_per_s']:.3f} | "
+                f"{sel['dp_total_kpa']:.1f} | "
+                f"{sel['arrival_pressure_kpa']:.1f}"
+            )
+        else:
+            selected_txt = "none pass"
+            detail = "- | - | - | - | -"
+        lines.append(
+            f"| {fl.get('id', '-')} | {fl['rate_m3_per_day']:.1f} | "
+            f"{fl['length_m']:.1f} | {selected_txt} | {detail} | "
+            f"{_flag(fl['passes'])} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _cable_section(cables: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "## Cable sizing screen",
+        "",
+        "| Run | Load [kW] | U [V] | I [A] | Length [m] | Selected [mm2] "
+        "| Ampacity [A] | dU [%] | Result |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for cb in cables:
+        sel = cb.get("selected")
+        if sel is not None:
+            detail = (
+                f"{sel['size_mm2']:g} | {sel['ampacity_a']:.1f} | "
+                f"{sel['voltage_drop_pct']:.2f}"
+            )
+        else:
+            detail = "none pass | - | -"
+        lines.append(
+            f"| {cb.get('id', '-')} | {cb['load_kw']:.1f} | "
+            f"{cb['line_voltage_v']:.0f} | {cb['current_a']:.1f} | "
+            f"{cb['length_m']:.1f} | {detail} | {_flag(cb['passes'])} |"
+        )
+    lines.append("")
+    return lines
+
+
+def screening_report(results: dict[str, Any], path: str | Path) -> str:
+    """Write a one-page deterministic markdown screening report.
+
+    ``results`` keys (all optional except ``field``):
+
+    - ``field``: layout/iteration name for the title;
+    - ``assumptions``: iteration-specific assumption strings (rendered before
+      the standard correlation citations);
+    - ``flowlines``: list of :func:`flowline_diameter_sweep` dicts (with
+      ``id`` keys, e.g. from :func:`sweep_layout_flowlines`);
+    - ``cables``: list of :func:`size_cable` dicts (each may carry an ``id``).
+
+    Deterministic by construction: no timestamps, fixed float formatting —
+    identical inputs give byte-identical files. Returns the written path.
+    """
+    lines: list[str] = [
+        f"# Screening report — {results['field']}",
+        "",
+        "Screening-tier sizing (epic #1507, workstream D). NOT a detailed "
+        "design; every correlation below is cited and its fidelity limits "
+        "are stated in `digitalmodel.field_development.screening`.",
+        "",
+        "## Assumptions",
+        "",
+    ]
+    for item in results.get("assumptions", []):
+        lines.append(f"- {item}")
+    for note in _CORRELATION_NOTES:
+        lines.append(f"- {note}")
+    lines.append("")
+
+    flowlines = results.get("flowlines", [])
+    if flowlines:
+        lines.extend(_flowline_section(flowlines))
+    cables = results.get("cables", [])
+    if cables:
+        lines.extend(_cable_section(cables))
+
+    overall = (
+        all(r["passes"] for r in [*flowlines, *cables])
+        if (flowlines or cables)
+        else False
+    )
+    lines.append(f"**Overall: {_flag(overall)}**")
+    lines.append("")
+
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("\n".join(lines), encoding="utf-8")
+    return str(dest)

--- a/tests/field_development/test_screening.py
+++ b/tests/field_development/test_screening.py
@@ -1,0 +1,370 @@
+# ABOUTME: Tests for field_development.screening (#1511, epic #1507): cable sizing,
+# ABOUTME: flowline diameter sweep, report. Every correlation vs a HAND-COMPUTED anchor.
+"""Tests for digitalmodel.field_development.screening.
+
+Every correlation is asserted against a value computed BY HAND in the test
+comments (calculator arithmetic from the cited formula), never against a
+snapshot of the code's own output.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.field_development.onshore_layout import (
+    build_layout,
+    load_field_config,
+)
+from digitalmodel.field_development.screening import (
+    cable_ampacity_screening,
+    conductor_resistance_ohm_per_m,
+    erosional_velocity_api_rp_14e,
+    flowline_diameter_sweep,
+    load_screening_defaults,
+    screening_report,
+    size_cable,
+    sweep_layout_flowlines,
+    voltage_drop_three_phase_v,
+)
+
+DEMO_CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+    / "onshore_demo_field.yml"
+)
+
+
+# --- defaults loader ---------------------------------------------------------
+class TestLoadScreeningDefaults:
+    def test_bundled_defaults_load_and_have_sections(self):
+        cfg = load_screening_defaults()
+        for section in ("erosional", "conductors", "cable_screening", "flowline_sweep"):
+            assert section in cfg
+        assert cfg["erosional"]["c_factor"] == 100.0
+
+    def test_non_mapping_defaults_rejected(self, tmp_path):
+        bad = tmp_path / "bad.yml"
+        bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="mapping"):
+            load_screening_defaults(bad)
+
+
+# --- erosional velocity (API RP 14E) -----------------------------------------
+class TestErosionalVelocity:
+    def test_hand_computed_oil_density(self):
+        # HAND CALC (API RP 14E, Ve = C/sqrt(rho lb/ft3), C = 100):
+        #   rho = 850 kg/m3 = 850 * 0.3048^3/0.45359237 = 53.06377 lb/ft3
+        #   Ve  = 100/sqrt(53.06377) = 13.72777 ft/s = 13.72777*0.3048
+        #       = 4.18422 m/s
+        assert erosional_velocity_api_rp_14e(850.0, 100.0) == pytest.approx(
+            4.18422, rel=1e-5
+        )
+
+    def test_hand_computed_water_matches_textbook(self):
+        # HAND CALC: rho = 1000 kg/m3 = 62.42796 lb/ft3;
+        #   Ve = 100/sqrt(62.42796) = 12.65640 ft/s (the well-known ~12.7 ft/s
+        #   RP 14E water figure) = 12.65640*0.3048 = 3.85767 m/s.
+        assert erosional_velocity_api_rp_14e(1000.0, 100.0) == pytest.approx(
+            3.85767, rel=1e-5
+        )
+
+    def test_scales_inversely_with_sqrt_density(self):
+        v1 = erosional_velocity_api_rp_14e(400.0, 100.0)
+        v2 = erosional_velocity_api_rp_14e(1600.0, 100.0)
+        assert v1 / v2 == pytest.approx(2.0, rel=1e-12)
+
+    @pytest.mark.parametrize("rho,c", [(0.0, 100.0), (850.0, 0.0), (-1.0, 100.0)])
+    def test_invalid_inputs_rejected(self, rho, c):
+        with pytest.raises(ValueError):
+            erosional_velocity_api_rp_14e(rho, c)
+
+
+# --- conductor resistance -----------------------------------------------------
+class TestConductorResistance:
+    def test_hand_computed_copper_95mm2_at_90c(self):
+        # HAND CALC (R = rho20*(1 + alpha*(T-20))/A, IEC 60228 copper
+        # rho20 = 1.7241e-8 ohm-m, alpha = 3.93e-3 /K):
+        #   R20 = 1.7241e-8/95e-6 = 1.814842e-4 ohm/m
+        #   R90 = 1.814842e-4 * (1 + 0.00393*70) = 1.814842e-4 * 1.2751
+        #       = 2.314105e-4 ohm/m
+        r = conductor_resistance_ohm_per_m(95.0, 90.0, material="copper")
+        assert r == pytest.approx(2.314105e-4, rel=1e-6)
+
+    def test_hand_computed_copper_1mm2_at_20c(self):
+        # HAND CALC: R20 = 1.7241e-8/1e-6 = 1.7241e-2 ohm/m (pure-resistivity
+        # value; IEC 60228 tabulated 1 mm2 class-1 is slightly higher because
+        # of stranding allowances — screening tier uses resistivity only).
+        r = conductor_resistance_ohm_per_m(1.0, 20.0, material="copper")
+        assert r == pytest.approx(1.7241e-2, rel=1e-9)
+
+    def test_aluminium_heavier_than_copper(self):
+        r_cu = conductor_resistance_ohm_per_m(50.0, 90.0, material="copper")
+        r_al = conductor_resistance_ohm_per_m(50.0, 90.0, material="aluminium")
+        assert r_al > r_cu
+
+    def test_unknown_material_and_bad_area_rejected(self):
+        with pytest.raises(KeyError, match="unobtainium"):
+            conductor_resistance_ohm_per_m(50.0, 90.0, material="unobtainium")
+        with pytest.raises(ValueError):
+            conductor_resistance_ohm_per_m(0.0, 90.0)
+
+
+# --- ampacity (IEC 60287-1-1, conductor-loss-only form) ------------------------
+class TestCableAmpacity:
+    def test_hand_computed_95mm2_copper(self):
+        # HAND CALC (I = sqrt(dTheta/(R*T)), R90 = 2.314105e-4 ohm/m from
+        # the resistance hand calc, dTheta = 90-30 = 60 K, T = 3.5 K.m/W):
+        #   R*T = 2.314105e-4*3.5 = 8.099368e-4
+        #   I   = sqrt(60/8.099368e-4) = sqrt(74079.85) = 272.176 A
+        r90 = 1.7241e-8 / 95e-6 * (1.0 + 3.93e-3 * 70.0)
+        i = cable_ampacity_screening(r90, 90.0, 30.0, 3.5)
+        assert i == pytest.approx(272.176, rel=1e-4)
+
+    def test_ambient_above_conductor_limit_rejected(self):
+        with pytest.raises(ValueError, match="exceed"):
+            cable_ampacity_screening(2.0e-4, 40.0, 40.0, 3.5)
+
+    def test_nonpositive_resistances_rejected(self):
+        with pytest.raises(ValueError):
+            cable_ampacity_screening(0.0, 90.0, 30.0, 3.5)
+        with pytest.raises(ValueError):
+            cable_ampacity_screening(2.0e-4, 90.0, 30.0, 0.0)
+
+
+# --- three-phase voltage drop --------------------------------------------------
+class TestVoltageDrop:
+    def test_hand_computed_round_numbers(self):
+        # HAND CALC (dU = sqrt(3)*I*L*(R'cos(phi) + X'sin(phi))):
+        #   I = 200 A, L = 1000 m, R' = 2.0e-4, X' = 1.0e-4, pf = 0.8
+        #   (sin(phi) = 0.6):
+        #   dU = 1.7320508*200*1000*(1.6e-4 + 0.6e-4)
+        #      = 1.7320508*200*1000*2.2e-4 = 76.21024 V
+        du = voltage_drop_three_phase_v(200.0, 1000.0, 2.0e-4, 1.0e-4, 0.8)
+        assert du == pytest.approx(76.21024, rel=1e-6)
+
+    def test_unity_power_factor_drops_reactive_term(self):
+        du = voltage_drop_three_phase_v(100.0, 500.0, 3.0e-4, 5.0e-4, 1.0)
+        # HAND CALC: sin(phi) = 0 so dU = sqrt(3)*100*500*3.0e-4 = 25.98076 V.
+        assert du == pytest.approx(25.98076, rel=1e-6)
+
+    def test_invalid_power_factor_rejected(self):
+        for pf in (0.0, -0.5, 1.1):
+            with pytest.raises(ValueError, match="power_factor"):
+                voltage_drop_three_phase_v(100.0, 500.0, 2.0e-4, 1.0e-4, pf)
+
+
+# --- cable sizing sweep ---------------------------------------------------------
+class TestSizeCable:
+    def test_hand_computed_selection_500kw_6600v(self):
+        # HAND CALC with the bundled defaults (Cu 90C, ambient 30C,
+        # T = 3.5 K.m/W, X' = 1.0e-4 ohm/m, limit 5 %):
+        #   I = 500e3/(sqrt(3)*6600*0.9) = 500000/10288.38 = 48.598 A
+        #   4 mm2 : R90 = 1.7241e-8/4e-6*1.2751 = 5.49600e-3 ohm/m
+        #           ampacity = sqrt(60/(5.496e-3*3.5)) = 55.85 A  (>= I, ok)
+        #           dU = sqrt(3)*48.598*800*(5.496e-3*0.9 + 1e-4*0.43589)
+        #              = 67339.9*4.98999e-3 = 336.03 V = 5.091 % > 5 %  FAIL
+        #   6 mm2 : R90 = 3.66400e-3; ampacity = sqrt(60/0.0128240) = 68.40 A
+        #           dU = 67339.9*(3.2976e-3 + 4.3589e-5) = 225.00 V
+        #              = 3.409 %  PASS -> smallest passing size = 6 mm2
+        result = size_cable(
+            load_kw=500.0, line_voltage_v=6600.0, length_m=800.0, power_factor=0.9
+        )
+        assert result["current_a"] == pytest.approx(48.598, rel=1e-4)
+        assert result["passes"] is True
+        assert result["selected"]["size_mm2"] == 6.0
+        assert result["selected"]["ampacity_a"] == pytest.approx(68.40, rel=1e-3)
+        assert result["selected"]["voltage_drop_pct"] == pytest.approx(3.409, rel=1e-3)
+        by_size = {c["size_mm2"]: c for c in result["candidates"]}
+        assert by_size[4.0]["ampacity_ok"] is True
+        assert by_size[4.0]["voltage_drop_ok"] is False
+        assert by_size[4.0]["voltage_drop_pct"] == pytest.approx(5.091, rel=1e-3)
+
+    def test_candidates_cover_all_standard_sizes_ascending(self):
+        result = size_cable(50.0, 400.0, 100.0, 0.9)
+        sizes = [c["size_mm2"] for c in result["candidates"]]
+        assert sizes == sorted(sizes)
+        assert sizes == load_screening_defaults()["conductors"]["standard_sizes_mm2"]
+
+    def test_impossible_run_returns_no_selection(self):
+        # 10 km at 400 V: no standard size meets a 5 % drop -> selected None.
+        result = size_cable(200.0, 400.0, 10_000.0, 0.9)
+        assert result["selected"] is None
+        assert result["passes"] is False
+
+    def test_invalid_inputs_rejected(self):
+        with pytest.raises(ValueError):
+            size_cable(0.0, 6600.0, 800.0, 0.9)
+        with pytest.raises(ValueError):
+            size_cable(500.0, 0.0, 800.0, 0.9)
+
+
+# --- flowline diameter sweep -----------------------------------------------------
+SWEEP_KWARGS = dict(
+    rate_m3_per_day=300.0,
+    length_m=2000.0,
+    elevation_change_m=15.0,
+    roughness_m=4.5e-5,
+    density_kg_per_m3=850.0,
+    viscosity_pa_s=2.0e-3,
+    inlet_pressure_kpa=2000.0,
+    target_arrival_pressure_kpa=1500.0,
+)
+
+
+class TestFlowlineDiameterSweep:
+    def test_hand_computed_selection_nps3(self):
+        # HAND CALC (defaults: NPS candidates 2..12 STD, ASME B36.10M IDs;
+        # Darcy-Weisbach + Swamee-Jain; API RP 14E Ve = 4.18422 m/s for
+        # rho = 850 from the erosional hand calc):
+        #   NPS 2 STD: ID = 2.067 in = 0.0525018 m, v = Q/A = 1.6039 m/s,
+        #     Re = 35789, eps/D = 8.5711e-4, f = 0.02501,
+        #     dp_f = f*(L/D)*rho*v^2/2 = 0.02501*38094.9*1093.3 = 1041.6 kPa
+        #     -> arrival = 2000 - (1041.6+125.0) = 833 kPa < 1500  FAIL
+        #   NPS 3 STD: ID = 3.068 in = 0.0779272 m,
+        #     A = pi/4*0.0779272^2 = 4.76944e-3 m2,
+        #     v = (300/86400)/4.76944e-3 = 0.72801 m/s  (< 4.184, ok)
+        #     Re = 850*0.72801*0.0779272/2e-3 = 24111, eps/D = 5.7746e-4,
+        #     f = 0.25/log10(5.7746e-4/3.7 + 5.74/24111^0.9)^2 = 0.026149
+        #     dp_f = 0.026149*(2000/0.0779272)*850*0.72801^2/2 = 151.2 kPa
+        #     dp_el = 850*9.80665*15 = 125.03 kPa; total = 276.2 kPa
+        #     arrival = 2000 - 276.2 = 1723.8 kPa >= 1500  PASS
+        #   -> smallest passing size = NPS 3.
+        result = flowline_diameter_sweep(**SWEEP_KWARGS)
+        assert result["passes"] is True
+        sel = result["selected"]
+        assert sel["nps"] == 3.0
+        assert sel["inner_diameter_m"] == pytest.approx(0.0779272, rel=1e-6)
+        assert sel["velocity_m_per_s"] == pytest.approx(0.72801, rel=1e-4)
+        assert sel["dp_total_kpa"] == pytest.approx(276.2, rel=5e-3)
+        assert sel["arrival_pressure_kpa"] == pytest.approx(1723.8, rel=1e-3)
+        assert result["erosional_velocity_m_per_s"] == pytest.approx(4.18422, rel=1e-5)
+        by_nps = {c["nps"]: c for c in result["candidates"]}
+        assert by_nps[2.0]["arrival_ok"] is False
+        assert by_nps[2.0]["velocity_ok"] is True
+
+    def test_erosional_limit_can_reject_a_size(self):
+        # Push the rate up so small sizes bust the RP 14E limit: at
+        # 3000 m3/day in NPS 2 (A = 2.16490e-3 m2) v = 16.04 m/s >> 4.18.
+        result = flowline_diameter_sweep(**{**SWEEP_KWARGS, "rate_m3_per_day": 3000.0})
+        by_nps = {c["nps"]: c for c in result["candidates"]}
+        assert by_nps[2.0]["velocity_ok"] is False
+        if result["selected"] is not None:
+            assert result["selected"]["velocity_ok"] is True
+
+    def test_no_size_passes_when_target_unreachable(self):
+        result = flowline_diameter_sweep(
+            **{**SWEEP_KWARGS, "target_arrival_pressure_kpa": 1999.0}
+        )
+        # Elevation head alone is 125 kPa, so no diameter can arrive >= 1999.
+        assert result["selected"] is None
+        assert result["passes"] is False
+
+    def test_inlet_must_exceed_target(self):
+        with pytest.raises(ValueError, match="exceed"):
+            flowline_diameter_sweep(**{**SWEEP_KWARGS, "inlet_pressure_kpa": 1500.0})
+
+    def test_candidates_ascending_and_from_config(self):
+        result = flowline_diameter_sweep(**SWEEP_KWARGS)
+        nps = [c["nps"] for c in result["candidates"]]
+        assert nps == sorted(nps)
+        assert nps == load_screening_defaults()["flowline_sweep"]["candidate_nps"]
+
+
+class TestSweepLayoutFlowlines:
+    def test_consumes_tracer_layout_objects(self):
+        config = load_field_config(DEMO_CONFIG)
+        layout = build_layout(config, base_dir=DEMO_CONFIG.parent)
+        results = sweep_layout_flowlines(
+            layout,
+            fluid=config["fluid"],
+            inlet_pressure_kpa=2000.0,
+            target_arrival_pressure_kpa=1500.0,
+        )
+        assert len(results) == len(layout.flowlines)
+        ids = [r["id"] for r in results]
+        assert ids == [fl.flowline_id for fl in layout.flowlines]
+        for r, fl in zip(results, layout.flowlines):
+            assert r["length_m"] == pytest.approx(fl.terrain_length_m)
+            assert r["rate_m3_per_day"] == fl.rate_m3_per_day
+            assert r["to"] == fl.to_id
+
+
+# --- screening report -------------------------------------------------------------
+def _report_inputs():
+    flowline = flowline_diameter_sweep(**SWEEP_KWARGS)
+    flowline["id"] = "FL-A"
+    cable = size_cable(500.0, 6600.0, 800.0, 0.9)
+    cable["id"] = "CAB-A"
+    return {
+        "field": "Unit Test Field",
+        "assumptions": ["Single-phase gross liquid; demo fluid properties."],
+        "flowlines": [flowline],
+        "cables": [cable],
+    }
+
+
+class TestScreeningReport:
+    def test_report_written_with_expected_content(self, tmp_path):
+        dest = tmp_path / "report" / "screening.md"
+        written = screening_report(_report_inputs(), dest)
+        assert Path(written) == dest
+        text = dest.read_text(encoding="utf-8")
+        assert text.startswith("# Screening report — Unit Test Field")
+        assert "## Assumptions" in text
+        assert "API RP 14E" in text
+        assert "Swamee-Jain" in text
+        assert "IEC 60287" in text
+        assert "| FL-A |" in text
+        assert "NPS 3 STD" in text
+        assert "| CAB-A |" in text
+        assert "**Overall: PASS**" in text
+
+    def test_report_is_deterministic(self, tmp_path):
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        screening_report(_report_inputs(), a)
+        screening_report(_report_inputs(), b)
+        assert a.read_bytes() == b.read_bytes()
+
+    def test_failing_line_flags_fail(self, tmp_path):
+        inputs = _report_inputs()
+        failing = flowline_diameter_sweep(
+            **{**SWEEP_KWARGS, "target_arrival_pressure_kpa": 1999.0}
+        )
+        failing["id"] = "FL-BAD"
+        inputs["flowlines"].append(failing)
+        dest = tmp_path / "fail.md"
+        screening_report(inputs, dest)
+        text = dest.read_text(encoding="utf-8")
+        assert "| FL-BAD |" in text
+        assert "none pass" in text
+        assert "**Overall: FAIL**" in text
+
+    def test_empty_results_report_overall_fail(self, tmp_path):
+        dest = tmp_path / "empty.md"
+        screening_report({"field": "Empty"}, dest)
+        text = dest.read_text(encoding="utf-8")
+        assert "**Overall: FAIL**" in text
+        assert "## Flowline" not in text
+        assert "## Cable" not in text
+
+
+# --- physics cross-checks ----------------------------------------------------------
+class TestPhysicsSanity:
+    def test_bigger_pipe_less_friction_drop(self):
+        result = flowline_diameter_sweep(**SWEEP_KWARGS)
+        drops = [c["dp_friction_kpa"] for c in result["candidates"]]
+        assert drops == sorted(drops, reverse=True)
+
+    def test_velocity_times_area_recovers_rate(self):
+        result = flowline_diameter_sweep(**SWEEP_KWARGS)
+        for c in result["candidates"]:
+            area = math.pi * c["inner_diameter_m"] ** 2 / 4.0
+            rate = c["velocity_m_per_s"] * area * 86_400.0
+            assert rate == pytest.approx(SWEEP_KWARGS["rate_m3_per_day"], rel=1e-9)


### PR DESCRIPTION
Closes #1511. Workstream D of epic #1507.

New module `src/digitalmodel/field_development/screening.py` (+ `data/screening_defaults.yml`, + `tests/field_development/test_screening.py`). No changes to `field_development/__init__.py` or `onshore_layout.py` — this slice only consumes the #1508 tracer's public objects; integration wiring is a follow-up PR, and the module stays decoupled from the parallel layout-schema lane (#1509) by reading `FlowlineRoute`/`FieldLayout` attributes only.

## What it adds

**1. Cable sizing screen (screening tier, cited)**
- `conductor_resistance_ohm_per_m` — R(θ) = ρ₂₀(1 + α₂₀(θ−20))/A with IEC 60228 material constants (from config).
- `cable_ampacity_screening` — IEC 60287-1-1 permissible-current equation reduced to its conductor-loss-only form, I = √(Δθ/(R·T)), with a lumped total thermal resistance (config). Explicitly documented as NOT a rated design.
- `voltage_drop_three_phase_v` — dU = √3·I·L·(R′cosφ + X′sinφ) (cf. IEC 60364-5-52 Annex G).
- `size_cable` — sweeps the IEC 60228 standard cross-sections ascending, returns the smallest size passing both ampacity and percent-voltage-drop screens.

**2. Flowline/pipeline diameter sweep**
- `flowline_diameter_sweep` — sweeps configured candidate NPS (ASME B36.10M IDs) smallest-first; per candidate computes pressure drop, arrival pressure vs target, and the API RP 14E §2.5a erosional-velocity check Ve = C/√ρₘ (C-factor from config; RP 14E field-unit definition converted to SI exactly).
- `sweep_layout_flowlines` — runs the sweep for every routed flowline of a #1508 tracer `FieldLayout` (reads terrain length, endpoint Δz, rate, roughness — read-only).

**3. One-page deterministic screening report**
- `screening_report(results, path)` — markdown: assumptions + standard correlation citations, per-flowline and per-cable-run tables with PASS/FAIL flags, overall verdict. No timestamps, fixed formatting — identical inputs give byte-identical files. No PDF in this slice.

## Reused (searched before writing)
- `digitalmodel.field_development.onshore_layout.darcy_weisbach_pressure_drop` (+ Swamee-Jain friction factor) — the tracer's hydraulic screen is the sweep's engine; not reimplemented.
- `digitalmodel.materials.line_pipe` — ASME B36.10M NPS/schedule catalog supplies candidate inner diameters (`line_pipe(...)`, `id_mm`, `api_5l_reference`).
- No existing erosional-velocity, ampacity, or voltage-drop utility exists in `src/digitalmodel/` (searched `erosional`, `ampacity`, `voltage_drop`, `14E`, `60287`) — those are new here.

## Config
All correlation constants externalized to `data/screening_defaults.yml` with cited sources in comments (API RP 14E C-factor; IEC 60228 resistivities/α; IEC 60502 conductor temperature limit; candidate NPS list + schedule + grade; voltage-drop limit). Nothing hardcoded.

## Tests
Every correlation asserted against a HAND-COMPUTED anchor written out in the test comments (not snapshots): RP 14E at 850 and 1000 kg/m³ (recovers the classic ~12.66 ft/s water figure), Cu 95 mm² resistance at 90 °C, the 272 A ampacity chain, round-number voltage drops, a full hand-worked 500 kW / 6.6 kV cable selection (6 mm², with the 4 mm² candidate failing V-drop at 5.09 %), and a full hand-worked flowline sweep (NPS 3 STD selected, NPS 2 failing arrival). Plus: erosional rejection case, no-passing-size cases, layout consumption against the bundled demo field, report content/determinism (byte-identical) in `tmp_path`, physics sanity (monotone dP vs diameter, v·A recovers the rate).
