### PR TITLE
Field-development visualization: generalized plots, typed 3D scene export, Blender per-kind rendering (#1510)

### DIFF
--- a/scripts/field_development/field_flythrough_bpy.py
+++ b/scripts/field_development/field_flythrough_bpy.py
@@ -1,0 +1,358 @@
+# ABOUTME: Blender (bpy) fly-through of a generalized field-layout scene JSON (#1510).
+# ABOUTME: REQUIRES BLENDER — run inside blender, not plain python; stdlib-only imports.
+"""Render a fly-through of a generalized field-layout scene in Blender.
+
+REQUIRES BLENDER (tested API target: Blender >= 3.6). This script imports
+``bpy`` and therefore CANNOT run under a plain Python interpreter — it must be
+executed by Blender itself, headless:
+
+    # 1. produce the scene JSON with the generalized visualization API
+    .venv/bin/python -c "
+    from digitalmodel.field_development.visualization import (
+        render_layout_visualization,
+    )
+    render_layout_visualization(
+        'src/digitalmodel/field_development/data/offshore_demo_field.yml',
+        output_dir='outputs/field_development',
+    )"
+
+    # 2. render the fly-through (default 96 frames @ 24 fps, MPEG-4)
+    blender --background --python \
+        scripts/field_development/field_flythrough_bpy.py -- \
+        --scene outputs/field_development/offshore_demo_field_scene.json \
+        --out outputs/field_development/offshore_demo_flythrough.mp4
+
+The scene JSON is schema ``digitalmodel.field_layout_scene/2``, produced by
+``digitalmodel.field_development.visualization.export_layout_scene_json``
+(JSON so Blender's bundled Python needs no third-party packages). It types
+every asset (host/vessel/well/tree/manifold) and connection
+(jumper/flowline/pipeline/umbilical), so each kind gets its own geometry and
+material here. The onshore #1508 tracer scene (v1 schema) keeps its own
+script, ``onshore_flythrough_bpy.py``. Rendered videos are NOT committed to
+the repo (see .gitignore) — re-render locally with the command above.
+
+Scene contents: surface mesh from the elevation grid (bathymetry = negative
+elevation), a translucent water plane at z = 0 for subsea scenes, per-kind
+asset geometry (pad cubes for hosts, hull boxes for vessels, cylinders for
+wells, slimmer/taller cylinders for trees, cones for manifolds), bevelled
+curves per connection kind, a sun lamp, and a camera orbiting the field
+centre with a slow descent. Camera clip range is scaled to the scene size —
+Blender's default clip_end (100 m) would cull a km-scale field entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import bpy  # noqa: F401  (only available inside Blender)
+
+# Vertical exaggeration makes gentle relief readable in the clip.
+Z_EXAGGERATION = 2.0
+
+# Base asset dimensions [m], scaled up on large domains (see _size_scale).
+HOST_SIZE_M = 120.0
+VESSEL_DIMS_M = (280.0, 80.0, 40.0)  # hull length, beam, depth
+WELL_RADIUS_M = 25.0
+WELL_HEIGHT_M = 60.0
+TREE_RADIUS_M = 12.0
+TREE_HEIGHT_M = 110.0
+MANIFOLD_RADIUS_M = 45.0
+MANIFOLD_HEIGHT_M = 80.0
+# Reference domain span for the base sizes; larger fields scale up (capped).
+REFERENCE_SPAN_M = 3000.0
+MAX_SIZE_SCALE = 4.0
+
+# Per-kind flat-shaded material colors (r, g, b, a) and connection bevels [m].
+ASSET_COLORS = {
+    "host": (0.12, 0.23, 0.37, 1.0),  # dark navy
+    "vessel": (0.70, 0.35, 0.11, 1.0),  # dark orange
+    "well": (0.13, 0.13, 0.13, 1.0),  # near-black
+    "tree": (0.18, 0.44, 0.25, 1.0),  # green
+    "manifold": (0.42, 0.25, 0.63, 1.0),  # purple
+}
+CONNECTION_COLORS = {
+    "jumper": (0.88, 0.48, 0.22, 1.0),
+    "flowline": (0.70, 0.09, 0.17, 1.0),
+    "pipeline": (0.40, 0.00, 0.12, 1.0),
+    "umbilical": (0.13, 0.40, 0.67, 1.0),
+}
+CONNECTION_BEVEL_M = {
+    "jumper": 6.0,
+    "flowline": 8.0,
+    "pipeline": 10.0,
+    "umbilical": 5.0,
+}
+SURFACE_COLOR_ONSHORE = (0.35, 0.45, 0.25, 1.0)
+SURFACE_COLOR_SUBSEA = (0.45, 0.40, 0.30, 1.0)  # seabed sediment
+WATER_COLOR = (0.05, 0.22, 0.45, 1.0)
+WATER_ALPHA = 0.22
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scene", required=True, help="scene JSON from export_layout_scene_json"
+    )
+    parser.add_argument("--out", required=True, help="output video path (.mp4)")
+    parser.add_argument(
+        "--frames", type=int, default=96, help="frame count (default 96 = 4 s)"
+    )
+    parser.add_argument("--fps", type=int, default=24, help="frames/s (default 24)")
+    parser.add_argument(
+        "--res-scale",
+        type=int,
+        default=100,
+        help="render resolution percentage of 1280x720 (default 100)",
+    )
+    return parser.parse_args(argv)
+
+
+def _clear_default_scene() -> None:
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+
+
+def _material(name: str, rgba: tuple, alpha: float = 1.0):
+    """Simple flat-shaded material; translucent when alpha < 1 (water)."""
+    material = bpy.data.materials.new(name)
+    material.diffuse_color = (*rgba[:3], alpha)
+    material.use_nodes = True
+    bsdf = material.node_tree.nodes.get("Principled BSDF")
+    if bsdf is not None:
+        bsdf.inputs["Base Color"].default_value = rgba
+        bsdf.inputs["Roughness"].default_value = 1.0
+        # Kill glossy sky reflections (flat shading); input name varies by
+        # Blender version (4.x: "Specular IOR Level", 3.x: "Specular").
+        for specular_input in ("Specular IOR Level", "Specular"):
+            if specular_input in bsdf.inputs:
+                bsdf.inputs[specular_input].default_value = 0.0
+                break
+        if alpha < 1.0:
+            bsdf.inputs["Alpha"].default_value = alpha
+    if alpha < 1.0:
+        material.blend_method = "BLEND"
+    return material
+
+
+def _size_scale(span_m: float) -> float:
+    """Scale factor for asset geometry so markers stay visible on big fields."""
+    return max(1.0, min(MAX_SIZE_SCALE, span_m / REFERENCE_SPAN_M))
+
+
+def _scene_z(z_m: float, z0: float) -> float:
+    return (z_m - z0) * Z_EXAGGERATION
+
+
+def _add_surface(surface: dict, subsea: bool) -> tuple[float, float]:
+    """Build the surface mesh; return (centre_x, centre_y)."""
+    xs, ys, zs = surface["x_m"], surface["y_m"], surface["z_m"]
+    nx, ny = len(xs), len(ys)
+    z0 = min(min(row) for row in zs)
+    verts = [
+        (xs[i], ys[j], (zs[j][i] - z0) * Z_EXAGGERATION)
+        for j in range(ny)
+        for i in range(nx)
+    ]
+    faces = [
+        (j * nx + i, j * nx + i + 1, (j + 1) * nx + i + 1, (j + 1) * nx + i)
+        for j in range(ny - 1)
+        for i in range(nx - 1)
+    ]
+    mesh = bpy.data.meshes.new("surface")
+    mesh.from_pydata(verts, [], faces)
+    mesh.update()
+    obj = bpy.data.objects.new("surface", mesh)
+    bpy.context.collection.objects.link(obj)
+    color = SURFACE_COLOR_SUBSEA if subsea else SURFACE_COLOR_ONSHORE
+    obj.data.materials.append(_material("surface_mat", color))
+    return 0.5 * (xs[0] + xs[-1]), 0.5 * (ys[0] + ys[-1])
+
+
+def _add_water_plane(surface: dict, z0: float) -> float:
+    """Translucent water surface at z = 0 (scene z); returns its scene height."""
+    xs, ys = surface["x_m"], surface["y_m"]
+    cx, cy = 0.5 * (xs[0] + xs[-1]), 0.5 * (ys[0] + ys[-1])
+    z_water = _scene_z(0.0, z0)
+    span = max(xs[-1] - xs[0], ys[-1] - ys[0])
+    bpy.ops.mesh.primitive_plane_add(size=1.2 * span, location=(cx, cy, z_water))
+    water = bpy.context.active_object
+    water.name = "water_surface"
+    water.data.materials.append(_material("water_mat", WATER_COLOR, WATER_ALPHA))
+    return z_water
+
+
+def _asset_scene_z(asset: dict, z0: float) -> float:
+    """Scene-space base elevation of one asset (explicit z for off-surface)."""
+    return _scene_z(asset["z_m"], z0)
+
+
+def _add_assets(scene: dict, z0: float, scale: float) -> float:
+    """Per-kind asset geometry; returns the highest asset top (scene z)."""
+    z_top = 0.0
+    for asset in scene["assets"]:
+        x, y = asset["x_m"], asset["y_m"]
+        z = _asset_scene_z(asset, z0)
+        kind = asset["kind"]
+        if kind == "host":
+            size = HOST_SIZE_M * scale
+            bpy.ops.mesh.primitive_cube_add(size=size, location=(x, y, z + size / 2))
+            top = z + size
+        elif kind == "vessel":
+            length, beam, depth = (d * scale for d in VESSEL_DIMS_M)
+            bpy.ops.mesh.primitive_cube_add(size=1.0, location=(x, y, z))
+            bpy.context.active_object.scale = (length, beam, depth)
+            top = z + depth / 2
+        elif kind == "tree":
+            radius, height = TREE_RADIUS_M * scale, TREE_HEIGHT_M * scale
+            bpy.ops.mesh.primitive_cylinder_add(
+                radius=radius, depth=height, location=(x, y, z + height / 2)
+            )
+            top = z + height
+        elif kind == "manifold":
+            radius, height = MANIFOLD_RADIUS_M * scale, MANIFOLD_HEIGHT_M * scale
+            bpy.ops.mesh.primitive_cone_add(
+                radius1=radius, depth=height, location=(x, y, z + height / 2)
+            )
+            top = z + height
+        else:  # well
+            radius, height = WELL_RADIUS_M * scale, WELL_HEIGHT_M * scale
+            bpy.ops.mesh.primitive_cylinder_add(
+                radius=radius, depth=height, location=(x, y, z + height / 2)
+            )
+            top = z + height
+        obj = bpy.context.active_object
+        obj.name = f"asset_{asset['id']}"
+        color = ASSET_COLORS.get(kind, ASSET_COLORS["well"])
+        obj.data.materials.append(_material(f"mat_{asset['id']}", color))
+        z_top = max(z_top, top)
+    return z_top
+
+
+def _add_connections(scene: dict, z0: float, scale: float) -> None:
+    """Bevelled curve per connection, styled by kind."""
+    for conn in scene["connections"]:
+        kind = conn["kind"]
+        bevel = CONNECTION_BEVEL_M.get(kind, 8.0) * scale
+        curve = bpy.data.curves.new(f"conn_{conn['id']}", type="CURVE")
+        curve.dimensions = "3D"
+        curve.bevel_depth = bevel
+        spline = curve.splines.new("POLY")
+        path = conn["path_xyz_m"]
+        spline.points.add(len(path) - 1)
+        for point, (x, y, z) in zip(spline.points, path):
+            point.co = (x, y, _scene_z(z, z0) + bevel, 1.0)
+        obj = bpy.data.objects.new(f"conn_{conn['id']}", curve)
+        bpy.context.collection.objects.link(obj)
+        color = CONNECTION_COLORS.get(kind, CONNECTION_COLORS["flowline"])
+        obj.data.materials.append(_material(f"mat_conn_{conn['id']}", color))
+
+
+def _add_camera_flythrough(
+    centre: tuple[float, float, float],
+    radius: float,
+    frame_count: int,
+    fps: int,
+) -> None:
+    cx, cy, cz = centre
+    target = bpy.data.objects.new("cam_target", None)
+    target.location = (cx, cy, cz)
+    bpy.context.collection.objects.link(target)
+
+    camera_data = bpy.data.cameras.new("camera")
+    # Field spans are km-scale; Blender's default clip_end (100 m) would cull
+    # the entire scene and render only the world background (#1518 lesson).
+    camera_data.clip_start = max(0.1, 0.001 * radius)
+    camera_data.clip_end = 20.0 * radius
+    camera = bpy.data.objects.new("camera", camera_data)
+    bpy.context.collection.objects.link(camera)
+    bpy.context.scene.camera = camera
+    track = camera.constraints.new(type="TRACK_TO")
+    track.target = target
+
+    scene = bpy.context.scene
+    scene.frame_start, scene.frame_end = 1, frame_count
+    scene.render.fps = fps
+    for frame in range(1, frame_count + 1):
+        t = (frame - 1) / max(1, frame_count - 1)
+        angle = math.radians(200.0) * t
+        height = radius * (0.9 - 0.45 * t)
+        camera.location = (
+            cx + radius * math.cos(angle),
+            cy + radius * math.sin(angle),
+            cz + height,
+        )
+        camera.keyframe_insert(data_path="location", frame=frame)
+
+    sun_data = bpy.data.lights.new("sun", type="SUN")
+    sun = bpy.data.objects.new("sun", sun_data)
+    sun.location = (cx, cy, cz + 2 * radius)
+    sun.rotation_euler = (math.radians(30), 0.0, math.radians(45))
+    bpy.context.collection.objects.link(sun)
+
+
+def _configure_render(out_path: str, res_scale: int) -> None:
+    scene = bpy.context.scene
+    # Filmic/AgX tone-mapping desaturates the flat per-kind colors badly;
+    # Standard keeps the schematic palette readable.
+    try:
+        scene.view_settings.view_transform = "Standard"
+    except TypeError:
+        pass
+    render = scene.render
+    render.resolution_x, render.resolution_y = 1280, 720
+    render.resolution_percentage = res_scale
+    render.image_settings.file_format = "FFMPEG"
+    render.ffmpeg.format = "MPEG4"
+    render.ffmpeg.codec = "H264"
+    render.filepath = out_path
+    # Prefer EEVEE (fast); engine id differs across Blender versions.
+    for engine in ("BLENDER_EEVEE_NEXT", "BLENDER_EEVEE", "BLENDER_WORKBENCH"):
+        try:
+            render.engine = engine
+            break
+        except TypeError:
+            continue
+
+
+def main() -> None:
+    argv = sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else []
+    args = _parse_args(argv)
+    with open(args.scene, "r", encoding="utf-8") as fh:
+        scene_data = json.load(fh)
+
+    _clear_default_scene()
+    surface = scene_data["surface"]
+    subsea = bool(scene_data.get("is_subsea"))
+    z0 = min(min(row) for row in surface["z_m"])
+    cx, cy = _add_surface(surface, subsea)
+
+    span_x = surface["x_m"][-1] - surface["x_m"][0]
+    span_y = surface["y_m"][-1] - surface["y_m"][0]
+    scale = _size_scale(max(span_x, span_y))
+
+    z_terrain_top = (max(max(row) for row in surface["z_m"]) - z0) * Z_EXAGGERATION
+    z_top = max(z_terrain_top, _add_assets(scene_data, z0, scale))
+    _add_connections(scene_data, z0, scale)
+    if subsea:
+        z_top = max(z_top, _add_water_plane(surface, z0))
+
+    centre = (cx, cy, 0.5 * z_top)
+    _add_camera_flythrough(
+        centre,
+        radius=0.85 * math.hypot(span_x, span_y),
+        frame_count=args.frames,
+        fps=args.fps,
+    )
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    _configure_render(args.out, args.res_scale)
+    bpy.ops.render.render(animation=True)
+    print(f"fly-through rendered to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/digitalmodel/field_development/visualization.py
+++ b/src/digitalmodel/field_development/visualization.py
@@ -1,0 +1,334 @@
+# ABOUTME: Visualization of the generalized field layout — 2D plot + 3D scene JSON.
+# ABOUTME: Issue #1510 (workstream C of epic #1507). Feeds the Blender fly-through.
+"""
+digitalmodel.field_development.visualization
+=============================================
+
+Workstream C (#1510) of the field-development epic (#1507): visualization of
+the GENERALIZED layout model
+(:mod:`digitalmodel.field_development.layout_model`, #1509) —
+
+1. **2D layout plot** — deterministic matplotlib figure over the surface
+   (hypsometric tints onshore; a single-hue blue ramp for bathymetry, where
+   elevation is negative), with a fixed marker/color per asset kind, a fixed
+   color/linestyle per connection kind, waypoint markers, per-connection
+   3D-length annotations, and a legend of the kinds present.
+2. **3D scene export** — a typed JSON scene (schema
+   ``digitalmodel.field_layout_scene/2``) carrying the surface grid, EVERY
+   asset kind, and every routed connection (with waypoints and the sampled
+   3D path), so the Blender script can style each kind differently. JSON so
+   Blender's bundled Python needs no third-party packages. Consumed by
+   ``scripts/field_development/field_flythrough_bpy.py``.
+3. **Pipeline convenience** — :func:`render_layout_visualization` runs
+   config -> model -> plot PNG -> scene JSON in one call.
+
+The #1508 onshore tracer keeps its own plot/scene export
+(:mod:`digitalmodel.field_development.onshore_layout`, v1 scene schema);
+this module supersedes them for the generalized model — the tracer's YAML
+loads here unchanged via the loader's back-compat normalization.
+
+Determinism: styles are module-level constant maps covering every kind in
+:data:`~digitalmodel.field_development.layout_model.ASSET_KINDS` /
+:data:`~digitalmodel.field_development.layout_model.CONNECTION_KINDS`;
+exports are plain data derived from the model — CI asserts file creation,
+schema content, and layout numbers, never pixels.
+
+Usage
+-----
+>>> from digitalmodel.field_development.layout_model import (
+...     build_layout_model_from_file,
+... )
+>>> from digitalmodel.field_development.visualization import (
+...     export_layout_scene_json, plot_field_layout,
+... )
+>>> model = build_layout_model_from_file(
+...     "src/digitalmodel/field_development/data/offshore_demo_field.yml"
+... )  # doctest: +SKIP
+>>> plot_field_layout(model, "outputs/offshore_layout.png")  # doctest: +SKIP
+>>> export_layout_scene_json(model, "outputs/offshore_scene.json")  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend for file output
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.lines import Line2D  # noqa: E402
+
+from .layout_model import (  # noqa: E402
+    FieldLayoutModel,
+    build_layout_model_from_file,
+    layout_summary,
+)
+from .schematics.renderer import render_figure  # noqa: E402
+
+#: Version tag written into every exported scene JSON (bump on schema change).
+SCENE_SCHEMA = "digitalmodel.field_layout_scene/2"
+
+# --- fixed per-kind styles (identity = fixed assignment, never cycled) --------
+#: Marker style per asset kind: (matplotlib marker, color, size_pt).
+ASSET_STYLES: dict[str, tuple[str, str, float]] = {
+    "host": ("s", "#1f3a5f", 12.0),  # square, dark navy
+    "vessel": ("D", "#b3591c", 11.0),  # diamond, dark orange
+    "well": ("o", "#222222", 8.0),  # circle, near-black
+    "tree": ("^", "#2e6f40", 8.0),  # triangle, green
+    "manifold": ("P", "#6b3fa0", 11.0),  # plus (filled), purple
+}
+#: Line style per connection kind: (color, linestyle, linewidth_pt).
+CONNECTION_STYLES: dict[str, tuple[str, str, float]] = {
+    "jumper": ("#e07b39", "-", 1.6),  # orange, solid, thin
+    "flowline": ("#b2182b", "-", 2.2),  # firebrick, solid
+    "pipeline": ("#67001f", "--", 2.6),  # dark maroon, dashed, thick
+    "umbilical": ("#2166ac", "-.", 1.6),  # steel blue, dash-dot
+}
+_WAYPOINT_STYLE = {"marker": "x", "color": "#444444", "s": 36.0}
+
+_SUBSEA_CMAP = "Blues_r"  # single-hue ramp: deeper water = darker blue
+_ONSHORE_CMAP = "terrain"  # domain-standard hypsometric tints (matches #1508)
+
+
+def _is_subsea(model: FieldLayoutModel) -> bool:
+    """True when the whole surface is under water (bathymetry only)."""
+    return bool(model.surface.z_m.max() <= 0.0)
+
+
+# ---------------------------------------------------------------------------
+# 2D layout plot
+# ---------------------------------------------------------------------------
+
+
+def plot_field_layout(
+    model: FieldLayoutModel,
+    output_path: str | Path,
+    output_format: str = "png",
+    dpi: int = 150,
+) -> str:
+    """Deterministic 2D layout figure for the generalized model.
+
+    Surface as filled contours (blue depth ramp for bathymetry, hypsometric
+    tints onshore) with labelled contour lines; every connection drawn in its
+    kind's fixed color/linestyle with waypoint markers and a 3D route-length
+    annotation; every asset in its kind's fixed marker; legend of the kinds
+    present (fixed order). Returns the saved path.
+    """
+    fig, ax = plt.subplots(figsize=(9, 8))
+    surface = model.surface
+    subsea = _is_subsea(model)
+    cmap = _SUBSEA_CMAP if subsea else _ONSHORE_CMAP
+    filled = ax.contourf(
+        surface.x_m, surface.y_m, surface.z_m, levels=12, cmap=cmap, alpha=0.75
+    )
+    lines = ax.contour(
+        surface.x_m,
+        surface.y_m,
+        surface.z_m,
+        levels=12,
+        colors="dimgray",
+        linewidths=0.5,
+    )
+    ax.clabel(lines, inline=True, fontsize=7, fmt="%.0f")
+    colorbar_label = (
+        "Elevation [m] (negative = water depth)" if subsea else "Elevation [m]"
+    )
+    fig.colorbar(filled, ax=ax, label=colorbar_label)
+
+    for conn in model.connections:
+        color, linestyle, width = CONNECTION_STYLES[conn.kind]
+        ax.plot(
+            conn.path_xyz_m[:, 0],
+            conn.path_xyz_m[:, 1],
+            color=color,
+            linestyle=linestyle,
+            linewidth=width,
+            zorder=3,
+        )
+        if conn.waypoints_plan_m:
+            ax.scatter(
+                [w[0] for w in conn.waypoints_plan_m],
+                [w[1] for w in conn.waypoints_plan_m],
+                zorder=4,
+                **_WAYPOINT_STYLE,
+            )
+        mid = conn.path_xyz_m[len(conn.path_xyz_m) // 2]
+        ax.annotate(
+            f"{conn.connection_id}: {conn.route_length_m:,.0f} m",
+            (mid[0], mid[1]),
+            textcoords="offset points",
+            xytext=(6, 6),
+            fontsize=8,
+            zorder=5,
+        )
+
+    for asset in model.assets:
+        marker, color, size = ASSET_STYLES[asset.kind]
+        ax.plot(
+            asset.x_m,
+            asset.y_m,
+            marker,
+            color=color,
+            markersize=size,
+            linestyle="none",
+            zorder=6,
+        )
+        if asset.kind != "tree":  # trees are co-located with wells; skip label
+            ax.annotate(
+                asset.asset_id,
+                (asset.x_m, asset.y_m),
+                textcoords="offset points",
+                xytext=(8, -12),
+                fontsize=8,
+                zorder=7,
+            )
+
+    ax.legend(
+        handles=_legend_handles(model),
+        loc="upper left",
+        fontsize=8,
+        framealpha=0.9,
+    )
+    ax.set_xlabel("Easting [m]")
+    ax.set_ylabel("Northing [m]")
+    setting = "subsea" if subsea else "onshore"
+    ax.set_title(f"{model.name} — {setting} layout (screening)")
+    ax.set_aspect("equal")
+    saved = render_figure(fig, str(output_path), output_format, dpi=dpi)
+    plt.close(fig)
+    return saved
+
+
+def _legend_handles(model: FieldLayoutModel) -> list[Line2D]:
+    """Legend proxies for the asset/connection kinds present (fixed order)."""
+    handles: list[Line2D] = []
+    present_assets = {a.kind for a in model.assets}
+    for kind in ASSET_STYLES:  # dict order = fixed legend order
+        if kind not in present_assets:
+            continue
+        marker, color, size = ASSET_STYLES[kind]
+        handles.append(
+            Line2D(
+                [],
+                [],
+                marker=marker,
+                color=color,
+                markersize=size * 0.75,
+                linestyle="none",
+                label=kind,
+            )
+        )
+    present_connections = {c.kind for c in model.connections}
+    for kind in CONNECTION_STYLES:
+        if kind not in present_connections:
+            continue
+        color, linestyle, width = CONNECTION_STYLES[kind]
+        handles.append(
+            Line2D(
+                [], [], color=color, linestyle=linestyle, linewidth=width, label=kind
+            )
+        )
+    return handles
+
+
+# ---------------------------------------------------------------------------
+# 3D scene export (Blender fly-through input)
+# ---------------------------------------------------------------------------
+
+
+def layout_scene_dict(model: FieldLayoutModel) -> dict[str, Any]:
+    """The typed scene mapping (schema :data:`SCENE_SCHEMA`) for a model.
+
+    Every asset carries its ``kind``/``subtype``/``on_surface`` and every
+    connection its ``kind``, waypoints, and sampled 3D path, so the Blender
+    script can style each kind differently. ``is_subsea`` tells the renderer
+    to add a water surface at z = 0. Plain JSON-able data only.
+    """
+    return {
+        "schema": SCENE_SCHEMA,
+        "field_name": model.name,
+        "is_subsea": _is_subsea(model),
+        "surface": {
+            "x_m": model.surface.x_m.tolist(),
+            "y_m": model.surface.y_m.tolist(),
+            "z_m": model.surface.z_m.tolist(),
+            "source": model.surface.source,
+        },
+        "assets": [
+            {
+                "id": a.asset_id,
+                "name": a.name,
+                "kind": a.kind,
+                "subtype": a.subtype,
+                "x_m": a.x_m,
+                "y_m": a.y_m,
+                "z_m": a.z_m,
+                "on_surface": a.on_surface,
+            }
+            for a in model.assets
+        ],
+        "connections": [
+            {
+                "id": c.connection_id,
+                "kind": c.kind,
+                "from": c.from_id,
+                "to": c.to_id,
+                "waypoints_plan_m": [[x, y] for x, y in c.waypoints_plan_m],
+                "route_length_m": c.route_length_m,
+                "path_xyz_m": c.path_xyz_m.tolist(),
+            }
+            for c in model.connections
+        ],
+    }
+
+
+def export_layout_scene_json(model: FieldLayoutModel, output_path: str | Path) -> str:
+    """Write :func:`layout_scene_dict` as JSON for the bpy fly-through script.
+
+    JSON (not YAML/pickle) so Blender's bundled Python can read it with the
+    standard library only. Consumed by
+    ``scripts/field_development/field_flythrough_bpy.py``. Returns the path.
+    """
+    dest = Path(output_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "w", encoding="utf-8") as fh:
+        json.dump(layout_scene_dict(model), fh)
+    return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline convenience: config -> model -> plot + scene
+# ---------------------------------------------------------------------------
+
+
+def render_layout_visualization(
+    config_path: str | Path,
+    output_dir: str | Path,
+    output_format: str = "png",
+    dpi: int = 150,
+    stem: Optional[str] = None,
+) -> dict[str, Any]:
+    """Config -> model -> 2D plot + 3D scene JSON, in one call.
+
+    Artifacts land in ``output_dir`` as ``<stem>_layout.<format>`` and
+    ``<stem>_scene.json`` (default stem: the config file's stem). Returns the
+    :func:`~digitalmodel.field_development.layout_model.layout_summary` plus
+    the artifact paths — the numbers CI asserts against.
+    """
+    config_file = Path(config_path)
+    model = build_layout_model_from_file(config_file)
+    base = stem if stem is not None else config_file.stem
+    out = Path(output_dir)
+    plot_path = plot_field_layout(
+        model,
+        out / f"{base}_layout.{output_format}",
+        output_format=output_format,
+        dpi=dpi,
+    )
+    scene_path = export_layout_scene_json(model, out / f"{base}_scene.json")
+    result = layout_summary(model)
+    result["plot_path"] = plot_path
+    result["scene_path"] = scene_path
+    return result

--- a/tests/field_development/test_visualization.py
+++ b/tests/field_development/test_visualization.py
@@ -1,0 +1,164 @@
+# ABOUTME: Tests for visualization — general 2D plot + typed 3D scene export (#1510).
+# ABOUTME: File-creation + layout-number + scene-schema assertions for both demos.
+"""Tests for digitalmodel.field_development.visualization.
+
+Offline and deterministic: no Blender needed — the Blender fly-through script
+consumes the scene JSON asserted here (schema digitalmodel.field_layout_scene/2).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.field_development.layout_model import (
+    ASSET_KINDS,
+    CONNECTION_KINDS,
+    build_layout_model_from_file,
+)
+from digitalmodel.field_development.visualization import (
+    ASSET_STYLES,
+    CONNECTION_STYLES,
+    SCENE_SCHEMA,
+    export_layout_scene_json,
+    layout_scene_dict,
+    plot_field_layout,
+    render_layout_visualization,
+)
+
+DATA_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+)
+OFFSHORE_CONFIG = DATA_DIR / "offshore_demo_field.yml"
+ONSHORE_CONFIG = DATA_DIR / "onshore_demo_field.yml"
+
+DEMO_CONFIGS = [
+    pytest.param(OFFSHORE_CONFIG, id="offshore"),
+    pytest.param(ONSHORE_CONFIG, id="onshore"),
+]
+
+
+# --- style completeness (fixed per-kind assignment, never cycled) --------------
+class TestStyles:
+    def test_every_asset_kind_has_a_style(self):
+        assert set(ASSET_STYLES) == set(ASSET_KINDS)
+
+    def test_every_connection_kind_has_a_style(self):
+        assert set(CONNECTION_STYLES) == set(CONNECTION_KINDS)
+
+    def test_styles_are_distinct_per_kind(self):
+        assert len({(m, c) for m, c, _ in ASSET_STYLES.values()}) == len(ASSET_STYLES)
+        assert len({(c, ls) for c, ls, _ in CONNECTION_STYLES.values()}) == len(
+            CONNECTION_STYLES
+        )
+
+
+# --- 2D plot -------------------------------------------------------------------
+class TestPlot:
+    @pytest.mark.parametrize("config", DEMO_CONFIGS)
+    def test_plot_creates_png(self, config, tmp_path):
+        model = build_layout_model_from_file(config)
+        out = tmp_path / "layout.png"
+        saved = plot_field_layout(model, out)
+        assert saved == str(out)
+        assert out.exists()
+        assert out.stat().st_size > 10_000  # a real figure, not an empty stub
+
+    def test_plot_svg_format(self, tmp_path):
+        model = build_layout_model_from_file(ONSHORE_CONFIG)
+        out = tmp_path / "layout.svg"
+        plot_field_layout(model, out, output_format="svg")
+        assert out.exists()
+        text = out.read_text(encoding="utf-8")
+        assert "<svg" in text
+
+
+# --- 3D scene export -----------------------------------------------------------
+class TestSceneExport:
+    @pytest.mark.parametrize("config", DEMO_CONFIGS)
+    def test_scene_json_written_and_loadable(self, config, tmp_path):
+        model = build_layout_model_from_file(config)
+        out = tmp_path / "scene.json"
+        saved = export_layout_scene_json(model, out)
+        assert saved == str(out)
+        scene = json.loads(out.read_text(encoding="utf-8"))
+        assert scene["schema"] == SCENE_SCHEMA
+        assert scene == layout_scene_dict(model)
+
+    def test_offshore_scene_carries_every_asset_kind(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        scene = layout_scene_dict(model)
+        assert {a["kind"] for a in scene["assets"]} == set(ASSET_KINDS)
+        assert {c["kind"] for c in scene["connections"]} == set(CONNECTION_KINDS)
+
+    def test_offshore_scene_flags_subsea_and_onshore_does_not(self):
+        offshore = layout_scene_dict(build_layout_model_from_file(OFFSHORE_CONFIG))
+        onshore = layout_scene_dict(build_layout_model_from_file(ONSHORE_CONFIG))
+        assert offshore["is_subsea"] is True
+        assert onshore["is_subsea"] is False
+
+    def test_waypoints_preserved_in_scene(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        scene = layout_scene_dict(model)
+        fl = next(c for c in scene["connections"] if c["id"] == "FL-1")
+        assert fl["waypoints_plan_m"] == [[3200.0, 3600.0]]
+        # the sampled 3D path passes exactly through the plan waypoint
+        assert any(x == 3200.0 and y == 3600.0 for x, y, _ in fl["path_xyz_m"])
+
+    def test_scene_geometry_matches_model(self):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        scene = layout_scene_dict(model)
+        fpso = next(a for a in scene["assets"] if a["id"] == "FPSO-1")
+        assert fpso["z_m"] == pytest.approx(0.0)
+        assert fpso["on_surface"] is False
+        for conn_dict, conn in zip(scene["connections"], model.connections):
+            assert conn_dict["route_length_m"] == pytest.approx(conn.route_length_m)
+            assert len(conn_dict["path_xyz_m"]) == len(conn.path_xyz_m)
+        surface = scene["surface"]
+        assert len(surface["z_m"]) == model.surface.z_m.shape[0]
+        assert len(surface["z_m"][0]) == model.surface.z_m.shape[1]
+        assert max(max(row) for row in surface["z_m"]) < 0.0  # bathymetry
+
+    def test_export_is_deterministic(self, tmp_path):
+        model = build_layout_model_from_file(OFFSHORE_CONFIG)
+        a, b = tmp_path / "a.json", tmp_path / "b.json"
+        export_layout_scene_json(model, a)
+        export_layout_scene_json(model, b)
+        assert a.read_bytes() == b.read_bytes()
+
+
+# --- pipeline convenience --------------------------------------------------------
+class TestRenderLayoutVisualization:
+    @pytest.mark.parametrize("config", DEMO_CONFIGS)
+    def test_end_to_end_artifacts_and_summary(self, config, tmp_path):
+        result = render_layout_visualization(config, tmp_path)
+        plot = Path(result["plot_path"])
+        scene_path = Path(result["scene_path"])
+        assert plot.exists() and plot.suffix == ".png"
+        assert scene_path.exists() and scene_path.suffix == ".json"
+        assert plot.name == f"{config.stem}_layout.png"
+        assert scene_path.name == f"{config.stem}_scene.json"
+        # summary numbers ride along for CI assertions
+        assert result["connections"]
+        for conn in result["connections"]:
+            assert conn["route_length_m"] >= conn["plan_length_m"] > 0.0
+
+    def test_offshore_summary_numbers(self, tmp_path):
+        result = render_layout_visualization(OFFSHORE_CONFIG, tmp_path)
+        assert result["field"] == "Demo Offshore Field"
+        assert result["surface"]["is_subsea"] is True
+        assert result["assets_by_kind"] == {
+            "vessel": 1,
+            "manifold": 1,
+            "well": 3,
+            "tree": 3,
+            "host": 1,
+        }
+        scene = json.loads(Path(result["scene_path"]).read_text(encoding="utf-8"))
+        assert {c["kind"] for c in scene["connections"]} == set(CONNECTION_KINDS)


### PR DESCRIPTION
Closes #1510. Workstream C of epic #1507, built on the generalized layout model (#1509).

## What

- **`src/digitalmodel/field_development/visualization.py`** (new)
  - `plot_field_layout` — deterministic 2D layout figure over the surface: single-hue blue depth ramp for bathymetry (negative elevation) vs hypsometric tints onshore; fixed per-kind asset markers and per-kind connection colors/linestyles (never cycled); waypoint markers; per-connection 3D route-length annotations; legend of kinds present.
  - `layout_scene_dict` / `export_layout_scene_json` — typed scene JSON (schema `digitalmodel.field_layout_scene/2`) carrying the surface grid, EVERY asset kind (host/vessel/well/tree/manifold with subtype + on_surface), every connection kind (jumper/flowline/pipeline/umbilical) with waypoints and the sampled 3D path, plus an `is_subsea` flag.
  - `render_layout_visualization` — one-call config → model → plot PNG + scene JSON pipeline.
- **`scripts/field_development/field_flythrough_bpy.py`** (new, generalized sibling of the #1508 onshore script)
  - Per-kind geometry: pad cubes (host), hull boxes (vessel), cylinders (well), slim/tall cylinders (tree), cones (manifold), per-kind bevelled curves + colors for connections; translucent water plane at z = 0 for subsea scenes; camera clip range scaled to scene size (#1518 lesson); Standard view transform (AgX washed out the flat palette); `--frames/--fps/--res-scale` for short verification renders.
  - Kept as a sibling rather than editing `onshore_flythrough_bpy.py`: the onshore script consumes the v1 tracer scene JSON still emitted by `onshore_layout.export_scene_json` (untouched — tracer/screening module is owned by workstream D right now); the generalized model exports a differently-typed v2 schema.
- **`tests/field_development/test_visualization.py`** — 16 offline tests (no Blender in CI): plot + scene export for BOTH demo configs, scene schema assertions (all asset/connection kinds present, waypoints preserved exactly, subsea flags, deterministic byte-identical export), style-map completeness over `ASSET_KINDS`/`CONNECTION_KINDS`, end-to-end pipeline artifact + layout-number checks.

No changes to `field_development/__init__.py` (parallel lane; wiring lands in the follow-up integration PR) and none to screening code.

## Render verification (real headless Blender 4.0.2 + ffmpeg)

Full pipeline run for BOTH demo configs: build model → plot PNG → scene JSON → `blender --background` render (24 frames @ 24 fps, 50% res) → ffmpeg mid-clip frame extraction → programmatic non-blank check:

| demo | exit | mid-frame distinct RGB | frame std | verdict |
|---|---|---|---|---|
| offshore (`offshore_demo_field.yml`) | 0 | 7,684 | 70.5 | non-blank; FPSO hull at waterline, riser/umbilical down to manifold cone, tree cylinders, seabed mesh + water plane visible |
| onshore (`onshore_demo_field.yml`, via loader back-compat) | 0 | 6,563 | 70.2 | non-blank; host cube, well cylinders, red flowline curves over terrain |

Rendered videos are NOT committed (`outputs/` is gitignored) — re-render with the command in the script docstring.

## Tests & lint

- `tests/field_development/`: **582 passed, 32 skipped** (includes the 16 new tests; run with pinned deps from `uv.lock` — CI authoritative).
- black 24.10.0, isort 5.13.2, flake8 6.1.0, ruff 0.15.1 all green on the three new files.