### PR TITLE
fix(cfd): coupled inlet as volumetric flow rate + render attached BCs (#1528)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/case_builder.py
+++ b/src/digitalmodel/solvers/openfoam/case_builder.py
@@ -412,8 +412,9 @@ mergePatchPairs
     def _write_zero(self, zero_dir: Path) -> None:
         """Write all initial field files in 0/."""
         is_mp = self._case.solver_config.is_multiphase
-        write_velocity_field(zero_dir)
-        write_pressure_field(zero_dir, is_multiphase=is_mp)
+        bcs = self._case.boundary_conditions
+        write_velocity_field(zero_dir, boundary_conditions=bcs)
+        write_pressure_field(zero_dir, is_multiphase=is_mp, boundary_conditions=bcs)
         write_turbulence_fields(zero_dir, self._case.turbulence_model)
         if is_mp:
-            write_alpha_water(zero_dir)
+            write_alpha_water(zero_dir, boundary_conditions=bcs)

--- a/src/digitalmodel/solvers/openfoam/case_coupling.py
+++ b/src/digitalmodel/solvers/openfoam/case_coupling.py
@@ -74,8 +74,10 @@ PHASE_CONVENTION = (
     "roll x(t)=A*sin(omega*t) [deg]; conduit pulse Q(t)=Q_peak*sin(omega*t) is "
     "taken in phase with roll velocity (positive Q = source->dest inflow at the "
     "inlet patch). Over one half-cycle V_transfer=integral_0^{T/2} Q dt="
-    "Q_peak*T/pi, i.e. Q_peak=pi*f*V_transfer. Inlet U is set to the peak "
-    "conduit velocity Q_peak/A_conduit; outlet is pressure-driven."
+    "Q_peak*T/pi, i.e. Q_peak=pi*f*V_transfer. The inlet is specified as a "
+    "VOLUMETRIC flow rate (flowRateInletVelocity), area-independent, at the mean "
+    "half-cycle rate 2*f*V_transfer so the integral over T/2 equals V_transfer; "
+    "outlet is pressure-driven."
 )
 
 
@@ -250,6 +252,19 @@ def peak_flow_rate(v_transfer: float, roll_period_s: float) -> float:
     return math.pi * f * v_transfer
 
 
+def mean_flow_rate(v_transfer: float, roll_period_s: float) -> float:
+    """Mean half-cycle conduit flow rate 2 * f * V_transfer (m^3/s).
+
+    This is the constant volumetric rate that, held over one half-cycle
+    ``T/2``, transfers exactly ``V_transfer`` (``q_mean * T/2 = V_transfer``).
+    Unlike a face velocity, a volumetric flow rate is independent of the inlet
+    patch area, which is why the exchange inlet BC uses it.
+    """
+    if roll_period_s <= 0.0:
+        raise ValueError(f"roll_period_s must be positive, got {roll_period_s}")
+    return 2.0 * v_transfer / roll_period_s
+
+
 # ============================================================================
 # Mapper: SweepCase -> OpenFOAMCase
 # ============================================================================
@@ -308,9 +323,15 @@ def map_sweep_case_to_openfoam_case(
 
     v_transfer = transfer_volume(sweep_case, spec)
     q_peak = peak_flow_rate(v_transfer, sweep_case.roll_period_s)
-    v_peak = q_peak / spec.conduit.area  # peak conduit velocity for the inlet BC
+    q_mean = mean_flow_rate(v_transfer, sweep_case.roll_period_s)
+    # Diagnostic only: the peak conduit velocity if the conduit area were the
+    # inlet face. The inlet BC itself is specified as a VOLUMETRIC flow rate
+    # (area-independent) so the flux is correct regardless of the inlet patch
+    # area -- imposing q_peak/A_conduit as a face velocity over-fluxed the tank
+    # by the ratio of face area to conduit area (#1528 slice-7 defect fix).
+    v_peak = q_peak / spec.conduit.area
 
-    case.boundary_conditions = _exchange_boundary_conditions(v_peak)
+    case.boundary_conditions = _exchange_boundary_conditions(q_mean)
 
     case.metadata = {
         "case_id": sweep_case.case_id,
@@ -322,6 +343,8 @@ def map_sweep_case_to_openfoam_case(
         "roll_frequency_hz": float(sweep_case.roll_frequency_hz),
         "transfer_volume_m3": float(v_transfer),
         "q_peak_m3_s": float(q_peak),
+        "volumetric_flow_rate_m3_s": float(q_mean),
+        "mean_half_cycle_rate_m3_s": float(q_mean),
         "peak_conduit_velocity_m_s": float(v_peak),
         "phase_convention": PHASE_CONVENTION,
     }
@@ -334,16 +357,21 @@ def map_sweep_case_to_openfoam_case(
     return case
 
 
-def _exchange_boundary_conditions(peak_velocity: float) -> list[BoundaryCondition]:
+def _exchange_boundary_conditions(flow_rate: float) -> list[BoundaryCondition]:
     """Inlet/outlet boundary conditions for the conduit exchange (interFoam).
 
-    The inlet drives the peak conduit velocity (in phase with the roll velocity
-    per the recorded phase convention); the outlet is pressure-driven. Fields
-    are the standard interFoam set (U, p_rgh, alpha.water).
+    The inlet imposes the conduit VOLUMETRIC flow rate via
+    ``flowRateInletVelocity`` (OpenFOAM computes the face velocity as
+    ``Q / A_patch`` internally, so the flux is correct regardless of the inlet
+    patch area); the outlet is pressure-driven. Fields are the standard
+    interFoam set (U, p_rgh, alpha.water).
     """
-    inlet_u = f"uniform ({peak_velocity:.10g} 0 0)"
     return [
-        BoundaryCondition("inlet", BoundaryType.FIXED_VALUE, "U", value=inlet_u),
+        BoundaryCondition(
+            "inlet", BoundaryType.FLOW_RATE_INLET_VELOCITY, "U",
+            value="uniform (0 0 0)",
+            extra={"volumetricFlowRate": f"constant {flow_rate:.10g}"},
+        ),
         BoundaryCondition("inlet", BoundaryType.ZERO_GRADIENT, "p_rgh"),
         BoundaryCondition(
             "inlet", BoundaryType.INLET_OUTLET, "alpha.water",

--- a/src/digitalmodel/solvers/openfoam/initial_fields.py
+++ b/src/digitalmodel/solvers/openfoam/initial_fields.py
@@ -44,92 +44,92 @@ def _foam_header(foam_class: str, foam_object: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# boundaryField rendering (default patches, overridden by attached BCs)
+# ---------------------------------------------------------------------------
+
+
+def _render_patch_block(patch: str, entries) -> str:
+    lines = [f"    {patch}", "    {"]
+    for key, val in entries.items():
+        lines.append(f"        {key}    {val};")
+    lines.append("    }")
+    return "\n".join(lines)
+
+
+def _boundary_field(field: str, defaults, boundary_conditions=None) -> str:
+    """Render a ``boundaryField`` block for ``field``.
+
+    ``defaults`` maps patch name -> ordered dict of foam entries. Any attached
+    :class:`BoundaryCondition` whose ``field`` matches overrides (or adds) that
+    patch's block, so the case builder honours per-case boundary conditions
+    (e.g. a conduit ``flowRateInletVelocity`` inlet) instead of the hardcoded
+    defaults. When no BC targets ``field`` the defaults are emitted verbatim.
+    """
+    overrides = {}
+    for bc in (boundary_conditions or []):
+        if bc.field == field:
+            block = bc.to_foam_dict()[bc.patch_name]
+            overrides[bc.patch_name] = {k: str(v) for k, v in block.items()}
+    blocks = [
+        _render_patch_block(patch, overrides.get(patch, entries))
+        for patch, entries in defaults.items()
+    ]
+    for patch, entries in overrides.items():
+        if patch not in defaults:
+            blocks.append(_render_patch_block(patch, entries))
+    return "boundaryField\n{\n" + "\n".join(blocks) + "\n}\n"
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-def write_velocity_field(zero_dir: Path) -> None:
-    """Write 0/U velocity initial and boundary conditions."""
-    content = _foam_header("volVectorField", "U")
-    content += """
-dimensions  [0 1 -1 0 0 0 0];
-
-internalField   uniform (0 0 0);
-
-boundaryField
-{
-    inlet
-    {
-        type    fixedValue;
-        value   uniform (1 0 0);
-    }
-    outlet
-    {
-        type    zeroGradient;
-    }
-    bottom
-    {
-        type    noSlip;
-    }
-    top
-    {
-        type    slip;
-    }
-    sides
-    {
-        type    symmetry;
-    }
+_U_DEFAULTS = {
+    "inlet": {"type": "fixedValue", "value": "uniform (1 0 0)"},
+    "outlet": {"type": "zeroGradient"},
+    "bottom": {"type": "noSlip"},
+    "top": {"type": "slip"},
+    "sides": {"type": "symmetry"},
 }
 
-"""
-    content += _FOOTER
+
+def write_velocity_field(zero_dir: Path, boundary_conditions=None) -> None:
+    """Write 0/U velocity initial and boundary conditions.
+
+    Attached ``boundary_conditions`` for field ``U`` override the defaults per
+    patch (e.g. a conduit ``flowRateInletVelocity`` inlet).
+    """
+    content = _foam_header("volVectorField", "U")
+    content += "\ndimensions  [0 1 -1 0 0 0 0];\n\ninternalField   uniform (0 0 0);\n\n"
+    content += _boundary_field("U", _U_DEFAULTS, boundary_conditions)
+    content += "\n" + _FOOTER
     (zero_dir / "U").write_text(content)
 
 
-def write_pressure_field(zero_dir: Path, is_multiphase: bool) -> None:
+def write_pressure_field(
+    zero_dir: Path, is_multiphase: bool, boundary_conditions=None
+) -> None:
     """Write 0/p or 0/p_rgh pressure initial and boundary conditions.
 
     For VOF (multiphase) simulations, OpenFOAM uses a modified pressure
     p_rgh = p - rho*g*h. The file is named accordingly so the solver
-    can find it.
+    can find it. Attached ``boundary_conditions`` for the pressure field
+    override the defaults per patch.
     """
     field_name = "p_rgh" if is_multiphase else "p"
     dims = "[1 -1 -2 0 0 0 0]"
-
+    defaults = {
+        "inlet": {"type": "zeroGradient"},
+        "outlet": {"type": "fixedValue", "value": "uniform 0"},
+        "bottom": {"type": "zeroGradient"},
+        "top": {"type": "totalPressure", "p0": "uniform 0"},
+        "sides": {"type": "symmetry"},
+    }
     content = _foam_header("volScalarField", field_name)
-    content += f"""
-dimensions  {dims};
-
-internalField   uniform 0;
-
-boundaryField
-{{
-    inlet
-    {{
-        type    zeroGradient;
-    }}
-    outlet
-    {{
-        type    fixedValue;
-        value   uniform 0;
-    }}
-    bottom
-    {{
-        type    zeroGradient;
-    }}
-    top
-    {{
-        type    totalPressure;
-        p0      uniform 0;
-    }}
-    sides
-    {{
-        type    symmetry;
-    }}
-}}
-
-"""
-    content += _FOOTER
+    content += f"\ndimensions  {dims};\n\ninternalField   uniform 0;\n\n"
+    content += _boundary_field(field_name, defaults, boundary_conditions)
+    content += "\n" + _FOOTER
     # Write to the correct filename for the solver
     (zero_dir / field_name).write_text(content)
 
@@ -155,43 +155,25 @@ def write_turbulence_fields(
         _write_epsilon_field(zero_dir)
 
 
-def write_alpha_water(zero_dir: Path) -> None:
-    """Write 0/alpha.water VOF phase fraction field."""
-    content = _foam_header("volScalarField", "alpha.water")
-    content += """
-dimensions  [0 0 0 0 0 0 0];
-
-internalField   uniform 0;
-
-boundaryField
-{
-    inlet
-    {
-        type    fixedValue;
-        value   uniform 0;
-    }
-    outlet
-    {
-        type    zeroGradient;
-    }
-    bottom
-    {
-        type    zeroGradient;
-    }
-    top
-    {
-        type    inletOutlet;
-        inletValue  uniform 0;
-        value       uniform 0;
-    }
-    sides
-    {
-        type    symmetry;
-    }
+_ALPHA_DEFAULTS = {
+    "inlet": {"type": "fixedValue", "value": "uniform 0"},
+    "outlet": {"type": "zeroGradient"},
+    "bottom": {"type": "zeroGradient"},
+    "top": {"type": "inletOutlet", "inletValue": "uniform 0", "value": "uniform 0"},
+    "sides": {"type": "symmetry"},
 }
 
-"""
-    content += _FOOTER
+
+def write_alpha_water(zero_dir: Path, boundary_conditions=None) -> None:
+    """Write 0/alpha.water VOF phase fraction field.
+
+    Attached ``boundary_conditions`` for ``alpha.water`` override the defaults
+    per patch (e.g. an ``inletOutlet`` inlet that admits water on inflow).
+    """
+    content = _foam_header("volScalarField", "alpha.water")
+    content += "\ndimensions  [0 0 0 0 0 0 0];\n\ninternalField   uniform 0;\n\n"
+    content += _boundary_field("alpha.water", _ALPHA_DEFAULTS, boundary_conditions)
+    content += "\n" + _FOOTER
     (zero_dir / "alpha.water").write_text(content)
 
 

--- a/src/digitalmodel/solvers/openfoam/models.py
+++ b/src/digitalmodel/solvers/openfoam/models.py
@@ -40,6 +40,7 @@ class BoundaryType(Enum):
     INLET_OUTLET = "inletOutlet"
     PRESSURE_INLET_OUTLET_VELOCITY = "pressureInletOutletVelocity"
     TOTAL_PRESSURE = "totalPressure"
+    FLOW_RATE_INLET_VELOCITY = "flowRateInletVelocity"
 
 
 class TurbulenceType(Enum):

--- a/tests/solvers/openfoam/test_conduit_inlet_flux.py
+++ b/tests/solvers/openfoam/test_conduit_inlet_flux.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Regression tests for the coupled-case inlet flux defect (#1528 slice 7
+follow-up). The mapper used to impose the conduit *velocity* Q_peak/A_conduit as
+a fixedValue over the whole inlet face, over-fluxing the tank by the ratio of
+face area to conduit area. The fix specifies a volumetric flow rate
+(flowRateInletVelocity), which is area-independent, and the case builder now
+renders attached boundary conditions into the 0/ fields instead of hardcoding
+them.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.solvers.openfoam.models import BoundaryType, CaseType, OpenFOAMCase
+from digitalmodel.solvers.openfoam.case_builder import OpenFOAMCaseBuilder
+from digitalmodel.solvers.openfoam.gravity_conduit import ConduitGeometry
+from digitalmodel.solvers.openfoam.case_coupling import (
+    CouplingSpec,
+    map_sweep_case_to_openfoam_case,
+    mean_flow_rate,
+    synthetic_sweep_case,
+)
+
+
+def _spec(conduit_area: float) -> CouplingSpec:
+    return CouplingSpec(
+        tank_length=20.0,
+        tank_width=6.0,
+        tank_height=10.0,
+        roll_amplitude_deg=5.0,
+        conduit=ConduitGeometry(area=conduit_area, discharge_coefficient=0.6,
+                                loss_coefficient=1.5),
+        dest_fill_fraction=0.30,
+    )
+
+
+def _inlet_u_bc(case: OpenFOAMCase):
+    return next(
+        bc for bc in case.boundary_conditions
+        if bc.patch_name == "inlet" and bc.field == "U"
+    )
+
+
+# ---------------------------------------------------------------------------
+# mean_flow_rate helper
+# ---------------------------------------------------------------------------
+
+
+def test_mean_flow_rate_integrates_to_transfer_over_half_cycle():
+    # Mean half-cycle rate 2*f*V_transfer, held over T/2, transfers exactly V.
+    v_transfer, period = 60.0, 6.2514
+    q_mean = mean_flow_rate(v_transfer, period)
+    assert q_mean == pytest.approx(2.0 * v_transfer / period)
+    assert q_mean * (period / 2.0) == pytest.approx(v_transfer)
+
+
+# ---------------------------------------------------------------------------
+# The defect: inlet flux must be area-INDEPENDENT
+# ---------------------------------------------------------------------------
+
+
+def test_inlet_flux_is_volumetric_flow_rate_not_raw_velocity():
+    sweep = synthetic_sweep_case()
+    case = map_sweep_case_to_openfoam_case(sweep, _spec(conduit_area=0.5))
+    bc = _inlet_u_bc(case)
+    assert bc.bc_type is BoundaryType.FLOW_RATE_INLET_VELOCITY
+    assert "volumetricFlowRate" in bc.extra
+    # It must encode the mean volumetric rate, not a bare face velocity.
+    q_mean = mean_flow_rate(
+        case.metadata["transfer_volume_m3"], case.metadata["roll_period_s"]
+    )
+    assert str(q_mean)[:6] in bc.extra["volumetricFlowRate"] or \
+        f"{q_mean:.10g}" in bc.extra["volumetricFlowRate"]
+
+
+def test_inlet_flux_independent_of_conduit_area():
+    # Same transfer volume + period, different conduit areas -> IDENTICAL inlet
+    # volumetric flow rate. (The old velocity-based BC scaled with 1/area.)
+    sweep = synthetic_sweep_case()
+    bc_small = _inlet_u_bc(map_sweep_case_to_openfoam_case(sweep, _spec(0.25)))
+    bc_large = _inlet_u_bc(map_sweep_case_to_openfoam_case(sweep, _spec(2.0)))
+    assert bc_small.extra["volumetricFlowRate"] == bc_large.extra["volumetricFlowRate"]
+
+
+def test_metadata_records_volumetric_flow_rate():
+    sweep = synthetic_sweep_case()
+    case = map_sweep_case_to_openfoam_case(sweep, _spec(0.5))
+    q_mean = mean_flow_rate(
+        case.metadata["transfer_volume_m3"], case.metadata["roll_period_s"]
+    )
+    assert case.metadata["volumetric_flow_rate_m3_s"] == pytest.approx(q_mean)
+
+
+# ---------------------------------------------------------------------------
+# The builder must RENDER attached BCs (previously hardcoded/ignored)
+# ---------------------------------------------------------------------------
+
+
+def test_builder_renders_flow_rate_inlet_into_zero_U(tmp_path):
+    sweep = synthetic_sweep_case()
+    case = map_sweep_case_to_openfoam_case(sweep, _spec(0.5))
+    case_dir = OpenFOAMCaseBuilder(case).build(tmp_path)
+    u_text = (case_dir / "0" / "U").read_text()
+    assert "flowRateInletVelocity" in u_text
+    assert "volumetricFlowRate" in u_text
+    # The old bug: a huge bare face velocity like "uniform (60 0 0)" must be gone.
+    assert "uniform (1 0 0)" not in u_text  # default inlet velocity replaced
+
+
+def test_builder_keeps_defaults_without_attached_bcs(tmp_path):
+    # Regression: a plain case (no attached BCs) still gets the default fields.
+    case = OpenFOAMCase.for_case_type(CaseType.SLOSHING, "plain_case")
+    case_dir = OpenFOAMCaseBuilder(case).build(tmp_path)
+    u_text = (case_dir / "0" / "U").read_text()
+    assert "boundaryField" in u_text
+    assert "inlet" in u_text and "outlet" in u_text


### PR DESCRIPTION
## Summary

Fixes a defect found while running the first coupled fill/drain case in interFoam on the CFD node (slice-7 of #1528).

**The bug:** `map_sweep_case_to_openfoam_case` specified the conduit exchange as the peak *velocity* `Q_peak / A_conduit`, imposed as a `fixedValue` over the **entire inlet face**. The resulting flux therefore scaled with the ratio of inlet-face area to conduit area — for the reference tank that over-fluxed by **~120×**, blowing up the Courant number and diverging interFoam. Compounding it, `OpenFOAMCaseBuilder` **hardcoded** the `0/` boundary fields and ignored the case's attached `boundary_conditions` entirely, so the exchange BCs were metadata-only and never actually rendered.

## Fixes
1. **Area-independent flux.** `case_coupling` now specifies the inlet as a **volumetric flow rate** (`flowRateInletVelocity`) at the mean half-cycle rate `2·f·V_transfer`, which integrates to exactly `V_transfer` over `T/2`. OpenFOAM derives the face velocity as `Q / A_patch` internally, so the flux is correct regardless of inlet patch area. Adds `mean_flow_rate()` and `BoundaryType.FLOW_RATE_INLET_VELOCITY`; records `volumetric_flow_rate_m3_s` in metadata (peak velocity retained as a diagnostic only) and updates the phase-convention string.
2. **Builder renders attached BCs.** `write_velocity_field` / `write_pressure_field` / `write_alpha_water` now render a case's attached `boundary_conditions` into the `0/` fields (per-patch overrides), falling back to the previous hardcoded defaults when no BC targets a patch — backward compatible.

## Testing (TDD)
New `test_conduit_inlet_flux.py` (6 tests):
- the inlet flux is **area-independent** (identical `volumetricFlowRate` for different conduit areas — the exact defect);
- `mean_flow_rate` integrates to `V_transfer` over `T/2`;
- the builder emits `flowRateInletVelocity` into `0/U` and still writes defaults for a plain case.

**480 openfoam tests pass** (excluding the two pre-existing env-limited paths: `test_workflow_router.py` needs `assetutilities`; `validation/` needs sparse-checkout data). No regressions in `test_case_coupling`/`test_case_builder`/`test_models`.

## Follow-up
This unblocks CFD-verifying the fill/drain **transfer magnitude** (the roll-only fallback in the prior slice-7 run could not exercise the conduit flow). The full 144-case coupled matrix remains a separate campaign.

Refs #1528.