### PR TITLE
Fix AQWA triangle and frequency deck generation (#1571)

### DIFF
--- a/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
+++ b/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
@@ -1,0 +1,165 @@
+# Plan for #1571: Fix AQWA GDF triangles, frequency ordering, and v261 discovery
+
+> **Status:** adversarial-reviewed — user approval checkpoint pending
+> **Complexity:** T2
+> **Date:** 2026-07-13
+> **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1571
+> **Client:** N/A — tests use synthetic meshes only; private Noble data stays outside this repository
+> **Lane:** lane:codex
+> **Execution mode:** single-lane
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py:281-300` returns `None` for a missing mesh but also catches every parser exception, so malformed existing files are silently downgraded to a warning card.
+- `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py:343-378` parses the four coordinate records required by GDF and deduplicates equal coordinates into equal node IDs, but silently drops truncated or non-numeric panels without verifying that the declared panel count was read.
+- `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py:525-540` incorrectly emits every parsed panel as four-node `QPPL DIFF`, including GDF triangles whose fourth coordinate repeats the third.
+- `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py:773-793` preserves the source order after period-to-frequency conversion; ascending periods therefore become descending frequencies.
+- `src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py:189-201` preserves `AQWA_PATH` precedence but its Windows standard-path list stops at v252.
+- `src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py:125-143` is a second AQWA DAT exporter with the same invalid repeated-node `QPPL` triangle behavior and stale documentation.
+- `src/digitalmodel/hydrodynamics/diffraction/input_schemas.py:369-386` silently filters nonpositive period values during conversion, preventing the backend from detecting that requested source values disappeared.
+
+### Reference evidence
+
+- Issue #1571 records the production symptom and the privacy boundary.
+- A private licensed-run listing reported repeated-node quadrilateral-card errors and a separate frequency/direction ordering error. This plan intentionally records only the error classes; no connectivity, client geometry, or native-result excerpt is included.
+- The client's original AQWA deck, inspected locally, uses three-node `TPPL DIFF` cards for triangular panels and four-node `QPPL DIFF` cards for quadrilaterals. This establishes the required AQWA card distinction.
+- `tests/hydrodynamics/diffraction/test_aqwa_runner.py:462-489` already tests executable discovery and environment precedence, providing the extension point for v261.
+- `tests/hydrodynamics/diffraction/test_orcawave_backend.py:444-455` demonstrates the repository convention of explicitly testing solver-required ordering.
+
+### Standards and external documents
+
+- No external engineering standard governs this serialization defect. The authoritative evidence is accepted AQWA deck syntax plus the fail-closed v261 solver diagnostics.
+- No drive-file search is needed: private project files supplied only runtime reproduction evidence and are prohibited from the public synthetic regression fixtures.
+
+### Gaps identified
+
+- No backend test distinguishes triangular GDF panels from true quadrilaterals at AQWA card emission.
+- No AQWA backend test asserts ascending generated frequency cards for period input.
+- No discovery test covers the installed v261 standard path.
+- No parser test requires the number of successfully parsed panels to equal the GDF-declared panel count, and `_load_mesh` currently hides malformed-file exceptions.
+- No backend validation rejects duplicate, nonfinite, or nonpositive converted frequencies before assigning AQWA indices.
+- The platform-gated `_STANDARD_PATHS` shape prevents deterministic cross-platform testing of Windows candidate ordering.
+
+### Reproduction proof
+
+The private licensed v261 run reached AQWA and failed on two input-validation classes: repeated-node quadrilateral cards and non-ascending frequency/direction cards. The same worker's synthetic license canary completed `rc=0`, isolating these failures from licensing. Exact client connectivity and verbatim native-result text are deliberately omitted from this public plan.
+
+Distinct sources: issue #1571; `aqwa_backend.py`; `aqwa_runner.py`; existing backend/runner tests; accepted original AQWA syntax.
+
+---
+
+## Deliverable
+
+AQWA deck generation that emits valid triangle/quad cards, ascending frequencies, and discovers ANSYS v261, with synthetic regression tests and no client data.
+
+## Design and Pseudocode
+
+```text
+for each parsed four-slot GDF panel:
+    unique_nodes = preserve_order(panel node IDs)
+    if panel shape is exactly [n1, n2, n3, n3] with n1/n2/n3 distinct:
+        emit TPPL DIFF with the first three node IDs
+    elif exactly 4 unique nodes:
+        emit QPPL DIFF with four node IDs
+    else:
+        fail closed with a descriptive invalid-panel error
+
+while parsing GDF:
+    require a valid positive declared panel count
+    require exactly four valid coordinate records per declared panel
+    require parsed panel count == declared panel count
+    require each panel is a canonical triangle or four-unique-node quad
+    raise a descriptive mesh-format error containing mesh path,
+        1-based panel number, and vertex slot on any violation
+
+when loading mesh:
+    return None only when the resolved path does not exist
+    propagate malformed existing-file errors so deck generation fails closed
+
+frequencies_hz = convert_to_hz(spec frequencies)
+conversion must preserve source cardinality; FrequencySpec raises on
+    nonfinite or nonpositive period/frequency inputs instead of filtering
+reject nonfinite, nonpositive, or duplicate converted values
+frequencies_hz = sorted(frequencies_hz)
+emit indexed HRTZ cards in ascending numeric order
+
+unconditional WINDOWS_AQWA_CANDIDATES = [v261, v252, existing descending versions]
+active standard paths = candidates only on Windows
+AQWA_PATH remains checked before standard paths
+
+gmsh DAT helper:
+    emit TPPL DIFF for three-node input
+    emit QPPL DIFF for four-unique-node input
+    reject all other cardinality/duplicate patterns
+```
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | `tests/hydrodynamics/diffraction/test_aqwa_backend.py` | Add triangle/quad, malformed-panel, and ascending-frequency regressions before code changes |
+| Modify | `src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py` | Emit TPPL/QPPL correctly and sort frequency cards |
+| Modify | `tests/hydrodynamics/diffraction/test_aqwa_runner.py` | Add v261 discovery and retain environment-precedence coverage |
+| Modify | `src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py` | Add v261 to standard discovery paths |
+| Modify | `tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py` | Replace the stale repeated-node-QPPL expectation with TPPL/quad/invalid-shape tests |
+| Modify | `src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py` | Make the second AQWA DAT exporter use valid TPPL syntax and correct its documentation |
+| Modify | `tests/hydrodynamics/diffraction/test_input_schemas.py` | Prove invalid period/frequency values fail instead of disappearing during conversion |
+| Modify | `src/digitalmodel/hydrodynamics/diffraction/input_schemas.py` | Preserve frequency-source cardinality by rejecting invalid values before conversion |
+
+## TDD Test List
+
+| Test | Verification |
+|---|---|
+| `test_deck2_emits_tppl_for_repeated_fourth_gdf_vertex` | A synthetic triangular GDF panel produces one three-node `TPPL DIFF` card |
+| `test_deck2_preserves_qppl_for_four_unique_vertices` | A true quad remains a four-node `QPPL DIFF` card |
+| `test_parse_gdf_rejects_truncated_declared_panel` | Missing coordinate records fail closed instead of silently dropping a panel |
+| `test_parse_gdf_rejects_non_numeric_panel_coordinate` | An existing malformed file raises a descriptive format error |
+| `test_parse_gdf_rejects_invalid_declared_panel_count` (parameterized) | Non-integer, zero, and negative NPAN values fail closed |
+| `test_load_mesh_propagates_malformed_existing_file` | Parser errors are not converted into warning-only missing meshes |
+| `test_load_mesh_missing_path_retains_missing_behavior` | A genuinely absent path still returns `None` for the existing caller contract |
+| `test_deck2_rejects_noncanonical_three_unique_duplicates` (parameterized) | Fourth-repeats-first, adjacent duplicates, and fewer than three unique nodes fail closed |
+| `test_deck2_tppl_and_qppl_have_exact_node_field_counts` | TPPL has three node fields, QPPL has four, and no repeated-node QPPL is emitted |
+| `test_deck6_sorts_period_derived_frequencies_with_exact_values_and_indices` | Exact Hz conversions are ascending and HRTZ indices are sequential |
+| `test_deck6_sorts_unsorted_explicit_frequencies_and_reindexes` | Explicit unsorted inputs receive deterministic solver order and indices |
+| `test_deck6_rejects_invalid_or_duplicate_converted_frequencies` (parameterized) | Duplicate, nonfinite, zero, and negative solver frequencies fail closed |
+| `test_frequency_conversion_rejects_nonpositive_or_nonfinite_source_values` (parameterized) | Period/frequency conversion never silently drops requested values |
+| `test_windows_candidates_put_v261_before_v252` | Candidate ordering is deterministic on every test platform |
+| `test_detect_executable_checks_v261_standard_path` | Selective existence mocking discovers v261 with environment state explicitly cleared |
+| `test_explicit_executable_path_wins_over_env_and_standard_candidates` | Caller configuration has highest precedence with all alternatives available |
+| `test_aqwa_path_env_wins_over_standard_candidates` | Agent environment wins when v261 and older installs also exist |
+| `test_v261_wins_over_older_existing_standard_candidates` | Standard discovery selects the newest installed supported version |
+| `test_dat_panel_triangle_uses_tppl_and_quad_uses_qppl` | The gmsh DAT helper follows the same valid card contract |
+| `test_dat_panel_rejects_invalid_duplicate_shapes` | The gmsh DAT helper fails closed on noncanonical connectivity |
+
+## Acceptance Criteria
+
+- [ ] New focused tests fail before implementation and pass afterward.
+- [ ] `uv run pytest tests/hydrodynamics/diffraction/test_aqwa_backend.py tests/hydrodynamics/diffraction/test_aqwa_runner.py tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py tests/hydrodynamics/diffraction/test_input_schemas.py -v` passes.
+- [ ] Existing AQWA/diffraction tests show no regression.
+- [ ] A dry-generated Noble deck contains `TPPL` for all repeated-vertex triangles, no repeated-node `QPPL`, and ascending HRTZ and DIRN values (private verification only; no connectivity or native output is copied into the public repository).
+- [ ] The private licensed-run retry gets past Deck 2 and Deck 6 input validation.
+- [ ] No private input or native result is committed to `digitalmodel`.
+
+## Adversarial Review Summary
+
+First review verdict: **MAJOR**. The reviewer found private excerpts, silent parser/load failures, insufficient negative triangle/frequency tests, platform-dependent discovery testing, and a second invalid DAT exporter. This revision removes all private excerpts; adds explicit parser cardinality and contextual errors; preserves only missing-file behavior; defines canonical triangle and frequency validity contracts; exposes testable Windows candidates; and includes `gmsh_mesh_builder.py`.
+
+Independent privacy/scope review verdict: **MINOR**. Privacy and scope are clean. The plan now adds the requested invalid-NPAN test, direct three-level executable-precedence tests, and private ascending-DIRN acceptance. Final test-design review remains pending before promotion.
+
+Independent test-design review verdict: **APPROVE**, with one implementation caution folded into the plan: `FrequencySpec` currently filters invalid periods, so source validation/cardinality preservation is now explicit and tested before backend ordering.
+
+Original review second-pass verdict: **APPROVE**. All prior MAJOR findings are resolved; no new blocking or minor defect was found.
+
+## Risks and Open Questions
+
+- GDF permits triangles by repeated coordinates; detection must be based on parsed node identity without reordering valid quadrilaterals. Only the conventional repeated third/fourth slot is accepted as a triangle; other duplicate patterns fail closed.
+- Sorting frequencies changes output indexing but is required by AQWA; downstream extraction must use the emitted solver order.
+- Frequency sorting changes solver indices; extraction and result ordering must follow the emitted sequence, so exact-value/index tests are required.
+
+## Complexity: T2
+
+Two small production fixes plus executable discovery, but correctness depends on solver-specific serialization and regression coverage.

--- a/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
+++ b/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
@@ -114,6 +114,7 @@ gmsh DAT helper:
 | Modify | `src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py` | Make the second AQWA DAT exporter use valid TPPL syntax and correct its documentation |
 | Modify | `tests/hydrodynamics/diffraction/test_input_schemas.py` | Prove invalid period/frequency values fail instead of disappearing during conversion |
 | Modify | `src/digitalmodel/hydrodynamics/diffraction/input_schemas.py` | Preserve frequency-source cardinality by rejecting invalid values before conversion |
+| Modify | `tests/hydrodynamics/diffraction/test_resolver.py` | Replace a headerless `.gdf` fixture exposed by strict parsing with a valid two-panel GDF |
 
 ## TDD Test List
 
@@ -142,6 +143,7 @@ gmsh DAT helper:
 | `test_dat_panel_triangle_uses_tppl_and_quad_uses_qppl` | The gmsh DAT helper follows the same valid card contract |
 | `test_dat_four_slot_triangle_uses_ordered_unique_tppl` (parameterized) | The gmsh DAT helper accepts all repeated-slot triangle representations |
 | `test_dat_panel_rejects_invalid_shapes` | The gmsh DAT helper fails closed on degenerate connectivity |
+| `test_ledger_travels_through_run_entrypoints` | Resolver integration continues to generate decks from a format-valid synthetic GDF fixture |
 
 ## Acceptance Criteria
 
@@ -165,6 +167,8 @@ Original review second-pass verdict: **APPROVE**. All prior MAJOR findings are r
 Implementation cross-review verdict: **MAJOR**. Repository GDF fixtures showed that valid WAMIT triangles repeat a node in multiple slots, not only the final slot; the reviewer also found that distinct full-precision frequencies could collide under AQWA's six-significant-digit HRTZ formatting. The implementation contract and tests now accept the corpus-valid cyclic-repeat forms in first-occurrence order, reject degenerate panels, and reject serialized frequency collisions.
 
 Implementation follow-up verdict: **MAJOR**. Accepting every exactly-three-unique four-slot sequence also admitted alternating repeats such as `[A, B, A, C]`. The contract now requires the repeated positions to be cyclic-adjacent—including the wraparound 1/4 pair used by valid WAMIT fixtures—and explicitly rejects the two alternating forms in the parser and exporters.
+
+CI regression review found one related stale fixture: `test_resolver.py` wrote eight bare coordinate records to a `.gdf` path without a GDF header. Strict parsing correctly rejected it, so the fixture now declares two valid panels. The other CI contract failures cite unrelated dynmoor force names and a `report_pack` routing mismatch outside this PR.
 
 ## Risks and Open Questions
 

--- a/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
+++ b/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
@@ -1,6 +1,6 @@
 # Plan for #1571: Fix AQWA GDF triangles, frequency ordering, and v261 discovery
 
-> **Status:** adversarial-reviewed — user approval checkpoint pending
+> **Status:** plan-approved — approved by user 2026-07-13
 > **Complexity:** T2
 > **Date:** 2026-07-13
 > **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1571

--- a/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
+++ b/docs/plans/2026-07-13-issue-1571-aqwa-triangles-frequency-v261.md
@@ -61,8 +61,8 @@ AQWA deck generation that emits valid triangle/quad cards, ascending frequencies
 ```text
 for each parsed four-slot GDF panel:
     unique_nodes = preserve_order(panel node IDs)
-    if panel shape is exactly [n1, n2, n3, n3] with n1/n2/n3 distinct:
-        emit TPPL DIFF with the first three node IDs
+    if exactly 3 unique nodes and the repeated slots are cyclic-adjacent:
+        emit TPPL DIFF with the ordered unique node IDs
     elif exactly 4 unique nodes:
         emit QPPL DIFF with four node IDs
     else:
@@ -72,7 +72,8 @@ while parsing GDF:
     require a valid positive declared panel count
     require exactly four valid coordinate records per declared panel
     require parsed panel count == declared panel count
-    require each panel is a canonical triangle or four-unique-node quad
+    require each panel has four unique nodes or three unique nodes with
+        a cyclic-adjacent repeat (slots 1/2, 2/3, 3/4, or 1/4)
     raise a descriptive mesh-format error containing mesh path,
         1-based panel number, and vertex slot on any violation
 
@@ -85,6 +86,8 @@ conversion must preserve source cardinality; FrequencySpec raises on
     nonfinite or nonpositive period/frequency inputs instead of filtering
 reject nonfinite, nonpositive, or duplicate converted values
 frequencies_hz = sorted(frequencies_hz)
+format frequencies exactly as HRTZ will serialize them
+reject values that collide after HRTZ formatting
 emit indexed HRTZ cards in ascending numeric order
 
 unconditional WINDOWS_AQWA_CANDIDATES = [v261, v252, existing descending versions]
@@ -93,8 +96,10 @@ AQWA_PATH remains checked before standard paths
 
 gmsh DAT helper:
     emit TPPL DIFF for three-node input
+    emit ordered-unique TPPL DIFF for four-slot input with 3 unique nodes
+        and a cyclic-adjacent repeated node
     emit QPPL DIFF for four-unique-node input
-    reject all other cardinality/duplicate patterns
+    reject all other cardinality/unique-node patterns
 ```
 
 ## Files to Change
@@ -114,18 +119,20 @@ gmsh DAT helper:
 
 | Test | Verification |
 |---|---|
-| `test_deck2_emits_tppl_for_repeated_fourth_gdf_vertex` | A synthetic triangular GDF panel produces one three-node `TPPL DIFF` card |
+| `test_deck2_emits_tppl_for_any_cyclic_repeat_triangle` (parameterized) | Every valid repeated-slot representation produces one ordered three-node `TPPL DIFF` card |
 | `test_deck2_preserves_qppl_for_four_unique_vertices` | A true quad remains a four-node `QPPL DIFF` card |
 | `test_parse_gdf_rejects_truncated_declared_panel` | Missing coordinate records fail closed instead of silently dropping a panel |
 | `test_parse_gdf_rejects_non_numeric_panel_coordinate` | An existing malformed file raises a descriptive format error |
 | `test_parse_gdf_rejects_invalid_declared_panel_count` (parameterized) | Non-integer, zero, and negative NPAN values fail closed |
 | `test_load_mesh_propagates_malformed_existing_file` | Parser errors are not converted into warning-only missing meshes |
 | `test_load_mesh_missing_path_retains_missing_behavior` | A genuinely absent path still returns `None` for the existing caller contract |
-| `test_deck2_rejects_noncanonical_three_unique_duplicates` (parameterized) | Fourth-repeats-first, adjacent duplicates, and fewer than three unique nodes fail closed |
+| `test_deck2_rejects_panels_with_fewer_than_three_unique_nodes` (parameterized) | Degenerate panels with fewer than three unique nodes fail closed |
+| `test_parse_gdf_rejects_nonadjacent_repeated_vertex` (parameterized) | Alternating repeats that would collapse or cross panel connectivity fail closed |
 | `test_deck2_tppl_and_qppl_have_exact_node_field_counts` | TPPL has three node fields, QPPL has four, and no repeated-node QPPL is emitted |
 | `test_deck6_sorts_period_derived_frequencies_with_exact_values_and_indices` | Exact Hz conversions are ascending and HRTZ indices are sequential |
 | `test_deck6_sorts_unsorted_explicit_frequencies_and_reindexes` | Explicit unsorted inputs receive deterministic solver order and indices |
 | `test_deck6_rejects_invalid_or_duplicate_converted_frequencies` (parameterized) | Duplicate, nonfinite, zero, and negative solver frequencies fail closed |
+| `test_deck6_rejects_frequencies_that_collide_after_formatting` | Distinct numeric values cannot serialize to duplicate HRTZ cards |
 | `test_frequency_conversion_rejects_nonpositive_or_nonfinite_source_values` (parameterized) | Period/frequency conversion never silently drops requested values |
 | `test_windows_candidates_put_v261_before_v252` | Candidate ordering is deterministic on every test platform |
 | `test_detect_executable_checks_v261_standard_path` | Selective existence mocking discovers v261 with environment state explicitly cleared |
@@ -133,7 +140,8 @@ gmsh DAT helper:
 | `test_aqwa_path_env_wins_over_standard_candidates` | Agent environment wins when v261 and older installs also exist |
 | `test_v261_wins_over_older_existing_standard_candidates` | Standard discovery selects the newest installed supported version |
 | `test_dat_panel_triangle_uses_tppl_and_quad_uses_qppl` | The gmsh DAT helper follows the same valid card contract |
-| `test_dat_panel_rejects_invalid_duplicate_shapes` | The gmsh DAT helper fails closed on noncanonical connectivity |
+| `test_dat_four_slot_triangle_uses_ordered_unique_tppl` (parameterized) | The gmsh DAT helper accepts all repeated-slot triangle representations |
+| `test_dat_panel_rejects_invalid_shapes` | The gmsh DAT helper fails closed on degenerate connectivity |
 
 ## Acceptance Criteria
 
@@ -154,9 +162,13 @@ Independent test-design review verdict: **APPROVE**, with one implementation cau
 
 Original review second-pass verdict: **APPROVE**. All prior MAJOR findings are resolved; no new blocking or minor defect was found.
 
+Implementation cross-review verdict: **MAJOR**. Repository GDF fixtures showed that valid WAMIT triangles repeat a node in multiple slots, not only the final slot; the reviewer also found that distinct full-precision frequencies could collide under AQWA's six-significant-digit HRTZ formatting. The implementation contract and tests now accept the corpus-valid cyclic-repeat forms in first-occurrence order, reject degenerate panels, and reject serialized frequency collisions.
+
+Implementation follow-up verdict: **MAJOR**. Accepting every exactly-three-unique four-slot sequence also admitted alternating repeats such as `[A, B, A, C]`. The contract now requires the repeated positions to be cyclic-adjacent—including the wraparound 1/4 pair used by valid WAMIT fixtures—and explicitly rejects the two alternating forms in the parser and exporters.
+
 ## Risks and Open Questions
 
-- GDF permits triangles by repeated coordinates; detection must be based on parsed node identity without reordering valid quadrilaterals. Only the conventional repeated third/fourth slot is accepted as a triangle; other duplicate patterns fail closed.
+- GDF permits triangles by repeating a coordinate in cyclic-adjacent slots of a four-slot panel; detection is based on parsed node identity, preserves first-occurrence cyclic order, rejects alternating repeats, and does not reorder four-unique-node quadrilaterals.
 - Sorting frequencies changes output indexing but is required by AQWA; downstream extraction must use the emitted solver order.
 - Frequency sorting changes solver indices; extraction and result ordering must follow the emitted sequence, so exact-value/index tests are required.
 

--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
@@ -389,15 +389,21 @@ class AQWABackend:
                 line_idx += 1
 
             unique_count = len(set(panel_vertices))
-            is_triangle = (
-                unique_count == 3
-                and panel_vertices[2] == panel_vertices[3]
-                and len(set(panel_vertices[:3])) == 3
+            repeated_positions = [
+                index
+                for index, node in enumerate(panel_vertices)
+                if panel_vertices.count(node) == 2
+            ]
+            is_triangle = unique_count == 3 and repeated_positions in (
+                [0, 1],
+                [1, 2],
+                [2, 3],
+                [0, 3],
             )
             if unique_count != 4 and not is_triangle:
                 raise ValueError(
                     f"{file_path}: panel {panel_number}: expected four unique "
-                    "vertices or canonical triangle [n1, n2, n3, n3]"
+                    "vertices or a triangle with a cyclic-adjacent repeated vertex"
                 )
             panels.append(panel_vertices)
 
@@ -550,22 +556,32 @@ class AQWABackend:
             cards.append(f"* Group ID    {group_id} is body named {vessel_name}")
 
             if mesh is not None:
-                # DIFF marks elements as diffracting. GDF triangles repeat
-                # vertex 3 in slot 4 and must be emitted as three-node TPPL;
-                # true quadrilaterals use four-node QPPL.
+                # DIFF marks elements as diffracting. GDF triangles contain
+                # three unique vertices in four slots and must be emitted as
+                # three-node TPPL; true quadrilaterals use four-node QPPL.
                 for elem_idx, panel in enumerate(mesh.panels, start=1):
                     # Panel contains 0-based indices, convert to 1-based
-                    n1 = panel[0] + 1
-                    n2 = panel[1] + 1
-                    n3 = panel[2] + 1
-                    n4 = panel[3] + 1
-                    unique_count = len({n1, n2, n3, n4})
-                    if unique_count == 4:
+                    nodes = [int(node) + 1 for node in panel]
+                    ordered_unique = list(dict.fromkeys(nodes))
+                    repeated_positions = [
+                        index
+                        for index, node in enumerate(nodes)
+                        if nodes.count(node) == 2
+                    ]
+                    is_triangle = len(ordered_unique) == 3 and repeated_positions in (
+                        [0, 1],
+                        [1, 2],
+                        [2, 3],
+                        [0, 3],
+                    )
+                    if len(ordered_unique) == 4:
+                        n1, n2, n3, n4 = ordered_unique
                         card = (
                             f"     {struct_idx}QPPL DIFF   {group_id}({struct_idx})"
                             f"({n1:>5d})({n2:>5d})({n3:>5d})({n4:>5d})"
                         )
-                    elif unique_count == 3 and n3 == n4 and len({n1, n2, n3}) == 3:
+                    elif is_triangle:
+                        n1, n2, n3 = ordered_unique
                         card = (
                             f"     {struct_idx}TPPL DIFF   {group_id}({struct_idx})"
                             f"({n1:>5d})({n2:>5d})({n3:>5d})"
@@ -573,8 +589,8 @@ class AQWABackend:
                     else:
                         raise ValueError(
                             f"Invalid panel {elem_idx} on structure {struct_idx}: "
-                            "expected four unique nodes or canonical triangle "
-                            "[n1, n2, n3, n3]"
+                            "expected four unique nodes or a triangle with a "
+                            "cyclic-adjacent repeated node"
                         )
                     cards.append(f"{card}  Aqwa Elem No: {elem_idx:>4d}")
             else:
@@ -824,9 +840,12 @@ class AQWABackend:
         if len(freqs_hz) != len(set(freqs_hz)):
             raise ValueError("AQWA frequencies must be unique")
         freqs_hz.sort()
+        freq_strings = [f"{freq_hz:g}" for freq_hz in freqs_hz]
+        if len(freq_strings) != len(set(freq_strings)):
+            raise ValueError("AQWA frequencies must be unique after HRTZ formatting")
 
-        for i, freq_hz in enumerate(freqs_hz, start=1):
-            freq_str = f"{freq_hz:>10g}"
+        for i, freq_value in enumerate(freq_strings, start=1):
+            freq_str = f"{freq_value:>10s}"
             cards.append(f"{_WS:>5s}1HRTZ{i:>5d}{i:>5d}{freq_str}")
 
         # Headings — AQWA requires -180 to +180 range for no-symmetry bodies

--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_backend.py
@@ -290,13 +290,15 @@ class AQWABackend:
         mesh_path = self._resolve_mesh_path(mesh_file)
         if not mesh_path.exists():
             return None
-
-        try:
-            mesh = self._parse_gdf(mesh_path)
-            self._mesh_cache[mesh_file] = mesh
-            return mesh
-        except Exception:
+        # This backend currently parses WAMIT GDF only. Other declared mesh
+        # formats retain the existing warning-only fallback until a dedicated
+        # parser is implemented; malformed existing GDF files fail closed.
+        if mesh_path.suffix.lower() != ".gdf":
             return None
+
+        mesh = self._parse_gdf(mesh_path)
+        self._mesh_cache[mesh_file] = mesh
+        return mesh
 
     def _parse_gdf(self, file_path: Path) -> ParsedMesh:
         """Parse a WAMIT GDF mesh file.
@@ -329,49 +331,75 @@ class AQWABackend:
             line_idx += 1
 
         # Read ULEN/GRAV and symmetry lines.
+        if line_idx + 2 >= len(lines):
+            raise ValueError(f"{file_path}: incomplete GDF header")
         line_idx += 2
 
         # Read number of panels (NPAN).
-        npan = 0
-        if line_idx < len(lines):
-            try:
-                npan = int(lines[line_idx].split()[0])
-            except (ValueError, IndexError):
-                pass
-            line_idx += 1
+        try:
+            npan = int(lines[line_idx].split()[0])
+        except (ValueError, IndexError) as exc:
+            raise ValueError(f"{file_path}: invalid panel count") from exc
+        if npan <= 0:
+            raise ValueError(
+                f"{file_path}: panel count must be greater than zero; got {npan}"
+            )
+        line_idx += 1
 
         # Read panel vertices (4 vertices per panel)
         vertices: list[tuple[float, float, float]] = []
         panels: list[list[int]] = []
         vertex_map: dict[tuple[float, float, float], int] = {}
 
-        for _ in range(npan):
+        for panel_number in range(1, npan + 1):
             panel_vertices: list[int] = []
-            for _ in range(4):
+            for vertex_slot in range(1, 5):
                 if line_idx >= len(lines):
-                    break
+                    raise ValueError(
+                        f"{file_path}: panel {panel_number}, vertex {vertex_slot}: "
+                        "missing coordinate record"
+                    )
                 line = lines[line_idx].strip()
-                if not line:
-                    line_idx += 1
-                    continue
                 parts = line.split()
-                if len(parts) >= 3:
-                    try:
-                        vertex = (
-                            float(parts[0]),
-                            float(parts[1]),
-                            float(parts[2]),
-                        )
-                        if vertex not in vertex_map:
-                            vertex_map[vertex] = len(vertices)
-                            vertices.append(vertex)
-                        panel_vertices.append(vertex_map[vertex])
-                    except ValueError:
-                        pass
+                if len(parts) < 3:
+                    raise ValueError(
+                        f"{file_path}: panel {panel_number}, vertex {vertex_slot}: "
+                        "expected three coordinates"
+                    )
+                try:
+                    vertex = (
+                        float(parts[0]),
+                        float(parts[1]),
+                        float(parts[2]),
+                    )
+                except ValueError as exc:
+                    raise ValueError(
+                        f"{file_path}: panel {panel_number}, vertex {vertex_slot}: "
+                        "coordinates must be numeric"
+                    ) from exc
+                if not all(np.isfinite(value) for value in vertex):
+                    raise ValueError(
+                        f"{file_path}: panel {panel_number}, vertex {vertex_slot}: "
+                        "coordinates must be finite"
+                    )
+                if vertex not in vertex_map:
+                    vertex_map[vertex] = len(vertices)
+                    vertices.append(vertex)
+                panel_vertices.append(vertex_map[vertex])
                 line_idx += 1
 
-            if len(panel_vertices) == 4:
-                panels.append(panel_vertices)
+            unique_count = len(set(panel_vertices))
+            is_triangle = (
+                unique_count == 3
+                and panel_vertices[2] == panel_vertices[3]
+                and len(set(panel_vertices[:3])) == 3
+            )
+            if unique_count != 4 and not is_triangle:
+                raise ValueError(
+                    f"{file_path}: panel {panel_number}: expected four unique "
+                    "vertices or canonical triangle [n1, n2, n3, n3]"
+                )
+            panels.append(panel_vertices)
 
         return ParsedMesh(
             vertices=np.array(vertices, dtype=np.float64),
@@ -485,7 +513,7 @@ class AQWABackend:
         """Build Deck 2: element connectivity cards.
 
         Parses mesh files referenced in the spec and emits panel
-        (element) connectivity in AQWA QPPL format (Workbench-compatible).
+        (element) connectivity in AQWA TPPL/QPPL format.
         """
         cards: list[str] = []
         cards.extend(_deck_banner(2))
@@ -522,20 +550,33 @@ class AQWABackend:
             cards.append(f"* Group ID    {group_id} is body named {vessel_name}")
 
             if mesh is not None:
-                # Emit element connectivity in QPPL DIFF format
-                # DIFF keyword marks elements as diffracting (required for panel method)
-                # Format: "     1QPPL DIFF   15(1)(    1)(    2)(    3)(    4)"
+                # DIFF marks elements as diffracting. GDF triangles repeat
+                # vertex 3 in slot 4 and must be emitted as three-node TPPL;
+                # true quadrilaterals use four-node QPPL.
                 for elem_idx, panel in enumerate(mesh.panels, start=1):
                     # Panel contains 0-based indices, convert to 1-based
                     n1 = panel[0] + 1
                     n2 = panel[1] + 1
                     n3 = panel[2] + 1
                     n4 = panel[3] + 1
-                    cards.append(
-                        f"     {struct_idx}QPPL DIFF   {group_id}({struct_idx})"
-                        f"({n1:>5d})({n2:>5d})({n3:>5d})({n4:>5d})"
-                        f"  Aqwa Elem No: {elem_idx:>4d}"
-                    )
+                    unique_count = len({n1, n2, n3, n4})
+                    if unique_count == 4:
+                        card = (
+                            f"     {struct_idx}QPPL DIFF   {group_id}({struct_idx})"
+                            f"({n1:>5d})({n2:>5d})({n3:>5d})({n4:>5d})"
+                        )
+                    elif unique_count == 3 and n3 == n4 and len({n1, n2, n3}) == 3:
+                        card = (
+                            f"     {struct_idx}TPPL DIFF   {group_id}({struct_idx})"
+                            f"({n1:>5d})({n2:>5d})({n3:>5d})"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Invalid panel {elem_idx} on structure {struct_idx}: "
+                            "expected four unique nodes or canonical triangle "
+                            "[n1, n2, n3, n3]"
+                        )
+                    cards.append(f"{card}  Aqwa Elem No: {elem_idx:>4d}")
             else:
                 cards.append(f"* WARNING: Mesh file '{mesh_file}' could not be loaded")
 
@@ -778,6 +819,11 @@ class AQWABackend:
         # Frequencies: convert rad/s -> Hz for AQWA HRTZ cards
         freqs_rad = spec.frequencies.to_frequencies_rad_s()
         freqs_hz = [rad_per_s_to_hz(w) for w in freqs_rad]
+        if any(not np.isfinite(value) or value <= 0 for value in freqs_hz):
+            raise ValueError("AQWA frequencies must be finite and greater than zero")
+        if len(freqs_hz) != len(set(freqs_hz)):
+            raise ValueError("AQWA frequencies must be unique")
+        freqs_hz.sort()
 
         for i, freq_hz in enumerate(freqs_hz, start=1):
             freq_str = f"{freq_hz:>10g}"

--- a/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/aqwa_runner.py
@@ -186,9 +186,8 @@ class AQWARunResult:
 # Standard ANSYS install paths (Windows only)
 # ---------------------------------------------------------------------------
 
-_STANDARD_PATHS: list[str] = []
-if platform.system() == "Windows":
-    _STANDARD_PATHS = [
+WINDOWS_AQWA_CANDIDATES: tuple[str, ...] = (
+        r"C:\Program Files\ANSYS Inc\v261\aqwa\bin\winx64\Aqwa.exe",
         r"C:\Program Files\ANSYS Inc\v252\aqwa\bin\winx64\Aqwa.exe",
         r"C:\Program Files\ANSYS Inc\v251\aqwa\bin\winx64\Aqwa.exe",
         r"C:\Program Files\ANSYS Inc\v241\aqwa\bin\winx64\Aqwa.exe",
@@ -196,7 +195,10 @@ if platform.system() == "Windows":
         r"C:\Program Files\ANSYS Inc\v231\aqwa\bin\winx64\Aqwa.exe",
         r"C:\Program Files\ANSYS Inc\v222\aqwa\bin\winx64\Aqwa.exe",
         r"C:\Program Files\ANSYS Inc\v181\aqwa\bin\winx64\Aqwa.exe",
-    ]
+)
+_STANDARD_PATHS: list[str] = (
+    list(WINDOWS_AQWA_CANDIDATES) if platform.system() == "Windows" else []
+)
 
 
 # ---------------------------------------------------------------------------

--- a/src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py
@@ -122,10 +122,10 @@ def _node_to_dat_line(node_id: int, xyz: tuple) -> str:
 
 
 def _panel_to_dat_line(panel_id: int, node_ids: tuple) -> str:
-    """Format an AQWA QPPL DIFF panel record.
+    """Format an AQWA TPPL/ QPPL DIFF panel record.
 
-    AQWA uses QPPL DIFF cards with four node IDs. Triangles repeat
-    the third node in the fourth position.
+    AQWA uses TPPL DIFF cards for triangles and QPPL DIFF cards for
+    quadrilaterals. Repeated-node quadrilaterals are invalid.
 
     Args:
         panel_id: 1-based panel identifier (unused in DAT format
@@ -137,10 +137,15 @@ def _panel_to_dat_line(panel_id: int, node_ids: tuple) -> str:
     """
     if len(node_ids) == 3:
         n1, n2, n3 = node_ids
-        n4 = n3
-    else:
+        if len({n1, n2, n3}) != 3:
+            raise ValueError("AQWA triangle nodes must be unique")
+        return f"TPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}"
+    if len(node_ids) == 4:
         n1, n2, n3, n4 = node_ids
-    return f"QPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}  {n4:6d}"
+        if len({n1, n2, n3, n4}) != 4:
+            raise ValueError("AQWA quadrilateral nodes must be unique")
+        return f"QPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}  {n4:6d}"
+    raise ValueError("AQWA panels require exactly three or four node IDs")
 
 
 # ---------------------------------------------------------------------------
@@ -489,8 +494,7 @@ class GmshMeshBuilder:
         """Write mesh to AQWA .DAT format.
 
         Nodes are written as 1-based NODE records followed by
-        QPPL DIFF panel records. Triangular panels repeat the third
-        node in the fourth position as required by AQWA.
+        TPPL DIFF triangle and QPPL DIFF quadrilateral panel records.
 
         Args:
             nodes: (N, 3) array of node coordinates.

--- a/src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/gmsh_mesh_builder.py
@@ -125,7 +125,7 @@ def _panel_to_dat_line(panel_id: int, node_ids: tuple) -> str:
     """Format an AQWA TPPL/ QPPL DIFF panel record.
 
     AQWA uses TPPL DIFF cards for triangles and QPPL DIFF cards for
-    quadrilaterals. Repeated-node quadrilaterals are invalid.
+    quadrilaterals. Four-slot triangles may repeat any one node.
 
     Args:
         panel_id: 1-based panel identifier (unused in DAT format
@@ -141,10 +141,28 @@ def _panel_to_dat_line(panel_id: int, node_ids: tuple) -> str:
             raise ValueError("AQWA triangle nodes must be unique")
         return f"TPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}"
     if len(node_ids) == 4:
-        n1, n2, n3, n4 = node_ids
-        if len({n1, n2, n3, n4}) != 4:
-            raise ValueError("AQWA quadrilateral nodes must be unique")
-        return f"QPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}  {n4:6d}"
+        ordered_unique = tuple(dict.fromkeys(node_ids))
+        repeated_positions = [
+            index
+            for index, node in enumerate(node_ids)
+            if node_ids.count(node) == 2
+        ]
+        is_triangle = len(ordered_unique) == 3 and repeated_positions in (
+            [0, 1],
+            [1, 2],
+            [2, 3],
+            [0, 3],
+        )
+        if is_triangle:
+            n1, n2, n3 = ordered_unique
+            return f"TPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}"
+        if len(ordered_unique) == 4:
+            n1, n2, n3, n4 = ordered_unique
+            return f"QPPL DIFF  {n1:6d}  {n2:6d}  {n3:6d}  {n4:6d}"
+        raise ValueError(
+            "AQWA four-slot panels require four unique nodes or a triangle "
+            "with a cyclic-adjacent repeated node"
+        )
     raise ValueError("AQWA panels require exactly three or four node IDs")
 
 

--- a/src/digitalmodel/hydrodynamics/diffraction/input_schemas.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/input_schemas.py
@@ -382,9 +382,16 @@ class FrequencySpec(BaseModel):
                     np.logspace(np.log10(r.start), np.log10(r.end), r.count)
                 )
 
+        invalid = [value for value in raw if not np.isfinite(value) or value <= 0]
+        if invalid:
+            raise ValueError(
+                "Frequency/period values must be finite and greater than zero; "
+                f"received {invalid!r}"
+            )
+
         if self.input_type == FrequencyInputType.PERIOD:
-            return [2.0 * np.pi / t for t in raw if t > 0]
-        return raw
+            return [2.0 * np.pi / t for t in raw]
+        return list(raw)
 
     def to_periods_s(self) -> list[float]:
         """Convert to periods in seconds regardless of input type."""

--- a/tests/hydrodynamics/diffraction/test_aqwa_backend.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_backend.py
@@ -12,7 +12,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
+from digitalmodel.hydrodynamics.diffraction.input_schemas import (
+    DiffractionSpec,
+    FrequencySpec,
+)
 
 
 # Fixtures directory for YAML specs
@@ -266,6 +269,55 @@ class TestFrequencyMapping:
         freq_value = float(tokens[-1])
         assert abs(freq_value - first_freq_hz) < 1e-4
 
+    @pytest.mark.parametrize(
+        ("input_type", "values"),
+        [
+            ("frequency", [1.0, 1.0]),
+            ("frequency", [1.0, math.inf]),
+        ],
+    )
+    def test_deck6_rejects_invalid_or_duplicate_frequencies(
+        self, input_type, values
+    ):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        spec = _load_ship_spec().model_copy(
+            update={"frequencies": FrequencySpec(input_type=input_type, values=values)}
+        )
+        with pytest.raises(ValueError):
+            AQWABackend().build_deck6(spec)
+
+    def test_period_frequencies_are_sorted_with_exact_values_and_indices(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        spec = _load_ship_spec().model_copy(
+            update={
+                "frequencies": FrequencySpec(
+                    input_type="period", values=[4.0, 8.0, 16.0]
+                )
+            }
+        )
+        lines = [line for line in AQWABackend().build_deck6(spec) if "HRTZ" in line]
+        values = [float(line.split()[-1]) for line in lines]
+        assert values == pytest.approx([1 / 16, 1 / 8, 1 / 4])
+        assert [line.split()[1:3] for line in lines] == [
+            ["1", "1"], ["2", "2"], ["3", "3"]
+        ]
+
+    def test_unsorted_explicit_frequencies_are_sorted_and_reindexed(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        spec = _load_ship_spec().model_copy(
+            update={
+                "frequencies": FrequencySpec(
+                    input_type="frequency", values=[2.0, 0.5, 1.0]
+                )
+            }
+        )
+        lines = [line for line in AQWABackend().build_deck6(spec) if "HRTZ" in line]
+        values = [float(line.split()[-1]) for line in lines]
+        assert values == pytest.approx([0.5 / (2 * math.pi), 1 / (2 * math.pi), 2 / (2 * math.pi)])
+
 
 # ---------------------------------------------------------------------------
 # Heading mapping tests
@@ -517,6 +569,87 @@ class TestDeckCardGeneration:
         assert "HRTZ" in card_text
         assert "DIRN" in card_text
         assert "END" in card_text
+
+
+class TestGDFPanelValidation:
+    """GDF parsing and AQWA panel cards fail closed."""
+
+    @staticmethod
+    def _write_gdf(path: Path, npan: str, vertex_lines: list[str]) -> None:
+        path.write_text(
+            "synthetic\n1.0 9.80665\n0 0\n" + npan + "\n"
+            + "\n".join(vertex_lines) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_deck2_emits_tppl_for_canonical_triangle_and_qppl_for_quad(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import (
+            AQWABackend,
+            ParsedMesh,
+        )
+
+        spec = _load_ship_spec()
+        mesh_file = spec.get_bodies()[0].vessel.geometry.mesh_file
+        backend = AQWABackend()
+        backend._mesh_cache[mesh_file] = ParsedMesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=float
+            ),
+            panels=np.array([[0, 1, 2, 2], [0, 1, 3, 2]], dtype=np.int32),
+            name="synthetic",
+        )
+        cards = backend.build_deck2(spec)
+        panel_cards = [line for line in cards if "PPL DIFF" in line]
+        assert "TPPL DIFF" in panel_cards[0]
+        assert panel_cards[0].count("(") == 4  # group + exactly three nodes
+        assert "QPPL DIFF" in panel_cards[1]
+        assert panel_cards[1].count("(") == 5  # group + exactly four nodes
+
+    @pytest.mark.parametrize(
+        "panel",
+        [[0, 1, 2, 0], [0, 0, 1, 2], [0, 1, 1, 2], [0, 1, 1, 1]],
+    )
+    def test_deck2_rejects_noncanonical_duplicate_panels(self, panel):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import (
+            AQWABackend,
+            ParsedMesh,
+        )
+
+        spec = _load_ship_spec()
+        mesh_file = spec.get_bodies()[0].vessel.geometry.mesh_file
+        backend = AQWABackend()
+        backend._mesh_cache[mesh_file] = ParsedMesh(
+            vertices=np.eye(4, 3),
+            panels=np.array([panel], dtype=np.int32),
+            name="synthetic",
+        )
+        with pytest.raises(ValueError):
+            backend.build_deck2(spec)
+
+    @pytest.mark.parametrize("npan", ["nope", "0", "-1"])
+    def test_parse_gdf_rejects_invalid_panel_count(self, tmp_path, npan):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        path = tmp_path / "invalid.gdf"
+        self._write_gdf(path, npan, [])
+        with pytest.raises(ValueError, match="panel count"):
+            AQWABackend()._parse_gdf(path)
+
+    def test_parse_gdf_rejects_truncated_panel_with_context(self, tmp_path):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        path = tmp_path / "truncated.gdf"
+        self._write_gdf(path, "1", ["0 0 0", "1 0 0", "0 1 0"])
+        with pytest.raises(ValueError, match=r"truncated\.gdf.*panel 1.*vertex 4"):
+            AQWABackend()._parse_gdf(path)
+
+    def test_parse_gdf_rejects_nonnumeric_vertex_with_context(self, tmp_path):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        path = tmp_path / "bad.gdf"
+        self._write_gdf(path, "1", ["0 0 0", "1 0 0", "bad 1 0", "0 0 0"])
+        with pytest.raises(ValueError, match=r"bad\.gdf.*panel 1.*vertex 3"):
+            AQWABackend()._load_mesh(str(path))
 
     def test_deck3_mass_cards(self):
         """Deck 3 generates MATE and mass line cards."""

--- a/tests/hydrodynamics/diffraction/test_aqwa_backend.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_backend.py
@@ -287,6 +287,19 @@ class TestFrequencyMapping:
         with pytest.raises(ValueError):
             AQWABackend().build_deck6(spec)
 
+    def test_deck6_rejects_frequencies_that_collide_after_formatting(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        spec = _load_ship_spec().model_copy(
+            update={
+                "frequencies": FrequencySpec(
+                    input_type="frequency", values=[1.0, 1.0000001]
+                )
+            }
+        )
+        with pytest.raises(ValueError, match="after HRTZ formatting"):
+            AQWABackend().build_deck6(spec)
+
     def test_period_frequencies_are_sorted_with_exact_values_and_indices(self):
         from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
 
@@ -582,7 +595,18 @@ class TestGDFPanelValidation:
             encoding="utf-8",
         )
 
-    def test_deck2_emits_tppl_for_canonical_triangle_and_qppl_for_quad(self):
+    @pytest.mark.parametrize(
+        ("panel", "expected_nodes"),
+        [
+            ([0, 0, 1, 2], [1, 2, 3]),
+            ([0, 1, 1, 2], [1, 2, 3]),
+            ([0, 1, 2, 2], [1, 2, 3]),
+            ([0, 1, 2, 0], [1, 2, 3]),
+        ],
+    )
+    def test_deck2_emits_tppl_for_any_cyclic_repeat_triangle(
+        self, panel, expected_nodes
+    ):
         from digitalmodel.hydrodynamics.diffraction.aqwa_backend import (
             AQWABackend,
             ParsedMesh,
@@ -595,21 +619,47 @@ class TestGDFPanelValidation:
             vertices=np.array(
                 [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=float
             ),
-            panels=np.array([[0, 1, 2, 2], [0, 1, 3, 2]], dtype=np.int32),
+            panels=np.array([panel], dtype=np.int32),
             name="synthetic",
         )
         cards = backend.build_deck2(spec)
         panel_cards = [line for line in cards if "PPL DIFF" in line]
         assert "TPPL DIFF" in panel_cards[0]
         assert panel_cards[0].count("(") == 4  # group + exactly three nodes
-        assert "QPPL DIFF" in panel_cards[1]
-        assert panel_cards[1].count("(") == 5  # group + exactly four nodes
+        for node in expected_nodes:
+            assert f"({node:>5d})" in panel_cards[0]
+
+    def test_deck2_emits_qppl_for_four_unique_nodes(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import (
+            AQWABackend,
+            ParsedMesh,
+        )
+
+        spec = _load_ship_spec()
+        mesh_file = spec.get_bodies()[0].vessel.geometry.mesh_file
+        backend = AQWABackend()
+        backend._mesh_cache[mesh_file] = ParsedMesh(
+            vertices=np.eye(4, 3),
+            panels=np.array([[0, 1, 3, 2]], dtype=np.int32),
+            name="synthetic",
+        )
+        panel_card = next(
+            line for line in backend.build_deck2(spec) if "PPL DIFF" in line
+        )
+        assert "QPPL DIFF" in panel_card
+        assert panel_card.count("(") == 5  # group + exactly four nodes
 
     @pytest.mark.parametrize(
         "panel",
-        [[0, 1, 2, 0], [0, 0, 1, 2], [0, 1, 1, 2], [0, 1, 1, 1]],
+        [
+            [0, 0, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 0, 0],
+            [0, 1, 0, 2],
+            [0, 1, 2, 1],
+        ],
     )
-    def test_deck2_rejects_noncanonical_duplicate_panels(self, panel):
+    def test_deck2_rejects_panels_with_fewer_than_three_unique_nodes(self, panel):
         from digitalmodel.hydrodynamics.diffraction.aqwa_backend import (
             AQWABackend,
             ParsedMesh,
@@ -650,6 +700,33 @@ class TestGDFPanelValidation:
         self._write_gdf(path, "1", ["0 0 0", "1 0 0", "bad 1 0", "0 0 0"])
         with pytest.raises(ValueError, match=r"bad\.gdf.*panel 1.*vertex 3"):
             AQWABackend()._load_mesh(str(path))
+
+    def test_parse_gdf_accepts_triangle_with_repeat_in_any_slot(self, tmp_path):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        path = tmp_path / "triangle.gdf"
+        self._write_gdf(
+            path,
+            "1",
+            ["0 0 0", "0 0 0", "1 0 0", "0 1 0"],
+        )
+        mesh = AQWABackend()._parse_gdf(path)
+        assert mesh.panels.tolist() == [[0, 0, 1, 2]]
+
+    @pytest.mark.parametrize(
+        "vertices",
+        [
+            ["0 0 0", "1 0 0", "0 0 0", "0 1 0"],
+            ["0 0 0", "1 0 0", "0 1 0", "1 0 0"],
+        ],
+    )
+    def test_parse_gdf_rejects_nonadjacent_repeated_vertex(self, tmp_path, vertices):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_backend import AQWABackend
+
+        path = tmp_path / "collapsed.gdf"
+        self._write_gdf(path, "1", vertices)
+        with pytest.raises(ValueError, match="cyclic-adjacent"):
+            AQWABackend()._parse_gdf(path)
 
     def test_deck3_mass_cards(self):
         """Deck 3 generates MATE and mass line cards."""

--- a/tests/hydrodynamics/diffraction/test_aqwa_runner.py
+++ b/tests/hydrodynamics/diffraction/test_aqwa_runner.py
@@ -470,6 +470,55 @@ class TestAQWARunnerDetectExecutable:
         detected = runner._detect_executable()
         assert detected == exe
 
+    def test_explicit_path_wins_over_env_and_standard_candidates(self, tmp_path):
+        explicit = tmp_path / "explicit-aqwa.exe"
+        env_exe = tmp_path / "env-aqwa.exe"
+        standard = tmp_path / "standard-aqwa.exe"
+        for path in (explicit, env_exe, standard):
+            path.touch()
+        runner = AQWARunner(AQWARunConfig(executable_path=explicit))
+        with patch.dict("os.environ", {"AQWA_PATH": str(env_exe)}, clear=True), patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_runner._STANDARD_PATHS",
+            [str(standard)],
+        ):
+            assert runner._detect_executable() == explicit
+
+    def test_env_path_wins_over_standard_candidates(self, tmp_path):
+        env_exe = tmp_path / "env-aqwa.exe"
+        standard = tmp_path / "standard-aqwa.exe"
+        env_exe.touch()
+        standard.touch()
+        runner = AQWARunner(AQWARunConfig())
+        with patch.dict("os.environ", {"AQWA_PATH": str(env_exe)}, clear=True), patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_runner._STANDARD_PATHS",
+            [str(standard)],
+        ):
+            assert runner._detect_executable() == env_exe
+
+    def test_windows_candidates_put_v261_before_v252(self):
+        from digitalmodel.hydrodynamics.diffraction.aqwa_runner import (
+            WINDOWS_AQWA_CANDIDATES,
+        )
+
+        versions = [path.split("ANSYS Inc\\", 1)[1].split("\\", 1)[0]
+                    for path in WINDOWS_AQWA_CANDIDATES]
+        assert "v261" in versions
+        assert versions.index("v261") < versions.index("v252")
+
+    def test_v261_wins_over_older_existing_standard_candidates(self, tmp_path):
+        v261 = tmp_path / "v261" / "Aqwa.exe"
+        v252 = tmp_path / "v252" / "Aqwa.exe"
+        v261.parent.mkdir()
+        v252.parent.mkdir()
+        v261.touch()
+        v252.touch()
+        runner = AQWARunner(AQWARunConfig())
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_runner._STANDARD_PATHS",
+            [str(v261), str(v252)],
+        ):
+            assert runner._detect_executable() == v261
+
     def test_env_variable_fallback(self):
         config = AQWARunConfig()
         runner = AQWARunner(config)
@@ -481,7 +530,9 @@ class TestAQWARunnerDetectExecutable:
     def test_shutil_which_fallback(self):
         config = AQWARunConfig()
         runner = AQWARunner(config)
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_runner._STANDARD_PATHS", []
+        ):
             with patch("shutil.which", return_value="/usr/local/bin/aqwa"):
                 detected = runner._detect_executable()
                 assert detected == Path("/usr/local/bin/aqwa")
@@ -489,7 +540,9 @@ class TestAQWARunnerDetectExecutable:
     def test_returns_none_when_not_found(self):
         config = AQWARunConfig()
         runner = AQWARunner(config)
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "digitalmodel.hydrodynamics.diffraction.aqwa_runner._STANDARD_PATHS", []
+        ):
             with patch("shutil.which", return_value=None):
                 detected = runner._detect_executable()
                 assert detected is None

--- a/tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py
+++ b/tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py
@@ -244,8 +244,8 @@ class TestDatExport:
         assert "DIFF" in line
         assert "10" in line and "20" in line
 
-    def test_dat_panel_triangle_repeats_node(self):
-        """_panel_to_dat_line repeats node 2 for triangles."""
+    def test_dat_panel_triangle_uses_tppl(self):
+        """_panel_to_dat_line emits a three-node TPPL for triangles."""
         from digitalmodel.hydrodynamics.diffraction.gmsh_mesh_builder import (
             _panel_to_dat_line,
         )
@@ -253,8 +253,20 @@ class TestDatExport:
         line = _panel_to_dat_line(
             panel_id=1, node_ids=(10, 20, 30)
         )
-        # Should have node 30 twice for AQWA tri-as-quad
-        assert line.count("30") >= 2
+        assert line.startswith("TPPL DIFF")
+        assert line.split()[-3:] == ["10", "20", "30"]
+
+    @pytest.mark.parametrize(
+        "node_ids",
+        [(1, 2), (1, 2, 3, 3), (1, 2, 3, 1), (1, 2, 3, 4, 5)],
+    )
+    def test_dat_panel_rejects_invalid_shapes(self, node_ids):
+        from digitalmodel.hydrodynamics.diffraction.gmsh_mesh_builder import (
+            _panel_to_dat_line,
+        )
+
+        with pytest.raises(ValueError):
+            _panel_to_dat_line(panel_id=1, node_ids=node_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -344,7 +356,7 @@ class TestGmshMeshBuilderWorkflow:
         assert dat_path.exists()
         content = dat_path.read_text()
         assert "NODE" in content
-        assert "QPPL" in content
+        assert "TPPL" in content or "QPPL" in content
 
     def test_build_box_barge_msh(self, tmp_path):
         """GmshMeshBuilder.build() generates MSH v2.2 for box_barge."""

--- a/tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py
+++ b/tests/hydrodynamics/diffraction/test_gmsh_mesh_builder.py
@@ -258,7 +258,27 @@ class TestDatExport:
 
     @pytest.mark.parametrize(
         "node_ids",
-        [(1, 2), (1, 2, 3, 3), (1, 2, 3, 1), (1, 2, 3, 4, 5)],
+        [(10, 10, 20, 30), (10, 20, 20, 30), (10, 20, 30, 30), (10, 20, 30, 10)],
+    )
+    def test_dat_four_slot_triangle_uses_ordered_unique_tppl(self, node_ids):
+        from digitalmodel.hydrodynamics.diffraction.gmsh_mesh_builder import (
+            _panel_to_dat_line,
+        )
+
+        line = _panel_to_dat_line(panel_id=1, node_ids=node_ids)
+        assert line.startswith("TPPL DIFF")
+        assert line.split()[-3:] == ["10", "20", "30"]
+
+    @pytest.mark.parametrize(
+        "node_ids",
+        [
+            (1, 2),
+            (1, 1, 2, 2),
+            (1, 2, 2, 2),
+            (1, 2, 1, 3),
+            (1, 2, 3, 2),
+            (1, 2, 3, 4, 5),
+        ],
     )
     def test_dat_panel_rejects_invalid_shapes(self, node_ids):
         from digitalmodel.hydrodynamics.diffraction.gmsh_mesh_builder import (

--- a/tests/hydrodynamics/diffraction/test_input_schemas.py
+++ b/tests/hydrodynamics/diffraction/test_input_schemas.py
@@ -195,6 +195,25 @@ class TestFrequencySpec:
                 range={"start": 0.1, "end": 1.0, "count": 10}
             )
 
+    @pytest.mark.parametrize(
+        ("input_type", "values"),
+        [
+            ("period", [10.0, 0.0]),
+            ("period", [10.0, -1.0]),
+            ("period", [10.0, math.inf]),
+            ("frequency", [1.0, 0.0]),
+            ("frequency", [1.0, math.nan]),
+        ],
+    )
+    def test_conversion_rejects_nonpositive_or_nonfinite_values(
+        self, input_type, values
+    ):
+        from digitalmodel.hydrodynamics.diffraction.input_schemas import FrequencySpec
+
+        freq = FrequencySpec(input_type=input_type, values=values)
+        with pytest.raises(ValueError):
+            freq.to_frequencies_rad_s()
+
 
 class TestWaveHeadingSpec:
     """Test wave heading specification handling."""

--- a/tests/hydrodynamics/diffraction/test_resolver.py
+++ b/tests/hydrodynamics/diffraction/test_resolver.py
@@ -56,6 +56,9 @@ def _write_box_mesh(path: Path) -> Path:
         "\n".join(
             [
                 "# box mesh",
+                "1.0 9.80665",
+                "0 0",
+                "2",
                 "0 0 -2",
                 "10 0 -2",
                 "10 4 -2",


### PR DESCRIPTION
Implements the user-approved, adversarially reviewed plan for #1571.

Changes:
- emit TPPL for all cyclic-adjacent WAMIT triangle encodings and QPPL only for true quads
- reject alternating/collapsed duplicate connectivity and malformed existing GDF input
- validate, sort, and index frequency cards; reject collisions after AQWA HRTZ formatting
- correct the gmsh DAT exporter under the same triangle/quad contract
- add v261 discovery with explicit > AQWA_PATH > standard precedence
- correct a headerless resolver `.gdf` fixture exposed by strict parsing

Verification:
- focused approved suite plus resolver integration: 196 passed
- isolated workflow/integration suite: 53 passed
- real repository corpus: both cited WAMIT/OrcaWave GDF fixtures parse, covering repeat pairs 1/2, 2/3, 3/4, and 1/4
- private Noble dry audit: 103 TPPL, 10,185 QPPL, zero repeated-node QPPL; 33 HRTZ unique/ascending and 25 DIRN ascending
- final independent implementation re-review: APPROVE
- private licensed production retry: finished rc=0; prior Deck 2/6 validation errors did not recur
- first CI run exposed and drove the resolver-fixture correction; its remaining contract failures are unrelated dynmoor force-name and report_pack routing mismatches
- full local diffraction directory attempted; unrelated pytest capture-stream closure cascades after early CLI failures, so it is not a usable regression signal on this host

No client input, connectivity, or native output is committed.
