### PR TITLE
Field-development renewables: wind turbine/substation assets + electrical cable connections (#1513)

### DIFF
--- a/scripts/field_development/field_flythrough_bpy.py
+++ b/scripts/field_development/field_flythrough_bpy.py
@@ -25,19 +25,23 @@ executed by Blender itself, headless:
 The scene JSON is schema ``digitalmodel.field_layout_scene/2``, produced by
 ``digitalmodel.field_development.visualization.export_layout_scene_json``
 (JSON so Blender's bundled Python needs no third-party packages). It types
-every asset (host/vessel/well/tree/manifold) and connection
-(jumper/flowline/pipeline/umbilical), so each kind gets its own geometry and
-material here. The onshore #1508 tracer scene (v1 schema) keeps its own
-script, ``onshore_flythrough_bpy.py``. Rendered videos are NOT committed to
-the repo (see .gitignore) — re-render locally with the command above.
+every asset (host/vessel/well/tree/manifold plus the #1513 renewables kinds
+wind_turbine/offshore_substation) and connection
+(jumper/flowline/pipeline/umbilical plus array_cable/export_cable), so each
+kind gets its own geometry and material here. The onshore #1508 tracer scene
+(v1 schema) keeps its own script, ``onshore_flythrough_bpy.py``. Rendered
+videos are NOT committed to the repo (see .gitignore) — re-render locally
+with the command above.
 
 Scene contents: surface mesh from the elevation grid (bathymetry = negative
 elevation), a translucent water plane at z = 0 for subsea scenes, per-kind
 asset geometry (pad cubes for hosts, hull boxes for vessels, cylinders for
-wells, slimmer/taller cylinders for trees, cones for manifolds), bevelled
-curves per connection kind, a sun lamp, and a camera orbiting the field
-centre with a slow descent. Camera clip range is scaled to the scene size —
-Blender's default clip_end (100 m) would cull a km-scale field entirely.
+wells, slimmer/taller cylinders for trees, cones for manifolds, schematic
+tower + hub + three-blade rotors for wind turbines, distinct topside boxes
+for offshore substations), bevelled curves per connection kind, a sun lamp,
+and a camera orbiting the field centre with a slow descent. Camera clip
+range is scaled to the scene size — Blender's default clip_end (100 m) would
+cull a km-scale field entirely.
 """
 
 from __future__ import annotations
@@ -62,6 +66,15 @@ TREE_RADIUS_M = 12.0
 TREE_HEIGHT_M = 110.0
 MANIFOLD_RADIUS_M = 45.0
 MANIFOLD_HEIGHT_M = 80.0
+# Wind turbine (#1513): schematic tower + hub + three flat blades.
+TURBINE_TOWER_RADIUS_M = 6.0
+TURBINE_TOWER_HEIGHT_M = 140.0
+TURBINE_HUB_RADIUS_M = 12.0
+TURBINE_BLADE_LENGTH_M = 100.0
+TURBINE_BLADE_CHORD_M = 14.0
+TURBINE_BLADE_THICKNESS_M = 3.0
+# Offshore substation (#1513): distinct wide topside box.
+SUBSTATION_DIMS_M = (110.0, 90.0, 55.0)  # length, width, height
 # Reference domain span for the base sizes; larger fields scale up (capped).
 REFERENCE_SPAN_M = 3000.0
 MAX_SIZE_SCALE = 4.0
@@ -73,18 +86,24 @@ ASSET_COLORS = {
     "well": (0.13, 0.13, 0.13, 1.0),  # near-black
     "tree": (0.18, 0.44, 0.25, 1.0),  # green
     "manifold": (0.42, 0.25, 0.63, 1.0),  # purple
+    "wind_turbine": (0.85, 0.87, 0.90, 1.0),  # off-white (#1513)
+    "offshore_substation": (0.55, 0.43, 0.12, 1.0),  # dark gold (#1513)
 }
 CONNECTION_COLORS = {
     "jumper": (0.88, 0.48, 0.22, 1.0),
     "flowline": (0.70, 0.09, 0.17, 1.0),
     "pipeline": (0.40, 0.00, 0.12, 1.0),
     "umbilical": (0.13, 0.40, 0.67, 1.0),
+    "array_cable": (0.25, 0.67, 0.36, 1.0),  # mid green (#1513)
+    "export_cable": (0.00, 0.27, 0.11, 1.0),  # darkest green (#1513)
 }
 CONNECTION_BEVEL_M = {
     "jumper": 6.0,
     "flowline": 8.0,
     "pipeline": 10.0,
     "umbilical": 5.0,
+    "array_cable": 5.0,
+    "export_cable": 7.0,
 }
 SURFACE_COLOR_ONSHORE = (0.35, 0.45, 0.25, 1.0)
 SURFACE_COLOR_SUBSEA = (0.45, 0.40, 0.30, 1.0)  # seabed sediment
@@ -190,6 +209,52 @@ def _asset_scene_z(asset: dict, z0: float) -> float:
     return _scene_z(asset["z_m"], z0)
 
 
+def _add_wind_turbine(asset: dict, x: float, y: float, z: float, scale: float) -> float:
+    """Schematic wind turbine (#1513): tower cylinder + hub sphere + 3 blades.
+
+    The rotor is a vertical plane (blades rotated 120 deg apart about the
+    field-y axis) — schematic per-kind geometry, not a vendor model. Returns
+    the turbine's top (scene z).
+    """
+    material = _material(f"mat_{asset['id']}", ASSET_COLORS["wind_turbine"])
+    tower_height = TURBINE_TOWER_HEIGHT_M * scale
+    blade_length = TURBINE_BLADE_LENGTH_M * scale
+    hub_z = z + tower_height
+
+    bpy.ops.mesh.primitive_cylinder_add(
+        radius=TURBINE_TOWER_RADIUS_M * scale,
+        depth=tower_height,
+        location=(x, y, z + tower_height / 2),
+    )
+    tower = bpy.context.active_object
+    tower.name = f"asset_{asset['id']}"
+    tower.data.materials.append(material)
+
+    bpy.ops.mesh.primitive_uv_sphere_add(
+        radius=TURBINE_HUB_RADIUS_M * scale, location=(x, y, hub_z), segments=12
+    )
+    hub = bpy.context.active_object
+    hub.name = f"asset_{asset['id']}_hub"
+    hub.data.materials.append(material)
+
+    for blade_index in range(3):
+        angle = math.radians(90.0 + 120.0 * blade_index)  # first blade points up
+        # Blade centre: half a blade-length from the hub, in the x-z rotor plane.
+        cx = x + 0.5 * blade_length * math.cos(angle)
+        cz = hub_z + 0.5 * blade_length * math.sin(angle)
+        bpy.ops.mesh.primitive_cube_add(size=1.0, location=(cx, y, cz))
+        blade = bpy.context.active_object
+        blade.name = f"asset_{asset['id']}_blade{blade_index + 1}"
+        blade.scale = (
+            blade_length,
+            TURBINE_BLADE_THICKNESS_M * scale,
+            TURBINE_BLADE_CHORD_M * scale,
+        )
+        blade.rotation_euler = (0.0, -angle, 0.0)  # long axis along the spoke
+        blade.data.materials.append(material)
+    return hub_z + blade_length
+
+
 def _add_assets(scene: dict, z0: float, scale: float) -> float:
     """Per-kind asset geometry; returns the highest asset top (scene z)."""
     z_top = 0.0
@@ -197,6 +262,9 @@ def _add_assets(scene: dict, z0: float, scale: float) -> float:
         x, y = asset["x_m"], asset["y_m"]
         z = _asset_scene_z(asset, z0)
         kind = asset["kind"]
+        if kind == "wind_turbine":
+            z_top = max(z_top, _add_wind_turbine(asset, x, y, z, scale))
+            continue
         if kind == "host":
             size = HOST_SIZE_M * scale
             bpy.ops.mesh.primitive_cube_add(size=size, location=(x, y, z + size / 2))
@@ -217,6 +285,11 @@ def _add_assets(scene: dict, z0: float, scale: float) -> float:
             bpy.ops.mesh.primitive_cone_add(
                 radius1=radius, depth=height, location=(x, y, z + height / 2)
             )
+            top = z + height
+        elif kind == "offshore_substation":
+            length, width, height = (d * scale for d in SUBSTATION_DIMS_M)
+            bpy.ops.mesh.primitive_cube_add(size=1.0, location=(x, y, z + height / 2))
+            bpy.context.active_object.scale = (length, width, height)
             top = z + height
         else:  # well
             radius, height = WELL_RADIUS_M * scale, WELL_HEIGHT_M * scale

--- a/src/digitalmodel/field_development/data/offshore_wind_demo_field.yml
+++ b/src/digitalmodel/field_development/data/offshore_wind_demo_field.yml
@@ -1,0 +1,146 @@
+# ABOUTME: Demo floating offshore wind farm for the layout model (#1513, epic #1507).
+# ABOUTME: Synthetic bathymetry + wind_turbine/offshore_substation assets + electrical cables.
+#
+# Synthetic demo field. Coordinates are a local Cartesian grid in metres
+# (easting/northing from an arbitrary field datum). Elevation is signed
+# relative to the sea surface: NEGATIVE values are water depth (bathymetry).
+# The synthetic surface stands in for a real bathymetry grid (e.g. GEBCO /
+# NOAA). ALL values below are generic demo values — no vendor, project, or
+# turbine model is referenced. Ratings/voltages follow common industry
+# conventions (multi-MW turbines, 66 kV inter-array collection, HV export),
+# not any specific development.
+
+field:
+  name: Demo Floating Wind Farm
+  coordinate_note: local Cartesian metres from field datum; z negative below sea surface
+
+surface:
+  kind: synthetic          # synthetic | csv_grid
+  x_min_m: 0.0
+  x_max_m: 9000.0
+  y_min_m: 0.0
+  y_max_m: 8000.0
+  nx: 91
+  ny: 81
+  base_elevation_m: -150.0    # nominal water depth 150 m (floating-wind range)
+  amplitude_m: 12.0
+  x_wavelength_m: 7000.0
+  y_wavelength_m: 5500.0
+
+assets:
+  # Two strings of three floating turbines each. Floating units get an
+  # explicit z_m: 0.0 (they float at the sea surface); a fixed-bottom
+  # variant would omit z_m so the base drapes onto the seabed.
+  - id: WTG-1
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 1
+    x_m: 1500.0
+    y_m: 2500.0
+    z_m: 0.0
+    rated_power_mw: 15.0     # generic multi-MW class (demo value)
+  - id: WTG-2
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 2
+    x_m: 3500.0
+    y_m: 2500.0
+    z_m: 0.0
+    rated_power_mw: 15.0
+  - id: WTG-3
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 3
+    x_m: 5500.0
+    y_m: 2500.0
+    z_m: 0.0
+    rated_power_mw: 15.0
+  - id: WTG-4
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 4
+    x_m: 1500.0
+    y_m: 5500.0
+    z_m: 0.0
+    rated_power_mw: 15.0
+  - id: WTG-5
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 5
+    x_m: 3500.0
+    y_m: 5500.0
+    z_m: 0.0
+    rated_power_mw: 15.0
+  - id: WTG-6
+    kind: wind_turbine
+    subtype: floating
+    name: Demo turbine 6
+    x_m: 5500.0
+    y_m: 5500.0
+    z_m: 0.0
+    rated_power_mw: 15.0
+  - id: OSS-1
+    kind: offshore_substation
+    subtype: floating
+    name: Demo offshore substation
+    x_m: 7000.0
+    y_m: 4000.0
+    z_m: 0.0
+  - id: SHORE-1                # export cable landfall / grid tie-in
+    kind: host
+    subtype: shore tie-in
+    name: Shore tie-in
+    x_m: 8800.0
+    y_m: 4000.0
+
+connections:
+  # Inter-array strings: turbine -> turbine -> substation, at collection voltage.
+  - id: AC-1
+    kind: array_cable
+    from: WTG-1
+    to: WTG-2
+    voltage_kv: 66.0           # common inter-array collection voltage
+    conductor_size_mm2: 300.0  # IEC 60228 cross-section (demo value)
+  - id: AC-2
+    kind: array_cable
+    from: WTG-2
+    to: WTG-3
+    voltage_kv: 66.0
+    conductor_size_mm2: 300.0
+  - id: AC-3
+    kind: array_cable
+    from: WTG-3
+    to: OSS-1
+    voltage_kv: 66.0
+    conductor_size_mm2: 400.0  # string trunk carries both upstream turbines
+  - id: AC-4
+    kind: array_cable
+    from: WTG-4
+    to: WTG-5
+    voltage_kv: 66.0
+    conductor_size_mm2: 300.0
+  - id: AC-5
+    kind: array_cable
+    from: WTG-5
+    to: WTG-6
+    voltage_kv: 66.0
+    conductor_size_mm2: 300.0
+  - id: AC-6
+    kind: array_cable
+    from: WTG-6
+    to: OSS-1
+    voltage_kv: 66.0
+    conductor_size_mm2: 400.0
+  # Export to shore at transmission voltage, routed via one waypoint.
+  - id: EXP-1
+    kind: export_cable
+    from: OSS-1
+    to: SHORE-1
+    voltage_kv: 220.0          # generic HV export level (demo value)
+    conductor_size_mm2: 800.0
+    waypoints:
+      - x_m: 8000.0
+        y_m: 4000.0
+
+routing:
+  sample_spacing_m: 50.0       # surface sampling step along each routed leg

--- a/src/digitalmodel/field_development/layout_model.py
+++ b/src/digitalmodel/field_development/layout_model.py
@@ -11,8 +11,13 @@ field-layout model, generalizing the onshore tracer
 1. **Full asset schema (YAML-first)** — beyond the tracer's host/wells the
    schema covers the subsea/onshore taxonomy: ``host``, ``vessel``, ``well``,
    ``tree``, ``manifold`` assets connected by ``jumper``, ``flowline``,
-   ``pipeline``, ``umbilical`` links. ALL configuration is externalized to
-   YAML (see ``data/offshore_demo_field.yml``); nothing is hardcoded here.
+   ``pipeline``, ``umbilical`` links. The renewables extension (#1513,
+   workstream B3) adds ``wind_turbine`` / ``offshore_substation`` assets and
+   electrical ``array_cable`` / ``export_cable`` connections (``voltage_kv``,
+   optional ``conductor_size_mm2``), validated so cables only connect
+   electrical-capable assets. ALL configuration is externalized to YAML (see
+   ``data/offshore_demo_field.yml`` and ``data/offshore_wind_demo_field.yml``);
+   nothing is hardcoded here.
 2. **Offshore-ready surface** — the surface is the tracer's
    :class:`~digitalmodel.field_development.onshore_layout.TerrainGrid`
    (bilinear DEM queries). Elevation is signed relative to the field datum
@@ -60,19 +65,68 @@ import yaml
 from .onshore_layout import TerrainGrid, build_terrain
 
 # --- schema vocabulary -------------------------------------------------------
-#: Recognized asset kinds (surface-placed field infrastructure).
-ASSET_KINDS = frozenset({"host", "vessel", "well", "tree", "manifold"})
-#: Recognized connection kinds (routed links between assets).
-CONNECTION_KINDS = frozenset({"jumper", "flowline", "pipeline", "umbilical"})
+#: Recognized asset kinds (surface-placed field infrastructure). The renewables
+#: extension (#1513) adds ``wind_turbine`` (fixed-bottom or floating via
+#: ``subtype``; rated electrical output via ``rated_power_mw``) and
+#: ``offshore_substation`` (array-collection / export transformer platform).
+ASSET_KINDS = frozenset(
+    {
+        "host",
+        "vessel",
+        "well",
+        "tree",
+        "manifold",
+        "wind_turbine",
+        "offshore_substation",
+    }
+)
+#: Recognized connection kinds (routed links between assets). ``array_cable``
+#: (inter-array power collection) and ``export_cable`` (substation-to-shore/host
+#: transmission) are ELECTRICAL kinds (#1513): they carry ``voltage_kv`` and an
+#: optional ``conductor_size_mm2`` — the same conductor cross-section vocabulary
+#: (IEC 60228 sizes in mm^2) used by the cable screens in
+#: :mod:`digitalmodel.field_development.screening` (``size_cable``).
+CONNECTION_KINDS = frozenset(
+    {"jumper", "flowline", "pipeline", "umbilical", "array_cable", "export_cable"}
+)
+#: Electrical connection kinds: endpoints must be electrical-capable assets.
+ELECTRICAL_CONNECTION_KINDS = frozenset({"array_cable", "export_cable"})
+#: Asset kinds that can terminate an electrical connection. ``host`` is
+#: included so an export cable can land at a shore/host tie-in.
+ELECTRICAL_ASSET_KINDS = frozenset({"wind_turbine", "offshore_substation", "host"})
+#: Power-only asset kinds: no bore, so flow/controls connections (jumper,
+#: flowline, pipeline, umbilical) may NOT terminate here — power to/from these
+#: assets travels on electrical connections only.
+_POWER_ONLY_ASSET_KINDS = frozenset({"wind_turbine", "offshore_substation"})
 
 _REQUIRED_SECTIONS = ("field", "assets", "connections")
 _TRACER_SECTIONS = ("host", "wells", "flowlines")
 
 _ASSET_KNOWN_KEYS = frozenset(
-    {"id", "kind", "subtype", "name", "x_m", "y_m", "z_m", "rate_m3_per_day"}
+    {
+        "id",
+        "kind",
+        "subtype",
+        "name",
+        "x_m",
+        "y_m",
+        "z_m",
+        "rate_m3_per_day",
+        "rated_power_mw",
+    }
 )
 _CONNECTION_KNOWN_KEYS = frozenset(
-    {"id", "kind", "from", "to", "waypoints", "inner_diameter_m", "roughness_m"}
+    {
+        "id",
+        "kind",
+        "from",
+        "to",
+        "waypoints",
+        "inner_diameter_m",
+        "roughness_m",
+        "voltage_kv",
+        "conductor_size_mm2",
+    }
 )
 
 _DEFAULT_SAMPLE_SPACING_M = 25.0
@@ -101,6 +155,7 @@ class LayoutAsset:
     subtype: str = ""
     on_surface: bool = True
     rate_m3_per_day: Optional[float] = None
+    rated_power_mw: Optional[float] = None
     properties: dict[str, Any] = field(default_factory=dict)
 
 
@@ -124,6 +179,8 @@ class RoutedConnection:
     elevation_change_m: float = 0.0
     inner_diameter_m: Optional[float] = None
     roughness_m: Optional[float] = None
+    voltage_kv: Optional[float] = None
+    conductor_size_mm2: Optional[float] = None
     properties: dict[str, Any] = field(default_factory=dict)
 
 
@@ -227,8 +284,10 @@ def normalize_layout_config(
 
 
 def _validate_schema(config: dict[str, Any], source: str) -> None:
-    """Schema-level checks: kinds, unique ids, connectivity (no dangling refs)."""
-    asset_ids: set[str] = set()
+    """Schema-level checks: kinds, unique ids, connectivity (no dangling refs),
+    and electrical compatibility (cables only between electrical-capable assets;
+    flow/controls links never terminate at power-only assets)."""
+    kind_by_id: dict[str, str] = {}
     for spec in config["assets"]:
         asset_id = str(spec.get("id"))
         kind = spec.get("kind")
@@ -237,12 +296,18 @@ def _validate_schema(config: dict[str, Any], source: str) -> None:
                 f"{source}: asset {asset_id!r} has unknown kind {kind!r}; "
                 f"expected one of {sorted(ASSET_KINDS)}"
             )
-        if asset_id in asset_ids:
+        if asset_id in kind_by_id:
             raise ValueError(f"{source}: duplicate asset id {asset_id!r}")
-        asset_ids.add(asset_id)
+        kind_by_id[asset_id] = str(kind)
         for key in ("x_m", "y_m"):
             if key not in spec:
                 raise ValueError(f"{source}: asset {asset_id!r} missing {key!r}")
+        rated_power = spec.get("rated_power_mw")
+        if rated_power is not None and float(rated_power) <= 0.0:
+            raise ValueError(
+                f"{source}: asset {asset_id!r} rated_power_mw must be > 0 "
+                f"(got {rated_power})"
+            )
     connection_ids: set[str] = set()
     for spec in config["connections"]:
         conn_id = str(spec.get("id"))
@@ -257,11 +322,59 @@ def _validate_schema(config: dict[str, Any], source: str) -> None:
         connection_ids.add(conn_id)
         for end in ("from", "to"):
             ref = str(spec.get(end))
-            if ref not in asset_ids:
+            if ref not in kind_by_id:
                 raise ValueError(
                     f"{source}: connection {conn_id!r} references unknown "
                     f"asset {ref!r} (dangling {end!r} reference)"
                 )
+        _validate_electrical(spec, conn_id, str(kind), kind_by_id, source)
+
+
+def _validate_electrical(
+    spec: dict[str, Any],
+    conn_id: str,
+    kind: str,
+    kind_by_id: dict[str, str],
+    source: str,
+) -> None:
+    """Electrical-compatibility rules for one connection (#1513).
+
+    1. Electrical connections (``array_cable``, ``export_cable``) may only
+       connect electrical-capable assets (:data:`ELECTRICAL_ASSET_KINDS`).
+    2. Non-electrical connections (flow/controls) may never terminate at a
+       power-only asset (``wind_turbine``, ``offshore_substation``) — there is
+       no bore to connect to.
+    3. ``voltage_kv``, when given, must be positive (electrical kinds only).
+    """
+    electrical = kind in ELECTRICAL_CONNECTION_KINDS
+    for end in ("from", "to"):
+        ref = str(spec.get(end))
+        ref_kind = kind_by_id[ref]
+        if electrical and ref_kind not in ELECTRICAL_ASSET_KINDS:
+            raise ValueError(
+                f"{source}: {kind} connection {conn_id!r} may only connect "
+                f"electrical-capable assets ({sorted(ELECTRICAL_ASSET_KINDS)}); "
+                f"{end!r} asset {ref!r} is a {ref_kind!r}"
+            )
+        if not electrical and ref_kind in _POWER_ONLY_ASSET_KINDS:
+            raise ValueError(
+                f"{source}: {kind} connection {conn_id!r} cannot terminate at "
+                f"power-only asset {ref!r} ({ref_kind!r}); use an electrical "
+                f"connection ({sorted(ELECTRICAL_CONNECTION_KINDS)})"
+            )
+    voltage = spec.get("voltage_kv")
+    if voltage is not None:
+        if not electrical:
+            raise ValueError(
+                f"{source}: connection {conn_id!r} ({kind}) carries voltage_kv "
+                f"but is not an electrical kind "
+                f"({sorted(ELECTRICAL_CONNECTION_KINDS)})"
+            )
+        if float(voltage) <= 0.0:
+            raise ValueError(
+                f"{source}: connection {conn_id!r} voltage_kv must be > 0 "
+                f"(got {voltage})"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +390,7 @@ def _place_asset(spec: dict[str, Any], surface: TerrainGrid) -> LayoutAsset:
     else:
         z, on_surface = surface.elevation_at(x, y), True
     rate = spec.get("rate_m3_per_day")
+    rated_power = spec.get("rated_power_mw")
     extras = {k: v for k, v in spec.items() if k not in _ASSET_KNOWN_KEYS}
     return LayoutAsset(
         asset_id=str(spec["id"]),
@@ -288,6 +402,7 @@ def _place_asset(spec: dict[str, Any], surface: TerrainGrid) -> LayoutAsset:
         subtype=str(spec.get("subtype", "")),
         on_surface=on_surface,
         rate_m3_per_day=None if rate is None else float(rate),
+        rated_power_mw=None if rated_power is None else float(rated_power),
         properties=extras,
     )
 
@@ -360,6 +475,8 @@ def route_connection(
 
     diameter = spec.get("inner_diameter_m")
     roughness = spec.get("roughness_m")
+    voltage = spec.get("voltage_kv")
+    conductor = spec.get("conductor_size_mm2")
     extras = {k: v for k, v in spec.items() if k not in _CONNECTION_KNOWN_KEYS}
     return RoutedConnection(
         connection_id=str(spec["id"]),
@@ -373,6 +490,8 @@ def route_connection(
         elevation_change_m=float(path[-1, 2] - path[0, 2]),
         inner_diameter_m=None if diameter is None else float(diameter),
         roughness_m=None if roughness is None else float(roughness),
+        voltage_kv=None if voltage is None else float(voltage),
+        conductor_size_mm2=None if conductor is None else float(conductor),
         properties=extras,
     )
 
@@ -439,6 +558,8 @@ def layout_model_to_config(model: FieldLayoutModel) -> dict[str, Any]:
             spec["z_m"] = a.z_m
         if a.rate_m3_per_day is not None:
             spec["rate_m3_per_day"] = a.rate_m3_per_day
+        if a.rated_power_mw is not None:
+            spec["rated_power_mw"] = a.rated_power_mw
         spec.update(a.properties)
         assets.append(spec)
     connections = []
@@ -455,6 +576,10 @@ def layout_model_to_config(model: FieldLayoutModel) -> dict[str, Any]:
             cspec["inner_diameter_m"] = c.inner_diameter_m
         if c.roughness_m is not None:
             cspec["roughness_m"] = c.roughness_m
+        if c.voltage_kv is not None:
+            cspec["voltage_kv"] = c.voltage_kv
+        if c.conductor_size_mm2 is not None:
+            cspec["conductor_size_mm2"] = c.conductor_size_mm2
         cspec.update(c.properties)
         connections.append(cspec)
     return {

--- a/src/digitalmodel/field_development/visualization.py
+++ b/src/digitalmodel/field_development/visualization.py
@@ -78,6 +78,8 @@ ASSET_STYLES: dict[str, tuple[str, str, float]] = {
     "well": ("o", "#222222", 8.0),  # circle, near-black
     "tree": ("^", "#2e6f40", 8.0),  # triangle, green
     "manifold": ("P", "#6b3fa0", 11.0),  # plus (filled), purple
+    "wind_turbine": ("*", "#0b7285", 14.0),  # star, teal (#1513)
+    "offshore_substation": ("h", "#8c6d1f", 12.0),  # hexagon, dark gold (#1513)
 }
 #: Line style per connection kind: (color, linestyle, linewidth_pt).
 CONNECTION_STYLES: dict[str, tuple[str, str, float]] = {
@@ -85,6 +87,8 @@ CONNECTION_STYLES: dict[str, tuple[str, str, float]] = {
     "flowline": ("#b2182b", "-", 2.2),  # firebrick, solid
     "pipeline": ("#67001f", "--", 2.6),  # dark maroon, dashed, thick
     "umbilical": ("#2166ac", "-.", 1.6),  # steel blue, dash-dot
+    "array_cable": ("#41ab5d", ":", 1.8),  # mid green, dotted (#1513)
+    "export_cable": ("#00441b", "--", 2.4),  # darkest green, dashed (#1513)
 }
 _WAYPOINT_STYLE = {"marker": "x", "color": "#444444", "s": 36.0}
 

--- a/tests/field_development/test_renewables_layout.py
+++ b/tests/field_development/test_renewables_layout.py
@@ -1,0 +1,357 @@
+# ABOUTME: Tests for the renewables layout extension (#1513, epic #1507 workstream B3).
+# ABOUTME: Wind asset kinds, electrical cable validation, wind demo e2e, determinism.
+"""Renewables extension of the field-layout schema (#1513).
+
+Covers the new asset kinds (``wind_turbine``, ``offshore_substation``), the
+electrical connection kinds (``array_cable``, ``export_cable`` with
+``voltage_kv`` / ``conductor_size_mm2``), the electrical-connectivity
+validation rules, the floating-wind demo config end-to-end (layout + plot +
+scene JSON), and determinism. Offline: no Blender needed — the fly-through
+script consumes the scene JSON asserted here.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.field_development.layout_model import (
+    ASSET_KINDS,
+    CONNECTION_KINDS,
+    ELECTRICAL_ASSET_KINDS,
+    ELECTRICAL_CONNECTION_KINDS,
+    build_layout_model,
+    build_layout_model_from_file,
+    layout_model_to_config,
+    layout_summary,
+    load_layout_config,
+)
+from digitalmodel.field_development.visualization import (
+    ASSET_STYLES,
+    CONNECTION_STYLES,
+    SCENE_SCHEMA,
+    export_layout_scene_json,
+    layout_scene_dict,
+    render_layout_visualization,
+)
+
+DATA_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "digitalmodel"
+    / "field_development"
+    / "data"
+)
+WIND_CONFIG = DATA_DIR / "offshore_wind_demo_field.yml"
+OFFSHORE_CONFIG = DATA_DIR / "offshore_demo_field.yml"
+
+
+def _flat_surface(base_elevation_m: float, extent_m: float = 1000.0) -> dict:
+    """Flat synthetic surface spec (amplitude 0) at a fixed elevation."""
+    return {
+        "kind": "synthetic",
+        "x_min_m": 0.0,
+        "x_max_m": extent_m,
+        "y_min_m": 0.0,
+        "y_max_m": extent_m,
+        "nx": 11,
+        "ny": 11,
+        "base_elevation_m": base_elevation_m,
+        "amplitude_m": 0.0,
+        "x_wavelength_m": extent_m / 2.0,
+        "y_wavelength_m": extent_m / 2.0,
+    }
+
+
+def _minimal_config(assets: list, connections: list) -> dict:
+    return {
+        "field": {"name": "T"},
+        "surface": _flat_surface(-100.0),
+        "assets": assets,
+        "connections": connections,
+        "routing": {"sample_spacing_m": 100.0},
+    }
+
+
+def _wind_assets() -> list:
+    """One of each electrical-capable kind plus a well/manifold for negatives."""
+    return [
+        {"id": "T1", "kind": "wind_turbine", "x_m": 0.0, "y_m": 0.0, "z_m": 0.0},
+        {"id": "T2", "kind": "wind_turbine", "x_m": 500.0, "y_m": 0.0, "z_m": 0.0},
+        {
+            "id": "OSS",
+            "kind": "offshore_substation",
+            "x_m": 500.0,
+            "y_m": 500.0,
+            "z_m": 0.0,
+        },
+        {"id": "H", "kind": "host", "x_m": 900.0, "y_m": 500.0},
+        {"id": "W", "kind": "well", "x_m": 0.0, "y_m": 500.0},
+        {"id": "M", "kind": "manifold", "x_m": 100.0, "y_m": 500.0},
+    ]
+
+
+# --- schema vocabulary ---------------------------------------------------------
+class TestSchemaVocabulary:
+    def test_wind_kinds_registered(self):
+        assert {"wind_turbine", "offshore_substation"} <= ASSET_KINDS
+        assert {"array_cable", "export_cable"} <= CONNECTION_KINDS
+        assert ELECTRICAL_CONNECTION_KINDS == {"array_cable", "export_cable"}
+        assert ELECTRICAL_ASSET_KINDS == {
+            "wind_turbine",
+            "offshore_substation",
+            "host",
+        }
+
+    def test_wind_demo_config_loads(self):
+        config = load_layout_config(WIND_CONFIG)
+        assert config["field"]["name"] == "Demo Floating Wind Farm"
+        kinds = {a["kind"] for a in config["assets"]}
+        assert kinds == {"wind_turbine", "offshore_substation", "host"}
+        assert {c["kind"] for c in config["connections"]} == {
+            "array_cable",
+            "export_cable",
+        }
+
+    def test_rated_power_and_subtype_parsed(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        turbines = model.assets_of_kind("wind_turbine")
+        assert len(turbines) == 6
+        for turbine in turbines:
+            assert turbine.subtype == "floating"
+            assert turbine.rated_power_mw == pytest.approx(15.0)
+            assert turbine.on_surface is False  # floats at the sea surface
+            assert turbine.z_m == pytest.approx(0.0)
+
+    def test_electrical_properties_parsed(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        for cable in model.connections_of_kind("array_cable"):
+            assert cable.voltage_kv == pytest.approx(66.0)
+            assert cable.conductor_size_mm2 in (300.0, 400.0)
+            assert cable.inner_diameter_m is None  # no bore hydraulics
+        export = model.connections_of_kind("export_cable")
+        assert len(export) == 1
+        assert export[0].voltage_kv == pytest.approx(220.0)
+        assert export[0].conductor_size_mm2 == pytest.approx(800.0)
+        assert export[0].voltage_kv > 66.0  # export above collection voltage
+
+
+# --- electrical-connectivity validation ----------------------------------------
+class TestElectricalValidation:
+    def test_array_cable_to_well_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [{"id": "AC", "kind": "array_cable", "from": "T1", "to": "W"}],
+        )
+        with pytest.raises(ValueError, match="electrical-capable.*'W' is a 'well'"):
+            build_layout_model(config)
+
+    def test_export_cable_from_manifold_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [{"id": "EX", "kind": "export_cable", "from": "M", "to": "H"}],
+        )
+        with pytest.raises(ValueError, match="'M' is a 'manifold'"):
+            build_layout_model(config)
+
+    def test_flowline_to_turbine_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [{"id": "FL", "kind": "flowline", "from": "M", "to": "T1"}],
+        )
+        with pytest.raises(ValueError, match="power-only asset 'T1'"):
+            build_layout_model(config)
+
+    def test_umbilical_to_substation_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [{"id": "UMB", "kind": "umbilical", "from": "H", "to": "OSS"}],
+        )
+        with pytest.raises(ValueError, match="power-only asset 'OSS'"):
+            build_layout_model(config)
+
+    def test_valid_electrical_topology_accepted(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [
+                {"id": "AC1", "kind": "array_cable", "from": "T1", "to": "T2"},
+                {"id": "AC2", "kind": "array_cable", "from": "T2", "to": "OSS"},
+                {"id": "EX1", "kind": "export_cable", "from": "OSS", "to": "H"},
+            ],
+        )
+        model = build_layout_model(config)
+        assert len(model.connections) == 3
+
+    def test_voltage_on_non_electrical_connection_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [
+                {
+                    "id": "FL",
+                    "kind": "flowline",
+                    "from": "W",
+                    "to": "M",
+                    "voltage_kv": 66.0,
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match="not an electrical kind"):
+            build_layout_model(config)
+
+    def test_non_positive_voltage_rejected(self):
+        config = _minimal_config(
+            _wind_assets(),
+            [
+                {
+                    "id": "AC",
+                    "kind": "array_cable",
+                    "from": "T1",
+                    "to": "T2",
+                    "voltage_kv": 0.0,
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match="voltage_kv must be > 0"):
+            build_layout_model(config)
+
+    def test_non_positive_rated_power_rejected(self):
+        assets = _wind_assets()
+        assets[0]["rated_power_mw"] = -5.0
+        with pytest.raises(ValueError, match="rated_power_mw must be > 0"):
+            build_layout_model(_minimal_config(assets, []))
+
+
+# --- schema round-trip ----------------------------------------------------------
+class TestRoundTrip:
+    def test_wind_demo_round_trips_through_yaml(self, tmp_path):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        config = layout_model_to_config(model)
+        dumped = tmp_path / "roundtrip.yml"
+        dumped.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+        rebuilt = build_layout_model_from_file(dumped)
+        assert layout_summary(rebuilt) == layout_summary(model)
+        for c0, c1 in zip(model.connections, rebuilt.connections):
+            assert c1.kind == c0.kind
+            assert c1.voltage_kv == c0.voltage_kv
+            assert c1.conductor_size_mm2 == c0.conductor_size_mm2
+            assert c1.route_length_m == pytest.approx(c0.route_length_m)
+        for a0, a1 in zip(model.assets, rebuilt.assets):
+            assert a1.kind == a0.kind
+            assert a1.subtype == a0.subtype
+            assert a1.rated_power_mw == a0.rated_power_mw
+
+    def test_electrical_properties_reemitted(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        config = layout_model_to_config(model)
+        ac1 = next(c for c in config["connections"] if c["id"] == "AC-1")
+        assert ac1["voltage_kv"] == pytest.approx(66.0)
+        assert ac1["conductor_size_mm2"] == pytest.approx(300.0)
+        wtg1 = next(a for a in config["assets"] if a["id"] == "WTG-1")
+        assert wtg1["rated_power_mw"] == pytest.approx(15.0)
+        assert wtg1["z_m"] == pytest.approx(0.0)  # floating override re-emitted
+
+
+# --- wind demo end-to-end -------------------------------------------------------
+class TestWindDemoEndToEnd:
+    def test_asset_taxonomy_counts(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        assert len(model.assets_of_kind("wind_turbine")) == 6
+        assert len(model.assets_of_kind("offshore_substation")) == 1
+        assert len(model.assets_of_kind("host")) == 1
+        assert len(model.connections_of_kind("array_cable")) == 6
+        assert len(model.connections_of_kind("export_cable")) == 1
+
+    def test_bathymetry_is_floating_wind_depth_range(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        assert float(model.surface.z_m.max()) < 0.0  # fully subsea
+        assert float(model.surface.z_m.min()) > -300.0  # not deepwater O&G depths
+
+    def test_array_cable_plan_length_hand_computed(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        ac1 = next(c for c in model.connections if c.connection_id == "AC-1")
+        # WTG-1 (1500, 2500) -> WTG-2 (3500, 2500): straight 2000 m in plan
+        assert ac1.plan_length_m == pytest.approx(2000.0)
+        # both ends float at z = 0 over ~150 m water depth: the sampled route
+        # dips to the seabed, so 3D length exceeds plan length
+        assert ac1.route_length_m > ac1.plan_length_m
+        assert ac1.elevation_change_m == pytest.approx(0.0)
+
+    def test_export_cable_routes_via_waypoint(self):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        export = model.connections_of_kind("export_cable")[0]
+        assert export.waypoints_plan_m == [(8000.0, 4000.0)]
+        # OSS-1 (7000,4000) -> WP (8000,4000) -> SHORE-1 (8800,4000)
+        assert export.plan_length_m == pytest.approx(
+            math.hypot(1000.0, 0.0) + math.hypot(800.0, 0.0)
+        )
+        assert export.route_length_m >= export.plan_length_m
+
+    def test_summary_is_json_able(self):
+        summary = layout_summary(build_layout_model_from_file(WIND_CONFIG))
+        assert summary["surface"]["is_subsea"] is True
+        assert summary["assets_by_kind"] == {
+            "wind_turbine": 6,
+            "offshore_substation": 1,
+            "host": 1,
+        }
+        json.dumps(summary)  # must not raise
+
+
+# --- visualization: 2D plot + scene JSON ----------------------------------------
+class TestWindVisualization:
+    def test_every_wind_kind_has_styles(self):
+        # style maps stay complete after the vocabulary extension
+        assert set(ASSET_STYLES) == set(ASSET_KINDS)
+        assert set(CONNECTION_STYLES) == set(CONNECTION_KINDS)
+
+    def test_demo_configs_jointly_cover_all_kinds(self):
+        wind = layout_scene_dict(build_layout_model_from_file(WIND_CONFIG))
+        oil = layout_scene_dict(build_layout_model_from_file(OFFSHORE_CONFIG))
+        asset_kinds = {a["kind"] for a in wind["assets"] + oil["assets"]}
+        connection_kinds = {c["kind"] for c in wind["connections"] + oil["connections"]}
+        assert asset_kinds == set(ASSET_KINDS)
+        assert connection_kinds == set(CONNECTION_KINDS)
+
+    def test_wind_scene_schema_unchanged_and_carries_kinds(self, tmp_path):
+        # New kinds ride inside the existing scene shape: schema stays at /2.
+        model = build_layout_model_from_file(WIND_CONFIG)
+        out = tmp_path / "scene.json"
+        export_layout_scene_json(model, out)
+        scene = json.loads(out.read_text(encoding="utf-8"))
+        assert scene["schema"] == SCENE_SCHEMA == "digitalmodel.field_layout_scene/2"
+        assert {a["kind"] for a in scene["assets"]} == {
+            "wind_turbine",
+            "offshore_substation",
+            "host",
+        }
+        assert scene["is_subsea"] is True
+        turbine = next(a for a in scene["assets"] if a["id"] == "WTG-1")
+        assert turbine["subtype"] == "floating"
+        assert turbine["on_surface"] is False
+
+    def test_end_to_end_artifacts(self, tmp_path):
+        result = render_layout_visualization(WIND_CONFIG, tmp_path)
+        plot = Path(result["plot_path"])
+        scene_path = Path(result["scene_path"])
+        assert plot.exists() and plot.stat().st_size > 10_000
+        assert scene_path.exists()
+        assert result["field"] == "Demo Floating Wind Farm"
+        for conn in result["connections"]:
+            assert conn["route_length_m"] >= conn["plan_length_m"] > 0.0
+
+    def test_scene_export_is_deterministic(self, tmp_path):
+        model = build_layout_model_from_file(WIND_CONFIG)
+        a, b = tmp_path / "a.json", tmp_path / "b.json"
+        export_layout_scene_json(model, a)
+        export_layout_scene_json(model, b)
+        assert a.read_bytes() == b.read_bytes()
+
+    def test_model_build_is_deterministic(self):
+        first = layout_summary(build_layout_model_from_file(WIND_CONFIG))
+        second = layout_summary(build_layout_model_from_file(WIND_CONFIG))
+        assert first == second

--- a/tests/field_development/test_visualization.py
+++ b/tests/field_development/test_visualization.py
@@ -91,11 +91,19 @@ class TestSceneExport:
         assert scene["schema"] == SCENE_SCHEMA
         assert scene == layout_scene_dict(model)
 
-    def test_offshore_scene_carries_every_asset_kind(self):
+    def test_offshore_scene_carries_every_oil_and_gas_kind(self):
+        # The O&G demo covers the non-renewables taxonomy; the #1513 wind demo
+        # covers wind_turbine/offshore_substation + array/export cables —
+        # combined coverage of ASSET_KINDS/CONNECTION_KINDS is asserted in
+        # test_renewables_layout.py.
         model = build_layout_model_from_file(OFFSHORE_CONFIG)
         scene = layout_scene_dict(model)
-        assert {a["kind"] for a in scene["assets"]} == set(ASSET_KINDS)
-        assert {c["kind"] for c in scene["connections"]} == set(CONNECTION_KINDS)
+        asset_kinds = {a["kind"] for a in scene["assets"]}
+        connection_kinds = {c["kind"] for c in scene["connections"]}
+        assert asset_kinds == {"host", "vessel", "well", "tree", "manifold"}
+        assert connection_kinds == {"jumper", "flowline", "pipeline", "umbilical"}
+        assert asset_kinds <= set(ASSET_KINDS)
+        assert connection_kinds <= set(CONNECTION_KINDS)
 
     def test_offshore_scene_flags_subsea_and_onshore_does_not(self):
         offshore = layout_scene_dict(build_layout_model_from_file(OFFSHORE_CONFIG))
@@ -161,4 +169,9 @@ class TestRenderLayoutVisualization:
             "host": 1,
         }
         scene = json.loads(Path(result["scene_path"]).read_text(encoding="utf-8"))
-        assert {c["kind"] for c in scene["connections"]} == set(CONNECTION_KINDS)
+        assert {c["kind"] for c in scene["connections"]} == {
+            "jumper",
+            "flowline",
+            "pipeline",
+            "umbilical",
+        }


### PR DESCRIPTION
Closes #1513. Workstream B3 of epic #1507 — renewables extension: wind assets in the field-layout schema.

## What

- **New asset kinds** (`layout_model.py`): `wind_turbine` (fixed-bottom or floating via `subtype`; `rated_power_mw` property) and `offshore_substation`. New connection kinds `array_cable` and `export_cable` — electrical, carrying `voltage_kv` and optional `conductor_size_mm2` (the same IEC 60228 cross-section vocabulary `screening.py`'s `size_cable` sweeps, so a future wiring of cable sizing to routed cable lengths is trivial; `screening.py` itself untouched).
- **Electrical-connectivity validation**: `array_cable`/`export_cable` may only connect electrical-capable assets (`wind_turbine`, `offshore_substation`, `host` — host included so an export cable can land at a shore tie-in). Flow/controls connections (jumper/flowline/pipeline/umbilical) may never terminate at a power-only asset. `voltage_kv` on a non-electrical kind, non-positive `voltage_kv`, and non-positive `rated_power_mw` are rejected with sourced error messages.
- **Demo config** `src/digitalmodel/field_development/data/offshore_wind_demo_field.yml`: synthetic floating-wind farm — 6 floating turbines in two 3-turbine strings, 1 floating substation, turbine→turbine→substation array cables at 66 kV, one 220 kV export cable to a shore tie-in host, over a synthetic ~150 m bathymetry. All constants externalized; generic demo values only (no vendor/model names, no performance claims).
- **Visualization**: fixed 2D marker/color per new kind (teal star turbine, gold hexagon substation, dotted/dashed green cables) and per-kind Blender geometry in `field_flythrough_bpy.py` (schematic tower + hub + three-blade rotor for turbines; distinct topside box for substations; green bevelled cable curves). Existing EEVEE specular=0 and Standard view transform handling untouched; camera clip still scales with scene size (#1518).
- **Tests**: `tests/field_development/test_renewables_layout.py` (25 tests) — schema round-trip through YAML with electrical properties preserved, electrical-connectivity rejections (array-cable→well, export-cable→manifold, flowline→turbine, umbilical→substation), demo config end-to-end (layout + plot + scene JSON), determinism, and combined demo coverage of the full kind vocabulary.

## Scene-schema decision

Stays at `digitalmodel.field_layout_scene/2`. The new kinds ride inside the existing scene shape (every asset already carries `kind`/`subtype`, every connection `kind`); no key was added, removed, or retyped, and the #1510 consumer contract is unchanged — v2 scenes without wind kinds render exactly as before. A structural change (new required keys, geometry encoding change) would bump to `/3`; adding vocabulary values is not one.

Two existing assertions in `test_visualization.py` that equated the O&G demo's kinds with the ENTIRE vocabulary were narrowed to the explicit O&G kind sets (the vocabulary is now a superset); combined coverage of `ASSET_KINDS`/`CONNECTION_KINDS` across both demos is asserted in the new test file.

## Verification

- `pytest tests/field_development/` — **641 passed, 32 skipped** (25 new; all pre-existing tests green; the only modified assertions are the two vocabulary-superset ones above).
- Lint: repo toolchain on changed files — black 24.10.0 clean, isort clean, ruff clean.
- **Real headless render** (required since the bpy script changed): Blender 4.0.2, `--frames 24`, wind demo scene → MP4 rendered; frames 1/12/24 extracted with ffmpeg and checked programmatically — all non-blank (RGB std 69.8/71.3/81.4, hundreds of distinct colors per frame). Visual check of frame 12: all 6 three-blade turbines, substation box, shore host, 6 array cables + 1 export cable visible; camera orbit correct, nothing culled. Renders not committed (gitignored), per repo policy.

Part of epic #1507 (B3). Rel: #1509 (schema), #1510 (visualization/bpy), #1511 (cable screens), #1518 (camera clip lesson).
