### PR TITLE
feat(orcawave): thread_count input.yml → solver, host-aware ~90%-of-cores default

### DIFF
--- a/examples/workflows/orcawave-diffraction-solve/input.yml
+++ b/examples/workflows/orcawave-diffraction-solve/input.yml
@@ -13,6 +13,9 @@ diffraction:
   operation: run_orcawave
   spec: spec.yml
   output_directory: results
+  # thread_count: 57   # OrcFxAPI solve threads (dm#1555). Unset -> ~90% of host
+  #                    # cores (64-core ace-win-1 -> 57); tiny canary cases don't
+  #                    # need it. Lower explicitly on memory-constrained hosts (#714).
 
 default:
   log_level: INFO

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_doctor.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_doctor.py
@@ -154,7 +154,9 @@ def run_doctor(
         guidance += f", {mem} GB RAM"
     guidance += (
         ". Moderate thread counts are safer: very high thread counts have "
-        "produced out-of-memory failures on large cases (see #714)."
+        "produced out-of-memory failures on large cases (see #714). Solves "
+        "dispatched via run_orcawave default to ~90% of cores (dm#1555); set "
+        "diffraction.thread_count explicitly to cap memory-constrained hosts."
     )
     checks.append(DoctorCheck("Threads/memory", "PASS", guidance))
 

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -156,7 +156,12 @@ class RunConfig(BaseModel):
     thread_count: int = Field(
         default=4,
         gt=0,
-        description="Number of threads for OrcFxAPI diffraction calculation.",
+        description=(
+            "Number of threads for OrcFxAPI diffraction calculation. Direct "
+            "RunConfig users get a conservative 4; the run_orcawave entry "
+            "point (the licensed-run dispatch path) resolves an unset value "
+            "to ~90% of host cores instead (dm#1555)."
+        ),
     )
     validate_outputs: bool = Field(
         default=True,
@@ -235,6 +240,25 @@ class RunResult:
     orcf_api_version: str | None = None
     thread_count: int | None = None
     assumption_ledger: "AssumptionLedger | None" = None
+
+
+# Owner resource policy (dm#1553/#1555): one OrcaWave solve may use ~90% of the
+# host's cores as OrcFxAPI threads (64-core ace-win-1 -> 57). Mirrors
+# WORKER_CORE_FRACTION in workflows/orcaflex_run_batch.py.
+THREAD_CORE_FRACTION = 0.9
+
+
+def default_thread_count(cpu_count: int | None = None) -> int:
+    """~90% of host cores, floored, never below 1 (dm#1555)."""
+    cores = cpu_count if cpu_count is not None else (os.cpu_count() or 1)
+    return max(1, int(THREAD_CORE_FRACTION * cores))
+
+
+def resolve_thread_count(explicit: int | None) -> int:
+    """Explicit input.yml value wins; unset resolves to the host-aware default."""
+    if explicit is None:
+        return default_thread_count()
+    return int(explicit)
 
 
 # ---------------------------------------------------------------------------
@@ -970,6 +994,7 @@ def run_orcawave(
     timeout_seconds: int = 7200,
     spec_path: Path | str | None = None,
     assumption_ledger: "AssumptionLedger | None" = None,
+    thread_count: int | None = None,
 ) -> RunResult:
     """Run an OrcaWave diffraction analysis from a DiffractionSpec.
 
@@ -984,6 +1009,9 @@ def run_orcawave(
                    mesh paths). Optional.
         assumption_ledger: Optional provenance ledger (e.g. from
             ``resolver.resolve``) carried onto the result for reporting.
+        thread_count: OrcFxAPI solve threads (API path only). None resolves
+            to ~90% of host cores (dm#1555); the effective value is echoed
+            on ``RunResult.thread_count``.
 
     Returns:
         RunResult with status, paths, and logs.
@@ -992,6 +1020,7 @@ def run_orcawave(
         output_dir=Path(output_dir),
         dry_run=dry_run,
         timeout_seconds=timeout_seconds,
+        thread_count=resolve_thread_count(thread_count),
     )
     runner = OrcaWaveRunner(config)
     return runner.run(

--- a/src/digitalmodel/hydrodynamics/diffraction/workflow.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/workflow.py
@@ -79,6 +79,17 @@ class DiffractionWorkflow:
         output_dir = self._resolve_output_dir(cfg, settings)
         requested_dry_run = bool(settings.get("dry_run", False))
 
+        solver_kwargs: dict[str, Any] = {}
+        if operation == "run_orcawave":
+            # dm#1555: one OrcaWave solve may use ~90% of host cores as
+            # OrcFxAPI threads (owner resource policy, dm#1553). An explicit
+            # diffraction.thread_count wins; None lets the runner resolve the
+            # host-aware default. AQWA keeps its own core handling (#546).
+            raw_threads = settings.get("thread_count")
+            solver_kwargs["thread_count"] = (
+                int(raw_threads) if raw_threads is not None else None
+            )
+
         spec = DiffractionSpec.from_yaml(spec_path)
         result = run_solve(
             spec,
@@ -86,9 +97,13 @@ class DiffractionWorkflow:
             dry_run=requested_dry_run,
             timeout_seconds=int(settings.get("timeout_seconds", 7200)),
             spec_path=spec_path,
+            **solver_kwargs,
         )
 
         status = str(getattr(result.status, "value", result.status)).lower()
+        effective_threads = getattr(result, "thread_count", None)
+        if effective_threads is not None:
+            settings["thread_count_effective"] = int(effective_threads)
         settings["spec_path"] = str(spec_path)
         settings["output_directory"] = str(getattr(result, "output_dir", output_dir))
         settings["run_status"] = status

--- a/tests/hydrodynamics/diffraction/test_orcawave_runner.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_runner.py
@@ -772,3 +772,49 @@ class TestOrcaWaveStrictMode:
         assert result.validation_verdict == "FAIL"
         assert result.status == RunStatus.COMPLETED
         assert result.return_code == 0
+
+
+# --- host-aware thread-count resolution (dm#1555) ----------------------------
+
+
+def test_default_thread_count_is_90_percent_of_cores_floored() -> None:
+    from digitalmodel.hydrodynamics.diffraction import orcawave_runner as runner
+
+    assert runner.default_thread_count(64) == 57
+    assert runner.default_thread_count(4) == 3
+    assert runner.default_thread_count(1) == 1  # never below 1
+
+
+def test_resolve_thread_count_explicit_wins_and_none_uses_host_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from digitalmodel.hydrodynamics.diffraction import orcawave_runner as runner
+
+    monkeypatch.setattr(runner.os, "cpu_count", lambda: 64)
+    assert runner.resolve_thread_count(None) == 57
+    assert runner.resolve_thread_count(8) == 8
+
+
+def test_run_orcawave_dry_run_resolves_thread_count_into_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from digitalmodel.hydrodynamics.diffraction import orcawave_runner as runner
+
+    monkeypatch.setattr(runner.os, "cpu_count", lambda: 64)
+    captured: dict = {}
+
+    class _FakeRunner:
+        def __init__(self, config):
+            captured["thread_count"] = config.thread_count
+
+        def run(self, spec, spec_path=None, assumption_ledger=None):
+            from types import SimpleNamespace
+
+            return SimpleNamespace(status="dry_run")
+
+    monkeypatch.setattr(runner, "OrcaWaveRunner", _FakeRunner)
+    spec = MagicMock()
+    runner.run_orcawave(spec, output_dir=tmp_path, dry_run=True)
+    assert captured["thread_count"] == 57
+    runner.run_orcawave(spec, output_dir=tmp_path, dry_run=True, thread_count=8)
+    assert captured["thread_count"] == 8

--- a/tests/hydrodynamics/diffraction/test_workflow_router.py
+++ b/tests/hydrodynamics/diffraction/test_workflow_router.py
@@ -232,3 +232,63 @@ def test_run_aqwa_silent_dry_run_fallback_raises(tmp_path: Path) -> None:
             DiffractionWorkflow().router(
                 _solve_cfg(tmp_path, dry_run=False, operation="run_aqwa")
             )
+
+
+# --- diffraction.thread_count forwarding (dm#1555) ---------------------------
+
+
+def _solve_cfg_with_threads(tmp_path: Path, thread_count: int | None) -> dict:
+    cfg = _solve_cfg(tmp_path, dry_run=False)
+    if thread_count is not None:
+        cfg["diffraction"]["thread_count"] = thread_count
+    return cfg
+
+
+def test_run_orcawave_forwards_explicit_thread_count(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=_fake_result("completed"),
+    ) as run_solve:
+        DiffractionWorkflow().router(_solve_cfg_with_threads(tmp_path, 8))
+    assert run_solve.call_args.kwargs["thread_count"] == 8
+
+
+def test_run_orcawave_unset_thread_count_forwards_none(tmp_path: Path) -> None:
+    # None lets run_orcawave resolve the host-aware ~90%-of-cores default.
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=_fake_result("completed"),
+    ) as run_solve:
+        DiffractionWorkflow().router(_solve_cfg_with_threads(tmp_path, None))
+    assert run_solve.call_args.kwargs["thread_count"] is None
+
+
+def test_run_orcawave_records_effective_thread_count(tmp_path: Path) -> None:
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    result = _fake_result("completed")
+    result.thread_count = 57
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.orcawave_runner.run_orcawave",
+        return_value=result,
+    ):
+        cfg = DiffractionWorkflow().router(_solve_cfg_with_threads(tmp_path, None))
+    assert cfg["diffraction"]["thread_count_effective"] == 57
+
+
+def test_run_aqwa_does_not_receive_thread_count(tmp_path: Path) -> None:
+    # AQWA keeps its own core handling (#546); the kwarg is OrcaWave-only.
+    from digitalmodel.hydrodynamics.diffraction.workflow import DiffractionWorkflow
+
+    with patch(
+        "digitalmodel.hydrodynamics.diffraction.aqwa_runner.run_aqwa",
+        return_value=_fake_aqwa_result("COMPLETED"),
+    ) as run_solve:
+        DiffractionWorkflow().router(
+            _solve_cfg(tmp_path, dry_run=False, operation="run_aqwa")
+        )
+    assert "thread_count" not in run_solve.call_args.kwargs


### PR DESCRIPTION
Closes #1555 (EPIC #1553 child B).

**What:** dispatched `orcawave-diffraction-solve` runs were solving on 4 threads — `workflow.py::_run_solver` never forwarded a thread count to `RunConfig.thread_count` (default 4), leaving ~94% of ace-win-1's 64 cores idle.

**How:** `run_orcawave` gains `thread_count: int | None`; `None` resolves via new `resolve_thread_count`/`default_thread_count` to `max(1, int(0.9 × cpu_count))` (64 → 57, owner resource policy dm#1553 — mirrors `WORKER_CORE_FRACTION` in orcaflex_run_batch). The workflow forwards `diffraction.thread_count` for the OrcaWave operation only (AQWA keeps its own core handling, #546) and records `thread_count_effective` from the result echo. Direct `RunConfig` constructors keep the conservative 4. Example input.yml documents the knob; orcawave_doctor guidance notes the new default + the #714 memory caveat (cap explicitly on memory-constrained hosts).

**Tests:** 7 new — forwarding explicit/None, effective echo, AQWA excluded from the kwarg, 0.9-floor math (64→57, 4→3, 1→1), explicit-wins, RunConfig resolution through run_orcawave. `test_workflow_router.py` + `test_orcawave_runner.py`: 69 passed.