### PR TITLE
feat(installation_pamphlet): roll-damping sensitivity band in §3 envelopes (#1538 follow-up)

### DIFF
--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -95,6 +95,24 @@ DEFAULT_OPERATIONS = ["transit", "dp_station_keeping", "heavy_lift"]
 DEFAULT_TP_GRID_S = [6.0, 8.0, 10.0, 12.0, 14.0, 16.0]
 
 # ----------------------------------------------------------------------------
+# Roll-damping sensitivity band (#1538 follow-up). BokaLift 2 diffraction was run
+# at two external roll-damping (B44) levels: zeta = 5% critical -> roll RAO peak
+# 23.5 deg/m; zeta = 10% (bilge keels / appendages) -> roll peak 19.2 deg/m,
+# heave 7.17. Roll is strongly damping-controlled at resonance, so the operation
+# envelopes (limiting Hs vs Tp) are honestly presented as an UNCERTAINTY BAND
+# across the zeta = 5-10% range rather than a single value.
+# ----------------------------------------------------------------------------
+DAMPING_BAND_NOTE = (
+    "Roll-damping sensitivity band: operation envelopes span the zeta = 5-10% "
+    "critical roll-damping range (BokaLift 2 external_damping B44: zeta = 5% -> "
+    "roll RAO peak 23.5 deg/m; zeta = 10% -> 19.2 deg/m, heave 7.17). Roll is "
+    "strongly damping-controlled at resonance, so the limiting Hs at each Tp is "
+    "presented as a range rather than a single value: the lower bound uses the "
+    "low-damping (zeta = 5%) RAO, the upper bound the high-damping (zeta = 10%, "
+    "bilge-keel / appendage) RAO."
+)
+
+# ----------------------------------------------------------------------------
 # Splash-zone (lowering through the wave zone) constants — DNV-RP-H103 (2011)
 # Sec 4 "Lifting through wave zone". Seawater density and g are fixed; the
 # lowering speed and snap/slack-sling margin are documented screening values.
@@ -376,6 +394,64 @@ def compute_envelopes(
     return env_out
 
 
+def compute_envelope_band(
+    rao_basis: str,
+    operations: list[str],
+    tp_grid_s: list[float],
+    rao_artifact_low: str | Path | None,
+    rao_artifact_high: str | Path | None,
+) -> dict[str, Any]:
+    """Roll-damping sensitivity BAND of the operation envelopes (#1538).
+
+    Given a LOW-damping (larger roll response, e.g. zeta = 5% critical) and a
+    HIGH-damping (smaller roll response, e.g. zeta = 10% with bilge keels /
+    appendages) vessel RAO artifact, compute the envelopes for each and zip them
+    into an uncertainty band. Roll is strongly damping-controlled at resonance,
+    so the limiting Hs vs Tp is honestly a range across the zeta = 5-10% bound
+    rather than a single value.
+
+    Returns an ordered dict keyed by operation, each value being::
+
+        {"alpha", "hs_by_tp_low", "hs_by_tp_high", "gov_by_tp_low", "gov_by_tp_high"}
+
+    ``hs_by_tp_low`` / ``hs_by_tp_high`` are the LOWER / UPPER Hs bound at each Tp
+    (``min`` / ``max`` of the two damping cases), so the band is always ORDERED
+    (``low <= high``) by construction. Physically the lower bound is the
+    low-damping (more onerous) case and the upper bound the high-damping case.
+    ``gov_by_tp_*`` carry the governing DOF of the respective bound.
+
+    This is purely additive — it composes :func:`compute_envelopes` twice and
+    leaves that function's signature and callers untouched. Deterministic.
+    """
+    low = compute_envelopes(rao_basis, operations, tp_grid_s, rao_artifact=rao_artifact_low)
+    high = compute_envelopes(rao_basis, operations, tp_grid_s, rao_artifact=rao_artifact_high)
+    band: dict[str, Any] = {}
+    for op in operations:
+        lo, hi = low[op], high[op]
+        hs_low: dict[str, float] = {}
+        hs_high: dict[str, float] = {}
+        gov_low: dict[str, str] = {}
+        gov_high: dict[str, str] = {}
+        for key, a in lo["hs_by_tp"].items():
+            b = hi["hs_by_tp"][key]
+            # order the band by Hs so hs_by_tp_low <= hs_by_tp_high always holds;
+            # track which damping case supplied each bound for the governing DOF.
+            if a <= b:
+                hs_low[key], hs_high[key] = a, b
+                gov_low[key], gov_high[key] = lo["gov_by_tp"][key], hi["gov_by_tp"][key]
+            else:
+                hs_low[key], hs_high[key] = b, a
+                gov_low[key], gov_high[key] = hi["gov_by_tp"][key], lo["gov_by_tp"][key]
+        band[op] = {
+            "alpha": lo["alpha"],
+            "hs_by_tp_low": hs_low,
+            "hs_by_tp_high": hs_high,
+            "gov_by_tp_low": gov_low,
+            "gov_by_tp_high": gov_high,
+        }
+    return band
+
+
 # ---------------------------------------------------------------- splash-zone envelope
 def compute_splashzone_envelope(
     structure: dict[str, Any],
@@ -592,6 +668,7 @@ def build_provenance(
     structure_catalog_used: bool = False,
     splashzone_computed: bool = False,
     rao_from_artifact: bool = False,
+    damping_band: bool = False,
 ) -> dict[str, Any]:
     """Run-state provenance manifest (T1..T8). Pure.
 
@@ -612,6 +689,11 @@ def build_provenance(
     ``"vessel"`` basis is only marked ``actual`` (OrcaWave diffraction) when a REAL
     vessel RAO artifact was actually ingested. With no artifact synced it stays on
     the ship-shaped proxy and carries the "RAO artifact not yet synced" note.
+
+    When ``damping_band`` is True the manifest carries a ``damping_note``
+    (:data:`DAMPING_BAND_NOTE`) recording that the operation envelopes are a
+    zeta = 5-10% roll-damping sensitivity band (roll is damping-controlled at
+    resonance). The T-task list is unchanged (the note is additive).
     """
     runs = list(completed_runs or [])
     prov = _effective_provenance(rao_basis, rao_from_artifact)
@@ -685,7 +767,7 @@ def build_provenance(
             )
         ),
     ]
-    return {
+    manifest: dict[str, Any] = {
         "vessel": vessel_name,
         "rao_basis": rao_basis,
         "rao_provenance": prov,
@@ -693,6 +775,9 @@ def build_provenance(
         "n_completed_runs": len(runs),
         "tasks": tasks,
     }
+    if damping_band:
+        manifest["damping_note"] = DAMPING_BAND_NOTE
+    return manifest
 
 
 # ---------------------------------------------------------------- assembly

--- a/src/digitalmodel/installation/installation_pamphlet/render.py
+++ b/src/digitalmodel/installation/installation_pamphlet/render.py
@@ -455,6 +455,44 @@ def render_pamphlet_html(result: dict[str, Any], generated_label: str | None = N
         else "Computed from the vessel-specific OrcaWave RAO solve."
     )
 
+    BAND = d.get("envelope_band") or {}
+
+    def band_block():
+        """Roll-damping sensitivity band (#1538). Additive: renders only when the
+        result carries an ``envelope_band``; absent -> "" (HTML byte-unchanged)."""
+        if not BAND:
+            return ""
+        labels = {
+            "transit": "Transit / sail-away",
+            "dp_station_keeping": "DP station-keeping",
+            "heavy_lift": "Heavy lift (splash zone)",
+        }
+
+        def cell(b, t):
+            lo = b["hs_by_tp_low"][str(float(t))]
+            hi = b["hs_by_tp_high"][str(float(t))]
+            return f"<td>{lo:.2f}&ndash;{hi:.2f}</td>"
+
+        rows = "".join(
+            f"<tr><td class='l'>{labels.get(op, op)} <small>&alpha;={b['alpha']}</small></td>"
+            + "".join(cell(b, t) for t in TP)
+            + "</tr>"
+            for op, b in BAND.items()
+        )
+        note = d.get("damping_note") or (
+            "Roll-damping sensitivity band across the zeta = 5-10% critical range; "
+            "roll is damping-controlled at resonance."
+        )
+        return (
+            "<h3 class='oph' style='margin-top:18px'>Roll-damping sensitivity band "
+            "(&zeta;=5&ndash;10% critical)</h3>"
+            '<div class="sub">Limiting Hs shown as a range: lower bound = low-damping '
+            "(&zeta;=5%) roll RAO, upper bound = high-damping (&zeta;=10%, "
+            "bilge-keel / appendage) roll RAO. Roll is damping-controlled at resonance.</div>"
+            f'<table><tr><th class="l">Operation</th>{ehead}</tr>{rows}</table>'
+            f'<div class="note">{note}</div>'
+        )
+
     script = _live_monitor_script(d["envelopes"], TP, DPCLASS)
 
     html = f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
@@ -578,7 +616,7 @@ Governing limits are <b>seakeeping</b> and <b>station-keeping</b> (&sect;5–6),
 <p class="sub" style="margin-top:8px">Header row = Tp (s).</p></div>
 </div>
 <div class="note"><b>Envelope basis:</b> {d['envelope_proxy']}. {envelope_note_tail}</div>
-
+{band_block()}
 {splashzone_block()}
 
 <h2>4 &nbsp;Lift Items (reference catalogs)</h2>

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -652,3 +652,148 @@ def test_resolve_rao_artifact_precedence(tmp_path):
     assert calc.resolve_rao_artifact("drillship", [run], "/explicit.json") is None
     # vessel basis with nothing available -> None
     assert calc.resolve_rao_artifact("vessel", [BOKALIFT_RUN], None) is None
+
+
+# ---------------------------------------------------------------- roll-damping sensitivity band (#1538 follow-up)
+# BokaLift 2 was run at two external roll-damping (B44) levels: zeta = 5% critical
+# (roll RAO peak 23.5 deg/m) and zeta = 10% with bilge keels (roll peak 19.2 deg/m).
+# Roll is damping-controlled at resonance, so the operation envelopes are presented
+# as an uncertainty BAND. These tests use SYNTHETIC two-case fixtures (NOT the real
+# 5% artifact): the high-damping case has a SMALLER roll response, so it tolerates a
+# higher limiting Hs. Heave/pitch are kept small so ROLL governs the heavy-lift bound.
+LOW_DAMPING_ROLL = 2.4   # zeta=5% proxy: LARGER roll response (more onerous -> lower Hs)
+HIGH_DAMPING_ROLL = 1.2  # zeta=10% proxy: smaller roll response (bilge keels -> higher Hs)
+
+
+def _rao_set_roll(roll_deg_per_m):
+    """Synthetic fixture RAOSet parametrized by a flat roll magnitude (deg/m).
+
+    Heave/pitch are small so ROLL is the governing DOF of the heavy-lift envelope
+    (the damping-controlled axis) and the ONLY thing that differs between the
+    low- and high-damping bounds. Clearly NOT real vessel data."""
+    import numpy as np
+
+    from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+        DOF,
+        FrequencyData,
+        HeadingData,
+        RAOComponent,
+        RAOSet,
+    )
+
+    periods = np.array([4.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0])
+    freqs = 2.0 * np.pi / periods
+    heads = np.array([0.0, 90.0, 180.0])
+    nf, nh = len(freqs), len(heads)
+
+    def comp(dof, val, unit):
+        mag = np.full((nf, nh), float(val))
+        return RAOComponent(
+            dof=dof,
+            magnitude=mag,
+            phase=np.zeros((nf, nh)),
+            frequencies=FrequencyData(
+                values=freqs, periods=periods, count=nf,
+                min_freq=float(freqs.min()), max_freq=float(freqs.max()),
+            ),
+            headings=HeadingData(
+                values=heads, count=nh,
+                min_heading=float(heads.min()), max_heading=float(heads.max()),
+            ),
+            unit=unit,
+        )
+
+    return RAOSet(
+        vessel_name=f"SYNTHETIC roll={roll_deg_per_m} deg/m (not real data)",
+        analysis_tool="OrcaWave", water_depth=1500.0,
+        surge=comp(DOF.SURGE, 0.0, "m/m"), sway=comp(DOF.SWAY, 0.0, "m/m"),
+        heave=comp(DOF.HEAVE, 0.35, "m/m"),
+        roll=comp(DOF.ROLL, roll_deg_per_m, "deg/m"),
+        pitch=comp(DOF.PITCH, 0.5, "deg/m"), yaw=comp(DOF.YAW, 0.0, "deg/m"),
+        created_date="2026-01-01",
+    )
+
+
+def _write_two_case_artifacts(tmp_path):
+    lo_dir = tmp_path / "lo"
+    hi_dir = tmp_path / "hi"
+    lo_dir.mkdir()
+    hi_dir.mkdir()
+    low_path = _write_rao_artifact(lo_dir, _rao_set_roll(LOW_DAMPING_ROLL))
+    high_path = _write_rao_artifact(hi_dir, _rao_set_roll(HIGH_DAMPING_ROLL))
+    return low_path, high_path
+
+
+def test_compute_envelope_band_is_ordered_and_roll_damping_controlled(tmp_path):
+    low_path, high_path = _write_two_case_artifacts(tmp_path)
+    band = calc.compute_envelope_band(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, low_path, high_path
+    )
+    # shape: every operation carries an ordered low/high band + governing DOFs
+    assert set(band) == set(calc.DEFAULT_OPERATIONS)
+    for op in calc.DEFAULT_OPERATIONS:
+        b = band[op]
+        assert set(b) == {
+            "alpha", "hs_by_tp_low", "hs_by_tp_high", "gov_by_tp_low", "gov_by_tp_high",
+        }
+        for k in b["hs_by_tp_low"]:
+            assert b["hs_by_tp_low"][k] <= b["hs_by_tp_high"][k]  # band ordered
+
+    # physical direction: high-damping (smaller roll) tolerates >= Hs, and the roll
+    # damping ACTUALLY moved the heavy-lift envelope (non-zero band width)
+    low_env = calc.compute_envelopes(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, rao_artifact=low_path
+    )
+    high_env = calc.compute_envelopes(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, rao_artifact=high_path
+    )
+    hl_lo = low_env["heavy_lift"]["hs_by_tp"]
+    hl_hi = high_env["heavy_lift"]["hs_by_tp"]
+    assert all(hl_hi[k] >= hl_lo[k] for k in hl_lo)
+    assert any(hl_hi[k] > hl_lo[k] for k in hl_lo)  # roll damping is the lever
+    # roll governs both heavy-lift bounds (the damping-controlled DOF)
+    assert set(band["heavy_lift"]["gov_by_tp_low"].values()) == {"roll"}
+    assert set(band["heavy_lift"]["gov_by_tp_high"].values()) == {"roll"}
+    # the band bounds are exactly min/max of the two single-damping envelopes
+    for k in hl_lo:
+        assert band["heavy_lift"]["hs_by_tp_low"][k] == pytest.approx(min(hl_lo[k], hl_hi[k]))
+        assert band["heavy_lift"]["hs_by_tp_high"][k] == pytest.approx(max(hl_lo[k], hl_hi[k]))
+
+
+def test_compute_envelopes_signature_unchanged_by_band(tmp_path):
+    """Backward-compat: compute_envelopes still returns the single-value shape."""
+    low_path, _ = _write_two_case_artifacts(tmp_path)
+    env = calc.compute_envelopes(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, rao_artifact=low_path
+    )
+    for op in calc.DEFAULT_OPERATIONS:
+        assert set(env[op]) == {"alpha", "hs_by_tp", "gov_by_tp"}
+
+
+def test_build_provenance_records_damping_band():
+    base = calc.build_provenance([DRILLSHIP_RUN], "drillship")
+    assert "damping_note" not in base  # default: no band recorded
+    prov = calc.build_provenance([DRILLSHIP_RUN], "drillship", damping_band=True)
+    assert "damping-controlled" in prov["damping_note"]
+    assert "5" in prov["damping_note"] and "10" in prov["damping_note"]
+    # task list is unchanged (the note is purely additive)
+    assert [t["id"] for t in prov["tasks"]] == ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"]
+
+
+def test_envelope_band_renders_section(vessel_info, lifts, tmp_path):
+    low_path, high_path = _write_two_case_artifacts(tmp_path)
+    band = calc.compute_envelope_band(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, low_path, high_path
+    )
+    res = _assemble(vessel_info, lifts, "drillship", runs=[DRILLSHIP_RUN])
+    res["envelope_band"] = band
+    res["damping_note"] = calc.DAMPING_BAND_NOTE
+    html = render_pamphlet_html(res, "LBL")
+    assert "Roll-damping sensitivity band" in html
+    assert "damping-controlled at resonance" in html
+    assert "&ndash;" in html  # the "lo&ndash;hi" range cells
+
+    # ABSENT band -> section not rendered, and HTML is byte-identical to plain §3
+    res_plain = _assemble(vessel_info, lifts, "drillship", runs=[DRILLSHIP_RUN])
+    html_plain = render_pamphlet_html(res_plain, "LBL")
+    assert "Roll-damping sensitivity band" not in html_plain


### PR DESCRIPTION
## Roll-damping sensitivity band in installation_pamphlet §3 (#1538 follow-up)

BokaLift 2 diffraction was run at two external roll-damping (B44) levels — ζ=5% critical (roll RAO peak 23.5 deg/m) and ζ=10% with bilge keels/appendages (roll peak 19.2 deg/m). Roll is strongly **damping-controlled at resonance**, so the §3 operation envelopes (limiting Hs vs Tp) are now honestly presented as an **uncertainty band** across the ζ=5–10% range rather than a single value.

### Design (all additive / backward-compatible)
- **`calculations.compute_envelope_band(rao_basis, operations, tp_grid_s, rao_artifact_low, rao_artifact_high)`** — composes the existing `compute_envelopes` twice (low- and high-damping RAO artifacts) and zips them into a per-operation band `{alpha, hs_by_tp_low, hs_by_tp_high, gov_by_tp_low, gov_by_tp_high}`. Bounds are ordered by Hs (`min`/`max`) so `low ≤ high` always holds; the lower bound is the low-damping (more onerous) case. `compute_envelopes` signature and callers are untouched.
- **`render.py` §3** — a new "Roll-damping sensitivity band (ζ=5–10% critical)" sub-block renders the limiting Hs as a range per Tp (e.g. `1.42–2.83`) with a provenance note that roll is damping-controlled at resonance. Rendered **only** when the result carries `envelope_band`; absent → HTML byte-identical to before (determinism preserved, no `datetime.now`).
- **`build_provenance(..., damping_band=True)`** — records a `damping_note` (`DAMPING_BAND_NOTE`) capturing the ζ=5–10% basis. Task list unchanged.

### Tests (synthetic two-case fixtures, `tests/installation/test_installation_pamphlet.py`)
- `test_compute_envelope_band_is_ordered_and_roll_damping_controlled` — band ordered at every Tp; high-damping (smaller roll) tolerates ≥ Hs; roll governs both heavy-lift bounds; band bounds == min/max of the two single envelopes.
- `test_compute_envelopes_signature_unchanged_by_band` — backward-compat shape check.
- `test_build_provenance_records_damping_band` — note present only with the flag; T1–T8 unchanged.
- `test_envelope_band_renders_section` — band section + note + range cells render; absent band → section not rendered.

Fixtures keep heave/pitch small so **roll** is the governing (damping-controlled) DOF — the only axis that differs between the two bounds. No real 5% artifact needed.

ruff (CI gate) clean on all three files. Tests run under the `tests-marine-ops-other` gate.
