### PR TITLE
feat(orcaflex): licensed orcaflex-run-batch — N-parallel dynamic time-domain batch sized to ~90% of host cores

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -433,6 +433,15 @@ workflows:
       - examples/workflows/orcaflex-strength-post/results/strength_loadcase_summary.csv
     test: tests/workflows/test_durable_workflows.py::test_workflow_registry[orcaflex-strength-post]
     runtime: requires-license
+  - id: orcaflex-run-batch
+    basename: orcaflex_run_batch
+    title: OrcaFlex dynamic time-domain batch — N sims in parallel sized to ~90% of host cores — needs OrcaFlex license
+    input: examples/workflows/orcaflex-run-batch/input.yml
+    outputs:
+      - examples/workflows/orcaflex-run-batch/results/cases.csv
+      - examples/workflows/orcaflex-run-batch/results/batch_summary.json
+    test: tests/workflows/test_orcaflex_run_batch.py::test_example_input_runs_mock_batch
+    runtime: requires-license
   - id: stress-strain-parametric
     basename: parametric_run
     title: Ramberg-Osgood material grade sweep for offshore pipeline steels

--- a/examples/workflows/orcaflex-run-batch/base_model.yml
+++ b/examples/workflows/orcaflex-run-batch/base_model.yml
@@ -1,0 +1,12 @@
+# Minimal OrcaFlex-style base model for the mock heading sweep. In mock mode
+# the file is only validated and rendered (variants + duration injected),
+# never loaded through OrcFxAPI. General.StageDuration = [build-up, stage-1];
+# analysis.duration overrides the main stage (index 1).
+General:
+  StageDuration: [8.0, 120.0]
+Environment:
+  WaterDepth: 100.0
+  WaveType: Airy
+  WaveDirection: 0.0
+  WaveHeight: 2.0
+  WavePeriod: 8.0

--- a/examples/workflows/orcaflex-run-batch/input.yml
+++ b/examples/workflows/orcaflex-run-batch/input.yml
@@ -1,0 +1,38 @@
+# OrcaFlex dynamic time-domain BATCH — REQUIRES-LICENSE workflow (issue #1554).
+#
+# One input.yml -> N OrcaFlex simulations run CONCURRENTLY through a process
+# pool sized to ~90% of host cores by default (run_batch.workers overrides;
+# owner resource policy dm#1553). Case generation reuses parametric_run's
+# variants schema (factorial/range/csv/yaml_matrix + dotted-path mapping).
+#
+# This example is a tiny 3-case wave-heading sweep in MOCK mode so it runs
+# license-free (CI). On a licensed host set run_batch.mock: false to execute
+# real statics + dynamics and save .sim files. Small conclusions land under
+# results/ (cases.csv + batch_summary.json) for the licensed-run queue's
+# return allowlist; .sim files stay on the host under batch_runs/sims/.
+basename: orcaflex_run_batch
+
+orcaflex_run_batch:
+  models:
+    files:
+      - base_model.yml
+  variants:
+    source: factorial
+    parameters:
+      - name: wave_heading_deg
+        values: [0.0, 45.0, 90.0]
+    mapping:
+      wave_heading_deg: Environment.WaveDirection
+  analysis:
+    type: both
+    duration: 20.0
+  run_batch:
+    workers: 2
+    mock: true
+    save_sim: true
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -407,6 +407,12 @@ def engine(
         from digitalmodel.workflows.parametric_run import router as parametric_run
 
         cfg_base = parametric_run(cfg_base)
+    elif basename == "orcaflex_run_batch":
+        from digitalmodel.workflows.orcaflex_run_batch import (
+            router as orcaflex_run_batch,
+        )
+
+        cfg_base = orcaflex_run_batch(cfg_base)
     elif basename == "parametric_query":
         from digitalmodel.parametric.query import router as parametric_query
 

--- a/src/digitalmodel/workflows/orcaflex_run_batch.py
+++ b/src/digitalmodel/workflows/orcaflex_run_batch.py
@@ -1,0 +1,365 @@
+"""Licensed OrcaFlex dynamic time-domain batch workflow (issue #1554).
+
+One input.yml -> N OrcaFlex simulations run CONCURRENTLY: composes
+parametric_run's case generation (factorial/range/csv/yaml_matrix) with the
+existing OrcaFlexParallelAnalysis ProcessPool executor. Worker count defaults
+to ~90% of host cores (owner resource policy, dm#1553); OrcaFlex sims are
+single-threaded each, so real runs use processes.
+
+Small conclusions (results/cases.csv + results/batch_summary.json) fit the
+licensed-run queue return allowlist; .sim files stay on the host.
+"""
+
+from __future__ import annotations
+
+import math
+import json
+import os
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+from loguru import logger
+
+from digitalmodel.solvers.orcaflex.orcaflex_parallel_analysis import (
+    OrcaFlexParallelAnalysis,
+)
+from digitalmodel.workflows.parametric_run import _load_cases, _set_dotted
+
+# Owner resource policy (dm#1553): OrcaFlex = multiple-batch mode sized to the
+# host's cores; each sim is single-threaded, so size the pool to ~90% of them.
+WORKER_CORE_FRACTION = 0.9
+DEFAULT_ANALYSIS_TYPE = "both"
+DEFAULT_OUTPUT_DIR = "results"
+DEFAULT_WORK_DIR = "batch_runs"
+CASE_FILENAME_PATTERN = "case_{index}_{stem}.yml"
+# OrcaFlex model YAML keeps stage durations under General.StageDuration
+# ([build-up, stage-1, ...]); the duration override targets the main stage.
+DEFAULT_DURATION_PATH = "General.StageDuration.1"
+MOCK_SIM_CONTENT = "mock OrcaFlex simulation (orcaflex_run_batch mock mode)\n"
+LICENSE_ERROR_MESSAGE = (
+    "OrcaFlex license / OrcFxAPI is not available on this host. "
+    "orcaflex_run_batch is a requires-license workflow: dispatch it to a "
+    "licensed host (deckhand licensed-run lane) or set run_batch.mock: true "
+    "for a license-free dry run."
+)
+
+_ANALYSIS_FLAGS = {
+    "statics": {"static": True, "dynamic": False},
+    "dynamics": {"static": False, "dynamic": True},
+    "both": {"static": True, "dynamic": True},
+}
+_YAML_SUFFIXES = {".yml", ".yaml"}
+_STATUS_LABELS = {"success": "completed"}
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("orcaflex_run_batch") or {}
+    cfg_dir = Path(cfg.get("_config_dir_path") or Path.cwd())
+
+    run_settings = settings.get("run_batch") or {}
+    mock = bool(run_settings.get("mock", False))
+    save_sim = bool(run_settings.get("save_sim", True))
+    workers = resolve_workers(run_settings)
+
+    if not mock and not _license_available():
+        raise RuntimeError(LICENSE_ERROR_MESSAGE)
+
+    model_files = _resolve_models(settings.get("models") or {}, cfg_dir)
+    variants = settings.get("variants") or {}
+    cases = _load_cases(variants, cfg_dir) if variants else [{}]
+    mapping = variants.get("mapping") or {}
+
+    analysis = settings.get("analysis") or {}
+    analysis_type = analysis.get("type", DEFAULT_ANALYSIS_TYPE)
+    if analysis_type not in _ANALYSIS_FLAGS:
+        raise ValueError(
+            "orcaflex_run_batch analysis.type must be statics|dynamics|both, "
+            f"got {analysis_type}"
+        )
+
+    results_dir = _resolve_dir(
+        run_settings.get("output_dir", DEFAULT_OUTPUT_DIR), cfg_dir
+    )
+    work_dir = _resolve_dir(run_settings.get("work_dir", DEFAULT_WORK_DIR), cfg_dir)
+
+    rendered = _render_cases(
+        model_files=model_files,
+        cases=cases,
+        mapping=mapping,
+        duration=analysis.get("duration"),
+        duration_path=analysis.get("duration_path", DEFAULT_DURATION_PATH),
+        work_dir=work_dir,
+    )
+
+    # Real sims are single-threaded OrcFxAPI solves -> ProcessPool. The mock
+    # leaf worker is trivial I/O -> threads (no process-spawn overhead in CI).
+    executor_class = _MockOrcaFlexBatch if mock else OrcaFlexParallelAnalysis
+    executor = executor_class(num_threads=workers, use_processes=not mock)
+    executor_config = {
+        **_ANALYSIS_FLAGS[analysis_type],
+        "save_sim": save_sim,
+        "save_dat": False,
+        "output_dir": str(work_dir / "sims"),
+    }
+
+    started_at = datetime.now(timezone.utc)
+    pool_summary = executor.process_files_parallel(
+        [str(item["input_file"]) for item in rendered], executor_config
+    )
+    finished_at = datetime.now(timezone.utc)
+
+    rows = _manifest_rows(rendered, pool_summary)
+    manifest_path = results_dir / "cases.csv"
+    summary_path = results_dir / "batch_summary.json"
+    _write_manifest(rows, manifest_path)
+    summary = _write_summary(
+        rows=rows,
+        path=summary_path,
+        pool_summary=pool_summary,
+        workers=workers,
+        mock=mock,
+        analysis_type=analysis_type,
+        save_sim=save_sim,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    if summary["failed"]:
+        logger.warning(
+            "orcaflex_run_batch: {} of {} cases failed; see {}",
+            summary["failed"],
+            summary["total_cases"],
+            manifest_path,
+        )
+
+    settings["cases"] = rows
+    settings["outputs"] = {
+        "manifest": str(manifest_path),
+        "summary": str(summary_path),
+    }
+    cfg["orcaflex_run_batch"] = settings
+    return cfg
+
+
+def default_workers(cpu_count: int | None = None) -> int:
+    """~90% of host cores, floored, never below 1 (dm#1553 resource policy)."""
+    cores = cpu_count if cpu_count is not None else (os.cpu_count() or 1)
+    return max(1, math.floor(WORKER_CORE_FRACTION * cores))
+
+
+def resolve_workers(run_settings: dict) -> int:
+    explicit = run_settings.get("workers")
+    if explicit is None:
+        return default_workers()
+    workers = int(explicit)
+    if workers < 1:
+        raise ValueError(f"run_batch.workers must be >= 1, got {explicit}")
+    return workers
+
+
+def _license_available() -> bool:
+    try:
+        from digitalmodel.solvers.orcaflex.orcaflex_utilities import (
+            OrcaflexUtilities,
+        )
+    except Exception:
+        return False
+    try:
+        return bool(OrcaflexUtilities().is_orcaflex_available())
+    except Exception:
+        return False
+
+
+def _resolve_models(models: dict, cfg_dir: Path) -> list[Path]:
+    files = models.get("files")
+    if files:
+        # Missing explicit files surface as per-case failures in cases.csv
+        # (the batch continues); glob patterns only ever match existing files.
+        return [_resolve_path(item, cfg_dir) for item in files]
+    pattern = models.get("pattern")
+    if not pattern:
+        raise ValueError(
+            "orcaflex_run_batch.models needs files: [...] or pattern: '*.yml'"
+        )
+    directory = _resolve_path(models.get("directory", "."), cfg_dir)
+    matched = sorted(directory.glob(pattern))
+    if not matched:
+        raise ValueError(
+            f"orcaflex_run_batch: no model files match {pattern} in {directory}"
+        )
+    return matched
+
+
+def _render_cases(
+    model_files: list[Path],
+    cases: list[dict[str, Any]],
+    mapping: dict[str, str],
+    duration: float | None,
+    duration_path: str,
+    work_dir: Path,
+) -> list[dict[str, Any]]:
+    rendered: list[dict[str, Any]] = []
+    index = 0
+    for model_path in model_files:
+        for case in cases:
+            needs_injection = bool(case) or duration is not None
+            if needs_injection:
+                if model_path.suffix.lower() not in _YAML_SUFFIXES:
+                    raise ValueError(
+                        "orcaflex_run_batch variants/duration need a YAML "
+                        f"OrcaFlex model to inject into, got {model_path.name}"
+                    )
+                case_model = deepcopy(_read_model_yaml(model_path))
+                for name, value in case.items():
+                    _set_dotted(case_model, mapping.get(name, name), value)
+                if duration is not None:
+                    _set_dotted(case_model, duration_path, duration)
+                case_file = work_dir / "cases" / CASE_FILENAME_PATTERN.format(
+                    index=index, stem=model_path.stem
+                )
+                case_file.parent.mkdir(parents=True, exist_ok=True)
+                case_file.write_text(yaml.safe_dump(case_model, sort_keys=False))
+            else:
+                case_file = model_path
+            rendered.append(
+                {
+                    "index": index,
+                    "model": model_path.name,
+                    "case": case,
+                    "input_file": case_file,
+                }
+            )
+            index += 1
+    return rendered
+
+
+def _manifest_rows(
+    rendered: list[dict[str, Any]], pool_summary: dict
+) -> list[dict[str, Any]]:
+    by_path = {
+        result["file_path"]: result for result in pool_summary.get("results", [])
+    }
+    rows = []
+    for item in rendered:
+        result = by_path.get(str(item["input_file"]), {})
+        sim_path = next(
+            (f for f in result.get("output_files") or [] if f.endswith(".sim")),
+            None,
+        )
+        rows.append(
+            {
+                "index": item["index"],
+                "model": item["model"],
+                **item["case"],
+                "input_file": str(item["input_file"]),
+                "status": _STATUS_LABELS.get(result.get("status"), "failed"),
+                "error": result.get("error"),
+                "wall_seconds": round(result.get("duration") or 0.0, 3),
+                "sim_path": sim_path,
+            }
+        )
+    return rows
+
+
+def _write_manifest(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _write_summary(
+    rows: list[dict[str, Any]],
+    path: Path,
+    pool_summary: dict,
+    workers: int,
+    mock: bool,
+    analysis_type: str,
+    save_sim: bool,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict:
+    completed = sum(1 for row in rows if row["status"] == "completed")
+    summary = {
+        "workflow": "orcaflex_run_batch",
+        "total_cases": len(rows),
+        "completed": completed,
+        "failed": len(rows) - completed,
+        "workers": workers,
+        "host_cpu_count": os.cpu_count(),
+        "mock": mock,
+        "analysis_type": analysis_type,
+        "save_sim": save_sim,
+        "wall_seconds_total": round(pool_summary.get("total_duration") or 0.0, 3),
+        "parallel_speedup": round(pool_summary.get("parallel_speedup") or 1.0, 3),
+        "started_at_utc": started_at.isoformat(),
+        "finished_at_utc": finished_at.isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2) + "\n")
+    return summary
+
+
+def _read_model_yaml(path: Path) -> dict:
+    with path.open() as stream:
+        loaded = yaml.safe_load(stream) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected mapping YAML OrcaFlex model in {path}")
+    return loaded
+
+
+def _resolve_path(path_value: str, cfg_dir: Path) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return cfg_dir / path
+
+
+def _resolve_dir(path_value: str, cfg_dir: Path) -> Path:
+    resolved = _resolve_path(path_value, cfg_dir)
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+class _MockOrcaFlexBatch(OrcaFlexParallelAnalysis):
+    """License-free stand-in: inherits the pool/summary/failure-isolation
+    machinery from OrcaFlexParallelAnalysis and only swaps the leaf worker
+    (no OrcFxAPI; writes a marker .sim so sim_path plumbing is exercised)."""
+
+    def process_single_file(self, file_info: dict[str, Any]) -> dict[str, Any]:
+        file_path = file_info["file_path"]
+        config = file_info.get("config", {})
+        result = {
+            "file_path": file_path,
+            "status": "pending",
+            "start_time": datetime.now(),
+            "end_time": None,
+            "duration": None,
+            "error": None,
+            "output_files": [],
+        }
+        try:
+            path = Path(file_path)
+            if not path.exists():
+                raise FileNotFoundError(f"Model file not found: {file_path}")
+            if config.get("static", True):
+                result["static_complete"] = True
+            if config.get("dynamic", False):
+                result["dynamic_complete"] = True
+            if config.get("save_sim", True):
+                output_dir = Path(config.get("output_dir") or path.parent)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                sim_path = output_dir / f"{path.stem}.sim"
+                sim_path.write_text(MOCK_SIM_CONTENT)
+                result["output_files"].append(str(sim_path))
+            result["status"] = "success"
+        except Exception as exc:  # per-case isolation: the batch continues
+            result["status"] = "failed"
+            result["error"] = str(exc)
+        finally:
+            result["end_time"] = datetime.now()
+            result["duration"] = (
+                result["end_time"] - result["start_time"]
+            ).total_seconds()
+        return result

--- a/tests/workflows/test_orcaflex_run_batch.py
+++ b/tests/workflows/test_orcaflex_run_batch.py
@@ -1,0 +1,142 @@
+"""License-free (mock-mode) tests for the orcaflex_run_batch workflow (#1554)."""
+
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.workflows import orcaflex_run_batch as orb
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "workflows" / "orcaflex-run-batch"
+
+
+def _copy_example(tmp_path: Path) -> dict:
+    for name in ("input.yml", "base_model.yml"):
+        (tmp_path / name).write_text((EXAMPLE_DIR / name).read_text())
+    cfg = yaml.safe_load((tmp_path / "input.yml").read_text())
+    cfg["_config_dir_path"] = str(tmp_path)
+    return cfg
+
+
+def test_example_input_runs_mock_batch(tmp_path):
+    cfg = _copy_example(tmp_path)
+
+    result = orb.router(cfg)
+
+    manifest = tmp_path / "results" / "cases.csv"
+    summary_path = tmp_path / "results" / "batch_summary.json"
+    assert manifest.exists()
+    assert summary_path.exists()
+
+    rows = pd.read_csv(manifest)
+    assert len(rows) == 3
+    assert rows["status"].tolist() == ["completed"] * 3
+    assert sorted(rows["wave_heading_deg"].tolist()) == [0.0, 45.0, 90.0]
+    assert all(rows["wall_seconds"] >= 0)
+
+    summary = json.loads(summary_path.read_text())
+    assert summary["total_cases"] == 3
+    assert summary["completed"] == 3
+    assert summary["failed"] == 0
+    assert summary["workers"] == 2
+    assert summary["mock"] is True
+    assert summary["host_cpu_count"] == os.cpu_count()
+
+    # Case-gen reuse: rendered case models carry the swept heading AND the
+    # simulation-duration override injected via parametric_run's _set_dotted.
+    rendered_headings = set()
+    for case_file in sorted((tmp_path / "batch_runs" / "cases").glob("*.yml")):
+        model = yaml.safe_load(case_file.read_text())
+        rendered_headings.add(model["Environment"]["WaveDirection"])
+        assert model["General"]["StageDuration"] == [8.0, 20.0]
+    assert rendered_headings == {0.0, 45.0, 90.0}
+
+    # Mock sims stay under batch_runs/sims, never under results/.
+    assert len(list((tmp_path / "batch_runs" / "sims").glob("*.sim"))) == 3
+    assert not list((tmp_path / "results").rglob("*.sim"))
+
+    outputs = result["orcaflex_run_batch"]["outputs"]
+    assert outputs["manifest"] == str(manifest)
+    assert outputs["summary"] == str(summary_path)
+
+
+def test_yaml_matrix_variants_reuse_parametric_case_gen(tmp_path):
+    cfg = _copy_example(tmp_path)
+    cfg["orcaflex_run_batch"]["variants"] = {
+        "source": "yaml_matrix",
+        "list": [
+            {"heading": 0.0, "height": 1.5},
+            {"heading": 90.0, "height": 3.0},
+        ],
+        "mapping": {
+            "heading": "Environment.WaveDirection",
+            "height": "Environment.WaveHeight",
+        },
+    }
+
+    orb.router(cfg)
+
+    rows = pd.read_csv(tmp_path / "results" / "cases.csv")
+    assert len(rows) == 2
+    assert rows["status"].tolist() == ["completed"] * 2
+    case_files = sorted((tmp_path / "batch_runs" / "cases").glob("*.yml"))
+    models = [yaml.safe_load(f.read_text()) for f in case_files]
+    assert {m["Environment"]["WaveHeight"] for m in models} == {1.5, 3.0}
+
+
+def test_workers_default_is_ninety_percent_of_cores(monkeypatch):
+    monkeypatch.setattr(orb.os, "cpu_count", lambda: 64)
+    assert orb.resolve_workers({}) == 57
+    # Explicit workers always wins over the host-aware default.
+    assert orb.resolve_workers({"workers": 4}) == 4
+
+
+def test_workers_default_never_below_one(monkeypatch):
+    monkeypatch.setattr(orb.os, "cpu_count", lambda: 1)
+    assert orb.resolve_workers({}) == 1
+
+
+def test_workers_default_applied_in_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(orb.os, "cpu_count", lambda: 4)
+    cfg = _copy_example(tmp_path)
+    del cfg["orcaflex_run_batch"]["run_batch"]["workers"]
+
+    orb.router(cfg)
+
+    summary = json.loads((tmp_path / "results" / "batch_summary.json").read_text())
+    assert summary["workers"] == 3
+
+
+def test_license_absent_and_mock_false_fails_fast(tmp_path, monkeypatch):
+    cfg = _copy_example(tmp_path)
+    cfg["orcaflex_run_batch"]["run_batch"]["mock"] = False
+    monkeypatch.setattr(orb, "_license_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="OrcaFlex license / OrcFxAPI"):
+        orb.router(cfg)
+
+
+def test_failing_case_does_not_kill_batch(tmp_path):
+    cfg = _copy_example(tmp_path)
+    settings = cfg["orcaflex_run_batch"]
+    settings["models"]["files"] = ["base_model.yml", "missing_model.yml"]
+    settings.pop("variants")
+    settings.pop("analysis")
+
+    orb.router(cfg)
+
+    rows = pd.read_csv(tmp_path / "results" / "cases.csv")
+    assert len(rows) == 2
+    by_model = dict(zip(rows["model"], rows["status"]))
+    assert by_model["base_model.yml"] == "completed"
+    assert by_model["missing_model.yml"] == "failed"
+    failed_row = rows[rows["model"] == "missing_model.yml"].iloc[0]
+    assert "not found" in failed_row["error"]
+
+    summary = json.loads((tmp_path / "results" / "batch_summary.json").read_text())
+    assert summary["completed"] == 1
+    assert summary["failed"] == 1


### PR DESCRIPTION
Closes #1554. Part of EPIC #1553 (child A).

## What

Registers a **licensed dynamic time-domain OrcaFlex batch workflow** — registry id `orcaflex-run-batch`, basename `orcaflex_run_batch` — so one licensed-run queue request runs N OrcaFlex simulations concurrently, sized to ~90% of host cores (≈57 workers on ace-win-1's 64 cores). Previously the only license-tagged OrcaFlex registry entry was post-processing (`orcaflex-strength-post`); the parallel executors existed but nothing dispatchable reached them.

## How

- **`src/digitalmodel/workflows/orcaflex_run_batch.py`** (new): `router(cfg)` that
  - resolves base models (explicit `models.files` list or `models.pattern` glob),
  - **reuses parametric_run's case generation** — imports `_load_cases` + `_set_dotted` from `src/digitalmodel/workflows/parametric_run.py:106-178` (factorial/range/csv/yaml_matrix + dotted-path mapping), so the sweep spec is one schema across the repo, not a fork,
  - renders each case as an injected copy of the base model YAML (swept params via `mapping`, optional `analysis.duration` override into `General.StageDuration.1` by default, path configurable),
  - executes cases **concurrently through the existing `OrcaFlexParallelAnalysis`** (`src/digitalmodel/solvers/orcaflex/orcaflex_parallel_analysis.py:32-247`) — ProcessPoolExecutor for real runs (OrcaFlex sims are single-threaded each), per-case status/timing capture and failure isolation inherited unchanged,
  - **host-aware workers**: `max(1, floor(0.9 × os.cpu_count()))` via module constant `WORKER_CORE_FRACTION = 0.9` (`orcaflex_run_batch.py:34`), never the hardcoded 30; explicit `run_batch.workers` wins,
  - **license gate**: `mock: false` + no OrcFxAPI/license → immediate `RuntimeError` with a clear dispatch-or-mock message (reuses `OrcaflexUtilities.is_orcaflex_available()`, `src/digitalmodel/solvers/orcaflex/orcaflex_utilities.py:55`, same gate as `orcaflex_analysis.py:36`),
  - **mock mode** (`run_batch.mock: true`): `_MockOrcaFlexBatch` subclass swaps only the leaf worker (validates the model file, writes a marker `.sim`) and runs on threads — the pool/summary/failure-isolation machinery is the same code path CI exercises,
  - writes `results/cases.csv` (index, model, swept params, input_file, status, error, wall_seconds, sim_path) + `results/batch_summary.json` (counts, timing, workers used, host cpu_count, mock flag) — small csv/json under `results/` for the deckhand return allowlist; `.sim` files land under `batch_runs/sims/` and stay on host.
- **`src/digitalmodel/engine.py:410-415`**: basename `orcaflex_run_batch` wired immediately after `parametric_run`, following its lazy-import pattern.
- **`docs/registry/workflows.yaml:436-445`**: schema_version-2 row, `runtime: requires-license`, mirroring the `orcaflex-strength-post` row shape; passes `tests/workflows/test_registry_versioning.py` and collects+skips in `test_durable_workflows.py::test_workflow_registry[orcaflex-run-batch]` like the other requires-license rows.
- **`examples/workflows/orcaflex-run-batch/`**: tiny 3-case wave-heading factorial sweep in mock mode (`input.yml` + `base_model.yml`), commented like `examples/workflows/orcawave-diffraction-solve/input.yml`. LF-only.

### Executor choice

`OrcaFlexParallelAnalysis` over `UniversalOrcaFlexRunner`/`BatchProcessor` because: (a) it is process-based (`ProcessPoolExecutor`, `orcaflex_parallel_analysis.py:188-191`) — right model for single-threaded OrcFxAPI solves; the universal `BatchProcessor` is thread-based (`batch_processor.py:13`) and drags in psutil/file-size-optimizer machinery irrelevant here; (b) `universal_runner.py:120-121` **silently downgrades to mock** when the license is missing — the opposite of this workflow's fail-fast requirement; (c) it already returns per-case status/duration/error with batch continuation and a summary dict, so the workflow only composes, it doesn't add pool code. Mock mode uses the same class via a leaf-worker-only subclass (threads, no spawn overhead in CI).

## Tests

`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/workflows/test_orcaflex_run_batch.py tests/workflows/test_registry_versioning.py tests/workflows/test_parametric_run.py -q` → **13 passed, 2 skipped** (skips = the two requires-license registry rows in the offline durable suite, as designed).

New `tests/workflows/test_orcaflex_run_batch.py` (all license-free, mirrors `test_parametric_run.py` router-direct style):
- example input → 3 cases completed concurrently, cases.csv/batch_summary.json shape + swept-heading and duration-override injection verified, sims under `batch_runs/` never `results/`;
- yaml_matrix variants reuse (2-case, 2-param);
- workers default = `floor(0.9×cpu_count)` (64→57), explicit wins, floor of 1 (monkeypatched `os.cpu_count`), and default applied end-to-end in batch_summary;
- license-absent + `mock: false` → fast `RuntimeError` matching "OrcaFlex license / OrcFxAPI";
- one missing-model case fails, batch continues, per-case status recorded.

## Resource policy

Owner policy (dm#1553): OrcaFlex = multiple-batch mode sized to cores. Default pool = `max(1, floor(0.9 × cpu_count))` ≈ 57 on the 64-core ace-win-1, externalized as `WORKER_CORE_FRACTION`; `run_batch.workers` in input.yml overrides for smaller batches. Queue return stays inside the deckhand allowlist: only `results/cases.csv` + `results/batch_summary.json` (small csv/json); `.sim` files remain on the licensed host.

## Notes / deviations

- `parametric_run`'s serial-only `run.mode=parallel` warning (`parametric_run.py:71-75`) is left untouched per scope — this workflow supersedes it for the OrcaFlex batch path; a general parametric_run parallel fix remains open under the EPIC.
- A batch with some failed cases does **not** raise: per-case status in cases.csv + counts in batch_summary.json are the contract (batch semantics), unlike parametric_run which aborts on first error. Flagged here for reviewer sign-off.
- The registry row's `test:` points at the new mock test (which actually runs in CI) rather than the always-skipped `test_workflow_registry[...]` param, giving the row live CI evidence.