### PR TITLE
Wire compute_envelope_band into installation_pamphlet §3 (#1538)

### DIFF
--- a/src/digitalmodel/installation/installation_pamphlet/calculations.py
+++ b/src/digitalmodel/installation/installation_pamphlet/calculations.py
@@ -792,6 +792,8 @@ def assemble_result(
     hs_scatter_limits: list[float],
     completed_runs: list[dict[str, Any]],
     rao_artifact: str | Path | None = None,
+    rao_artifact_low: str | Path | None = None,
+    rao_artifact_high: str | Path | None = None,
 ) -> dict[str, Any]:
     """Compose the full deterministic pamphlet ``result`` payload (pure).
 
@@ -800,12 +802,47 @@ def assemble_result(
     ``rao_artifact`` field), the operation envelopes are driven by the REAL
     ingested RAO and provenance is honestly marked ``actual``. Otherwise the
     vessel basis honestly falls back to the ship-shaped proxy.
+
+    Roll-damping sensitivity BAND (#1538). When ``rao_basis == "vessel"`` AND BOTH
+    ``rao_artifact_low`` (low-damping / larger roll / more onerous) and
+    ``rao_artifact_high`` (high-damping / smaller roll) are supplied, the result
+    additionally carries an ``envelope_band`` (from :func:`compute_envelope_band`)
+    plus a ``damping_note``, and the provenance manifest is built with
+    ``damping_band=True`` (so it too carries a ``damping_note``). This drives the
+    §3 roll-damping band section in the rendered pamphlet.
+
+    Single-vs-band behavior (least-surprising, documented): the single-case §3
+    envelopes / table always render. An explicit or completed-run-resolved single
+    ``rao_artifact`` wins as their driver (behavior unchanged from before the
+    band). Otherwise, when a band is active, the single case is driven by the
+    LOW-damping (``rao_artifact_low``, zeta = 5%, more onerous) bound so the
+    single-case table stays conservative and coincides with the band's lower edge;
+    provenance is then honestly ``actual`` (a real vessel RAO drove it). When
+    neither ``rao_artifact_low``/``rao_artifact_high`` is supplied, behavior is
+    EXACTLY as before: no ``envelope_band``/``damping_note`` keys, ``damping_band``
+    defaults false, and the single ``rao_artifact`` path is fully intact.
     """
     artifact_path = resolve_rao_artifact(rao_basis, completed_runs, rao_artifact)
-    rao_from_artifact = artifact_path is not None
+    band_active = bool(
+        rao_basis == "vessel" and rao_artifact_low and rao_artifact_high
+    )
+    # Single-case §3 driver: an explicit/resolved single artifact wins; else, when a
+    # band is configured, drive the single case from the LOW (more-onerous) bound so
+    # the single-case table is conservative and matches the band's lower edge.
+    single_artifact = artifact_path
+    if single_artifact is None and band_active:
+        single_artifact = str(rao_artifact_low)
+    rao_from_artifact = single_artifact is not None
     lift_rows = assess_lifts(vessel_info, lifts, radius_m, daf)
     envelopes = compute_envelopes(
-        rao_basis, operations, tp_grid_s, rao_artifact=artifact_path
+        rao_basis, operations, tp_grid_s, rao_artifact=single_artifact
+    )
+    envelope_band = (
+        compute_envelope_band(
+            rao_basis, operations, tp_grid_s, rao_artifact_low, rao_artifact_high
+        )
+        if band_active
+        else None
     )
     splashzone = compute_splashzone_set(
         lifts, tp_grid_s, heavy_lift_env=envelopes.get("heavy_lift")
@@ -821,8 +858,9 @@ def assemble_result(
         structure_catalog_used=structure_catalog_used,
         splashzone_computed=bool(splashzone),
         rao_from_artifact=rao_from_artifact,
+        damping_band=band_active,
     )
-    return {
+    result: dict[str, Any] = {
         "vessel": vessel_info,
         "lift_radius_m": float(radius_m),
         "daf": float(daf),
@@ -833,8 +871,12 @@ def assemble_result(
         "rao_basis": rao_basis,
         "rao_provenance": _effective_provenance(rao_basis, rao_from_artifact),
         "rao_from_artifact": rao_from_artifact,
-        "rao_artifact": str(artifact_path) if artifact_path else None,
+        "rao_artifact": str(single_artifact) if single_artifact else None,
         "envelope_proxy": _effective_label(rao_basis, rao_from_artifact),
         "op_table": op_table,
         "provenance": provenance,
     }
+    if band_active:
+        result["envelope_band"] = envelope_band
+        result["damping_note"] = DAMPING_BAND_NOTE
+    return result

--- a/src/digitalmodel/installation/installation_pamphlet/workflow.py
+++ b/src/digitalmodel/installation/installation_pamphlet/workflow.py
@@ -52,6 +52,17 @@ def router(cfg: dict) -> dict:
     rao_artifact = (
         str(_config_path(cfg, rao_artifact_cfg)) if rao_artifact_cfg else None
     )
+    # Optional roll-damping sensitivity band (#1538): two vessel RAO artifacts
+    # (low- and high-damping). Resolved like the single artifact; when BOTH are
+    # set on the "vessel" basis, assemble_result renders the §3 band.
+    rao_artifact_low_cfg = settings.get("rao_artifact_low")
+    rao_artifact_low = (
+        str(_config_path(cfg, rao_artifact_low_cfg)) if rao_artifact_low_cfg else None
+    )
+    rao_artifact_high_cfg = settings.get("rao_artifact_high")
+    rao_artifact_high = (
+        str(_config_path(cfg, rao_artifact_high_cfg)) if rao_artifact_high_cfg else None
+    )
 
     result = calc.assemble_result(
         vessel_info=vessel_info,
@@ -64,6 +75,8 @@ def router(cfg: dict) -> dict:
         hs_scatter_limits=hs_scatter_limits,
         completed_runs=completed_runs,
         rao_artifact=rao_artifact,
+        rao_artifact_low=rao_artifact_low,
+        rao_artifact_high=rao_artifact_high,
     )
     html = render_pamphlet_html(result, generated_label)
 

--- a/tests/installation/test_installation_pamphlet.py
+++ b/tests/installation/test_installation_pamphlet.py
@@ -797,3 +797,115 @@ def test_envelope_band_renders_section(vessel_info, lifts, tmp_path):
     res_plain = _assemble(vessel_info, lifts, "drillship", runs=[DRILLSHIP_RUN])
     html_plain = render_pamphlet_html(res_plain, "LBL")
     assert "Roll-damping sensitivity band" not in html_plain
+
+
+def test_assemble_result_wires_envelope_band(vessel_info, lifts, tmp_path):
+    """assemble_result WIRES the band when BOTH damping artifacts are supplied on
+    the "vessel" basis: the result carries an ordered envelope_band + damping_note,
+    provenance records the damping band, the single-case §3 envelopes are driven by
+    the LOW (more-onerous) bound, and the rendered §3 shows the band section."""
+    low_path, high_path = _write_two_case_artifacts(tmp_path)
+    res = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[BOKALIFT_RUN],
+        rao_artifact_low=str(low_path), rao_artifact_high=str(high_path),
+    )
+
+    # the band is present, well-shaped and ORDERED (low <= high) at every Tp
+    band = res["envelope_band"]
+    assert set(band) == set(calc.DEFAULT_OPERATIONS)
+    for op in calc.DEFAULT_OPERATIONS:
+        b = band[op]
+        assert set(b) == {
+            "alpha", "hs_by_tp_low", "hs_by_tp_high", "gov_by_tp_low", "gov_by_tp_high",
+        }
+        for k in b["hs_by_tp_low"]:
+            assert b["hs_by_tp_low"][k] <= b["hs_by_tp_high"][k]
+    # it equals the standalone band builder (assemble_result just wires it)
+    assert band == calc.compute_envelope_band(
+        "vessel", calc.DEFAULT_OPERATIONS, calc.DEFAULT_TP_GRID_S, str(low_path), str(high_path)
+    )
+
+    # provenance + result carry the damping note
+    assert "damping-controlled" in res["provenance"]["damping_note"]
+    assert res["damping_note"] == calc.DAMPING_BAND_NOTE
+
+    # single-case §3 envelopes still render, driven by the LOW (more-onerous) bound;
+    # provenance is honestly "actual" (a real vessel RAO drove them)
+    assert res["envelopes"] == _envelopes_from_rao(_rao_set_roll(LOW_DAMPING_ROLL))
+    assert res["rao_provenance"] == "actual"
+    assert res["rao_from_artifact"] is True
+    assert res["rao_artifact"] == str(low_path)
+
+    # rendered §3 band section is present
+    html = render_pamphlet_html(res, "LBL")
+    assert "Roll-damping sensitivity band" in html
+    assert "damping-controlled at resonance" in html
+    assert "&ndash;" in html  # lo&ndash;hi range cells
+
+
+def test_assemble_result_without_band_is_backward_compatible(vessel_info, lifts, tmp_path):
+    """WITHOUT both damping artifacts, assemble_result is EXACTLY as before: no
+    envelope_band / damping_note keys, no provenance damping_note, unchanged HTML.
+    Both artifacts are REQUIRED; one alone or a non-vessel basis does not band."""
+    low_path, high_path = _write_two_case_artifacts(tmp_path)
+
+    # no band artifacts at all -> unchanged behavior
+    base = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[BOKALIFT_RUN],
+    )
+    assert "envelope_band" not in base
+    assert "damping_note" not in base
+    assert "damping_note" not in base["provenance"]
+    html_base = render_pamphlet_html(base, "LBL")
+    assert "Roll-damping sensitivity band" not in html_base
+
+    # exactly as the pre-band call with the same inputs (byte-identical HTML)
+    prior = _assemble(vessel_info, lifts, "vessel", runs=[BOKALIFT_RUN])
+    assert render_pamphlet_html(prior, "LBL") == html_base
+
+    # only ONE artifact supplied -> band requires BOTH, so no band
+    one = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="vessel", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[BOKALIFT_RUN], rao_artifact_low=str(low_path),
+    )
+    assert "envelope_band" not in one
+
+    # non-vessel basis with BOTH artifacts -> band does not apply
+    drill = calc.assemble_result(
+        vessel_info=vessel_info, lifts=lifts, radius_m=40.0, daf=1.30,
+        rao_basis="drillship", operations=calc.DEFAULT_OPERATIONS,
+        tp_grid_s=calc.DEFAULT_TP_GRID_S, hs_scatter_limits=HS_LIMITS,
+        completed_runs=[DRILLSHIP_RUN],
+        rao_artifact_low=str(low_path), rao_artifact_high=str(high_path),
+    )
+    assert "envelope_band" not in drill
+
+
+def test_router_wires_envelope_band_from_settings(vessel_info, lifts, tmp_path):
+    """The workflow router reads rao_artifact_low / rao_artifact_high from settings
+    (resolved like rao_artifact) and wires the §3 band end-to-end into the HTML."""
+    low_path, high_path = _write_two_case_artifacts(tmp_path)
+    out_dir = tmp_path / "out"
+    cfg = yaml.safe_load(BASE_CONFIG.read_text())
+    cfg["installation_pamphlet"]["output_dir"] = str(out_dir)
+    cfg["installation_pamphlet"]["rao_basis"] = "vessel"
+    cfg["installation_pamphlet"]["rao_artifact_low"] = str(low_path)
+    cfg["installation_pamphlet"]["rao_artifact_high"] = str(high_path)
+    cfg["_config_file_path"] = str(tmp_path / "case.yml")
+
+    out = router(cfg)
+
+    result = out["installation_pamphlet"]["result"]
+    assert "envelope_band" in result
+    assert result["damping_note"] == calc.DAMPING_BAND_NOTE
+    assert "damping-controlled" in result["provenance"]["damping_note"]
+    html = (out_dir / "case_pamphlet.html").read_text()
+    assert "Roll-damping sensitivity band" in html


### PR DESCRIPTION
## What

Wires the already-merged \`compute_envelope_band\` (PR #1543) into the installation_pamphlet workflow so the §3 roll-damping sensitivity band renders when two vessel RAO artifacts are configured. Purely additive and backward-compatible — no client data (synthetic RAO fixtures only).

## Changes

- **\`calculations.assemble_result\`**: two new optional params \`rao_artifact_low=None, rao_artifact_high=None\`. When BOTH are set AND \`rao_basis == "vessel"\`, it calls \`compute_envelope_band(...)\` and adds \`result["envelope_band"]\` + \`result["damping_note"]\`, and builds provenance with \`damping_band=True\`. Otherwise behavior is EXACTLY as before (no new keys, \`damping_band\` false, single \`rao_artifact\` path fully intact).
  - **Single-vs-band decision (documented in the docstring):** the single-case §3 table always renders. An explicit/completed-run-resolved single \`rao_artifact\` still wins as its driver (unchanged). When a band is active with no single artifact, the single case is driven by the LOW-damping (ζ=5%, more-onerous) bound, so the single-case table stays conservative and coincides with the band's lower edge; provenance is then honestly \`actual\`.
- **\`workflow.router\`**: reads \`rao_artifact_low\` / \`rao_artifact_high\` from settings, resolves each via \`_config_path\` (like \`rao_artifact\`), and passes them into \`assemble_result\`.
- **Tests** (synthetic low/high RAO fixtures; high-damping = smaller roll): band present & ordered (low ≤ high), provenance carries \`damping_note\`, §3 band section renders; without them no \`envelope_band\` and HTML unchanged; one-artifact-only and non-vessel basis do not band; router wires it end-to-end from settings.

## Verification

- \`ruff check\` clean on all three files.
- Local run (overlaying current-main + these edits): \`39 passed\` in the pamphlet suite; the 3 new tests (\`test_assemble_result_wires_envelope_band\`, \`test_assemble_result_without_band_is_backward_compatible\`, \`test_router_wires_envelope_band_from_settings\`) confirmed PASSED.