### PR TITLE
feat(workflows): openfoam-run-batch — one request saturates a CFD node (#1560)

### DIFF
--- a/examples/workflows/openfoam-run-batch/input.yml
+++ b/examples/workflows/openfoam-run-batch/input.yml
@@ -1,0 +1,49 @@
+# OpenFOAM CFD BATCH — REQUIRES-SOLVER workflow (issue #1560).
+#
+# One input.yml -> a deterministic case matrix that saturates a dedicated CFD
+# node. Two modes (run_batch.mode):
+#   pool (default): N single-rank cases run CONCURRENTLY through a bounded
+#     thread pool sized to ~90% of host cores (run_batch.workers overrides;
+#     owner resource policy dm#1553). Each case reuses the fail-closed
+#     OpenFOAM build + solve path (the same code the `basename: openfoam`
+#     engine route uses, landed via #1161).
+#   mpi: ONE large case across ranks — decomposePar -force (scotch) ->
+#     mpirun -np <workers> <solver> -parallel -> reconstructPar -> processor*
+#     dirs pruned. Set exactly one case for mpi mode.
+#
+# Case generation reuses parametric_run's variants schema
+# (factorial/range/csv/yaml_matrix + dotted-path mapping).
+#
+# This example is a tiny 2-case current-loading sweep in MOCK mode so it runs
+# solver-free (CI): the license-free builder authors each case tree but no
+# solver runs. On a solver-capable host set run_batch.mock: false to mesh +
+# solve for real. Small conclusions land under results/ (cases.csv +
+# batch_summary.json) for the licensed-run queue's return allowlist; heavy
+# case trees stay under batch_runs/ and processor* dirs are pruned.
+basename: openfoam_run_batch
+
+openfoam_run_batch:
+  base:
+    case_type: current_loading
+    solver: simpleFoam
+    mesh_utility: blockMesh
+    to_vtk: false
+  # Explicit case list: each case names its dir and overrides base settings via
+  # a dotted path (mapping identity here). For a parametric sweep instead, drop
+  # `cases:` and add a `variants:` block (parametric_run's factorial/range/csv/
+  # yaml_matrix schema) — see tests for a yaml_matrix example.
+  cases:
+    - name: current_simpleFoam
+      solver: simpleFoam
+    - name: current_pimpleFoam
+      solver: pimpleFoam
+  run_batch:
+    mode: pool
+    workers: 2
+    mock: true
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/examples/workflows/openfoam-run-batch/input.yml
+++ b/examples/workflows/openfoam-run-batch/input.yml
@@ -8,8 +8,13 @@
 #     OpenFOAM build + solve path (the same code the `basename: openfoam`
 #     engine route uses, landed via #1161).
 #   mpi: ONE large case across ranks — decomposePar -force (scotch) ->
-#     mpirun -np <workers> <solver> -parallel -> reconstructPar -> processor*
-#     dirs pruned. Set exactly one case for mpi mode.
+#     mpirun -np <workers> <solver> -parallel -> reconstructPar. processor*
+#     dirs are pruned only after a SUCCESSFUL reconstruction; with
+#     run_batch.reconstruct: false the decomposed fields are the deliverable
+#     and are preserved. Set exactly one case for mpi mode, and SIZE IT to
+#     finish well inside one dispatch wall-clock window — a fresh retry
+#     restarts from t=0 unless run_batch.resume: true picks up an existing
+#     processor* decomposition and restarts the solver from latestTime.
 #
 # Case generation reuses parametric_run's variants schema
 # (factorial/range/csv/yaml_matrix + dotted-path mapping).
@@ -29,14 +34,18 @@ openfoam_run_batch:
     mesh_utility: blockMesh
     to_vtk: false
   # Explicit case list: each case names its dir and overrides base settings via
-  # a dotted path (mapping identity here). For a parametric sweep instead, drop
-  # `cases:` and add a `variants:` block (parametric_run's factorial/range/csv/
-  # yaml_matrix schema) — see tests for a yaml_matrix example.
+  # mapping's dotted paths. Knob names must not collide with reserved manifest
+  # columns (index/name/status/solver/...) — hence solver_app mapped onto the
+  # solver setting. For a parametric sweep instead, drop `cases:` and add a
+  # `variants:` block (parametric_run's factorial/range/csv/yaml_matrix
+  # schema) — see tests for a yaml_matrix example.
   cases:
     - name: current_simpleFoam
-      solver: simpleFoam
+      solver_app: simpleFoam
     - name: current_pimpleFoam
-      solver: pimpleFoam
+      solver_app: pimpleFoam
+  mapping:
+    solver_app: solver
   run_batch:
     mode: pool
     workers: 2

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -413,6 +413,12 @@ def engine(
         )
 
         cfg_base = orcaflex_run_batch(cfg_base)
+    elif basename == "openfoam_run_batch":
+        from digitalmodel.workflows.openfoam_run_batch import (
+            router as openfoam_run_batch,
+        )
+
+        cfg_base = openfoam_run_batch(cfg_base)
     elif basename == "parametric_query":
         from digitalmodel.parametric.query import router as parametric_query
 

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -10,8 +10,20 @@ in one of two ways (``run_batch.mode``):
   ``basename: openfoam`` engine route uses (landed via #1161).
 * ``mpi``: ONE large case spread across ranks —
   ``decomposePar -force`` (scotch) -> ``mpirun -np <workers> <solver> -parallel``
-  -> optional ``reconstructPar`` -> ``processor*`` dirs ALWAYS pruned (mirrors
-  ``scripts/cfd/run_sloshing_3d_benchmark.py``).
+  -> optional ``reconstructPar`` (mirrors
+  ``scripts/cfd/run_sloshing_3d_benchmark.py``). ``processor*`` dirs are
+  pruned only after a SUCCESSFUL reconstruction; with ``reconstruct: false``
+  the decomposed fields ARE the deliverable and are preserved in the work dir.
+
+WALL-CLOCK SIZING (mpi mode): a fresh mpi attempt restarts the solve from
+``startTime`` — size the case (end time, mesh, rank count) to finish well
+inside one dispatch wall-clock window, or a killed-and-retried run will redo
+the same physics from t=0 on every attempt. ``run_batch.resume: true``
+mitigates this: when a previous attempt's ``processor*`` decomposition already
+exists, the retry skips meshing/decomposition and restarts the solver from
+``latestTime`` instead of t=0 (requires the case's ``writeInterval`` to land
+intermediate time dirs). The batch summary records ``timeout_seconds`` so the
+dispatch side can compare its cap against the expected wall time.
 
 Case generation reuses parametric_run's helpers (``_load_cases`` /
 ``_set_dotted``) so the factorial/range/csv/yaml_matrix schema and dotted-path
@@ -19,10 +31,13 @@ mapping behave identically to orcaflex_run_batch (#1554).
 
 Idempotent/resumable: each case writes a ``_result.json`` checkpoint under its
 work dir; a re-run skips a case whose checkpoint is ``completed`` (a retry after
-a queue timeout safely re-enqueues the same input). Small conclusions
-(``results/cases.csv`` + ``results/batch_summary.json``) land under ``results/``
-for the licensed-run queue's return allowlist; heavy case trees (meshes, fields,
-VTK, ``processor*``) stay in the work dir and never reach ``results/``.
+a queue timeout safely re-enqueues the same input). A failed, truncated or
+missing checkpoint is retried — from a CLEAN rebuilt case dir (unless mpi
+``resume`` picks up an existing decomposition), never on top of a dirty tree
+of stale timestep dirs and logs. Small conclusions (``results/cases.csv`` +
+``results/batch_summary.json``) land under ``results/`` for the licensed-run
+queue's return allowlist; heavy case trees (meshes, fields, VTK,
+``processor*``) stay in the work dir and never reach ``results/``.
 """
 
 from __future__ import annotations
@@ -30,6 +45,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -56,6 +72,24 @@ CHECKPOINT_FILENAME = "_result.json"
 # the ONLY suffixes allowed under it; heavy case trees stay in the work dir.
 _RESULTS_ALLOWED_SUFFIXES = {".csv", ".json"}
 VALID_MODES = ("pool", "mpi")
+DEFAULT_TIMEOUT_SECONDS = 43200
+# Manifest columns owned by the workflow. A case knob with one of these names
+# would be silently clobbered by the reserved value in the manifest row, so
+# knob names colliding with them are rejected up front (rename the knob and
+# route it onto the settings path via mapping:, e.g. solver_app: solver).
+_RESERVED_ROW_KEYS = frozenset(
+    {
+        "index",
+        "name",
+        "status",
+        "solver",
+        "mock",
+        "error",
+        "case_dir",
+        "wall_seconds",
+        "mpi_plan",
+    }
+)
 
 SOLVER_ERROR_MESSAGE = (
     "OpenFOAM solver / utilities are not on PATH on this host. "
@@ -86,16 +120,25 @@ def router(cfg: dict) -> dict:
     mesh_utility = base.get("mesh_utility", DEFAULT_MESH_UTILITY)
     solver = base.get("solver")
 
+    reconstruct = bool(run_settings.get("reconstruct", True))
+    timeout_seconds = int(
+        run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    )
+
     # Fail-closed once, up front: a real run on a solver-less host must never
     # silently downgrade to a build-only dry run (the licensed-run lane would
     # record a false finish). Per-case failures below (divergence, bad mesh)
-    # are isolated; a missing toolchain is not.
-    if not mock and not _solver_ready(mode, mesh_utility, solver):
+    # are isolated; a missing toolchain is not. The check covers EVERY utility
+    # the plan will invoke — including reconstructPar when mode: mpi ends with
+    # a reconstruction — so hours of solve can't fail at the final stage.
+    if not mock and not _solver_ready(mode, mesh_utility, solver, reconstruct):
         raise RuntimeError(SOLVER_ERROR_MESSAGE)
 
     variants = settings.get("variants") or {}
     cases = _resolve_case_matrix(settings.get("cases"), variants, cfg_dir)
-    mapping = variants.get("mapping") or {}
+    # An explicit cases: list is mutually exclusive with variants:, so accept
+    # a top-level mapping: for renaming its knobs onto dotted settings paths.
+    mapping = settings.get("mapping") or variants.get("mapping") or {}
 
     results_dir = _resolve_dir(
         run_settings.get("output_dir", DEFAULT_OUTPUT_DIR), cfg_dir
@@ -126,6 +169,7 @@ def router(cfg: dict) -> dict:
         mode=mode,
         workers=workers,
         mock=mock,
+        timeout_seconds=timeout_seconds,
         started_at=started_at,
         finished_at=finished_at,
     )
@@ -194,6 +238,14 @@ def _render_cases(
         # A "name" field names the case dir; every other field is a swept knob
         # injected into the per-case OpenFOAM settings via a dotted path.
         params = {k: v for k, v in case.items() if k != "name"}
+        collisions = _RESERVED_ROW_KEYS.intersection(params)
+        if collisions:
+            raise ValueError(
+                "openfoam_run_batch: case parameter name(s) "
+                f"{sorted(collisions)} collide with reserved manifest "
+                "columns; rename the knob and route it onto the settings "
+                "path via mapping: (e.g. solver_app: solver)"
+            )
         for name, value in params.items():
             _set_dotted(case_settings, mapping.get(name, name), value)
         case_name = case.get("name") or f"{base_name}_{index:03d}"
@@ -248,6 +300,10 @@ def _run_case_pool(
 
     start = time.monotonic()
     try:
+        # A retry (absent/failed/corrupt checkpoint) must never rebuild on top
+        # of a dirty tree — stale timestep dirs/logs would mix inconsistent
+        # artifacts into the new solve.
+        _clean_case_dir(item["work_dir"])
         case_dir = _build_case(item)
         if mock:
             # Mock leaf: the real (license-free) builder authored the case tree,
@@ -305,7 +361,8 @@ def _run_case_mpi(
     mock: bool,
     command_runner: Callable[..., int] | None = None,
 ) -> dict[str, Any]:
-    checkpoint = _load_checkpoint(item["work_dir"])
+    work_dir = item["work_dir"]
+    checkpoint = _load_checkpoint(work_dir)
     if checkpoint is not None:
         return checkpoint
 
@@ -315,20 +372,37 @@ def _run_case_mpi(
     if not solver:
         row = _row(item, status="failed",
                    error="mode: mpi requires base.solver to be set")
-        _write_checkpoint(item["work_dir"], row)
+        _write_checkpoint(work_dir, row)
         return row
     reconstruct = bool(run_settings.get("reconstruct", True))
-    timeout = int(run_settings.get("timeout_seconds", 43200))
+    timeout = int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
+    # Resume (run_batch.resume: true): a previous killed attempt left its
+    # decomposed state behind -> restart the solver from latestTime instead of
+    # redoing mesh/decompose/solve from t=0 (retry-livelock mitigation for
+    # cases near the dispatch wall-clock cap).
+    resuming = (
+        not mock
+        and bool(run_settings.get("resume", False))
+        and _has_processor_dirs(work_dir)
+    )
 
     start = time.monotonic()
     try:
-        case_dir = _build_case(item)
+        if resuming:
+            case_dir = work_dir
+            _set_start_from_latest_time(case_dir)
+        else:
+            # Fresh attempt: never rebuild on top of a dirty tree (stale
+            # timestep dirs/logs from a killed run mix inconsistent artifacts).
+            _clean_case_dir(work_dir)
+            case_dir = _build_case(item)
         plan = mpi_command_plan(
             solver=solver,
             workers=workers,
             mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
             run_set_fields=bool(settings.get("run_set_fields", False)),
             reconstruct=reconstruct,
+            resume=resuming,
         )
         if mock:
             # Explicit mock: record the exact command plan without executing.
@@ -336,16 +410,20 @@ def _run_case_mpi(
                        solver=solver, mock=True)
             row["mpi_plan"] = [" ".join(argv) for argv in plan]
         else:
-            _write_decompose_par_dict(case_dir, workers)
+            if not resuming:
+                _write_decompose_par_dict(case_dir, workers)
             row = _execute_mpi_plan(item, case_dir, plan, solver, run, timeout)
+            # processor* holds the ONLY copy of the solved fields until
+            # reconstructPar merges them back: prune ONLY after a successful
+            # reconstruction. With reconstruct: false the decomposed fields
+            # ARE the deliverable and stay in the work dir; on failure they
+            # are kept for diagnosis and a possible resume.
+            if reconstruct and row["status"] == "completed":
+                _prune_processor_dirs(case_dir)
     except Exception as exc:  # noqa: BLE001 - checkpoint the failure
         row = _row(item, status="failed", error=str(exc))
-    finally:
-        # ALWAYS prune processor* dirs — decomposed sub-meshes are heavy and
-        # must never leak into results/ or bloat the work dir (benchmark rule).
-        _prune_processor_dirs(item["work_dir"])
     row["wall_seconds"] = round(time.monotonic() - start, 3)
-    _write_checkpoint(item["work_dir"], row)
+    _write_checkpoint(work_dir, row)
     return row
 
 
@@ -377,14 +455,19 @@ def mpi_command_plan(
     mesh_utility: str = DEFAULT_MESH_UTILITY,
     run_set_fields: bool = False,
     reconstruct: bool = True,
+    resume: bool = False,
 ) -> list[list[str]]:
     """Ordered utility argv for an MPI solve: mesh -> decompose -> solve ->
     (reconstruct). decomposePar ALWAYS precedes mpirun; the solver runs
-    ``-parallel`` under ``mpirun -np <workers>`` (mirrors the 3D benchmark)."""
-    plan: list[list[str]] = [[mesh_utility]]
-    if run_set_fields:
-        plan.append(["setFields"])
-    plan.append(["decomposePar", "-force"])
+    ``-parallel`` under ``mpirun -np <workers>`` (mirrors the 3D benchmark).
+    A resume skips the mesh/decompose stages entirely — the previous attempt's
+    decomposition is reused and the solver restarts from latestTime."""
+    plan: list[list[str]] = []
+    if not resume:
+        plan.append([mesh_utility])
+        if run_set_fields:
+            plan.append(["setFields"])
+        plan.append(["decomposePar", "-force"])
     plan.append(
         ["mpirun", "-np", str(workers), "--oversubscribe", solver, "-parallel"]
     )
@@ -415,14 +498,20 @@ def _build_case(item: dict[str, Any]) -> Path:
     return Path(build_cfg["openfoam"]["case_dir"])
 
 
-def _solver_ready(mode: str, mesh_utility: str, solver: str | None) -> bool:
-    """The CFD ready-gate: the utilities this run will invoke are on PATH.
-    Mirrors OpenFOAMRunner._openfoam_available / 'openfoam doctor'."""
+def _solver_ready(
+    mode: str, mesh_utility: str, solver: str | None, reconstruct: bool = True
+) -> bool:
+    """The CFD ready-gate: EVERY utility this run will invoke is on PATH —
+    including reconstructPar when the mpi plan ends with a reconstruction
+    (otherwise hours of solve would fail at the very last stage). Mirrors
+    OpenFOAMRunner._openfoam_available / 'openfoam doctor'."""
     required = [mesh_utility]
     if solver:
         required.append(solver)
     if mode == "mpi":
         required += ["decomposePar", "mpirun"]
+        if reconstruct:
+            required.append("reconstructPar")
     return all(shutil.which(exe) is not None for exe in required)
 
 
@@ -468,6 +557,31 @@ def _prune_processor_dirs(case_dir: Path) -> None:
         shutil.rmtree(proc_dir, ignore_errors=True)
 
 
+def _has_processor_dirs(case_dir: Path) -> bool:
+    return case_dir.is_dir() and any(case_dir.glob("processor*"))
+
+
+def _clean_case_dir(case_dir: Path) -> None:
+    """Remove a stale case tree before a fresh rebuild (retry hygiene)."""
+    if case_dir.is_dir():
+        shutil.rmtree(case_dir, ignore_errors=True)
+
+
+def _set_start_from_latest_time(case_dir: Path) -> None:
+    """Patch system/controlDict to ``startFrom latestTime`` so a resumed MPI
+    solve continues from the last written time dir instead of t=0."""
+    control = case_dir / "system" / "controlDict"
+    if not control.is_file():
+        raise RuntimeError(
+            f"resume requested but no system/controlDict in {case_dir}"
+        )
+    text = control.read_text()
+    patched = re.sub(r"startFrom\s+\w+\s*;", "startFrom       latestTime;", text)
+    if patched == text and "startFrom" not in text:
+        patched = text + "\nstartFrom       latestTime;\n"
+    control.write_text(patched)
+
+
 def _load_checkpoint(work_dir: Path) -> dict[str, Any] | None:
     checkpoint = work_dir / CHECKPOINT_FILENAME
     if not checkpoint.is_file():
@@ -476,14 +590,23 @@ def _load_checkpoint(work_dir: Path) -> dict[str, Any] | None:
         row = json.loads(checkpoint.read_text())
     except (OSError, json.JSONDecodeError):
         return None
-    # Only a completed case is idempotently skipped; a failed checkpoint is
-    # re-run so a transient failure can be retried by re-enqueuing the input.
+    if not isinstance(row, dict):
+        return None
+    # Only a completed case is idempotently skipped; a failed (or truncated /
+    # corrupt) checkpoint is re-run so a transient failure can be retried by
+    # re-enqueuing the same input.
     return row if row.get("status") == "completed" else None
 
 
 def _write_checkpoint(work_dir: Path, row: dict[str, Any]) -> None:
+    # Atomic: a kill mid-write must leave either the old checkpoint or the new
+    # one, never a truncated file (a corrupt checkpoint reads as "no
+    # checkpoint" and the case is retried).
     work_dir.mkdir(parents=True, exist_ok=True)
-    (work_dir / CHECKPOINT_FILENAME).write_text(json.dumps(row, indent=2) + "\n")
+    target = work_dir / CHECKPOINT_FILENAME
+    tmp = work_dir / f"{CHECKPOINT_FILENAME}.tmp"
+    tmp.write_text(json.dumps(row, indent=2) + "\n")
+    os.replace(tmp, target)
 
 
 def _row(
@@ -519,6 +642,7 @@ def _write_summary(
     mode: str,
     workers: int,
     mock: bool,
+    timeout_seconds: int,
     started_at: datetime,
     finished_at: datetime,
 ) -> dict:
@@ -532,6 +656,9 @@ def _write_summary(
         "workers": workers,
         "host_cpu_count": os.cpu_count(),
         "mock": mock,
+        # The per-stage wall cap — dispatch lanes compare their own wall-clock
+        # window against this when sizing mpi cases (see module docstring).
+        "timeout_seconds": timeout_seconds,
         "started_at_utc": started_at.isoformat(),
         "finished_at_utc": finished_at.isoformat(),
     }

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -1,0 +1,553 @@
+"""OpenFOAM CFD batch workflow — one request saturates a CFD node (issue #1560).
+
+One input.yml -> a deterministic case matrix that saturates a dedicated CFD box
+in one of two ways (``run_batch.mode``):
+
+* ``pool`` (default): N cases run CONCURRENTLY, each single-rank, through a
+  bounded thread pool sized to ~90% of host cores (owner resource policy,
+  dm#1553). Each case reuses the existing fail-closed per-case path
+  (OpenFOAMWorkflow build + OpenFOAMRunner solve) — the same code the
+  ``basename: openfoam`` engine route uses (landed via #1161).
+* ``mpi``: ONE large case spread across ranks —
+  ``decomposePar -force`` (scotch) -> ``mpirun -np <workers> <solver> -parallel``
+  -> optional ``reconstructPar`` -> ``processor*`` dirs ALWAYS pruned (mirrors
+  ``scripts/cfd/run_sloshing_3d_benchmark.py``).
+
+Case generation reuses parametric_run's helpers (``_load_cases`` /
+``_set_dotted``) so the factorial/range/csv/yaml_matrix schema and dotted-path
+mapping behave identically to orcaflex_run_batch (#1554).
+
+Idempotent/resumable: each case writes a ``_result.json`` checkpoint under its
+work dir; a re-run skips a case whose checkpoint is ``completed`` (a retry after
+a queue timeout safely re-enqueues the same input). Small conclusions
+(``results/cases.csv`` + ``results/batch_summary.json``) land under ``results/``
+for the licensed-run queue's return allowlist; heavy case trees (meshes, fields,
+VTK, ``processor*``) stay in the work dir and never reach ``results/``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+from loguru import logger
+
+from digitalmodel.workflows.parametric_run import _load_cases, _set_dotted
+
+# Owner resource policy (dm#1553): a CFD node is saturated by sizing the pool
+# (or the MPI rank count) to ~90% of the host's cores.
+WORKER_CORE_FRACTION = 0.9
+DEFAULT_MODE = "pool"
+DEFAULT_MESH_UTILITY = "blockMesh"
+DEFAULT_OUTPUT_DIR = "results"
+DEFAULT_WORK_DIR = "batch_runs"
+CHECKPOINT_FILENAME = "_result.json"
+# results/ is the licensed-run return allowlist: small rollups only. These are
+# the ONLY suffixes allowed under it; heavy case trees stay in the work dir.
+_RESULTS_ALLOWED_SUFFIXES = {".csv", ".json"}
+VALID_MODES = ("pool", "mpi")
+
+SOLVER_ERROR_MESSAGE = (
+    "OpenFOAM solver / utilities are not on PATH on this host. "
+    "openfoam_run_batch is a requires-solver workflow: dispatch it to a "
+    "solver-capable host (run 'openfoam doctor --require-solver' to confirm) "
+    "or set run_batch.mock: true for a solver-free case-build dry run."
+)
+
+_YAML_SUFFIXES = {".yml", ".yaml"}
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("openfoam_run_batch") or {}
+    cfg_dir = Path(cfg.get("_config_dir_path") or Path.cwd())
+
+    run_settings = settings.get("run_batch") or {}
+    mode = run_settings.get("mode", DEFAULT_MODE)
+    if mode not in VALID_MODES:
+        raise ValueError(
+            f"openfoam_run_batch run_batch.mode must be pool|mpi, got {mode}"
+        )
+    mock = bool(run_settings.get("mock", False))
+    workers = resolve_workers(run_settings)
+
+    base = settings.get("base") or {}
+    if not base.get("case_type"):
+        raise ValueError("openfoam_run_batch.base.case_type is required")
+    mesh_utility = base.get("mesh_utility", DEFAULT_MESH_UTILITY)
+    solver = base.get("solver")
+
+    # Fail-closed once, up front: a real run on a solver-less host must never
+    # silently downgrade to a build-only dry run (the licensed-run lane would
+    # record a false finish). Per-case failures below (divergence, bad mesh)
+    # are isolated; a missing toolchain is not.
+    if not mock and not _solver_ready(mode, mesh_utility, solver):
+        raise RuntimeError(SOLVER_ERROR_MESSAGE)
+
+    variants = settings.get("variants") or {}
+    cases = _resolve_case_matrix(settings.get("cases"), variants, cfg_dir)
+    mapping = variants.get("mapping") or {}
+
+    results_dir = _resolve_dir(
+        run_settings.get("output_dir", DEFAULT_OUTPUT_DIR), cfg_dir
+    )
+    work_dir = _resolve_dir(run_settings.get("work_dir", DEFAULT_WORK_DIR), cfg_dir)
+
+    rendered = _render_cases(base, cases, mapping, work_dir)
+
+    started_at = datetime.now(timezone.utc)
+    if mode == "mpi":
+        if len(rendered) != 1:
+            raise ValueError(
+                "openfoam_run_batch mode: mpi runs exactly ONE case across "
+                f"ranks; the matrix produced {len(rendered)} cases. Use "
+                "mode: pool for a multi-case sweep."
+            )
+        rows = [_run_case_mpi(rendered[0], run_settings, workers, mock)]
+    else:
+        rows = _run_pool(rendered, run_settings, workers, mock)
+    finished_at = datetime.now(timezone.utc)
+
+    manifest_path = results_dir / "cases.csv"
+    summary_path = results_dir / "batch_summary.json"
+    _write_manifest(rows, manifest_path)
+    summary = _write_summary(
+        rows=rows,
+        path=summary_path,
+        mode=mode,
+        workers=workers,
+        mock=mock,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    if summary["failed"]:
+        logger.warning(
+            "openfoam_run_batch: {} of {} cases failed; see {}",
+            summary["failed"],
+            summary["total_cases"],
+            manifest_path,
+        )
+
+    settings["cases"] = rows
+    settings["outputs"] = {
+        "manifest": str(manifest_path),
+        "summary": str(summary_path),
+    }
+    cfg["openfoam_run_batch"] = settings
+    return cfg
+
+
+def default_workers(cpu_count: int | None = None) -> int:
+    """~90% of host cores, floored, never below 1 (dm#1553 resource policy)."""
+    cores = cpu_count if cpu_count is not None else (os.cpu_count() or 1)
+    return max(1, math.floor(WORKER_CORE_FRACTION * cores))
+
+
+def resolve_workers(run_settings: dict) -> int:
+    explicit = run_settings.get("workers")
+    if explicit is None:
+        return default_workers()
+    workers = int(explicit)
+    if workers < 1:
+        raise ValueError(f"run_batch.workers must be >= 1, got {explicit}")
+    return workers
+
+
+# --------------------------------------------------------------------------- #
+#  case matrix (reuses parametric_run's case generation)                      #
+# --------------------------------------------------------------------------- #
+def _resolve_case_matrix(
+    explicit: list[dict] | None, variants: dict, cfg_dir: Path
+) -> list[dict[str, Any]]:
+    if explicit:
+        if variants:
+            raise ValueError(
+                "openfoam_run_batch: give either cases: [...] or variants:, "
+                "not both"
+            )
+        return [dict(case) for case in explicit]
+    if variants:
+        return _load_cases(variants, cfg_dir)
+    # No matrix -> a single case built from base alone.
+    return [{}]
+
+
+def _render_cases(
+    base: dict,
+    cases: list[dict[str, Any]],
+    mapping: dict[str, str],
+    work_dir: Path,
+) -> list[dict[str, Any]]:
+    base_name = base.get("name") or f"{base['case_type']}_case"
+    rendered: list[dict[str, Any]] = []
+    for index, case in enumerate(cases):
+        case_settings = deepcopy(base)
+        # A "name" field names the case dir; every other field is a swept knob
+        # injected into the per-case OpenFOAM settings via a dotted path.
+        params = {k: v for k, v in case.items() if k != "name"}
+        for name, value in params.items():
+            _set_dotted(case_settings, mapping.get(name, name), value)
+        case_name = case.get("name") or f"{base_name}_{index:03d}"
+        case_settings["name"] = case_name
+        rendered.append(
+            {
+                "index": index,
+                "name": case_name,
+                "case": params,
+                "settings": case_settings,
+                "work_dir": work_dir / case_name,
+            }
+        )
+    return rendered
+
+
+# --------------------------------------------------------------------------- #
+#  pool mode — bounded thread pool of single-rank cases                       #
+# --------------------------------------------------------------------------- #
+def _run_pool(
+    rendered: list[dict[str, Any]],
+    run_settings: dict,
+    workers: int,
+    mock: bool,
+) -> list[dict[str, Any]]:
+    # Each leaf blocks on its own OpenFOAM subprocess -> threads give true
+    # parallelism with no process-spawn overhead (same shape as the sloshing
+    # backbone sweep). Pool is bounded to `workers` so the node is saturated,
+    # not oversubscribed.
+    rows_by_index: dict[int, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=min(workers, len(rendered))) as pool:
+        futures = {
+            pool.submit(_run_case_pool, item, run_settings, mock): item
+            for item in rendered
+        }
+        for future, item in futures.items():
+            try:
+                rows_by_index[item["index"]] = future.result()
+            except Exception as exc:  # noqa: BLE001 - per-case isolation
+                rows_by_index[item["index"]] = _row(
+                    item, status="failed", error=str(exc)
+                )
+    return [rows_by_index[item["index"]] for item in rendered]
+
+
+def _run_case_pool(
+    item: dict[str, Any], run_settings: dict, mock: bool
+) -> dict[str, Any]:
+    checkpoint = _load_checkpoint(item["work_dir"])
+    if checkpoint is not None:
+        return checkpoint
+
+    start = time.monotonic()
+    try:
+        case_dir = _build_case(item)
+        if mock:
+            # Mock leaf: the real (license-free) builder authored the case tree,
+            # but no solver ran. Never a silent downgrade — mock is explicit.
+            row = _row(item, status="completed", case_dir=case_dir,
+                       solver=item["settings"].get("solver"), mock=True)
+        else:
+            row = _solve_serial(item, case_dir, run_settings)
+    except Exception as exc:  # noqa: BLE001 - per-case isolation
+        row = _row(item, status="failed", error=str(exc))
+    row["wall_seconds"] = round(time.monotonic() - start, 3)
+    _write_checkpoint(item["work_dir"], row)
+    return row
+
+
+def _solve_serial(
+    item: dict[str, Any], case_dir: Path, run_settings: dict
+) -> dict[str, Any]:
+    """Run one prepared case single-rank through the fail-closed runner."""
+    from digitalmodel.solvers.openfoam.runner import (
+        OpenFOAMRunConfig,
+        OpenFOAMRunner,
+    )
+
+    settings = item["settings"]
+    run_cfg = OpenFOAMRunConfig(
+        solver=settings.get("solver"),
+        mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
+        run_snappy=bool(settings.get("run_snappy", False)),
+        run_set_fields=bool(settings.get("run_set_fields", False)),
+        to_vtk=bool(settings.get("to_vtk", False)),
+        timeout_seconds=int(run_settings.get("timeout_seconds", 43200)),
+    )
+    result = OpenFOAMRunner(run_cfg).run(case_dir)
+    status = str(getattr(result.status, "value", result.status)).lower()
+    if status == "completed":
+        return _row(item, status="completed", case_dir=case_dir,
+                    solver=result.solver)
+    return _row(
+        item,
+        status="failed",
+        case_dir=case_dir,
+        solver=result.solver,
+        error=result.error_message or f"runner status {status}",
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  mpi mode — one case across ranks (decomposePar -> mpirun -> reconstruct)    #
+# --------------------------------------------------------------------------- #
+def _run_case_mpi(
+    item: dict[str, Any],
+    run_settings: dict,
+    workers: int,
+    mock: bool,
+    command_runner: Callable[..., int] | None = None,
+) -> dict[str, Any]:
+    checkpoint = _load_checkpoint(item["work_dir"])
+    if checkpoint is not None:
+        return checkpoint
+
+    run = command_runner or _run_command
+    settings = item["settings"]
+    solver = settings.get("solver")
+    if not solver:
+        row = _row(item, status="failed",
+                   error="mode: mpi requires base.solver to be set")
+        _write_checkpoint(item["work_dir"], row)
+        return row
+    reconstruct = bool(run_settings.get("reconstruct", True))
+    timeout = int(run_settings.get("timeout_seconds", 43200))
+
+    start = time.monotonic()
+    try:
+        case_dir = _build_case(item)
+        plan = mpi_command_plan(
+            solver=solver,
+            workers=workers,
+            mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
+            run_set_fields=bool(settings.get("run_set_fields", False)),
+            reconstruct=reconstruct,
+        )
+        if mock:
+            # Explicit mock: record the exact command plan without executing.
+            row = _row(item, status="completed", case_dir=case_dir,
+                       solver=solver, mock=True)
+            row["mpi_plan"] = [" ".join(argv) for argv in plan]
+        else:
+            _write_decompose_par_dict(case_dir, workers)
+            row = _execute_mpi_plan(item, case_dir, plan, solver, run, timeout)
+    except Exception as exc:  # noqa: BLE001 - checkpoint the failure
+        row = _row(item, status="failed", error=str(exc))
+    finally:
+        # ALWAYS prune processor* dirs — decomposed sub-meshes are heavy and
+        # must never leak into results/ or bloat the work dir (benchmark rule).
+        _prune_processor_dirs(item["work_dir"])
+    row["wall_seconds"] = round(time.monotonic() - start, 3)
+    _write_checkpoint(item["work_dir"], row)
+    return row
+
+
+def _execute_mpi_plan(
+    item: dict[str, Any],
+    case_dir: Path,
+    plan: list[list[str]],
+    solver: str,
+    run: Callable[..., int],
+    timeout: int,
+) -> dict[str, Any]:
+    for argv in plan:
+        log = case_dir / f"log.{argv[0]}"
+        rc = run(argv, case_dir, log, timeout)
+        if rc != 0:
+            return _row(
+                item,
+                status="failed",
+                case_dir=case_dir,
+                solver=solver,
+                error=f"stage '{argv[0]}' returned non-zero exit code {rc}",
+            )
+    return _row(item, status="completed", case_dir=case_dir, solver=solver)
+
+
+def mpi_command_plan(
+    solver: str,
+    workers: int,
+    mesh_utility: str = DEFAULT_MESH_UTILITY,
+    run_set_fields: bool = False,
+    reconstruct: bool = True,
+) -> list[list[str]]:
+    """Ordered utility argv for an MPI solve: mesh -> decompose -> solve ->
+    (reconstruct). decomposePar ALWAYS precedes mpirun; the solver runs
+    ``-parallel`` under ``mpirun -np <workers>`` (mirrors the 3D benchmark)."""
+    plan: list[list[str]] = [[mesh_utility]]
+    if run_set_fields:
+        plan.append(["setFields"])
+    plan.append(["decomposePar", "-force"])
+    plan.append(
+        ["mpirun", "-np", str(workers), "--oversubscribe", solver, "-parallel"]
+    )
+    if reconstruct:
+        plan.append(["reconstructPar"])
+    return plan
+
+
+# --------------------------------------------------------------------------- #
+#  shared helpers                                                             #
+# --------------------------------------------------------------------------- #
+def _build_case(item: dict[str, Any]) -> Path:
+    """Author the case tree via the license-free OpenFOAM builder (reuses the
+    engine handler's build path) under this case's isolated work dir."""
+    from digitalmodel.solvers.openfoam.workflow import OpenFOAMWorkflow
+
+    settings = deepcopy(item["settings"])
+    settings["operation"] = "build_case"
+    # Build into work_dir's parent so the case tree IS item["work_dir"]
+    # (name == the case dir): the tree, its log.* files and the _result.json
+    # checkpoint all live in one isolated per-case dir (backbone convention).
+    build_cfg = {
+        "basename": "openfoam",
+        "Analysis": {"result_folder": str(item["work_dir"].parent)},
+        "openfoam": settings,
+    }
+    OpenFOAMWorkflow().router(build_cfg)
+    return Path(build_cfg["openfoam"]["case_dir"])
+
+
+def _solver_ready(mode: str, mesh_utility: str, solver: str | None) -> bool:
+    """The CFD ready-gate: the utilities this run will invoke are on PATH.
+    Mirrors OpenFOAMRunner._openfoam_available / 'openfoam doctor'."""
+    required = [mesh_utility]
+    if solver:
+        required.append(solver)
+    if mode == "mpi":
+        required += ["decomposePar", "mpirun"]
+    return all(shutil.which(exe) is not None for exe in required)
+
+
+def _run_command(argv: list[str], cwd: Path, log: Path, timeout: int) -> int:
+    """Real subprocess stage (fail-closed on OSError/timeout). Persists the
+    utility's stdout+stderr to log.<utility> inside the case dir."""
+    try:
+        with log.open("w") as fh:
+            proc = subprocess.run(  # noqa: S603 - argv is fixed utility names.
+                argv,
+                cwd=str(cwd),
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                timeout=timeout,
+                check=False,
+            )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("openfoam_run_batch: {} invocation failed: {}", argv[0], exc)
+        return 1
+    return proc.returncode
+
+
+_DECOMPOSE_PAR_DICT = """\
+FoamFile {{ version 2.0; format ascii; class dictionary; object decomposeParDict; }}
+
+numberOfSubdomains {n};
+method scotch;
+"""
+
+
+def _write_decompose_par_dict(case_dir: Path, workers: int) -> None:
+    """Author system/decomposeParDict for `workers` scotch subdomains (the
+    case builder emits a placeholder; the MPI run pins it to the rank count)."""
+    (case_dir / "system" / "decomposeParDict").write_text(
+        _DECOMPOSE_PAR_DICT.format(n=workers)
+    )
+
+
+def _prune_processor_dirs(case_dir: Path) -> None:
+    if not case_dir.is_dir():
+        return
+    for proc_dir in case_dir.glob("processor*"):
+        shutil.rmtree(proc_dir, ignore_errors=True)
+
+
+def _load_checkpoint(work_dir: Path) -> dict[str, Any] | None:
+    checkpoint = work_dir / CHECKPOINT_FILENAME
+    if not checkpoint.is_file():
+        return None
+    try:
+        row = json.loads(checkpoint.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    # Only a completed case is idempotently skipped; a failed checkpoint is
+    # re-run so a transient failure can be retried by re-enqueuing the input.
+    return row if row.get("status") == "completed" else None
+
+
+def _write_checkpoint(work_dir: Path, row: dict[str, Any]) -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / CHECKPOINT_FILENAME).write_text(json.dumps(row, indent=2) + "\n")
+
+
+def _row(
+    item: dict[str, Any],
+    *,
+    status: str,
+    case_dir: Path | None = None,
+    solver: str | None = None,
+    error: str | None = None,
+    mock: bool = False,
+) -> dict[str, Any]:
+    return {
+        "index": item["index"],
+        "name": item["name"],
+        **item["case"],
+        "status": status,
+        "solver": solver,
+        "mock": mock,
+        "error": error,
+        "case_dir": str(case_dir) if case_dir else None,
+        "wall_seconds": 0.0,
+    }
+
+
+def _write_manifest(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _write_summary(
+    rows: list[dict[str, Any]],
+    path: Path,
+    mode: str,
+    workers: int,
+    mock: bool,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict:
+    completed = sum(1 for row in rows if row["status"] == "completed")
+    summary = {
+        "workflow": "openfoam_run_batch",
+        "mode": mode,
+        "total_cases": len(rows),
+        "completed": completed,
+        "failed": len(rows) - completed,
+        "workers": workers,
+        "host_cpu_count": os.cpu_count(),
+        "mock": mock,
+        "started_at_utc": started_at.isoformat(),
+        "finished_at_utc": finished_at.isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2) + "\n")
+    return summary
+
+
+def _resolve_path(path_value: str, cfg_dir: Path) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return cfg_dir / path
+
+
+def _resolve_dir(path_value: str, cfg_dir: Path) -> Path:
+    resolved = _resolve_path(path_value, cfg_dir)
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved

--- a/tests/workflows/test_openfoam_run_batch.py
+++ b/tests/workflows/test_openfoam_run_batch.py
@@ -43,6 +43,8 @@ def test_example_input_runs_mock_batch(tmp_path):
     assert len(rows) == 2
     assert rows["status"].tolist() == ["completed", "completed"]
     assert rows["name"].tolist() == ["current_simpleFoam", "current_pimpleFoam"]
+    # The swept knob column AND the reserved actual-solver column both land.
+    assert sorted(rows["solver_app"].tolist()) == ["pimpleFoam", "simpleFoam"]
     assert sorted(rows["solver"].tolist()) == ["pimpleFoam", "simpleFoam"]
     assert bool(rows["mock"].all())
 
@@ -54,11 +56,14 @@ def test_example_input_runs_mock_batch(tmp_path):
     assert summary["workers"] == 2
     assert summary["mock"] is True
     assert summary["host_cpu_count"] == os.cpu_count()
+    assert summary["timeout_seconds"] == 43200
 
     # The license-free builder authored a real case tree per case, under the
     # work dir (never under results/).
     for name in ("current_simpleFoam", "current_pimpleFoam"):
         assert (tmp_path / "batch_runs" / name / "system" / "controlDict").is_file()
+    # Atomic checkpoint writes leave no temp files behind.
+    assert not list((tmp_path / "batch_runs").rglob("*.tmp"))
 
     outputs = result["openfoam_run_batch"]["outputs"]
     assert outputs["manifest"] == str(manifest)
@@ -74,8 +79,8 @@ def test_case_matrix_is_deterministic(tmp_path):
     base = {"case_type": "current_loading", "solver": "simpleFoam"}
     variants = {
         "source": "yaml_matrix",
-        "list": [{"solver": "simpleFoam"}, {"solver": "pimpleFoam"}],
-        "mapping": {"solver": "solver"},
+        "list": [{"solver_app": "simpleFoam"}, {"solver_app": "pimpleFoam"}],
+        "mapping": {"solver_app": "solver"},
     }
 
     first = ofb._render_cases(
@@ -99,10 +104,11 @@ def test_variants_yaml_matrix_runs_through_router(tmp_path):
     cfg = _example_cfg(tmp_path)
     settings = cfg["openfoam_run_batch"]
     settings.pop("cases")
+    settings.pop("mapping")
     settings["variants"] = {
         "source": "yaml_matrix",
-        "list": [{"solver": "simpleFoam"}, {"solver": "interFoam"}],
-        "mapping": {"solver": "solver"},
+        "list": [{"solver_app": "simpleFoam"}, {"solver_app": "interFoam"}],
+        "mapping": {"solver_app": "solver"},
     }
 
     ofb.router(cfg)
@@ -272,3 +278,136 @@ def test_mpi_mode_rejects_multi_case_matrix(tmp_path):
     cfg["openfoam_run_batch"]["run_batch"]["mode"] = "mpi"  # 2-case matrix
     with pytest.raises(ValueError, match="exactly ONE case"):
         ofb.router(cfg)
+
+
+def test_mpi_reconstruct_false_preserves_processor_dirs(tmp_path):
+    # With reconstruct: false the decomposed fields under processor* are the
+    # ONLY copy of the solved output — pruning them would destroy the result.
+    base = {"case_type": "current_loading", "solver": "interFoam"}
+    item = ofb._render_cases(base, [{}], {}, tmp_path / "work")[0]
+
+    recorded = []
+
+    def fake_runner(argv, cwd, log, timeout):
+        recorded.append(argv)
+        if argv[0] == "decomposePar":
+            (Path(cwd) / "processor0").mkdir(parents=True, exist_ok=True)
+        return 0
+
+    row = ofb._run_case_mpi(
+        item, {"reconstruct": False}, workers=4, mock=False,
+        command_runner=fake_runner,
+    )
+
+    assert row["status"] == "completed"
+    names = [argv[0] for argv in recorded]
+    assert "reconstructPar" not in names
+    assert (tmp_path / "work" / item["name"] / "processor0").is_dir()
+
+
+def test_mpi_stage_failure_fails_case_and_is_retried(tmp_path):
+    # A non-zero stage exit must mark the case failed (no false "completed"
+    # checkpoint), preserve processor* for diagnosis, and a re-run must RETRY
+    # (only a completed checkpoint is skipped).
+    base = {"case_type": "current_loading", "solver": "interFoam"}
+    item = ofb._render_cases(base, [{}], {}, tmp_path / "work")[0]
+    case_dir = tmp_path / "work" / item["name"]
+
+    def failing_runner(argv, cwd, log, timeout):
+        if argv[0] == "decomposePar":
+            (Path(cwd) / "processor0").mkdir(parents=True, exist_ok=True)
+        return 1 if argv[0] == "mpirun" else 0
+
+    row = ofb._run_case_mpi(
+        item, {}, workers=2, mock=False, command_runner=failing_runner
+    )
+    assert row["status"] == "failed"
+    assert "mpirun" in row["error"]
+    checkpoint = json.loads((case_dir / "_result.json").read_text())
+    assert checkpoint["status"] == "failed"
+    # Decomposed state is kept on failure (diagnosis / potential resume).
+    assert (case_dir / "processor0").is_dir()
+
+    # Retry with a healthy runner: the failed checkpoint does NOT short-circuit.
+    row2 = ofb._run_case_mpi(
+        item, {}, workers=2, mock=False,
+        command_runner=lambda argv, cwd, log, timeout: 0,
+    )
+    assert row2["status"] == "completed"
+
+
+def test_mpi_resume_restarts_from_latest_time(tmp_path):
+    # resume: true + an existing processor* decomposition -> skip mesh and
+    # decompose stages, patch controlDict to latestTime, never rebuild.
+    base = {"case_type": "current_loading", "solver": "interFoam"}
+    item = ofb._render_cases(base, [{}], {}, tmp_path / "work")[0]
+    case_dir = tmp_path / "work" / item["name"]
+    (case_dir / "system").mkdir(parents=True)
+    (case_dir / "system" / "controlDict").write_text(
+        "application     interFoam;\nstartFrom       startTime;\n"
+    )
+    (case_dir / "processor0").mkdir()
+
+    recorded = []
+
+    def fake_runner(argv, cwd, log, timeout):
+        recorded.append(argv)
+        return 0
+
+    with patch.object(
+        ofb, "_build_case",
+        side_effect=AssertionError("resume must not rebuild the case"),
+    ):
+        row = ofb._run_case_mpi(
+            item, {"resume": True, "reconstruct": True}, workers=4, mock=False,
+            command_runner=fake_runner,
+        )
+
+    assert row["status"] == "completed"
+    assert [argv[0] for argv in recorded] == ["mpirun", "reconstructPar"]
+    assert "latestTime" in (case_dir / "system" / "controlDict").read_text()
+    assert ofb.mpi_command_plan("interFoam", 4, resume=True)[0][0] == "mpirun"
+
+
+def test_failed_pool_checkpoint_is_retried(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    case0 = tmp_path / "batch_runs" / "current_simpleFoam"
+    case0.mkdir(parents=True)
+    (case0 / "_result.json").write_text(
+        json.dumps({"index": 0, "name": "current_simpleFoam",
+                    "status": "failed", "error": "killed"})
+    )
+
+    ofb.router(cfg)
+
+    rows = pd.read_csv(tmp_path / "results" / "cases.csv")
+    row0 = rows[rows["name"] == "current_simpleFoam"].iloc[0]
+    assert row0["status"] == "completed"  # retried, not skipped as failed
+
+
+def test_corrupt_checkpoint_is_treated_as_absent(tmp_path):
+    work = tmp_path / "case"
+    work.mkdir()
+    (work / "_result.json").write_text('{"status": "compl')  # truncated
+    assert ofb._load_checkpoint(work) is None
+    (work / "_result.json").write_text("[]")  # valid JSON, wrong shape
+    assert ofb._load_checkpoint(work) is None
+
+
+def test_solver_ready_requires_reconstructpar_for_mpi(monkeypatch):
+    present = {"blockMesh", "interFoam", "decomposePar", "mpirun"}
+    monkeypatch.setattr(
+        ofb.shutil, "which",
+        lambda exe: "/usr/bin/stub" if exe in present else None,
+    )
+    assert not ofb._solver_ready("mpi", "blockMesh", "interFoam", True)
+    assert ofb._solver_ready("mpi", "blockMesh", "interFoam", False)
+    assert ofb._solver_ready("pool", "blockMesh", "interFoam", True)
+
+
+def test_reserved_case_knob_name_raises(tmp_path):
+    base = {"case_type": "current_loading"}
+    with pytest.raises(ValueError, match="reserved manifest"):
+        ofb._render_cases(base, [{"status": "x"}], {}, tmp_path / "w")
+    with pytest.raises(ValueError, match="reserved manifest"):
+        ofb._render_cases(base, [{"solver": "interFoam"}], {}, tmp_path / "w")

--- a/tests/workflows/test_openfoam_run_batch.py
+++ b/tests/workflows/test_openfoam_run_batch.py
@@ -1,0 +1,274 @@
+"""Solver-free (mock-mode) tests for the openfoam_run_batch workflow (#1560).
+
+No OpenFOAM on PATH is needed: mock mode authors each case tree with the
+license-free builder but runs no solver, and the MPI command plan is asserted
+via an injected command runner. Mirrors the #1558 orcaflex_run_batch tests.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+import yaml
+
+from digitalmodel.workflows import openfoam_run_batch as ofb
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "workflows" / "openfoam-run-batch"
+
+
+def _example_cfg(tmp_path: Path) -> dict:
+    cfg = yaml.safe_load((EXAMPLE_DIR / "input.yml").read_text())
+    cfg["_config_dir_path"] = str(tmp_path)
+    return cfg
+
+
+# --------------------------------------------------------------------------- #
+#  example input: mock batch end-to-end                                       #
+# --------------------------------------------------------------------------- #
+def test_example_input_runs_mock_batch(tmp_path):
+    cfg = _example_cfg(tmp_path)
+
+    result = ofb.router(cfg)
+
+    manifest = tmp_path / "results" / "cases.csv"
+    summary_path = tmp_path / "results" / "batch_summary.json"
+    assert manifest.exists()
+    assert summary_path.exists()
+
+    rows = pd.read_csv(manifest)
+    assert len(rows) == 2
+    assert rows["status"].tolist() == ["completed", "completed"]
+    assert rows["name"].tolist() == ["current_simpleFoam", "current_pimpleFoam"]
+    assert sorted(rows["solver"].tolist()) == ["pimpleFoam", "simpleFoam"]
+    assert bool(rows["mock"].all())
+
+    summary = json.loads(summary_path.read_text())
+    assert summary["total_cases"] == 2
+    assert summary["completed"] == 2
+    assert summary["failed"] == 0
+    assert summary["mode"] == "pool"
+    assert summary["workers"] == 2
+    assert summary["mock"] is True
+    assert summary["host_cpu_count"] == os.cpu_count()
+
+    # The license-free builder authored a real case tree per case, under the
+    # work dir (never under results/).
+    for name in ("current_simpleFoam", "current_pimpleFoam"):
+        assert (tmp_path / "batch_runs" / name / "system" / "controlDict").is_file()
+
+    outputs = result["openfoam_run_batch"]["outputs"]
+    assert outputs["manifest"] == str(manifest)
+    assert outputs["summary"] == str(summary_path)
+
+
+# --------------------------------------------------------------------------- #
+#  matrix determinism                                                         #
+# --------------------------------------------------------------------------- #
+def test_case_matrix_is_deterministic(tmp_path):
+    # A yaml_matrix variants block reuses parametric_run's _load_cases and
+    # accepts string knobs (factorial's ParameterSweep is numeric-only).
+    base = {"case_type": "current_loading", "solver": "simpleFoam"}
+    variants = {
+        "source": "yaml_matrix",
+        "list": [{"solver": "simpleFoam"}, {"solver": "pimpleFoam"}],
+        "mapping": {"solver": "solver"},
+    }
+
+    first = ofb._render_cases(
+        base, ofb._resolve_case_matrix(None, variants, tmp_path),
+        variants["mapping"], tmp_path / "w",
+    )
+    second = ofb._render_cases(
+        base, ofb._resolve_case_matrix(None, variants, tmp_path),
+        variants["mapping"], tmp_path / "w",
+    )
+    assert [i["name"] for i in first] == [i["name"] for i in second]
+    assert [i["case"] for i in first] == [i["case"] for i in second]
+    assert [i["settings"]["solver"] for i in first] == ["simpleFoam", "pimpleFoam"]
+    # Deterministic, index-ordered case names.
+    assert [i["name"] for i in first] == [
+        "current_loading_case_000", "current_loading_case_001",
+    ]
+
+
+def test_variants_yaml_matrix_runs_through_router(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    settings = cfg["openfoam_run_batch"]
+    settings.pop("cases")
+    settings["variants"] = {
+        "source": "yaml_matrix",
+        "list": [{"solver": "simpleFoam"}, {"solver": "interFoam"}],
+        "mapping": {"solver": "solver"},
+    }
+
+    ofb.router(cfg)
+
+    rows = pd.read_csv(tmp_path / "results" / "cases.csv")
+    assert len(rows) == 2
+    assert sorted(rows["solver"].tolist()) == ["interFoam", "simpleFoam"]
+    assert rows["status"].tolist() == ["completed", "completed"]
+
+
+def test_explicit_cases_and_variants_are_mutually_exclusive(tmp_path):
+    with pytest.raises(ValueError, match="either cases"):
+        ofb._resolve_case_matrix([{"name": "a"}], {"source": "factorial"}, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+#  worker defaults (0.9 x cores, floor, min 1)                                #
+# --------------------------------------------------------------------------- #
+def test_workers_default_is_ninety_percent_of_cores(monkeypatch):
+    monkeypatch.setattr(ofb.os, "cpu_count", lambda: 64)
+    assert ofb.resolve_workers({}) == 57
+    assert ofb.resolve_workers({"workers": 4}) == 4
+
+
+def test_workers_default_never_below_one(monkeypatch):
+    monkeypatch.setattr(ofb.os, "cpu_count", lambda: 1)
+    assert ofb.resolve_workers({}) == 1
+
+
+def test_workers_default_applied_in_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(ofb.os, "cpu_count", lambda: 4)
+    cfg = _example_cfg(tmp_path)
+    del cfg["openfoam_run_batch"]["run_batch"]["workers"]
+
+    ofb.router(cfg)
+
+    summary = json.loads((tmp_path / "results" / "batch_summary.json").read_text())
+    assert summary["workers"] == 3
+
+
+# --------------------------------------------------------------------------- #
+#  idempotent / resumable checkpoints                                         #
+# --------------------------------------------------------------------------- #
+def test_completed_checkpoint_is_skipped(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    # Pre-seed a completed checkpoint for the first case with a sentinel marker.
+    case0 = tmp_path / "batch_runs" / "current_simpleFoam"
+    case0.mkdir(parents=True)
+    (case0 / "_result.json").write_text(
+        json.dumps({
+            "index": 0, "name": "current_simpleFoam",
+            "status": "completed", "solver": "sentinel", "mock": True,
+            "error": None, "case_dir": str(case0), "wall_seconds": 0.0,
+        })
+    )
+
+    build_calls = []
+    real_build = ofb._build_case
+    with patch.object(ofb, "_build_case",
+                      side_effect=lambda item: build_calls.append(item["name"])
+                      or real_build(item)):
+        ofb.router(cfg)
+
+    # The pre-seeded case came from its checkpoint (never rebuilt); only the
+    # other case was built.
+    assert build_calls == ["current_pimpleFoam"]
+    rows = pd.read_csv(tmp_path / "results" / "cases.csv")
+    row0 = rows[rows["name"] == "current_simpleFoam"].iloc[0]
+    assert row0["solver"] == "sentinel"
+
+
+# --------------------------------------------------------------------------- #
+#  results contract: only small .csv/.json rollups under results/             #
+# --------------------------------------------------------------------------- #
+def test_results_dir_holds_only_csv_json_rollups(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    ofb.router(cfg)
+
+    results = tmp_path / "results"
+    files = [p for p in results.rglob("*") if p.is_file()]
+    assert files, "expected rollups under results/"
+    for path in files:
+        assert path.suffix in {".csv", ".json"}, path
+        assert path.stat().st_size < 2 * 1024 * 1024
+    assert len(files) <= 100
+    # No heavy case artifacts ever land under results/.
+    assert not list(results.rglob("processor*"))
+    assert not list(results.rglob("*.foam"))
+    assert not list(results.rglob("VTK"))
+
+
+# --------------------------------------------------------------------------- #
+#  fail-closed: real run with no solver on PATH                               #
+# --------------------------------------------------------------------------- #
+def test_no_solver_and_mock_false_fails_fast(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    cfg["openfoam_run_batch"]["run_batch"]["mock"] = False
+    with patch.object(ofb.shutil, "which", return_value=None):
+        with pytest.raises(RuntimeError, match="requires-solver"):
+            ofb.router(cfg)
+
+
+# --------------------------------------------------------------------------- #
+#  engine / registry routing reaches the workflow                             #
+# --------------------------------------------------------------------------- #
+def test_engine_resolves_basename_to_workflow():
+    from digitalmodel.engine import engine
+
+    cfg = {"basename": "openfoam_run_batch", "openfoam_run_batch": {}}
+    with patch("digitalmodel.engine.app_manager") as mock_app_manager:
+        mock_app_manager.save_cfg.return_value = None
+        with patch(
+            "digitalmodel.workflows.openfoam_run_batch.router",
+            return_value=cfg,
+        ) as mock_router:
+            result = engine(cfg=cfg, config_flag=False)
+    mock_router.assert_called_once()
+    assert result is not None
+
+
+# --------------------------------------------------------------------------- #
+#  mpi mode: command construction + processor* prune                          #
+# --------------------------------------------------------------------------- #
+def test_mpi_command_plan_shape():
+    plan = ofb.mpi_command_plan(solver="interFoam", workers=16, reconstruct=True)
+    names = [argv[0] for argv in plan]
+    assert names.index("decomposePar") < names.index("mpirun")
+    mpirun = next(a for a in plan if a[0] == "mpirun")
+    assert mpirun[:3] == ["mpirun", "-np", "16"]
+    assert "-parallel" in mpirun and "interFoam" in mpirun
+    assert names[-1] == "reconstructPar"
+    assert ofb.mpi_command_plan("interFoam", 4, reconstruct=False)[-1][0] == "mpirun"
+
+
+def test_mpi_run_executes_plan_and_prunes(tmp_path):
+    base = {"case_type": "current_loading", "solver": "interFoam"}
+    item = ofb._render_cases(base, [{}], {}, tmp_path / "work")[0]
+
+    recorded = []
+
+    def fake_runner(argv, cwd, log, timeout):
+        recorded.append(argv)
+        if argv[0] == "decomposePar":
+            # Simulate the decomposed sub-meshes the prune step must remove.
+            (Path(cwd) / "processor0").mkdir(parents=True, exist_ok=True)
+            (Path(cwd) / "processor1").mkdir(parents=True, exist_ok=True)
+        return 0
+
+    row = ofb._run_case_mpi(
+        item, {"reconstruct": True}, workers=8, mock=False,
+        command_runner=fake_runner,
+    )
+
+    assert row["status"] == "completed"
+    names = [argv[0] for argv in recorded]
+    assert names.index("decomposePar") < names.index("mpirun")
+    assert ["mpirun", "-np", "8"] == recorded[names.index("mpirun")][:3]
+    # processor* dirs were pruned after the solve.
+    assert not list((tmp_path / "work" / item["name"]).glob("processor*"))
+    # decomposeParDict was pinned to the rank count.
+    dpd = (tmp_path / "work" / item["name"] / "system" / "decomposeParDict").read_text()
+    assert "numberOfSubdomains 8" in dpd
+
+
+def test_mpi_mode_rejects_multi_case_matrix(tmp_path):
+    cfg = _example_cfg(tmp_path)
+    cfg["openfoam_run_batch"]["run_batch"]["mode"] = "mpi"  # 2-case matrix
+    with pytest.raises(ValueError, match="exactly ONE case"):
+        ofb.router(cfg)


### PR DESCRIPTION
Implements the remaining scope of #1560: an `openfoam-run-batch` workflow so one `python -m digitalmodel <input.yml>` invocation saturates a dedicated CFD node — the CFD analog of `orcaflex-run-batch` (#1554 / PR #1558).

## Verified state (issue item 1 is already done)
The CFD execution surface is **already on main** (landed via #1161): `src/digitalmodel/solvers/openfoam/{workflow.py,runner.py,doctor.py,...}` exist and `engine.py` routes `basename in [openfoam, cfd]` → `OpenFOAMWorkflow().router`. This PR does **not** re-land or duplicate any of it — issue item 1 ("land the CFD execution surface") is a no-op. Scope here is only the saturating batch workflow (item 2–4).

## What this adds
- `src/digitalmodel/workflows/openfoam_run_batch.py` — the workflow (registry id `openfoam_run_batch`).
- Engine wiring: `elif basename == "openfoam_run_batch"` in `src/digitalmodel/engine.py`.
- `examples/workflows/openfoam-run-batch/input.yml` — a 2-case current-loading sweep in mock mode.
- `tests/workflows/test_openfoam_run_batch.py` — mock-based, no OpenFOAM needed in CI.

## Design (mirrors orcaflex_run_batch conventions)
- **Case matrix**: deterministic — either an explicit `cases:` list or a `variants:` sweep, reusing parametric_run's `_load_cases` / `_set_dotted`.
- **Two saturation modes** (`run_batch.mode`):
  - `pool` (default): N single-rank cases run concurrently in a bounded thread pool, `workers = floor(0.9 × cpu_count)` by default (override `run_batch.workers`), reusing the fail-closed OpenFOAM build + `OpenFOAMRunner` solve path.
  - `mpi`: one case across ranks — `decomposePar -force` (scotch) → `mpirun -np <workers> <solver> -parallel` → optional `reconstructPar` → `processor*` dirs **always** pruned (mirrors `scripts/cfd/run_sloshing_3d_benchmark.py`).
- **Idempotent/resumable**: per-case `_result.json` checkpoint; a completed case is skipped on re-run (safe retry after a queue timeout).
- **Results contract**: `results/` gets only small `.csv`/`.json` rollups (`cases.csv` + `batch_summary.json`); heavy case trees stay in the work dir; no meshes/fields/VTK/`processor*` in `results/`.
- **Mock mode**: explicit `mock: true` for CI (license-free builder authors the case tree, no solver runs) — never a silent dry-run downgrade; fail-closed up front when a solver is required but absent (`openfoam doctor` is the ready-gate).

## Test evidence
`pytest tests/workflows/test_openfoam_run_batch.py` → **14 passed**. Run together with the anchor suites (`test_orcaflex_run_batch.py`, `tests/solvers/openfoam/test_workflow_router.py`) → **30 passed**. Coverage: example mock batch end-to-end, matrix determinism, worker default (0.9×cores floor / min 1), checkpoint resume (skips completed), results contract (only csv/json), fail-closed when `mock:false` + no solver, engine/registry routing, and mpi-mode command construction (decomposePar before mpirun, `-np` value, `processor*` pruned, decomposeParDict pinned to rank count). `ruff check` clean on both new files.

## Dispatch lane
The dispatch-lane side (workflow id `openfoam-run-batch`, 43200 s cap) is already allowlisted in the private orchestration repo; this PR is the digitalmodel-side implementation the fixed lane command drives.

Closes part of #1560 (item 1 already satisfied on main via #1161). Related: #1553, #1528, #1495, #1500.

## Review fixes (adversarial review round 1)
Commit `f98c086c` addresses all confirmed findings:

1. **Data-safe prune (HIGH)** — `processor*` is pruned only after a *successful* `reconstructPar`. With `reconstruct: false` the decomposed fields are the deliverable and are preserved in the work dir; on failure they are kept for diagnosis/resume. (Previously an unconditional `finally`-prune could destroy the only copy of the solved fields.)
2. **MPI retry livelock (HIGH)** — wall-clock sizing documented loudly (module docstring + example input); `batch_summary.json` now records `timeout_seconds`; and new `run_batch.resume: true` support: when a prior attempt's `processor*` decomposition exists, the retry skips mesh/`decomposePar` and restarts the solver from `latestTime` instead of t=0 (controlDict patched, no rebuild).
3. **Ready-gate completeness (MED)** — `_solver_ready` also requires `reconstructPar` when `mode: mpi` ends with a reconstruction, so hours of solve can't fail at the final stage.
4. **Retry hygiene (MED)** — a retry (absent/failed/corrupt checkpoint) cleans the stale case dir before rebuilding (pool and non-resume mpi paths); no mixed artifacts from a killed attempt.
5. **Manifest integrity (LOW/MED)** — case knob names colliding with reserved manifest columns are rejected up front with a clear error; explicit `cases:` lists get a top-level `mapping:` for renaming knobs onto settings paths (example sweeps `solver_app` → `solver`).
6. **Atomic checkpoints (LOW)** — `_result.json` written via tmp + `os.replace`; truncated/corrupt/non-dict checkpoints read as absent and the case is retried.

New tests for each scenario: reconstruct:false preserves `processor*`; failed MPI stage → failed row + no false checkpoint + retried on re-run; resume-from-latestTime plan shape (no mesh/decompose, no rebuild); failed pool checkpoint retried; corrupt checkpoint ignored; mpi ready-gate requires reconstructPar; reserved knob name raises. Suite: **21 tests** in `test_openfoam_run_batch.py` (was 14); with anchor suites → **37 passed**. `ruff check` clean.
