### PR TITLE
feat(cfd): reduced-order sloshing fill/drain workflow + case coupling (#1528 slices 2,3,4,5,6)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/__init__.py
+++ b/src/digitalmodel/solvers/openfoam/__init__.py
@@ -60,6 +60,40 @@ from .pressure_taps import (
     render_probes_entry,
     render_surface_entry,
 )
+from .gravity_conduit import (
+    ConduitGeometry,
+    G_STANDARD,
+    GravityExchangeResult,
+    TankState,
+    check_transfer_feasibility,
+    conduit_flow_rate,
+    signed_hydrostatic_head,
+    simulate_gravity_exchange,
+)
+from .sloshing_sweep import (
+    NaturalPeriodResult,
+    SweepCase,
+    SweepConfig,
+    SweepManifest,
+    first_sloshing_natural_period,
+    generate_sweep,
+    period_ratio,
+)
+from .time_history import (
+    ExtractionConfig,
+    RawCFDOutputs,
+    SynchronizedTimeHistory,
+    TimeSeriesChannel,
+    ValidationFlags,
+    extract_time_history,
+    phase_lag_deg,
+    validate_synchronized_time,
+)
+from .report import (
+    REQUIRED_SECTIONS,
+    render_aggregate_report,
+    render_case_report,
+)
 
 __all__ = [
     "BoundaryCondition",
@@ -106,4 +140,30 @@ __all__ = [
     "SloshingCase",
     "SloshingCouplingModel",
     "TuningReport",
+    "ConduitGeometry",
+    "G_STANDARD",
+    "GravityExchangeResult",
+    "TankState",
+    "check_transfer_feasibility",
+    "conduit_flow_rate",
+    "signed_hydrostatic_head",
+    "simulate_gravity_exchange",
+    "NaturalPeriodResult",
+    "SweepCase",
+    "SweepConfig",
+    "SweepManifest",
+    "first_sloshing_natural_period",
+    "generate_sweep",
+    "period_ratio",
+    "ExtractionConfig",
+    "RawCFDOutputs",
+    "SynchronizedTimeHistory",
+    "TimeSeriesChannel",
+    "ValidationFlags",
+    "extract_time_history",
+    "phase_lag_deg",
+    "validate_synchronized_time",
+    "REQUIRED_SECTIONS",
+    "render_aggregate_report",
+    "render_case_report",
 ]

--- a/src/digitalmodel/solvers/openfoam/__init__.py
+++ b/src/digitalmodel/solvers/openfoam/__init__.py
@@ -94,6 +94,20 @@ from .report import (
     render_aggregate_report,
     render_case_report,
 )
+from .case_coupling import (
+    CaseManifest,
+    CouplingSpec,
+    SyntheticCase,
+    VerificationResult,
+    build_case_manifest,
+    emit_synthetic_gravity_exchange_case,
+    map_sweep_case_to_openfoam_case,
+    peak_flow_rate,
+    synthetic_coupling_spec,
+    synthetic_sweep_case,
+    transfer_volume,
+    verify_coupling,
+)
 
 __all__ = [
     "BoundaryCondition",
@@ -166,4 +180,16 @@ __all__ = [
     "REQUIRED_SECTIONS",
     "render_aggregate_report",
     "render_case_report",
+    "CaseManifest",
+    "CouplingSpec",
+    "SyntheticCase",
+    "VerificationResult",
+    "build_case_manifest",
+    "emit_synthetic_gravity_exchange_case",
+    "map_sweep_case_to_openfoam_case",
+    "peak_flow_rate",
+    "synthetic_coupling_spec",
+    "synthetic_sweep_case",
+    "transfer_volume",
+    "verify_coupling",
 ]

--- a/src/digitalmodel/solvers/openfoam/case_coupling.py
+++ b/src/digitalmodel/solvers/openfoam/case_coupling.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: CFD case coupling and pre-run verification for the reduced-order
+sloshing fill/drain workflow (#1528 slice 4). Maps a deterministic SweepCase
+(+ a tank/conduit/roll spec) into a buildable multiphase OpenFOAMCase, then runs
+a solver-free verification GATE that must pass BEFORE any CFD is launched: it
+checks the half-sine flow-pulse volume-integral identity, mass/volume
+conservation of the planned exchange (reusing gravity_conduit), and rejects
+dry-out / overflow and missing/inconsistent boundary conditions. It also emits a
+de-identified synthetic gravity-exchange case with a small, hashed manifest (not
+a full raw case tree).
+
+Half-sine transfer law (issue #1528)
+------------------------------------
+The roll-driven conduit pulse over one half-cycle is a half sine::
+
+    Q(t) = Q_peak * sin(omega * t),   omega = 2*pi/T,   f = 1/T
+
+so that the transferred volume over a half-cycle equals the integral of the
+positive lobe::
+
+    V_transfer = integral_0^{T/2} Q_peak sin(omega t) dt = Q_peak * T / pi
+    Q_peak     = pi * f * V_transfer          (equivalently Q_peak = pi V_transfer / T)
+    half-cycle mean flow = V_transfer / (T/2) = 2 f V_transfer
+
+The volume-integral identity ``V_transfer == Q_peak * T / pi`` is the
+conservation invariant the gate verifies independently of any CFD run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
+
+from loguru import logger
+
+from .gravity_conduit import (
+    ConduitGeometry,
+    G_STANDARD,
+    TankState,
+    check_transfer_feasibility,
+    simulate_gravity_exchange,
+)
+from .models import (
+    BoundaryCondition,
+    BoundaryType,
+    CaseType,
+    DomainConfig,
+    OpenFOAMCase,
+)
+from .motion import MotionType, PrescribedMotion
+from .sloshing_sweep import SweepCase
+
+Vec3 = Tuple[float, float, float]
+
+# Manifest schema version (bump on breaking field changes).
+COUPLING_SCHEMA_VERSION = "1.0"
+
+# Absolute tolerance for the flow-pulse volume-integral identity (m^3).
+_PULSE_TOL: float = 1e-9
+
+# Absolute tolerance for the planned-exchange mass residual (kg).
+_MASS_TOL: float = 1e-6
+
+# Rounding applied to inputs before hashing (kills float noise for reproducible
+# manifest hashes across platforms).
+_ROUND = 6
+
+# Explicit, recorded motion/flow phase convention for the coupled exchange.
+PHASE_CONVENTION = (
+    "roll x(t)=A*sin(omega*t) [deg]; conduit pulse Q(t)=Q_peak*sin(omega*t) is "
+    "taken in phase with roll velocity (positive Q = source->dest inflow at the "
+    "inlet patch). Over one half-cycle V_transfer=integral_0^{T/2} Q dt="
+    "Q_peak*T/pi, i.e. Q_peak=pi*f*V_transfer. Inlet U is set to the peak "
+    "conduit velocity Q_peak/A_conduit; outlet is pressure-driven."
+)
+
+
+# ============================================================================
+# Coupling spec
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class CouplingSpec:
+    """Physical tank/conduit/roll spec paired with a SweepCase for coupling.
+
+    The SweepCase carries the dimensionless sweep axes (fill fraction, conduit
+    capacity, period ratio) and the roll period; this spec carries the dimensional
+    geometry needed to build the OpenFOAM domain and to run the reduced-order
+    conservation check for the coupled pair of tanks.
+
+    Attributes:
+        tank_length: Tank length in the sloshing (x) direction (m, > 0).
+        tank_width: Tank transverse width (y) (m, > 0).
+        tank_height: Tank internal height (z) (m, > 0); must be consistent with
+            the SweepCase ``fill_depth = fill_fraction * tank_height``.
+        roll_amplitude_deg: Prescribed roll amplitude (degrees, > 0).
+        roll_origin: Roll rotation centre (m), passed to PrescribedMotion.
+        conduit: Connecting-conduit geometry/losses (gravity_conduit.ConduitGeometry).
+        dest_fill_fraction: Initial fill fraction of the paired destination tank
+            (0-1); the SweepCase fill_fraction is the source/primary tank.
+        density: Liquid density used for the mass residual (kg/m^3, > 0).
+        n_cells: Background block-mesh cell counts (nx, ny, nz); the z count sets
+            the free-surface snap resolution for the partial-fill setFieldsDict.
+        gravity: Gravitational acceleration for the exchange check (m/s^2).
+    """
+
+    tank_length: float
+    tank_width: float
+    tank_height: float
+    roll_amplitude_deg: float
+    conduit: ConduitGeometry
+    dest_fill_fraction: float
+    roll_origin: Vec3 = (0.0, 0.0, 0.0)
+    density: float = 1025.0
+    n_cells: Tuple[int, int, int] = (40, 8, 40)
+    gravity: float = G_STANDARD
+
+    def __post_init__(self) -> None:
+        for name in ("tank_length", "tank_width", "tank_height", "roll_amplitude_deg", "density"):
+            if getattr(self, name) <= 0.0:
+                raise ValueError(f"{name} must be positive, got {getattr(self, name)}")
+        if not (0.0 <= self.dest_fill_fraction <= 1.0):
+            raise ValueError(
+                f"dest_fill_fraction must be in [0, 1], got {self.dest_fill_fraction}"
+            )
+        if len(self.n_cells) != 3 or any(n < 1 for n in self.n_cells):
+            raise ValueError(f"n_cells must be three counts >= 1, got {self.n_cells}")
+        if len(self.roll_origin) != 3:
+            raise ValueError("roll_origin must be a 3-tuple (x y z)")
+
+    @property
+    def plan_area(self) -> float:
+        """Horizontal (plan) cross-sectional area (m^2) = length * width."""
+        return self.tank_length * self.tank_width
+
+    @property
+    def tank_volume(self) -> float:
+        """Tank capacity (m^3) = plan_area * tank_height."""
+        return self.plan_area * self.tank_height
+
+
+# ============================================================================
+# Verification-gate result + manifest types
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Verdict of the pre-run coupling verification gate.
+
+    Attributes:
+        case_id: Coupled case identifier.
+        passed: True only when every check passed.
+        transfer_volume_m3: Planned half-cycle transfer volume V_transfer.
+        q_peak_m3_s: Peak conduit flow rate Q_peak = pi * f * V_transfer.
+        pulse_integral_m3: Half-sine volume integral Q_peak * T / pi (== V_transfer).
+        pulse_integral_residual_m3: |pulse_integral - V_transfer| (~0 by identity).
+        mass_residual_kg: Max mass drift of the planned exchange (from
+            gravity_conduit.simulate_gravity_exchange).
+        volume_residual_m3: Total-volume drift of the planned exchange (~0).
+        feasible: True if the transfer avoids dry-out and overflow.
+        boundary_conditions_ok: True if inlet+outlet BCs and the phase
+            convention are present and consistent.
+        phase_convention: The recorded motion/flow phase convention string.
+        checks: Ordered mapping of check name -> pass/fail.
+    """
+
+    case_id: str
+    passed: bool
+    transfer_volume_m3: float
+    q_peak_m3_s: float
+    pulse_integral_m3: float
+    pulse_integral_residual_m3: float
+    mass_residual_kg: float
+    volume_residual_m3: float
+    feasible: bool
+    boundary_conditions_ok: bool
+    phase_convention: str
+    checks: Dict[str, bool] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CaseManifest:
+    """Small, hashed, de-identified record of a coupled case (not a case tree).
+
+    Attributes:
+        schema_version: Manifest schema version.
+        case_id: Coupled case identifier.
+        inputs: De-identified scalar inputs (fill, geometry, conduit, roll).
+        solver: Solver/time-stepping summary.
+        fill_level: VOF partial-fill level (fraction of tank height).
+        transfer_volume_m3: Planned half-cycle transfer volume.
+        q_peak_m3_s: Peak conduit flow rate.
+        phase_convention: Recorded motion/flow phase convention.
+        gate_passed: Whether the verification gate passed.
+        content_hash: 16-hex digest over the canonical inputs + solver + schema.
+    """
+
+    schema_version: str
+    case_id: str
+    inputs: Dict[str, Any]
+    solver: Dict[str, Any]
+    fill_level: float
+    transfer_volume_m3: float
+    q_peak_m3_s: float
+    phase_convention: str
+    gate_passed: bool
+    content_hash: str
+
+
+@dataclass(frozen=True)
+class SyntheticCase:
+    """Bundle produced by :func:`emit_synthetic_gravity_exchange_case`."""
+
+    case: OpenFOAMCase
+    sweep_case: SweepCase
+    spec: CouplingSpec
+    verification: VerificationResult
+    manifest: CaseManifest
+
+
+# ============================================================================
+# Half-sine flow law (independent, solver-free)
+# ============================================================================
+
+
+def transfer_volume(sweep_case: SweepCase, spec: CouplingSpec) -> float:
+    """Planned half-cycle transfer volume V_transfer (m^3).
+
+    The dimensionless ``conduit_capacity`` is a fraction of tank volume per
+    half-cycle, so ``V_transfer = conduit_capacity * tank_volume``.
+    """
+    return sweep_case.conduit_capacity * spec.tank_volume
+
+
+def peak_flow_rate(v_transfer: float, roll_period_s: float) -> float:
+    """Peak conduit flow rate Q_peak = pi * f * V_transfer (m^3/s).
+
+    Derived from the half-sine pulse ``Q(t) = Q_peak sin(omega t)`` whose
+    half-cycle integral equals ``V_transfer`` (see module docstring).
+    """
+    if roll_period_s <= 0.0:
+        raise ValueError(f"roll_period_s must be positive, got {roll_period_s}")
+    f = 1.0 / roll_period_s
+    return math.pi * f * v_transfer
+
+
+# ============================================================================
+# Mapper: SweepCase -> OpenFOAMCase
+# ============================================================================
+
+
+def map_sweep_case_to_openfoam_case(
+    sweep_case: SweepCase, spec: CouplingSpec
+) -> OpenFOAMCase:
+    """Map one reduced-order SweepCase (+ spec) to a buildable OpenFOAMCase.
+
+    Sets the VOF fill level from the fill fraction, a ROLL prescribed motion from
+    the sweep roll period and the spec amplitude, the domain box from the tank
+    dimensions, inlet/outlet boundary conditions for the conduit exchange, and
+    metadata carrying the case id, conduit capacity, the flow-law scalars, and an
+    explicit motion/flow phase convention.
+
+    Args:
+        sweep_case: One deterministic sweep row.
+        spec: Dimensional tank/conduit/roll spec for the coupled pair.
+
+    Returns:
+        A multiphase ``interFoam`` :class:`OpenFOAMCase` ready to build/verify.
+
+    Raises:
+        ValueError: If the spec geometry is inconsistent with the sweep case
+            (fill depth mismatch) or the fill fraction is out of range.
+    """
+    if not (0.0 <= sweep_case.fill_fraction <= 1.0):
+        raise ValueError(
+            f"fill_fraction must be in [0, 1], got {sweep_case.fill_fraction}"
+        )
+    expected_depth = sweep_case.fill_fraction * spec.tank_height
+    if not math.isclose(expected_depth, sweep_case.fill_depth, rel_tol=1e-6, abs_tol=1e-9):
+        raise ValueError(
+            f"spec tank_height {spec.tank_height} m is inconsistent with the sweep "
+            f"case fill_depth {sweep_case.fill_depth} m at fill_fraction "
+            f"{sweep_case.fill_fraction} (expected fill_depth {expected_depth} m); "
+            "the spec must describe the same tank the sweep was generated for."
+        )
+
+    case = OpenFOAMCase.for_case_type(CaseType.SLOSHING, name=sweep_case.case_id)
+    case.fill_level = float(sweep_case.fill_fraction)
+
+    case.domain = DomainConfig(
+        min_coords=[0.0, 0.0, 0.0],
+        max_coords=[spec.tank_length, spec.tank_width, spec.tank_height],
+        n_cells=list(spec.n_cells),
+    )
+
+    case.motion = PrescribedMotion(
+        motion_type=MotionType.ROLL,
+        amplitude=spec.roll_amplitude_deg,
+        period=sweep_case.roll_period_s,
+        origin=tuple(spec.roll_origin),
+    )
+
+    v_transfer = transfer_volume(sweep_case, spec)
+    q_peak = peak_flow_rate(v_transfer, sweep_case.roll_period_s)
+    v_peak = q_peak / spec.conduit.area  # peak conduit velocity for the inlet BC
+
+    case.boundary_conditions = _exchange_boundary_conditions(v_peak)
+
+    case.metadata = {
+        "case_id": sweep_case.case_id,
+        "fill_fraction": float(sweep_case.fill_fraction),
+        "conduit_capacity": float(sweep_case.conduit_capacity),
+        "period_ratio": float(sweep_case.period_ratio),
+        "near_resonance": bool(sweep_case.near_resonance),
+        "roll_period_s": float(sweep_case.roll_period_s),
+        "roll_frequency_hz": float(sweep_case.roll_frequency_hz),
+        "transfer_volume_m3": float(v_transfer),
+        "q_peak_m3_s": float(q_peak),
+        "peak_conduit_velocity_m_s": float(v_peak),
+        "phase_convention": PHASE_CONVENTION,
+    }
+    logger.info(
+        "Mapped coupled case '{}': fill={:.3f}, T_roll={:.4g}s, cap={:.4g}, "
+        "V_transfer={:.4g} m^3, Q_peak={:.4g} m^3/s",
+        sweep_case.case_id, sweep_case.fill_fraction, sweep_case.roll_period_s,
+        sweep_case.conduit_capacity, v_transfer, q_peak,
+    )
+    return case
+
+
+def _exchange_boundary_conditions(peak_velocity: float) -> list[BoundaryCondition]:
+    """Inlet/outlet boundary conditions for the conduit exchange (interFoam).
+
+    The inlet drives the peak conduit velocity (in phase with the roll velocity
+    per the recorded phase convention); the outlet is pressure-driven. Fields
+    are the standard interFoam set (U, p_rgh, alpha.water).
+    """
+    inlet_u = f"uniform ({peak_velocity:.10g} 0 0)"
+    return [
+        BoundaryCondition("inlet", BoundaryType.FIXED_VALUE, "U", value=inlet_u),
+        BoundaryCondition("inlet", BoundaryType.ZERO_GRADIENT, "p_rgh"),
+        BoundaryCondition(
+            "inlet", BoundaryType.INLET_OUTLET, "alpha.water",
+            value="uniform 1", extra={"inletValue": "uniform 1"},
+        ),
+        BoundaryCondition(
+            "outlet", BoundaryType.PRESSURE_INLET_OUTLET_VELOCITY, "U",
+            value="uniform (0 0 0)",
+        ),
+        BoundaryCondition(
+            "outlet", BoundaryType.TOTAL_PRESSURE, "p_rgh",
+            value="uniform 0", extra={"p0": "uniform 0"},
+        ),
+        BoundaryCondition(
+            "outlet", BoundaryType.INLET_OUTLET, "alpha.water",
+            value="uniform 0", extra={"inletValue": "uniform 0"},
+        ),
+    ]
+
+
+# ============================================================================
+# Verification gate
+# ============================================================================
+
+
+def verify_coupling(
+    case: OpenFOAMCase, sweep_case: SweepCase, spec: CouplingSpec
+) -> VerificationResult:
+    """Pre-run verification gate for a coupled case (no CFD required).
+
+    Runs, in order and BEFORE any CFD: (1) the half-sine flow-pulse volume
+    integral identity ``Q_peak*T/pi == V_transfer`` and a cross-check that the
+    case metadata's recorded flow law is self-consistent (rejects a tampered /
+    non-conserving plan); (2) dry-out / overflow feasibility via
+    :func:`gravity_conduit.check_transfer_feasibility`; (3) mass & volume
+    conservation of the planned exchange via
+    :func:`gravity_conduit.simulate_gravity_exchange`; (4) boundary-condition and
+    phase-convention presence/consistency.
+
+    Args:
+        case: The mapped OpenFOAM case (source of BCs + recorded flow law).
+        sweep_case: The originating sweep row.
+        spec: The dimensional tank/conduit/roll spec.
+
+    Returns:
+        A :class:`VerificationResult` with ``passed=True`` when every check holds.
+
+    Raises:
+        ValueError: On any failing check, with an actionable diagnostic (dry-out,
+            overflow, non-conserving plan, missing/inconsistent boundary
+            conditions or phase convention).
+    """
+    checks: Dict[str, bool] = {}
+
+    # --- (1) Flow-pulse volume-integral identity + metadata self-consistency ---
+    v_transfer = transfer_volume(sweep_case, spec)
+    q_peak = peak_flow_rate(v_transfer, sweep_case.roll_period_s)
+    pulse_integral = q_peak * sweep_case.roll_period_s / math.pi
+    pulse_residual = abs(pulse_integral - v_transfer)
+    checks["pulse_integral_identity"] = pulse_residual <= _PULSE_TOL
+    if not checks["pulse_integral_identity"]:  # pragma: no cover - identity is exact
+        raise ValueError(
+            f"flow-pulse integral Q_peak*T/pi={pulse_integral:.6g} m^3 does not "
+            f"equal the requested transfer V_transfer={v_transfer:.6g} m^3 "
+            f"(residual {pulse_residual:.3g} m^3); the half-sine plan is not "
+            "volume-conserving."
+        )
+
+    meta = case.metadata
+    for key, truth in (("transfer_volume_m3", v_transfer), ("q_peak_m3_s", q_peak)):
+        recorded = meta.get(key)
+        if recorded is None:
+            raise ValueError(
+                f"case metadata is missing '{key}'; cannot verify the flow law. "
+                "Re-map the case with map_sweep_case_to_openfoam_case."
+            )
+        if not math.isclose(float(recorded), truth, rel_tol=1e-6, abs_tol=1e-9):
+            raise ValueError(
+                f"non-conserving plan: case metadata '{key}'={recorded:.6g} does "
+                f"not match the half-sine flow law value {truth:.6g} "
+                "(Q_peak=pi*f*V_transfer, V_transfer=Q_peak*T/pi); the recorded "
+                "pulse integral is inconsistent with the requested transfer."
+            )
+    checks["metadata_flow_law_consistent"] = True
+
+    # --- (2) Dry-out / overflow feasibility of the requested transfer ---------
+    source = TankState(
+        volume=sweep_case.fill_fraction * spec.tank_volume,
+        plan_area=spec.plan_area,
+        height=spec.tank_height,
+    )
+    dest = TankState(
+        volume=spec.dest_fill_fraction * spec.tank_volume,
+        plan_area=spec.plan_area,
+        height=spec.tank_height,
+    )
+    check_transfer_feasibility(source, dest, v_transfer)  # raises on dry-out/overflow
+    checks["transfer_feasible"] = True
+
+    # --- (3) Mass & volume conservation of the planned exchange ---------------
+    duration = max(2.0 * sweep_case.roll_period_s, sweep_case.roll_period_s)
+    dt = sweep_case.roll_period_s / 100.0
+    exchange = simulate_gravity_exchange(
+        source, dest, spec.conduit,
+        duration=duration, dt=dt, density=spec.density, g=spec.gravity,
+    )
+    v0 = exchange.source_volume[0] + exchange.dest_volume[0]
+    v1 = exchange.source_volume[-1] + exchange.dest_volume[-1]
+    volume_residual = abs(v1 - v0)
+    checks["mass_conserved"] = exchange.mass_residual <= _MASS_TOL
+    checks["volume_conserved"] = volume_residual <= _PULSE_TOL
+    if not checks["mass_conserved"] or not checks["volume_conserved"]:
+        raise ValueError(
+            f"non-conserving plan: the planned gravity exchange drifts "
+            f"(mass_residual={exchange.mass_residual:.3g} kg, "
+            f"volume_residual={volume_residual:.3g} m^3); the coupled transfer is "
+            "not mass/volume conserving."
+        )
+
+    # --- (4) Boundary conditions + phase convention ---------------------------
+    patches = {bc.patch_name for bc in case.boundary_conditions}
+    missing = {"inlet", "outlet"} - patches
+    if missing:
+        raise ValueError(
+            f"missing boundary condition(s) for patch(es) {sorted(missing)}; the "
+            "coupled exchange needs both an 'inlet' and an 'outlet' patch defined."
+        )
+    fields_by_patch = {
+        p: {bc.field for bc in case.boundary_conditions if bc.patch_name == p}
+        for p in ("inlet", "outlet")
+    }
+    for p in ("inlet", "outlet"):
+        if "U" not in fields_by_patch[p]:
+            raise ValueError(
+                f"boundary patch '{p}' has no velocity (U) condition; inlet and "
+                "outlet must both define U for the conduit exchange."
+            )
+    phase = meta.get("phase_convention")
+    if not phase:
+        raise ValueError(
+            "case metadata is missing a non-empty 'phase_convention'; the "
+            "motion/flow phase convention must be recorded before a CFD run."
+        )
+    checks["boundary_conditions_present"] = True
+    checks["phase_convention_recorded"] = True
+
+    passed = all(checks.values())
+    logger.info(
+        "Verification gate for '{}': {} (V_transfer={:.4g} m^3, Q_peak={:.4g} "
+        "m^3/s, mass_residual={:.2g} kg)",
+        meta.get("case_id", case.name), "PASS" if passed else "FAIL",
+        v_transfer, q_peak, exchange.mass_residual,
+    )
+    return VerificationResult(
+        case_id=str(meta.get("case_id", case.name)),
+        passed=passed,
+        transfer_volume_m3=v_transfer,
+        q_peak_m3_s=q_peak,
+        pulse_integral_m3=pulse_integral,
+        pulse_integral_residual_m3=pulse_residual,
+        mass_residual_kg=exchange.mass_residual,
+        volume_residual_m3=volume_residual,
+        feasible=True,
+        boundary_conditions_ok=True,
+        phase_convention=str(phase),
+        checks=checks,
+    )
+
+
+# ============================================================================
+# Case manifest
+# ============================================================================
+
+
+def build_case_manifest(
+    case: OpenFOAMCase,
+    sweep_case: SweepCase,
+    spec: CouplingSpec,
+    verification: VerificationResult,
+) -> CaseManifest:
+    """Build a small, hashed, de-identified manifest for a coupled case.
+
+    The manifest records the scalar inputs, solver summary and flow-law scalars
+    plus a deterministic content hash; it intentionally holds no case directory
+    tree and no absolute filesystem paths.
+    """
+    conduit = spec.conduit
+    inputs: Dict[str, Any] = {
+        "fill_fraction": round(sweep_case.fill_fraction, _ROUND),
+        "dest_fill_fraction": round(spec.dest_fill_fraction, _ROUND),
+        "conduit_capacity": round(sweep_case.conduit_capacity, _ROUND),
+        "period_ratio": round(sweep_case.period_ratio, _ROUND),
+        "near_resonance": bool(sweep_case.near_resonance),
+        "tank_length_m": round(spec.tank_length, _ROUND),
+        "tank_width_m": round(spec.tank_width, _ROUND),
+        "tank_height_m": round(spec.tank_height, _ROUND),
+        "roll_amplitude_deg": round(spec.roll_amplitude_deg, _ROUND),
+        "roll_period_s": round(sweep_case.roll_period_s, _ROUND),
+        "roll_origin_m": [round(float(x), _ROUND) for x in spec.roll_origin],
+        "conduit_area_m2": round(conduit.area, _ROUND),
+        "conduit_discharge_coefficient": round(conduit.discharge_coefficient, _ROUND),
+        "conduit_loss_coefficient": round(conduit.loss_coefficient, _ROUND),
+        "density_kg_m3": round(spec.density, _ROUND),
+        "n_cells": [int(n) for n in spec.n_cells],
+        "gravity_m_s2": round(spec.gravity, _ROUND),
+    }
+    sc = case.solver_config
+    solver: Dict[str, Any] = {
+        "solver_name": sc.solver_name,
+        "is_multiphase": bool(sc.is_multiphase),
+        "end_time_s": sc.end_time,
+        "delta_t_s": sc.delta_t,
+        "write_interval": sc.write_interval,
+    }
+    content_hash = _content_hash(
+        {"schema": COUPLING_SCHEMA_VERSION, "inputs": inputs, "solver": solver}
+    )
+    return CaseManifest(
+        schema_version=COUPLING_SCHEMA_VERSION,
+        case_id=case.name,
+        inputs=inputs,
+        solver=solver,
+        fill_level=float(case.fill_level if case.fill_level is not None else 0.0),
+        transfer_volume_m3=verification.transfer_volume_m3,
+        q_peak_m3_s=verification.q_peak_m3_s,
+        phase_convention=verification.phase_convention,
+        gate_passed=verification.passed,
+        content_hash=content_hash,
+    )
+
+
+def _content_hash(payload: Dict[str, Any]) -> str:
+    """16-hex SHA-256 digest over a canonical (sorted, compact) JSON payload."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# ============================================================================
+# Synthetic (de-identified) gravity-exchange case
+# ============================================================================
+
+
+def synthetic_coupling_spec() -> CouplingSpec:
+    """A de-identified, feasible synthetic tank/conduit/roll spec.
+
+    Generic prismatic ballast tank (no client geometry or names): a 20 x 6 x 10 m
+    tank, 5 deg roll, a lossy 0.5 m^2 conduit, destination tank 30% full.
+    """
+    return CouplingSpec(
+        tank_length=20.0,
+        tank_width=6.0,
+        tank_height=10.0,
+        roll_amplitude_deg=5.0,
+        roll_origin=(10.0, 3.0, 0.0),
+        conduit=ConduitGeometry(
+            area=0.5, discharge_coefficient=0.6, loss_coefficient=1.5
+        ),
+        dest_fill_fraction=0.30,
+        density=1025.0,
+        n_cells=(40, 8, 40),
+    )
+
+
+def synthetic_sweep_case() -> SweepCase:
+    """A de-identified near-resonance sweep row with a non-zero conduit capacity.
+
+    Half-full source tank, conduit capacity 0.08 of tank volume per half-cycle,
+    roll period ratio 1.0 (near resonance). The natural period comes from the
+    analytical tanh dispersion via the slice-3 sweep helper for provenance.
+    """
+    from .sloshing_sweep import first_sloshing_natural_period
+
+    length, height, fill = 20.0, 10.0, 0.50
+    nat = first_sloshing_natural_period(length, height, fill)
+    roll_period = 1.0 * nat.natural_period_s  # period_ratio = 1.0
+    return SweepCase(
+        case_id="synthetic-grav-exch-1528s4",
+        fill_fraction=fill,
+        fill_depth=nat.fill_depth,
+        conduit_capacity=0.08,
+        period_ratio=1.0,
+        natural_frequency_hz=nat.natural_frequency_hz,
+        natural_period_s=nat.natural_period_s,
+        roll_frequency_hz=1.0 / roll_period,
+        roll_period_s=roll_period,
+        near_resonance=True,
+        approximation=nat.approximation,
+    )
+
+
+def emit_synthetic_gravity_exchange_case() -> SyntheticCase:
+    """Produce one buildable, gate-passing synthetic coupled case + manifest.
+
+    Returns:
+        A :class:`SyntheticCase` bundling the mapped OpenFOAMCase, its sweep row
+        and spec, the passing :class:`VerificationResult`, and a hashed
+        :class:`CaseManifest` (no raw case tree, no absolute paths).
+    """
+    spec = synthetic_coupling_spec()
+    sweep_case = synthetic_sweep_case()
+    case = map_sweep_case_to_openfoam_case(sweep_case, spec)
+    verification = verify_coupling(case, sweep_case, spec)
+    manifest = build_case_manifest(case, sweep_case, spec, verification)
+    return SyntheticCase(
+        case=case,
+        sweep_case=sweep_case,
+        spec=spec,
+        verification=verification,
+        manifest=manifest,
+    )

--- a/src/digitalmodel/solvers/openfoam/gravity_conduit.py
+++ b/src/digitalmodel/solvers/openfoam/gravity_conduit.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Gravity-driven conduit exchange model for coupled tank fill/drain
+(#1528 slice 2). Computes signed hydrostatic head between two prismatic tanks,
+a Cd/A/conduit-loss orifice flow law, and an RK4 integrator that moves liquid
+through the conduit while conserving volume and mass, reversing with the head
+sign, and rejecting (or flagging) dry-out and overflow states.
+
+The reduced-order model here feeds the OpenFOAM/VOF coupling layers; it is
+deliberately solver-free so the flow-law integral and conservation invariants
+can be verified analytically without a CFD run.
+
+Physics
+-------
+For two prismatic tanks joined by a conduit, the driving head is the signed
+difference of free-surface elevations (plus any externally imposed head, e.g. a
+roll-induced tilt)::
+
+    H = z_surface_source - z_surface_dest (+ external_head(t))
+
+The conduit obeys an orifice/Bernoulli law with an effective discharge
+coefficient that folds minor losses (K) and Darcy friction (f L / D) into the
+nominal discharge coefficient::
+
+    Cd_eff = Cd / sqrt(1 + K + f L / D)
+    Q      = sign(H) * Cd_eff * A * sqrt(2 g |H|)
+
+Positive Q moves liquid from source to destination. Because the integrator
+carries a single state variable (the source volume) and derives the destination
+volume as ``V_total - V_source``, total volume -- and therefore mass for a single
+incompressible fluid -- is conserved to machine precision by construction.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+from loguru import logger
+
+# Standard gravity (m/s^2), matching the CFD case conventions in this package.
+G_STANDARD: float = 9.80665
+
+# Absolute tolerance for fill-range validation (m^3) to absorb float round-off.
+_VOLUME_TOL: float = 1e-9
+
+
+# ============================================================================
+# Tank state
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class TankState:
+    """Instantaneous liquid state of one prismatic tank.
+
+    Attributes:
+        volume: Current liquid volume (m^3), must be in ``[0, capacity]``.
+        plan_area: Horizontal cross-sectional (plan) area (m^2, > 0).
+        height: Internal tank height (m, > 0).
+        floor_elevation: Absolute elevation of the tank floor (m).
+
+    Raises:
+        ValueError: If the geometry is non-physical or the volume falls outside
+            ``[0, capacity]`` (dry-out below empty / overflow above capacity).
+    """
+
+    volume: float
+    plan_area: float
+    height: float
+    floor_elevation: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.plan_area <= 0.0:
+            raise ValueError(f"plan_area must be positive, got {self.plan_area}")
+        if self.height <= 0.0:
+            raise ValueError(f"height must be positive, got {self.height}")
+        capacity = self.plan_area * self.height
+        if self.volume < -_VOLUME_TOL:
+            raise ValueError(
+                f"volume {self.volume} m^3 is below empty (dry-out); must be >= 0"
+            )
+        if self.volume > capacity + _VOLUME_TOL:
+            raise ValueError(
+                f"volume {self.volume} m^3 exceeds capacity {capacity} m^3 (overflow)"
+            )
+
+    @property
+    def capacity(self) -> float:
+        """Maximum liquid volume (m^3) = ``plan_area * height``."""
+        return self.plan_area * self.height
+
+    @property
+    def fill_fraction(self) -> float:
+        """Liquid volume as a fraction of capacity (0-1)."""
+        return self.volume / self.capacity
+
+    @property
+    def liquid_depth(self) -> float:
+        """Still-water liquid depth above the floor (m) = ``volume / plan_area``."""
+        return self.volume / self.plan_area
+
+    @property
+    def surface_elevation(self) -> float:
+        """Absolute free-surface elevation (m) = ``floor_elevation + liquid_depth``."""
+        return self.floor_elevation + self.liquid_depth
+
+    @property
+    def free_volume(self) -> float:
+        """Remaining volume before overflow (m^3) = ``capacity - volume``."""
+        return self.capacity - self.volume
+
+    def with_volume(self, volume: float) -> "TankState":
+        """Return a copy of this tank with a new liquid ``volume`` (m^3)."""
+        return TankState(
+            volume=volume,
+            plan_area=self.plan_area,
+            height=self.height,
+            floor_elevation=self.floor_elevation,
+        )
+
+
+# ============================================================================
+# Conduit geometry + flow law
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ConduitGeometry:
+    """Geometry and loss parameters for the connecting conduit.
+
+    The nominal discharge coefficient and the loss terms combine into an
+    effective discharge coefficient ``Cd / sqrt(1 + K_total)`` where
+    ``K_total = loss_coefficient + friction_factor * length / diameter``. The
+    friction term is optional; if any of ``friction_factor``/``length``/
+    ``diameter`` is supplied, all three are required.
+
+    Attributes:
+        area: Conduit flow cross-sectional area (m^2, > 0).
+        discharge_coefficient: Nominal orifice discharge coefficient Cd (0-1].
+        loss_coefficient: Sum of minor (K) loss coefficients (>= 0).
+        friction_factor: Darcy friction factor f (optional, >= 0).
+        length: Conduit length L (m, optional, > 0).
+        diameter: Conduit hydraulic diameter D (m, optional, > 0).
+        invert_elevation: Absolute elevation of the conduit connection (m). Flow
+            requires the higher of the two liquid surfaces to sit above this.
+    """
+
+    area: float
+    discharge_coefficient: float = 0.6
+    loss_coefficient: float = 0.0
+    friction_factor: Optional[float] = None
+    length: Optional[float] = None
+    diameter: Optional[float] = None
+    invert_elevation: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.area <= 0.0:
+            raise ValueError(f"area must be positive, got {self.area}")
+        if not 0.0 < self.discharge_coefficient <= 1.0:
+            raise ValueError(
+                f"discharge_coefficient must be in (0, 1], got "
+                f"{self.discharge_coefficient}"
+            )
+        if self.loss_coefficient < 0.0:
+            raise ValueError(
+                f"loss_coefficient must be >= 0, got {self.loss_coefficient}"
+            )
+        friction_terms = (self.friction_factor, self.length, self.diameter)
+        if any(t is not None for t in friction_terms):
+            if any(t is None for t in friction_terms):
+                raise ValueError(
+                    "friction_factor, length and diameter must all be given "
+                    "together to include the Darcy friction term"
+                )
+            if self.friction_factor < 0.0:
+                raise ValueError(
+                    f"friction_factor must be >= 0, got {self.friction_factor}"
+                )
+            if self.length <= 0.0:
+                raise ValueError(f"length must be positive, got {self.length}")
+            if self.diameter <= 0.0:
+                raise ValueError(f"diameter must be positive, got {self.diameter}")
+
+    @property
+    def total_loss_coefficient(self) -> float:
+        """Combined minor + friction loss coefficient ``K + f L / D``."""
+        k = self.loss_coefficient
+        if self.friction_factor is not None:
+            k += self.friction_factor * self.length / self.diameter
+        return k
+
+    @property
+    def effective_discharge_coefficient(self) -> float:
+        """Loss-adjusted discharge coefficient ``Cd / sqrt(1 + K_total)``."""
+        return self.discharge_coefficient / math.sqrt(1.0 + self.total_loss_coefficient)
+
+
+def signed_hydrostatic_head(source: TankState, dest: TankState) -> float:
+    """Signed hydrostatic head (m) driving flow from ``source`` to ``dest``.
+
+    Positive values mean the source free surface is higher and liquid tends to
+    flow source -> dest; negative values drive the reverse.
+    """
+    return source.surface_elevation - dest.surface_elevation
+
+
+def conduit_flow_rate(
+    head: float, conduit: ConduitGeometry, *, g: float = G_STANDARD
+) -> float:
+    """Volumetric flow rate (m^3/s) through the conduit for a signed ``head`` (m).
+
+    Applies the loss-adjusted orifice law
+    ``Q = sign(H) * Cd_eff * A * sqrt(2 g |H|)``. The sign of the result follows
+    the sign of ``head`` so the same primitive handles flow reversal; a zero head
+    yields exactly zero flow.
+    """
+    if head == 0.0:
+        return 0.0
+    magnitude = (
+        conduit.effective_discharge_coefficient
+        * conduit.area
+        * math.sqrt(2.0 * g * abs(head))
+    )
+    return math.copysign(magnitude, head)
+
+
+def check_transfer_feasibility(
+    source: TankState, dest: TankState, transfer_volume: float
+) -> None:
+    """Validate that ``transfer_volume`` (m^3) can move source -> dest.
+
+    A positive ``transfer_volume`` moves liquid out of ``source`` into ``dest``;
+    a negative value moves it the other way. The check rejects transfers that
+    would drain a tank below empty (dry-out) or fill one past capacity
+    (overflow) with an actionable diagnostic.
+
+    Raises:
+        ValueError: If the requested transfer exceeds the available liquid volume
+            (dry-out) or the available free volume (overflow) on either side.
+    """
+    out_tank, in_tank = (source, dest) if transfer_volume >= 0.0 else (dest, source)
+    magnitude = abs(transfer_volume)
+    if magnitude > out_tank.volume + _VOLUME_TOL:
+        raise ValueError(
+            f"requested transfer {magnitude} m^3 exceeds available liquid "
+            f"{out_tank.volume} m^3 (dry-out)"
+        )
+    if magnitude > in_tank.free_volume + _VOLUME_TOL:
+        raise ValueError(
+            f"requested transfer {magnitude} m^3 exceeds available free volume "
+            f"{in_tank.free_volume} m^3 (overflow)"
+        )
+
+
+# ============================================================================
+# Coupled gravity-exchange integrator
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class GravityExchangeResult:
+    """Synchronized time histories and summary of a gravity-exchange run.
+
+    Attributes:
+        time: Sample times (s).
+        source_volume: Source liquid volume at each time (m^3).
+        dest_volume: Destination liquid volume at each time (m^3).
+        head: Signed driving head at each time, including external head (m).
+        flow_rate: Signed conduit flow rate at each time (m^3/s).
+        transferred_volume: Net source -> dest volume moved over the run (m^3).
+        mass_residual: Max absolute deviation of total mass from its initial
+            value across the run (kg); ~0 for a conservative run.
+        reversed_flow: True if the flow rate changed sign during the run.
+        termination: Why the run ended -- one of ``"duration"``,
+            ``"equilibrium"``, ``"source_dry"``, ``"dest_dry"``,
+            ``"source_overflow"``, ``"dest_overflow"``, or ``"no_flow"``.
+        density: Fluid density used for the mass residual (kg/m^3).
+    """
+
+    time: List[float]
+    source_volume: List[float]
+    dest_volume: List[float]
+    head: List[float]
+    flow_rate: List[float]
+    transferred_volume: float
+    mass_residual: float
+    reversed_flow: bool
+    termination: str
+    density: float = 1025.0
+
+
+def simulate_gravity_exchange(
+    source: TankState,
+    dest: TankState,
+    conduit: ConduitGeometry,
+    *,
+    duration: float,
+    dt: float,
+    density: float = 1025.0,
+    g: float = G_STANDARD,
+    external_head: Optional[Callable[[float], float]] = None,
+    equilibrium_tol: float = 1e-9,
+    reject_dryout: bool = False,
+    reject_overflow: bool = False,
+) -> GravityExchangeResult:
+    """Integrate gravity-driven exchange between two tanks through a conduit.
+
+    The source volume is advanced with a classic RK4 step under
+    ``dV_source/dt = -Q(H)``; the destination volume is derived as
+    ``V_total - V_source`` so volume (and mass, for one incompressible fluid) is
+    conserved to machine precision at every step -- including when the head
+    changes sign and the flow reverses. Steps that would push a tank below empty
+    or above capacity are clamped; with ``reject_dryout``/``reject_overflow`` the
+    run raises instead of clamping.
+
+    Args:
+        source: Initial source tank state.
+        dest: Initial destination tank state.
+        conduit: Conduit geometry and loss parameters.
+        duration: Total simulated time (s, > 0).
+        dt: Fixed time step (s, > 0).
+        density: Fluid density (kg/m^3) for the mass residual.
+        g: Gravitational acceleration (m/s^2).
+        external_head: Optional callable ``t -> head offset (m)`` added to the
+            geometric head (e.g. a roll-induced surface tilt); enables and tests
+            flow reversal within a single run.
+        equilibrium_tol: Head magnitude (m) below which -- with no external head
+            -- the run is considered equilibrated and stops early.
+        reject_dryout: Raise ``ValueError`` if a tank would drain below empty.
+        reject_overflow: Raise ``ValueError`` if a tank would fill past capacity.
+
+    Returns:
+        A :class:`GravityExchangeResult` with synchronized histories and summary.
+
+    Raises:
+        ValueError: For non-physical ``duration``/``dt``, or on a dry-out/overflow
+            event when the corresponding reject flag is set.
+    """
+    if duration <= 0.0:
+        raise ValueError(f"duration must be positive, got {duration}")
+    if dt <= 0.0:
+        raise ValueError(f"dt must be positive, got {dt}")
+    if source.plan_area <= 0.0 or dest.plan_area <= 0.0:
+        raise ValueError("both tanks must have positive plan area")
+
+    ext = external_head if external_head is not None else (lambda _t: 0.0)
+
+    area_s = source.plan_area
+    area_d = dest.plan_area
+    floor_s = source.floor_elevation
+    floor_d = dest.floor_elevation
+    v_total = source.volume + dest.volume
+
+    # Source volume bounds that keep BOTH tanks physical (0 <= V <= capacity).
+    vs_min = max(0.0, v_total - dest.capacity)   # dest would overflow below this
+    vs_max = min(source.capacity, v_total)       # source would overflow above this
+
+    def head_of(vs: float, t: float) -> float:
+        z_source = floor_s + vs / area_s
+        z_dest = floor_d + (v_total - vs) / area_d
+        return (z_source - z_dest) + ext(t)
+
+    def dvs_dt(vs: float, t: float) -> float:
+        h = head_of(vs, t)
+        # Submergence guard: the higher surface must reach the conduit invert,
+        # otherwise the conduit is not submerged on the driving side -> no flow.
+        z_source = floor_s + vs / area_s
+        z_dest = floor_d + (v_total - vs) / area_d
+        if max(z_source, z_dest) <= conduit.invert_elevation:
+            return 0.0
+        return -conduit_flow_rate(h, conduit, g=g)
+
+    times: List[float] = [0.0]
+    vs_hist: List[float] = [source.volume]
+    vd_hist: List[float] = [dest.volume]
+    head_hist: List[float] = [head_of(source.volume, 0.0)]
+    q_hist: List[float] = [-dvs_dt(source.volume, 0.0)]
+
+    vs = source.volume
+    n_steps = int(math.ceil(duration / dt))
+    termination = "duration"
+    any_flow = q_hist[0] != 0.0
+
+    for step in range(1, n_steps + 1):
+        t0 = (step - 1) * dt
+        h_dt = min(dt, duration - t0)
+        if h_dt <= 0.0:
+            break
+
+        prev_head = head_hist[-1]
+
+        # Classic RK4 on the source volume.
+        k1 = dvs_dt(vs, t0)
+        k2 = dvs_dt(vs + 0.5 * h_dt * k1, t0 + 0.5 * h_dt)
+        k3 = dvs_dt(vs + 0.5 * h_dt * k2, t0 + 0.5 * h_dt)
+        k4 = dvs_dt(vs + h_dt * k3, t0 + h_dt)
+        vs_new = vs + (h_dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+
+        clamp_event: Optional[str] = None
+        if vs_new < vs_min:
+            clamp_event = "dest_overflow" if vs_min > 0.0 else "source_dry"
+            vs_new = vs_min
+        elif vs_new > vs_max:
+            clamp_event = "source_overflow" if vs_max < v_total else "dest_dry"
+            vs_new = vs_max
+
+        t1 = t0 + h_dt
+        q = (vs - vs_new) / h_dt            # exact conduit flow implied by the step
+        vs = vs_new
+        new_head = head_of(vs, t1)
+
+        times.append(t1)
+        vs_hist.append(vs)
+        vd_hist.append(v_total - vs)
+        head_hist.append(new_head)
+        q_hist.append(q)
+        if q != 0.0:
+            any_flow = True
+
+        # Static equilibrium (only when no external head keeps re-energising the
+        # system). The sqrt-head flow law is non-Lipschitz at H=0, so a fixed-step
+        # integrator cannot land exactly on H=0 -- it either crosses zero or stalls
+        # a hair short. Both mean the levels have equalised, as does the head
+        # simply falling below tolerance. The head decreases monotonically through
+        # the physical transient, so "stopped decreasing" is a dt-independent
+        # equilibrium signal rather than a hand-tuned threshold.
+        if clamp_event is None and external_head is None and any_flow:
+            crossed_zero = prev_head * new_head < 0.0
+            stalled = abs(new_head) >= abs(prev_head)
+            if abs(new_head) <= equilibrium_tol or crossed_zero or stalled:
+                termination = "equilibrium"
+                break
+
+        if clamp_event is not None:
+            if clamp_event.endswith("overflow") and reject_overflow:
+                raise ValueError(
+                    f"gravity exchange would cause {clamp_event.replace('_', ' ')} "
+                    f"at t={t1:.4g}s; requested transfer exceeds available free volume"
+                )
+            if clamp_event.endswith("dry") and reject_dryout:
+                raise ValueError(
+                    f"gravity exchange would cause {clamp_event.replace('_', ' ')} "
+                    f"at t={t1:.4g}s; requested transfer exceeds available liquid"
+                )
+            termination = clamp_event
+            logger.warning(
+                "Gravity exchange clamped at t={:.4g}s ({}); flow stopped to keep "
+                "tank volumes physical.",
+                t1,
+                clamp_event,
+            )
+            break
+
+    if not any_flow:
+        termination = "no_flow"
+
+    reversed_flow = _has_sign_change(q_hist)
+    transferred_volume = vs_hist[0] - vs_hist[-1]
+    mass_residual = max(
+        abs(density * (vs + vd) - density * v_total)
+        for vs, vd in zip(vs_hist, vd_hist)
+    )
+
+    return GravityExchangeResult(
+        time=times,
+        source_volume=vs_hist,
+        dest_volume=vd_hist,
+        head=head_hist,
+        flow_rate=q_hist,
+        transferred_volume=transferred_volume,
+        mass_residual=mass_residual,
+        reversed_flow=reversed_flow,
+        termination=termination,
+        density=density,
+    )
+
+
+def _has_sign_change(values: List[float]) -> bool:
+    """True if the non-zero entries of ``values`` include both signs."""
+    seen_positive = False
+    seen_negative = False
+    for v in values:
+        if v > 0.0:
+            seen_positive = True
+        elif v < 0.0:
+            seen_negative = True
+        if seen_positive and seen_negative:
+            return True
+    return False

--- a/src/digitalmodel/solvers/openfoam/report.py
+++ b/src/digitalmodel/solvers/openfoam/report.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+"""ABOUTME: Self-contained HTML engineering-report layer for the OpenFOAM sloshing
+gravity-conduit surrogate study (#1528).
+
+Renders two report kinds from plain result shapes (dicts or dataclasses):
+
+* a **case-level report** for one CFD case (elevation, pressure, mass,
+  centre-of-mass and inlet/outlet-flow traces plus validation), and
+* an **aggregate matrix report** over the fill-fraction x T_roll/T_natural sweep
+  (heatmaps + a full case matrix).
+
+Every report is a single, offline HTML document: all plots are hand-built inline
+SVG (no matplotlib, no external CSS/JS/font/CDN), so the file renders with no
+network access. Output is de-identified - client names, field IDs and absolute
+machine paths are scrubbed before rendering. Invalid / failed cases are never
+silently dropped; they appear explicitly flagged.
+
+The public functions accept the sibling schemas by structural shape so they drop
+onto the real ``sloshing_sweep.SweepCase`` / ``time_history.SynchronizedTimeHistory``
+objects once those land on ``main``.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from loguru import logger
+
+REQUIRED_SECTIONS: Tuple[str, ...] = (
+    "Inputs",
+    "Methodology",
+    "Visualizations",
+    "Validation",
+    "Outputs",
+    "Limitations",
+)
+
+_MISSING = object()
+
+# Absolute-path scrubbing: unix paths with >=2 components, or windows drive paths.
+_UNIX_PATH_RE = re.compile(r"(?:/[\w.+\-]+){2,}/?")
+_WIN_PATH_RE = re.compile(r"[A-Za-z]:\\[\w.+\\\-]*")
+
+
+# ============================================================================
+# Structural accessors (dict OR dataclass/object)
+# ============================================================================
+
+
+def _get(obj: Any, key: str, default: Any = _MISSING) -> Any:
+    """Read ``key`` from a mapping or an object attribute.
+
+    Args:
+        obj: A mapping or an object.
+        key: Field / attribute name.
+        default: Returned when absent; if omitted a ValueError is raised.
+
+    Returns:
+        The looked-up value.
+
+    Raises:
+        ValueError: When the key is absent and no default was supplied.
+    """
+    if isinstance(obj, Mapping):
+        if key in obj:
+            return obj[key]
+    elif hasattr(obj, key):
+        return getattr(obj, key)
+    if default is _MISSING:
+        raise ValueError(f"required field '{key}' missing from result shape")
+    return default
+
+
+def _channel_values(channels: Mapping[str, Any], name: str) -> List[float]:
+    """Return numeric values for a named channel, raising if it is absent."""
+    if name not in channels:
+        raise ValueError(
+            f"required channel '{name}' missing; available: "
+            f"{sorted(channels.keys())}"
+        )
+    ch = channels[name]
+    values = _get(ch, "values")
+    return [float(v) for v in values]
+
+
+def _channel_units(channels: Mapping[str, Any], name: str) -> str:
+    ch = channels.get(name, {})
+    return str(_get(ch, "units", "")) if ch else ""
+
+
+# ============================================================================
+# De-identification
+# ============================================================================
+
+
+def _scrub(text: Any) -> str:
+    """Strip absolute machine paths (unix + windows) down to their basename."""
+    s = str(text)
+    s = _UNIX_PATH_RE.sub(lambda m: m.group(0).rstrip("/").split("/")[-1] or "path", s)
+    s = _WIN_PATH_RE.sub(
+        lambda m: m.group(0).replace("\\", "/").rstrip("/").split("/")[-1] or "path",
+        s,
+    )
+    return s
+
+
+def _esc(text: Any) -> str:
+    """HTML-escape after path-scrubbing."""
+    return _html.escape(_scrub(text))
+
+
+# ============================================================================
+# Inline SVG primitives (self-contained, no xmlns -> no http reference)
+# ============================================================================
+
+_SERIES_COLORS = ("#1f6feb", "#d1242f", "#1a7f37", "#9a6700", "#8250df")
+
+
+def _num_fmt(v: float) -> str:
+    av = abs(v)
+    if v == 0:
+        return "0"
+    if av >= 1000 or av < 0.01:
+        return f"{v:.2e}"
+    return f"{v:.3g}"
+
+
+def _line_plot_svg(
+    t: Sequence[float],
+    series: Sequence[Dict[str, Any]],
+    title: str,
+    ylabel: str,
+    width: int = 540,
+    height: int = 220,
+) -> str:
+    """Build a self-contained inline-SVG line plot.
+
+    Args:
+        t: Shared x-axis (time) values.
+        series: List of ``{"label", "values", "color"}`` traces.
+        title: Plot title (rendered as a caption above the SVG).
+        ylabel: Y-axis label.
+        width: SVG width in px.
+        height: SVG height in px.
+
+    Returns:
+        An ``<figure>`` containing the caption and inline ``<svg>``.
+    """
+    ml, mr, mt, mb = 58, 14, 12, 34
+    pw, ph = width - ml - mr, height - mt - mb
+    xs = [float(x) for x in t]
+    x_lo, x_hi = (min(xs), max(xs)) if xs else (0.0, 1.0)
+    if x_hi == x_lo:
+        x_hi = x_lo + 1.0
+    all_y: List[float] = []
+    for s in series:
+        all_y.extend(float(v) for v in s["values"])
+    y_lo, y_hi = (min(all_y), max(all_y)) if all_y else (0.0, 1.0)
+    if y_hi == y_lo:
+        pad = abs(y_hi) * 0.1 or 1.0
+        y_lo, y_hi = y_lo - pad, y_hi + pad
+
+    def px(x: float) -> float:
+        return ml + (x - x_lo) / (x_hi - x_lo) * pw
+
+    def py(y: float) -> float:
+        return mt + ph - (y - y_lo) / (y_hi - y_lo) * ph
+
+    parts: List[str] = []
+    parts.append(
+        f'<svg class="lineplot" role="img" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}">'
+    )
+    # plot frame
+    parts.append(
+        f'<rect x="{ml}" y="{mt}" width="{pw}" height="{ph}" '
+        f'fill="none" stroke="#c9d1d9"/>'
+    )
+    # gridlines + y ticks
+    for i in range(5):
+        yv = y_lo + (y_hi - y_lo) * i / 4
+        yy = py(yv)
+        parts.append(
+            f'<line x1="{ml}" y1="{yy:.1f}" x2="{ml + pw}" y2="{yy:.1f}" '
+            f'stroke="#eaeef2"/>'
+        )
+        parts.append(
+            f'<text x="{ml - 6}" y="{yy + 3:.1f}" text-anchor="end" '
+            f'font-size="9" fill="#57606a">{_num_fmt(yv)}</text>'
+        )
+    # x ticks
+    for i in range(5):
+        xv = x_lo + (x_hi - x_lo) * i / 4
+        xx = px(xv)
+        parts.append(
+            f'<text x="{xx:.1f}" y="{mt + ph + 14}" text-anchor="middle" '
+            f'font-size="9" fill="#57606a">{_num_fmt(xv)}</text>'
+        )
+    # series polylines
+    for idx, s in enumerate(series):
+        color = s.get("color") or _SERIES_COLORS[idx % len(_SERIES_COLORS)]
+        pts = " ".join(
+            f"{px(xs[j]):.1f},{py(float(s['values'][j])):.1f}"
+            for j in range(min(len(xs), len(s["values"])))
+        )
+        parts.append(
+            f'<polyline fill="none" stroke="{color}" stroke-width="1.8" '
+            f'points="{pts}"/>'
+        )
+    # legend
+    lx = ml + 6
+    for idx, s in enumerate(series):
+        color = s.get("color") or _SERIES_COLORS[idx % len(_SERIES_COLORS)]
+        parts.append(
+            f'<rect x="{lx}" y="{mt + 4}" width="10" height="6" fill="{color}"/>'
+        )
+        label = _esc(s["label"])
+        parts.append(
+            f'<text x="{lx + 14}" y="{mt + 10}" font-size="9" '
+            f'fill="#24292f">{label}</text>'
+        )
+        lx += 16 + 7 * len(str(s["label"]))
+    # axis titles
+    parts.append(
+        f'<text x="{ml + pw / 2:.0f}" y="{height - 4}" text-anchor="middle" '
+        f'font-size="10" fill="#24292f">time (s)</text>'
+    )
+    parts.append(
+        f'<text x="12" y="{mt + ph / 2:.0f}" text-anchor="middle" font-size="10" '
+        f'fill="#24292f" transform="rotate(-90 12 {mt + ph / 2:.0f})">'
+        f"{_esc(ylabel)}</text>"
+    )
+    parts.append("</svg>")
+    return (
+        f'<figure class="plot"><figcaption>{_esc(title)}</figcaption>'
+        + "".join(parts)
+        + "</figure>"
+    )
+
+
+def _color_scale(t: float) -> str:
+    """Blue->yellow->red diverging colour for normalised ``t`` in [0, 1]."""
+    t = 0.0 if t < 0 else 1.0 if t > 1 else t
+    if t < 0.5:
+        f = t / 0.5
+        r = int(44 + (255 - 44) * f)
+        g = int(123 + (255 - 123) * f)
+        b = int(182 + (191 - 182) * f)
+    else:
+        f = (t - 0.5) / 0.5
+        r = int(255 + (215 - 255) * f)
+        g = int(255 + (25 - 255) * f)
+        b = int(191 + (28 - 191) * f)
+    return f"rgb({r},{g},{b})"
+
+
+def _heatmap_svg(
+    row_labels: Sequence[str],
+    col_labels: Sequence[str],
+    matrix: Sequence[Sequence[Optional[float]]],
+    title: str,
+    x_axis_title: str,
+    y_axis_title: str,
+) -> str:
+    """Build a self-contained inline-SVG heatmap.
+
+    ``None`` cells (missing / invalid) are drawn hatched-grey with an X marker so
+    they are visible rather than omitted.
+    """
+    cell = 46
+    ml, mt = 90, 40
+    rows, cols = len(row_labels), len(col_labels)
+    width = ml + cols * cell + 20
+    height = mt + rows * cell + 46
+    flat = [v for r in matrix for v in r if v is not None]
+    vmin, vmax = (min(flat), max(flat)) if flat else (0.0, 1.0)
+    if vmax == vmin:
+        vmax = vmin + 1.0
+    parts: List[str] = [
+        f'<svg class="heatmap" role="img" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}">'
+    ]
+    for i in range(rows):
+        for j in range(cols):
+            x = ml + j * cell
+            y = mt + i * cell
+            v = matrix[i][j]
+            if v is None:
+                parts.append(
+                    f'<rect x="{x}" y="{y}" width="{cell}" height="{cell}" '
+                    f'fill="#e1e4e8" stroke="#fff"/>'
+                )
+                parts.append(
+                    f'<text x="{x + cell / 2:.0f}" y="{y + cell / 2 + 4:.0f}" '
+                    f'text-anchor="middle" font-size="12" fill="#57606a">n/a</text>'
+                )
+                continue
+            color = _color_scale((v - vmin) / (vmax - vmin))
+            parts.append(
+                f'<rect x="{x}" y="{y}" width="{cell}" height="{cell}" '
+                f'fill="{color}" stroke="#fff"/>'
+            )
+            parts.append(
+                f'<text x="{x + cell / 2:.0f}" y="{y + cell / 2 + 4:.0f}" '
+                f'text-anchor="middle" font-size="9" fill="#0b1015">'
+                f"{_num_fmt(v)}</text>"
+            )
+    # row labels (y axis)
+    for i, lab in enumerate(row_labels):
+        y = mt + i * cell + cell / 2 + 3
+        parts.append(
+            f'<text x="{ml - 8}" y="{y:.0f}" text-anchor="end" font-size="10" '
+            f'fill="#24292f">{_esc(lab)}</text>'
+        )
+    # col labels (x axis)
+    for j, lab in enumerate(col_labels):
+        x = ml + j * cell + cell / 2
+        parts.append(
+            f'<text x="{x:.0f}" y="{mt - 8}" text-anchor="middle" font-size="10" '
+            f'fill="#24292f">{_esc(lab)}</text>'
+        )
+    parts.append(
+        f'<text x="{ml + cols * cell / 2:.0f}" y="{height - 6}" '
+        f'text-anchor="middle" font-size="11" fill="#24292f">'
+        f"{_esc(x_axis_title)}</text>"
+    )
+    parts.append(
+        f'<text x="14" y="{mt + rows * cell / 2:.0f}" text-anchor="middle" '
+        f'font-size="11" fill="#24292f" '
+        f'transform="rotate(-90 14 {mt + rows * cell / 2:.0f})">'
+        f"{_esc(y_axis_title)}</text>"
+    )
+    parts.append("</svg>")
+    return (
+        f'<figure class="plot"><figcaption>{_esc(title)}</figcaption>'
+        + "".join(parts)
+        + "</figure>"
+    )
+
+
+# ============================================================================
+# Shared HTML shell + validity logic
+# ============================================================================
+
+_STYLE = """
+body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+color:#24292f;margin:0;padding:0 24px 48px;line-height:1.5;background:#fff}
+h1{font-size:22px;margin:20px 0 4px}h2{font-size:16px;border-bottom:1px solid #d0d7de;
+padding-bottom:4px;margin-top:32px}nav a{margin-right:12px;font-size:12px}
+table{border-collapse:collapse;font-size:12px;margin:8px 0}
+th,td{border:1px solid #d0d7de;padding:4px 8px;text-align:right}
+th{background:#f6f8fa}td.k{text-align:left}
+tr.invalid{background:#ffebe9}.badge{font-weight:700;padding:1px 6px;border-radius:6px}
+.badge.pass{background:#dafbe1;color:#116329}.badge.fail{background:#ffebe9;color:#cf222e}
+figure.plot{display:inline-block;margin:8px 12px 8px 0;vertical-align:top}
+figcaption{font-size:12px;font-weight:600;margin-bottom:2px}
+.meta{color:#57606a;font-size:12px}ul{font-size:13px}
+""".strip()
+
+
+def _shell(title: str, subtitle: str, sections_html: str) -> str:
+    nav = " ".join(
+        f'<a href="#{s.lower()}">{s}</a>' for s in REQUIRED_SECTIONS
+    )
+    doc = (
+        "<!doctype html>\n"
+        '<html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{_esc(title)}</title><style>{_STYLE}</style></head><body>"
+        f"<h1>{_esc(title)}</h1>"
+        f'<p class="meta">{_esc(subtitle)}</p>'
+        f"<nav>{nav}</nav>"
+        f"{sections_html}"
+        "</body></html>"
+    )
+    # Safety net: scrub any absolute path that slipped through free-text fields.
+    return _scrub(doc)
+
+
+def _section(name: str, body: str) -> str:
+    return f'<section id="{name.lower()}"><h2>{name}</h2>{body}</section>'
+
+
+def _is_valid(validation: Mapping[str, Any]) -> bool:
+    """A case is valid when mass balance holds and no failure event fired."""
+    return bool(
+        _get(validation, "mass_balance_ok", True)
+        and not _get(validation, "dry_out", False)
+        and not _get(validation, "overflow", False)
+        and not _get(validation, "impact", False)
+    )
+
+
+def _flag_reasons(validation: Mapping[str, Any]) -> List[str]:
+    reasons = []
+    if not _get(validation, "mass_balance_ok", True):
+        reasons.append("mass-balance fail")
+    if _get(validation, "dry_out", False):
+        reasons.append("dry-out")
+    if _get(validation, "overflow", False):
+        reasons.append("overflow")
+    if _get(validation, "impact", False):
+        reasons.append("impact")
+    return reasons
+
+
+# ============================================================================
+# Case-level report
+# ============================================================================
+
+
+def render_case_report(history: Any, case: Any = None) -> str:
+    """Render a self-contained HTML report for a single CFD case.
+
+    Args:
+        history: A ``SynchronizedTimeHistory``-shaped object/mapping with
+            ``case_id, time, channels, validation, metadata``.
+        case: Optional ``SweepCase``-shaped object/mapping with the case inputs.
+
+    Returns:
+        A complete offline HTML document (str).
+
+    Raises:
+        ValueError: When a required channel is absent from the history.
+    """
+    case_id = str(_get(history, "case_id"))
+    logger.info("Rendering case report for {}", case_id)
+    t = [float(x) for x in _get(history, "time")]
+    channels = _get(history, "channels")
+    validation = _get(history, "validation", {})
+    metadata = _get(history, "metadata", {})
+
+    # Required channels (raise, never silently skip).
+    elevation = _channel_values(channels, "free_surface_elevation")
+    pressure = _channel_values(channels, "wall_pressure")
+    mass = _channel_values(channels, "liquid_mass")
+    inlet = _channel_values(channels, "inlet_flow_rate")
+    outlet = _channel_values(channels, "outlet_flow_rate")
+    valid = _is_valid(validation)
+    reasons = _flag_reasons(validation)
+
+    # ---- Inputs ----
+    if case is not None:
+        rows = [
+            ("Case ID", _esc(_get(case, "case_id", case_id))),
+            ("Fill fraction", _num_fmt(float(_get(case, "fill_fraction", 0.0)))),
+            ("Fill depth (m)", _num_fmt(float(_get(case, "fill_depth", 0.0)))),
+            ("Conduit capacity", _num_fmt(float(_get(case, "conduit_capacity", 0.0)))),
+            ("Period ratio T_roll/T_natural",
+             _num_fmt(float(_get(case, "period_ratio", 0.0)))),
+            ("Natural frequency (Hz)",
+             _num_fmt(float(_get(case, "natural_frequency_hz", 0.0)))),
+            ("Natural period (s)",
+             _num_fmt(float(_get(case, "natural_period_s", 0.0)))),
+            ("Roll frequency (Hz)",
+             _num_fmt(float(_get(case, "roll_frequency_hz", 0.0)))),
+            ("Roll period (s)", _num_fmt(float(_get(case, "roll_period_s", 0.0)))),
+            ("Near resonance", "yes" if _get(case, "near_resonance", False) else "no"),
+        ]
+    else:
+        rows = [("Case ID", _esc(case_id))]
+    inputs_tbl = "".join(
+        f'<tr><td class="k">{k}</td><td>{v}</td></tr>' for k, v in rows
+    )
+    inputs = _section(
+        "Inputs",
+        "<p>Governing inputs for this case (gravity-conduit sloshing surrogate).</p>"
+        f"<table>{inputs_tbl}</table>",
+    )
+
+    # ---- Methodology ----
+    methodology = _section(
+        "Methodology",
+        "<ul>"
+        "<li>Roll excitation is imposed on a partially filled prismatic tank; the "
+        "internal free surface is modelled with a reduced-order gravity-conduit "
+        "surrogate calibrated to the CFD (VOF) response.</li>"
+        "<li>Channels are extracted per timestep and synchronized onto a common "
+        "time base; a mass-balance residual check guards conservation.</li>"
+        "<li>Dry-out, overflow and wall-impact events are detected and reported.</li>"
+        "</ul>",
+    )
+
+    # ---- Visualizations ----
+    plots = [
+        _line_plot_svg(
+            t,
+            [
+                {"label": "eta", "values": elevation},
+            ]
+            + (
+                [{"label": "eta_max", "values": _channel_values(channels, "elevation_max")}]
+                if "elevation_max" in channels
+                else []
+            ),
+            "Free-Surface Elevation",
+            f"elevation ({_channel_units(channels, 'free_surface_elevation') or 'm'})",
+        ),
+        _line_plot_svg(
+            t,
+            [{"label": "p_wall", "values": pressure}],
+            "Wall Pressure",
+            f"pressure ({_channel_units(channels, 'wall_pressure') or 'Pa'})",
+        ),
+        _line_plot_svg(
+            t,
+            [{"label": "mass", "values": mass}],
+            "Liquid Mass",
+            f"mass ({_channel_units(channels, 'liquid_mass') or 'kg'})",
+        ),
+        _line_plot_svg(
+            t,
+            [
+                {"label": lbl, "values": _channel_values(channels, ch)}
+                for lbl, ch in (("x", "com_x"), ("y", "com_y"), ("z", "com_z"))
+                if ch in channels
+            ],
+            "Center of Mass",
+            "position (m)",
+        ),
+        _line_plot_svg(
+            t,
+            [
+                {"label": "inlet", "values": inlet},
+                {"label": "outlet", "values": outlet},
+            ],
+            "Inlet / Outlet Flow",
+            f"flow rate ({_channel_units(channels, 'inlet_flow_rate') or 'm^3/s'})",
+        ),
+    ]
+    visualizations = _section(
+        "Visualizations",
+        "<p>All plots are inline SVG and render offline.</p>" + "".join(plots),
+    )
+
+    # ---- Validation ----
+    badge = (
+        '<span class="badge pass">PASS - valid</span>'
+        if valid
+        else '<span class="badge fail">INVALID - flagged: '
+        + _esc(", ".join(reasons) or "failed")
+        + "</span>"
+    )
+    val_rows = [
+        ("Overall status", badge),
+        ("Mass balance residual",
+         _num_fmt(float(_get(validation, "mass_balance_residual", float("nan"))))),
+        ("Mass balance OK",
+         "yes" if _get(validation, "mass_balance_ok", True) else "no"),
+        ("Dry-out", "yes" if _get(validation, "dry_out", False) else "no"),
+        ("Overflow", "yes" if _get(validation, "overflow", False) else "no"),
+        ("Impact", "yes" if _get(validation, "impact", False) else "no"),
+        ("Synchronized samples",
+         str(len(_get(validation, "synchronized_time", t) or t))),
+    ]
+    validation_html = _section(
+        "Validation",
+        "<table>"
+        + "".join(f'<tr><td class="k">{k}</td><td>{v}</td></tr>' for k, v in val_rows)
+        + "</table>",
+    )
+
+    # ---- Outputs ----
+    out_rows = [
+        ("Peak free-surface elevation (m)", _num_fmt(max(elevation))),
+        ("Peak wall pressure (Pa)", _num_fmt(max(pressure))),
+        ("Liquid mass drift (kg)", _num_fmt(max(mass) - min(mass))),
+        ("Peak inlet flow", _num_fmt(max(inlet))),
+        ("Peak outlet flow", _num_fmt(max(outlet))),
+        ("Solver", _esc(_get(metadata, "solver", "gravity_conduit_surrogate"))),
+    ]
+    outputs = _section(
+        "Outputs",
+        "<table>"
+        + "".join(f'<tr><td class="k">{k}</td><td>{v}</td></tr>' for k, v in out_rows)
+        + "</table>",
+    )
+
+    # ---- Limitations ----
+    limitations = _section(
+        "Limitations",
+        "<ul>"
+        "<li>Reduced-order gravity-conduit surrogate; not a substitute for a fully "
+        "resolved VOF CFD run at extreme fills or violent impact regimes.</li>"
+        "<li>Single-case view: cross-case resonance context is in the aggregate "
+        "report.</li>"
+        "<li>Wall-impact pressures are indicative and require dedicated slam "
+        "analysis for design loads.</li>"
+        "</ul>",
+    )
+
+    body = (
+        inputs + methodology + visualizations + validation_html + outputs + limitations
+    )
+    subtitle = f"Case {case_id} - status: {'VALID' if valid else 'INVALID (flagged)'}"
+    return _shell("Sloshing CFD Case Report", subtitle, body)
+
+
+# ============================================================================
+# Aggregate matrix report
+# ============================================================================
+
+
+def _grid_axes(cases: Sequence[Any]) -> Tuple[List[float], List[float]]:
+    fills = sorted({round(float(_get(c, "fill_fraction")), 6) for c in cases})
+    ratios = sorted({round(float(_get(c, "period_ratio")), 6) for c in cases})
+    return fills, ratios
+
+
+def render_aggregate_report(manifest: Any, histories: Any = None) -> str:
+    """Render a self-contained HTML matrix report over the sweep.
+
+    Args:
+        manifest: A shape with ``schema_version, study_name, provenance, cases,
+            content_hash`` where ``cases`` is a sequence of ``SweepCase`` shapes.
+        histories: Optional mapping ``case_id -> SynchronizedTimeHistory`` used to
+            populate result heatmaps and validity flags. When absent the heatmaps
+            fall back to input-derived quantities.
+
+    Returns:
+        A complete offline HTML document (str).
+
+    Raises:
+        ValueError: When the manifest carries no cases.
+    """
+    cases = list(_get(manifest, "cases"))
+    if not cases:
+        raise ValueError("aggregate report requires at least one case in the manifest")
+    hist_map: Dict[str, Any] = dict(histories or {})
+    study = _get(manifest, "study_name", "CFD Sloshing Study")
+    logger.info("Rendering aggregate report '{}' over {} cases", study, len(cases))
+
+    fills, ratios = _grid_axes(cases)
+    # lookup (fill, ratio) -> case
+    lut: Dict[Tuple[float, float], Any] = {}
+    for c in cases:
+        lut[(round(float(_get(c, "fill_fraction")), 6),
+             round(float(_get(c, "period_ratio")), 6))] = c
+
+    # validity per case
+    def case_valid(c: Any) -> Optional[bool]:
+        h = hist_map.get(str(_get(c, "case_id")))
+        if h is None:
+            return None
+        return _is_valid(_get(h, "validation", {}))
+
+    invalid_ids = [
+        str(_get(c, "case_id")) for c in cases if case_valid(c) is False
+    ]
+
+    # ---- heatmap matrices ----
+    have_hist = bool(hist_map)
+    m1: List[List[Optional[float]]] = []
+    m2: List[List[Optional[float]]] = []
+    for f in fills:
+        r1, r2 = [], []
+        for r in ratios:
+            c = lut.get((f, r))
+            if c is None:
+                r1.append(None)
+                r2.append(None)
+                continue
+            h = hist_map.get(str(_get(c, "case_id")))
+            if have_hist and h is not None and _is_valid(_get(h, "validation", {})):
+                ch = _get(h, "channels")
+                r1.append(max(_channel_values(ch, "free_surface_elevation")))
+                r2.append(max(_channel_values(ch, "wall_pressure")))
+            elif have_hist and h is not None:
+                r1.append(None)  # invalid -> shown as n/a in heatmap, flagged in table
+                r2.append(None)
+            else:
+                r1.append(float(_get(c, "period_ratio")))
+                r2.append(1.0 if _get(c, "near_resonance", False) else 0.0)
+        m1.append(r1)
+        m2.append(r2)
+
+    row_labels = [f"fill {f:g}" for f in fills]
+    col_labels = [f"{r:g}" for r in ratios]
+    if have_hist:
+        t1 = "Peak Free-Surface Elevation (m)"
+        t2 = "Peak Wall Pressure (Pa)"
+    else:
+        t1 = "Period Ratio (T_roll / T_natural)"
+        t2 = "Near Resonance (1 = yes)"
+    heat1 = _heatmap_svg(
+        row_labels, col_labels, m1, t1,
+        "Period Ratio (T_roll / T_natural)", "Fill Fraction",
+    )
+    heat2 = _heatmap_svg(
+        row_labels, col_labels, m2, t2,
+        "Period Ratio (T_roll / T_natural)", "Fill Fraction",
+    )
+
+    # ---- Inputs ----
+    in_rows = [
+        ("Study", _esc(study)),
+        ("Schema version", _esc(_get(manifest, "schema_version", "?"))),
+        ("Provenance", _esc(_get(manifest, "provenance", "n/a"))),
+        ("Content hash", _esc(_get(manifest, "content_hash", "n/a"))),
+        ("Number of cases", str(len(cases))),
+        ("Fill fractions", _esc(", ".join(f"{f:g}" for f in fills))),
+        ("Period ratios", _esc(", ".join(f"{r:g}" for r in ratios))),
+    ]
+    inputs = _section(
+        "Inputs",
+        "<table>"
+        + "".join(f'<tr><td class="k">{k}</td><td>{v}</td></tr>' for k, v in in_rows)
+        + "</table>",
+    )
+
+    # ---- Methodology ----
+    methodology = _section(
+        "Methodology",
+        "<ul>"
+        "<li>Two-axis parametric sweep over fill fraction and the roll-to-natural "
+        "period ratio T_roll/T_natural.</li>"
+        "<li>Each case is solved with the gravity-conduit sloshing surrogate and "
+        "synchronized; per-case validation guards mass conservation and detects "
+        "dry-out / overflow / impact.</li>"
+        "<li>Heatmaps aggregate per-case peak responses across the two sweep axes; "
+        "invalid cases are excluded from colour scaling and shown explicitly "
+        "flagged below.</li>"
+        "</ul>",
+    )
+
+    # ---- Visualizations ----
+    visualizations = _section(
+        "Visualizations",
+        "<p>Response heatmaps over the fill x period-ratio grid (inline SVG).</p>"
+        + heat1
+        + heat2,
+    )
+
+    # ---- Validation ----
+    n_invalid = len(invalid_ids)
+    if hist_map:
+        summary = (
+            f"<p><b>{n_invalid} invalid</b> of {len(cases)} cases flagged "
+            f"(mass-balance / dry-out / overflow / impact).</p>"
+        )
+        if invalid_ids:
+            inv_rows = []
+            for cid in invalid_ids:
+                h = hist_map.get(cid)
+                reasons = _flag_reasons(_get(h, "validation", {})) if h else ["failed"]
+                inv_rows.append(
+                    f'<tr class="invalid"><td class="k">{_esc(cid)}</td>'
+                    f'<td>{_esc(", ".join(reasons))}</td></tr>'
+                )
+            summary += (
+                "<table><tr><th>Flagged case</th><th>Reason</th></tr>"
+                + "".join(inv_rows)
+                + "</table>"
+            )
+        else:
+            summary += "<p>All cases passed validation.</p>"
+    else:
+        summary = (
+            "<p>No time-history validation supplied; per-case validity is not "
+            "available in this render.</p>"
+        )
+    validation_html = _section("Validation", summary)
+
+    # ---- Outputs: full matrix, every case, invalids flagged ----
+    header = (
+        "<tr><th>Case</th><th>Fill</th><th>Ratio</th><th>T_nat (s)</th>"
+        "<th>T_roll (s)</th><th>Resonance</th><th>Status</th></tr>"
+    )
+    body_rows = []
+    for c in cases:
+        cid = str(_get(c, "case_id"))
+        v = case_valid(c)
+        if v is False:
+            status = '<span class="badge fail">INVALID</span>'
+            rowcls = ' class="invalid"'
+        elif v is True:
+            status = '<span class="badge pass">valid</span>'
+            rowcls = ""
+        else:
+            status = "n/a"
+            rowcls = ""
+        body_rows.append(
+            f"<tr{rowcls}><td class=\"k\">{_esc(cid)}</td>"
+            f"<td>{_num_fmt(float(_get(c, 'fill_fraction')))}</td>"
+            f"<td>{_num_fmt(float(_get(c, 'period_ratio')))}</td>"
+            f"<td>{_num_fmt(float(_get(c, 'natural_period_s', 0.0)))}</td>"
+            f"<td>{_num_fmt(float(_get(c, 'roll_period_s', 0.0)))}</td>"
+            f"<td>{'yes' if _get(c, 'near_resonance', False) else 'no'}</td>"
+            f"<td>{status}</td></tr>"
+        )
+    outputs = _section(
+        "Outputs",
+        "<p>Full case matrix - no case omitted; invalid cases are flagged.</p>"
+        f"<table>{header}{''.join(body_rows)}</table>",
+    )
+
+    # ---- Limitations ----
+    limitations = _section(
+        "Limitations",
+        "<ul>"
+        "<li>Grid resolution is limited to the sampled fills and period ratios; "
+        "peaks between grid nodes are not captured.</li>"
+        "<li>Invalid cases are excluded from heatmap colour scaling (shown n/a) but "
+        "retained and flagged in the matrix and validation tables.</li>"
+        "<li>Surrogate model; extreme regimes require full VOF CFD confirmation.</li>"
+        "</ul>",
+    )
+
+    body = (
+        inputs + methodology + visualizations + validation_html + outputs + limitations
+    )
+    subtitle = (
+        f"{len(cases)} cases - {n_invalid} flagged invalid - "
+        f"schema {_esc(_get(manifest, 'schema_version', '?'))}"
+    )
+    return _shell(f"Sloshing Sweep Aggregate Report", subtitle, body)

--- a/src/digitalmodel/solvers/openfoam/sloshing_sweep.py
+++ b/src/digitalmodel/solvers/openfoam/sloshing_sweep.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: dm#1528 slice 3 - first fluid sloshing natural period (from the linear
+tanh dispersion relation, provenance retained) plus deterministic sweep
+generation over fill fraction x conduit capacity x T_roll/T_natural, with
+refined sampling around the natural-period response region (ratio = 1) and
+stable, reproducible case IDs / manifest hashes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from loguru import logger
+
+from .spectral_analysis import GRAVITY, prismatic_tank_natural_frequency
+
+# Schema version for the generated manifest (bump on breaking field changes).
+SWEEP_SCHEMA_VERSION = "1.0"
+
+# Label + provenance for the analytical approximation used for the natural period.
+_APPROXIMATION_LABEL = "linear_potential_tanh_dispersion"
+_PROVENANCE = (
+    "First fluid sloshing mode from the linear-potential prismatic-tank "
+    "dispersion relation omega^2 = (n*pi*g/L)*tanh(n*pi*h/L) "
+    "(spectral_analysis.prismatic_tank_natural_frequency); reference geometry "
+    "is a prismatic tank; approximation is linear/inviscid and strictly valid "
+    "for small-amplitude sloshing. See digitalmodel #1528 slice 3."
+)
+
+# Rounding used to normalize inputs before hashing (kills float noise so IDs are
+# reproducible across platforms) and to snap generated ratios.
+_ROUND = 6
+
+
+# ============================================================================
+# Natural period
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class NaturalPeriodResult:
+    """First sloshing natural period for a prismatic reference tank.
+
+    Attributes:
+        fill_fraction: Nominal fill fraction (0, 1) exclusive.
+        fill_depth: Still-water fill depth h = fill_fraction * tank_height (m).
+        length: Tank length L in the sloshing direction (m).
+        tank_height: Tank internal height (m).
+        mode: Sloshing mode number n (>= 1); 1 = first/fundamental mode.
+        gravity: Gravitational acceleration used (m/s^2).
+        natural_frequency_hz: First-mode natural frequency f_n (Hz).
+        natural_period_s: First-mode natural period T_n = 1/f_n (s).
+        approximation: Short machine label for the approximation used.
+        provenance: Human-readable provenance / validity note (retained).
+    """
+
+    fill_fraction: float
+    fill_depth: float
+    length: float
+    tank_height: float
+    mode: int
+    gravity: float
+    natural_frequency_hz: float
+    natural_period_s: float
+    approximation: str
+    provenance: str
+
+
+def first_sloshing_natural_period(
+    length: float,
+    tank_height: float,
+    fill_fraction: float,
+    *,
+    mode: int = 1,
+    gravity: float = GRAVITY,
+) -> NaturalPeriodResult:
+    """Compute the first fluid sloshing natural period for a prismatic tank.
+
+    The still-water fill depth is ``h = fill_fraction * tank_height`` and the
+    natural frequency comes from the linear tanh dispersion relation via
+    :func:`spectral_analysis.prismatic_tank_natural_frequency` (built upon, not
+    duplicated). The approximation label and provenance are retained on the
+    result per #1528.
+
+    Args:
+        length: Tank length L in the sloshing direction (m).
+        tank_height: Tank internal height H (m).
+        fill_fraction: Nominal fill fraction in the open interval (0, 1).
+        mode: Sloshing mode number n (>= 1).
+        gravity: Gravitational acceleration (m/s^2).
+
+    Returns:
+        NaturalPeriodResult with frequency, period, and provenance.
+
+    Raises:
+        ValueError: If ``fill_fraction`` is not in (0, 1), or geometry / mode /
+            gravity are non-physical.
+    """
+    if not (0.0 < fill_fraction < 1.0):
+        raise ValueError(
+            f"fill_fraction must be in the open interval (0, 1); got "
+            f"{fill_fraction!r}. Use a nominal fill strictly between empty and full."
+        )
+    if length <= 0:
+        raise ValueError(f"length must be positive; got {length!r}.")
+    if tank_height <= 0:
+        raise ValueError(f"tank_height must be positive; got {tank_height!r}.")
+
+    fill_depth = fill_fraction * tank_height
+    # Delegates dispersion + mode/gravity validation to the spectral module.
+    f_n = prismatic_tank_natural_frequency(
+        length, fill_depth, mode=mode, gravity=gravity
+    )
+    if f_n <= 0:  # pragma: no cover - guarded upstream, defensive only
+        raise ValueError("Computed a non-positive natural frequency.")
+    return NaturalPeriodResult(
+        fill_fraction=float(fill_fraction),
+        fill_depth=float(fill_depth),
+        length=float(length),
+        tank_height=float(tank_height),
+        mode=int(mode),
+        gravity=float(gravity),
+        natural_frequency_hz=float(f_n),
+        natural_period_s=float(1.0 / f_n),
+        approximation=_APPROXIMATION_LABEL,
+        provenance=_PROVENANCE,
+    )
+
+
+def period_ratio(roll_period: float, natural_period: float) -> float:
+    """Return the resonance ratio T_roll / T_natural.
+
+    A value near 1.0 indicates the imposed roll period is close to the fluid's
+    first sloshing natural period (the response region refined by the sweep).
+
+    Args:
+        roll_period: Imposed vessel roll period T_roll (s).
+        natural_period: Fluid first sloshing natural period T_natural (s).
+
+    Returns:
+        Dimensionless ratio T_roll / T_natural.
+
+    Raises:
+        ValueError: If either period is non-positive.
+    """
+    if roll_period <= 0:
+        raise ValueError(f"roll_period must be positive; got {roll_period!r}.")
+    if natural_period <= 0:
+        raise ValueError(
+            f"natural_period must be positive; got {natural_period!r}."
+        )
+    return roll_period / natural_period
+
+
+# ============================================================================
+# Sweep configuration
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SweepConfig:
+    """Deterministic sweep specification for the reference prismatic tank.
+
+    The sweep is a full factorial over ``fill_fractions`` x
+    ``conduit_capacities`` x effective period ratios, where the effective ratio
+    set augments ``base_period_ratios`` with a refined cluster of
+    ``resonance_points`` samples inside +/- ``resonance_band`` of
+    ``resonance_center`` (default 1.0, the natural-period response region).
+
+    Attributes:
+        length: Tank length L in the sloshing direction (m).
+        tank_height: Tank internal height H (m).
+        study_name: Prefix for generated case IDs (also part of the ID hash).
+        mode: Sloshing mode number n for the natural period (>= 1).
+        gravity: Gravitational acceleration (m/s^2).
+        fill_fractions: Nominal fills; default covers the required set.
+        conduit_capacities: Dimensionless conduit-capacity levels (>= 0);
+            ``0.0`` is the no-flow control. Units documented in the manifest.
+        base_period_ratios: Base T_roll/T_natural sampling spanning the
+            operating range.
+        resonance_center: Ratio around which sampling is refined (default 1.0).
+        resonance_band: Half-width of the refinement/near-resonance band.
+        resonance_points: Number of refined samples across the band (>= 1).
+    """
+
+    length: float
+    tank_height: float
+    study_name: str = ""
+    mode: int = 1
+    gravity: float = GRAVITY
+    fill_fractions: Tuple[float, ...] = (0.10, 0.25, 0.40, 0.50, 0.65, 0.80)
+    conduit_capacities: Tuple[float, ...] = (0.0, 0.05, 0.10)
+    base_period_ratios: Tuple[float, ...] = (0.7, 0.85, 1.0, 1.2, 1.5)
+    resonance_center: float = 1.0
+    resonance_band: float = 0.15
+    resonance_points: int = 5
+
+    # Units recorded in the manifest for the (dimensionless) conduit capacity.
+    conduit_capacity_units: str = "fraction_tank_volume_per_half_cycle"
+
+    def effective_period_ratios(self) -> Tuple[float, ...]:
+        """Return the sorted, de-duplicated ratio set (base + refined band).
+
+        The refined samples are a deterministic linear spacing across
+        ``[center - band, center + band]``; values are rounded so the union is
+        reproducible.
+
+        Returns:
+            Ascending tuple of unique T_roll/T_natural ratios.
+        """
+        refined = _linspace(
+            self.resonance_center - self.resonance_band,
+            self.resonance_center + self.resonance_band,
+            self.resonance_points,
+        )
+        merged = {round(r, _ROUND) for r in self.base_period_ratios}
+        merged.update(round(r, _ROUND) for r in refined)
+        return tuple(sorted(merged))
+
+    def schema_key(self) -> dict:
+        """Manifest-level identity (excludes the per-case sweep axes)."""
+        return {
+            "version": SWEEP_SCHEMA_VERSION,
+            "study": self.study_name,
+            "length_m": round(self.length, _ROUND),
+            "tank_height_m": round(self.tank_height, _ROUND),
+            "mode": int(self.mode),
+            "gravity": round(self.gravity, _ROUND),
+        }
+
+
+# ============================================================================
+# Sweep case + manifest
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SweepCase:
+    """One deterministic sweep case (a matrix row).
+
+    Attributes:
+        case_id: Stable ID = ``<study>-<12 hex>`` (or bare hash if no study),
+            hashed from the normalized case-defining inputs.
+        fill_fraction: Nominal fill fraction.
+        fill_depth: Still-water fill depth (m).
+        conduit_capacity: Dimensionless conduit-capacity level.
+        period_ratio: Target T_roll / T_natural for this case.
+        natural_frequency_hz: First-mode natural frequency (Hz).
+        natural_period_s: First-mode natural period (s).
+        roll_frequency_hz: Imposed roll frequency (Hz) = 1 / roll_period_s.
+        roll_period_s: Imposed roll period = period_ratio * natural_period_s (s).
+        near_resonance: True when the ratio is within the resonance band.
+        approximation: Natural-period approximation label (retained).
+    """
+
+    case_id: str
+    fill_fraction: float
+    fill_depth: float
+    conduit_capacity: float
+    period_ratio: float
+    natural_frequency_hz: float
+    natural_period_s: float
+    roll_frequency_hz: float
+    roll_period_s: float
+    near_resonance: bool
+    approximation: str
+
+
+@dataclass(frozen=True)
+class SweepManifest:
+    """Deterministic, reproducible manifest for a generated sweep.
+
+    Attributes:
+        schema_version: Manifest schema version.
+        study_name: Study prefix.
+        provenance: Natural-period approximation provenance (retained).
+        length: Tank length L (m).
+        tank_height: Tank internal height H (m).
+        mode: Sloshing mode number.
+        gravity: Gravitational acceleration (m/s^2).
+        conduit_capacity_units: Units label for conduit_capacity values.
+        cases: Ordered tuple of SweepCase rows.
+        content_hash: 16-hex digest over the ordered case IDs + schema version;
+            identical inputs always yield the identical hash.
+    """
+
+    schema_version: str
+    study_name: str
+    provenance: str
+    length: float
+    tank_height: float
+    mode: int
+    gravity: float
+    conduit_capacity_units: str
+    cases: Tuple[SweepCase, ...]
+    content_hash: str
+
+
+def generate_sweep(config: SweepConfig) -> SweepManifest:
+    """Generate the deterministic fill x conduit x period-ratio sweep.
+
+    Cases are produced as a full factorial in a fixed, sorted order (fill, then
+    conduit capacity, then ratio) so the output - including case IDs and the
+    manifest content hash - is byte-for-byte reproducible.
+
+    Args:
+        config: The sweep specification.
+
+    Returns:
+        SweepManifest with one SweepCase per combination.
+
+    Raises:
+        ValueError: If any fill/conduit/ratio value is non-physical.
+    """
+    if not config.fill_fractions:
+        raise ValueError("At least one fill fraction is required.")
+    for cap in config.conduit_capacities:
+        if cap < 0:
+            raise ValueError(
+                f"conduit_capacity must be >= 0; got {cap!r} "
+                "(0.0 is the no-flow control)."
+            )
+    if not config.conduit_capacities:
+        raise ValueError("At least one conduit capacity is required.")
+
+    ratios = config.effective_period_ratios()
+    if not ratios:
+        raise ValueError("At least one period ratio is required.")
+    for r in ratios:
+        if r <= 0:
+            raise ValueError(
+                f"period ratio must be positive; got {r!r}."
+            )
+
+    # Natural period depends only on fill -> compute once per fill (validates).
+    natural_by_fill = {
+        fill: first_sloshing_natural_period(
+            config.length, config.tank_height, fill,
+            mode=config.mode, gravity=config.gravity,
+        )
+        for fill in config.fill_fractions
+    }
+
+    cases: list[SweepCase] = []
+    n_control = 0
+    for fill, cap, ratio in itertools.product(
+        sorted(config.fill_fractions),
+        sorted(config.conduit_capacities),
+        ratios,
+    ):
+        nat = natural_by_fill[fill]
+        roll_period = ratio * nat.natural_period_s
+        near = abs(ratio - config.resonance_center) <= config.resonance_band
+        if cap == 0.0:
+            n_control += 1
+        case_id = _make_case_id(config, fill, cap, ratio)
+        cases.append(
+            SweepCase(
+                case_id=case_id,
+                fill_fraction=round(fill, _ROUND),
+                fill_depth=round(nat.fill_depth, _ROUND),
+                conduit_capacity=round(cap, _ROUND),
+                period_ratio=round(ratio, _ROUND),
+                natural_frequency_hz=nat.natural_frequency_hz,
+                natural_period_s=nat.natural_period_s,
+                roll_frequency_hz=1.0 / roll_period,
+                roll_period_s=roll_period,
+                near_resonance=bool(near),
+                approximation=nat.approximation,
+            )
+        )
+
+    content_hash = _content_hash(config.schema_key(), [c.case_id for c in cases])
+    logger.info(
+        "Generated dm#1528 sweep '{}': {} cases ({} controls), hash {}",
+        config.study_name or "(unnamed)", len(cases), n_control, content_hash,
+    )
+    return SweepManifest(
+        schema_version=SWEEP_SCHEMA_VERSION,
+        study_name=config.study_name,
+        provenance=_PROVENANCE,
+        length=float(config.length),
+        tank_height=float(config.tank_height),
+        mode=int(config.mode),
+        gravity=float(config.gravity),
+        conduit_capacity_units=config.conduit_capacity_units,
+        cases=tuple(cases),
+        content_hash=content_hash,
+    )
+
+
+# ============================================================================
+# Private helpers
+# ============================================================================
+
+
+def _linspace(a: float, b: float, n: int) -> list[float]:
+    """Deterministic inclusive linear spacing (pure Python, no numpy noise)."""
+    if n < 1:
+        raise ValueError(f"resonance_points must be >= 1; got {n!r}.")
+    if n == 1:
+        return [(a + b) / 2.0]
+    return [a + (b - a) * i / (n - 1) for i in range(n)]
+
+
+def _canonical(obj: dict) -> str:
+    """Deterministic JSON encoding (sorted keys, compact) for hashing."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _make_case_id(
+    config: SweepConfig, fill: float, cap: float, ratio: float
+) -> str:
+    """Stable case ID from normalized case-defining inputs."""
+    payload = {
+        "study": config.study_name,
+        "length_m": round(config.length, _ROUND),
+        "tank_height_m": round(config.tank_height, _ROUND),
+        "mode": int(config.mode),
+        "gravity": round(config.gravity, _ROUND),
+        "fill_fraction": round(fill, _ROUND),
+        "conduit_capacity": round(cap, _ROUND),
+        "period_ratio": round(ratio, _ROUND),
+    }
+    digest = hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()[:12]
+    return f"{config.study_name}-{digest}" if config.study_name else digest
+
+
+def _content_hash(schema_key: dict, case_ids: list[str]) -> str:
+    """16-hex digest over the schema key and the ordered case IDs."""
+    payload = _canonical({"schema": schema_key, "cases": case_ids})
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+

--- a/src/digitalmodel/solvers/openfoam/time_history.py
+++ b/src/digitalmodel/solvers/openfoam/time_history.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""ABOUTME: Synchronized CFD time-history output extraction for sloshing/marine
+interFoam cases (#1528, slice 5). Assembles a common-time-base bundle of
+provenance-stamped series - free-surface elevation (spatial max/min/mean +
+probe transect), wall pressure vs elevation and time, liquid mass / volume /
+fill fraction with a mass-balance residual, liquid centre of mass, inlet/outlet
+flow rate and integrated flow volume, and imposed roll angle / angular velocity
+/ phase plus the roll-to-response phase lag. Every series carries units, a case
+id, its source CFD field and a provenance note; a synchronized-time check fails
+on mismatched / unsorted / ragged / non-finite time vectors. No OpenFOAM
+install is required - the extractor operates on already-parsed arrays, and the
+tests drive it with independently constructed synthetic (de-identified) signals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+from loguru import logger
+from scipy.signal import hilbert
+
+from .results_models import ProbeTimeSeries
+from .pressure_taps import PressureTapStatistics, compute_tap_statistics
+from .spectral_analysis import extract_natural_frequency
+
+__all__ = [
+    "TimeSeriesChannel",
+    "ValidationFlags",
+    "SynchronizedTimeHistory",
+    "RawCFDOutputs",
+    "ExtractionConfig",
+    "extract_time_history",
+    "validate_synchronized_time",
+    "phase_lag_deg",
+]
+
+
+# ============================================================================
+# Synchronized-time validation
+# ============================================================================
+
+
+def validate_synchronized_time(time: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Validate a common time base for a synchronized bundle.
+
+    A valid time base is a 1-D, finite, strictly increasing vector of at least
+    two samples. This is the synchronized-time gate: it rejects unsorted,
+    ragged (non-1-D) and non-finite time vectors so downstream series cannot be
+    silently misaligned.
+
+    Args:
+        time: Candidate time vector (s).
+
+    Returns:
+        The time vector as a contiguous ``float64`` array.
+
+    Raises:
+        ValueError: If the vector is not 1-D, has < 2 samples, contains
+            non-finite entries, or is not strictly increasing (unsorted).
+    """
+    arr = np.asarray(time, dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError(
+            f"time base must be 1-D; got shape {arr.shape}. "
+            "Ragged/multi-dim time vectors cannot be synchronized."
+        )
+    if arr.size < 2:
+        raise ValueError("time base must contain at least two samples.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("time base contains non-finite (nan/inf) samples.")
+    if np.any(np.diff(arr) <= 0.0):
+        raise ValueError(
+            "time base must be strictly increasing (sorted, no duplicates)."
+        )
+    return arr
+
+
+# ============================================================================
+# TimeSeriesChannel: the per-series envelope (units + provenance)
+# ============================================================================
+
+
+@dataclass(frozen=True, eq=False)
+class TimeSeriesChannel:
+    """One extracted CFD series with explicit units and provenance.
+
+    The envelope carries everything needed to interpret and audit a series: its
+    ``times`` (the timestamps, s), ``values`` (1-D scalar or 2-D multichannel
+    ``(n_times, n_locations)``), ``units``, the originating ``case_id``, the
+    ``source_field`` (the CFD field / function object it derives from) and a
+    free-form ``provenance`` note describing how it was computed. Optional
+    ``locations`` give the probe coordinates for a multichannel series (e.g. the
+    elevation transect or the pressure probes).
+
+    Attributes:
+        name: Channel key (e.g. ``"free_surface_elevation"``).
+        times: Timestamps (s), 1-D, strictly increasing.
+        values: Series values; shape ``(n_times,)`` or ``(n_times, n_loc)``.
+        units: Physical units string (e.g. ``"m"``, ``"Pa"``, ``"m^3/s"``,
+            ``"1"`` for dimensionless).
+        case_id: Originating case identifier.
+        source_field: CFD field / function object the series derives from.
+        provenance: How the series was computed (audit note).
+        locations: Optional probe coordinates ``(n_loc, 3)`` for a multichannel
+            series.
+        location_labels: Optional per-location labels aligned with columns.
+    """
+
+    name: str
+    times: NDArray[np.float64]
+    values: NDArray[np.float64]
+    units: str
+    case_id: str
+    source_field: str
+    provenance: str
+    locations: Optional[NDArray[np.float64]] = None
+    location_labels: Optional[Tuple[str, ...]] = None
+
+    def __post_init__(self) -> None:
+        for attr in ("name", "units", "case_id", "source_field", "provenance"):
+            val = getattr(self, attr)
+            if not isinstance(val, str) or not val.strip():
+                raise ValueError(
+                    f"TimeSeriesChannel.{attr} must be a non-empty string "
+                    f"(got {val!r}); every series must carry units and provenance."
+                )
+        times = np.asarray(self.times, dtype=np.float64)
+        values = np.asarray(self.values, dtype=np.float64)
+        object.__setattr__(self, "times", times)
+        object.__setattr__(self, "values", values)
+
+        if times.ndim != 1:
+            raise ValueError(
+                f"{self.name}: times must be 1-D (got shape {times.shape})."
+            )
+        if times.size < 1:
+            raise ValueError(f"{self.name}: times must be non-empty.")
+        if values.shape[0] != times.shape[0]:
+            raise ValueError(
+                f"{self.name}: ragged series - values leading dim "
+                f"{values.shape[0]} != len(times) {times.shape[0]}."
+            )
+        if times.size >= 2 and np.any(np.diff(times) <= 0.0):
+            raise ValueError(
+                f"{self.name}: times must be strictly increasing (sorted)."
+            )
+        if not np.all(np.isfinite(times)):
+            raise ValueError(f"{self.name}: times contain non-finite values.")
+        if self.locations is not None:
+            loc = np.asarray(self.locations, dtype=np.float64)
+            object.__setattr__(self, "locations", loc)
+            if loc.ndim != 2 or loc.shape[1] != 3:
+                raise ValueError(
+                    f"{self.name}: locations must be (n_loc, 3); got {loc.shape}."
+                )
+            if values.ndim == 2 and loc.shape[0] != values.shape[1]:
+                raise ValueError(
+                    f"{self.name}: locations rows {loc.shape[0]} != value "
+                    f"columns {values.shape[1]}."
+                )
+
+    @property
+    def n_samples(self) -> int:
+        """Number of time samples."""
+        return int(self.times.shape[0])
+
+    @property
+    def is_multichannel(self) -> bool:
+        """True when the series has a spatial (location) axis."""
+        return self.values.ndim == 2
+
+    @property
+    def peak(self) -> float:
+        """Maximum value over all samples (and locations)."""
+        return float(np.max(self.values))
+
+    @property
+    def trough(self) -> float:
+        """Minimum value over all samples (and locations)."""
+        return float(np.min(self.values))
+
+    @property
+    def mean(self) -> float:
+        """Mean value over all samples (and locations)."""
+        return float(np.mean(self.values))
+
+    @property
+    def spatial_max(self) -> NDArray[np.float64]:
+        """Per-timestep maximum across locations (multichannel only)."""
+        self._require_multichannel("spatial_max")
+        return np.max(self.values, axis=1)
+
+    @property
+    def spatial_min(self) -> NDArray[np.float64]:
+        """Per-timestep minimum across locations (multichannel only)."""
+        self._require_multichannel("spatial_min")
+        return np.min(self.values, axis=1)
+
+    @property
+    def spatial_mean(self) -> NDArray[np.float64]:
+        """Per-timestep mean across locations (multichannel only)."""
+        self._require_multichannel("spatial_mean")
+        return np.mean(self.values, axis=1)
+
+    def _require_multichannel(self, what: str) -> None:
+        if not self.is_multichannel:
+            raise ValueError(
+                f"{self.name}: {what} requires a multichannel (2-D) series."
+            )
+
+    def to_provenance(self) -> Dict[str, object]:
+        """Scalar provenance record (drops arrays) for logging/serialisation."""
+        return {
+            "name": self.name,
+            "units": self.units,
+            "case_id": self.case_id,
+            "source_field": self.source_field,
+            "provenance": self.provenance,
+            "n_samples": self.n_samples,
+            "multichannel": self.is_multichannel,
+        }
+
+
+# ============================================================================
+# ValidationFlags
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ValidationFlags:
+    """Boolean/scalar validation summary for an extracted bundle.
+
+    Attributes:
+        synchronized_time: True when every series shares the common time base.
+        mass_balance_residual: Relative mass-balance residual
+            ``max|m - m_expected| / max|m|`` (dimensionless).
+        mass_balance_ok: True when ``mass_balance_residual`` is within tolerance.
+        dry_out: True if the fill fraction fell below the dry-out threshold.
+        overflow: True if the fill fraction exceeded the overflow threshold.
+        impact: True if any wall-pressure sample exceeded the impact threshold.
+        mass_balance_rtol: The tolerance used for ``mass_balance_ok``.
+        dry_out_fill_fraction: The dry-out fill-fraction threshold used.
+        overflow_fill_fraction: The overflow fill-fraction threshold used.
+        impact_pressure: The impact pressure threshold used (Pa).
+    """
+
+    synchronized_time: bool
+    mass_balance_residual: float
+    mass_balance_ok: bool
+    dry_out: bool
+    overflow: bool
+    impact: bool
+    mass_balance_rtol: float = 1.0e-3
+    dry_out_fill_fraction: float = 0.02
+    overflow_fill_fraction: float = 0.98
+    impact_pressure: float = float("inf")
+
+    def to_dict(self) -> Dict[str, object]:
+        """Plain-dict view for logging / serialisation."""
+        return {
+            "synchronized_time": self.synchronized_time,
+            "mass_balance_residual": self.mass_balance_residual,
+            "mass_balance_ok": self.mass_balance_ok,
+            "dry_out": self.dry_out,
+            "overflow": self.overflow,
+            "impact": self.impact,
+            "mass_balance_rtol": self.mass_balance_rtol,
+            "dry_out_fill_fraction": self.dry_out_fill_fraction,
+            "overflow_fill_fraction": self.overflow_fill_fraction,
+            "impact_pressure": self.impact_pressure,
+        }
+
+
+# ============================================================================
+# SynchronizedTimeHistory bundle
+# ============================================================================
+
+
+@dataclass(frozen=True, eq=False)
+class SynchronizedTimeHistory:
+    """A bundle of provenance-stamped series sharing one common time base.
+
+    Attributes:
+        case_id: Originating case identifier.
+        time: The common time base (s) every channel is aligned to.
+        channels: Mapping ``name -> TimeSeriesChannel``.
+        validation: The validation-flag summary.
+        metadata: Free-form provenance metadata (density, tank volume, source).
+    """
+
+    case_id: str
+    time: NDArray[np.float64]
+    channels: Mapping[str, TimeSeriesChannel]
+    validation: ValidationFlags
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_channels(
+        cls,
+        *,
+        case_id: str,
+        channels: Mapping[str, TimeSeriesChannel],
+        validation: ValidationFlags,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> "SynchronizedTimeHistory":
+        """Assemble a bundle, enforcing a single shared time base.
+
+        Args:
+            case_id: Case identifier.
+            channels: The series to bundle (must be non-empty).
+            validation: Validation-flag summary.
+            metadata: Optional provenance metadata.
+
+        Returns:
+            The synchronized bundle.
+
+        Raises:
+            ValueError: If ``channels`` is empty or any channel's ``times`` do
+                not match the common base (mismatched / ragged synchronization).
+        """
+        if not channels:
+            raise ValueError("from_channels requires at least one channel.")
+        first = next(iter(channels.values()))
+        base = validate_synchronized_time(first.times)
+        for name, ch in channels.items():
+            if ch.times.shape != base.shape or not np.array_equal(ch.times, base):
+                raise ValueError(
+                    f"channel {name!r} is not synchronized to the common time "
+                    f"base (time base mismatch)."
+                )
+        return cls(
+            case_id=case_id,
+            time=base,
+            channels=dict(channels),
+            validation=validation,
+            metadata=dict(metadata or {}),
+        )
+
+    def pressure_vs_elevation(
+        self, time_index: int, channel: str = "wall_pressure"
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Return ``(elevations, pressures)`` at one instant, sorted by z.
+
+        Args:
+            time_index: Index into the common time base.
+            channel: Multichannel pressure channel name.
+
+        Returns:
+            Tuple of the probe elevations (m, ascending) and the aligned
+            pressures (Pa) at ``time_index``.
+
+        Raises:
+            ValueError: If the channel is missing, not multichannel, or has no
+                locations.
+        """
+        ch = self.channels.get(channel)
+        if ch is None or not ch.is_multichannel or ch.locations is None:
+            raise ValueError(
+                f"pressure_vs_elevation needs a multichannel channel with "
+                f"locations; {channel!r} is unavailable."
+            )
+        z = ch.locations[:, 2]
+        order = np.argsort(z)
+        return z[order], ch.values[time_index, order]
+
+    def pressure_tap_statistics(
+        self, channel: str = "wall_pressure", **kwargs: object
+    ) -> Dict[str, PressureTapStatistics]:
+        """Per-probe pressure statistics, reusing ``pressure_taps``.
+
+        Wraps the multichannel pressure channel in a
+        :class:`~digitalmodel.solvers.openfoam.results_models.ProbeTimeSeries`
+        and delegates to
+        :func:`~digitalmodel.solvers.openfoam.pressure_taps.compute_tap_statistics`.
+
+        Args:
+            channel: Multichannel pressure channel name.
+            **kwargs: Forwarded to ``compute_tap_statistics``.
+
+        Returns:
+            Mapping ``probe_name -> PressureTapStatistics``.
+        """
+        ch = self.channels.get(channel)
+        if ch is None or not ch.is_multichannel:
+            raise ValueError(f"{channel!r} is not a multichannel pressure channel.")
+        coords = (
+            ch.locations.tolist()
+            if ch.locations is not None
+            else [[0.0, 0.0, 0.0]] * ch.values.shape[1]
+        )
+        series = ProbeTimeSeries(
+            times=ch.times,
+            probe_coords=coords,
+            values=ch.values,
+            field_name=ch.source_field,
+        )
+        names = list(ch.location_labels) if ch.location_labels else None
+        return compute_tap_statistics(series, names, **kwargs)  # type: ignore[arg-type]
+
+    def phase_lag_deg(
+        self, response_channel: str, reference_channel: str = "roll_angle"
+    ) -> float:
+        """Phase lag (deg) of a response channel behind a reference channel.
+
+        Both channels must be scalar (1-D). See :func:`phase_lag_deg`.
+        """
+        ref = self.channels[reference_channel]
+        resp = self.channels[response_channel]
+        if ref.is_multichannel or resp.is_multichannel:
+            raise ValueError("phase_lag_deg needs scalar (1-D) channels.")
+        return phase_lag_deg(ref.values, resp.values, times=self.time)
+
+
+# ============================================================================
+# Phase lag helper (reuses spectral_analysis for the dominant frequency)
+# ============================================================================
+
+
+def phase_lag_deg(
+    reference: NDArray[np.float64],
+    response: NDArray[np.float64],
+    *,
+    times: Optional[NDArray[np.float64]] = None,
+    sample_rate: Optional[float] = None,
+    frequency: Optional[float] = None,
+) -> float:
+    """Phase lag (deg) of ``response`` behind ``reference`` at their tone.
+
+    The dominant frequency of ``reference`` is found via
+    :func:`~digitalmodel.solvers.openfoam.spectral_analysis.extract_natural_frequency`
+    (unless ``frequency`` is given), and the phase difference of the complex
+    FFT bins nearest that frequency is returned wrapped to ``(-180, 180]``. A
+    positive value means the response lags the reference.
+
+    Args:
+        reference: Reference signal (e.g. imposed roll).
+        response: Response signal (e.g. elevation, force, CoM).
+        times: Uniform time vector (s) used to infer ``sample_rate``.
+        sample_rate: Explicit sampling frequency (Hz); overrides ``times``.
+        frequency: Optional explicit frequency (Hz) to evaluate the phase at.
+
+    Returns:
+        Phase lag in degrees, positive when ``response`` lags ``reference``.
+
+    Raises:
+        ValueError: If neither ``times`` nor ``sample_rate`` is given, or the
+            signals differ in length.
+    """
+    ref = np.asarray(reference, dtype=np.float64).ravel()
+    resp = np.asarray(response, dtype=np.float64).ravel()
+    if ref.size != resp.size:
+        raise ValueError("reference and response must have equal length.")
+    if sample_rate is None:
+        if times is None:
+            raise ValueError("Provide either 'times' or 'sample_rate'.")
+        t = validate_synchronized_time(times)
+        sample_rate = float(1.0 / np.mean(np.diff(t)))
+
+    if frequency is None:
+        spec = extract_natural_frequency(
+            ref, sample_rate=sample_rate, method="fft", min_frequency=0.0
+        )
+        frequency = spec.dominant_frequency
+
+    n = ref.size
+    freqs = np.fft.rfftfreq(n, d=1.0 / sample_rate)
+    k = int(np.argmin(np.abs(freqs - frequency)))
+
+    ref_c = np.fft.rfft(ref - np.mean(ref))
+    resp_c = np.fft.rfft(resp - np.mean(resp))
+    lag_rad = np.angle(ref_c[k]) - np.angle(resp_c[k])
+    # wrap to (-pi, pi]
+    lag_rad = (lag_rad + np.pi) % (2.0 * np.pi) - np.pi
+    return float(np.rad2deg(lag_rad))
+
+
+# ============================================================================
+# Raw inputs + extraction config
+# ============================================================================
+
+
+@dataclass(frozen=True, eq=False)
+class RawCFDOutputs:
+    """Already-parsed CFD outputs on a common time base for extraction.
+
+    All time-varying arrays share ``time`` as their leading axis; the extractor
+    never re-times them, so this container is where the raw synchronization is
+    validated (ragged / unsorted inputs are rejected here).
+
+    Attributes:
+        case_id: Case identifier stamped onto every extracted channel.
+        time: Common time base (s).
+        elevation: Free-surface elevation above nominal ``(n_t, n_pos)`` (m).
+        elevation_positions: Elevation-probe coordinates ``(n_pos, 3)`` (m).
+        pressure: Wall pressure ``(n_t, n_p)`` (Pa).
+        pressure_locations: Pressure-probe coordinates ``(n_p, 3)`` (m).
+        liquid_volume: Instantaneous liquid volume ``(n_t,)`` (m^3).
+        com: Liquid centre of mass ``(n_t, 3)`` (m).
+        inlet_flow_rate: Inlet volumetric flow rate ``(n_t,)`` (m^3/s).
+        outlet_flow_rate: Outlet volumetric flow rate ``(n_t,)`` (m^3/s).
+        roll_angle: Imposed roll angle ``(n_t,)`` (rad).
+        density: Liquid density (kg/m^3).
+        tank_volume: Total tank volume (m^3) for the fill fraction.
+        roll_rate: Optional angular velocity ``(n_t,)`` (rad/s); derived by
+            gradient of ``roll_angle`` when omitted.
+        source: Provenance base string (e.g. solver / function-object family).
+    """
+
+    case_id: str
+    time: NDArray[np.float64]
+    elevation: NDArray[np.float64]
+    elevation_positions: NDArray[np.float64]
+    pressure: NDArray[np.float64]
+    pressure_locations: NDArray[np.float64]
+    liquid_volume: NDArray[np.float64]
+    com: NDArray[np.float64]
+    inlet_flow_rate: NDArray[np.float64]
+    outlet_flow_rate: NDArray[np.float64]
+    roll_angle: NDArray[np.float64]
+    density: float = 1025.0
+    tank_volume: float = 0.0
+    roll_rate: Optional[NDArray[np.float64]] = None
+    source: str = "interFoam"
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.case_id.strip():
+            raise ValueError("case_id must be a non-empty string.")
+        t = validate_synchronized_time(self.time)
+        object.__setattr__(self, "time", t)
+        n = t.shape[0]
+
+        def _arr(name: str, expect_cols: Optional[int] = None) -> NDArray[np.float64]:
+            a = np.asarray(getattr(self, name), dtype=np.float64)
+            if a.shape[0] != n:
+                raise ValueError(
+                    f"{name}: ragged input - leading dim {a.shape[0]} != "
+                    f"len(time) {n}; all series must share the time base."
+                )
+            if expect_cols is not None and (a.ndim != 2 or a.shape[1] != expect_cols):
+                raise ValueError(
+                    f"{name}: expected shape (n_t, {expect_cols}); got {a.shape}."
+                )
+            object.__setattr__(self, name, a)
+            return a
+
+        _arr("elevation")
+        _arr("pressure")
+        _arr("liquid_volume")
+        _arr("com", expect_cols=3)
+        _arr("inlet_flow_rate")
+        _arr("outlet_flow_rate")
+        _arr("roll_angle")
+        if self.roll_rate is not None:
+            _arr("roll_rate")
+
+        pos = np.asarray(self.elevation_positions, dtype=np.float64)
+        if pos.ndim != 2 or pos.shape[1] != 3:
+            raise ValueError("elevation_positions must be shape (n_pos, 3).")
+        object.__setattr__(self, "elevation_positions", pos)
+        if self.elevation.ndim == 2 and self.elevation.shape[1] != pos.shape[0]:
+            raise ValueError("elevation columns must match elevation_positions rows.")
+
+        plocs = np.asarray(self.pressure_locations, dtype=np.float64)
+        if plocs.ndim != 2 or plocs.shape[1] != 3:
+            raise ValueError("pressure_locations must be shape (n_p, 3).")
+        object.__setattr__(self, "pressure_locations", plocs)
+        if self.pressure.ndim == 2 and self.pressure.shape[1] != plocs.shape[0]:
+            raise ValueError("pressure columns must match pressure_locations rows.")
+
+        if self.density <= 0.0:
+            raise ValueError("density must be positive.")
+        if self.tank_volume <= 0.0:
+            raise ValueError("tank_volume must be positive.")
+
+
+@dataclass(frozen=True)
+class ExtractionConfig:
+    """Thresholds for the extraction validation flags.
+
+    Attributes:
+        mass_balance_rtol: Relative tolerance for the mass-balance residual.
+        dry_out_fill_fraction: Fill fraction below which dry-out is flagged.
+        overflow_fill_fraction: Fill fraction above which overflow is flagged.
+        impact_pressure: Wall pressure (Pa) above which an impact is flagged
+            (default ``inf`` = disabled unless configured).
+    """
+
+    mass_balance_rtol: float = 1.0e-3
+    dry_out_fill_fraction: float = 0.02
+    overflow_fill_fraction: float = 0.98
+    impact_pressure: float = float("inf")
+
+
+# ============================================================================
+# Extraction
+# ============================================================================
+
+
+def _cumulative_trapezoid(
+    y: NDArray[np.float64], x: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Cumulative trapezoidal integral of ``y`` over ``x``, starting at 0."""
+    dt = np.diff(x)
+    increments = 0.5 * (y[1:] + y[:-1]) * dt
+    return np.concatenate([[0.0], np.cumsum(increments)])
+
+
+def extract_time_history(
+    raw: RawCFDOutputs, *, config: Optional[ExtractionConfig] = None
+) -> SynchronizedTimeHistory:
+    """Extract a synchronized, provenance-stamped time-history bundle.
+
+    Builds every scope channel on ``raw.time`` (so the bundle is synchronized by
+    construction), computes the derived spatial/temporal/integral series, and
+    evaluates the validation flags (mass-balance residual vs the flow integral,
+    dry-out / overflow on the fill fraction, and wall-pressure impact).
+
+    Args:
+        raw: Parsed CFD outputs on a common time base.
+        config: Validation thresholds (defaults used when omitted).
+
+    Returns:
+        The :class:`SynchronizedTimeHistory` bundle.
+    """
+    cfg = config or ExtractionConfig()
+    t = raw.time
+    cid = raw.case_id
+    src = raw.source
+
+    def ch(
+        name: str,
+        values: NDArray[np.float64],
+        units: str,
+        source_field: str,
+        provenance: str,
+        *,
+        locations: Optional[NDArray[np.float64]] = None,
+        location_labels: Optional[Tuple[str, ...]] = None,
+    ) -> TimeSeriesChannel:
+        return TimeSeriesChannel(
+            name=name,
+            times=t,
+            values=values,
+            units=units,
+            case_id=cid,
+            source_field=source_field,
+            provenance=f"[{src}] {provenance}",
+            locations=locations,
+            location_labels=location_labels,
+        )
+
+    channels: Dict[str, TimeSeriesChannel] = {}
+
+    # --- free-surface elevation (transect + spatial reductions) ---
+    elev_labels = tuple(f"eta_probe_{i}" for i in range(raw.elevation.shape[1]))
+    channels["free_surface_elevation"] = ch(
+        "free_surface_elevation",
+        raw.elevation,
+        "m",
+        "alpha.water",
+        "interface elevation above nominal at probe transect",
+        locations=raw.elevation_positions,
+        location_labels=elev_labels,
+    )
+    channels["elevation_max"] = ch(
+        "elevation_max",
+        np.max(raw.elevation, axis=1),
+        "m",
+        "alpha.water",
+        "spatial max of free-surface elevation across probes",
+    )
+    channels["elevation_min"] = ch(
+        "elevation_min",
+        np.min(raw.elevation, axis=1),
+        "m",
+        "alpha.water",
+        "spatial min of free-surface elevation across probes",
+    )
+    channels["elevation_mean"] = ch(
+        "elevation_mean",
+        np.mean(raw.elevation, axis=1),
+        "m",
+        "alpha.water",
+        "spatial mean of free-surface elevation across probes",
+    )
+
+    # --- wall pressure (vs elevation and time) ---
+    p_labels = tuple(
+        f"p_z{loc[2]:.3g}" for loc in raw.pressure_locations
+    )
+    channels["wall_pressure"] = ch(
+        "wall_pressure",
+        raw.pressure,
+        "Pa",
+        "p",
+        "wall pressure at lower/middle/upper elevation probes",
+        locations=raw.pressure_locations,
+        location_labels=p_labels,
+    )
+
+    # --- liquid volume / mass / fill fraction ---
+    channels["liquid_volume"] = ch(
+        "liquid_volume",
+        raw.liquid_volume,
+        "m^3",
+        "alpha.water",
+        "instantaneous liquid volume (alpha integral over cells)",
+    )
+    liquid_mass = raw.density * raw.liquid_volume
+    channels["liquid_mass"] = ch(
+        "liquid_mass",
+        liquid_mass,
+        "kg",
+        "alpha.water",
+        f"total liquid mass = density({raw.density}) * liquid volume",
+    )
+    fill_fraction = raw.liquid_volume / raw.tank_volume
+    channels["fill_fraction"] = ch(
+        "fill_fraction",
+        fill_fraction,
+        "1",
+        "alpha.water",
+        f"fill fraction = liquid volume / tank volume ({raw.tank_volume} m^3)",
+    )
+
+    # --- inlet / outlet flow + integrated volumes ---
+    channels["inlet_flow_rate"] = ch(
+        "inlet_flow_rate",
+        raw.inlet_flow_rate,
+        "m^3/s",
+        "phi",
+        "inlet volumetric flow rate (patch flux)",
+    )
+    channels["outlet_flow_rate"] = ch(
+        "outlet_flow_rate",
+        raw.outlet_flow_rate,
+        "m^3/s",
+        "phi",
+        "outlet volumetric flow rate (patch flux)",
+    )
+    inlet_volume = _cumulative_trapezoid(raw.inlet_flow_rate, t)
+    outlet_volume = _cumulative_trapezoid(raw.outlet_flow_rate, t)
+    channels["inlet_volume"] = ch(
+        "inlet_volume",
+        inlet_volume,
+        "m^3",
+        "phi",
+        "integrated inlet volume (cumulative trapezoid of inlet flow)",
+    )
+    channels["outlet_volume"] = ch(
+        "outlet_volume",
+        outlet_volume,
+        "m^3",
+        "phi",
+        "integrated outlet volume (cumulative trapezoid of outlet flow)",
+    )
+
+    # --- mass-balance residual vs the flow integral ---
+    net_volume_in = inlet_volume - outlet_volume
+    expected_mass = liquid_mass[0] + raw.density * net_volume_in
+    residual_series = liquid_mass - expected_mass
+    mass_ref = float(np.max(np.abs(liquid_mass)))
+    rel_residual = (
+        float(np.max(np.abs(residual_series)) / mass_ref) if mass_ref > 0 else 0.0
+    )
+    channels["mass_balance_residual"] = ch(
+        "mass_balance_residual",
+        residual_series,
+        "kg",
+        "alpha.water",
+        "mass - (mass[0] + density * integral(Qin - Qout))",
+    )
+
+    # --- centre of mass ---
+    for axis, key in enumerate(("com_x", "com_y", "com_z")):
+        channels[key] = ch(
+            key,
+            raw.com[:, axis],
+            "m",
+            "alpha.water",
+            f"liquid centre-of-mass {key[-1]}-coordinate (alpha-weighted)",
+        )
+
+    # --- roll angle / rate / phase ---
+    channels["roll_angle"] = ch(
+        "roll_angle",
+        raw.roll_angle,
+        "rad",
+        "sixDoFRigidBodyMotion",
+        "imposed roll angle",
+    )
+    if raw.roll_rate is not None:
+        roll_rate = raw.roll_rate
+        rate_prov = "imposed roll angular velocity"
+    else:
+        roll_rate = np.gradient(raw.roll_angle, t)
+        rate_prov = "roll angular velocity (gradient of roll angle)"
+    channels["roll_rate"] = ch(
+        "roll_rate", roll_rate, "rad/s", "sixDoFRigidBodyMotion", rate_prov
+    )
+    roll_phase = np.unwrap(np.angle(hilbert(raw.roll_angle - np.mean(raw.roll_angle))))
+    channels["roll_phase"] = ch(
+        "roll_phase",
+        roll_phase,
+        "rad",
+        "sixDoFRigidBodyMotion",
+        "imposed-motion instantaneous phase (Hilbert analytic signal)",
+    )
+
+    # --- validation flags ---
+    dry_out = bool(np.any(fill_fraction < cfg.dry_out_fill_fraction))
+    overflow = bool(np.any(fill_fraction > cfg.overflow_fill_fraction))
+    impact = bool(np.any(raw.pressure > cfg.impact_pressure))
+    mass_ok = rel_residual <= cfg.mass_balance_rtol
+
+    if not mass_ok:
+        logger.warning(
+            "case {} mass-balance residual {:.3e} exceeds rtol {:.3e}",
+            cid,
+            rel_residual,
+            cfg.mass_balance_rtol,
+        )
+
+    validation = ValidationFlags(
+        synchronized_time=True,
+        mass_balance_residual=rel_residual,
+        mass_balance_ok=mass_ok,
+        dry_out=dry_out,
+        overflow=overflow,
+        impact=impact,
+        mass_balance_rtol=cfg.mass_balance_rtol,
+        dry_out_fill_fraction=cfg.dry_out_fill_fraction,
+        overflow_fill_fraction=cfg.overflow_fill_fraction,
+        impact_pressure=cfg.impact_pressure,
+    )
+
+    metadata: Dict[str, object] = {
+        "density_kg_m3": raw.density,
+        "tank_volume_m3": raw.tank_volume,
+        "source": src,
+        "n_elevation_probes": int(raw.elevation.shape[1]),
+        "n_pressure_probes": int(raw.pressure.shape[1]),
+    }
+
+    return SynchronizedTimeHistory.from_channels(
+        case_id=cid,
+        channels=channels,
+        validation=validation,
+        metadata=metadata,
+    )

--- a/tests/solvers/openfoam/test_case_coupling.py
+++ b/tests/solvers/openfoam/test_case_coupling.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: TDD tests for the CFD case-coupling and pre-run verification layer
+(#1528 slice 4). Maps a reduced-order SweepCase (+ tank/conduit/roll spec) into a
+buildable OpenFOAMCase, verifies the half-sine flow-pulse integral, mass/volume
+conservation and dry-out/overflow feasibility BEFORE any CFD run, and emits a
+de-identified synthetic gravity-exchange case + manifest. Independent oracles
+(hand-computed Q_peak, builder-emitted dict files) stand in for truth.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.solvers.openfoam.case_builder import OpenFOAMCaseBuilder
+from digitalmodel.solvers.openfoam.gravity_conduit import ConduitGeometry
+from digitalmodel.solvers.openfoam.models import CaseType, OpenFOAMCase
+from digitalmodel.solvers.openfoam.motion import MotionType
+from digitalmodel.solvers.openfoam.sloshing_sweep import SweepCase
+from digitalmodel.solvers.openfoam.case_coupling import (
+    CaseManifest,
+    CouplingSpec,
+    SyntheticCase,
+    VerificationResult,
+    build_case_manifest,
+    emit_synthetic_gravity_exchange_case,
+    map_sweep_case_to_openfoam_case,
+    synthetic_coupling_spec,
+    synthetic_sweep_case,
+    verify_coupling,
+)
+
+
+# ============================================================================
+# Test fixtures / helpers (de-identified, synthetic)
+# ============================================================================
+
+
+def _spec(**overrides) -> CouplingSpec:
+    """A feasible synthetic tank/conduit/roll spec (overridable)."""
+    base = dict(
+        tank_length=20.0,
+        tank_width=6.0,
+        tank_height=10.0,
+        roll_amplitude_deg=5.0,
+        roll_origin=(10.0, 3.0, 0.0),
+        conduit=ConduitGeometry(area=0.5, discharge_coefficient=0.6, loss_coefficient=1.5),
+        dest_fill_fraction=0.30,
+        density=1025.0,
+        n_cells=(40, 8, 40),
+    )
+    base.update(overrides)
+    return CouplingSpec(**base)
+
+
+def _sweep_case(
+    *,
+    fill_fraction: float = 0.50,
+    conduit_capacity: float = 0.08,
+    tank_height: float = 10.0,
+    roll_period_s: float = 6.0,
+    near_resonance: bool = True,
+) -> SweepCase:
+    """Construct a SweepCase row directly (public frozen dataclass)."""
+    return SweepCase(
+        case_id="synthetic-abcdef012345",
+        fill_fraction=fill_fraction,
+        fill_depth=fill_fraction * tank_height,
+        conduit_capacity=conduit_capacity,
+        period_ratio=1.0,
+        natural_frequency_hz=1.0 / roll_period_s,
+        natural_period_s=roll_period_s,
+        roll_frequency_hz=1.0 / roll_period_s,
+        roll_period_s=roll_period_s,
+        near_resonance=near_resonance,
+        approximation="linear_potential_tanh_dispersion",
+    )
+
+
+# ============================================================================
+# Mapper: SweepCase -> OpenFOAMCase
+# ============================================================================
+
+
+class TestMapper:
+    def test_returns_multiphase_sloshing_interfoam_case(self):
+        case = map_sweep_case_to_openfoam_case(_sweep_case(), _spec())
+        assert isinstance(case, OpenFOAMCase)
+        assert case.case_type is CaseType.SLOSHING
+        assert case.solver_config.solver_name == "interFoam"
+        assert case.solver_config.is_multiphase is True
+
+    def test_case_name_is_case_id(self):
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, _spec())
+        assert case.name == sc.case_id
+
+    def test_fill_level_from_fill_fraction(self):
+        sc = _sweep_case(fill_fraction=0.42)
+        case = map_sweep_case_to_openfoam_case(sc, _spec())
+        assert case.fill_level == pytest.approx(0.42)
+
+    def test_domain_from_tank_dimensions(self):
+        case = map_sweep_case_to_openfoam_case(_sweep_case(), _spec())
+        assert case.domain.min_coords == [0.0, 0.0, 0.0]
+        assert case.domain.max_coords == [20.0, 6.0, 10.0]
+        # Vertical (z) extent must equal tank_height so fill_level*height == fill_depth.
+        assert case.domain.max_coords[2] - case.domain.min_coords[2] == pytest.approx(10.0)
+
+    def test_roll_motion_from_roll_period(self):
+        sc = _sweep_case(roll_period_s=6.0)
+        case = map_sweep_case_to_openfoam_case(sc, _spec())
+        assert case.motion is not None
+        assert case.motion.motion_type is MotionType.ROLL
+        assert case.motion.period == pytest.approx(6.0)
+        assert case.motion.amplitude == pytest.approx(5.0)
+        assert case.motion.frequency_hz == pytest.approx(sc.roll_frequency_hz)
+        assert case.motion.origin == (10.0, 3.0, 0.0)
+
+    def test_defines_inlet_and_outlet_boundary_conditions(self):
+        case = map_sweep_case_to_openfoam_case(_sweep_case(), _spec())
+        patches = {bc.patch_name for bc in case.boundary_conditions}
+        assert "inlet" in patches
+        assert "outlet" in patches
+
+    def test_metadata_carries_case_id_capacity_and_phase_convention(self):
+        sc = _sweep_case(conduit_capacity=0.08)
+        case = map_sweep_case_to_openfoam_case(sc, _spec())
+        assert case.metadata["case_id"] == sc.case_id
+        assert case.metadata["conduit_capacity"] == pytest.approx(0.08)
+        assert isinstance(case.metadata["phase_convention"], str)
+        assert case.metadata["phase_convention"]  # non-empty
+
+    def test_metadata_q_peak_matches_hand_computed_half_sine_law(self):
+        spec = _spec()
+        sc = _sweep_case(fill_fraction=0.50, conduit_capacity=0.08, roll_period_s=6.0)
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        # Independent oracle.
+        capacity = spec.tank_length * spec.tank_width * spec.tank_height
+        v_transfer = 0.08 * capacity
+        f = 1.0 / 6.0
+        q_peak = math.pi * f * v_transfer
+        assert case.metadata["transfer_volume_m3"] == pytest.approx(v_transfer)
+        assert case.metadata["q_peak_m3_s"] == pytest.approx(q_peak)
+
+    def test_rejects_spec_inconsistent_with_sweep_fill_depth(self):
+        # sweep fill_depth built on tank_height=10; spec says 12 -> inconsistent.
+        sc = _sweep_case(fill_fraction=0.5, tank_height=10.0)
+        with pytest.raises(ValueError, match="fill_depth"):
+            map_sweep_case_to_openfoam_case(sc, _spec(tank_height=12.0))
+
+
+# ============================================================================
+# Verification gate
+# ============================================================================
+
+
+class TestGatePasses:
+    def test_gate_passes_for_feasible_case(self):
+        spec = _spec()
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        assert isinstance(result, VerificationResult)
+        assert result.passed is True
+        assert result.feasible is True
+        assert result.boundary_conditions_ok is True
+
+    def test_gate_pulse_integral_identity(self):
+        spec = _spec()
+        sc = _sweep_case(conduit_capacity=0.08, roll_period_s=6.0)
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        capacity = spec.tank_length * spec.tank_width * spec.tank_height
+        v_transfer = 0.08 * capacity
+        q_peak = math.pi * (1.0 / 6.0) * v_transfer
+        # V_transfer == Q_peak * T / pi (the volume-integral identity).
+        assert result.q_peak_m3_s == pytest.approx(q_peak)
+        assert result.pulse_integral_m3 == pytest.approx(v_transfer)
+        assert result.pulse_integral_m3 == pytest.approx(q_peak * 6.0 / math.pi)
+        assert result.transfer_volume_m3 == pytest.approx(v_transfer)
+
+    def test_gate_reports_small_mass_and_volume_residual(self):
+        spec = _spec()
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        assert result.mass_residual_kg < 1e-6
+        assert result.volume_residual_m3 < 1e-9
+
+    def test_gate_passes_zero_capacity_control(self):
+        spec = _spec()
+        sc = _sweep_case(conduit_capacity=0.0)
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        assert result.passed is True
+        assert result.transfer_volume_m3 == pytest.approx(0.0)
+        assert result.q_peak_m3_s == pytest.approx(0.0)
+
+
+class TestGateFailures:
+    def test_rejects_transfer_exceeding_available_liquid_dryout(self):
+        spec = _spec()
+        # source volume = 0.05*1200 = 60; V_transfer = 0.10*1200 = 120 -> dry-out.
+        sc = _sweep_case(fill_fraction=0.05, conduit_capacity=0.10)
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        with pytest.raises(ValueError, match="(?i)dry-out|available liquid"):
+            verify_coupling(case, sc, spec)
+
+    def test_rejects_transfer_exceeding_free_volume_overflow(self):
+        spec = _spec(dest_fill_fraction=0.95)  # dest free = 0.05*1200 = 60
+        sc = _sweep_case(fill_fraction=0.5, conduit_capacity=0.10)  # V_transfer=120
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        with pytest.raises(ValueError, match="(?i)overflow|free volume"):
+            verify_coupling(case, sc, spec)
+
+    def test_rejects_missing_boundary_conditions(self):
+        spec = _spec()
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        case.boundary_conditions = []  # strip the inlet/outlet BCs
+        with pytest.raises(ValueError, match="(?i)inlet|outlet|boundary"):
+            verify_coupling(case, sc, spec)
+
+    def test_rejects_non_conserving_plan_tampered_q_peak(self):
+        spec = _spec()
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        # Corrupt the recorded flow law so Q_peak*T/pi != V_transfer.
+        case.metadata["q_peak_m3_s"] = case.metadata["q_peak_m3_s"] * 2.0
+        with pytest.raises(ValueError, match="(?i)conserv|pulse|q_peak|integral"):
+            verify_coupling(case, sc, spec)
+
+    def test_rejects_missing_phase_convention(self):
+        spec = _spec()
+        sc = _sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        del case.metadata["phase_convention"]
+        with pytest.raises(ValueError, match="(?i)phase convention"):
+            verify_coupling(case, sc, spec)
+
+
+# ============================================================================
+# Synthetic case + manifest
+# ============================================================================
+
+
+class TestSyntheticCase:
+    def test_synthetic_spec_and_case_are_feasible_and_pass_gate(self):
+        spec = synthetic_coupling_spec()
+        sc = synthetic_sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        assert result.passed is True
+
+    def test_emit_returns_buildable_case_that_passes_gate(self):
+        synthetic = emit_synthetic_gravity_exchange_case()
+        assert isinstance(synthetic, SyntheticCase)
+        assert synthetic.verification.passed is True
+        assert synthetic.case.solver_config.is_multiphase is True
+
+    def test_builder_emits_case_tree_with_key_dicts(self, tmp_path):
+        synthetic = emit_synthetic_gravity_exchange_case()
+        case_dir = OpenFOAMCaseBuilder(synthetic.case).build(tmp_path)
+        assert (case_dir / "system" / "controlDict").is_file()
+        assert (case_dir / "system" / "blockMeshDict").is_file()
+        # motion -> dynamicMeshDict ; partial fill -> setFieldsDict
+        assert (case_dir / "constant" / "dynamicMeshDict").is_file()
+        assert (case_dir / "system" / "setFieldsDict").is_file()
+
+    def test_manifest_has_case_id_inputs_solver_and_hash(self):
+        synthetic = emit_synthetic_gravity_exchange_case()
+        m = synthetic.manifest
+        assert isinstance(m, CaseManifest)
+        assert m.case_id == synthetic.case.name
+        assert isinstance(m.inputs, dict) and m.inputs
+        assert isinstance(m.solver, dict) and m.solver.get("solver_name") == "interFoam"
+        assert m.content_hash and len(m.content_hash) >= 8
+
+    def test_manifest_is_deterministic(self):
+        a = emit_synthetic_gravity_exchange_case().manifest
+        b = emit_synthetic_gravity_exchange_case().manifest
+        assert a.content_hash == b.content_hash
+
+    def test_manifest_carries_no_absolute_paths(self):
+        m = emit_synthetic_gravity_exchange_case().manifest
+
+        def _walk(obj):
+            if isinstance(obj, dict):
+                for v in obj.values():
+                    yield from _walk(v)
+            elif isinstance(obj, (list, tuple)):
+                for v in obj:
+                    yield from _walk(v)
+            elif isinstance(obj, str):
+                yield obj
+
+        for s in _walk({"inputs": m.inputs, "solver": m.solver}):
+            assert not s.startswith("/"), f"absolute path leaked: {s!r}"
+            assert ":\\" not in s, f"windows abs path leaked: {s!r}"
+
+    def test_build_case_manifest_matches_metadata_flow_law(self):
+        spec = synthetic_coupling_spec()
+        sc = synthetic_sweep_case()
+        case = map_sweep_case_to_openfoam_case(sc, spec)
+        result = verify_coupling(case, sc, spec)
+        m = build_case_manifest(case, sc, spec, result)
+        assert m.transfer_volume_m3 == pytest.approx(case.metadata["transfer_volume_m3"])
+        assert m.q_peak_m3_s == pytest.approx(case.metadata["q_peak_m3_s"])

--- a/tests/solvers/openfoam/test_gravity_conduit.py
+++ b/tests/solvers/openfoam/test_gravity_conduit.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for the gravity-driven conduit exchange model (#1528 slice 2).
+Covers signed hydrostatic head, the Cd/A/conduit-loss flow law, flow reversal,
+volume/mass conservation under coupled draining, and dry-out/overflow rejection.
+
+The numerical integrator is checked against an independent closed-form Torricelli
+draining oracle -- the analytic answer never comes from the code under test. No
+OpenFOAM installation or CFD data is required.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.solvers.openfoam.gravity_conduit import (
+    ConduitGeometry,
+    GravityExchangeResult,
+    TankState,
+    check_transfer_feasibility,
+    conduit_flow_rate,
+    signed_hydrostatic_head,
+    simulate_gravity_exchange,
+    G_STANDARD,
+)
+
+
+# ============================================================================
+# TankState geometry + validation
+# ============================================================================
+
+
+def test_tank_state_derived_geometry():
+    tank = TankState(volume=6.0, plan_area=4.0, height=3.0, floor_elevation=1.0)
+    assert tank.capacity == pytest.approx(12.0)
+    assert tank.fill_fraction == pytest.approx(0.5)
+    assert tank.liquid_depth == pytest.approx(1.5)          # 6 / 4
+    assert tank.surface_elevation == pytest.approx(2.5)     # floor 1.0 + depth 1.5
+    assert tank.free_volume == pytest.approx(6.0)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(volume=-1.0, plan_area=1.0, height=1.0),   # dry-out below empty
+        dict(volume=2.0, plan_area=1.0, height=1.0),    # overflow above capacity
+        dict(volume=0.5, plan_area=0.0, height=1.0),    # non-physical area
+        dict(volume=0.5, plan_area=1.0, height=0.0),    # non-physical height
+    ],
+)
+def test_tank_state_rejects_impossible_states(kwargs):
+    with pytest.raises(ValueError):
+        TankState(**kwargs)
+
+
+# ============================================================================
+# Signed hydrostatic head
+# ============================================================================
+
+
+def test_head_zero_when_surfaces_level():
+    a = TankState(volume=5.0, plan_area=2.0, height=5.0)          # depth 2.5
+    b = TankState(volume=2.5, plan_area=1.0, height=5.0)          # depth 2.5
+    assert signed_hydrostatic_head(a, b) == pytest.approx(0.0)
+
+
+def test_head_sign_follows_higher_surface():
+    high = TankState(volume=4.0, plan_area=1.0, height=5.0)       # surf 4.0
+    low = TankState(volume=1.0, plan_area=1.0, height=5.0)        # surf 1.0
+    assert signed_hydrostatic_head(high, low) == pytest.approx(3.0)
+    assert signed_hydrostatic_head(low, high) == pytest.approx(-3.0)
+
+
+def test_head_accounts_for_floor_elevation():
+    # Same liquid depth (1 m) but source floor is 2 m higher -> head +2 m.
+    src = TankState(volume=1.0, plan_area=1.0, height=5.0, floor_elevation=2.0)
+    dst = TankState(volume=1.0, plan_area=1.0, height=5.0, floor_elevation=0.0)
+    assert signed_hydrostatic_head(src, dst) == pytest.approx(2.0)
+
+
+# ============================================================================
+# Cd / A / conduit-loss flow law
+# ============================================================================
+
+
+def test_flow_law_matches_orifice_equation():
+    conduit = ConduitGeometry(area=0.02, discharge_coefficient=0.6)
+    head = 1.5
+    expected = 0.6 * 0.02 * math.sqrt(2.0 * G_STANDARD * head)
+    assert conduit_flow_rate(head, conduit) == pytest.approx(expected)
+
+
+def test_zero_head_gives_zero_flow():
+    conduit = ConduitGeometry(area=0.02)
+    assert conduit_flow_rate(0.0, conduit) == 0.0
+
+
+def test_minor_and_friction_losses_reduce_effective_cd():
+    lossless = ConduitGeometry(area=0.02, discharge_coefficient=1.0)
+    # K_total = minor 3.0 + friction f*L/D = 0.02*50/0.1 = 10 -> 13
+    lossy = ConduitGeometry(
+        area=0.02,
+        discharge_coefficient=1.0,
+        loss_coefficient=3.0,
+        friction_factor=0.02,
+        length=50.0,
+        diameter=0.1,
+    )
+    assert lossy.total_loss_coefficient == pytest.approx(13.0)
+    assert lossy.effective_discharge_coefficient == pytest.approx(
+        1.0 / math.sqrt(1.0 + 13.0)
+    )
+    # More loss -> strictly less flow for the same head.
+    assert abs(conduit_flow_rate(2.0, lossy)) < abs(conduit_flow_rate(2.0, lossless))
+
+
+def test_conduit_rejects_partial_friction_spec():
+    with pytest.raises(ValueError):
+        ConduitGeometry(area=0.02, friction_factor=0.02, length=50.0)  # diameter missing
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(area=0.0),
+        dict(area=0.02, discharge_coefficient=0.0),
+        dict(area=0.02, discharge_coefficient=1.5),
+        dict(area=0.02, loss_coefficient=-1.0),
+    ],
+)
+def test_conduit_rejects_impossible_parameters(kwargs):
+    with pytest.raises(ValueError):
+        ConduitGeometry(**kwargs)
+
+
+# ============================================================================
+# Flow reversal
+# ============================================================================
+
+
+def test_flow_reverses_with_head_sign():
+    conduit = ConduitGeometry(area=0.02)
+    forward = conduit_flow_rate(1.0, conduit)
+    backward = conduit_flow_rate(-1.0, conduit)
+    assert forward > 0.0
+    assert backward < 0.0
+    assert forward == pytest.approx(-backward)          # symmetric magnitude
+
+
+def test_reversal_flagged_and_conserved_under_oscillating_external_head():
+    # A steady geometric head of +0.5 m plus a larger sinusoidal head (roll-like)
+    # forces the sign of the driving head -- and thus the flow -- to flip.
+    src = TankState(volume=5.0, plan_area=2.0, height=5.0)
+    dst = TankState(volume=5.0, plan_area=2.0, height=5.0)
+    conduit = ConduitGeometry(area=0.005)
+    result = simulate_gravity_exchange(
+        src,
+        dst,
+        conduit,
+        duration=20.0,
+        dt=0.01,
+        external_head=lambda t: 1.0 * math.sin(2.0 * math.pi * t / 5.0),
+    )
+    assert result.reversed_flow is True
+    assert min(result.flow_rate) < 0.0 < max(result.flow_rate)
+    # Volume conserved exactly even as the head changes sign.
+    total0 = result.source_volume[0] + result.dest_volume[0]
+    for vs, vd in zip(result.source_volume, result.dest_volume):
+        assert vs + vd == pytest.approx(total0, abs=1e-9)
+
+
+# ============================================================================
+# Volume and mass conservation (+ analytic drain oracle)
+# ============================================================================
+
+
+def test_numeric_drain_matches_torricelli_analytic():
+    # Tank draining through a bottom conduit into an effectively fixed reservoir.
+    plan_area = 1.0
+    h0 = 1.0
+    src = TankState(volume=h0 * plan_area, plan_area=plan_area, height=2.0)
+    # Huge, near-empty reservoir -> its surface stays ~0, so head ~= source depth.
+    reservoir = TankState(volume=0.0, plan_area=1.0e12, height=1.0e6)
+    conduit = ConduitGeometry(area=0.01, discharge_coefficient=0.6)
+
+    duration = 30.0
+    result = simulate_gravity_exchange(
+        src, reservoir, conduit, duration=duration, dt=0.005, density=1000.0
+    )
+
+    cd_eff = conduit.effective_discharge_coefficient
+    k = cd_eff * conduit.area * math.sqrt(2.0 * G_STANDARD) / (2.0 * plan_area)
+    t_empty = math.sqrt(h0) / k
+    t = min(duration, 0.9 * t_empty)
+    sqrt_h = math.sqrt(h0) - k * t
+    h_analytic = sqrt_h * sqrt_h
+    transferred_analytic = (h0 - h_analytic) * plan_area
+
+    # Find the simulated transferred volume at time t.
+    idx = min(range(len(result.time)), key=lambda i: abs(result.time[i] - t))
+    transferred_numeric = result.source_volume[0] - result.source_volume[idx]
+    assert transferred_numeric == pytest.approx(transferred_analytic, rel=2e-3)
+
+
+def test_two_tank_exchange_reaches_level_equilibrium_and_conserves_mass():
+    src = TankState(volume=8.0, plan_area=2.0, height=5.0)      # surf 4.0
+    dst = TankState(volume=1.0, plan_area=1.0, height=5.0)      # surf 1.0
+    conduit = ConduitGeometry(area=0.05)
+    density = 1025.0
+    result = simulate_gravity_exchange(
+        src, dst, conduit, duration=600.0, dt=0.02, density=density
+    )
+
+    assert result.termination == "equilibrium"
+
+    # Analytic equilibrium: equal surface elevations, total volume preserved.
+    v_total = 8.0 + 1.0
+    # floor_s + Vs/As = floor_d + Vd/Ad ; Vs + Vd = v_total ; floors = 0
+    #  Vs/2 = (v_total - Vs)/1  -> Vs = 2*v_total/3
+    vs_eq = 2.0 * v_total / 3.0
+    assert result.source_volume[-1] == pytest.approx(vs_eq, abs=1e-3)
+
+    # Volume + mass conservation.
+    assert result.source_volume[-1] + result.dest_volume[-1] == pytest.approx(
+        v_total, abs=1e-9
+    )
+    assert result.mass_residual == pytest.approx(0.0, abs=1e-6)
+    assert result.transferred_volume == pytest.approx(8.0 - vs_eq, abs=1e-3)
+
+
+# ============================================================================
+# Dry-out / overflow rejection
+# ============================================================================
+
+
+def test_transfer_feasibility_rejects_dryout_and_overflow():
+    src = TankState(volume=2.0, plan_area=1.0, height=10.0)     # 2 m3 available
+    dst = TankState(volume=9.0, plan_area=1.0, height=10.0)     # 1 m3 free
+    check_transfer_feasibility(src, dst, 1.0)                   # ok: within both
+    with pytest.raises(ValueError, match="dry"):
+        check_transfer_feasibility(src, dst, 3.0)              # more than source has
+    with pytest.raises(ValueError, match="overflow"):
+        check_transfer_feasibility(src, dst, 1.5)             # more than dest free vol
+
+
+def test_simulation_rejects_overflow_when_requested():
+    # Elevated source (floor +5 m) drives flow down into a nearly full
+    # destination; reject_overflow -> raise before the destination brims over.
+    src = TankState(volume=9.0, plan_area=5.0, height=2.0, floor_elevation=5.0)  # surf 6.8
+    dst = TankState(volume=1.95, plan_area=1.0, height=2.0)     # 0.05 m3 free, surf 1.95
+    conduit = ConduitGeometry(area=0.05)
+    with pytest.raises(ValueError, match="overflow"):
+        simulate_gravity_exchange(
+            src, dst, conduit, duration=100.0, dt=0.01, reject_overflow=True
+        )
+
+
+def test_simulation_rejects_dryout_when_requested():
+    # Source empties while the (much lower) reservoir keeps the head positive, so
+    # the flow law would keep pulling liquid that no longer exists -> genuine
+    # dry-out, distinct from a level equilibrium.
+    src = TankState(volume=0.05, plan_area=1.0, height=2.0)                 # surf 0.05
+    dst = TankState(volume=0.0, plan_area=1.0e9, height=1.0e3, floor_elevation=-50.0)
+    conduit = ConduitGeometry(area=0.02)
+    with pytest.raises(ValueError, match="dry"):
+        simulate_gravity_exchange(
+            src, dst, conduit, duration=100.0, dt=0.01, reject_dryout=True
+        )
+
+
+def test_simulation_clamps_and_flags_dryout_without_reject():
+    src = TankState(volume=0.05, plan_area=1.0, height=2.0)
+    dst = TankState(volume=0.0, plan_area=1.0e9, height=1.0e3, floor_elevation=-50.0)
+    conduit = ConduitGeometry(area=0.02)
+    result = simulate_gravity_exchange(
+        src, dst, conduit, duration=100.0, dt=0.01, reject_dryout=False
+    )
+    assert result.termination == "source_dry"
+    # Never goes negative and never loses mass.
+    assert min(result.source_volume) >= 0.0
+    assert result.source_volume[-1] == pytest.approx(0.0, abs=1e-9)
+    assert result.source_volume[-1] + result.dest_volume[-1] == pytest.approx(
+        0.05, abs=1e-9
+    )
+
+
+def test_no_flow_when_conduit_invert_above_both_surfaces():
+    # Conduit connection sits above both liquid surfaces -> not submerged -> no flow.
+    src = TankState(volume=1.0, plan_area=1.0, height=10.0)     # surf 1.0
+    dst = TankState(volume=0.5, plan_area=1.0, height=10.0)     # surf 0.5
+    conduit = ConduitGeometry(area=0.05, invert_elevation=5.0)
+    result = simulate_gravity_exchange(src, dst, conduit, duration=50.0, dt=0.05)
+    assert result.transferred_volume == pytest.approx(0.0, abs=1e-12)
+    assert result.termination == "no_flow"
+
+
+def test_result_type_is_returned():
+    src = TankState(volume=2.0, plan_area=1.0, height=5.0)
+    dst = TankState(volume=1.0, plan_area=1.0, height=5.0)
+    result = simulate_gravity_exchange(
+        src, dst, ConduitGeometry(area=0.02), duration=1.0, dt=0.1
+    )
+    assert isinstance(result, GravityExchangeResult)
+    assert len(result.time) == len(result.flow_rate) == len(result.source_volume)

--- a/tests/solvers/openfoam/test_report.py
+++ b/tests/solvers/openfoam/test_report.py
@@ -129,7 +129,10 @@ def make_manifest():
     return {
         "schema_version": "1.0.0",
         "study_name": "Partial-Fill Sloshing Screening",
-        "provenance": "/mnt/local-analysis/secret-client/run_2026/manifest.json",
+        # Deliberately dev/client-looking absolute path: this fixture verifies the
+        # report scrubs it to a basename (asserted below). Exempted from the
+        # no-abs-paths CI gate because the literal is the test's adversarial input.
+        "provenance": "/mnt/local-analysis/secret-client/run_2026/manifest.json",  # abs-path-allowed
         "cases": cases,
         "content_hash": "abc123def456",
     }

--- a/tests/solvers/openfoam/test_report.py
+++ b/tests/solvers/openfoam/test_report.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""ABOUTME: Tests for the OpenFOAM sloshing HTML engineering report layer (#1528).
+
+Fixture-first: sibling sweep/extraction modules are not on origin/main, so these
+tests define small synthetic, de-identified fixtures shaped like the real
+``sloshing_sweep.SweepCase`` / ``time_history.SynchronizedTimeHistory`` outputs
+and render the report from those plain shapes.
+"""
+
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+
+import pytest
+
+from digitalmodel.solvers.openfoam.report import (
+    render_aggregate_report,
+    render_case_report,
+    REQUIRED_SECTIONS,
+)
+
+
+# ============================================================================
+# Fixtures shaped like the real sibling schemas
+# ============================================================================
+
+
+def _channel(values, units, source_field, provenance="synthetic"):
+    """Build a channel dict mirroring SynchronizedTimeHistory channel shape."""
+    return {
+        "values": list(values),
+        "units": units,
+        "source_field": source_field,
+        "provenance": provenance,
+    }
+
+
+def make_history(
+    case_id="case_00",
+    *,
+    mass_balance_ok=True,
+    dry_out=False,
+    overflow=False,
+    impact=False,
+    mass_balance_residual=1.0e-4,
+):
+    """Synthetic SynchronizedTimeHistory-like mapping (de-identified)."""
+    t = [0.0, 0.5, 1.0, 1.5, 2.0]
+    return {
+        "case_id": case_id,
+        "time": t,
+        "channels": {
+            "free_surface_elevation": _channel(
+                [0.0, 0.12, 0.31, 0.18, 0.05], "m", "alpha.water"
+            ),
+            "elevation_max": _channel(
+                [0.0, 0.12, 0.31, 0.31, 0.31], "m", "alpha.water"
+            ),
+            "wall_pressure": _channel(
+                [1000.0, 1400.0, 2200.0, 1600.0, 1100.0], "Pa", "p_rgh"
+            ),
+            "liquid_mass": _channel(
+                [500.0, 500.1, 499.9, 500.0, 500.05], "kg", "alpha.water"
+            ),
+            "com_x": _channel([0.0, 0.02, 0.05, 0.03, 0.01], "m", "alpha.water"),
+            "com_y": _channel([0.0, 0.0, 0.0, 0.0, 0.0], "m", "alpha.water"),
+            "com_z": _channel([0.4, 0.41, 0.44, 0.42, 0.40], "m", "alpha.water"),
+            "inlet_flow_rate": _channel(
+                [0.0, 1.2, 2.4, 1.1, 0.2], "m^3/s", "phi"
+            ),
+            "outlet_flow_rate": _channel(
+                [0.0, 0.1, 0.9, 1.5, 0.4], "m^3/s", "phi"
+            ),
+            "roll_angle": _channel([0.0, 5.0, 0.0, -5.0, 0.0], "deg", "prescribed"),
+        },
+        "validation": {
+            "synchronized_time": t,
+            "mass_balance_residual": mass_balance_residual,
+            "mass_balance_ok": mass_balance_ok,
+            "dry_out": dry_out,
+            "overflow": overflow,
+            "impact": impact,
+        },
+        "metadata": {"solver": "gravity_conduit_surrogate", "n_samples": len(t)},
+    }
+
+
+def make_case(
+    case_id="case_00",
+    *,
+    fill_fraction=0.5,
+    period_ratio=1.0,
+    near_resonance=True,
+):
+    """Synthetic SweepCase-like mapping."""
+    natural_period = 2.0
+    return {
+        "case_id": case_id,
+        "fill_fraction": fill_fraction,
+        "fill_depth": fill_fraction * 1.0,
+        "conduit_capacity": 3.5,
+        "period_ratio": period_ratio,
+        "natural_frequency_hz": 1.0 / natural_period,
+        "natural_period_s": natural_period,
+        "roll_frequency_hz": 1.0 / (natural_period * period_ratio),
+        "roll_period_s": natural_period * period_ratio,
+        "near_resonance": near_resonance,
+    }
+
+
+def make_manifest():
+    """Synthetic manifest over a fill x period_ratio sweep."""
+    fills = [0.25, 0.5, 0.75]
+    ratios = [0.8, 1.0, 1.2]
+    cases = []
+    i = 0
+    for f in fills:
+        for r in ratios:
+            cases.append(
+                make_case(
+                    case_id=f"case_{i:02d}",
+                    fill_fraction=f,
+                    period_ratio=r,
+                    near_resonance=abs(r - 1.0) < 0.15,
+                )
+            )
+            i += 1
+    return {
+        "schema_version": "1.0.0",
+        "study_name": "Partial-Fill Sloshing Screening",
+        "provenance": "/mnt/local-analysis/secret-client/run_2026/manifest.json",
+        "cases": cases,
+        "content_hash": "abc123def456",
+    }
+
+
+def make_histories_for(manifest, invalid_case_id="case_04"):
+    """One history per case; one is flagged invalid (mass-balance fail + impact)."""
+    out = {}
+    for case in manifest["cases"]:
+        cid = case["case_id"]
+        if cid == invalid_case_id:
+            out[cid] = make_history(
+                case_id=cid,
+                mass_balance_ok=False,
+                impact=True,
+                mass_balance_residual=0.42,
+            )
+        else:
+            out[cid] = make_history(case_id=cid)
+    return out
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+class _Parseable(HTMLParser):
+    def error(self, message):  # pragma: no cover - defensive
+        raise ValueError(message)
+
+
+def _assert_parses(html: str) -> None:
+    parser = _Parseable()
+    parser.feed(html)
+    parser.close()
+
+
+def _assert_no_external_refs(html: str) -> None:
+    low = html.lower()
+    assert "http://" not in low, "external http reference present"
+    assert "https://" not in low, "external https reference present"
+    assert "<link" not in low, "external stylesheet <link> present"
+    assert "cdn" not in low, "CDN reference present"
+    assert "src=" not in low or 'src="data:' in low, "non-data src reference"
+
+
+def _assert_deidentified(html: str) -> None:
+    assert "secret-client" not in html
+    assert "/mnt/" not in html
+    assert "/home/" not in html
+    assert not re.search(r"[A-Za-z]:\\", html), "windows absolute path leaked"
+
+
+# ============================================================================
+# Schema / API tests
+# ============================================================================
+
+
+def test_required_sections_constant():
+    assert REQUIRED_SECTIONS == (
+        "Inputs",
+        "Methodology",
+        "Visualizations",
+        "Validation",
+        "Outputs",
+        "Limitations",
+    )
+
+
+def test_case_report_has_all_required_sections():
+    html = render_case_report(make_history(), make_case())
+    for section in REQUIRED_SECTIONS:
+        assert f'id="{section.lower()}"' in html, f"missing section id {section}"
+        assert section in html, f"missing section heading {section}"
+
+
+def test_aggregate_report_has_all_required_sections():
+    manifest = make_manifest()
+    html = render_aggregate_report(manifest, make_histories_for(manifest))
+    for section in REQUIRED_SECTIONS:
+        assert f'id="{section.lower()}"' in html, f"missing section id {section}"
+        assert section in html, f"missing section heading {section}"
+
+
+# ============================================================================
+# Case-report render tests
+# ============================================================================
+
+
+def test_case_report_is_valid_self_contained_html():
+    html = render_case_report(make_history(), make_case())
+    assert html.lstrip().lower().startswith("<!doctype html>")
+    assert "</html>" in html
+    _assert_parses(html)
+    _assert_no_external_refs(html)
+    _assert_deidentified(html)
+
+
+def test_case_report_embeds_all_required_plots():
+    html = render_case_report(make_history(), make_case())
+    assert html.count("<svg") >= 5
+    for title in (
+        "Free-Surface Elevation",
+        "Wall Pressure",
+        "Liquid Mass",
+        "Center of Mass",
+        "Inlet / Outlet Flow",
+    ):
+        assert title in html, f"missing plot: {title}"
+
+
+def test_case_report_shows_validation_metrics():
+    html = render_case_report(make_history(), make_case())
+    assert "mass_balance" in html.lower() or "mass balance" in html.lower()
+    # a passing case should be marked valid
+    assert "PASS" in html or "valid" in html.lower()
+
+
+def test_case_report_flags_invalid_case():
+    bad = make_history(case_id="case_bad", mass_balance_ok=False, impact=True)
+    html = render_case_report(bad, make_case(case_id="case_bad"))
+    low = html.lower()
+    assert "invalid" in low or "fail" in low or "flag" in low
+
+
+def test_case_report_missing_channels_raises():
+    hist = make_history()
+    del hist["channels"]["wall_pressure"]
+    with pytest.raises(ValueError):
+        render_case_report(hist, make_case())
+
+
+# ============================================================================
+# Aggregate-report render tests
+# ============================================================================
+
+
+def test_aggregate_report_is_valid_self_contained_html():
+    manifest = make_manifest()
+    html = render_aggregate_report(manifest, make_histories_for(manifest))
+    assert html.lstrip().lower().startswith("<!doctype html>")
+    assert "</html>" in html
+    _assert_parses(html)
+    _assert_no_external_refs(html)
+    _assert_deidentified(html)
+
+
+def test_aggregate_report_embeds_heatmaps():
+    manifest = make_manifest()
+    html = render_aggregate_report(manifest, make_histories_for(manifest))
+    assert 'class="heatmap"' in html
+    # heatmaps span both sweep axes
+    assert "Fill Fraction" in html
+    assert "Period Ratio" in html or "T_roll / T_natural" in html
+
+
+def test_aggregate_report_lists_every_case_none_omitted():
+    manifest = make_manifest()
+    html = render_aggregate_report(manifest, make_histories_for(manifest))
+    for case in manifest["cases"]:
+        assert case["case_id"] in html, f"case omitted: {case['case_id']}"
+
+
+def test_aggregate_report_flags_invalid_cases_visibly():
+    manifest = make_manifest()
+    histories = make_histories_for(manifest, invalid_case_id="case_04")
+    html = render_aggregate_report(manifest, histories)
+    # invalid case is present AND flagged, not silently dropped
+    assert "case_04" in html
+    assert "INVALID" in html or 'class="invalid"' in html
+    # count of invalid cases surfaced
+    assert re.search(r"1\s*(invalid|flagged|failed)", html, re.IGNORECASE)
+
+
+def test_aggregate_report_without_histories_still_renders():
+    manifest = make_manifest()
+    html = render_aggregate_report(manifest)
+    for case in manifest["cases"]:
+        assert case["case_id"] in html
+    _assert_no_external_refs(html)
+
+
+def test_aggregate_report_empty_cases_raises():
+    manifest = make_manifest()
+    manifest["cases"] = []
+    with pytest.raises(ValueError):
+        render_aggregate_report(manifest)

--- a/tests/solvers/openfoam/test_sloshing_sweep.py
+++ b/tests/solvers/openfoam/test_sloshing_sweep.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for dm#1528 slice 3 - natural-period calculation and deterministic
+sweep generation (fill fraction x conduit capacity x T_roll/T_natural). Oracles
+are computed independently of the code under test (analytic tanh dispersion,
+plain arithmetic) so the tests remain trustworthy truth sources.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.solvers.openfoam.sloshing_sweep import (
+    GRAVITY,
+    NaturalPeriodResult,
+    SweepCase,
+    SweepConfig,
+    SweepManifest,
+    first_sloshing_natural_period,
+    generate_sweep,
+    period_ratio,
+)
+
+
+# ---------------------------------------------------------------------------
+# Independent analytic oracle for the first sloshing natural period
+# ---------------------------------------------------------------------------
+
+
+def _oracle_natural_period(length, fill_depth, mode=1, gravity=GRAVITY):
+    """Linear-potential tanh dispersion, computed from scratch (not the SUT)."""
+    k = mode * math.pi / length
+    omega = math.sqrt(gravity * k * math.tanh(k * fill_depth))
+    return 2.0 * math.pi / omega
+
+
+# ============================================================================
+# Natural period
+# ============================================================================
+
+
+class TestNaturalPeriod:
+    def test_matches_analytic_oracle(self):
+        length, height, fill = 20.0, 10.0, 0.5
+        res = first_sloshing_natural_period(length, height, fill)
+        expected = _oracle_natural_period(length, fill * height)
+        assert res.natural_period_s == pytest.approx(expected, rel=1e-12)
+
+    def test_frequency_is_inverse_of_period(self):
+        res = first_sloshing_natural_period(20.0, 10.0, 0.4)
+        assert res.natural_frequency_hz == pytest.approx(
+            1.0 / res.natural_period_s, rel=1e-12
+        )
+
+    def test_fill_depth_derived_from_fraction(self):
+        res = first_sloshing_natural_period(20.0, 10.0, 0.25)
+        assert res.fill_depth == pytest.approx(2.5, rel=1e-12)
+
+    def test_provenance_retained(self):
+        res = first_sloshing_natural_period(20.0, 10.0, 0.5)
+        assert isinstance(res, NaturalPeriodResult)
+        assert res.approximation  # non-empty approximation label
+        assert "1528" in res.provenance
+        assert "tanh" in res.provenance.lower()
+
+    def test_higher_fill_gives_shorter_period(self):
+        # tanh(kh) increases with h -> omega increases -> period decreases.
+        low = first_sloshing_natural_period(20.0, 10.0, 0.2).natural_period_s
+        high = first_sloshing_natural_period(20.0, 10.0, 0.8).natural_period_s
+        assert high < low
+
+    @pytest.mark.parametrize("fill", [0.0, 1.0, 1.5, -0.1])
+    def test_rejects_invalid_fill_fraction(self, fill):
+        with pytest.raises(ValueError, match="fill_fraction"):
+            first_sloshing_natural_period(20.0, 10.0, fill)
+
+    def test_rejects_nonpositive_geometry(self):
+        with pytest.raises(ValueError):
+            first_sloshing_natural_period(0.0, 10.0, 0.5)
+        with pytest.raises(ValueError):
+            first_sloshing_natural_period(20.0, 0.0, 0.5)
+
+
+# ============================================================================
+# Period ratio
+# ============================================================================
+
+
+class TestPeriodRatio:
+    def test_basic_ratio(self):
+        assert period_ratio(12.0, 6.0) == pytest.approx(2.0)
+
+    def test_resonance_unity(self):
+        assert period_ratio(6.0, 6.0) == pytest.approx(1.0)
+
+    def test_rejects_nonpositive_natural_period(self):
+        with pytest.raises(ValueError):
+            period_ratio(6.0, 0.0)
+
+    def test_rejects_nonpositive_roll_period(self):
+        with pytest.raises(ValueError):
+            period_ratio(0.0, 6.0)
+
+
+# ============================================================================
+# Sweep generation
+# ============================================================================
+
+
+def _default_config():
+    return SweepConfig(
+        length=20.0,
+        tank_height=10.0,
+        study_name="ref",
+    )
+
+
+class TestSweepGeneration:
+    def test_default_fill_matrix_covers_required_fills(self):
+        cfg = _default_config()
+        fills = sorted({c.fill_fraction for c in generate_sweep(cfg).cases})
+        for required in (0.10, 0.25, 0.40, 0.50, 0.65, 0.80):
+            assert required in fills
+
+    def test_case_count_is_full_factorial(self):
+        cfg = _default_config()
+        man = generate_sweep(cfg)
+        n_fill = len(cfg.fill_fractions)
+        n_cap = len(cfg.conduit_capacities)
+        n_ratio = len(cfg.effective_period_ratios())
+        assert len(man.cases) == n_fill * n_cap * n_ratio
+
+    def test_roll_period_consistent_with_ratio_and_natural_period(self):
+        cfg = _default_config()
+        for case in generate_sweep(cfg).cases:
+            assert case.roll_period_s == pytest.approx(
+                case.period_ratio * case.natural_period_s, rel=1e-12
+            )
+
+    def test_natural_period_matches_oracle_per_case(self):
+        cfg = _default_config()
+        for case in generate_sweep(cfg).cases:
+            expected = _oracle_natural_period(cfg.length, case.fill_depth)
+            assert case.natural_period_s == pytest.approx(expected, rel=1e-12)
+
+    def test_refinement_adds_points_near_resonance(self):
+        cfg = _default_config()
+        ratios = cfg.effective_period_ratios()
+        # There must be strictly more ratios than the base set (refinement added).
+        assert len(ratios) > len(cfg.base_period_ratios)
+        # At least three distinct ratios lie strictly inside the resonance band.
+        band = [
+            r for r in ratios
+            if abs(r - cfg.resonance_center) <= cfg.resonance_band
+        ]
+        assert len(band) >= 3
+
+    def test_near_resonance_flag_matches_band(self):
+        cfg = _default_config()
+        for case in generate_sweep(cfg).cases:
+            expected = abs(case.period_ratio - cfg.resonance_center) <= cfg.resonance_band
+            assert case.near_resonance == expected
+
+    def test_control_no_flow_case_present(self):
+        cfg = _default_config()
+        caps = {c.conduit_capacity for c in generate_sweep(cfg).cases}
+        assert 0.0 in caps  # no-flow control coverage
+
+    def test_case_ids_unique(self):
+        man = generate_sweep(_default_config())
+        ids = [c.case_id for c in man.cases]
+        assert len(ids) == len(set(ids))
+
+    def test_rejects_bad_fill_in_config(self):
+        with pytest.raises(ValueError):
+            generate_sweep(SweepConfig(length=20.0, tank_height=10.0,
+                                       fill_fractions=(0.0,)))
+
+    def test_rejects_negative_conduit_capacity(self):
+        with pytest.raises(ValueError):
+            generate_sweep(SweepConfig(length=20.0, tank_height=10.0,
+                                       conduit_capacities=(-0.1,)))
+
+    def test_rejects_nonpositive_ratio(self):
+        with pytest.raises(ValueError):
+            generate_sweep(SweepConfig(length=20.0, tank_height=10.0,
+                                       base_period_ratios=(0.0,)))
+
+
+# ============================================================================
+# Determinism
+# ============================================================================
+
+
+class TestDeterminism:
+    def test_regeneration_is_bit_identical(self):
+        cfg = _default_config()
+        a = generate_sweep(cfg)
+        b = generate_sweep(cfg)
+        assert [c.case_id for c in a.cases] == [c.case_id for c in b.cases]
+        assert a.content_hash == b.content_hash
+
+    def test_case_id_stable_hash_format(self):
+        man = generate_sweep(_default_config())
+        cid = man.cases[0].case_id
+        assert cid.startswith("ref-")
+        assert len(cid.split("-")[-1]) == 12
+
+    def test_input_change_changes_case_id(self):
+        base = generate_sweep(SweepConfig(length=20.0, tank_height=10.0,
+                                          study_name="ref"))
+        moved = generate_sweep(SweepConfig(length=21.0, tank_height=10.0,
+                                           study_name="ref"))
+        assert base.cases[0].case_id != moved.cases[0].case_id
+
+    def test_manifest_is_frozen(self):
+        man = generate_sweep(_default_config())
+        assert isinstance(man, SweepManifest)
+        with pytest.raises(Exception):
+            man.content_hash = "x"  # frozen dataclass
+
+    def test_deterministic_snapshot(self):
+        """Frozen snapshot of a tiny config: exact IDs must never drift."""
+        cfg = SweepConfig(
+            length=20.0,
+            tank_height=10.0,
+            study_name="snap",
+            fill_fractions=(0.25, 0.50),
+            conduit_capacities=(0.0, 0.05),
+            base_period_ratios=(0.8, 1.0, 1.25),
+            resonance_center=1.0,
+            resonance_band=0.15,
+            resonance_points=3,
+        )
+        man = generate_sweep(cfg)
+        # 2 fills x 2 caps x effective ratios
+        rows = [
+            (c.case_id, c.fill_fraction, c.conduit_capacity,
+             round(c.period_ratio, 6))
+            for c in man.cases
+        ]
+        assert rows == SNAPSHOT_ROWS
+        assert man.content_hash == SNAPSHOT_CONTENT_HASH
+
+
+# Frozen after first green run (deterministic algorithm defines the truth).
+# Regenerate ONLY on an intentional ID-algorithm change; drift here = bug.
+SNAPSHOT_ROWS = [
+    ('snap-6eee2f1988fe', 0.25, 0.0, 0.8),
+    ('snap-9ed81e7b0e77', 0.25, 0.0, 0.85),
+    ('snap-05b0e2f508dc', 0.25, 0.0, 1.0),
+    ('snap-569eff5336b1', 0.25, 0.0, 1.15),
+    ('snap-9321d1018f93', 0.25, 0.0, 1.25),
+    ('snap-2c7968381d03', 0.25, 0.05, 0.8),
+    ('snap-f73bdf5e9ddc', 0.25, 0.05, 0.85),
+    ('snap-eb5abf43f3f5', 0.25, 0.05, 1.0),
+    ('snap-5a4d3cc6044a', 0.25, 0.05, 1.15),
+    ('snap-e369dd69a01c', 0.25, 0.05, 1.25),
+    ('snap-63ded130401d', 0.5, 0.0, 0.8),
+    ('snap-cebf79634685', 0.5, 0.0, 0.85),
+    ('snap-e73b10c9475c', 0.5, 0.0, 1.0),
+    ('snap-600d66aebbd2', 0.5, 0.0, 1.15),
+    ('snap-f82ca54717fc', 0.5, 0.0, 1.25),
+    ('snap-ad76d9fd597a', 0.5, 0.05, 0.8),
+    ('snap-aaad8952f8d0', 0.5, 0.05, 0.85),
+    ('snap-eabb66f7c5de', 0.5, 0.05, 1.0),
+    ('snap-7a208c23bc52', 0.5, 0.05, 1.15),
+    ('snap-10672c5d73c9', 0.5, 0.05, 1.25),
+]
+SNAPSHOT_CONTENT_HASH = "da68b2a708b5b941"

--- a/tests/solvers/openfoam/test_time_history.py
+++ b/tests/solvers/openfoam/test_time_history.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for synchronized CFD time-history extraction (#1528, slice 5).
+Truth comes from independently constructed synthetic sloshing signals (known
+elevation transects, mass/volume balance, flow integrals, roll/response phase
+lag), never from the code under test. Also exercises the per-series units/
+provenance envelope and the synchronized-time / mass-balance / dry-out /
+overflow / impact validation flags.
+"""
+
+import numpy as np
+import pytest
+
+from digitalmodel.solvers.openfoam.time_history import (
+    ExtractionConfig,
+    RawCFDOutputs,
+    SynchronizedTimeHistory,
+    TimeSeriesChannel,
+    ValidationFlags,
+    extract_time_history,
+    phase_lag_deg,
+    validate_synchronized_time,
+)
+
+
+DENSITY = 1025.0  # kg/m^3
+TANK_VOLUME = 100.0  # m^3
+
+
+# ============================================================================
+# Independent synthetic-fixture builders (the oracle)
+# ============================================================================
+
+
+def _cumtrap(y: np.ndarray, x: np.ndarray) -> np.ndarray:
+    """Independent cumulative trapezoid starting at 0 (oracle, not prod code)."""
+    dt = np.diff(x)
+    incr = 0.5 * (y[1:] + y[:-1]) * dt
+    return np.concatenate([[0.0], np.cumsum(incr)])
+
+
+def _build_raw(
+    *,
+    duration: float = 20.0,
+    fs: float = 10.0,
+    roll_amp: float = 0.15,  # rad
+    roll_freq: float = 0.25,  # Hz
+    response_lag_deg: float = 30.0,
+    volume_consistent: bool = True,
+    fill_dip: float = 0.0,
+    fill_bump: float = 0.0,
+    pressure_spike: float = 0.0,
+    case_id: str = "synthetic_tank_case_A",
+) -> RawCFDOutputs:
+    """Build a fully synthetic, de-identified RawCFDOutputs on a common base."""
+    n = int(round(duration * fs))
+    t = np.arange(n) / fs
+
+    # --- roll (imposed motion) and a phase-lagged response driver ---
+    omega = 2.0 * np.pi * roll_freq
+    roll = roll_amp * np.sin(omega * t)
+    lag_rad = np.deg2rad(response_lag_deg)
+
+    # --- free-surface elevation transect (above nominal), n_pos probes ---
+    x_pos = np.array([0.5, 2.0, 4.0, 6.0, 7.5])
+    positions = np.column_stack([x_pos, np.full_like(x_pos, 1.0), np.zeros_like(x_pos)])
+    # Standing-wave-like shape: amplitude grows toward the ends, lags roll.
+    shape = np.cos(np.pi * (x_pos - x_pos.mean()) / (x_pos.max() - x_pos.min()))
+    eta = 0.2 * np.outer(np.sin(omega * t - lag_rad), shape)  # (n, n_pos)
+
+    # --- wall pressure at lower/middle/upper probes (Pa), lags roll ---
+    p_locs = np.array(
+        [[3.0, 1.0, 0.1], [3.0, 1.0, 2.5], [3.0, 1.0, 4.9]]  # z = low/mid/high
+    )
+    base_p = np.array([4.0e4, 2.0e4, 5.0e3])  # hydrostatic-ish per elevation
+    pressure = base_p[None, :] + 3.0e3 * np.sin(omega * t - lag_rad)[:, None]
+    if pressure_spike > 0.0:
+        pressure[n // 2, 0] += pressure_spike  # single impact spike, lower probe
+
+    # --- inlet/outlet flows (m^3/s) ---
+    q_in = 0.5 + 0.1 * np.sin(0.5 * omega * t)
+    q_out = 0.4 + 0.1 * np.cos(0.5 * omega * t)
+
+    # --- liquid volume (m^3): consistent with flows unless told otherwise ---
+    v0 = 50.0
+    if volume_consistent:
+        volume = v0 + _cumtrap(q_in - q_out, t)
+    else:
+        volume = v0 + 5.0 * t  # unrelated to the flows -> residual explodes
+
+    # inject a dry-out dip and/or overflow bump on the fill fraction
+    if fill_dip > 0.0:
+        volume = volume.copy()
+        volume[n // 3] = fill_dip * TANK_VOLUME
+    if fill_bump > 0.0:
+        volume = volume.copy()
+        volume[2 * n // 3] = fill_bump * TANK_VOLUME
+
+    # --- centre of mass (m) ---
+    com = np.column_stack(
+        [
+            3.0 + 0.3 * np.sin(omega * t - lag_rad),
+            np.full(n, 1.0),
+            1.2 + 0.05 * np.sin(2.0 * omega * t),
+        ]
+    )
+
+    return RawCFDOutputs(
+        case_id=case_id,
+        time=t,
+        elevation=eta,
+        elevation_positions=positions,
+        pressure=pressure,
+        pressure_locations=p_locs,
+        liquid_volume=volume,
+        com=com,
+        inlet_flow_rate=q_in,
+        outlet_flow_rate=q_out,
+        roll_angle=roll,
+        density=DENSITY,
+        tank_volume=TANK_VOLUME,
+    )
+
+
+# ============================================================================
+# TimeSeriesChannel envelope: units / provenance / ragged / unsorted
+# ============================================================================
+
+
+def _ok_channel(**over):
+    kw = dict(
+        name="demo",
+        times=np.array([0.0, 1.0, 2.0]),
+        values=np.array([1.0, 2.0, 3.0]),
+        units="m",
+        case_id="c1",
+        source_field="alpha.water",
+        provenance="synthetic",
+    )
+    kw.update(over)
+    return TimeSeriesChannel(**kw)
+
+
+@pytest.mark.parametrize("blank", ["units", "case_id", "source_field", "provenance"])
+def test_channel_requires_units_and_provenance(blank):
+    with pytest.raises(ValueError):
+        _ok_channel(**{blank: ""})
+
+
+def test_channel_ragged_times_values_raises():
+    with pytest.raises(ValueError, match="ragged|length|shape"):
+        _ok_channel(values=np.array([1.0, 2.0]))  # 2 vs 3 times
+
+
+def test_channel_unsorted_time_raises():
+    with pytest.raises(ValueError, match="increasing|sorted"):
+        _ok_channel(times=np.array([0.0, 2.0, 1.0]))
+
+
+def test_channel_scalar_stats():
+    ch = _ok_channel(values=np.array([-2.0, 5.0, 1.0]))
+    assert ch.n_samples == 3
+    assert ch.peak == 5.0
+    assert ch.trough == -2.0
+    assert ch.mean == pytest.approx(4.0 / 3.0)
+    assert not ch.is_multichannel
+
+
+def test_channel_multichannel_spatial_reductions():
+    vals = np.array([[1.0, 3.0, 2.0], [-1.0, 0.0, 4.0]])  # (2 times, 3 locs)
+    ch = _ok_channel(
+        times=np.array([0.0, 1.0]),
+        values=vals,
+        locations=np.array([[0.0, 0, 0], [1, 0, 0], [2, 0, 0]]),
+    )
+    assert ch.is_multichannel
+    np.testing.assert_allclose(ch.spatial_max, [3.0, 4.0])
+    np.testing.assert_allclose(ch.spatial_min, [1.0, -1.0])
+    np.testing.assert_allclose(ch.spatial_mean, [2.0, 1.0])
+
+
+# ============================================================================
+# Synchronized-time validation
+# ============================================================================
+
+
+def test_validate_synchronized_time_accepts_uniform():
+    validate_synchronized_time(np.array([0.0, 0.1, 0.2, 0.3]))
+
+
+def test_validate_synchronized_time_rejects_unsorted():
+    with pytest.raises(ValueError):
+        validate_synchronized_time(np.array([0.0, 0.2, 0.1]))
+
+
+def test_validate_synchronized_time_rejects_nonfinite():
+    with pytest.raises(ValueError):
+        validate_synchronized_time(np.array([0.0, np.nan, 0.2]))
+
+
+def test_from_channels_mismatched_base_raises():
+    a = _ok_channel(name="a", times=np.array([0.0, 1.0, 2.0]))
+    b = _ok_channel(name="b", times=np.array([0.0, 1.0, 2.5]))  # different base
+    with pytest.raises(ValueError, match="synchron|time base|mismatch"):
+        SynchronizedTimeHistory.from_channels(
+            case_id="c1",
+            channels={"a": a, "b": b},
+            validation=ValidationFlags(
+                synchronized_time=True,
+                mass_balance_residual=0.0,
+                mass_balance_ok=True,
+                dry_out=False,
+                overflow=False,
+                impact=False,
+            ),
+        )
+
+
+def test_from_channels_accepts_shared_base():
+    t = np.array([0.0, 1.0, 2.0])
+    a = _ok_channel(name="a", times=t)
+    b = _ok_channel(name="b", times=t.copy(), values=np.array([9.0, 8.0, 7.0]))
+    bundle = SynchronizedTimeHistory.from_channels(
+        case_id="c1",
+        channels={"a": a, "b": b},
+        validation=ValidationFlags(
+            synchronized_time=True,
+            mass_balance_residual=0.0,
+            mass_balance_ok=True,
+            dry_out=False,
+            overflow=False,
+            impact=False,
+        ),
+    )
+    np.testing.assert_allclose(bundle.time, t)
+    assert bundle.validation.synchronized_time is True
+
+
+# ============================================================================
+# RawCFDOutputs input validation
+# ============================================================================
+
+
+def test_raw_rejects_ragged_channel():
+    raw_kwargs = _build_raw()
+    bad_vol = raw_kwargs.liquid_volume[:-1]  # one short
+    with pytest.raises(ValueError):
+        RawCFDOutputs(
+            case_id=raw_kwargs.case_id,
+            time=raw_kwargs.time,
+            elevation=raw_kwargs.elevation,
+            elevation_positions=raw_kwargs.elevation_positions,
+            pressure=raw_kwargs.pressure,
+            pressure_locations=raw_kwargs.pressure_locations,
+            liquid_volume=bad_vol,
+            com=raw_kwargs.com,
+            inlet_flow_rate=raw_kwargs.inlet_flow_rate,
+            outlet_flow_rate=raw_kwargs.outlet_flow_rate,
+            roll_angle=raw_kwargs.roll_angle,
+            density=DENSITY,
+            tank_volume=TANK_VOLUME,
+        )
+
+
+# ============================================================================
+# Extraction: elevation channels
+# ============================================================================
+
+
+def test_extract_elevation_spatial_reductions():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+
+    fse = bundle.channels["free_surface_elevation"]
+    assert fse.units == "m"
+    assert fse.is_multichannel
+    np.testing.assert_allclose(fse.values, raw.elevation)
+    np.testing.assert_allclose(fse.locations, raw.elevation_positions)
+
+    # Independent spatial reductions.
+    np.testing.assert_allclose(
+        bundle.channels["elevation_max"].values, raw.elevation.max(axis=1)
+    )
+    np.testing.assert_allclose(
+        bundle.channels["elevation_min"].values, raw.elevation.min(axis=1)
+    )
+    np.testing.assert_allclose(
+        bundle.channels["elevation_mean"].values, raw.elevation.mean(axis=1)
+    )
+    assert bundle.channels["elevation_max"].units == "m"
+
+
+# ============================================================================
+# Extraction: pressure vs elevation and time
+# ============================================================================
+
+
+def test_extract_pressure_channel_and_profile():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+
+    wp = bundle.channels["wall_pressure"]
+    assert wp.units == "Pa"
+    np.testing.assert_allclose(wp.values, raw.pressure)
+    # locations carry the probe elevations (z) for pressure-vs-elevation.
+    np.testing.assert_allclose(wp.locations[:, 2], raw.pressure_locations[:, 2])
+
+    # pressure-vs-elevation at a chosen instant = (z sorted, p aligned)
+    idx = 5
+    z, p = bundle.pressure_vs_elevation(idx)
+    assert np.all(np.diff(z) >= 0)  # sorted ascending by elevation
+    # lower probe (z=0.1) must read higher pressure than upper (z=4.9)
+    assert p[0] > p[-1]
+
+
+def test_pressure_tap_statistics_reuse():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+    stats = bundle.pressure_tap_statistics()
+    # one entry per pressure probe, reusing pressure_taps.compute_tap_statistics
+    assert len(stats) == raw.pressure.shape[1]
+    for s in stats.values():
+        assert s.peak >= s.mean
+
+
+# ============================================================================
+# Extraction: mass, volume, fill fraction, mass-balance residual
+# ============================================================================
+
+
+def test_mass_volume_fill_fraction():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+
+    np.testing.assert_allclose(
+        bundle.channels["liquid_volume"].values, raw.liquid_volume
+    )
+    assert bundle.channels["liquid_volume"].units == "m^3"
+
+    np.testing.assert_allclose(
+        bundle.channels["liquid_mass"].values, DENSITY * raw.liquid_volume
+    )
+    assert bundle.channels["liquid_mass"].units == "kg"
+
+    np.testing.assert_allclose(
+        bundle.channels["fill_fraction"].values, raw.liquid_volume / TANK_VOLUME
+    )
+    assert bundle.channels["fill_fraction"].units == "1"
+
+
+def test_mass_balance_ok_when_volume_consistent_with_flows():
+    raw = _build_raw(volume_consistent=True)
+    bundle = extract_time_history(raw)
+    assert bundle.validation.mass_balance_ok is True
+    assert abs(bundle.validation.mass_balance_residual) < 1e-6
+
+
+def test_mass_balance_flags_violation():
+    raw = _build_raw(volume_consistent=False)
+    bundle = extract_time_history(raw)
+    assert bundle.validation.mass_balance_ok is False
+    assert bundle.validation.mass_balance_residual > 1e-2
+
+
+# ============================================================================
+# Extraction: flow rates + integrated volumes
+# ============================================================================
+
+
+def test_flow_rates_and_integrated_volume():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+
+    np.testing.assert_allclose(
+        bundle.channels["inlet_flow_rate"].values, raw.inlet_flow_rate
+    )
+    assert bundle.channels["inlet_flow_rate"].units == "m^3/s"
+
+    expected_in = _cumtrap(raw.inlet_flow_rate, raw.time)
+    np.testing.assert_allclose(
+        bundle.channels["inlet_volume"].values, expected_in, rtol=1e-9, atol=1e-9
+    )
+    assert bundle.channels["inlet_volume"].units == "m^3"
+
+
+# ============================================================================
+# Extraction: centre of mass
+# ============================================================================
+
+
+def test_com_channels():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+    np.testing.assert_allclose(bundle.channels["com_x"].values, raw.com[:, 0])
+    np.testing.assert_allclose(bundle.channels["com_y"].values, raw.com[:, 1])
+    np.testing.assert_allclose(bundle.channels["com_z"].values, raw.com[:, 2])
+    for k in ("com_x", "com_y", "com_z"):
+        assert bundle.channels[k].units == "m"
+
+
+# ============================================================================
+# Extraction: roll angle / rate / phase and phase lag
+# ============================================================================
+
+
+def test_roll_angle_rate_phase_channels():
+    raw = _build_raw(roll_amp=0.15, roll_freq=0.25)
+    bundle = extract_time_history(raw)
+
+    np.testing.assert_allclose(bundle.channels["roll_angle"].values, raw.roll_angle)
+    assert bundle.channels["roll_angle"].units == "rad"
+    assert bundle.channels["roll_rate"].units == "rad/s"
+
+    # analytic rate of A*sin(w t) is A*w*cos(w t) (interior points).
+    w = 2.0 * np.pi * 0.25
+    analytic_rate = 0.15 * w * np.cos(w * raw.time)
+    rate = bundle.channels["roll_rate"].values
+    np.testing.assert_allclose(rate[2:-2], analytic_rate[2:-2], atol=0.02)
+
+    assert bundle.channels["roll_phase"].units == "rad"
+
+
+def test_phase_lag_recovers_known_lag():
+    fs = 20.0
+    f = 0.25
+    n = int(round(40.0 * fs))  # integer periods -> bin aligned
+    t = np.arange(n) / fs
+    w = 2.0 * np.pi * f
+    ref = np.sin(w * t)
+    lag = 35.0  # degrees; response lags reference
+    resp = np.sin(w * t - np.deg2rad(lag))
+
+    got = phase_lag_deg(ref, resp, times=t)
+    assert got == pytest.approx(lag, abs=1.0)
+
+
+def test_bundle_phase_lag_roll_vs_response():
+    raw = _build_raw(response_lag_deg=30.0, duration=40.0, fs=20.0)
+    bundle = extract_time_history(raw)
+    lag = bundle.phase_lag_deg("elevation_mean")
+    assert lag == pytest.approx(30.0, abs=3.0)
+
+
+# ============================================================================
+# Validation flags: dry-out / overflow / impact / synchronized
+# ============================================================================
+
+
+def test_dry_out_flag():
+    raw = _build_raw(fill_dip=0.005)  # 0.5% fill -> below default dry-out threshold
+    bundle = extract_time_history(raw)
+    assert bundle.validation.dry_out is True
+    assert bundle.validation.overflow is False
+
+
+def test_overflow_flag():
+    raw = _build_raw(fill_bump=1.05)  # 105% fill -> overflow
+    bundle = extract_time_history(raw)
+    assert bundle.validation.overflow is True
+
+
+def test_impact_flag():
+    cfg = ExtractionConfig(impact_pressure=1.0e5)
+    calm = extract_time_history(_build_raw(), config=cfg)
+    assert calm.validation.impact is False
+
+    hit = extract_time_history(_build_raw(pressure_spike=2.0e5), config=cfg)
+    assert hit.validation.impact is True
+
+
+def test_synchronized_flag_true_for_extracted_bundle():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+    assert bundle.validation.synchronized_time is True
+
+
+# ============================================================================
+# End-to-end: provenance / units on every series + shared time base
+# ============================================================================
+
+
+def test_every_channel_carries_units_and_provenance_on_shared_base():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+
+    assert bundle.channels  # non-empty
+    for name, ch in bundle.channels.items():
+        assert ch.units, f"{name} missing units"
+        assert ch.case_id == raw.case_id, f"{name} wrong case_id"
+        assert ch.source_field, f"{name} missing source_field"
+        assert ch.provenance, f"{name} missing provenance"
+        # every series shares the common time base
+        np.testing.assert_allclose(ch.times, bundle.time)
+
+
+def test_expected_channel_set_present():
+    raw = _build_raw()
+    bundle = extract_time_history(raw)
+    expected = {
+        "free_surface_elevation",
+        "elevation_max",
+        "elevation_min",
+        "elevation_mean",
+        "wall_pressure",
+        "liquid_volume",
+        "fill_fraction",
+        "liquid_mass",
+        "mass_balance_residual",
+        "com_x",
+        "com_y",
+        "com_z",
+        "inlet_flow_rate",
+        "outlet_flow_rate",
+        "inlet_volume",
+        "outlet_volume",
+        "roll_angle",
+        "roll_rate",
+        "roll_phase",
+    }
+    assert expected.issubset(set(bundle.channels))


### PR DESCRIPTION
## Summary

Implements the solver-free, analytically-verifiable reduced-order layers of #1528 (coupled tank fill/drain sloshing study) **plus the OpenFOAM/VOF case-coupling gate**, built via strict TDD across five slices. No OpenFOAM install or client data required.

| Slice | Module | Tests |
|---|---|---|
| 2 — Gravity conduit model | `gravity_conduit.py` | 26 |
| 3 — Natural period + sweep matrix | `sloshing_sweep.py` | 30 |
| 4 — CFD case coupling + verification gate | `case_coupling.py` | 25 |
| 5 — CFD output extraction | `time_history.py` | 31 |
| 6 — HTML report layer | `report.py` | 14 |

**126 new tests pass.**

## What each slice does

- **`gravity_conduit.py`** — signed hydrostatic head; Cd/A/conduit-loss orifice flow law; RK4 exchange integrator conserving volume & mass to machine precision (single-state formulation); flow reversal under imposed oscillating head; dry-out/overflow rejection. Verified vs the analytic Torricelli drainage oracle.
- **`sloshing_sweep.py`** — first sloshing natural period (on the existing `spectral_analysis` dispersion relation); `T_roll/T_natural` ratios; deterministic fill × conduit-capacity × period-ratio matrix (default 6×3×8 = 144 cases) with hash-stable case IDs and a content-hashed manifest, refined near resonance.
- **`case_coupling.py`** — maps each `SweepCase` onto the existing interFoam/VOF case contract (fill_level, ROLL `PrescribedMotion`, inlet/outlet BCs, explicit phase-convention metadata) and runs a **pre-CFD verification gate**: half-sine flow-integral identity `Q_peak = π·f·V_transfer`, mass/volume conservation (via the slice-2 exchange), dry-out/overflow feasibility, and BC checks. Emits a deterministic de-identified case manifest + a synthetic gravity-exchange case that `OpenFOAMCaseBuilder.build()` renders to a full case tree.
- **`time_history.py`** — 19 synchronized channels (elevation / pressure-vs-elevation / mass / volume / COM / inlet-outlet-flow / roll+phase) each carrying units, timestamps, case ID, source field, provenance; validation flags for mass balance, dry-out, overflow, impact, synchronized-time.
- **`report.py`** — self-contained case + aggregate HTML reports with inline-SVG plots and fill × T_roll/T_natural heatmaps (no external/CDN refs), the six required sections (Inputs, Methodology, Visualizations, Validation, Outputs, Limitations), and invalid cases shown flagged (never silently omitted). De-identified output.

## Testing

- **126 new tests pass.** Truth comes from independent oracles (Torricelli drainage, bit-identical hash regeneration, hand-computed flow-law scalars, independently-constructed synthetic signals, DOM/section assertions), not the code under test.
- Full `tests/solvers/openfoam/` suite: **474 passed** excluding two pre-existing env-limited paths (`test_workflow_router.py` needs `assetutilities`; `validation/` needs `scripts/` + reference CSVs absent from a sparse checkout). Neither is touched by this PR.
- `Run Quality Gates` no-abs-paths enforcement satisfied (a deliberate scrub-test adversarial path carries the sanctioned `# abs-path-allowed` marker).
- Exports in `solvers/openfoam/__init__.py` are additive only.

## Scope / out of scope

Addresses acceptance items for the flow-law integral, phase continuity, mass/volume balance, deterministic matrix generation, CFD case mapping + pre-run conservation/feasibility/BC verification, time-history extraction with units/provenance, and HTML case+aggregate report schema. Does **not** include the on-node CFD matrix run (slice 7) or HF publication — those remain follow-ups.

Refs #1528.