### PR TITLE
feat(fatigue): port legacy FATG closed-form spectral fatigue with validation suite

### DIFF
--- a/docs/domains/fatigue/fatg-legacy-spectral-fatigue.md
+++ b/docs/domains/fatigue/fatg-legacy-spectral-fatigue.md
@@ -1,0 +1,110 @@
+# FATG — legacy closed-form spectral fatigue (validation lineage)
+
+## What this is
+
+`digitalmodel.fatigue.fatg` and the routed workflow basename
+`fatg_spectral_fatigue` are a port of a legacy in-house Fortran
+spectral-fatigue program ("FATG", 1989–1991 era, several successive
+variants) used for plate structures and tubular jack-up legs. The method
+is the classic closed-form narrow-band chain:
+
+```
+stress RAO  ×  Bretschneider wave spectrum  ×  wave scatter table
+            ×  directional spreading        ×  one-slope DNV S-N
+            →  Miner damage per year
+```
+
+## Method, as the legacy code actually computes it
+
+1. **Significant stress response** per sea state: trapezoidal integration
+   of `RAO(ω)² · S_B(ω)` on the RAO's own frequency grid (the legacy deck
+   was a fixed 18 points). The legacy integration constants (1400, 700,
+   with a factor 2 inside the square root) are algebraically identical to
+   a standard Bretschneider spectrum
+   `S(ω) = (5/16) Hs² ωp⁴ ω⁻⁵ exp(−1.25 (ωp/ω)⁴)` with
+   `ωp = 560^0.25 / Tz` (i.e. `Tp ≈ 1.2916·Tz`), the result being the
+   significant stress **range** `4·√m0`. (The source comments quote
+   `Tp = Tz/0.71` and echo `Tp = 1.3·Tz`; the integration constants above
+   are what the code computes. This equivalence is asserted to 1e-12 in
+   the tests.)
+2. **Three-block Rayleigh discretisation**: the stress-range distribution
+   in each sea state collapses to three constant-amplitude blocks at
+   `(1.271, 0.59, 0.28) ×` significant range, each carrying 1/3 of the
+   cycles of its heading group. Cycle counts use the zero-upcrossing
+   period: `n = T·occurrence/Tz` with `T = 31 536 000 s/yr`.
+3. **Directional spreading**: cycles are split over 0°/±45°/90° heading
+   groups by a fixed spreading matrix applied to input percentages
+   `(p0, p45, p90)`, with per-heading stress reduction factors. Presets:
+   - `general` (original program): factors `(1, cos 45°, cos 78.75°)` —
+     the 90° factor is "theoretically 0 but that would not be
+     conservative" per the source comments;
+   - `chord` (later 3-chord-leg variant): `(1, 1, cos 78.75°)`;
+   - `diagonal` (diagonals/horizontals): `(1, 1, 1)`.
+   With no spreading input, the original program's uniform mode is
+   reproduced: every heading group carries the full `T·occ/(3·Tz)` count
+   per block (deliberately conservative — each wave is counted in all
+   three heading groups).
+4. **S-N + Miner**: one-slope curve `log10 N = log10_a − m·log10 S`,
+   `m = 3`, with the legacy DNV constants in English units (stress in
+   psi): E = 18.499, F = 18.2845, T = 18.64786. The curve — hard-coded in
+   the first program version, selectable in the last — is fully
+   selectable here (named legacy constants or any `log10_a`/`slope`,
+   which also makes the chain metric if a metric intercept is supplied).
+
+## Relationship to the modern spectral-fatigue modules
+
+`spectral_fatigue` / `rao_spectral_fatigue` build a stress PSD on a
+generated spectral grid and apply closed-form damage estimators (Dirlik,
+narrow-band with the Γ-function Rayleigh closed form, etc.). FATG differs
+in every stage that matters for reproducing legacy results: Tz-parameterised
+Bretschneider evaluated on the RAO's own ω-grid, significant-response
+trapezoid, discrete 3-block Rayleigh Miner roll-up, and the fixed
+0°/45°/90° spreading matrix. The port therefore reproduces the legacy
+arithmetic exactly rather than re-expressing it through the modern chain.
+
+## Validation
+
+No executable or original input/output decks survived with the source, so
+the source of truth is a **line-by-line Python transliteration of the
+Fortran arithmetic** (Fortran `REAL*8` ≡ IEEE float64), kept inside
+`tests/fatigue/test_fatg.py` together with frozen golden values for a
+fully synthetic 18-point RAO + 3-row scatter deck:
+
+- library vs transliteration and vs frozen goldens: **rel 1e-9**
+  (the only systematic difference is the legacy truncated
+  `PI = 3.141592654` inside the direction cosines, ~3e-10 relative);
+- FATG spectrum kernel vs standard Bretschneider form: **rel 1e-12**
+  (algebraic identity);
+- sweeps over all member presets × S-N curves, both spreading modes,
+  plus slope-3 scaling and Hs-linearity property checks.
+
+Gap: validation against an output deck produced by the compiled legacy
+binary is still outstanding (no Fortran compiler on the porting machine);
+the transliteration oracle is the interim source of truth. Re-running
+`gfortran -std=legacy` on the original source against the synthetic deck
+in `tests/fatigue/test_fatg.py` would close this.
+
+## Usage
+
+```yaml
+basename: fatg_spectral_fatigue
+fatg_spectral_fatigue:
+  design_life_years: 20.0
+  dff: 1.0
+  sn_curve: F                # E | F | T, or {log10_a: ..., slope: 3.0}
+  member_type: chord         # general | chord | diagonal
+  rao:
+    omega_rad_per_s: [0.2, 0.3, ...]          # strictly increasing
+    stress_per_wave_height: [120.0, 260.0, ...]  # psi per unit wave height
+  sea_states:
+    - hs: 3.0
+      tz: 5.0
+      occurrence_fraction: 0.55
+      spreading: {p0: 0.6, p45: 0.3, p90: 0.1}   # omit for uniform mode
+  output_dir: results
+```
+
+Outputs: per-sea-state CSV (Hs, Tz, Tp echo, significant stress range,
+damage/year), summary CSV, and the legacy report echoes
+(`life_used_percent_1yr`, `life_used_percent_10yr`) alongside the modern
+`fatigue_life_years` / `margin` / `screening_status` fields.

--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -62,6 +62,7 @@ of duplicating its detailed issue history.
 | `materials` | `src/digitalmodel/materials/` | `tests/materials/` | `docs/domains/README.md` | Material grades and line-pipe property data | NumPy, pandas |
 | `workflow_api` | `src/digitalmodel/workflow_api/` | `tests/workflow_api/` | `docs/domains/README.md` | Workflow runner, provenance and golden-output API | repo workflow conventions |
 | `compare_tool` | `src/digitalmodel/compare_tool/` | `tests/compare_tool/` | `docs/domains/README.md` | Result/model comparison utilities across runs and tools | pandas, NumPy |
+| `fatg_spectral_fatigue` | `src/digitalmodel/fatg_spectral_fatigue/` | `tests/fatigue/test_fatg.py` | `docs/domains/fatigue/fatg-legacy-spectral-fatigue.md` | Legacy FATG closed-form spectral fatigue (RAO x Bretschneider x scatter x S-N Miner) | fatigue standards |
 | `installation` | `src/digitalmodel/installation/` | `tests/` | `docs/domains/installation/` | Offshore installation analysis, lift/lay operability, weather windows | marine engineering standards |
 | `lifting_lug` | `src/digitalmodel/lifting_lug/` | `tests/` | `docs/domains/README.md` | Lifting-lug/padeye sizing and closed-form structural checks | structural standards |
 | `mooring_fatigue` | `src/digitalmodel/mooring_fatigue/` | `tests/` | `docs/domains/README.md` | Mooring-line fatigue analysis and parametric atlases | fatigue standards, NumPy |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -266,6 +266,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/compare_tool/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#compare_tool
+  - module: fatg_spectral_fatigue
+    entry_point: src/digitalmodel/fatg_spectral_fatigue/
+    maturity: development
+    owner_wiki: docs/domains/fatigue/fatg-legacy-spectral-fatigue.md
+    key_tests: [tests/fatigue/test_fatg.py, tests/fatigue/test_fatg_workflow.py]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#fatg_spectral_fatigue
   - module: installation
     entry_point: src/digitalmodel/installation/
     maturity: beta

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -335,6 +335,12 @@ def engine(
         )
 
         cfg_base = rao_spectral_fatigue(cfg_base)
+    elif basename == "fatg_spectral_fatigue":
+        from digitalmodel.fatg_spectral_fatigue.workflow import (
+            router as fatg_spectral_fatigue,
+        )
+
+        cfg_base = fatg_spectral_fatigue(cfg_base)
     elif basename == "vessel_seakeeping":
         from digitalmodel.vessel_seakeeping.workflow import (
             router as vessel_seakeeping,

--- a/src/digitalmodel/fatg_spectral_fatigue/__init__.py
+++ b/src/digitalmodel/fatg_spectral_fatigue/__init__.py
@@ -1,0 +1,5 @@
+"""Routed workflow for the legacy FATG closed-form spectral fatigue method."""
+
+from digitalmodel.fatg_spectral_fatigue.workflow import router
+
+__all__ = ["router"]

--- a/src/digitalmodel/fatg_spectral_fatigue/workflow.py
+++ b/src/digitalmodel/fatg_spectral_fatigue/workflow.py
@@ -1,0 +1,240 @@
+"""Durable workflow: legacy FATG closed-form spectral fatigue.
+
+Wires the ported legacy FATG method (``digitalmodel.fatigue.fatg``) into a
+registry workflow: stress RAO x Bretschneider (Tz-parameterised, evaluated on
+the RAO's own frequency grid) x wave scatter table x directional spreading x
+one-slope S-N -> Miner damage per year.
+
+This complements ``rao_spectral_fatigue`` (which builds a stress PSD on a
+generated spectral grid and applies Dirlik/narrow-band closed forms): the FATG
+chain instead reproduces the legacy Fortran program's arithmetic exactly --
+significant-response trapezoid, three-block Rayleigh discretisation and the
+fixed 0/45/90-degree spreading matrix -- so results are traceable to the
+validated legacy tool.
+
+Config schema (YAML basename ``fatg_spectral_fatigue``)::
+
+    basename: fatg_spectral_fatigue
+    fatg_spectral_fatigue:
+      design_life_years: 20.0
+      dff: 1.0
+      sn_curve: F                # legacy E/F/T (psi), or {log10_a: ..., slope: 3.0}
+      member_type: general       # general | chord | diagonal
+      rao:
+        omega_rad_per_s: [ ... ] # strictly increasing (legacy decks used 18 points)
+        stress_per_wave_height: [ ... ]  # stress RAO ordinate, per unit wave height
+      sea_states:
+        - hs: 3.0
+          tz: 5.0
+          occurrence_fraction: 0.55
+          spreading: {p0: 0.6, p45: 0.3, p90: 0.1}   # omit for uniform mode
+      output_dir: results
+
+Units: consistent with the S-N intercept (the legacy E/F/T constants are psi;
+Hs in the RAO's wave-height unit; Tz in seconds).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.fatigue.fatg import (
+    FATG_SN_CURVES,
+    FatgSeaState,
+    fatg_annual_damage,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("fatg_spectral_fatigue") or {}
+    design_life_years = _positive_float(settings, "design_life_years")
+    dff = _positive_float(settings, "dff")
+    sn_curve, log10_a, slope = _sn_curve(settings)
+    member_type = str(settings.get("member_type", "general")).strip().lower()
+    omega, stress_rao = _rao(settings)
+    sea_states = _sea_states(settings)
+
+    result = fatg_annual_damage(
+        omega,
+        stress_rao,
+        sea_states,
+        sn_curve=sn_curve,
+        log10_a=log10_a,
+        slope=slope,
+        member_type=member_type,
+    )
+
+    fatigue_life_years = result.fatigue_life_years
+    required_years = design_life_years * dff
+    margin = fatigue_life_years / required_years
+    screening_status = "pass" if margin >= 1.0 else "fail"
+
+    rows = [
+        {
+            "sea_state_index": index,
+            "hs": item.hs,
+            "tz": item.tz,
+            "tp": item.tp,
+            "occurrence_fraction": item.occurrence,
+            "significant_stress_range": item.significant_stress_range,
+            "damage_per_year": item.damage_per_year,
+        }
+        for index, item in enumerate(result.sea_states)
+    ]
+    summary = {
+        "method": "fatg_closed_form_narrow_band",
+        "member_type": member_type,
+        "sn_log10_a": log10_a if log10_a is not None else FATG_SN_CURVES[sn_curve],
+        "sn_slope": slope,
+        "annual_damage": result.annual_damage,
+        "fatigue_life_years": fatigue_life_years,
+        "life_used_percent_1yr": result.life_used_percent_1yr,
+        "life_used_percent_10yr": result.life_used_percent_10yr,
+        "required_life_years": required_years,
+        "margin": margin,
+        "passes": margin >= 1.0,
+    }
+
+    csv_path = _output_path(cfg, settings, "fatg_spectral_fatigue.csv")
+    summary_path = _output_path(cfg, settings, "fatg_spectral_fatigue_summary.csv")
+    _write_csv(csv_path, rows)
+    _write_csv(summary_path, [summary])
+
+    cfg["fatg_spectral_fatigue"] = {
+        "design_life_years": design_life_years,
+        "dff": dff,
+        **summary,
+        "screening_status": screening_status,
+        "sea_states": rows,
+        "results_csv": _display_path(csv_path),
+        "summary_csv": _display_path(summary_path),
+    }
+    cfg["screening_status"] = screening_status
+    return cfg
+
+
+def _sn_curve(settings: dict[str, Any]) -> tuple[str | None, float | None, float]:
+    sn = settings.get("sn_curve", "F")
+    if isinstance(sn, dict):
+        log10_a = _positive_float(sn, "log10_a", "sn_curve.log10_a")
+        slope = float(sn.get("slope", 3.0))
+        if slope <= 0.0:
+            raise ValueError("fatg_spectral_fatigue sn_curve.slope must be positive")
+        return None, log10_a, slope
+    name = str(sn).strip().upper()
+    if name not in FATG_SN_CURVES:
+        raise ValueError(
+            "fatg_spectral_fatigue sn_curve must be one of "
+            f"{sorted(FATG_SN_CURVES)} or a {{log10_a, slope}} mapping; got {sn!r}"
+        )
+    return name, None, 3.0
+
+
+def _rao(settings: dict[str, Any]) -> tuple[list[float], list[float]]:
+    rao = settings.get("rao")
+    if not isinstance(rao, dict):
+        raise ValueError("fatg_spectral_fatigue rao mapping is required")
+    omega = rao.get("omega_rad_per_s")
+    stress = rao.get("stress_per_wave_height")
+    if not isinstance(omega, list) or not isinstance(stress, list):
+        raise ValueError(
+            "fatg_spectral_fatigue rao needs list omega_rad_per_s and "
+            "stress_per_wave_height"
+        )
+    return [float(v) for v in omega], [float(v) for v in stress]
+
+
+def _sea_states(settings: dict[str, Any]) -> list[FatgSeaState]:
+    raw = settings.get("sea_states")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("fatg_spectral_fatigue sea_states must be a non-empty list")
+    states: list[FatgSeaState] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"sea_states[{index}] must be a mapping")
+        label = f"sea_states[{index}]"
+        hs = _positive_float(item, "hs", f"{label}.hs")
+        tz = _positive_float(item, "tz", f"{label}.tz")
+        occurrence = _positive_float(
+            item, "occurrence_fraction", f"{label}.occurrence_fraction"
+        )
+        spreading = None
+        if item.get("spreading") is not None:
+            spread = item["spreading"]
+            if not isinstance(spread, dict):
+                raise ValueError(f"{label}.spreading must be a mapping (p0/p45/p90)")
+            spreading = (
+                _non_negative_float(spread, "p0", f"{label}.spreading.p0"),
+                _non_negative_float(spread, "p45", f"{label}.spreading.p45"),
+                _non_negative_float(spread, "p90", f"{label}.spreading.p90"),
+            )
+        states.append(
+            FatgSeaState(hs=hs, tz=tz, occurrence=occurrence, spreading=spreading)
+        )
+    return states
+
+
+def _positive_float(
+    source: dict[str, Any], name: str, label: str | None = None
+) -> float:
+    label = label or name
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"fatg_spectral_fatigue {label} is required")
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError(f"fatg_spectral_fatigue {label} must be positive")
+    return value
+
+
+def _non_negative_float(source: dict[str, Any], name: str, label: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"fatg_spectral_fatigue {label} is required")
+    value = float(value)
+    if value < 0.0:
+        raise ValueError(f"fatg_spectral_fatigue {label} must be non-negative")
+    return value
+
+
+def _output_path(cfg: dict, settings: dict[str, Any], suffix: str) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir / f"{_input_stem(cfg)}_{suffix}"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "fatg_spectral_fatigue"))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("fatg_spectral_fatigue cannot write empty results")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/src/digitalmodel/fatigue/__init__.py
+++ b/src/digitalmodel/fatigue/__init__.py
@@ -47,6 +47,10 @@ from .spectral_fatigue import (
     wirsching_light_damage, dirlik_damage, benasciutti_tovo_damage,
     SpectralMoments, SpectralFatigueResult,
 )
+from .fatg import (
+    fatg_significant_stress_range, fatg_sea_state_damage, fatg_annual_damage,
+    FatgSeaState, FatgResult, FATG_SN_CURVES,
+)
 from .weld_classification import (
     classify_weld_detail, list_dnv_detail_categories,
     WeldDetail, ClassificationResult,
@@ -136,6 +140,13 @@ __all__ = [
     "benasciutti_tovo_damage",
     "SpectralMoments",
     "SpectralFatigueResult",
+    # fatg (legacy closed-form spectral fatigue)
+    "fatg_significant_stress_range",
+    "fatg_sea_state_damage",
+    "fatg_annual_damage",
+    "FatgSeaState",
+    "FatgResult",
+    "FATG_SN_CURVES",
     # weld_classification
     "classify_weld_detail",
     "list_dnv_detail_categories",

--- a/src/digitalmodel/fatigue/fatg.py
+++ b/src/digitalmodel/fatigue/fatg.py
@@ -1,0 +1,322 @@
+"""Closed-form narrow-band spectral fatigue (legacy FATG method).
+
+Port of a legacy in-house Fortran spectral-fatigue program ("FATG",
+1989-1991 era) used for plate structures and tubular jack-up legs. The
+method is the classic closed-form chain:
+
+    stress RAO x Bretschneider wave spectrum x wave scatter table
+    x directional spreading x S-N curve -> Miner damage summation
+
+Algorithm (faithful to the Fortran arithmetic):
+
+1. **Significant stress response** per sea state (``SPECTO`` subroutine)::
+
+       sigma_s = Hs * sqrt( 2 * trapz( RAO(w)^2 * 1400/(Tz^4 w^5)
+                                       * exp(-700/(Tz^4 w^4)), w ) )
+
+   The kernel is algebraically identical to a standard Bretschneider
+   spectrum ``S(w) = (5/16) Hs^2 wp^4 / w^5 * exp(-1.25 (wp/w)^4)`` with
+   peak frequency ``wp = 560**0.25 / Tz`` (i.e. ``Tp ~= 1.2916 Tz``), and
+   ``sigma_s`` is then the *significant stress range* ``4*sqrt(m0)`` of
+   the response.  (The source comments quote ``Tp = Tz/0.71`` and print
+   ``Tp = 1.3 Tz``; the integration constants above are what the code
+   actually computes.)
+
+2. **Three-block Rayleigh discretisation**: the stress-range distribution
+   in each sea state is collapsed to three constant-amplitude blocks at
+   ``(1.271, 0.59, 0.28) * sigma_s``, each carrying one third of the
+   cycles of its wave-heading group.
+
+3. **Directional spreading**: cycles are distributed over three heading
+   groups (0deg, +/-45deg, 90deg to the primary direction) through a fixed
+   spreading matrix applied to the input percentages ``(p0, p45, p90)``::
+
+       n0   ~ 0.475*p0 + 0.5*p45 + 0.025*p90
+       n45  ~ 0.25 *p0 + 0.5*p45 + 0.25 *p90
+       n90  ~ 0.025*p0 + 0.5*p45 + 0.475*p90
+
+   and per-heading stress reduction factors are applied (member-type
+   presets below).  With ``spreading=None`` the program's uniform mode is
+   reproduced: every heading group carries the full cycle count
+   ``T * occurrence / (3 Tz)`` per block (deliberately conservative).
+
+4. **S-N + Miner**: one-slope S-N curve ``log10(N) = log10_a - m*log10(S)``
+   with legacy DNV constants (English units, stress in psi, m = 3):
+   E = 18.499, F = 18.2845, T = 18.64786.  Damage per year is the Miner
+   sum over sea states, blocks and headings.
+
+Units: any consistent set. The legacy constants assume stress RAO in psi
+per unit wave height (ft), Hs in ft, Tz in s. Supplying a metric S-N
+intercept makes the whole chain metric.
+
+Validated against a line-by-line transliteration of the legacy Fortran
+(see ``tests/fatigue/test_fatg.py`` for the oracle and tolerances).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+__all__ = [
+    "SECONDS_PER_YEAR",
+    "FATG_SN_CURVES",
+    "FATG_BLOCK_FACTORS",
+    "FATG_SPREADING_MATRIX",
+    "FATG_DIRECTION_FACTOR_PRESETS",
+    "FatgSeaState",
+    "FatgSeaStateResult",
+    "FatgResult",
+    "fatg_significant_stress_range",
+    "fatg_heading_cycles",
+    "fatg_sea_state_damage",
+    "fatg_annual_damage",
+]
+
+# Seconds per (365-day) year, as hard-coded in the legacy program (TIME).
+SECONDS_PER_YEAR = 31_536_000.0
+
+# Legacy one-slope DNV S-N intercepts, log10(a), English units (psi), m = 3.
+FATG_SN_CURVES = {
+    "E": 18.499,
+    "F": 18.2845,
+    "T": 18.64786,
+}
+
+# Three-block discretisation of the Rayleigh stress-range distribution:
+# block stress = factor * significant stress range, each block carries an
+# equal share (1/3) of the heading-group cycle count.
+FATG_BLOCK_FACTORS = (1.271, 0.59, 0.28)
+
+# Fixed spreading matrix: rows = heading group (0, 45, 90 deg), columns =
+# input percentage (p0, p45, p90).
+FATG_SPREADING_MATRIX = (
+    (0.475, 0.5, 0.025),
+    (0.25, 0.5, 0.25),
+    (0.025, 0.5, 0.475),
+)
+
+# Per-heading stress reduction factors (0deg, 45deg, 90deg groups).
+#   general  : original program (cos 45deg at 45; cos 78.75deg at 90 --
+#              "theoretically 0 but that would not be conservative")
+#   chord    : later 3-chord-leg variant, chord members (unity at 0 and 45)
+#   diagonal : later variant, diagonals/horizontals (no reduction)
+FATG_DIRECTION_FACTOR_PRESETS = {
+    "general": (1.0, math.cos(math.pi / 4.0), math.cos(math.pi * 7.0 / 16.0)),
+    "chord": (1.0, 1.0, math.cos(math.pi * 7.0 / 16.0)),
+    "diagonal": (1.0, 1.0, 1.0),
+}
+
+
+@dataclass(frozen=True)
+class FatgSeaState:
+    """One row of the wave scatter table.
+
+    ``occurrence`` is the fraction of the year spent in this sea state.
+    ``spreading = (p0, p45, p90)`` are the directional percentages of the
+    legacy input deck (typically summing to 1); ``None`` selects the
+    program's uniform (no-spreading-input) mode.
+    """
+
+    hs: float
+    tz: float
+    occurrence: float
+    spreading: Optional[tuple[float, float, float]] = None
+
+
+@dataclass(frozen=True)
+class FatgSeaStateResult:
+    hs: float
+    tz: float
+    tp: float
+    occurrence: float
+    significant_stress_range: float
+    damage_per_year: float
+
+
+@dataclass(frozen=True)
+class FatgResult:
+    """Aggregate result. ``annual_damage`` is the Miner sum per year;
+    the legacy report echoes are ``life_used_percent_*``."""
+
+    annual_damage: float
+    fatigue_life_years: float
+    life_used_percent_1yr: float
+    life_used_percent_10yr: float
+    sea_states: list[FatgSeaStateResult] = field(default_factory=list)
+
+
+def fatg_significant_stress_range(
+    omega: Sequence[float],
+    stress_rao: Sequence[float],
+    hs: float,
+    tz: float,
+) -> float:
+    """Significant stress range of the response in one sea state.
+
+    Trapezoidal integration of ``RAO(w)^2 * S_B(w)`` on the RAO's own
+    frequency grid (rad/s), exactly as the legacy ``SPECTO`` subroutine.
+    The legacy deck always used 18 points; any length >= 2 is accepted.
+    """
+    _validate_rao(omega, stress_rao)
+    if hs < 0.0:
+        raise ValueError("hs must be non-negative")
+    if tz <= 0.0:
+        raise ValueError("tz must be positive")
+
+    st4 = 1.0 / tz**4
+    st2 = 1400.0 * st4
+    st3 = 700.0 * st4
+
+    def ordinate(i: int) -> float:
+        w = omega[i]
+        return stress_rao[i] ** 2 * w ** (-5) * st2 * math.exp(-st3 * w ** (-4))
+
+    total = 0.0
+    for i in range(len(omega) - 1):
+        total += 0.5 * (ordinate(i) + ordinate(i + 1)) * (omega[i + 1] - omega[i])
+    return math.sqrt(2.0 * total) * hs
+
+
+def fatg_heading_cycles(
+    tz: float,
+    occurrence: float,
+    spreading: Optional[tuple[float, float, float]] = None,
+    seconds_per_year: float = SECONDS_PER_YEAR,
+) -> tuple[float, float, float]:
+    """Cycles per year *per stress block* in each heading group (0/45/90).
+
+    With ``spreading`` given, the fixed spreading matrix distributes the
+    sea state's cycles over the heading groups. With ``spreading=None``
+    (legacy uniform mode) every heading group carries the same full count
+    ``T*occurrence/(3*Tz)`` -- conservative by construction.
+    """
+    if tz <= 0.0:
+        raise ValueError("tz must be positive")
+    if occurrence <= 0.0:
+        raise ValueError("occurrence must be positive")
+    base = seconds_per_year * occurrence / tz / 3.0
+    if spreading is None:
+        return (base, base, base)
+    p0, p45, p90 = spreading
+    if min(p0, p45, p90) < 0.0:
+        raise ValueError("spreading percentages must be non-negative")
+    return tuple(
+        base * (row[0] * p0 + row[1] * p45 + row[2] * p90)
+        for row in FATG_SPREADING_MATRIX
+    )  # type: ignore[return-value]
+
+
+def fatg_sea_state_damage(
+    significant_stress_range: float,
+    tz: float,
+    occurrence: float,
+    log10_a: float,
+    slope: float = 3.0,
+    direction_factors: tuple[float, float, float] = FATG_DIRECTION_FACTOR_PRESETS[
+        "general"
+    ],
+    spreading: Optional[tuple[float, float, float]] = None,
+    seconds_per_year: float = SECONDS_PER_YEAR,
+) -> float:
+    """Miner damage per year contributed by one sea state.
+
+    3 stress blocks x 3 heading groups; each block-heading combination has
+    stress ``block_factor * direction_factor * sigma_s`` and the heading's
+    per-block cycle count against ``N = 10**(log10_a - slope*log10(S))``.
+    """
+    if significant_stress_range <= 0.0:
+        raise ValueError("significant_stress_range must be positive")
+    cycles = fatg_heading_cycles(tz, occurrence, spreading, seconds_per_year)
+    damage = 0.0
+    for n_heading, factor in zip(cycles, direction_factors):
+        for block in FATG_BLOCK_FACTORS:
+            stress = significant_stress_range * block * factor
+            n_fail = 10.0 ** (log10_a - slope * math.log10(stress))
+            damage += n_heading / n_fail
+    return damage
+
+
+def fatg_annual_damage(
+    omega: Sequence[float],
+    stress_rao: Sequence[float],
+    sea_states: Sequence[FatgSeaState],
+    sn_curve: str | None = "F",
+    log10_a: float | None = None,
+    slope: float = 3.0,
+    member_type: str = "general",
+    seconds_per_year: float = SECONDS_PER_YEAR,
+) -> FatgResult:
+    """Full legacy FATG run: scatter table -> Miner damage per year.
+
+    ``sn_curve`` selects a legacy constant (E/F/T, psi units); passing
+    ``log10_a`` explicitly overrides it (any consistent unit system).
+    ``member_type`` selects the direction-factor preset
+    (general/chord/diagonal).
+    """
+    if log10_a is None:
+        if sn_curve is None:
+            raise ValueError("provide sn_curve or log10_a")
+        key = str(sn_curve).strip().upper()
+        if key not in FATG_SN_CURVES:
+            raise ValueError(
+                f"sn_curve must be one of {sorted(FATG_SN_CURVES)}; got {sn_curve!r}"
+            )
+        log10_a = FATG_SN_CURVES[key]
+    preset = str(member_type).strip().lower()
+    if preset not in FATG_DIRECTION_FACTOR_PRESETS:
+        raise ValueError(
+            "member_type must be one of "
+            f"{sorted(FATG_DIRECTION_FACTOR_PRESETS)}; got {member_type!r}"
+        )
+    direction_factors = FATG_DIRECTION_FACTOR_PRESETS[preset]
+    if not sea_states:
+        raise ValueError("sea_states must be non-empty")
+
+    results: list[FatgSeaStateResult] = []
+    total = 0.0
+    for state in sea_states:
+        sigma_s = fatg_significant_stress_range(omega, stress_rao, state.hs, state.tz)
+        damage = fatg_sea_state_damage(
+            sigma_s,
+            state.tz,
+            state.occurrence,
+            log10_a,
+            slope,
+            direction_factors,
+            state.spreading,
+            seconds_per_year,
+        )
+        total += damage
+        results.append(
+            FatgSeaStateResult(
+                hs=state.hs,
+                tz=state.tz,
+                tp=1.3 * state.tz,  # legacy report echo
+                occurrence=state.occurrence,
+                significant_stress_range=sigma_s,
+                damage_per_year=damage,
+            )
+        )
+
+    if total <= 0.0:
+        raise ValueError("accumulated zero damage; check the RAO and scatter inputs")
+    return FatgResult(
+        annual_damage=total,
+        fatigue_life_years=1.0 / total,
+        life_used_percent_1yr=total * 100.0,
+        life_used_percent_10yr=total * 1000.0,
+        sea_states=results,
+    )
+
+
+def _validate_rao(omega: Sequence[float], stress_rao: Sequence[float]) -> None:
+    if len(omega) != len(stress_rao) or len(omega) < 2:
+        raise ValueError("omega and stress_rao must be equal-length (>= 2)")
+    if any(b <= a for a, b in zip(omega, omega[1:])):
+        raise ValueError("omega must be strictly increasing")
+    if omega[0] <= 0.0:
+        raise ValueError("omega must be positive (rad/s)")
+    if any(v < 0.0 for v in stress_rao):
+        raise ValueError("stress_rao ordinates must be non-negative")

--- a/tests/fatigue/test_fatg.py
+++ b/tests/fatigue/test_fatg.py
@@ -1,0 +1,330 @@
+"""Validation of the legacy FATG closed-form spectral fatigue port.
+
+Source of truth
+---------------
+The legacy program survives as Fortran source only (no executable, no
+retained input/output decks), so the oracle here is a line-by-line Python
+transliteration of the Fortran arithmetic (``_specto`` / ``_fatg_run``
+below), preserving variable names, operation order and the program's
+hard-coded constants (``PI = 3.141592654``, ``TIME = 31536000``).
+Fortran ``REAL*8`` is IEEE float64, i.e. bit-comparable with Python floats.
+
+The input deck is fully synthetic (round-number RAO and scatter rows
+invented for this test; no project data).
+
+Tolerances
+----------
+* library vs transliteration and vs frozen golden values: rel 1e-9.
+  The only systematic difference is the legacy truncated PI
+  (3.141592654 vs math.pi) inside the direction cosines, worth ~3e-10
+  relative in damage; everything else agrees to machine precision.
+* FATG spectrum kernel vs the standard Bretschneider form: rel 1e-12
+  (algebraic identity, see test below).
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.fatigue.fatg import (
+    FATG_DIRECTION_FACTOR_PRESETS,
+    FATG_SN_CURVES,
+    FatgSeaState,
+    fatg_annual_damage,
+    fatg_sea_state_damage,
+    fatg_significant_stress_range,
+)
+
+REL = 1e-9
+
+# ---------------------------------------------------------------------------
+# Transliteration oracle (line-by-line port of the legacy Fortran)
+# ---------------------------------------------------------------------------
+
+_PI = 3.141592654  # hard-coded in the legacy source (not math.pi)
+_TIME = 31536000.0
+
+
+def _specto(we, sigma, hs, tz):
+    """SPECTO subroutine: significant stress response, exact arithmetic."""
+    ST4 = 1.0 / tz**4
+    ST2 = 1400.0 * ST4
+    ST3 = 700.0 * ST4
+    SSIGMA = 0.0
+    for i in range(len(we) - 1):
+        ST9 = sigma[i] ** 2 * we[i] ** (-5) * ST2 * math.exp(-(we[i] ** (-4)) * ST3)
+        ST9 += (
+            sigma[i + 1] ** 2
+            * we[i + 1] ** (-5)
+            * ST2
+            * math.exp(-(we[i + 1] ** (-4)) * ST3)
+        )
+        SSIGMA += (ST9 / 2.0) * (we[i + 1] - we[i])
+    return math.sqrt(2.0 * SSIGMA) * hs
+
+
+def _fatg_run(we, sigma, states, curve, adc, bdc, uniform=False):
+    """Main damage loop shared by the FATG variants.
+
+    * original program:      adc=cos(PI/4), bdc=cos(PI*7/16)
+    * chord variant:         adc=1,         bdc=cos(PI*7/16)
+    * diagonal variant:      adc=1,         bdc=1
+    * uniform=True reproduces the no-spreading-input mode
+      (AN0 = AN45 = AN90 = TIME*ANOC/TZ/3).
+    """
+    TLIFE = 0.0
+    per_state = []
+    for HS, TZ, ANOC, PER0, PER45, PER90 in states:
+        SIGMAS = _specto(we, sigma, HS, TZ)
+        stresses_0 = [SIGMAS * 1.271, SIGMAS * 0.59, SIGMAS * 0.28]
+        stresses_45 = [s * adc for s in stresses_0]
+        stresses_90 = [s * bdc for s in stresses_0]
+        if uniform:
+            AN0 = AN45 = AN90 = _TIME * ANOC / TZ / 3
+        else:
+            AN0 = _TIME * ANOC * (PER0 * 0.475 + PER45 * 0.5 + PER90 * 0.025) / TZ / 3
+            AN45 = _TIME * ANOC * (PER0 * 0.25 + PER45 * 0.5 + PER90 * 0.25) / TZ / 3
+            AN90 = _TIME * ANOC * (PER0 * 0.025 + PER45 * 0.5 + PER90 * 0.475) / TZ / 3
+        ALIFEU = 0.0
+        for n, group in ((AN0, stresses_0), (AN45, stresses_45), (AN90, stresses_90)):
+            for s in group:
+                ALIFEU += n / 10 ** (curve - 3 * math.log10(s))
+        TLIFE += ALIFEU
+        per_state.append((SIGMAS, ALIFEU))
+    return TLIFE, per_state
+
+
+# ---------------------------------------------------------------------------
+# Synthetic validation deck (invented round numbers; 18-point RAO as in the
+# legacy fixed-size input)
+# ---------------------------------------------------------------------------
+
+OMEGA = [0.2 + 0.1 * i for i in range(18)]  # rad/s
+RAO = [
+    120.0, 260.0, 450.0, 700.0, 1050.0, 1500.0,
+    2050.0, 2600.0, 2950.0, 3000.0, 2750.0, 2300.0,
+    1800.0, 1350.0, 950.0, 620.0, 380.0, 210.0,
+]  # psi per ft of wave height
+
+# (Hs ft, Tz s, occurrence fraction, p0, p45, p90)
+SCATTER = [
+    (3.0, 5.0, 0.55, 0.6, 0.3, 0.1),
+    (8.0, 7.0, 0.35, 0.5, 0.35, 0.15),
+    (15.0, 9.5, 0.10, 0.4, 0.4, 0.2),
+]
+
+SEA_STATES = [
+    FatgSeaState(hs=hs, tz=tz, occurrence=occ, spreading=(p0, p45, p90))
+    for hs, tz, occ, p0, p45, p90 in SCATTER
+]
+SEA_STATES_UNIFORM = [
+    FatgSeaState(hs=hs, tz=tz, occurrence=occ) for hs, tz, occ, *_ in SCATTER
+]
+
+# Frozen golden values, generated once from the transliteration oracle above
+# (float64 arithmetic; see module docstring for provenance).
+GOLDEN_SIGMAS = [6943.628770341245, 16200.00493131268, 21588.825957978726]
+GOLDEN = {
+    # (member preset, curve, uniform) -> annual damage
+    ("chord", "E", False): 2.035808341410647,
+    ("chord", "F", False): 3.3360833254500593,
+    ("chord", "T", False): 1.4450300864887822,
+    ("diagonal", "F", False): 4.511863410469105,
+    ("general", "E", False): 1.4425179007211983,
+    ("general", "E", True): 3.674478689295206,
+}
+GOLDEN_CHORD_E_PER_STATE = [
+    0.2138040700644533, 1.220603311567063, 0.6014009597791309,
+]
+
+
+class TestSignificantStressResponse:
+    def test_matches_transliteration_on_validation_deck(self):
+        for hs, tz, *_ in SCATTER:
+            expected = _specto(OMEGA, RAO, hs, tz)
+            got = fatg_significant_stress_range(OMEGA, RAO, hs, tz)
+            assert got == pytest.approx(expected, rel=REL)
+
+    def test_matches_transliteration_across_scatter_grid(self):
+        for hs in (0.5, 2.0, 6.0, 10.0, 20.0):
+            for tz in (3.5, 5.5, 8.0, 12.0):
+                expected = _specto(OMEGA, RAO, hs, tz)
+                got = fatg_significant_stress_range(OMEGA, RAO, hs, tz)
+                assert got == pytest.approx(expected, rel=REL)
+
+    def test_golden_values(self):
+        for (hs, tz, *_), expected in zip(SCATTER, GOLDEN_SIGMAS):
+            got = fatg_significant_stress_range(OMEGA, RAO, hs, tz)
+            assert got == pytest.approx(expected, rel=REL)
+
+    def test_kernel_is_standard_bretschneider(self):
+        """The legacy integration constants (1400, 700, factor 2 in the
+        significant response) are algebraically a standard Bretschneider
+        spectrum S(w) = (5/16) Hs^2 wp^4 w^-5 exp(-1.25 (wp/w)^4) with
+        wp = 560**0.25 / Tz (Tp ~= 1.2916 Tz), the response significant
+        *range* being 4*sqrt(m0)."""
+        hs, tz = 5.0, 7.0
+        wp = 560.0**0.25 / tz
+        assert 2.0 * math.pi / wp == pytest.approx(1.29159 * tz, rel=1e-4)
+        for w in OMEGA:
+            legacy_kernel = 175.0 * hs**2 / tz**4 * w**-5 * math.exp(
+                -700.0 / (tz**4 * w**4)
+            )
+            standard = (
+                (5.0 / 16.0) * hs**2 * wp**4 * w**-5
+                * math.exp(-1.25 * (wp / w) ** 4)
+            )
+            assert legacy_kernel == pytest.approx(standard, rel=1e-12)
+        # and sigma_s = 4*sqrt(m0) of that spectrum transferred by RAO^2
+        m0 = 0.0
+        for i in range(len(OMEGA) - 1):
+            def ordinate(j):
+                w = OMEGA[j]
+                return RAO[j] ** 2 * 175.0 * hs**2 / tz**4 * w**-5 * math.exp(
+                    -700.0 / (tz**4 * w**4)
+                )
+            m0 += 0.5 * (ordinate(i) + ordinate(i + 1)) * (OMEGA[i + 1] - OMEGA[i])
+        assert fatg_significant_stress_range(OMEGA, RAO, hs, tz) == pytest.approx(
+            4.0 * math.sqrt(m0), rel=1e-12
+        )
+
+    def test_linear_in_hs(self):
+        base = fatg_significant_stress_range(OMEGA, RAO, 1.0, 6.0)
+        assert fatg_significant_stress_range(OMEGA, RAO, 7.5, 6.0) == pytest.approx(
+            7.5 * base, rel=1e-12
+        )
+
+
+class TestAnnualDamageGoldens:
+    @pytest.mark.parametrize("curve", ["E", "F", "T"])
+    def test_chord_curves(self, curve):
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve=curve, member_type="chord"
+        )
+        assert result.annual_damage == pytest.approx(
+            GOLDEN[("chord", curve, False)], rel=REL
+        )
+
+    def test_chord_curve_e_per_sea_state(self):
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve="E", member_type="chord"
+        )
+        for item, expected_sigma, expected_damage in zip(
+            result.sea_states, GOLDEN_SIGMAS, GOLDEN_CHORD_E_PER_STATE
+        ):
+            assert item.significant_stress_range == pytest.approx(
+                expected_sigma, rel=REL
+            )
+            assert item.damage_per_year == pytest.approx(expected_damage, rel=REL)
+
+    def test_diagonal(self):
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve="F", member_type="diagonal"
+        )
+        assert result.annual_damage == pytest.approx(
+            GOLDEN[("diagonal", "F", False)], rel=REL
+        )
+
+    def test_general_with_spreading(self):
+        """Original program, spreading-input mode (hard-coded 18.499)."""
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve="E", member_type="general"
+        )
+        assert result.annual_damage == pytest.approx(
+            GOLDEN[("general", "E", False)], rel=REL
+        )
+
+    def test_general_uniform_mode(self):
+        """Original program, no-spreading-input mode."""
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES_UNIFORM, sn_curve="E", member_type="general"
+        )
+        assert result.annual_damage == pytest.approx(
+            GOLDEN[("general", "E", True)], rel=REL
+        )
+
+    def test_legacy_report_echoes(self):
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve="F", member_type="chord"
+        )
+        assert result.life_used_percent_1yr == pytest.approx(
+            result.annual_damage * 100.0
+        )
+        assert result.life_used_percent_10yr == pytest.approx(
+            result.annual_damage * 1000.0
+        )
+        assert result.fatigue_life_years == pytest.approx(1.0 / result.annual_damage)
+        for item, (hs, tz, *_) in zip(result.sea_states, SCATTER):
+            assert item.tp == pytest.approx(1.3 * tz)
+
+
+class TestAgainstTransliterationSweep:
+    """Cross-check the clean implementation against the oracle for every
+    member preset and curve on the validation deck."""
+
+    @pytest.mark.parametrize("member", ["general", "chord", "diagonal"])
+    @pytest.mark.parametrize("curve", ["E", "F", "T"])
+    def test_all_presets_and_curves(self, member, curve):
+        adc_lib, bdc_lib = FATG_DIRECTION_FACTOR_PRESETS[member][1:]
+        # oracle uses the legacy truncated PI in its cosines
+        oracle_factors = {
+            "general": (math.cos(_PI / 4), math.cos(_PI * 7 / 16)),
+            "chord": (1.0, math.cos(_PI * 7 / 16)),
+            "diagonal": (1.0, 1.0),
+        }[member]
+        expected, _ = _fatg_run(
+            OMEGA, RAO, SCATTER, FATG_SN_CURVES[curve], *oracle_factors
+        )
+        result = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve=curve, member_type=member
+        )
+        assert result.annual_damage == pytest.approx(expected, rel=REL)
+        # the truncated-PI direction factors agree with math.pi to ~1e-10
+        assert adc_lib == pytest.approx(oracle_factors[0], rel=1e-9)
+        assert bdc_lib == pytest.approx(oracle_factors[1], rel=1e-9)
+
+
+class TestProperties:
+    def test_damage_scales_with_rao_cubed_for_slope_3(self):
+        scaled = [2.0 * v for v in RAO]
+        base = fatg_annual_damage(OMEGA, RAO, SEA_STATES, sn_curve="F")
+        double = fatg_annual_damage(OMEGA, scaled, SEA_STATES, sn_curve="F")
+        assert double.annual_damage == pytest.approx(
+            8.0 * base.annual_damage, rel=1e-9
+        )
+
+    def test_explicit_log10_a_overrides_curve_name(self):
+        named = fatg_annual_damage(OMEGA, RAO, SEA_STATES, sn_curve="F")
+        explicit = fatg_annual_damage(
+            OMEGA, RAO, SEA_STATES, sn_curve=None, log10_a=18.2845
+        )
+        assert explicit.annual_damage == pytest.approx(named.annual_damage, rel=1e-12)
+
+    def test_sea_state_damage_matches_sum_of_blocks(self):
+        sigma_s = 10000.0
+        damage = fatg_sea_state_damage(
+            sigma_s, 6.0, 0.25, log10_a=18.2845, spreading=(0.5, 0.3, 0.2)
+        )
+        assert damage > 0.0
+
+
+class TestValidation:
+    def test_rejects_mismatched_rao(self):
+        with pytest.raises(ValueError):
+            fatg_significant_stress_range([0.2, 0.4], [1.0], 1.0, 6.0)
+
+    def test_rejects_non_increasing_omega(self):
+        with pytest.raises(ValueError):
+            fatg_significant_stress_range([0.4, 0.2], [1.0, 1.0], 1.0, 6.0)
+
+    def test_rejects_unknown_curve(self):
+        with pytest.raises(ValueError):
+            fatg_annual_damage(OMEGA, RAO, SEA_STATES, sn_curve="Z")
+
+    def test_rejects_unknown_member_type(self):
+        with pytest.raises(ValueError):
+            fatg_annual_damage(OMEGA, RAO, SEA_STATES, member_type="brace")
+
+    def test_rejects_empty_scatter(self):
+        with pytest.raises(ValueError):
+            fatg_annual_damage(OMEGA, RAO, [])

--- a/tests/fatigue/test_fatg_workflow.py
+++ b/tests/fatigue/test_fatg_workflow.py
@@ -1,0 +1,163 @@
+"""Workflow (router) tests for the fatg_spectral_fatigue basename."""
+
+import csv
+
+import pytest
+
+from digitalmodel.fatg_spectral_fatigue.workflow import router
+from digitalmodel.fatigue.fatg import FatgSeaState, fatg_annual_damage
+
+OMEGA = [0.2 + 0.1 * i for i in range(18)]
+RAO = [
+    120.0, 260.0, 450.0, 700.0, 1050.0, 1500.0,
+    2050.0, 2600.0, 2950.0, 3000.0, 2750.0, 2300.0,
+    1800.0, 1350.0, 950.0, 620.0, 380.0, 210.0,
+]
+SCATTER = [
+    (3.0, 5.0, 0.55, 0.6, 0.3, 0.1),
+    (8.0, 7.0, 0.35, 0.5, 0.35, 0.15),
+    (15.0, 9.5, 0.10, 0.4, 0.4, 0.2),
+]
+
+
+def _cfg(tmp_path, **overrides):
+    settings = {
+        "design_life_years": 20.0,
+        "dff": 1.0,
+        "sn_curve": "F",
+        "member_type": "chord",
+        "rao": {
+            "omega_rad_per_s": OMEGA,
+            "stress_per_wave_height": RAO,
+        },
+        "sea_states": [
+            {
+                "hs": hs,
+                "tz": tz,
+                "occurrence_fraction": occ,
+                "spreading": {"p0": p0, "p45": p45, "p90": p90},
+            }
+            for hs, tz, occ, p0, p45, p90 in SCATTER
+        ],
+        "output_dir": str(tmp_path / "results"),
+    }
+    settings.update(overrides)
+    return {
+        "basename": "fatg_spectral_fatigue",
+        "fatg_spectral_fatigue": settings,
+        "_config_dir_path": str(tmp_path),
+    }
+
+
+def _library_reference(sn_curve="F", member_type="chord", spreading=True):
+    states = [
+        FatgSeaState(
+            hs=hs,
+            tz=tz,
+            occurrence=occ,
+            spreading=(p0, p45, p90) if spreading else None,
+        )
+        for hs, tz, occ, p0, p45, p90 in SCATTER
+    ]
+    return fatg_annual_damage(
+        OMEGA, RAO, states, sn_curve=sn_curve, member_type=member_type
+    )
+
+
+def test_router_matches_library(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    expected = _library_reference()
+    result = cfg["fatg_spectral_fatigue"]
+    assert result["annual_damage"] == pytest.approx(expected.annual_damage, rel=1e-12)
+    assert result["fatigue_life_years"] == pytest.approx(
+        expected.fatigue_life_years, rel=1e-12
+    )
+    assert result["life_used_percent_1yr"] == pytest.approx(
+        expected.annual_damage * 100.0, rel=1e-12
+    )
+    assert result["life_used_percent_10yr"] == pytest.approx(
+        expected.annual_damage * 1000.0, rel=1e-12
+    )
+    per_state = [row["damage_per_year"] for row in result["sea_states"]]
+    assert per_state == pytest.approx(
+        [item.damage_per_year for item in expected.sea_states], rel=1e-12
+    )
+
+
+def test_router_screening_status(tmp_path):
+    # the synthetic deck uses ~3.3 lives per year -> fails a 20-year check
+    cfg = router(_cfg(tmp_path))
+    assert cfg["fatg_spectral_fatigue"]["screening_status"] == "fail"
+    assert cfg["screening_status"] == "fail"
+    assert cfg["fatg_spectral_fatigue"]["margin"] < 1.0
+
+    # a much softer RAO passes
+    soft = {"omega_rad_per_s": OMEGA, "stress_per_wave_height": [v / 200.0 for v in RAO]}
+    cfg = router(_cfg(tmp_path, rao=soft))
+    assert cfg["fatg_spectral_fatigue"]["screening_status"] == "pass"
+    assert cfg["screening_status"] == "pass"
+
+
+def test_router_writes_csv_outputs(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    result = cfg["fatg_spectral_fatigue"]
+    results_csv = tmp_path / "results" / "fatg_spectral_fatigue_fatg_spectral_fatigue.csv"
+    summary_csv = (
+        tmp_path / "results" / "fatg_spectral_fatigue_fatg_spectral_fatigue_summary.csv"
+    )
+    assert results_csv.exists()
+    assert summary_csv.exists()
+    with results_csv.open() as stream:
+        rows = list(csv.DictReader(stream))
+    assert len(rows) == len(SCATTER)
+    assert float(rows[0]["significant_stress_range"]) == pytest.approx(
+        result["sea_states"][0]["significant_stress_range"]
+    )
+
+
+def test_router_explicit_sn_mapping_equals_named_curve(tmp_path):
+    named = router(_cfg(tmp_path))["fatg_spectral_fatigue"]["annual_damage"]
+    explicit = router(
+        _cfg(tmp_path, sn_curve={"log10_a": 18.2845, "slope": 3.0})
+    )["fatg_spectral_fatigue"]["annual_damage"]
+    assert explicit == pytest.approx(named, rel=1e-12)
+
+
+def test_router_uniform_mode_when_spreading_omitted(tmp_path):
+    sea_states = [
+        {"hs": hs, "tz": tz, "occurrence_fraction": occ}
+        for hs, tz, occ, *_ in SCATTER
+    ]
+    cfg = router(_cfg(tmp_path, sea_states=sea_states, member_type="general"))
+    expected = _library_reference(member_type="general", spreading=False)
+    assert cfg["fatg_spectral_fatigue"]["annual_damage"] == pytest.approx(
+        expected.annual_damage, rel=1e-12
+    )
+
+
+def test_router_rejects_bad_inputs(tmp_path):
+    with pytest.raises(ValueError):
+        router(_cfg(tmp_path, sn_curve="Z"))
+    with pytest.raises(ValueError):
+        router(_cfg(tmp_path, sea_states=[]))
+    with pytest.raises(ValueError):
+        router(_cfg(tmp_path, rao={"omega_rad_per_s": OMEGA}))
+    missing_dff = _cfg(tmp_path)
+    del missing_dff["fatg_spectral_fatigue"]["dff"]
+    with pytest.raises(ValueError):
+        router(missing_dff)
+
+
+def test_engine_registers_basename():
+    """The engine dispatch table includes basename fatg_spectral_fatigue.
+
+    Checked against the source file (not an engine import) to keep this
+    test lightweight; the router itself is exercised above.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.find_spec("digitalmodel.engine")
+    source = Path(spec.origin).read_text(encoding="utf-8", errors="ignore")
+    assert 'basename == "fatg_spectral_fatigue"' in source
+    assert "from digitalmodel.fatg_spectral_fatigue.workflow import" in source


### PR DESCRIPTION
## Summary
First legacy-code migration under the ACMA analysis-readiness program (llm-wiki-acma#249/#256-series): faithful port of the FATG closed-form spectral fatigue workflow (Tz-parameterised Bretschneider on the RAO's native grid, 3-block Rayleigh discretisation, 0/45/90 spreading matrix, member-type direction factors) as a routed workflow (basename `fatg_spectral_fatigue`), with the S-N curve made selectable (closes the original Fortran's own TODO).

## Validation
- Line-by-line Fortran transliteration embedded in tests as source of truth (no sample decks survive; synthetic 18-point RAO + 3-row scatter decks; identifier scan clean)
- 37/37 new tests; full tests/fatigue 302/302 pass; rel tol 1e-9 (transliteration + frozen goldens), 1e-12 Bretschneider-kernel identity
- Method finding documented: legacy SPECTO constants ≡ standard Bretschneider with Tp ≈ 1.2916·Tz

## Outstanding
- Compiled-binary cross-check needs gfortran on a Linux box — recipe in docs/domains/fatigue/fatg-legacy-spectral-fatigue.md
- Pre-existing failure in test_durable_workflows (spectral-fatigue-atlas-query) confirmed present on clean main — unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)