### PR TITLE
feat(diffraction): emit standardized HTML report + results JSON from the solve pipeline (#1537)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/postprocess.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/postprocess.py
@@ -46,6 +46,7 @@ class PostprocResult:
     exports: Dict[str, Path] = field(default_factory=dict)
     plots: List[Path] = field(default_factory=list)
     validation_report: Path | None = None
+    report: Path | None = None
     index: Path | None = None
 
 
@@ -99,7 +100,12 @@ def postprocess_diffraction_run(
     # 3) RAO plots (optional dep; skipped cleanly if matplotlib is absent).
     plots = _plot_raos(results, out) if make_plots else []
 
-    # 4) Index manifest.
+    # 4) Standardized self-contained HTML report (the same generator the
+    #    benchmark path uses; a view over the bundle, never a copy). Optional
+    #    like the plots — a missing plotly/report dep never fails postprocess.
+    report_path = _build_html_report(results, out, report)
+
+    # 5) Index manifest.
     index = {
         "vessel": results.vessel_name,
         "analysis_tool": results.analysis_tool,
@@ -108,6 +114,7 @@ def postprocess_diffraction_run(
         "validation_report": validation_path.name,
         "exports": {k: Path(v).name for k, v in exports.items()},
         "plots": [p.name for p in plots],
+        "report": report_path.name if report_path is not None else None,
     }
     index_path = out / "index.json"
     index_path.write_text(json.dumps(index, indent=2, default=str))
@@ -119,8 +126,69 @@ def postprocess_diffraction_run(
         exports={k: Path(v) for k, v in exports.items()},
         plots=plots,
         validation_report=validation_path,
+        report=report_path,
         index=index_path,
     )
+
+
+def _build_html_report(
+    results: DiffractionResults, out: Path, validation_report: Dict[str, Any]
+) -> Path | None:
+    """Render the standardized diffraction HTML report from the bundle.
+
+    Reuses ``generate_diffraction_report`` (the benchmark path's generator) so a
+    single-solver run gets the same report shape. Self-contained
+    (``include_plotlyjs`` inline) and deterministic: ``report_date`` is taken
+    from the results' own analysis/created date, never ``datetime.now``.
+
+    Returns the path, or ``None`` if the optional report/plotly dependencies are
+    absent or anything fails — the report is a convenience, not a contract
+    (same policy as the RAO plots).
+    """
+    try:
+        from digitalmodel.hydrodynamics.diffraction.report_generator import (
+            build_report_data_from_solver_results,
+            compute_natural_periods,
+            compute_stability,
+            generate_diffraction_report,
+        )
+
+        if build_report_data_from_solver_results is None:
+            return None
+
+        report_data = build_report_data_from_solver_results(
+            {results.analysis_tool: results}, vessel_name=results.vessel_name
+        )
+        # Deterministic label from the bundle itself.
+        report_data.report_date = results.analysis_date or results.created_date or ""
+
+        # Enrich with stability + natural periods when hydrostatics travelled
+        # in the bundle (Optional on DiffractionResults). Clean field mapping;
+        # skipped silently when absent.
+        if results.hydrostatics is not None:
+            report_data.hydrostatics = results.hydrostatics
+            stability = compute_stability(results.hydrostatics)
+            report_data.gm_transverse = stability.get("gm_transverse")
+            report_data.gm_longitudinal = stability.get("gm_longitudinal")
+            report_data.bm_transverse = stability.get("bm_transverse")
+            report_data.bm_longitudinal = stability.get("bm_longitudinal")
+            report_data.kb = stability.get("kb")
+            if report_data.added_mass_diagonal:
+                report_data.natural_periods = compute_natural_periods(
+                    results.hydrostatics,
+                    report_data.added_mass_diagonal,
+                    report_data.frequencies_rad_s,
+                )
+
+        report_path = out / f"{results.vessel_name}_diffraction_report.html"
+        return generate_diffraction_report(
+            report_data,
+            report_path,
+            include_plotlyjs=True,
+            validation_report=validation_report,
+        )
+    except Exception:  # noqa: BLE001 - report is optional, never fatal
+        return None
 
 
 def _plot_raos(results: DiffractionResults, out: Path) -> List[Path]:

--- a/src/digitalmodel/hydrodynamics/diffraction/workflow.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/workflow.py
@@ -111,7 +111,46 @@ class DiffractionWorkflow:
                 f"{label} solver unavailable: run fell back to dry-run "
                 f"(no {label} executable/license found). Run on a licensed host."
             )
+        if status == "completed":
+            exported = self._export_results_json(result, settings)
+            if exported is not None:
+                settings["outputs"]["diffraction_results_json"] = str(exported)
         return cfg
+
+    @staticmethod
+    def _export_results_json(result: Any, settings: dict[str, Any]) -> Path | None:
+        """Serialize ``DiffractionResults`` into the solve output directory.
+
+        ``diffraction_results.json`` is the bundle authority consumed by the
+        license-free side (``postprocess.load_results_bundle``,
+        ``DiffractionResults.from_dict``) and, being a small JSON in the
+        results tree, is picked up by the licensed-run queue's result-return
+        mechanism — so RAOs leave the licensed host without extra
+        infrastructure (#1537 / deckhand#545).
+        """
+        results_obj = getattr(result, "diffraction_results", None)
+        if results_obj is None:
+            return None
+        import json
+
+        out_dir = Path(
+            str(getattr(result, "output_dir", None) or settings["output_directory"])
+        )
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path = out_dir / "diffraction_results.json"
+        path.write_text(
+            json.dumps(
+                results_obj.to_dict(),
+                indent=2,
+                # numpy scalars/arrays from the extraction layer
+                default=lambda o: (
+                    o.item()
+                    if hasattr(o, "item")
+                    else (o.tolist() if hasattr(o, "tolist") else str(o))
+                ),
+            )
+        )
+        return path
 
     @staticmethod
     def _resolve_spec_path(cfg: dict[str, Any], settings: dict[str, Any]) -> Path:

--- a/tests/hydrodynamics/diffraction/test_postprocess.py
+++ b/tests/hydrodynamics/diffraction/test_postprocess.py
@@ -100,6 +100,52 @@ def test_postprocess_run_produces_exports_validation_and_index(
     assert "exports" in index
 
 
+def test_postprocess_run_emits_standardized_html_report(
+    tmp_path: Path, mock_diffraction_results
+):
+    # #1537: the license-free postprocess emits the same standardized report
+    # the benchmark path uses, self-contained (inline plotly, no CDN), and the
+    # index references it.
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "diffraction_results.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    out = tmp_path / "postproc"
+
+    result = postprocess_diffraction_run(bundle, out, make_plots=False)
+
+    assert result.report is not None, "expected an HTML report (plotly present)"
+    expected = out / f"{mock_diffraction_results.vessel_name}_diffraction_report.html"
+    assert result.report == expected
+    assert result.report.is_file()
+    html = result.report.read_text()
+    assert mock_diffraction_results.vessel_name in html
+    # Self-contained: inline plotly, never a CDN <script src>.
+    assert "cdn.plot.ly" not in html
+    index = json.loads((out / "index.json").read_text())
+    assert index["report"] == result.report.name
+
+
+def test_postprocess_report_date_is_deterministic_from_bundle(
+    tmp_path: Path, mock_diffraction_results
+):
+    # The report label comes from the bundle's own date, never datetime.now,
+    # so repeated renders of the same bundle carry the same date (#1019 SSOT).
+    mock_diffraction_results.analysis_date = "2026-07-11 00:00:00"
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "diffraction_results.json").write_text(
+        json.dumps(mock_diffraction_results.to_dict())
+    )
+    out = tmp_path / "postproc"
+
+    result = postprocess_diffraction_run(bundle, out, make_plots=False)
+
+    assert result.report is not None
+    assert "2026-07-11 00:00:00" in result.report.read_text()
+
+
 def test_postprocess_run_no_heavy_files_emitted(
     tmp_path: Path, mock_diffraction_results
 ):

--- a/tests/hydrodynamics/diffraction/test_workflow_router.py
+++ b/tests/hydrodynamics/diffraction/test_workflow_router.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 UNIT_BOX = REPO_ROOT / "examples" / "hydrodynamics" / "diffraction" / "unit_box_rao"
@@ -27,9 +26,7 @@ def _workflow_cfg(tmp_path: Path, solver: str) -> dict:
 
 
 def test_diffraction_workflow_generates_orcawave_input(tmp_path: Path) -> None:
-    from digitalmodel.hydrodynamics.diffraction.workflow import (
-        DiffractionWorkflow,
-    )
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
 
     cfg = DiffractionWorkflow().router(_workflow_cfg(tmp_path, "orcawave"))
 
@@ -48,9 +45,7 @@ def test_diffraction_workflow_generates_orcawave_input(tmp_path: Path) -> None:
 
 
 def test_diffraction_workflow_generates_aqwa_deck(tmp_path: Path) -> None:
-    from digitalmodel.hydrodynamics.diffraction.workflow import (
-        DiffractionWorkflow,
-    )
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
 
     cfg = DiffractionWorkflow().router(_workflow_cfg(tmp_path, "aqwa"))
 
@@ -136,6 +131,52 @@ def test_run_orcawave_silent_dry_run_fallback_raises(tmp_path: Path) -> None:
     ):
         with pytest.raises(RuntimeError, match="fell back to dry-run"):
             DiffractionWorkflow().router(_solve_cfg(tmp_path, dry_run=False))
+
+
+def test_run_orcawave_completed_exports_results_json(tmp_path: Path) -> None:
+    # A successful solve must serialize DiffractionResults.to_dict() into the
+    # output dir so the license-free side (postprocess, pamphlet rao_artifact,
+    # queue result-return) can consume it (#1537).
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    out_dir = tmp_path / "results" / "out"
+    fake = _fake_result("completed")
+    fake.output_dir = str(out_dir)
+    fake.diffraction_results = SimpleNamespace(
+        to_dict=lambda: {"vessel_name": "UnitBoxRAO", "raos": {"frequencies": [0.5]}}
+    )
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=fake,
+    ):
+        cfg = DiffractionWorkflow().router(_solve_cfg(tmp_path, dry_run=False))
+
+    settings = cfg["diffraction"]
+    exported = Path(settings["outputs"]["diffraction_results_json"])
+    assert exported == out_dir / "diffraction_results.json"
+    import json
+
+    data = json.loads(exported.read_text())
+    assert data["vessel_name"] == "UnitBoxRAO"
+    assert data["raos"]["frequencies"] == [0.5]
+
+
+def test_run_orcawave_completed_without_results_object(tmp_path: Path) -> None:
+    # Runners that carry no diffraction_results (e.g. AQWA path today) must not
+    # break: no file, no settings key.
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    fake = _fake_result("completed")
+    fake.output_dir = str(tmp_path / "results" / "out")
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=fake,
+    ):
+        cfg = DiffractionWorkflow().router(_solve_cfg(tmp_path, dry_run=False))
+
+    assert "diffraction_results_json" not in cfg["diffraction"]["outputs"]
 
 
 # --- operation: run_aqwa (issue #939) ---------------------------------------


### PR DESCRIPTION
Closes #1537.

## What this does
Wires the **existing** standardized diffraction report generator (`report_generator.py`, 25-section `ReportBackbone`, Plotly) into the solve/postprocess pipeline — previously only the benchmark path called it, so real vessel solves (e.g. the BokaLift 2 licensed-run chain, llm-wiki-acma#218) produced CSVs + validation JSON but no report.

**Two changes:**
1. `workflow.py` — on a **completed** solve, serialize `DiffractionResults.to_dict()` (the bundle authority) into the output dir as `diffraction_results.json`. It's small JSON in the results tree, so the licensed-run queue's existing result-return mechanism ships it off the licensed host with **zero new infrastructure** — this is the linchpin that unblocks **deckhand#545** (RAOs currently never leave ace-win-1) and the pamphlet `rao_artifact` path (#1538).
2. `postprocess.py` — the license-free `postprocess_diffraction_run` now emits `{vessel}_diffraction_report.html` via `generate_diffraction_report`: self-contained (**inline Plotly**), **deterministic** (report date sourced from the bundle, never `datetime.now` — #1019 SSOT), enriched with stability + natural periods when hydrostatics are present, and registered in `index.json`. Optional-by-contract (returns `None` on any failure, exactly like the RAO plots).

Scope discipline: mesh-quality-JSON and peak-response enrichment deferred to a follow-up — the bundle's gate JSON (element-size/aspect stats) doesn't map cleanly onto `MeshQualityData` (area stats), and peak-response scanning needs careful RAO-array unit handling; both risk correctness without a real fixture. This lands the report core.

## Tests
- `test_workflow_router.py`: 2 new tests — completed solve exports `diffraction_results.json`; runners without a results object don't break. (**This file's suite passed 11/11 locally.**)
- `test_postprocess.py`: 2 new tests — report emitted + registered in index, self-contained (no CDN), deterministic date from bundle.

## ⚠️ Local-test caveat (please let CI gate this)
The two new **postprocess** tests could **not be run locally**: the dev machine's NTFS-FUSE mount degraded to where even `import numpy` times out (>60s), so no pytest can execute against this checkout right now (infra, not code). Offline verification that *did* pass: **ruff** (the CI linter) clean, **black/isort** clean, and the `workflow.py` test suite 11/11 (run while the mount was healthy). CI runs in a clean environment — **please rely on it to confirm the postprocess tests** before merge.

Refs: #1537, deckhand#545, #1538 (pamphlet), llm-wiki-acma#218 (BokaLift chain).
