### PR TITLE
fix(workflows): ship engine base-config for openfoam_run_batch (#1560)

### DIFF
--- a/src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml
+++ b/src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml
@@ -1,0 +1,39 @@
+# Engine base config for the openfoam_run_batch workflow (issue #1560).
+#
+# Loaded by assetutilities ApplicationManager.configure (pkgutil from the
+# installed package: base_configs/modules/<basename>/<basename>.yml) and
+# deep-merged UNDER the user's input.yml (update_deep_dictionary — user
+# values always win). Without this file the canonical
+# `python -m digitalmodel <input.yml>` invocation dies in configure with
+# FileNotFoundError before ever reaching the workflow router.
+#
+# Keep the defaults minimal and identical to the code defaults in
+# src/digitalmodel/workflows/openfoam_run_batch.py so merge order can never
+# change behaviour.
+basename: openfoam_run_batch
+
+openfoam_run_batch:
+  base:
+    case_type: null        # required from the user's input.yml
+    solver: null           # else read from the case's controlDict
+    mesh_utility: blockMesh
+    to_vtk: false
+  cases: []                # explicit case list (mutually exclusive w/ variants)
+  variants: {}             # parametric_run sweep schema
+  mapping: {}              # knob name -> dotted settings path
+  run_batch:
+    mode: pool             # pool | mpi
+    workers: null          # null -> floor(0.9 x host cores), min 1 (dm#1553)
+    mock: false
+    reconstruct: true      # mpi only: reconstructPar then prune processor*
+    resume: false          # mpi only: restart solver from latestTime if
+                           # a previous attempt's processor* dirs exist
+    timeout_seconds: 43200
+    output_dir: results
+    work_dir: batch_runs
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/tests/workflows/test_openfoam_run_batch.py
+++ b/tests/workflows/test_openfoam_run_batch.py
@@ -411,3 +411,35 @@ def test_reserved_case_knob_name_raises(tmp_path):
         ofb._render_cases(base, [{"status": "x"}], {}, tmp_path / "w")
     with pytest.raises(ValueError, match="reserved manifest"):
         ofb._render_cases(base, [{"solver": "interFoam"}], {}, tmp_path / "w")
+
+
+# --------------------------------------------------------------------------- #
+#  REAL engine configure path (base-config module must be packaged)           #
+# --------------------------------------------------------------------------- #
+def test_engine_configure_path_runs_example_end_to_end(tmp_path, monkeypatch):
+    """The canonical ``python -m digitalmodel <input.yml>`` path: engine()
+    with the REAL ApplicationManager.configure, which loads the packaged
+    base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml and
+    deep-merges it under the user input.
+
+    Guards the integration gap the initial #1560 PR shipped: workflow +
+    engine route existed but no base-config module yml, so configure raised
+    FileNotFoundError on the real host before ever reaching the router —
+    invisible to the router-level tests above, which bypass configure."""
+    from digitalmodel.engine import engine
+
+    (tmp_path / "input.yml").write_text((EXAMPLE_DIR / "input.yml").read_text())
+    monkeypatch.chdir(tmp_path)
+
+    result = engine(inputfile=str(tmp_path / "input.yml"))
+
+    settings = result["openfoam_run_batch"]
+    rows = pd.read_csv(settings["outputs"]["manifest"])
+    assert rows["status"].tolist() == ["completed", "completed"]
+    assert sorted(rows["solver"].tolist()) == ["pimpleFoam", "simpleFoam"]
+    summary = json.loads(Path(settings["outputs"]["summary"]).read_text())
+    assert summary["mock"] is True
+    assert summary["total_cases"] == 2
+    # Base-config defaults merged in without clobbering the user's input.
+    assert summary["mode"] == "pool"
+    assert summary["workers"] == 2


### PR DESCRIPTION
Follow-up to #1561 (merged): the canonical engine invocation for the new workflow failed on the real host before ever reaching the workflow router.

## Host traceback
```
FileNotFoundError: Application input file base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml not found
```
Raised by assetutilities `ApplicationManager.configure` → `unify_application_and_default_and_custom_yamls` (called from `engine.py` line ~201) on `python -m digitalmodel <input.yml>` with `basename: openfoam_run_batch`. The configure step resolves a per-basename application config via `pkgutil.get_data("digitalmodel", "base_configs/modules/<basename>/<basename>.yml")` and fails closed when it is absent.

## Why the tests missed it
#1561's tests exercised the workflow router directly and asserted engine *dispatch* with a patched `app_manager` + patched router — both paths bypass the real `configure` step, so the missing packaged yml was invisible to CI. Reproduced locally: without the yml, `python -m digitalmodel examples/workflows/openfoam-run-batch/input.yml` dies with exactly the host traceback; with it, the run exits 0 and completes the 2-case mock batch.

## Fix
- **`src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml`** — engine base config, mirroring `parametric_run`'s module yml shape (`basename` + module defaults + `default:` block). Defaults are kept identical to the code defaults in `openfoam_run_batch.py` (pool mode, host-aware workers, `mock: false`, `reconstruct: true`, `resume: false`, 43200 s timeout, `results`/`batch_runs` dirs), so the deep merge (`update_deep_dictionary`, user values win) can never change behaviour. Packaging is already covered by the existing `base_configs/**/*.yml` package-data glob.
- **`tests/workflows/test_openfoam_run_batch.py::test_engine_configure_path_runs_example_end_to_end`** — new engine-level regression test that runs the example input through the REAL `ApplicationManager.configure` (`engine(inputfile=...)`, mock mode, cwd = tmp dir) and asserts the batch completes with the merged defaults intact. Verified it reproduces the exact `FileNotFoundError` when the yml is removed, and passes with it.

## Evidence
- End-to-end sanity: `python -m digitalmodel input.yml` (example input, mock mode, PYTHONPATH=src + assetutilities) → exit 0, `results/batch_summary.json` = 2/2 completed, `results/cases.csv` written, case trees under `batch_runs/`.
- Targeted tests: `test_openfoam_run_batch.py` → **22 passed** (21 prior + new engine-path test); with anchor suites (`test_orcaflex_run_batch.py`, `tests/solvers/openfoam/test_workflow_router.py`) → **38 passed**. `ruff check` clean.

## Noted gap (not fixed here)
`orcaflex_run_batch` (#1554 / PR #1558) has the same latent gap: no `base_configs/modules/orcaflex_run_batch/orcaflex_run_batch.yml` and no configure-path test, so the same canonical invocation will raise the same `FileNotFoundError`. Left untouched per scope; should be tracked as its own issue.

Refs #1560.
