### PR TITLE
Field-development representative API: layout / screen / visualize / analogs (#1512)

### DIFF
--- a/scripts/field_development/representative_api_demo.py
+++ b/scripts/field_development/representative_api_demo.py
@@ -1,0 +1,71 @@
+# ABOUTME: Demo of the representative field-development API (#1512, epic #1507):
+# ABOUTME: iterate rate variants of a demo config through layout/screen/visualize.
+"""Iterate the demo field through the representative API — no file edits.
+
+Runs the bundled offshore demo config through ``api.layout`` once, then a
+handful of ``api.screen`` iterations (the target usage: several models per
+case, 10-20 cheap iterations each) by overriding one well rate per call, and
+finally renders the base case with ``api.visualize``.
+
+Usage (from the repo root)::
+
+    python scripts/field_development/representative_api_demo.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from digitalmodel.field_development import api  # noqa: E402
+
+CONFIG = (
+    REPO_ROOT
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+    / "offshore_demo_field.yml"
+)
+FLUID = {"density_kg_per_m3": 850.0, "viscosity_pa_s": 2.0e-3}
+
+
+def main(output_dir: str | Path = "outputs/field_development/api_demo") -> None:
+    summary = api.layout(CONFIG)
+    print(f"# {summary['field']}")
+    print(f"assets by kind: {summary['assets_by_kind']}")
+    print(f"is_subsea: {summary['surface']['is_subsea']}")
+    print()
+
+    print("W-1 rate [m3/d] | FL-1 selected | FL-1 arrival [kPa] | overall")
+    print("---|---|---|---")
+    for rate in (600.0, 950.0, 1300.0, 1650.0, 2000.0):
+        result = api.screen(
+            CONFIG,
+            inlet_pressure_kpa=25000.0,
+            target_arrival_pressure_kpa=5000.0,
+            fluid=FLUID,
+            assets={"W-1": {"rate_m3_per_day": rate}},
+        )
+        fl1 = next(fl for fl in result["flowlines"] if fl["id"] == "FL-1")
+        sel = fl1["selected"]
+        selected = "none pass" if sel is None else f"NPS {sel['nps']:g}"
+        arrival = "-" if sel is None else f"{sel['arrival_pressure_kpa']:.0f}"
+        overall = "PASS" if result["passes"] else "FAIL"
+        print(f"{rate:.0f} | {selected} | {arrival} | {overall}")
+    print()
+
+    rendered = api.visualize(CONFIG, output_dir)
+    print(f"plot:  {rendered['plot_path']}")
+    print(f"scene: {rendered['scene_path']}")
+
+    analogs = api.analogs({"water_depth_m": 1450.0, "host_kind": "fpso"})
+    status = "available" if analogs["available"] else "unavailable (adapter)"
+    print(f"analogs backend: {status}")
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:2])

--- a/src/digitalmodel/field_development/api.py
+++ b/src/digitalmodel/field_development/api.py
@@ -1,0 +1,505 @@
+# ABOUTME: Representative field-development API — layout / screen / visualize / analogs.
+# ABOUTME: Issue #1512 (workstream E of epic #1507). Thin, iteration-cheap entry surface.
+"""
+digitalmodel.field_development.api
+===================================
+
+Workstream E (#1512) of the field-development epic (#1507): ONE coherent
+entry surface over the domain modules landed in the earlier workstreams.
+"API" here means the repo's convention — a clean set of plain-Python
+functions (YAML config in, JSON-serializable dicts out), NOT an HTTP layer.
+
+The four calls
+--------------
+- :func:`layout` — build the generalized layout model (#1509) and return its
+  summary dict (assets, connections, true 3D lengths, ``is_subsea``).
+- :func:`screen` — layout + flowline diameter sweeps (#1511) for every
+  hydraulic connection, cable sizing screens when the config declares
+  ``cables``, and an optional one-page markdown report.
+- :func:`visualize` — 2D layout plot + 3D scene JSON (#1510), delegating to
+  :func:`~digitalmodel.field_development.visualization.render_layout_visualization`.
+- :func:`analogs` — thin adapter to the ``worldenergydata`` analog finder
+  (cross-repo; see the function docstring for the contract).
+
+Iteration cheapness (the design goal)
+-------------------------------------
+Real usage is several models per case with 10-20 iterations each, so every
+call accepts ``**overrides``: dict-deep overrides of the YAML config applied
+IN MEMORY, without editing the file. Mappings merge recursively; a mapping
+override on a list of ``id``-keyed specs (``assets``, ``connections``,
+``wells``, ``flowlines``, ``cables``) addresses entries BY ID; scalars
+replace. Example — three rate variants of the demo field, no file edits:
+
+>>> from digitalmodel.field_development import api  # doctest: +SKIP
+>>> for rate in (280.0, 400.0, 520.0):  # doctest: +SKIP
+...     result = api.screen(
+...         "src/digitalmodel/field_development/data/onshore_demo_field.yml",
+...         inlet_pressure_kpa=2000.0,
+...         target_arrival_pressure_kpa=1500.0,
+...         wells={"W-1": {"rate_m3_per_day": rate}},
+...     )
+...     print(rate, result["flowlines"][0]["selected"]["nps"])
+
+Adapter honesty
+---------------
+:func:`screen` is where the generalized #1509 model meets the #1511
+screening layer. ``screening.sweep_layout_flowlines`` consumes the #1508
+tracer's ``FieldLayout`` objects, so THIS module adapts instead of editing
+``screening.py``: it feeds each hydraulic connection of the generalized
+model straight into
+:func:`~digitalmodel.field_development.screening.flowline_diameter_sweep`,
+resolving the line rate from (in order) an explicit ``rate_m3_per_day`` on
+the connection spec, the from-asset's rate, a co-located rated asset (a tree
+sits on its well), or the summed throughput of upstream hydraulic
+connections. Connections whose rate cannot be resolved are reported under
+``skipped_connections``, never silently dropped.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .layout_model import (
+    FieldLayoutModel,
+    RoutedConnection,
+    build_layout_model,
+    layout_summary,
+)
+from .screening import flowline_diameter_sweep, screening_report, size_cable
+
+#: Connection kinds screened hydraulically by :func:`screen` (umbilicals
+#: carry controls/chemicals, not the production bore, so they are excluded).
+HYDRAULIC_CONNECTION_KINDS: tuple[str, ...] = ("jumper", "flowline", "pipeline")
+
+#: Dotted path of the cross-repo analog finder (see :func:`analogs`).
+ANALOGS_MODULE = "worldenergydata.field_development.analogs"
+
+#: Plan-coordinate tolerance [m] for treating two assets as co-located
+#: (e.g. a tree stacked on its well) when resolving line rates.
+CO_LOCATION_TOLERANCE_M = 1.0e-6
+
+
+# ---------------------------------------------------------------------------
+# Config loading with dict-deep overrides
+# ---------------------------------------------------------------------------
+
+
+def deep_override(base: Any, override: Any) -> Any:
+    """Merge ``override`` into ``base`` without mutating either.
+
+    Rules (applied recursively):
+
+    - mapping onto mapping — per-key recursive merge;
+    - mapping onto a list of ``id``-keyed mappings — the override's keys
+      address list entries BY ID (KeyError if an id is absent, so a typo
+      never silently adds an asset);
+    - anything else — the override value replaces the base value.
+    """
+    if isinstance(base, dict) and isinstance(override, dict):
+        merged = dict(base)
+        for key, value in override.items():
+            merged[key] = deep_override(base[key], value) if key in base else value
+        return merged
+    if isinstance(base, list) and isinstance(override, dict):
+        if not all(isinstance(entry, dict) and "id" in entry for entry in base):
+            raise ValueError(
+                "mapping override targets a list whose entries are not all "
+                "'id'-keyed mappings; pass a full replacement list instead"
+            )
+        ids = [str(entry["id"]) for entry in base]
+        merged_list: list[Any] = [dict(entry) for entry in base]
+        for entry_id, patch in override.items():
+            if str(entry_id) not in ids:
+                raise KeyError(f"override id {entry_id!r} not found; available: {ids}")
+            index = ids.index(str(entry_id))
+            merged_list[index] = deep_override(merged_list[index], patch)
+        return merged_list
+    return override
+
+
+def load_config_with_overrides(
+    config_path: str | Path, overrides: dict[str, Any]
+) -> dict[str, Any]:
+    """Parse the YAML config and apply ``overrides`` (raw, pre-normalization).
+
+    Overrides are applied to the config AS WRITTEN, so both the generalized
+    schema (``assets``/``connections``) and the #1508 tracer schema
+    (``host``/``wells``/``flowlines``) are addressable with the section names
+    the author used. Schema normalization/validation happens downstream in
+    :func:`~digitalmodel.field_development.layout_model.build_layout_model`.
+    """
+    path = Path(config_path)
+    with open(path, "r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+    if not isinstance(config, dict):
+        raise ValueError(f"config {path} did not parse to a mapping")
+    if overrides:
+        config = deep_override(config, overrides)
+    return config
+
+
+def _build_model(
+    config_path: str | Path, overrides: dict[str, Any]
+) -> tuple[FieldLayoutModel, dict[str, Any]]:
+    """Config file + overrides -> (built model, merged raw config)."""
+    path = Path(config_path)
+    config = load_config_with_overrides(path, overrides)
+    model = build_layout_model(config, base_dir=path.parent)
+    return model, config
+
+
+# ---------------------------------------------------------------------------
+# 1. layout
+# ---------------------------------------------------------------------------
+
+
+def layout(config_path: str | Path, **overrides: Any) -> dict[str, Any]:
+    """Build the generalized layout model and return its summary dict.
+
+    ``config_path`` is a YAML layout config (generalized #1509 schema or the
+    #1508 tracer schema — both load). ``**overrides`` are dict-deep config
+    overrides per :func:`deep_override`, keyed by top-level section name.
+
+    Returns the
+    :func:`~digitalmodel.field_development.layout_model.layout_summary`
+    mapping: field name, surface ranges + ``is_subsea``, assets by kind, and
+    per-connection plan/3D lengths. JSON-serializable.
+    """
+    model, _ = _build_model(config_path, overrides)
+    return layout_summary(model)
+
+
+# ---------------------------------------------------------------------------
+# 2. screen — layout + flowline sweeps + cable screens (+ optional report)
+# ---------------------------------------------------------------------------
+
+
+def _co_located_rate(model: FieldLayoutModel, asset_id: str) -> Optional[float]:
+    """Summed rate of OTHER rated assets at the same plan position, if any."""
+    asset = model.asset(asset_id)
+    total, found = 0.0, False
+    for other in model.assets:
+        if other.asset_id == asset.asset_id or other.rate_m3_per_day is None:
+            continue
+        if (
+            abs(other.x_m - asset.x_m) <= CO_LOCATION_TOLERANCE_M
+            and abs(other.y_m - asset.y_m) <= CO_LOCATION_TOLERANCE_M
+        ):
+            total += other.rate_m3_per_day
+            found = True
+    return total if found else None
+
+
+def _asset_throughput(
+    model: FieldLayoutModel,
+    asset_id: str,
+    kinds: tuple[str, ...],
+    visiting: frozenset[str],
+) -> Optional[float]:
+    """Screening-grade throughput of an asset [m3/day], or None if unresolvable.
+
+    own rate (or a co-located rated asset's — a tree sits on its well)
+    + the resolved rates of all hydraulic connections INTO the asset.
+    ``visiting`` guards against connection-graph cycles.
+    """
+    asset = model.asset(asset_id)
+    own = asset.rate_m3_per_day
+    if own is None:
+        own = _co_located_rate(model, asset_id)
+    total = own or 0.0
+    for conn in model.connections:
+        if conn.kind in kinds and conn.to_id == asset_id:
+            inflow = _connection_rate(model, conn, kinds, visiting)
+            if inflow is not None:
+                total += inflow
+    return total if total > 0.0 else None
+
+
+def _connection_rate(
+    model: FieldLayoutModel,
+    conn: RoutedConnection,
+    kinds: tuple[str, ...],
+    visiting: frozenset[str] = frozenset(),
+) -> Optional[float]:
+    """Rate carried by one connection [m3/day], or None if unresolvable.
+
+    Resolution order: explicit ``rate_m3_per_day`` on the connection spec
+    (cheapest per-iteration override), then the from-asset's throughput
+    (:func:`_asset_throughput`).
+    """
+    explicit = conn.properties.get("rate_m3_per_day")
+    if explicit is not None:
+        return float(explicit)
+    if conn.from_id in visiting:  # cycle in the connection graph
+        return None
+    return _asset_throughput(model, conn.from_id, kinds, visiting | {conn.from_id})
+
+
+def _screen_cables(
+    config: dict[str, Any],
+    connections: dict[str, RoutedConnection],
+    defaults: Optional[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Run :func:`~digitalmodel.field_development.screening.size_cable` for
+    every spec in the config's ``cables`` section.
+
+    Each spec needs ``load_kw``, ``line_voltage_v``, ``power_factor`` and a
+    length: either ``length_m`` or ``connection: <id>`` (the routed
+    connection's true 3D length — e.g. size a power core along an umbilical).
+    """
+    results: list[dict[str, Any]] = []
+    for spec in config.get("cables") or []:
+        if "length_m" in spec:
+            length_m = float(spec["length_m"])
+        elif "connection" in spec:
+            ref = str(spec["connection"])
+            if ref not in connections:
+                raise ValueError(
+                    f"cable {spec.get('id')!r} references unknown connection {ref!r}"
+                )
+            length_m = connections[ref].route_length_m
+        else:
+            raise ValueError(
+                f"cable {spec.get('id')!r} needs 'length_m' or 'connection'"
+            )
+        result = size_cable(
+            load_kw=float(spec["load_kw"]),
+            line_voltage_v=float(spec["line_voltage_v"]),
+            length_m=length_m,
+            power_factor=float(spec["power_factor"]),
+            defaults=defaults,
+        )
+        result["id"] = str(spec.get("id", spec.get("connection", "-")))
+        results.append(result)
+    return results
+
+
+def screen(
+    config_path: str | Path,
+    *,
+    inlet_pressure_kpa: Optional[float] = None,
+    target_arrival_pressure_kpa: Optional[float] = None,
+    fluid: Optional[dict[str, Any]] = None,
+    connection_kinds: tuple[str, ...] = HYDRAULIC_CONNECTION_KINDS,
+    screening_defaults: Optional[dict[str, Any]] = None,
+    report_path: Optional[str | Path] = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Layout + engineering screens for one config iteration.
+
+    Builds the layout model, then for every connection whose kind is in
+    ``connection_kinds`` runs the #1511 flowline diameter sweep (smallest
+    standard pipe size meeting arrival pressure + the API RP 14E erosional
+    limit) over the connection's TRUE 3D route length and endpoint elevation
+    change. When the config declares a ``cables`` section, each entry gets
+    the #1511 cable sizing screen (see :func:`_screen_cables` for the spec).
+
+    Screening inputs resolve keyword-first, config-second: ``fluid`` falls
+    back to the config's ``fluid`` section; the two pressures fall back to
+    ``screening.inlet_pressure_kpa`` / ``screening.target_arrival_pressure_kpa``.
+    A missing input raises ValueError (no invented numbers).
+    ``screening_defaults`` overrides the bundled correlation constants
+    (``data/screening_defaults.yml``); ``report_path`` additionally writes
+    the deterministic one-page markdown report. ``**overrides`` are
+    dict-deep config overrides per :func:`deep_override`.
+
+    Returns ``{"field", "layout", "flowlines", "cables",
+    "skipped_connections", "passes", "report_path"}`` — JSON-serializable;
+    unresolvable lines land in ``skipped_connections`` with a reason.
+    """
+    model, config = _build_model(config_path, overrides)
+    screening_cfg = config.get("screening") or {}
+    if inlet_pressure_kpa is None:
+        inlet_pressure_kpa = screening_cfg.get("inlet_pressure_kpa")
+    if target_arrival_pressure_kpa is None:
+        target_arrival_pressure_kpa = screening_cfg.get("target_arrival_pressure_kpa")
+    if fluid is None:
+        fluid = config.get("fluid")
+    missing = [
+        name
+        for name, value in (
+            ("inlet_pressure_kpa", inlet_pressure_kpa),
+            ("target_arrival_pressure_kpa", target_arrival_pressure_kpa),
+            ("fluid", fluid),
+        )
+        if value is None
+    ]
+    if missing:
+        raise ValueError(
+            f"screen() inputs missing (pass as keywords or config sections): {missing}"
+        )
+
+    flowlines: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    for conn in model.connections:
+        if conn.kind not in connection_kinds:
+            continue
+        rate = _connection_rate(model, conn, connection_kinds)
+        if rate is None:
+            skipped.append(
+                {
+                    "id": conn.connection_id,
+                    "kind": conn.kind,
+                    "reason": "no resolvable rate (no explicit, asset, "
+                    "co-located, or upstream rate)",
+                }
+            )
+            continue
+        if conn.roughness_m is None:
+            skipped.append(
+                {
+                    "id": conn.connection_id,
+                    "kind": conn.kind,
+                    "reason": "no roughness_m on the connection spec",
+                }
+            )
+            continue
+        sweep = flowline_diameter_sweep(
+            rate_m3_per_day=rate,
+            length_m=conn.route_length_m,
+            elevation_change_m=conn.elevation_change_m,
+            roughness_m=conn.roughness_m,
+            density_kg_per_m3=float(fluid["density_kg_per_m3"]),
+            viscosity_pa_s=float(fluid["viscosity_pa_s"]),
+            inlet_pressure_kpa=float(inlet_pressure_kpa),
+            target_arrival_pressure_kpa=float(target_arrival_pressure_kpa),
+            defaults=screening_defaults,
+        )
+        sweep["id"] = conn.connection_id
+        sweep["kind"] = conn.kind
+        sweep["from"] = conn.from_id
+        sweep["to"] = conn.to_id
+        flowlines.append(sweep)
+
+    connection_map = {c.connection_id: c for c in model.connections}
+    cables = _screen_cables(config, connection_map, screening_defaults)
+
+    screened = [*flowlines, *cables]
+    result: dict[str, Any] = {
+        "field": model.name,
+        "layout": layout_summary(model),
+        "flowlines": flowlines,
+        "cables": cables,
+        "skipped_connections": skipped,
+        "passes": all(r["passes"] for r in screened) if screened else False,
+        "report_path": None,
+    }
+    if report_path is not None:
+        assumptions = [
+            f"Fluid: density {float(fluid['density_kg_per_m3']):.1f} kg/m3, "
+            f"viscosity {float(fluid['viscosity_pa_s']):.6f} Pa-s.",
+            f"Inlet pressure {float(inlet_pressure_kpa):.1f} kPa; target "
+            f"arrival {float(target_arrival_pressure_kpa):.1f} kPa.",
+            "Line lengths/elevations from the routed layout model "
+            "(true 3D route lengths).",
+        ]
+        result["report_path"] = screening_report(
+            {
+                "field": model.name,
+                "assumptions": assumptions,
+                "flowlines": flowlines,
+                "cables": cables,
+            },
+            report_path,
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 3. visualize
+# ---------------------------------------------------------------------------
+
+
+def visualize(
+    config_path: str | Path,
+    output_dir: str | Path,
+    *,
+    output_format: str = "png",
+    dpi: int = 150,
+    stem: Optional[str] = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """2D layout plot + 3D scene JSON for one config iteration.
+
+    Delegates to
+    :func:`~digitalmodel.field_development.visualization.render_layout_visualization`
+    (#1510); with ``**overrides`` the merged config is built here first and
+    rendered through the same plot/scene calls with the same artifact naming
+    (``<stem>_layout.<format>``, ``<stem>_scene.json``; default stem = config
+    file stem). Returns the layout summary plus ``plot_path``/``scene_path``.
+
+    The visualization module (matplotlib) is imported lazily so
+    :func:`layout`/:func:`screen` iterations never pay for it.
+    """
+    from . import visualization  # matplotlib import deferred to first use
+
+    config_file = Path(config_path)
+    if not overrides:
+        return visualization.render_layout_visualization(
+            config_file, output_dir, output_format=output_format, dpi=dpi, stem=stem
+        )
+    model, _ = _build_model(config_file, overrides)
+    base = stem if stem is not None else config_file.stem
+    out = Path(output_dir)
+    plot_path = visualization.plot_field_layout(
+        model,
+        out / f"{base}_layout.{output_format}",
+        output_format=output_format,
+        dpi=dpi,
+    )
+    scene_path = visualization.export_layout_scene_json(
+        model, out / f"{base}_scene.json"
+    )
+    result = layout_summary(model)
+    result["plot_path"] = plot_path
+    result["scene_path"] = scene_path
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 4. analogs — cross-repo adapter (worldenergydata)
+# ---------------------------------------------------------------------------
+
+
+def analogs(criteria: dict[str, Any]) -> dict[str, Any]:
+    """Find analog fields/developments via the ``worldenergydata`` repo.
+
+    Cross-repo contract (ADAPTER, documented here because ``digitalmodel``
+    cannot depend on ``worldenergydata``): when the module named by
+    :data:`ANALOGS_MODULE` (``worldenergydata.field_development.analogs``)
+    is importable in the running environment, its ``find_analogs`` callable
+    is invoked with ``criteria`` unpacked as keyword arguments and must
+    return JSON-serializable data. When it is not importable (the normal
+    case for a standalone ``digitalmodel`` install), this function does NOT
+    raise — it returns a structured unavailability response so screening
+    pipelines keep running::
+
+        {"available": False, "reason": "...", "criteria": {...}}
+
+    On success the response is
+    ``{"available": True, "criteria": {...}, "result": <find_analogs(...)>}``.
+    """
+    if not isinstance(criteria, dict):
+        raise TypeError(f"criteria must be a mapping, got {type(criteria).__name__}")
+    try:
+        module = importlib.import_module(ANALOGS_MODULE)
+        find_analogs = module.find_analogs
+    except (ImportError, AttributeError) as exc:
+        return {
+            "available": False,
+            "reason": (
+                f"{ANALOGS_MODULE}.find_analogs is not importable in this "
+                f"environment ({exc}); install/point PYTHONPATH at the "
+                "worldenergydata repo to enable analog lookups"
+            ),
+            "criteria": dict(criteria),
+        }
+    return {
+        "available": True,
+        "criteria": dict(criteria),
+        "result": find_analogs(**criteria),
+    }

--- a/tests/field_development/test_api.py
+++ b/tests/field_development/test_api.py
@@ -1,0 +1,453 @@
+# ABOUTME: Tests for field_development.api (#1512, epic #1507): the representative
+# ABOUTME: layout/screen/visualize/analogs surface, incl. dict-deep config overrides.
+"""Tests for digitalmodel.field_development.api.
+
+The screen() numeric anchor reuses the HAND-COMPUTED flowline-sweep values
+from ``test_screening.py`` (same rate/length/fluid, elevation term dropped on
+a flat surface) — never a snapshot of the code's own output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.field_development import api
+from digitalmodel.field_development.screening import size_cable
+
+DATA_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+)
+ONSHORE_CONFIG = DATA_DIR / "onshore_demo_field.yml"
+OFFSHORE_CONFIG = DATA_DIR / "offshore_demo_field.yml"
+
+#: Flat-surface anchor config: one 2000 m flowline at constant elevation, so
+#: the sweep inputs equal test_screening's SWEEP_KWARGS with the elevation
+#: term dropped (hand calc reproduced in TestScreenHandAnchored).
+FLAT_ANCHOR_CONFIG = {
+    "field": {"name": "Flat Anchor Field"},
+    "surface": {
+        "kind": "synthetic",
+        "x_min_m": 0.0,
+        "x_max_m": 2500.0,
+        "y_min_m": 0.0,
+        "y_max_m": 500.0,
+        "nx": 6,
+        "ny": 3,
+        "base_elevation_m": 100.0,
+        "amplitude_m": 0.0,  # flat: route length = plan length exactly
+        "x_wavelength_m": 1000.0,
+        "y_wavelength_m": 1000.0,
+    },
+    "assets": [
+        {
+            "id": "WH-1",
+            "kind": "well",
+            "x_m": 200.0,
+            "y_m": 250.0,
+            "rate_m3_per_day": 300.0,
+        },
+        {"id": "HOST-1", "kind": "host", "x_m": 2200.0, "y_m": 250.0},
+    ],
+    "connections": [
+        {
+            "id": "FL-1",
+            "kind": "flowline",
+            "from": "WH-1",
+            "to": "HOST-1",
+            "roughness_m": 4.5e-5,
+        },
+    ],
+}
+
+ANCHOR_FLUID = {"density_kg_per_m3": 850.0, "viscosity_pa_s": 2.0e-3}
+
+
+def _write_anchor_config(tmp_path: Path) -> Path:
+    path = tmp_path / "flat_anchor_field.yml"
+    path.write_text(yaml.safe_dump(FLAT_ANCHOR_CONFIG), encoding="utf-8")
+    return path
+
+
+# --- deep_override -----------------------------------------------------------
+class TestDeepOverride:
+    def test_mappings_merge_recursively(self):
+        base = {"fluid": {"density_kg_per_m3": 850.0, "viscosity_pa_s": 5e-3}}
+        merged = api.deep_override(base, {"fluid": {"viscosity_pa_s": 2e-3}})
+        assert merged["fluid"] == {
+            "density_kg_per_m3": 850.0,
+            "viscosity_pa_s": 2e-3,
+        }
+        # No mutation of the base mapping.
+        assert base["fluid"]["viscosity_pa_s"] == 5e-3
+
+    def test_id_keyed_list_merge(self):
+        base = {"wells": [{"id": "W-1", "rate": 1.0}, {"id": "W-2", "rate": 2.0}]}
+        merged = api.deep_override(base, {"wells": {"W-2": {"rate": 9.0}}})
+        assert merged["wells"] == [
+            {"id": "W-1", "rate": 1.0},
+            {"id": "W-2", "rate": 9.0},
+        ]
+        assert base["wells"][1]["rate"] == 2.0
+
+    def test_unknown_id_raises_keyerror(self):
+        base = {"wells": [{"id": "W-1"}]}
+        with pytest.raises(KeyError, match="W-9"):
+            api.deep_override(base, {"wells": {"W-9": {"rate": 1.0}}})
+
+    def test_mapping_onto_plain_list_rejected(self):
+        with pytest.raises(ValueError, match="id"):
+            api.deep_override({"xs": [1, 2, 3]}, {"xs": {"a": 1}})
+
+    def test_scalars_and_lists_replace(self):
+        merged = api.deep_override({"a": 1, "xs": [1, 2]}, {"a": 2, "xs": [3]})
+        assert merged == {"a": 2, "xs": [3]}
+
+    def test_new_top_level_section_added(self):
+        merged = api.deep_override({"a": 1}, {"cables": [{"id": "C-1"}]})
+        assert merged["cables"] == [{"id": "C-1"}]
+
+
+# --- layout ------------------------------------------------------------------
+class TestLayout:
+    def test_onshore_demo_tracer_schema(self):
+        summary = api.layout(ONSHORE_CONFIG)
+        assert summary["field"] == "Demo Onshore Field"
+        assert summary["surface"]["is_subsea"] is False
+        assert summary["assets_by_kind"] == {"host": 1, "well": 3}
+        assert len(summary["connections"]) == 3
+        for conn in summary["connections"]:
+            assert conn["route_length_m"] >= conn["plan_length_m"]
+        json.dumps(summary)  # JSON-serializable contract
+
+    def test_offshore_demo_generalized_schema(self):
+        summary = api.layout(OFFSHORE_CONFIG)
+        assert summary["field"] == "Demo Offshore Field"
+        assert summary["surface"]["is_subsea"] is True
+        assert summary["assets_by_kind"] == {
+            "vessel": 1,
+            "manifold": 1,
+            "well": 3,
+            "tree": 3,
+            "host": 1,
+        }
+        assert {c["kind"] for c in summary["connections"]} == {
+            "jumper",
+            "flowline",
+            "pipeline",
+            "umbilical",
+        }
+
+    def test_override_changes_result_without_editing_file(self):
+        base = api.layout(ONSHORE_CONFIG)
+        moved = api.layout(
+            ONSHORE_CONFIG,
+            field={"name": "Iteration 2"},
+            wells={"W-1": {"x_m": 600.0}},
+        )
+        assert moved["field"] == "Iteration 2"
+        fl1_base = next(c for c in base["connections"] if c["id"] == "FL-1")
+        fl1_moved = next(c for c in moved["connections"] if c["id"] == "FL-1")
+        assert fl1_moved["plan_length_m"] < fl1_base["plan_length_m"]
+
+
+# --- screen: hand-anchored numbers -------------------------------------------
+class TestScreenHandAnchored:
+    def test_flat_single_flowline_matches_hand_calc(self, tmp_path):
+        # HAND CALC — same arithmetic as test_screening's SWEEP_KWARGS anchor
+        # (300 m3/d, 2000 m, rho 850, mu 2e-3, eps 4.5e-5, inlet 2000 kPa,
+        # target 1500 kPa) with the elevation term dropped (flat surface,
+        # dp_el = 0):
+        #   NPS 2 STD: dp_f = 1041.6 kPa -> arrival = 958.4 < 1500   FAIL
+        #   NPS 3 STD: ID = 0.0779272 m, v = 0.72801 m/s,
+        #     dp_f = 151.2 kPa -> arrival = 2000 - 151.2 = 1848.8    PASS
+        #   -> smallest passing size = NPS 3; Ve(RP 14E) = 4.18422 m/s.
+        config_path = _write_anchor_config(tmp_path)
+        result = api.screen(
+            config_path,
+            inlet_pressure_kpa=2000.0,
+            target_arrival_pressure_kpa=1500.0,
+            fluid=ANCHOR_FLUID,
+        )
+        assert result["passes"] is True
+        assert result["skipped_connections"] == []
+        (sweep,) = result["flowlines"]
+        assert sweep["id"] == "FL-1"
+        assert sweep["length_m"] == pytest.approx(2000.0)
+        assert sweep["elevation_change_m"] == pytest.approx(0.0)
+        assert sweep["rate_m3_per_day"] == pytest.approx(300.0)
+        sel = sweep["selected"]
+        assert sel["nps"] == 3.0
+        assert sel["inner_diameter_m"] == pytest.approx(0.0779272, rel=1e-6)
+        assert sel["velocity_m_per_s"] == pytest.approx(0.72801, rel=1e-4)
+        assert sel["dp_total_kpa"] == pytest.approx(151.2, rel=5e-3)
+        assert sel["arrival_pressure_kpa"] == pytest.approx(1848.8, rel=1e-3)
+        assert sweep["erosional_velocity_m_per_s"] == pytest.approx(4.18422, rel=1e-5)
+        by_nps = {c["nps"]: c for c in sweep["candidates"]}
+        assert by_nps[2.0]["arrival_ok"] is False
+
+
+# --- screen: demo configs end-to-end ------------------------------------------
+class TestScreenDemoConfigs:
+    def test_onshore_demo_screens_all_flowlines(self, tmp_path):
+        report = tmp_path / "onshore" / "screening.md"
+        result = api.screen(
+            ONSHORE_CONFIG,
+            inlet_pressure_kpa=2000.0,
+            target_arrival_pressure_kpa=1500.0,
+            report_path=report,
+        )
+        assert result["field"] == "Demo Onshore Field"
+        assert [fl["id"] for fl in result["flowlines"]] == ["FL-1", "FL-2", "FL-3"]
+        # Fluid fell back to the config's fluid section.
+        assert result["flowlines"][0]["density_kg_per_m3"] == 850.0
+        assert result["flowlines"][0]["viscosity_pa_s"] == 0.005
+        # Line rates come from the from-well of each tracer flowline.
+        assert [fl["rate_m3_per_day"] for fl in result["flowlines"]] == [
+            280.0,
+            320.0,
+            260.0,
+        ]
+        assert result["layout"]["field"] == "Demo Onshore Field"
+        assert result["report_path"] == str(report)
+        text = report.read_text(encoding="utf-8")
+        assert text.startswith("# Screening report — Demo Onshore Field")
+        assert "FL-1" in text
+        json.dumps(result)
+
+    def test_offshore_demo_rate_accumulation(self):
+        # Trees carry no rate but sit ON their wells (co-located), so each
+        # jumper inherits its well's rate; the manifold flowline carries the
+        # summed 950 + 820 + 780 = 2550 m3/d; the export pipeline carries the
+        # FPSO throughput (same 2550). The umbilical is not hydraulic.
+        result = api.screen(
+            OFFSHORE_CONFIG,
+            inlet_pressure_kpa=25000.0,
+            target_arrival_pressure_kpa=5000.0,
+            fluid=ANCHOR_FLUID,
+        )
+        rates = {fl["id"]: fl["rate_m3_per_day"] for fl in result["flowlines"]}
+        assert rates == {
+            "JMP-1": 950.0,
+            "JMP-2": 820.0,
+            "JMP-3": 780.0,
+            "FL-1": 2550.0,
+            "PL-1": 2550.0,
+        }
+        assert result["skipped_connections"] == []
+        assert "UMB-1" not in rates
+
+    def test_explicit_connection_rate_wins(self):
+        result = api.screen(
+            OFFSHORE_CONFIG,
+            inlet_pressure_kpa=25000.0,
+            target_arrival_pressure_kpa=5000.0,
+            fluid=ANCHOR_FLUID,
+            connections={"FL-1": {"rate_m3_per_day": 1234.0}},
+        )
+        rates = {fl["id"]: fl["rate_m3_per_day"] for fl in result["flowlines"]}
+        assert rates["FL-1"] == 1234.0
+        # Downstream accumulation uses the explicit value too.
+        assert rates["PL-1"] == 1234.0
+
+    def test_missing_inputs_raise(self):
+        with pytest.raises(ValueError, match="target_arrival_pressure_kpa"):
+            api.screen(OFFSHORE_CONFIG, inlet_pressure_kpa=25000.0, fluid=ANCHOR_FLUID)
+        with pytest.raises(ValueError, match="fluid"):
+            api.screen(
+                OFFSHORE_CONFIG,
+                inlet_pressure_kpa=25000.0,
+                target_arrival_pressure_kpa=5000.0,
+            )
+
+
+# --- screen: cables ------------------------------------------------------------
+class TestScreenCables:
+    CABLE_OVERRIDE = {
+        "cables": [
+            {
+                "id": "CAB-1",
+                "connection": "UMB-1",  # length = the umbilical's 3D route
+                "load_kw": 500.0,
+                "line_voltage_v": 6600.0,
+                "power_factor": 0.9,
+            },
+            {
+                "id": "CAB-2",
+                "length_m": 800.0,
+                "load_kw": 500.0,
+                "line_voltage_v": 6600.0,
+                "power_factor": 0.9,
+            },
+        ]
+    }
+
+    def test_cables_screened_when_declared(self):
+        result = api.screen(
+            OFFSHORE_CONFIG,
+            inlet_pressure_kpa=25000.0,
+            target_arrival_pressure_kpa=5000.0,
+            fluid=ANCHOR_FLUID,
+            **self.CABLE_OVERRIDE,
+        )
+        assert [cb["id"] for cb in result["cables"]] == ["CAB-1", "CAB-2"]
+        umb = next(c for c in result["layout"]["connections"] if c["id"] == "UMB-1")
+        cab1 = result["cables"][0]
+        assert cab1["length_m"] == pytest.approx(umb["route_length_m"], abs=0.01)
+        # The connection-referenced screen equals a direct size_cable call.
+        direct = size_cable(500.0, 6600.0, cab1["length_m"], 0.9)
+        assert cab1["selected"] == direct["selected"]
+        # CAB-2 at 800 m reproduces test_screening's hand-anchored selection.
+        cab2 = result["cables"][1]
+        assert cab2["selected"]["size_mm2"] == 6.0
+        assert cab2["selected"]["ampacity_a"] == pytest.approx(68.40, rel=1e-3)
+
+    def test_unknown_connection_reference_rejected(self):
+        with pytest.raises(ValueError, match="NOPE"):
+            api.screen(
+                OFFSHORE_CONFIG,
+                inlet_pressure_kpa=25000.0,
+                target_arrival_pressure_kpa=5000.0,
+                fluid=ANCHOR_FLUID,
+                cables=[
+                    {
+                        "id": "CAB-X",
+                        "connection": "NOPE",
+                        "load_kw": 1.0,
+                        "line_voltage_v": 400.0,
+                        "power_factor": 0.9,
+                    }
+                ],
+            )
+
+    def test_cable_without_length_source_rejected(self):
+        with pytest.raises(ValueError, match="length_m"):
+            api.screen(
+                OFFSHORE_CONFIG,
+                inlet_pressure_kpa=25000.0,
+                target_arrival_pressure_kpa=5000.0,
+                fluid=ANCHOR_FLUID,
+                cables=[
+                    {
+                        "id": "CAB-X",
+                        "load_kw": 1.0,
+                        "line_voltage_v": 400.0,
+                        "power_factor": 0.9,
+                    }
+                ],
+            )
+
+
+# --- screen: iteration cheapness ----------------------------------------------
+class TestScreenIteration:
+    def test_three_rate_variants_give_distinct_results(self):
+        # The design goal: 10-20 iterations per case, no file edits. Three
+        # W-1 rate variants of the SAME demo config must yield distinct
+        # screening results, monotonic in rate for a fixed candidate size.
+        results = [
+            api.screen(
+                ONSHORE_CONFIG,
+                inlet_pressure_kpa=2000.0,
+                target_arrival_pressure_kpa=1500.0,
+                wells={"W-1": {"rate_m3_per_day": rate}},
+            )
+            for rate in (280.0, 900.0, 2600.0)
+        ]
+        fl1 = [next(fl for fl in r["flowlines"] if fl["id"] == "FL-1") for r in results]
+        assert [fl["rate_m3_per_day"] for fl in fl1] == [280.0, 900.0, 2600.0]
+        # Friction dp of the FIXED NPS 4 candidate strictly increases with rate.
+        dp4 = [
+            {c["nps"]: c for c in fl["candidates"]}[4.0]["dp_friction_kpa"]
+            for fl in fl1
+        ]
+        assert dp4[0] < dp4[1] < dp4[2]
+        # The three iteration outcomes are pairwise distinct.
+        signatures = {
+            (
+                None if fl["selected"] is None else fl["selected"]["nps"],
+                round(dp, 6),
+            )
+            for fl, dp in zip(fl1, dp4)
+        }
+        assert len(signatures) == 3
+        # Other lines are untouched by the W-1 override.
+        fl2_rates = {
+            next(fl for fl in r["flowlines"] if fl["id"] == "FL-2")["rate_m3_per_day"]
+            for r in results
+        }
+        assert fl2_rates == {320.0}
+
+
+# --- visualize ------------------------------------------------------------------
+class TestVisualize:
+    def test_offshore_demo_artifacts(self, tmp_path):
+        result = api.visualize(OFFSHORE_CONFIG, tmp_path)
+        plot = Path(result["plot_path"])
+        scene = Path(result["scene_path"])
+        assert plot.name == "offshore_demo_field_layout.png"
+        assert plot.exists() and plot.stat().st_size > 0
+        assert scene.exists()
+        scene_data = json.loads(scene.read_text(encoding="utf-8"))
+        assert scene_data["is_subsea"] is True
+        assert result["surface"]["is_subsea"] is True
+
+    def test_override_and_stem(self, tmp_path):
+        result = api.visualize(
+            ONSHORE_CONFIG,
+            tmp_path,
+            stem="iter02",
+            field={"name": "Onshore Iteration 2"},
+            wells={"W-1": {"x_m": 600.0}},
+        )
+        assert result["field"] == "Onshore Iteration 2"
+        assert Path(result["plot_path"]).name == "iter02_layout.png"
+        assert Path(result["scene_path"]).name == "iter02_scene.json"
+        assert Path(result["plot_path"]).exists()
+        scene_data = json.loads(Path(result["scene_path"]).read_text(encoding="utf-8"))
+        assert scene_data["field_name"] == "Onshore Iteration 2"
+
+
+# --- analogs ----------------------------------------------------------------------
+class TestAnalogs:
+    CRITERIA = {"water_depth_m": 1450.0, "host_kind": "fpso"}
+
+    def test_unavailable_returns_structured_response(self):
+        # worldenergydata is NOT a dependency of this repo; the adapter must
+        # degrade to a structured response, never raise.
+        assert "worldenergydata" not in sys.modules
+        result = api.analogs(self.CRITERIA)
+        assert result["available"] is False
+        assert "worldenergydata" in result["reason"]
+        assert result["criteria"] == self.CRITERIA
+        json.dumps(result)
+
+    def test_available_path_calls_find_analogs(self, monkeypatch):
+        calls: dict[str, object] = {}
+        fake = types.ModuleType("worldenergydata.field_development.analogs")
+
+        def find_analogs(**criteria):
+            calls.update(criteria)
+            return [{"field": "Analog A", "score": 0.91}]
+
+        fake.find_analogs = find_analogs
+        monkeypatch.setitem(
+            sys.modules, "worldenergydata.field_development.analogs", fake
+        )
+        result = api.analogs(self.CRITERIA)
+        assert result["available"] is True
+        assert result["result"] == [{"field": "Analog A", "score": 0.91}]
+        assert calls == self.CRITERIA
+        assert result["criteria"] == self.CRITERIA
+
+    def test_non_mapping_criteria_rejected(self):
+        with pytest.raises(TypeError, match="mapping"):
+            api.analogs(["not", "a", "mapping"])  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1512. Workstream E of epic #1507.

## What

New module `src/digitalmodel/field_development/api.py` — ONE coherent, documented entry surface over the merged workstream modules. Plain-Python functions (the repo's "API" convention — no HTTP layer): YAML config in, JSON-serializable dicts out.

| Call | Does | Consumes |
|---|---|---|
| `layout(config, **overrides)` | build generalized layout model, return `layout_summary()` dict (assets, connections, true 3D lengths, `is_subsea`) | `layout_model` (#1509) |
| `screen(config, **options, **overrides)` | layout + flowline diameter sweeps per hydraulic connection (+ cable screens when the config declares `cables`) + optional deterministic markdown report | `screening` (#1511) |
| `visualize(config, output_dir, ...)` | 2D plot PNG + 3D scene JSON | `visualization` (#1510) |
| `analogs(criteria)` | cross-repo adapter to `worldenergydata.field_development.analogs.find_analogs`; structured `{"available": false, "reason": ...}` when not importable (digitalmodel takes NO dependency on worldenergydata) | worldenergydata (adapter) |

## Iteration cheapness (the design goal)

Every call accepts dict-deep `**overrides` applied in memory — mappings merge recursively; a mapping override on an `id`-keyed list (`assets`, `wells`, `connections`, ...) addresses entries by id (typo -> KeyError, never a silent new asset). A 10-20-iteration case loop needs zero file edits; tests iterate 3 rate variants of the demo config and assert distinct results. Demo loop: `scripts/field_development/representative_api_demo.py`.

## Adapter notes (lane boundaries respected)

- `screening.sweep_layout_flowlines` reads the #1508 tracer's `FieldLayout`; this PR does NOT edit `screening.py` — `api.screen` adapts the generalized model by feeding each hydraulic connection (jumper/flowline/pipeline; umbilicals excluded) into `flowline_diameter_sweep` with its true 3D route length + endpoint elevation change. Line rates resolve: explicit `rate_m3_per_day` on the connection spec -> from-asset rate -> co-located rated asset (tree sits on its well) -> summed upstream throughput; unresolvable lines land in `skipped_connections` with a reason.
- `field_development/__init__.py` untouched (integration PR wires exports); submodules imported directly.
- `onshore_layout.py` tracer untouched and its schema still loads through every call.

## Tests

23 new tests in `tests/field_development/test_api.py`: all four calls end-to-end against BOTH demo configs; `screen()` hand-anchored against the #1511 hand-computed sweep values (flat-surface config reproduces the SWEEP_KWARGS arithmetic with the elevation term dropped: NPS 3, dp 151.2 kPa, arrival 1848.8 kPa, Ve 4.18422 m/s); cable screen anchored at the 6 mm2 / 68.40 A hand calc; analogs tested on both the unavailable path and a mocked-import available path; deep-override semantics unit-tested.

Local: `tests/field_development/` 639 passed, 32 skipped. Lint: repo-pinned ruff 0.15.1 / black 24.10.0 / isort 5.13.2 clean on all new files.