### PR TITLE
fix(openfoam): isolate hosted batch work roots (#1565)

### DIFF
--- a/.planning/plan-approved/1565.md
+++ b/.planning/plan-approved/1565.md
@@ -1,0 +1,6 @@
+# Plan Approval: Issue 1565
+
+Approved by: user
+Approved plan SHA: `e2e0da51633d1e32b8c508b84b47ce73c78d2301`
+Approved on: 2026-07-14
+Scope: Code implementation and synthetic verification only. Host configuration and real Deckhand canary require separate owner approval.

--- a/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
+++ b/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
@@ -1,14 +1,14 @@
 # Plan for [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565): External OpenFOAM batch work root
 
-> **Status:** draft
-> **Complexity:** T2
+> **Status:** draft — r1 MAJOR findings incorporated; r2 adversarial review required
+> **Complexity:** T3
 > **Date:** 2026-07-13
 > **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1565
 > **Client:** N/A
 > **Project:** N/A
 > **Lane:** lane:claude
-> **Execution mode:** single-lane implementation after approval; read-only evidence gathering was serialized because every available agent slot was occupied
-> **Review artifacts:** pending — this draft will require adversarial plan review before it can enter `status:plan-review`
+> **Execution mode:** single-lane implementation after explicit user approval
+> **Review artifact:** scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md
 
 ---
 
@@ -16,64 +16,70 @@
 
 ### Existing repository behavior
 
-- `src/digitalmodel/workflows/openfoam_run_batch.py:104-148` resolves relative `output_dir` and `work_dir` against `_config_dir_path`, so the defaults create `results/` and `batch_runs/` beside the input.
-- Lines 228-262 append the user-controlled case name without rejecting duplicates, absolute names, separators, `..`, or symlink escape.
-- Lines 294-319 and 555-567 delete/rebuild cases and prune `processor*` without an explicit trusted-root containment check.
-- Lines 585-609 atomically reuse completed `_result.json` checkpoints without binding them to the selecting configuration.
-- Lines 612-666 place absolute `case_dir` values in returned CSV/in-memory data, which would expose an external host path.
-- `tests/workflows/test_openfoam_run_batch.py:32-70,155-200` freezes the default layout, checkpoint reuse, and small-result allowlist for compatibility.
-- `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml:24-33` has `output_dir: results` and `work_dir: batch_runs` but no neutral work-root setting.
+- src/digitalmodel/workflows/openfoam_run_batch.py resolves relative output_dir
+  and work_dir against _config_dir_path, so the defaults place results/ and
+  batch_runs/ beside the dispatch input.
+- The 680-line workflow contains an 89-line router plus configuration, matrix
+  expansion, pool/MPI execution, cleanup, checkpoint, and publication logic.
+- tests/workflows/test_openfoam_run_batch.py is 445 lines. Both files already
+  exceed the universal 400-line limit before this change.
+- Case names reach filesystem joins without a closed single-component contract.
+  Cleanup and processor pruning do not have a shared root-confinement object.
+- Completed checkpoints carry result rows but are not bound to the selecting
+  source/package/config/input/tool identity.
+- Deckhand runs the workflow from the scope checkout, inherits operator-provided
+  systemd environment, and returns allowlisted small files from the input-local
+  results/ directory. Host configuration and queue transport remain separate
+  authority surfaces.
 
-### Precedent and related issues
+### Reproduction evidence
 
-- [#1560](https://github.com/vamseeachanta/digitalmodel/issues/1560) is closed; its contract keeps heavy cases/checkpoints under the work directory and only CSV/JSON under `results/`.
-- [#1553](https://github.com/vamseeachanta/digitalmodel/issues/1553) remains open and requires deterministic script-only execution; no LLM, scheduler, or host-agent dependency will be added.
-- [#1564](https://github.com/vamseeachanta/digitalmodel/issues/1564) remains open and concerns an OrcaFlex base-config gap, not work placement.
-- `src/digitalmodel/workflows/orcaflex_run_batch.py:59-107` uses the same config-directory resolution; it is current-behavior precedent, not an external-root solution, and will remain unchanged.
-- Squash commits `d70685e4`, `1a833df5`, and `38074785` establish the OpenFOAM workflow, engine config, and OrcaFlex batch shape.
+At base SHA 2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4, a synthetic input under
+scope-repo/cases/openfoam-run-batch reproduces the placement:
 
-### Resource and location intelligence
-
-- The Drive query `openfoam batch work root` (`plan-resource-intel`, `2026-07-14T04:31:42Z`) returned no relevant design and no coverage gaps; three stale indexes make this negative evidence only. Irrelevant identifying paths are excluded.
-- The online-resource registry has OpenFOAM upstream entries, but it, the standards/code registries, and the relevant CFD routing wiki define no scratch-root/return contract. No calculation standard applies.
-- A live inventory found 62 first-level directories and 23 Git repositories within depth two. This is machine-local evidence only; no fleet claim or file movement will follow.
-- Input/config and relative `output_dir` residency will remain unchanged; only heavy work will become overridable. The legacy data-mount alias is unrelated.
-
-### Gaps identified
-
-- No environment/config root or deterministic run namespace separates different batches with identical case names.
-- Completed checkpoints are not bound to the effective configuration.
-- Destructive cleanup lacks an explicit canonical-root containment contract.
-- Case/path traversal, duplicate names, symlinks, absolute-path leakage, output residency, and legacy compatibility lack coverage.
-
-### Embedded verification evidence
-
-**Live issue state** (`gh issue view`, `2026-07-14T04:31:53Z`):
-
-```text
-#1553 OPEN   EPIC: Continuous batch mini-runs ...
-#1560 CLOSED Land CFD execution surface on main + openfoam-run-batch saturating workflow
-#1564 OPEN   orcaflex_run_batch: missing engine base-config yml ...
-#1565 OPEN   openfoam_run_batch: default work/output dirs land inside the input's directory ...
-```
-
-Issue #1565 currently has no labels. This planning branch will not mutate
-labels; the orchestrator will need to reconcile exactly one `lane:claude` label
-before review-state promotion.
-
-**Reproduction proof** (`2026-07-14T04:33:11Z`; exact helpers were extracted from the source AST because this isolated worktree cannot resolve its sibling editable dependency):
-
-```text
-$ python3 <AST harness selecting openfoam_run_batch._resolve_path/_resolve_dir>
+~~~text
 work_parent_is_config=True
 output_parent_is_config=True
 inside_config=True
 rc=0
-```
+~~~
 
-The harness executed lines 670-680 against a synthetic `scope-repo/cases/openfoam-run-batch`; the placement matches the claim. Direct `uv run` stopped before import on the unavailable worktree-relative editable dependency and did not contradict this result.
+The reproduction executes the exact path-resolution helpers extracted from the
+source AST. The isolated planning worktree cannot resolve its sibling editable
+dependency, so the implementation verification will run from a correctly linked
+checkout and will not treat the AST harness as a regression suite.
 
-Distinct sources: #1565; #1553/#1560/#1564; OpenFOAM and OrcaFlex code/tests; engine config; commits; registries/wiki; Drive index; live inventory.
+### Related issues and landing order
+
+The shared contracts will land in this order:
+
+1. [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565) will own
+   RunIdentity v1, work-layout v1, namespace ownership/locking, and result-policy
+   v1.
+2. [#1575](https://github.com/vamseeachanta/digitalmodel/issues/1575) will pin the
+   merged #1565 SHA and will add normalized case-definition bytes to the shared
+   RunIdentity referenced-input/config surfaces.
+3. [#1576](https://github.com/vamseeachanta/digitalmodel/issues/1576) will pin the
+   merged #1565 and #1575 SHAs, consume RunIdentity v1 unchanged, and register
+   artifact_index.json through result-policy v1.
+
+No downstream plan will duplicate fingerprint, checkpoint, work-root, or result
+allowlist logic. Any incompatible shared-schema change will require a version
+increment and an upstream issue rather than an inline downstream fork.
+
+Related [deckhand#557](https://github.com/vamseeachanta/deckhand/issues/557)
+owns the OpenFOAM execution-host agent. #1565 will not mutate its systemd
+environment, create host directories, restart the agent, or dispatch a run
+without a separate owner-approved transaction.
+
+### Resource and privacy intelligence
+
+- The OrcaFlex batch workflow has the same config-directory default but no
+  reviewed external-root contract and will remain unchanged.
+- No engineering standard or calculation constant applies.
+- Fixtures and reports will remain synthetic. Public output will contain no host
+  path, username, mount root, client/project identifier, or private case data.
+- The plan will not move or delete any existing legacy batch_runs/ tree.
 
 ---
 
@@ -81,304 +87,453 @@ Distinct sources: #1565; #1553/#1560/#1564; OpenFOAM and OrcaFlex code/tests; en
 
 | Artifact | Path |
 |---|---|
-| This plan | `docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md` |
-| Plan index | `docs/plans/README.md` |
-| Production workflow | `src/digitalmodel/workflows/openfoam_run_batch.py` |
-| Engine defaults | `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml` |
-| Focused tests | `tests/workflows/test_openfoam_run_batch.py` |
-| Plan reviews | `scripts/review/results/2026-07-13-plan-1565-{claude,codex,gemini}.md` (future review outputs) |
-
-No private input, host path, project identifier, native solver result, or
-heavy work tree will become a repository artifact.
-
----
+| Plan | docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md |
+| Consolidated r1 review | scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md |
+| Public workflow facade | src/digitalmodel/workflows/openfoam_run_batch.py |
+| Configuration and identity | src/digitalmodel/workflows/openfoam_batch_config.py |
+| Work layout and locks | src/digitalmodel/workflows/openfoam_batch_layout.py |
+| Pool/MPI orchestration | src/digitalmodel/workflows/openfoam_batch_execution.py |
+| Checkpoint/result policy | src/digitalmodel/workflows/openfoam_batch_results.py |
+| Base configuration | src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml |
+| Legacy/facade tests | tests/workflows/test_openfoam_run_batch.py |
+| Identity tests | tests/workflows/test_openfoam_batch_identity.py |
+| Layout/lock tests | tests/workflows/test_openfoam_batch_layout.py |
+| Result-policy tests | tests/workflows/test_openfoam_batch_results.py |
+| Structural limits | tests/workflows/test_openfoam_batch_structure.py |
+| Baseline comparator | scripts/testing/compare_pytest_json.py; tests/scripts/test_compare_pytest_json.py |
 
 ## Deliverable
 
-`openfoam_run_batch` will support a validated external heavy-work root selected
-by trusted host environment or explicit configuration, while preserving the
-current layout when no override is supplied and keeping returned CSV/JSON
-rollups beside the input.
+openfoam_run_batch will place heavy case work in an operator-authorized external
+root without moving input-local bounded results. A shared RunIdentity will bind
+checkpoint and namespace reuse to clean source/package/config/input/tool
+identity. Atomic ownership markers and locks will prevent concurrent or foreign
+mutation. Result-policy v1 will retain the two-file base contract while exposing
+a closed extension registry for #1576.
+
+---
 
 ## Normative Design Contract
 
-### 1. Configuration and precedence
+### 1. Execution context and root authority
 
-The implementation will add one neutral base-config key:
+The parser will classify the invocation before resolving a work root. Hosted
+classification will come only from operator environment, never request YAML:
 
-```yaml
-openfoam_run_batch:
-  run_batch:
-    work_root: null
-```
+~~~text
+DIGITALMODEL_EXECUTION_CONTEXT=hosted-deckhand
+DIGITALMODEL_WORK_ROOT=<operator-private absolute root>
+~~~
 
-The effective heavy-work base will be selected in this exact order:
+Hosted Deckhand mode will require a non-empty DIGITALMODEL_WORK_ROOT inherited
+from the operator-controlled agent environment. Request YAML will never select
+an absolute host root in hosted mode. run_batch.work_root_namespace will be the
+only hosted YAML placement field; its packaged default will be
+openfoam-run-batch. It will be a non-empty portable relative path
+with no absolute form, empty/dot/dot-dot component, separator ambiguity,
+control/NUL byte, or symlink traversal. A missing/invalid operator root will fail
+before directory creation, cleanup, checkpoint reads, threads, or commands.
+An input-supplied execution_context that conflicts with the operator environment
+will reject and cannot downgrade hosted execution.
 
-1. A non-empty `DIGITALMODEL_WORK_ROOT` environment value will win. This is the
-   trusted dispatch-host policy and cannot be overridden by request YAML.
-2. Otherwise, a non-empty `run_batch.work_root` value will apply.
-3. Otherwise, legacy resolution will apply exactly: relative `work_dir` will be
-   based at `_config_dir_path`, and an absolute `work_dir` will remain absolute.
+Trusted-local mode will be opt-in through run_batch.execution_context:
+trusted-local, and will be available only when the hosted environment marker is
+absent. Only that explicit context may use run_batch.work_root as an absolute
+precreated directory. The root will be canonicalized, required to be a writable
+directory outside the input Git checkout, and rejected when it or any descendant
+component is a symlink. Relative or implicit trusted-local roots will not be
+accepted.
 
-An empty environment value and `null`/omitted config value will mean “unset.” A
-non-string root will raise `ValueError`. An external root will be expanded for
-the current user's home, canonicalized, required to exist as a writable
-directory, and will never be created implicitly. Environment-variable
-interpolation inside YAML values will not be added.
+When neither external mode is selected nor a hosted context is asserted, legacy
+work_dir resolution will remain byte-compatible. output_dir will remain
+independently based at _config_dir_path so Deckhand can return small results.
 
-When an external root is active, `work_dir` will be a non-empty relative path.
-Absolute paths, `.`/`..` components, NULs, and paths that resolve outside the
-canonical root will fail before any case directory or result file is created.
-The canonical external root will also be required to sit outside the nearest
-Git checkout containing `_config_dir_path`; if no Git sentinel is present, it
-will at minimum be outside the canonical config directory. A trusted root-level
-symlink may resolve to its canonical target, but existing symlinks below that
-target will fail closed.
+In either external mode, work_dir will be a non-empty safe relative path. Case
+names will be unique non-empty portable single components. Absolute paths,
+separator variants, dot components, controls/NULs, duplicate names, or a
+resolved escape will reject for the complete batch before any filesystem or
+worker side effect.
 
-`output_dir` will retain its current independent resolution against
-`_config_dir_path`. The external work-root setting will never rebase or copy
-`results/`.
+The operator root value and canonical host path will remain process-internal.
+CSV, JSON, checkpoints, exceptions, log messages, stdout, and stderr will expose
+only stable relative work references and non-sensitive source labels.
 
-### 2. Deterministic run isolation
+### 2. RunIdentity v1
 
-External mode will create this logical layout:
+src/digitalmodel/workflows/openfoam_batch_config.py will own canonical
+digitalmodel-run-identity-v1. Canonical JSON will use UTF-8, sorted object keys,
+compact separators, integers without Boolean coercion, finite JSON numbers, and
+exact schema validation. Non-JSON input will reject rather than use repr().
 
-```text
-<canonical-external-root>/openfoam-run-<fingerprint>/<relative-work-dir>/<case-name>/
-```
+The identity payload will contain:
 
-`fingerprint` will be the lowercase SHA-256 of canonical JSON encoded as UTF-8
-with sorted keys and compact separators. The versioned payload will include the
-resolved `base`, ordered resolved `cases`, `mapping`, mode, workers, mock flag,
-reconstruct/resume flags, timeout, relative work directory, and a
-`work_layout_version` constant. It will exclude timestamps, host paths,
-environment-source labels, and output location. Non-JSON values will fail
-closed rather than falling back to `repr()`.
+~~~text
+schema_version = 1
+identity_kind = openfoam-run-batch
+source:
+  git_commit_sha
+  tracked_tree_clean = true
+  package_name
+  package_version
+  package_content_sha256
+effective_config_sha256
+referenced_inputs[]:
+  role
+  safe_repo_relative_path
+  size_bytes
+  content_sha256
+selected_executables[]:
+  role
+  basename
+  content_sha256
+result_policy_version
+work_layout_version
+identity_sha256
+~~~
 
-The same effective batch input will therefore reuse the same namespace across
-retries; any physics/execution-affecting configuration change will select a
-different namespace. Every newly written checkpoint will carry the full
-fingerprint. External-mode checkpoint reuse will require `status == completed`
-and an exact fingerprint match. A missing or mismatched fingerprint will cause
-a clean rerun inside the already selected safe namespace, never reuse.
+The source checkout will be pinned to HEAD with no staged or tracked working-tree
+changes and no untracked files under src/, pyproject.toml, uv.lock, packaged base
+config, or referenced-input paths. Unrelated legacy runtime residue will not
+alter source identity, but it will never be read as an input. package_content_sha256
+will cover the installed package RECORD when wheel-installed or the exact
+tracked source/package file set when source-installed.
 
-Case names will be non-empty single path components with no `/`, `\\`, NUL,
-`.` or `..`. Resolved case names will be unique. Validation of every case name,
-the full matrix, the namespace, and both roots will complete before threads,
-directory creation, cleanup, or result publication begins.
+Referenced inputs will include the top-level input bytes and every YAML/CSV/file
+used to form the case matrix. #1575 will add its canonical case definition and
+prebuilt-manifest evidence through this same typed collection. Paths will be
+repository-relative public locators; absolute host paths will not enter the
+payload.
 
-### 3. Destructive-operation boundary
+Selected executable identity will cover every executable in the validated argv
+plan, including nested MPI solver execution. It will record basenames and byte
+hashes, not resolved paths. Hashing and preflight will finish before work-tree
+mutation. #1576 will consume this list and revalidate executable/content identity
+around real execution; it will not define another tool hash.
 
-Every cleanup/prune entrypoint will receive or derive the canonical run root
-and will verify immediately before mutation that:
+identity_sha256 will hash the canonical payload excluding identity_sha256 itself.
+The full lowercase SHA-256 will name the run namespace and will bind every
+external-mode checkpoint. Any source, package, effective config, referenced
+input, executable, result policy, or layout change will select a new identity.
 
-- the target is a strict descendant of that run root;
-- the target and existing descendants being removed are not symlinks;
-- the run root is itself a strict descendant of the canonical external root;
-- the target is not the external root, run root, config directory, or Git root.
+### 3. Work layout, ownership marker, and locks
 
-Failed containment, symlink, or type checks will raise a descriptive exception;
-cleanup will not use `ignore_errors=True` to turn an unsafe or incomplete
-deletion into a fresh solve. MPI resume will remain inside the same validated
-case directory. This issue will not move, archive, or delete any pre-existing
-legacy `batch_runs/` tree.
+External mode will use:
 
-### 4. Public/small output boundary
+~~~text
+<operator-root>/<validated-namespace>/openfoam-run-<identity-sha256>/
+  .digitalmodel-run-owner.json
+  .locks/
+  <relative-work-dir>/<case-name>/
+~~~
 
-Only `cases.csv` and `batch_summary.json` will be written beneath the resolved
-`output_dir`, retaining the existing suffix/count/size contract. Heavy case
-trees, checkpoints, solver logs, VTK output, and `processor*` will remain under
-the external work namespace.
+The run directory will be created as a strict descendant of the canonical
+operator root. The ownership marker will be created with exclusive no-follow
+semantics, restrictive permissions, file fsync, and parent-directory fsync. It
+will contain only schema version, RunIdentity, layout version, and a random
+ownership token. An existing directory without a valid marker, with a symlinked
+marker, or with a mismatched identity will reject without cleanup or adoption.
 
-In external mode, returned/in-memory rows and errors will use a stable relative
-work reference rooted at the opaque fingerprint namespace. They will not
-contain the canonical external-root string, home directory, or another absolute
-host path. `batch_summary.json` will add only non-sensitive fields such as
-`external_work_root: true`, `work_root_source: environment|config`,
-`work_layout_version`, and the opaque fingerprint. Legacy mode will preserve
-the existing `case_dir` representation and summary shape except for additions
-explicitly accepted during review.
+Before checkpoint inspection or mutation, the process will acquire an exclusive
+run lock. Each worker will also acquire an exclusive case lock before reading,
+cleaning, building, solving, or checkpointing its case. Lock records will contain
+schema version, identity, case name when applicable, random token, PID, local
+boot ID, process-start token, creation time, and heartbeat time. These records
+will remain private host-local state. Release will unlink only a token-matching
+record.
 
-### 5. Compatibility boundary
+Contention will wait only for the configured bounded lock timeout, then fail
+without mutation. Automatic stale reclamation will require all of:
 
-- With neither override present, default `batch_runs/`, explicit relative and
-  absolute `work_dir`, relative/absolute `output_dir`, checkpoint behavior,
-  pool/MPI execution, and returned paths will remain compatible with current
-  tests.
-- `work_root: null` in the packaged base config will not activate external
-  mode or change deep-merge precedence.
-- Existing external-mode-invalid inputs will fail before side effects with a
-  stable `ValueError`; there will be no silent fallback into the checkout.
-- OrcaFlex will remain unchanged. A shared cross-workflow root contract, if
-  desired, will require a separate issue and review.
+1. heartbeat age above the configured stale threshold;
+2. the boot ID/process-start/PID tuple proves the recorded process is not live
+   or belongs to a prior boot;
+3. identity and owner marker still match;
+4. the claimant atomically renames the stale record to a tokenized tombstone;
+5. containment and no-symlink checks pass again immediately before replacement.
+
+Unknown liveness, a live PID, marker drift, or rename loss will never reclaim.
+Tombstones will remain bounded diagnostic records until a later successful
+owner-matched cleanup; #1565 will not delete unrelated lock files.
+
+Every destructive helper will accept a validated WorkLayout rather than a raw
+Path. It will revalidate owner token, canonical containment, file type, and
+no-symlink ancestry immediately before mutation. The target must be a strict
+case descendant and must not equal the operator root, namespace, run root,
+config directory, or Git root.
+
+### 4. Checkpoint reuse
+
+External checkpoints will use schema version 2 and will carry the exact
+RunIdentity plus owner token, case name, status, and bounded result row. Reuse
+will require a completed status and exact schema/identity/owner/case match.
+Missing, corrupt, legacy, mismatched, or foreign checkpoints will never skip
+execution.
+
+A rejected checkpoint will trigger a clean rerun only after the current process
+holds both valid locks and revalidates the ownership marker. Legacy mode will
+retain the existing checkpoint shape and semantics until a separately reviewed
+migration.
+
+### 5. Versioned result policy
+
+result-policy-v1 will define two mandatory base files:
+
+~~~text
+cases.csv
+batch_summary.json
+~~~
+
+Only registered code-owned producers may extend the set. YAML paths, globs,
+suffix-only discovery, and arbitrary copying will not register a producer. Each
+extension will declare an immutable extension ID, exact relative basename,
+schema validator, media type, maximum bytes, and policy version.
+
+#1576 will register openfoam-artifact-index-v1 for artifact_index.json. It will
+consume result-policy-v1 and RunIdentity v1; it will not modify the two-file base
+or add a second allowlist. Unknown IDs, duplicate basenames, unsupported policy
+versions, producer failures, or validation failures will reject publication.
+
+All result files will remain beneath input-local results/. Heavy case trees,
+checkpoints, solver logs, VTK, mesh/field trees, and processor directories will
+remain beneath the external namespace.
+
+### 6. Deckhand external-state gate and canary
+
+Code merge will not authorize host mutation. Before hosted activation, the
+owner will receive a transaction preview containing:
+
+- the execution-context and root environment keys to add, service/drop-in files
+  affected, directory ownership/mode requirements, restart command, rollback,
+  and non-sensitive verification commands;
+- confirmation that no root value will be committed or echoed;
+- the exact agent/source SHA and digitalmodel SHA to activate.
+
+Only after explicit owner approval may an operator create the directory, update
+the environment, and restart the agent. Readback will prove, without printing
+the value, that the running process inherited a non-empty root, the canonical
+root is outside the scope checkout, owner/mode/writability are valid, and the
+agent reports the intended code SHA.
+
+The owner-approved synthetic dispatch canary will then prove:
+
+1. two mock cases create case trees, ownership marker, locks/checkpoints, and no
+   heavy data beneath the scope checkout;
+2. cases.csv and batch_summary.json return through the existing Deckhand result
+   policy and no other file returns;
+3. stdout/stderr tails, result JSON, returned files, and logs contain neither the
+   canonical root bytes nor an absolute heavy-work path;
+4. retry reuses the exact identity while a one-byte referenced-input change
+   selects a new namespace;
+5. the canary performs no real solver run or client-data access.
+
+The canary result will be evidence for activation, not authorization to run a
+production CFD batch.
 
 ---
 
-## Pseudocode
+## File Decomposition and Limits
 
-```text
-resolve_work_layout(cfg_dir, run_settings, base, cases, mapping):
-    root_value, source = first_nonempty(host_env, config_work_root)
-    if no root_value:
-        return legacy_resolve(work_dir, cfg_dir)
-    canonical_root = validate_precreated_external_root(root_value, cfg_dir)
-    relative_work_dir = validate_relative_descendant(run_settings.work_dir)
-    fingerprint = sha256(canonical_json(versioned_effective_batch_payload))
-    run_root = contained_child(canonical_root, "openfoam-run-" + fingerprint)
-    work_dir = contained_child(run_root, relative_work_dir)
-    validate_no_existing_symlink_components(canonical_root, work_dir)
-    return WorkLayout(root, run_root, work_dir, fingerprint, source, external=True)
+The refactor will precede behavior changes and will preserve characterization
+tests:
 
-render_cases(..., layout):
-    resolve every case name
-    reject unsafe or duplicate case names before creating anything
-    attach internal absolute path and stable public work reference separately
-
-load_checkpoint(case_dir, expected_fingerprint, external):
-    parse object
-    return only completed rows
-    if external, also require exact fingerprint
-
-safe_clean_case(case_dir, layout):
-    revalidate canonical containment and no symlink target
-    remove; surface any incomplete deletion as failure
-
-publish_rows(rows, layout):
-    external mode strips/replaces absolute work-root prefixes
-    assert serialized CSV/JSON does not contain the external-root bytes
-    write only small rollups to independently resolved output_dir
-```
-
----
-
-## Files to Change
-
-| Action | Path | Reason |
+| File | Responsibility | Target |
 |---|---|---|
-| Modify | `tests/workflows/test_openfoam_run_batch.py` | Tests will be written first for precedence, isolation, containment, output residency, leakage, and compatibility |
-| Modify | `src/digitalmodel/workflows/openfoam_run_batch.py` | The workflow will resolve and enforce the external work layout |
-| Modify | `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml` | A neutral `work_root: null` key will expose the input contract without changing defaults |
-| Keep | `src/digitalmodel/workflows/orcaflex_run_batch.py` | The sibling behavior will remain explicitly out of scope |
-| Keep | `tests/workflows/test_orcaflex_run_batch.py` | Existing sibling tests will remain regression evidence only |
+| openfoam_run_batch.py | public constants, compatibility imports, router facade | <=200 lines; router <=50 |
+| openfoam_batch_config.py | exact config parsing, RunIdentity, selected-input/tool identity | <=350 lines |
+| openfoam_batch_layout.py | WorkLayout, ownership marker, locks, containment | <=350 lines |
+| openfoam_batch_execution.py | pool/MPI orchestration using validated objects | <=350 lines |
+| openfoam_batch_results.py | checkpoint v2, rows, result-policy registry/publication | <=350 lines |
+| test_openfoam_run_batch.py | facade and legacy compatibility only | <=300 lines |
+| test_openfoam_batch_identity.py | identity codecs/change matrix | <=350 lines |
+| test_openfoam_batch_layout.py | root/marker/lock/concurrency/destruction | <=350 lines |
+| test_openfoam_batch_results.py | checkpoint and result-policy contracts | <=350 lines |
+| test_openfoam_batch_structure.py | file/function-size enforcement | <=200 lines |
 
-No implementation file will be edited until this plan receives adversarial
-review and explicit user approval.
+Every touched Python file will be at most 400 lines and every function/method at
+most 50 physical lines. The structural test will parse the named touched-file
+manifest and AST; it will fail when a new touched Python path is omitted.
 
 ---
 
 ## TDD Test List
 
-| Test | Contract frozen before implementation |
+Tests will be committed RED before each behavior slice. The decomposition slice
+will begin with GREEN characterization tests and will make no behavior change.
+
+| Test | Contract |
 |---|---|
-| `test_work_root_environment_wins_over_config` | A trusted non-empty host value will win over a different YAML root, and the summary will record `environment` without exposing the path |
-| `test_work_root_config_used_when_environment_unset` | An absolute precreated config root will activate external mode when the environment key is absent/empty |
-| `test_no_override_preserves_legacy_layout_and_outputs` | Default work/results paths and current row/checkpoint behavior will remain byte-compatible where currently asserted |
-| `test_base_config_null_work_root_does_not_activate_external_mode` | Real engine deep merge will preserve legacy behavior |
-| `test_external_root_requires_preexisting_writable_directory` | Missing, file, non-string, and non-writable roots will fail before side effects |
-| `test_external_root_rejects_scope_git_checkout_descendant` | A root in the input checkout, including a sibling of the config directory, will fail |
-| `test_external_work_dir_rejects_absolute_and_traversal` | Absolute, empty, `.`, `..`, separator escape, and NUL forms will fail |
-| `test_external_root_canonicalizes_trusted_root_symlink` | A root-level symlink will be checked against its canonical target and will remain outside the checkout |
-| `test_external_work_path_rejects_descendant_symlink` | A pre-existing symlink below the canonical root will fail before cleanup/write |
-| `test_case_names_reject_traversal_and_separators` | Explicit and generated names cannot escape their work directory |
-| `test_duplicate_case_names_fail_before_any_directory_creation` | Pool workers cannot race on one case/checkpoint directory |
-| `test_fingerprint_is_stable_for_equivalent_mapping_order` | Canonical JSON key order will not change the run namespace |
-| `test_fingerprint_changes_for_effective_case_or_run_setting` | Changes to resolved cases, base, mode, workers, mock, reconstruction/resume, timeout, or layout version will isolate the run |
-| `test_external_retry_reuses_matching_completed_checkpoint` | The exact same effective input will reuse a completed checkpoint in the same namespace |
-| `test_external_retry_rejects_missing_or_mismatched_fingerprint` | A stale/foreign checkpoint will never skip execution |
-| `test_pool_retry_cleanup_is_contained` | A failed pool retry will remove only its validated case subtree |
-| `test_mpi_resume_and_processor_prune_stay_in_run_root` | Resume/prune will preserve current semantics without touching another namespace |
-| `test_cleanup_rejects_root_case_and_symlink_targets` | Destructive helpers will fail closed for the external root, run root, config/Git root, and symlink targets |
-| `test_results_remain_beside_input_when_work_is_external` | CSV/JSON will remain under `output_dir`; heavy trees/checkpoints/logs will exist only under the external namespace |
-| `test_external_outputs_do_not_contain_absolute_work_root` | CSV, JSON, returned settings, checkpoint-derived rows, and sanitized error text will contain no external-root bytes |
-| `test_results_allowlist_still_rejects_heavy_artifacts` | Existing suffix, count, size, VTK, Foam, and processor exclusions will remain enforced |
-| `test_external_pool_and_mpi_paths_are_deterministic` | Both execution modes will select the same layout algorithm and stable per-case paths |
-| Existing focused suite | All current matrix, workers, fail-closed solver, checkpoint, MPI, and engine-path tests will continue to pass |
+| test_hosted_mode_requires_operator_environment_root | Hosted input cannot fall back to YAML or checkout-local heavy work |
+| test_yaml_cannot_downgrade_operator_hosted_context | Request config cannot claim trusted-local under hosted policy |
+| test_hosted_yaml_accepts_only_relative_namespace | Absolute/traversal/control/symlink forms reject pre-side-effect |
+| test_trusted_local_absolute_root_requires_explicit_context | Absolute config authority is never implicit |
+| test_external_work_dir_and_case_names_are_safe_unique_components | Whole matrix rejects escape/duplicates before side effects |
+| test_operator_root_never_appears_in_outputs_or_captured_streams | CSV/JSON/checkpoints/errors/log/stdout/stderr redact host paths |
+| test_run_identity_canonical_golden_vector | Exact codec and SHA are stable |
+| test_identity_changes_for_each_bound_surface | Source/package/config/input/executable/policy/layout changes isolate runs |
+| test_identity_rejects_dirty_or_unbound_source | Modified governed source/input cannot claim clean identity |
+| test_referenced_input_bytes_are_complete | Every selected YAML/CSV/file contributes size/hash/role |
+| test_mpi_nested_solver_is_in_executable_identity | Selected-plan hashing cannot omit the solver under mpirun |
+| test_owner_marker_create_and_exact_reopen | Atomic marker permits exact retry only |
+| test_foreign_missing_symlinked_marker_rejects | Existing unowned/unsafe namespaces are never adopted |
+| test_concurrent_identical_runs_have_one_owner | Two processes cannot clean/build the same namespace |
+| test_case_lock_serializes_duplicate_external_access | Case mutation requires token-matched ownership |
+| test_live_unknown_and_recent_locks_never_reclaim | Stale policy fails closed |
+| test_dead_expired_lock_reclaim_is_atomic | Only one claimant wins tombstone/replacement |
+| test_cleanup_revalidates_owner_and_containment | Marker/path drift blocks deletion |
+| test_checkpoint_v2_requires_exact_identity_owner_case | Foreign/stale checkpoint cannot skip |
+| test_legacy_no_override_is_byte_compatible | Existing default paths/rows/checkpoints remain unchanged |
+| test_result_policy_v1_requires_two_base_files | Base return contract is exact |
+| test_result_extension_registry_is_closed_and_versioned | YAML/glob/unknown/duplicate producers reject |
+| test_artifact_index_extension_contract_is_reserved_for_1576 | Shared seam accepts the exact future registration without publishing it now |
+| test_deckhand_canary_external_work_and_bounded_return | Owner-approved dispatch proves the end-to-end boundary |
+| test_touched_python_files_are_within_400_lines | Named manifest and physical line cap hold |
+| test_touched_functions_are_within_50_lines | AST function/method cap holds |
+| test_compare_pytest_json_rejects_new_failure | Baseline comparator is fail-closed and deterministic |
+
+---
+
+## Implementation Sequence
+
+1. Verify issue/approval state, parallel work, exact base SHA, and merged dependency
+   state. Stop unless the user has approved this revised plan.
+2. Capture focused and full same-base test reports before edits.
+3. Add/retain GREEN characterization tests, then split the workflow/router/tests
+   into the named modules. Run focused tests after each file move.
+4. Add RED RunIdentity codec, completeness, dirty-source, and change-isolation
+   tests; implement the shared v1 identity.
+5. Add RED hosted/trusted-local authority, owner-marker, locking, stale-reclaim,
+   concurrency, containment, and redaction tests; implement WorkLayout.
+6. Add RED checkpoint-v2 and result-policy tests; implement the closed base and
+   extension registry.
+7. Integrate the validated objects into pool/MPI execution without changing
+   legacy no-override behavior.
+8. Run focused/full/baseline, lint, compile, size, legal, and privacy commands.
+9. Run T3 adversarial code/artifact review. Resolve every MAJOR.
+10. Prepare the Deckhand host-config transaction preview. Stop for separate owner
+    approval before any directory, environment, service, or dispatch change.
+11. After approval, perform readback and the synthetic canary, then post only
+    non-sensitive evidence. Production execution remains out of scope.
+
+---
+
+## Exact Verification Commands
+
+Focused:
+
+~~~bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_run_batch.py tests/workflows/test_openfoam_batch_identity.py tests/workflows/test_openfoam_batch_layout.py tests/workflows/test_openfoam_batch_results.py tests/workflows/test_openfoam_batch_structure.py tests/workflows/test_orcaflex_run_batch.py tests/scripts/test_compare_pytest_json.py
+~~~
+
+Canonical full suite:
+
+~~~bash
+PYTHONPATH=src uv run python -m pytest -q
+~~~
+
+Paired same-base no-new-failure oracle, with VERIFY_PARENT set to a directory
+whose sibling assetutilities checkout is the same for both worktrees:
+
+~~~bash
+test -n "$VERIFY_PARENT"
+test -d "$VERIFY_PARENT/assetutilities"
+git worktree add --detach "$VERIFY_PARENT/dm-1565-base" 2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4
+git worktree add --detach "$VERIFY_PARENT/dm-1565-candidate" HEAD
+(cd "$VERIFY_PARENT/dm-1565-base" && uv sync --locked && PYTHONPATH=src uv run python -m pytest -p no:randomly --json-report --json-report-file="$VERIFY_PARENT/1565-base.json")
+(cd "$VERIFY_PARENT/dm-1565-candidate" && uv sync --locked && PYTHONPATH=src uv run python -m pytest -p no:randomly --json-report --json-report-file="$VERIFY_PARENT/1565-candidate.json")
+PYTHONPATH=src uv run python scripts/testing/compare_pytest_json.py --baseline "$VERIFY_PARENT/1565-base.json" --candidate "$VERIFY_PARENT/1565-candidate.json" --require-candidate-failures-subset
+~~~
+
+The comparator will normalize collection phase, node ID, exception type, and
+final exception message while stripping only the two verification-root prefixes.
+Candidate failures must be a subset of base failures; every touched-scope failure,
+new collection error, missing report, or malformed record will block.
+
+Size, lint, and compile:
+
+~~~bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_batch_structure.py::test_touched_python_files_are_within_400_lines tests/workflows/test_openfoam_batch_structure.py::test_touched_functions_are_within_50_lines
+uv run ruff check src/digitalmodel/workflows/openfoam_run_batch.py src/digitalmodel/workflows/openfoam_batch_config.py src/digitalmodel/workflows/openfoam_batch_layout.py src/digitalmodel/workflows/openfoam_batch_execution.py src/digitalmodel/workflows/openfoam_batch_results.py tests/workflows/test_openfoam_run_batch.py tests/workflows/test_openfoam_batch_identity.py tests/workflows/test_openfoam_batch_layout.py tests/workflows/test_openfoam_batch_results.py tests/workflows/test_openfoam_batch_structure.py scripts/testing/compare_pytest_json.py tests/scripts/test_compare_pytest_json.py
+uv run python -m compileall -q src/digitalmodel/workflows/openfoam_run_batch.py src/digitalmodel/workflows/openfoam_batch_config.py src/digitalmodel/workflows/openfoam_batch_layout.py src/digitalmodel/workflows/openfoam_batch_execution.py src/digitalmodel/workflows/openfoam_batch_results.py scripts/testing/compare_pytest_json.py
+git diff --check
+~~~
+
+Cross-repository legal scan, after the reviewed candidate SHA is checked out at
+the workspace-hub canonical digitalmodel sibling:
+
+~~~bash
+test -n "$WORKSPACE_HUB_ROOT"
+test "$(git -C "$WORKSPACE_HUB_ROOT/digitalmodel" rev-parse HEAD)" = "$(git rev-parse HEAD)"
+(cd "$WORKSPACE_HUB_ROOT" && bash scripts/legal/legal-sanity-scan.sh --repo=digitalmodel --diff-only)
+~~~
+
+Any command failure blocks closeout. Test reports, hashes, and the normalized
+base/candidate failure delta will be attached as non-sensitive review evidence.
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] New tests will be committed before production changes and will demonstrate
-      a red-to-green TDD sequence.
-- [ ] `DIGITALMODEL_WORK_ROOT` will override `run_batch.work_root`; config will
-      apply only when the environment is unset/empty; neither will preserve the
-      current layout.
-- [ ] External mode will create heavy work only under
-      `<root>/openfoam-run-<sha256>/<work_dir>/<case>` with deterministic
-      fingerprint-bound retries.
-- [ ] A changed effective batch configuration will not reuse a prior completed
-      checkpoint; an exact retry will.
-- [ ] Traversal, absolute external-mode `work_dir`, duplicate/unsafe case names,
-      descendant symlinks, and roots inside the scope Git checkout will fail
-      before filesystem side effects.
-- [ ] Cleanup and MPI pruning will revalidate containment immediately before
-      deletion and will surface incomplete deletion instead of ignoring it.
-- [ ] `results/cases.csv` and `results/batch_summary.json` will remain based at
-      the input/config directory by default, and no heavy artifact will enter
-      that output tree.
-- [ ] No returned CSV/JSON/in-memory row or error will contain the canonical
-      external-root string or an absolute heavy-work path.
-- [ ] With no override, current relative/absolute work/output path behavior,
-      pool/MPI behavior, and checkpoint semantics will remain compatible.
-- [ ] OrcaFlex code and behavior will remain unchanged.
-- [ ] `PYTHONPATH=src uv run pytest tests/workflows/test_openfoam_run_batch.py -q`
-      will pass in a correctly linked repository checkout.
-- [ ] `PYTHONPATH=src uv run pytest tests/workflows/test_orcaflex_run_batch.py -q`
-      will pass as sibling regression evidence.
-- [ ] `uv run ruff check src/digitalmodel/workflows/openfoam_run_batch.py tests/workflows/test_openfoam_run_batch.py`
-      will pass.
-- [ ] `uv run python -m compileall -q src/digitalmodel/workflows/openfoam_run_batch.py`
-      will pass.
-- [ ] The canonical repository test command will show zero new failures against
-      a same-base baseline if unrelated failures remain.
-- [ ] The workspace legal sanity scan will pass without publishing private
-      paths, host identifiers, project names, or input/result content.
-- [ ] Plan-stage and code-stage adversarial reviews will complete at the required
-      tier before the issue can close.
+- [ ] Hosted mode accepts an operator environment root only; YAML supplies only
+      a validated relative namespace and cannot select an absolute host path.
+- [ ] Trusted-local absolute config is available only through explicit opt-in.
+- [ ] RunIdentity v1 binds clean source SHA/package, effective config, every
+      referenced input byte set, selected executable hashes, and schema versions.
+- [ ] #1575 and #1576 consume the shared identity/layout/result schemas in the
+      declared landing order and pin merged predecessor SHAs.
+- [ ] Ownership marker plus exclusive run/case locks prevent concurrent/foreign
+      mutation; stale reclamation satisfies the full fail-closed policy.
+- [ ] Checkpoint v2 reuses only exact completed identity/owner/case matches.
+- [ ] result-policy-v1 preserves cases.csv and batch_summary.json and exposes only
+      the closed artifact-index registration seam for #1576.
+- [ ] Legacy no-override behavior remains compatible.
+- [ ] The workflow facade is <=200 lines, router <=50, and every touched Python
+      file/function satisfies 400/50.
+- [ ] Focused, canonical full, paired same-base, lint, compile, diff, and legal
+      commands pass; candidate failures are a subset of the exact base failures.
+- [ ] A separate owner-approved Deckhand preview/readback precedes activation.
+- [ ] The synthetic dispatch canary proves external heavy residency, bounded
+      result return, identity isolation/retry, and stdout/stderr/path redaction.
+- [ ] No private data, real solver run, host path publication, legacy-tree
+      deletion, self-approval, self-merge, self-close, or production promotion
+      occurs.
+- [ ] T3 code/artifact review reaches no-MAJOR before implementation closeout and
+      the issue receives the required implementation summary comment.
 
 ---
 
 ## Adversarial Review Summary
 
-| Provider | Verdict | Key findings |
-|---|---|---|
-| Claude | PENDING | No review has been requested by this drafting task |
-| Codex | PENDING | No review has been requested by this drafting task |
-| Gemini | PENDING | No review has been requested by this drafting task |
+R1 returned MAJOR across the supplied Claude/Codex/Gemini review wave. The
+consolidated artifact records the provider themes and exact r2 dispositions.
 
-**Overall result:** PENDING — draft only; not approval-ready.
+This revision incorporates the r1 blockers: hosted root authority, owner-approved
+Deckhand preview/readback and canary, atomic ownership/locking, shared complete
+RunIdentity, landing order, versioned result extensions, explicit module/test
+decomposition, literal verification commands, and conservative status wording.
 
----
-
-## Risks and Open Questions
-
-- **Risk — fingerprint evolution:** A future execution-affecting field could be
-  omitted from the canonical payload. The payload will carry an explicit layout
-  version and tests will enumerate every current field; future changes will
-  need to update both.
-- **Risk — TOCTOU:** Path revalidation reduces but cannot eliminate a hostile
-  same-user race between validation and filesystem mutation. The dispatch host
-  and work root are assumed to be controlled by the same trusted account; a
-  stronger dirfd/sandbox boundary would require a separate security issue.
-- **Risk — output compatibility:** Replacing absolute `case_dir` in external
-  mode may affect a consumer that treats returned rows as host-local paths.
-  Legacy mode will stay unchanged, and external mode will expose a stable
-  relative work reference instead of a misleading/unusable returned host path.
-- **Risk — work retention:** This issue will relocate heavy work but will not
-  define quotas, garbage collection, or migration. Retention/cleanup policy
-  will require a separately approved transaction.
-- **Open — environment provisioning:** The host operator will need to create and
-  permission the external root before enabling the environment value. This plan
-  will not change host state.
-- **Governance gap:** Issue #1565 has no lane/status labels at drafting time.
-  Label reconciliation remains an orchestrator action after review evidence;
-  this branch will not perform it.
+**Overall result:** revised draft for r2 adversarial review. It is not approved,
+not approval-ready until r2 returns no MAJOR, and does not authorize
+implementation or external-state changes.
 
 ---
 
-## Complexity: T2
+## Risks and Open Decisions
 
-The production change will remain localized to one workflow and its packaged
-defaults, but filesystem deletion safety, deterministic checkpoint isolation,
-host/config precedence, privacy-safe output, and legacy compatibility require a
-substantial focused test matrix and independent adversarial review.
+- A host root is an external-state capability. Code merge and operator activation
+  will remain separate approvals.
+- Source/tool identity hashing adds startup cost but prevents false checkpoint
+  reuse; #1576 may optimize caching only while preserving exact revalidation.
+- Lock reclamation can destroy active work if liveness is guessed. Unknown
+  liveness therefore blocks automatic reclaim.
+- Full-suite baseline debt may remain on the exact base SHA. The machine-readable
+  subset oracle will distinguish inherited failures from candidate regressions.
+- Result extensions can become a covert queue bypass if callers register arbitrary
+  paths. Registration will remain code-owned, exact-name, schema-validated, and
+  versioned.
+
+## Complexity: T3
+
+The revision spans filesystem authority, concurrent destructive operations,
+checkpoint identity, cross-issue shared schemas, Deckhand external state, queue
+publication, a mandatory large-file decomposition, and paired regression
+evidence.

--- a/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
+++ b/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
@@ -1,0 +1,384 @@
+# Plan for [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565): External OpenFOAM batch work root
+
+> **Status:** draft
+> **Complexity:** T2
+> **Date:** 2026-07-13
+> **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1565
+> **Client:** N/A
+> **Project:** N/A
+> **Lane:** lane:claude
+> **Execution mode:** single-lane implementation after approval; read-only evidence gathering was serialized because every available agent slot was occupied
+> **Review artifacts:** pending — this draft will require adversarial plan review before it can enter `status:plan-review`
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repository behavior
+
+- `src/digitalmodel/workflows/openfoam_run_batch.py:104-148` resolves relative `output_dir` and `work_dir` against `_config_dir_path`, so the defaults create `results/` and `batch_runs/` beside the input.
+- Lines 228-262 append the user-controlled case name without rejecting duplicates, absolute names, separators, `..`, or symlink escape.
+- Lines 294-319 and 555-567 delete/rebuild cases and prune `processor*` without an explicit trusted-root containment check.
+- Lines 585-609 atomically reuse completed `_result.json` checkpoints without binding them to the selecting configuration.
+- Lines 612-666 place absolute `case_dir` values in returned CSV/in-memory data, which would expose an external host path.
+- `tests/workflows/test_openfoam_run_batch.py:32-70,155-200` freezes the default layout, checkpoint reuse, and small-result allowlist for compatibility.
+- `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml:24-33` has `output_dir: results` and `work_dir: batch_runs` but no neutral work-root setting.
+
+### Precedent and related issues
+
+- [#1560](https://github.com/vamseeachanta/digitalmodel/issues/1560) is closed; its contract keeps heavy cases/checkpoints under the work directory and only CSV/JSON under `results/`.
+- [#1553](https://github.com/vamseeachanta/digitalmodel/issues/1553) remains open and requires deterministic script-only execution; no LLM, scheduler, or host-agent dependency will be added.
+- [#1564](https://github.com/vamseeachanta/digitalmodel/issues/1564) remains open and concerns an OrcaFlex base-config gap, not work placement.
+- `src/digitalmodel/workflows/orcaflex_run_batch.py:59-107` uses the same config-directory resolution; it is current-behavior precedent, not an external-root solution, and will remain unchanged.
+- Squash commits `d70685e4`, `1a833df5`, and `38074785` establish the OpenFOAM workflow, engine config, and OrcaFlex batch shape.
+
+### Resource and location intelligence
+
+- The Drive query `openfoam batch work root` (`plan-resource-intel`, `2026-07-14T04:31:42Z`) returned no relevant design and no coverage gaps; three stale indexes make this negative evidence only. Irrelevant identifying paths are excluded.
+- The online-resource registry has OpenFOAM upstream entries, but it, the standards/code registries, and the relevant CFD routing wiki define no scratch-root/return contract. No calculation standard applies.
+- A live inventory found 62 first-level directories and 23 Git repositories within depth two. This is machine-local evidence only; no fleet claim or file movement will follow.
+- Input/config and relative `output_dir` residency will remain unchanged; only heavy work will become overridable. The legacy data-mount alias is unrelated.
+
+### Gaps identified
+
+- No environment/config root or deterministic run namespace separates different batches with identical case names.
+- Completed checkpoints are not bound to the effective configuration.
+- Destructive cleanup lacks an explicit canonical-root containment contract.
+- Case/path traversal, duplicate names, symlinks, absolute-path leakage, output residency, and legacy compatibility lack coverage.
+
+### Embedded verification evidence
+
+**Live issue state** (`gh issue view`, `2026-07-14T04:31:53Z`):
+
+```text
+#1553 OPEN   EPIC: Continuous batch mini-runs ...
+#1560 CLOSED Land CFD execution surface on main + openfoam-run-batch saturating workflow
+#1564 OPEN   orcaflex_run_batch: missing engine base-config yml ...
+#1565 OPEN   openfoam_run_batch: default work/output dirs land inside the input's directory ...
+```
+
+Issue #1565 currently has no labels. This planning branch will not mutate
+labels; the orchestrator will need to reconcile exactly one `lane:claude` label
+before review-state promotion.
+
+**Reproduction proof** (`2026-07-14T04:33:11Z`; exact helpers were extracted from the source AST because this isolated worktree cannot resolve its sibling editable dependency):
+
+```text
+$ python3 <AST harness selecting openfoam_run_batch._resolve_path/_resolve_dir>
+work_parent_is_config=True
+output_parent_is_config=True
+inside_config=True
+rc=0
+```
+
+The harness executed lines 670-680 against a synthetic `scope-repo/cases/openfoam-run-batch`; the placement matches the claim. Direct `uv run` stopped before import on the unavailable worktree-relative editable dependency and did not contradict this result.
+
+Distinct sources: #1565; #1553/#1560/#1564; OpenFOAM and OrcaFlex code/tests; engine config; commits; registries/wiki; Drive index; live inventory.
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | `docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md` |
+| Plan index | `docs/plans/README.md` |
+| Production workflow | `src/digitalmodel/workflows/openfoam_run_batch.py` |
+| Engine defaults | `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml` |
+| Focused tests | `tests/workflows/test_openfoam_run_batch.py` |
+| Plan reviews | `scripts/review/results/2026-07-13-plan-1565-{claude,codex,gemini}.md` (future review outputs) |
+
+No private input, host path, project identifier, native solver result, or
+heavy work tree will become a repository artifact.
+
+---
+
+## Deliverable
+
+`openfoam_run_batch` will support a validated external heavy-work root selected
+by trusted host environment or explicit configuration, while preserving the
+current layout when no override is supplied and keeping returned CSV/JSON
+rollups beside the input.
+
+## Normative Design Contract
+
+### 1. Configuration and precedence
+
+The implementation will add one neutral base-config key:
+
+```yaml
+openfoam_run_batch:
+  run_batch:
+    work_root: null
+```
+
+The effective heavy-work base will be selected in this exact order:
+
+1. A non-empty `DIGITALMODEL_WORK_ROOT` environment value will win. This is the
+   trusted dispatch-host policy and cannot be overridden by request YAML.
+2. Otherwise, a non-empty `run_batch.work_root` value will apply.
+3. Otherwise, legacy resolution will apply exactly: relative `work_dir` will be
+   based at `_config_dir_path`, and an absolute `work_dir` will remain absolute.
+
+An empty environment value and `null`/omitted config value will mean “unset.” A
+non-string root will raise `ValueError`. An external root will be expanded for
+the current user's home, canonicalized, required to exist as a writable
+directory, and will never be created implicitly. Environment-variable
+interpolation inside YAML values will not be added.
+
+When an external root is active, `work_dir` will be a non-empty relative path.
+Absolute paths, `.`/`..` components, NULs, and paths that resolve outside the
+canonical root will fail before any case directory or result file is created.
+The canonical external root will also be required to sit outside the nearest
+Git checkout containing `_config_dir_path`; if no Git sentinel is present, it
+will at minimum be outside the canonical config directory. A trusted root-level
+symlink may resolve to its canonical target, but existing symlinks below that
+target will fail closed.
+
+`output_dir` will retain its current independent resolution against
+`_config_dir_path`. The external work-root setting will never rebase or copy
+`results/`.
+
+### 2. Deterministic run isolation
+
+External mode will create this logical layout:
+
+```text
+<canonical-external-root>/openfoam-run-<fingerprint>/<relative-work-dir>/<case-name>/
+```
+
+`fingerprint` will be the lowercase SHA-256 of canonical JSON encoded as UTF-8
+with sorted keys and compact separators. The versioned payload will include the
+resolved `base`, ordered resolved `cases`, `mapping`, mode, workers, mock flag,
+reconstruct/resume flags, timeout, relative work directory, and a
+`work_layout_version` constant. It will exclude timestamps, host paths,
+environment-source labels, and output location. Non-JSON values will fail
+closed rather than falling back to `repr()`.
+
+The same effective batch input will therefore reuse the same namespace across
+retries; any physics/execution-affecting configuration change will select a
+different namespace. Every newly written checkpoint will carry the full
+fingerprint. External-mode checkpoint reuse will require `status == completed`
+and an exact fingerprint match. A missing or mismatched fingerprint will cause
+a clean rerun inside the already selected safe namespace, never reuse.
+
+Case names will be non-empty single path components with no `/`, `\\`, NUL,
+`.` or `..`. Resolved case names will be unique. Validation of every case name,
+the full matrix, the namespace, and both roots will complete before threads,
+directory creation, cleanup, or result publication begins.
+
+### 3. Destructive-operation boundary
+
+Every cleanup/prune entrypoint will receive or derive the canonical run root
+and will verify immediately before mutation that:
+
+- the target is a strict descendant of that run root;
+- the target and existing descendants being removed are not symlinks;
+- the run root is itself a strict descendant of the canonical external root;
+- the target is not the external root, run root, config directory, or Git root.
+
+Failed containment, symlink, or type checks will raise a descriptive exception;
+cleanup will not use `ignore_errors=True` to turn an unsafe or incomplete
+deletion into a fresh solve. MPI resume will remain inside the same validated
+case directory. This issue will not move, archive, or delete any pre-existing
+legacy `batch_runs/` tree.
+
+### 4. Public/small output boundary
+
+Only `cases.csv` and `batch_summary.json` will be written beneath the resolved
+`output_dir`, retaining the existing suffix/count/size contract. Heavy case
+trees, checkpoints, solver logs, VTK output, and `processor*` will remain under
+the external work namespace.
+
+In external mode, returned/in-memory rows and errors will use a stable relative
+work reference rooted at the opaque fingerprint namespace. They will not
+contain the canonical external-root string, home directory, or another absolute
+host path. `batch_summary.json` will add only non-sensitive fields such as
+`external_work_root: true`, `work_root_source: environment|config`,
+`work_layout_version`, and the opaque fingerprint. Legacy mode will preserve
+the existing `case_dir` representation and summary shape except for additions
+explicitly accepted during review.
+
+### 5. Compatibility boundary
+
+- With neither override present, default `batch_runs/`, explicit relative and
+  absolute `work_dir`, relative/absolute `output_dir`, checkpoint behavior,
+  pool/MPI execution, and returned paths will remain compatible with current
+  tests.
+- `work_root: null` in the packaged base config will not activate external
+  mode or change deep-merge precedence.
+- Existing external-mode-invalid inputs will fail before side effects with a
+  stable `ValueError`; there will be no silent fallback into the checkout.
+- OrcaFlex will remain unchanged. A shared cross-workflow root contract, if
+  desired, will require a separate issue and review.
+
+---
+
+## Pseudocode
+
+```text
+resolve_work_layout(cfg_dir, run_settings, base, cases, mapping):
+    root_value, source = first_nonempty(host_env, config_work_root)
+    if no root_value:
+        return legacy_resolve(work_dir, cfg_dir)
+    canonical_root = validate_precreated_external_root(root_value, cfg_dir)
+    relative_work_dir = validate_relative_descendant(run_settings.work_dir)
+    fingerprint = sha256(canonical_json(versioned_effective_batch_payload))
+    run_root = contained_child(canonical_root, "openfoam-run-" + fingerprint)
+    work_dir = contained_child(run_root, relative_work_dir)
+    validate_no_existing_symlink_components(canonical_root, work_dir)
+    return WorkLayout(root, run_root, work_dir, fingerprint, source, external=True)
+
+render_cases(..., layout):
+    resolve every case name
+    reject unsafe or duplicate case names before creating anything
+    attach internal absolute path and stable public work reference separately
+
+load_checkpoint(case_dir, expected_fingerprint, external):
+    parse object
+    return only completed rows
+    if external, also require exact fingerprint
+
+safe_clean_case(case_dir, layout):
+    revalidate canonical containment and no symlink target
+    remove; surface any incomplete deletion as failure
+
+publish_rows(rows, layout):
+    external mode strips/replaces absolute work-root prefixes
+    assert serialized CSV/JSON does not contain the external-root bytes
+    write only small rollups to independently resolved output_dir
+```
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | `tests/workflows/test_openfoam_run_batch.py` | Tests will be written first for precedence, isolation, containment, output residency, leakage, and compatibility |
+| Modify | `src/digitalmodel/workflows/openfoam_run_batch.py` | The workflow will resolve and enforce the external work layout |
+| Modify | `src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml` | A neutral `work_root: null` key will expose the input contract without changing defaults |
+| Keep | `src/digitalmodel/workflows/orcaflex_run_batch.py` | The sibling behavior will remain explicitly out of scope |
+| Keep | `tests/workflows/test_orcaflex_run_batch.py` | Existing sibling tests will remain regression evidence only |
+
+No implementation file will be edited until this plan receives adversarial
+review and explicit user approval.
+
+---
+
+## TDD Test List
+
+| Test | Contract frozen before implementation |
+|---|---|
+| `test_work_root_environment_wins_over_config` | A trusted non-empty host value will win over a different YAML root, and the summary will record `environment` without exposing the path |
+| `test_work_root_config_used_when_environment_unset` | An absolute precreated config root will activate external mode when the environment key is absent/empty |
+| `test_no_override_preserves_legacy_layout_and_outputs` | Default work/results paths and current row/checkpoint behavior will remain byte-compatible where currently asserted |
+| `test_base_config_null_work_root_does_not_activate_external_mode` | Real engine deep merge will preserve legacy behavior |
+| `test_external_root_requires_preexisting_writable_directory` | Missing, file, non-string, and non-writable roots will fail before side effects |
+| `test_external_root_rejects_scope_git_checkout_descendant` | A root in the input checkout, including a sibling of the config directory, will fail |
+| `test_external_work_dir_rejects_absolute_and_traversal` | Absolute, empty, `.`, `..`, separator escape, and NUL forms will fail |
+| `test_external_root_canonicalizes_trusted_root_symlink` | A root-level symlink will be checked against its canonical target and will remain outside the checkout |
+| `test_external_work_path_rejects_descendant_symlink` | A pre-existing symlink below the canonical root will fail before cleanup/write |
+| `test_case_names_reject_traversal_and_separators` | Explicit and generated names cannot escape their work directory |
+| `test_duplicate_case_names_fail_before_any_directory_creation` | Pool workers cannot race on one case/checkpoint directory |
+| `test_fingerprint_is_stable_for_equivalent_mapping_order` | Canonical JSON key order will not change the run namespace |
+| `test_fingerprint_changes_for_effective_case_or_run_setting` | Changes to resolved cases, base, mode, workers, mock, reconstruction/resume, timeout, or layout version will isolate the run |
+| `test_external_retry_reuses_matching_completed_checkpoint` | The exact same effective input will reuse a completed checkpoint in the same namespace |
+| `test_external_retry_rejects_missing_or_mismatched_fingerprint` | A stale/foreign checkpoint will never skip execution |
+| `test_pool_retry_cleanup_is_contained` | A failed pool retry will remove only its validated case subtree |
+| `test_mpi_resume_and_processor_prune_stay_in_run_root` | Resume/prune will preserve current semantics without touching another namespace |
+| `test_cleanup_rejects_root_case_and_symlink_targets` | Destructive helpers will fail closed for the external root, run root, config/Git root, and symlink targets |
+| `test_results_remain_beside_input_when_work_is_external` | CSV/JSON will remain under `output_dir`; heavy trees/checkpoints/logs will exist only under the external namespace |
+| `test_external_outputs_do_not_contain_absolute_work_root` | CSV, JSON, returned settings, checkpoint-derived rows, and sanitized error text will contain no external-root bytes |
+| `test_results_allowlist_still_rejects_heavy_artifacts` | Existing suffix, count, size, VTK, Foam, and processor exclusions will remain enforced |
+| `test_external_pool_and_mpi_paths_are_deterministic` | Both execution modes will select the same layout algorithm and stable per-case paths |
+| Existing focused suite | All current matrix, workers, fail-closed solver, checkpoint, MPI, and engine-path tests will continue to pass |
+
+---
+
+## Acceptance Criteria
+
+- [ ] New tests will be committed before production changes and will demonstrate
+      a red-to-green TDD sequence.
+- [ ] `DIGITALMODEL_WORK_ROOT` will override `run_batch.work_root`; config will
+      apply only when the environment is unset/empty; neither will preserve the
+      current layout.
+- [ ] External mode will create heavy work only under
+      `<root>/openfoam-run-<sha256>/<work_dir>/<case>` with deterministic
+      fingerprint-bound retries.
+- [ ] A changed effective batch configuration will not reuse a prior completed
+      checkpoint; an exact retry will.
+- [ ] Traversal, absolute external-mode `work_dir`, duplicate/unsafe case names,
+      descendant symlinks, and roots inside the scope Git checkout will fail
+      before filesystem side effects.
+- [ ] Cleanup and MPI pruning will revalidate containment immediately before
+      deletion and will surface incomplete deletion instead of ignoring it.
+- [ ] `results/cases.csv` and `results/batch_summary.json` will remain based at
+      the input/config directory by default, and no heavy artifact will enter
+      that output tree.
+- [ ] No returned CSV/JSON/in-memory row or error will contain the canonical
+      external-root string or an absolute heavy-work path.
+- [ ] With no override, current relative/absolute work/output path behavior,
+      pool/MPI behavior, and checkpoint semantics will remain compatible.
+- [ ] OrcaFlex code and behavior will remain unchanged.
+- [ ] `PYTHONPATH=src uv run pytest tests/workflows/test_openfoam_run_batch.py -q`
+      will pass in a correctly linked repository checkout.
+- [ ] `PYTHONPATH=src uv run pytest tests/workflows/test_orcaflex_run_batch.py -q`
+      will pass as sibling regression evidence.
+- [ ] `uv run ruff check src/digitalmodel/workflows/openfoam_run_batch.py tests/workflows/test_openfoam_run_batch.py`
+      will pass.
+- [ ] `uv run python -m compileall -q src/digitalmodel/workflows/openfoam_run_batch.py`
+      will pass.
+- [ ] The canonical repository test command will show zero new failures against
+      a same-base baseline if unrelated failures remain.
+- [ ] The workspace legal sanity scan will pass without publishing private
+      paths, host identifiers, project names, or input/result content.
+- [ ] Plan-stage and code-stage adversarial reviews will complete at the required
+      tier before the issue can close.
+
+---
+
+## Adversarial Review Summary
+
+| Provider | Verdict | Key findings |
+|---|---|---|
+| Claude | PENDING | No review has been requested by this drafting task |
+| Codex | PENDING | No review has been requested by this drafting task |
+| Gemini | PENDING | No review has been requested by this drafting task |
+
+**Overall result:** PENDING — draft only; not approval-ready.
+
+---
+
+## Risks and Open Questions
+
+- **Risk — fingerprint evolution:** A future execution-affecting field could be
+  omitted from the canonical payload. The payload will carry an explicit layout
+  version and tests will enumerate every current field; future changes will
+  need to update both.
+- **Risk — TOCTOU:** Path revalidation reduces but cannot eliminate a hostile
+  same-user race between validation and filesystem mutation. The dispatch host
+  and work root are assumed to be controlled by the same trusted account; a
+  stronger dirfd/sandbox boundary would require a separate security issue.
+- **Risk — output compatibility:** Replacing absolute `case_dir` in external
+  mode may affect a consumer that treats returned rows as host-local paths.
+  Legacy mode will stay unchanged, and external mode will expose a stable
+  relative work reference instead of a misleading/unusable returned host path.
+- **Risk — work retention:** This issue will relocate heavy work but will not
+  define quotas, garbage collection, or migration. Retention/cleanup policy
+  will require a separately approved transaction.
+- **Open — environment provisioning:** The host operator will need to create and
+  permission the external root before enabling the environment value. This plan
+  will not change host state.
+- **Governance gap:** Issue #1565 has no lane/status labels at drafting time.
+  Label reconciliation remains an orchestrator action after review evidence;
+  this branch will not perform it.
+
+---
+
+## Complexity: T2
+
+The production change will remain localized to one workflow and its packaged
+defaults, but filesystem deletion safety, deterministic checkpoint isolation,
+host/config precedence, privacy-safe output, and legacy compatibility require a
+substantial focused test matrix and independent adversarial review.

--- a/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
+++ b/docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
@@ -1,539 +1,221 @@
 # Plan for [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565): External OpenFOAM batch work root
 
-> **Status:** draft — r1 MAJOR findings incorporated; r2 adversarial review required
+> **Status:** draft — r2 MAJOR findings resolved inline in r3; user approval required
 > **Complexity:** T3
 > **Date:** 2026-07-13
-> **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/1565
-> **Client:** N/A
-> **Project:** N/A
+> **Client/Project:** N/A
 > **Lane:** lane:claude
-> **Execution mode:** single-lane implementation after explicit user approval
-> **Review artifact:** scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md
+> **Review artifacts:** `scripts/review/results/2026-07-13-plan-1565-r{1,2}-consolidated.md`
 
----
+## Resource Intelligence and Reproduction
 
-## Resource Intelligence Summary
+- `openfoam_run_batch.py` currently resolves heavy case work below the input
+  checkout, returns absolute `case_dir`, and performs clean/prune operations
+  without an operator-root ownership contract. It is 680 lines; `router` and
+  `_run_case_mpi` exceed 50 lines. Its test is 445 lines.
+- Existing `oracaflex_run_batch.py` is behavior precedent only; it will not be
+  changed. CFD host/environment docs require heavy work outside git and small
+  results inside the dispatch scope.
+- Issue [#1575](https://github.com/vamseeachanta/digitalmodel/issues/1575) will
+  consume this layout/identity; [#1576](https://github.com/vamseeachanta/digitalmodel/issues/1576)
+  will consume both. Order is **#1565 → #1575 → #1576**.
+- A synthetic config resolved `_work_dir` below its config directory and emitted
+  an absolute case path at base `2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4`.
+  No private input or solver license is needed to reproduce the placement leak.
+- Drive/standards/wiki searches found no reusable root/return contract. No
+  standards-derived calculation applies.
 
-### Existing repository behavior
-
-- src/digitalmodel/workflows/openfoam_run_batch.py resolves relative output_dir
-  and work_dir against _config_dir_path, so the defaults place results/ and
-  batch_runs/ beside the dispatch input.
-- The 680-line workflow contains an 89-line router plus configuration, matrix
-  expansion, pool/MPI execution, cleanup, checkpoint, and publication logic.
-- tests/workflows/test_openfoam_run_batch.py is 445 lines. Both files already
-  exceed the universal 400-line limit before this change.
-- Case names reach filesystem joins without a closed single-component contract.
-  Cleanup and processor pruning do not have a shared root-confinement object.
-- Completed checkpoints carry result rows but are not bound to the selecting
-  source/package/config/input/tool identity.
-- Deckhand runs the workflow from the scope checkout, inherits operator-provided
-  systemd environment, and returns allowlisted small files from the input-local
-  results/ directory. Host configuration and queue transport remain separate
-  authority surfaces.
-
-### Reproduction evidence
-
-At base SHA 2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4, a synthetic input under
-scope-repo/cases/openfoam-run-batch reproduces the placement:
-
-~~~text
-work_parent_is_config=True
-output_parent_is_config=True
-inside_config=True
-rc=0
-~~~
-
-The reproduction executes the exact path-resolution helpers extracted from the
-source AST. The isolated planning worktree cannot resolve its sibling editable
-dependency, so the implementation verification will run from a correctly linked
-checkout and will not treat the AST harness as a regression suite.
-
-### Related issues and landing order
-
-The shared contracts will land in this order:
-
-1. [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565) will own
-   RunIdentity v1, work-layout v1, namespace ownership/locking, and result-policy
-   v1.
-2. [#1575](https://github.com/vamseeachanta/digitalmodel/issues/1575) will pin the
-   merged #1565 SHA and will add normalized case-definition bytes to the shared
-   RunIdentity referenced-input/config surfaces.
-3. [#1576](https://github.com/vamseeachanta/digitalmodel/issues/1576) will pin the
-   merged #1565 and #1575 SHAs, consume RunIdentity v1 unchanged, and register
-   artifact_index.json through result-policy v1.
-
-No downstream plan will duplicate fingerprint, checkpoint, work-root, or result
-allowlist logic. Any incompatible shared-schema change will require a version
-increment and an upstream issue rather than an inline downstream fork.
-
-Related [deckhand#557](https://github.com/vamseeachanta/deckhand/issues/557)
-owns the OpenFOAM execution-host agent. #1565 will not mutate its systemd
-environment, create host directories, restart the agent, or dispatch a run
-without a separate owner-approved transaction.
-
-### Resource and privacy intelligence
-
-- The OrcaFlex batch workflow has the same config-directory default but no
-  reviewed external-root contract and will remain unchanged.
-- No engineering standard or calculation constant applies.
-- Fixtures and reports will remain synthetic. Public output will contain no host
-  path, username, mount root, client/project identifier, or private case data.
-- The plan will not move or delete any existing legacy batch_runs/ tree.
-
----
-
-## Artifact Map
+## Artifacts
 
 | Artifact | Path |
 |---|---|
-| Plan | docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md |
-| Consolidated r1 review | scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md |
-| Public workflow facade | src/digitalmodel/workflows/openfoam_run_batch.py |
-| Configuration and identity | src/digitalmodel/workflows/openfoam_batch_config.py |
-| Work layout and locks | src/digitalmodel/workflows/openfoam_batch_layout.py |
-| Pool/MPI orchestration | src/digitalmodel/workflows/openfoam_batch_execution.py |
-| Checkpoint/result policy | src/digitalmodel/workflows/openfoam_batch_results.py |
-| Base configuration | src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml |
-| Legacy/facade tests | tests/workflows/test_openfoam_run_batch.py |
-| Identity tests | tests/workflows/test_openfoam_batch_identity.py |
-| Layout/lock tests | tests/workflows/test_openfoam_batch_layout.py |
-| Result-policy tests | tests/workflows/test_openfoam_batch_results.py |
-| Structural limits | tests/workflows/test_openfoam_batch_structure.py |
-| Baseline comparator | scripts/testing/compare_pytest_json.py; tests/scripts/test_compare_pytest_json.py |
+| Plan | `docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md` |
+| Config/identity | `src/digitalmodel/workflows/openfoam_batch_config.py` |
+| Layout/locks | `src/digitalmodel/workflows/openfoam_batch_layout.py` |
+| Execution | `src/digitalmodel/workflows/openfoam_batch_execution.py` |
+| Results | `src/digitalmodel/workflows/openfoam_batch_results.py` |
+| Facade | `src/digitalmodel/workflows/openfoam_run_batch.py` |
+| Tests | `tests/workflows/test_openfoam_batch_{identity,layout,execution,results,structure}.py` |
 
-## Deliverable
+## Deliverable and Landing Boundary
 
-openfoam_run_batch will place heavy case work in an operator-authorized external
-root without moving input-local bounded results. A shared RunIdentity will bind
-checkpoint and namespace reuse to clean source/package/config/input/tool
-identity. Atomic ownership markers and locks will prevent concurrent or foreign
-mutation. Result-policy v1 will retain the two-file base contract while exposing
-a closed extension registry for #1576.
+The workflow will place heavy cases beneath an operator-authorized external root,
+keep bounded results below input-local `results/`, bind reuse to source/input/tool
+identity, and perform destructive work only through owned descriptor-confined
+layouts. No host mutation, dispatch, approval label, or queue publication is
+authorized by this plan.
 
----
+## Execution Context and Root Authority
 
-## Normative Design Contract
+Hosted classification comes only from operator environment:
 
-### 1. Execution context and root authority
-
-The parser will classify the invocation before resolving a work root. Hosted
-classification will come only from operator environment, never request YAML:
-
-~~~text
+```text
 DIGITALMODEL_EXECUTION_CONTEXT=hosted-deckhand
 DIGITALMODEL_WORK_ROOT=<operator-private absolute root>
-~~~
+```
 
-Hosted Deckhand mode will require a non-empty DIGITALMODEL_WORK_ROOT inherited
-from the operator-controlled agent environment. Request YAML will never select
-an absolute host root in hosted mode. run_batch.work_root_namespace will be the
-only hosted YAML placement field; its packaged default will be
-openfoam-run-batch. It will be a non-empty portable relative path
-with no absolute form, empty/dot/dot-dot component, separator ambiguity,
-control/NUL byte, or symlink traversal. A missing/invalid operator root will fail
-before directory creation, cleanup, checkpoint reads, threads, or commands.
-An input-supplied execution_context that conflicts with the operator environment
-will reject and cannot downgrade hosted execution.
+Hosted YAML may supply only `run_batch.work_root_namespace`, a portable relative
+path with no empty/dot/dot-dot/control/NUL/absolute/symlink component. Missing or
+invalid operator root fails before side effects. YAML cannot downgrade hosted
+mode or choose an absolute root.
 
-Trusted-local mode will be opt-in through run_batch.execution_context:
-trusted-local, and will be available only when the hosted environment marker is
-absent. Only that explicit context may use run_batch.work_root as an absolute
-precreated directory. The root will be canonicalized, required to be a writable
-directory outside the input Git checkout, and rejected when it or any descendant
-component is a symlink. Relative or implicit trusted-local roots will not be
-accepted.
+Trusted-local mode requires explicit `run_batch.execution_context: trusted-local`
+with no hosted marker. Only there may `run_batch.work_root` name a precreated
+writable absolute directory outside every Git checkout; symlinks reject. With no
+external context, legacy placement remains byte-compatible. `output_dir` stays
+input-local in all modes.
 
-When neither external mode is selected nor a hosted context is asserted, legacy
-work_dir resolution will remain byte-compatible. output_dir will remain
-independently based at _config_dir_path so Deckhand can return small results.
+## RunIdentity v1
 
-In either external mode, work_dir will be a non-empty safe relative path. Case
-names will be unique non-empty portable single components. Absolute paths,
-separator variants, dot components, controls/NULs, duplicate names, or a
-resolved escape will reject for the complete batch before any filesystem or
-worker side effect.
+`openfoam_batch_config.py` will canonicalize strict JSON into:
 
-The operator root value and canonical host path will remain process-internal.
-CSV, JSON, checkpoints, exceptions, log messages, stdout, and stderr will expose
-only stable relative work references and non-sensitive source labels.
-
-### 2. RunIdentity v1
-
-src/digitalmodel/workflows/openfoam_batch_config.py will own canonical
-digitalmodel-run-identity-v1. Canonical JSON will use UTF-8, sorted object keys,
-compact separators, integers without Boolean coercion, finite JSON numbers, and
-exact schema validation. Non-JSON input will reject rather than use repr().
-
-The identity payload will contain:
-
-~~~text
-schema_version = 1
-identity_kind = openfoam-run-batch
-source:
-  git_commit_sha
-  tracked_tree_clean = true
-  package_name
-  package_version
-  package_content_sha256
+```text
+schema_version, identity_kind
+source: git_commit_sha, tracked_tree_clean, package_name/version/content_sha256
 effective_config_sha256
-referenced_inputs[]:
-  role
-  safe_repo_relative_path
-  size_bytes
-  content_sha256
-selected_executables[]:
-  role
-  basename
-  content_sha256
-result_policy_version
-work_layout_version
-identity_sha256
-~~~
+referenced_inputs[]: role, safe_relative_path, size_bytes, content_sha256
+selected_executables[]: role, basename, content_sha256
+host_capabilities: visible_rank_count, dispatcher_rank_limit
+result_policy_version, work_layout_version, identity_sha256
+```
 
-The source checkout will be pinned to HEAD with no staged or tracked working-tree
-changes and no untracked files under src/, pyproject.toml, uv.lock, packaged base
-config, or referenced-input paths. Unrelated legacy runtime residue will not
-alter source identity, but it will never be read as an input. package_content_sha256
-will cover the installed package RECORD when wheel-installed or the exact
-tracked source/package file set when source-installed.
+The candidate checkout must be clean for package/config/input paths. Wheel mode
+will parse every RECORD entry, reject missing/unrecorded package files, verify
+actual size/hash against RECORD, and hash canonical actual-byte records; RECORD-
+only hashing is forbidden. Source mode hashes exact tracked package bytes.
+Referenced input identity includes the top-level request and every YAML/CSV/case
+byte, including #1575 prebuilt evidence.
 
-Referenced inputs will include the top-level input bytes and every YAML/CSV/file
-used to form the case matrix. #1575 will add its canonical case definition and
-prebuilt-manifest evidence through this same typed collection. Paths will be
-repository-relative public locators; absolute host paths will not enter the
-payload.
+Every selected executable will be content-hashed before mutation, reopened and
+revalidated immediately before and after every launch, and represented by
+basename only. The full lowercase identity SHA names the namespace. Any source,
+package, config, input, tool, host-ceiling, policy, or layout drift selects a new
+identity and cannot reuse a checkpoint.
 
-Selected executable identity will cover every executable in the validated argv
-plan, including nested MPI solver execution. It will record basenames and byte
-hashes, not resolved paths. Hashing and preflight will finish before work-tree
-mutation. #1576 will consume this list and revalidate executable/content identity
-around real execution; it will not define another tool hash.
+## Owned Layout, Locks, and Destructive Safety
 
-identity_sha256 will hash the canonical payload excluding identity_sha256 itself.
-The full lowercase SHA-256 will name the run namespace and will bind every
-external-mode checkpoint. Any source, package, effective config, referenced
-input, executable, result policy, or layout change will select a new identity.
-
-### 3. Work layout, ownership marker, and locks
-
-External mode will use:
-
-~~~text
-<operator-root>/<validated-namespace>/openfoam-run-<identity-sha256>/
+```text
+<operator-root>/<namespace>/openfoam-run-<identity>/
   .digitalmodel-run-owner.json
   .locks/
-  <relative-work-dir>/<case-name>/
-~~~
+  <work-dir>/<case>/
+```
 
-The run directory will be created as a strict descendant of the canonical
-operator root. The ownership marker will be created with exclusive no-follow
-semantics, restrictive permissions, file fsync, and parent-directory fsync. It
-will contain only schema version, RunIdentity, layout version, and a random
-ownership token. An existing directory without a valid marker, with a symlinked
-marker, or with a mismatched identity will reject without cleanup or adoption.
+The process will atomically create the run directory and an owner marker binding
+schema, uid, identity, canonical root device/inode, and random owner token. A
+preexisting unowned/mismatched namespace rejects. Run and case locks are acquired
+before checkpoint read or mutation; they record boot ID/PID/start/heartbeat.
+Stale reclaim requires expired heartbeat, proven-dead process/prior boot, matching
+owner, and atomic tombstone rename. Unknown liveness never reclaims.
 
-Before checkpoint inspection or mutation, the process will acquire an exclusive
-run lock. Each worker will also acquire an exclusive case lock before reading,
-cleaning, building, solving, or checkpointing its case. Lock records will contain
-schema version, identity, case name when applicable, random token, PID, local
-boot ID, process-start token, creation time, and heartbeat time. These records
-will remain private host-local state. Release will unlink only a token-matching
-record.
+Destructive helpers accept `WorkLayout`, open the owned root once with directory/
+no-follow flags, walk using `dir_fd|O_DIRECTORY|O_NOFOLLOW`, compare device/inode/
+owner, and mutate descriptor-relatively. Path-only check-then-delete is forbidden.
+Targets must be strict case descendants and never equal operator/namespace/run/
+config/Git roots. Race tests substitute renames/symlinks at every clean/prune
+seam and must leave replacements untouched.
 
-Contention will wait only for the configured bounded lock timeout, then fail
-without mutation. Automatic stale reclamation will require all of:
+## Checkpoint and Result Policy
 
-1. heartbeat age above the configured stale threshold;
-2. the boot ID/process-start/PID tuple proves the recorded process is not live
-   or belongs to a prior boot;
-3. identity and owner marker still match;
-4. the claimant atomically renames the stale record to a tokenized tombstone;
-5. containment and no-symlink checks pass again immediately before replacement.
+External checkpoint v2 carries exact RunIdentity, owner token, case, status, and
+bounded result row. Only completed exact matches skip. Corrupt/legacy/foreign
+records rerun only while both locks and marker remain valid. Legacy mode retains
+its current schema until a separate migration.
 
-Unknown liveness, a live PID, marker drift, or rename loss will never reclaim.
-Tombstones will remain bounded diagnostic records until a later successful
-owner-matched cleanup; #1565 will not delete unrelated lock files.
+`result-policy-v1` has mandatory `cases.csv` and `batch_summary.json`. Extensions
+are code-owned records with ID, exact basename, schema, media type, byte bound,
+and policy version; YAML/glob discovery cannot register one. #1576 reserves but
+does not activate `openfoam-artifact-index-v1` while Deckhand
+[#564](https://github.com/vamseeachanta/deckhand/issues/564) is open. Activation
+requires #564 merged plus separately approved integration/readback. Heavy trees,
+checkpoints, logs, mesh/field/VTK/processor output remain external.
 
-Every destructive helper will accept a validated WorkLayout rather than a raw
-Path. It will revalidate owner token, canonical containment, file type, and
-no-symlink ancestry immediately before mutation. The target must be a strict
-case descendant and must not equal the operator root, namespace, run root,
-config directory, or Git root.
+## Deckhand External-State Gate
 
-### 4. Checkpoint reuse
+Code merge will not authorize host configuration. The owner must separately
+approve a preview naming environment/drop-in files, ownership/mode, restart,
+rollback, exact agent/digitalmodel SHAs, and non-sensitive readback. After that,
+a synthetic Deckhand canary must prove:
 
-External checkpoints will use schema version 2 and will carry the exact
-RunIdentity plus owner token, case name, status, and bounded result row. Reuse
-will require a completed status and exact schema/identity/owner/case match.
-Missing, corrupt, legacy, mismatched, or foreign checkpoints will never skip
-execution.
+- systemd/agent inherits hosted context/root without logging it;
+- heavy work is outside the scope checkout;
+- bounded results still return input-locally;
+- CSV/JSON/stdout/stderr/errors contain no host path; and
+- rollback restores prior service/root behavior.
 
-A rejected checkpoint will trigger a clean rerun only after the current process
-holds both valid locks and revalidates the ownership marker. Legacy mode will
-retain the existing checkpoint shape and semantics until a separately reviewed
-migration.
+## File Decomposition
 
-### 5. Versioned result policy
+Before behavior changes, characterization tests will freeze argv, rows,
+checkpoints, pool/MPI order, and legacy placement. The 680-line facade will split
+into config/layout/execution/results modules; facade ≤200 lines/router ≤50. The
+445-line test will split by identity/layout/execution/results. Every touched file
+must be ≤400 lines and function ≤50 before feature edits. #1575/#1576 will modify,
+not recreate, these exact modules.
 
-result-policy-v1 will define two mandatory base files:
+## TDD Matrix
 
-~~~text
-cases.csv
-batch_summary.json
-~~~
-
-Only registered code-owned producers may extend the set. YAML paths, globs,
-suffix-only discovery, and arbitrary copying will not register a producer. Each
-extension will declare an immutable extension ID, exact relative basename,
-schema validator, media type, maximum bytes, and policy version.
-
-#1576 will register openfoam-artifact-index-v1 for artifact_index.json. It will
-consume result-policy-v1 and RunIdentity v1; it will not modify the two-file base
-or add a second allowlist. Unknown IDs, duplicate basenames, unsupported policy
-versions, producer failures, or validation failures will reject publication.
-
-All result files will remain beneath input-local results/. Heavy case trees,
-checkpoints, solver logs, VTK, mesh/field trees, and processor directories will
-remain beneath the external namespace.
-
-### 6. Deckhand external-state gate and canary
-
-Code merge will not authorize host mutation. Before hosted activation, the
-owner will receive a transaction preview containing:
-
-- the execution-context and root environment keys to add, service/drop-in files
-  affected, directory ownership/mode requirements, restart command, rollback,
-  and non-sensitive verification commands;
-- confirmation that no root value will be committed or echoed;
-- the exact agent/source SHA and digitalmodel SHA to activate.
-
-Only after explicit owner approval may an operator create the directory, update
-the environment, and restart the agent. Readback will prove, without printing
-the value, that the running process inherited a non-empty root, the canonical
-root is outside the scope checkout, owner/mode/writability are valid, and the
-agent reports the intended code SHA.
-
-The owner-approved synthetic dispatch canary will then prove:
-
-1. two mock cases create case trees, ownership marker, locks/checkpoints, and no
-   heavy data beneath the scope checkout;
-2. cases.csv and batch_summary.json return through the existing Deckhand result
-   policy and no other file returns;
-3. stdout/stderr tails, result JSON, returned files, and logs contain neither the
-   canonical root bytes nor an absolute heavy-work path;
-4. retry reuses the exact identity while a one-byte referenced-input change
-   selects a new namespace;
-5. the canary performs no real solver run or client-data access.
-
-The canary result will be evidence for activation, not authorization to run a
-production CFD batch.
-
----
-
-## File Decomposition and Limits
-
-The refactor will precede behavior changes and will preserve characterization
-tests:
-
-| File | Responsibility | Target |
-|---|---|---|
-| openfoam_run_batch.py | public constants, compatibility imports, router facade | <=200 lines; router <=50 |
-| openfoam_batch_config.py | exact config parsing, RunIdentity, selected-input/tool identity | <=350 lines |
-| openfoam_batch_layout.py | WorkLayout, ownership marker, locks, containment | <=350 lines |
-| openfoam_batch_execution.py | pool/MPI orchestration using validated objects | <=350 lines |
-| openfoam_batch_results.py | checkpoint v2, rows, result-policy registry/publication | <=350 lines |
-| test_openfoam_run_batch.py | facade and legacy compatibility only | <=300 lines |
-| test_openfoam_batch_identity.py | identity codecs/change matrix | <=350 lines |
-| test_openfoam_batch_layout.py | root/marker/lock/concurrency/destruction | <=350 lines |
-| test_openfoam_batch_results.py | checkpoint and result-policy contracts | <=350 lines |
-| test_openfoam_batch_structure.py | file/function-size enforcement | <=200 lines |
-
-Every touched Python file will be at most 400 lines and every function/method at
-most 50 physical lines. The structural test will parse the named touched-file
-manifest and AST; it will fail when a new touched Python path is omitted.
-
----
-
-## TDD Test List
-
-Tests will be committed RED before each behavior slice. The decomposition slice
-will begin with GREEN characterization tests and will make no behavior change.
-
-| Test | Contract |
-|---|---|
-| test_hosted_mode_requires_operator_environment_root | Hosted input cannot fall back to YAML or checkout-local heavy work |
-| test_yaml_cannot_downgrade_operator_hosted_context | Request config cannot claim trusted-local under hosted policy |
-| test_hosted_yaml_accepts_only_relative_namespace | Absolute/traversal/control/symlink forms reject pre-side-effect |
-| test_trusted_local_absolute_root_requires_explicit_context | Absolute config authority is never implicit |
-| test_external_work_dir_and_case_names_are_safe_unique_components | Whole matrix rejects escape/duplicates before side effects |
-| test_operator_root_never_appears_in_outputs_or_captured_streams | CSV/JSON/checkpoints/errors/log/stdout/stderr redact host paths |
-| test_run_identity_canonical_golden_vector | Exact codec and SHA are stable |
-| test_identity_changes_for_each_bound_surface | Source/package/config/input/executable/policy/layout changes isolate runs |
-| test_identity_rejects_dirty_or_unbound_source | Modified governed source/input cannot claim clean identity |
-| test_referenced_input_bytes_are_complete | Every selected YAML/CSV/file contributes size/hash/role |
-| test_mpi_nested_solver_is_in_executable_identity | Selected-plan hashing cannot omit the solver under mpirun |
-| test_owner_marker_create_and_exact_reopen | Atomic marker permits exact retry only |
-| test_foreign_missing_symlinked_marker_rejects | Existing unowned/unsafe namespaces are never adopted |
-| test_concurrent_identical_runs_have_one_owner | Two processes cannot clean/build the same namespace |
-| test_case_lock_serializes_duplicate_external_access | Case mutation requires token-matched ownership |
-| test_live_unknown_and_recent_locks_never_reclaim | Stale policy fails closed |
-| test_dead_expired_lock_reclaim_is_atomic | Only one claimant wins tombstone/replacement |
-| test_cleanup_revalidates_owner_and_containment | Marker/path drift blocks deletion |
-| test_checkpoint_v2_requires_exact_identity_owner_case | Foreign/stale checkpoint cannot skip |
-| test_legacy_no_override_is_byte_compatible | Existing default paths/rows/checkpoints remain unchanged |
-| test_result_policy_v1_requires_two_base_files | Base return contract is exact |
-| test_result_extension_registry_is_closed_and_versioned | YAML/glob/unknown/duplicate producers reject |
-| test_artifact_index_extension_contract_is_reserved_for_1576 | Shared seam accepts the exact future registration without publishing it now |
-| test_deckhand_canary_external_work_and_bounded_return | Owner-approved dispatch proves the end-to-end boundary |
-| test_touched_python_files_are_within_400_lines | Named manifest and physical line cap hold |
-| test_touched_functions_are_within_50_lines | AST function/method cap holds |
-| test_compare_pytest_json_rejects_new_failure | Baseline comparator is fail-closed and deterministic |
-
----
+- Environment root wins; hosted mode rejects missing root or YAML absolute root.
+- Trusted-local requires explicit opt-in and rejects Git/symlink roots.
+- Namespace traversal/control/collision/foreign marker reject before side effect.
+- Wheel/source/input/tool/host-capability mutation changes or rejects identity.
+- Concurrent identical runs serialize; stale-lock reclaim follows every predicate.
+- Descriptor clean/prune resists rename/symlink/inode substitution.
+- Checkpoint exact-match skips; every identity/owner/schema drift reruns.
+- Result base is stable; unknown/active-before-#564 extensions reject.
+- External outputs/log tails redact canonical root; legacy mode stays identical.
+- Real engine deep merge and OrcaFlex regression remain unchanged.
+- Structure tests enforce 400/50 on every touched Python path.
 
 ## Implementation Sequence
 
-1. Verify issue/approval state, parallel work, exact base SHA, and merged dependency
-   state. Stop unless the user has approved this revised plan.
-2. Capture focused and full same-base test reports before edits.
-3. Add/retain GREEN characterization tests, then split the workflow/router/tests
-   into the named modules. Run focused tests after each file move.
-4. Add RED RunIdentity codec, completeness, dirty-source, and change-isolation
-   tests; implement the shared v1 identity.
-5. Add RED hosted/trusted-local authority, owner-marker, locking, stale-reclaim,
-   concurrency, containment, and redaction tests; implement WorkLayout.
-6. Add RED checkpoint-v2 and result-policy tests; implement the closed base and
-   extension registry.
-7. Integrate the validated objects into pool/MPI execution without changing
-   legacy no-override behavior.
-8. Run focused/full/baseline, lint, compile, size, legal, and privacy commands.
-9. Run T3 adversarial code/artifact review. Resolve every MAJOR.
-10. Prepare the Deckhand host-config transaction preview. Stop for separate owner
-    approval before any directory, environment, service, or dispatch change.
-11. After approval, perform readback and the synthetic canary, then post only
-    non-sensitive evidence. Production execution remains out of scope.
+1. Commit RED characterization, authority, identity, lock, path-race, checkpoint,
+   result-policy, and redaction tests.
+2. Land the behavior-preserving file split with characterization green.
+3. Implement strict config plus RunIdentity actual-byte/tool binding.
+4. Implement owned layout, descriptor operations, locks, checkpoint v2.
+5. Implement result policy/redaction and inactive #1576 extension seam.
+6. Run exact acceptance and T3 code/artifact review.
+7. After merge only, request separate owner approval for host preview/canary.
 
----
+## Exact Verification and Acceptance
 
-## Exact Verification Commands
-
-Focused:
-
-~~~bash
-PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_run_batch.py tests/workflows/test_openfoam_batch_identity.py tests/workflows/test_openfoam_batch_layout.py tests/workflows/test_openfoam_batch_results.py tests/workflows/test_openfoam_batch_structure.py tests/workflows/test_orcaflex_run_batch.py tests/scripts/test_compare_pytest_json.py
-~~~
-
-Canonical full suite:
-
-~~~bash
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_run_batch.py tests/workflows/test_openfoam_batch_identity.py tests/workflows/test_openfoam_batch_layout.py tests/workflows/test_openfoam_batch_execution.py tests/workflows/test_openfoam_batch_results.py tests/workflows/test_openfoam_batch_structure.py tests/workflows/test_orcaflex_run_batch.py
 PYTHONPATH=src uv run python -m pytest -q
-~~~
-
-Paired same-base no-new-failure oracle, with VERIFY_PARENT set to a directory
-whose sibling assetutilities checkout is the same for both worktrees:
-
-~~~bash
-test -n "$VERIFY_PARENT"
-test -d "$VERIFY_PARENT/assetutilities"
-git worktree add --detach "$VERIFY_PARENT/dm-1565-base" 2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4
-git worktree add --detach "$VERIFY_PARENT/dm-1565-candidate" HEAD
-(cd "$VERIFY_PARENT/dm-1565-base" && uv sync --locked && PYTHONPATH=src uv run python -m pytest -p no:randomly --json-report --json-report-file="$VERIFY_PARENT/1565-base.json")
-(cd "$VERIFY_PARENT/dm-1565-candidate" && uv sync --locked && PYTHONPATH=src uv run python -m pytest -p no:randomly --json-report --json-report-file="$VERIFY_PARENT/1565-candidate.json")
-PYTHONPATH=src uv run python scripts/testing/compare_pytest_json.py --baseline "$VERIFY_PARENT/1565-base.json" --candidate "$VERIFY_PARENT/1565-candidate.json" --require-candidate-failures-subset
-~~~
-
-The comparator will normalize collection phase, node ID, exception type, and
-final exception message while stripping only the two verification-root prefixes.
-Candidate failures must be a subset of base failures; every touched-scope failure,
-new collection error, missing report, or malformed record will block.
-
-Size, lint, and compile:
-
-~~~bash
-PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_batch_structure.py::test_touched_python_files_are_within_400_lines tests/workflows/test_openfoam_batch_structure.py::test_touched_functions_are_within_50_lines
-uv run ruff check src/digitalmodel/workflows/openfoam_run_batch.py src/digitalmodel/workflows/openfoam_batch_config.py src/digitalmodel/workflows/openfoam_batch_layout.py src/digitalmodel/workflows/openfoam_batch_execution.py src/digitalmodel/workflows/openfoam_batch_results.py tests/workflows/test_openfoam_run_batch.py tests/workflows/test_openfoam_batch_identity.py tests/workflows/test_openfoam_batch_layout.py tests/workflows/test_openfoam_batch_results.py tests/workflows/test_openfoam_batch_structure.py scripts/testing/compare_pytest_json.py tests/scripts/test_compare_pytest_json.py
-uv run python -m compileall -q src/digitalmodel/workflows/openfoam_run_batch.py src/digitalmodel/workflows/openfoam_batch_config.py src/digitalmodel/workflows/openfoam_batch_layout.py src/digitalmodel/workflows/openfoam_batch_execution.py src/digitalmodel/workflows/openfoam_batch_results.py scripts/testing/compare_pytest_json.py
+uv run ruff check src/digitalmodel/workflows/openfoam_*.py tests/workflows/test_openfoam*.py
+uv run python -m compileall -q src/digitalmodel/workflows
+PYTHONPATH=src uv run python -m pytest -q tests/workflows/test_openfoam_batch_structure.py
 git diff --check
-~~~
+```
 
-Cross-repository legal scan, after the reviewed candidate SHA is checked out at
-the workspace-hub canonical digitalmodel sibling:
+For the legal gate, set `WORKSPACE_HUB_ROOT` and a candidate-relative
+`DIGITALMODEL_REL_FROM_HUB`, then run:
 
-~~~bash
-test -n "$WORKSPACE_HUB_ROOT"
-test "$(git -C "$WORKSPACE_HUB_ROOT/digitalmodel" rev-parse HEAD)" = "$(git rev-parse HEAD)"
-(cd "$WORKSPACE_HUB_ROOT" && bash scripts/legal/legal-sanity-scan.sh --repo=digitalmodel --diff-only)
-~~~
+```bash
+EXPECTED_SHA="$(git rev-parse HEAD)"
+test "$(git -C "$WORKSPACE_HUB_ROOT/$DIGITALMODEL_REL_FROM_HUB" rev-parse HEAD)" = "$EXPECTED_SHA"
+(cd "$WORKSPACE_HUB_ROOT" && bash scripts/legal/legal-sanity-scan.sh --repo="$DIGITALMODEL_REL_FROM_HUB" --diff-only)
+```
 
-Any command failure blocks closeout. Test reports, hashes, and the normalized
-base/candidate failure delta will be attached as non-sensitive review evidence.
+Acceptance additionally requires RED-before-GREEN evidence, exact merged
+predecessor SHAs, zero new full-suite failures against base, real canary only
+after separate approval, issue implementation comment, and no self-merge/close.
 
----
+## Adversarial Review
 
-## Acceptance Criteria
+R1 and R2 each reached three-provider MAJOR consensus. R1 required hosted root
+authority, owned locking, source/tool identity, landing order, module split, and
+Deckhand readback. R2 required actual installed-byte verification, descriptor-
+anchored deletion, per-launch tool revalidation, dormant #564 return extension,
+and portable legal invocation. Consolidated artifacts record exact reviewed SHAs.
+All distinct findings are resolved inline in r3; under the loop-break rule r3 is
+not redispatched. The plan remains draft until the user explicitly approves it;
+no agent may create approval state.
 
-- [ ] Hosted mode accepts an operator environment root only; YAML supplies only
-      a validated relative namespace and cannot select an absolute host path.
-- [ ] Trusted-local absolute config is available only through explicit opt-in.
-- [ ] RunIdentity v1 binds clean source SHA/package, effective config, every
-      referenced input byte set, selected executable hashes, and schema versions.
-- [ ] #1575 and #1576 consume the shared identity/layout/result schemas in the
-      declared landing order and pin merged predecessor SHAs.
-- [ ] Ownership marker plus exclusive run/case locks prevent concurrent/foreign
-      mutation; stale reclamation satisfies the full fail-closed policy.
-- [ ] Checkpoint v2 reuses only exact completed identity/owner/case matches.
-- [ ] result-policy-v1 preserves cases.csv and batch_summary.json and exposes only
-      the closed artifact-index registration seam for #1576.
-- [ ] Legacy no-override behavior remains compatible.
-- [ ] The workflow facade is <=200 lines, router <=50, and every touched Python
-      file/function satisfies 400/50.
-- [ ] Focused, canonical full, paired same-base, lint, compile, diff, and legal
-      commands pass; candidate failures are a subset of the exact base failures.
-- [ ] A separate owner-approved Deckhand preview/readback precedes activation.
-- [ ] The synthetic dispatch canary proves external heavy residency, bounded
-      result return, identity isolation/retry, and stdout/stderr/path redaction.
-- [ ] No private data, real solver run, host path publication, legacy-tree
-      deletion, self-approval, self-merge, self-close, or production promotion
-      occurs.
-- [ ] T3 code/artifact review reaches no-MAJOR before implementation closeout and
-      the issue receives the required implementation summary comment.
+## Risks and Non-Goals
 
----
-
-## Adversarial Review Summary
-
-R1 returned MAJOR across the supplied Claude/Codex/Gemini review wave. The
-consolidated artifact records the provider themes and exact r2 dispositions.
-
-This revision incorporates the r1 blockers: hosted root authority, owner-approved
-Deckhand preview/readback and canary, atomic ownership/locking, shared complete
-RunIdentity, landing order, versioned result extensions, explicit module/test
-decomposition, literal verification commands, and conservative status wording.
-
-**Overall result:** revised draft for r2 adversarial review. It is not approved,
-not approval-ready until r2 returns no MAJOR, and does not authorize
-implementation or external-state changes.
-
----
-
-## Risks and Open Decisions
-
-- A host root is an external-state capability. Code merge and operator activation
-  will remain separate approvals.
-- Source/tool identity hashing adds startup cost but prevents false checkpoint
-  reuse; #1576 may optimize caching only while preserving exact revalidation.
-- Lock reclamation can destroy active work if liveness is guessed. Unknown
-  liveness therefore blocks automatic reclaim.
-- Full-suite baseline debt may remain on the exact base SHA. The machine-readable
-  subset oracle will distinguish inherited failures from candidate regressions.
-- Result extensions can become a covert queue bypass if callers register arbitrary
-  paths. Registration will remain code-owned, exact-name, schema-validated, and
-  versioned.
-
-## Complexity: T3
-
-The revision spans filesystem authority, concurrent destructive operations,
-checkpoint identity, cross-issue shared schemas, Deckhand external state, queue
-publication, a mandatory large-file decomposition, and paired regression
-evidence.
+- Same-account malicious host processes are outside the cooperative lock model;
+  descriptor confinement still protects against path substitution.
+- External roots may exhaust disk; owner provisioning/monitoring is separate.
+- No host mutation, queue dispatch, public heavy result, OrcaFlex change, approval,
+  merge, or close is included.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,8 +1,0 @@
-# Issue Plans
-
-This is the active issue-plan index for `digitalmodel`. Historical plans in
-this directory predate this index and are not backfilled here.
-
-| Issue # | Title / Slug | Plan File | Date | Status | Complexity | Notes |
-|---|---|---|---|---|---|---|
-| [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565) | openfoam-external-work-root | `docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md` | 2026-07-13 | draft | T2 | Public synthetic plan only; adversarial review and explicit user approval remain required before implementation. |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,8 @@
+# Issue Plans
+
+This is the active issue-plan index for `digitalmodel`. Historical plans in
+this directory predate this index and are not backfilled here.
+
+| Issue # | Title / Slug | Plan File | Date | Status | Complexity | Notes |
+|---|---|---|---|---|---|---|
+| [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565) | openfoam-external-work-root | `docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md` | 2026-07-13 | draft | T2 | Public synthetic plan only; adversarial review and explicit user approval remain required before implementation. |

--- a/scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md
+++ b/scripts/review/results/2026-07-13-plan-1565-r1-consolidated.md
@@ -1,0 +1,164 @@
+# Issue #1565 plan review — r1 consolidated MAJOR findings
+
+## Review target
+
+- Plan:
+  docs/plans/2026-07-13-issue-1565-openfoam-external-work-root.md
+- Reviewed pushed head:
+  c69ca6e5afb2ae326e53d526f84b5fe57e5e2fd5
+- Review posture: adversarial; default non-approval
+- R1 outcome: MAJOR
+
+This artifact consolidates the r1 findings supplied by the orchestrator with the
+locally verified Claude review and Gemini theme summary. The standalone Codex
+#1565 artifact was not present in this worktree; the Codex verdict/themes below
+are therefore recorded from the orchestrator-supplied consensus rather than
+represented as a verbatim provider transcript. A Codex downstream review of
+#1575 independently confirmed that #1575 must consume the merged #1565
+RunIdentity/layout and pin its SHA.
+
+## Provider verdicts and themes
+
+| Provider | Verdict | MAJOR themes |
+|---|---|---|
+| Claude | MAJOR | Untrusted YAML could select a host root; deterministic namespaces lacked locks; checkpoint identity omitted source/tool identity; no Deckhand activation/readback/canary oracle; the 680-line workflow and 445-line test violated 400/50 without a split; exact legal/full-suite commands were absent. |
+| Codex | MAJOR, per orchestrator-supplied r1 consensus | Shared source/package/config/input/tool identity and landing order had to be frozen upstream; downstream #1575/#1576 could not redefine layout/checkpoint identity; hosted filesystem authority and exact verification remained blocking. |
+| Gemini | MAJOR | The 680-line workflow/89-line router required explicit decomposition; the fingerprint omitted clean source/package/tool identity; a two-file frozen result set conflicted with #1576 artifact_index.json; Deckhand systemd root provisioning/readback required separate owner authority. |
+
+## Consolidated blocking findings
+
+### R1-1 — Hosted filesystem authority was granted to request YAML
+
+The r1 plan allowed run_batch.work_root to select an arbitrary absolute writable
+directory whenever DIGITALMODEL_WORK_ROOT was unset. A Deckhand request could
+therefore acquire host placement authority that belongs to the operator.
+
+Required disposition:
+
+- hosted mode will require the operator-provisioned environment root;
+- hosted YAML will provide only a validated relative namespace;
+- an absolute config root will require explicit trusted-local mode;
+- hosted mode will fail before side effects when operator policy is missing.
+
+R2 location: Normative Design Contract §1.
+
+### R1-2 — Host activation lacked an owner gate and end-to-end oracle
+
+Unit tests alone could not prove that the running Deckhand agent inherited the
+root, that heavy work stayed outside the scope checkout, or that returned
+stdout/stderr and bounded files did not disclose the path.
+
+Required disposition:
+
+- code merge and host mutation will be separate transactions;
+- an owner will approve the exact environment/service/directory preview;
+- privacy-safe readback will precede activation;
+- a synthetic dispatch canary will prove external heavy work, two-file bounded
+  return, retry/isolation behavior, and path redaction;
+- the canary will not run a real solver.
+
+R2 location: Normative Design Contract §6 and Acceptance Criteria.
+
+### R1-3 — Deterministic namespace reuse was race-unsafe
+
+Identical inputs selected the same directory, while cleanup/checkpoint operations
+had no intrinsic run/case ownership lock. Deckhand's current host-level
+serialization was an external implementation detail and did not protect local or
+future execution surfaces.
+
+Required disposition:
+
+- atomically create and fsync an identity-bound ownership marker;
+- acquire exclusive run and case locks before checkpoint reads or mutations;
+- use bounded contention and token-matched release;
+- reclaim only dead, expired locks through an atomic tombstone claim;
+- never guess liveness or adopt an unowned directory;
+- add real concurrency/stale-lock tests.
+
+R2 location: Normative Design Contract §3 and TDD Test List.
+
+### R1-4 — The fingerprint was not a complete execution identity
+
+The r1 fingerprint bound selected config but omitted source/package/tool identity
+and referenced-input byte closure. A deployment or executable change could reuse
+a stale completed checkpoint.
+
+Required disposition:
+
+- create canonical digitalmodel-run-identity-v1;
+- bind clean source commit, package content, effective config, all referenced
+  input bytes, selected executable hashes, result-policy version, and layout
+  version;
+- use the full identity digest for namespace/checkpoint reuse;
+- require #1575 and #1576 to consume the shared schema rather than duplicate it.
+
+R2 location: Normative Design Contract §2 and §4.
+
+### R1-5 — Landing order and result extension ownership were undefined
+
+#1565 froze exactly two returned files while #1576 required
+artifact_index.json. All three issues also modify the same batch workflow.
+
+Required disposition:
+
+- land #1565, then #1575, then #1576 with exact predecessor SHA pins;
+- keep cases.csv and batch_summary.json as the mandatory base;
+- expose a code-owned, exact-name, schema-validated result extension registry;
+- reserve openfoam-artifact-index-v1 for #1576;
+- prohibit YAML/glob/suffix-only extension registration.
+
+R2 location: Related issues and landing order; Normative Design Contract §5.
+
+### R1-6 — The implementation plan violated the 400/50 limits
+
+The r1 plan proposed adding behavior to a 680-line module containing an 89-line
+router and a 445-line test without an explicit decomposition.
+
+Required disposition:
+
+- split configuration/identity, layout/locks, execution, and results into named
+  modules before behavior changes;
+- reduce the public facade to at most 200 lines and router to at most 50;
+- split tests by responsibility;
+- make a touched-path manifest plus AST structural tests fail on file/function
+  excess or an omitted touched Python path.
+
+R2 location: File Decomposition and Limits.
+
+### R1-7 — Acceptance was not executable
+
+The r1 plan used an unnamed canonical suite, a non-local legal scan, and no
+machine-readable same-base failure oracle.
+
+Required disposition:
+
+- freeze literal focused, canonical full, paired base/candidate JSON-report,
+  comparator, size, Ruff, compileall, diff, and cross-repository legal commands;
+- pin base SHA 2ff0f72c9c5ce9022bfca763a6bb24ae4fb768d4;
+- require candidate failure signatures to be a subset of base signatures;
+- fail on touched-scope failures, collection drift, missing reports, or malformed
+  evidence.
+
+R2 location: Exact Verification Commands.
+
+### R1-8 — Planning metadata overstated or referenced false artifacts
+
+The r1 draft listed a local docs/plans/README.md artifact even though the branch
+removed that false index, and its execution-mode text described transient past
+agent-slot state rather than proposed work.
+
+Required disposition:
+
+- remove the false plan-index artifact;
+- express proposed execution in future tense;
+- record r1 as resolved-in-r2 draft only;
+- require a fresh r2 review and user approval before implementation.
+
+R2 location: plan header, Artifact Map, and Adversarial Review Summary.
+
+## R1 disposition
+
+All listed MAJOR themes are incorporated into the revised plan contract. This is
+not a no-MAJOR verdict: the revised plan requires a fresh adversarial r2 review.
+No provider or agent has approved implementation, host mutation, dispatch,
+labels, issue comments, merge, or close.

--- a/scripts/review/results/2026-07-13-plan-1565-r2-consolidated.md
+++ b/scripts/review/results/2026-07-13-plan-1565-r2-consolidated.md
@@ -1,0 +1,10 @@
+# Issue 1565 Plan Review — Round 2
+
+Exact reviewed draft: `346f11dfea578e1a26d9d650b4762b48917d0bc9`.
+
+Claude, Codex, and Gemini returned MAJOR. Distinct findings required actual
+installed-package byte verification rather than RECORD-only hashing, descriptor-
+anchored destructive operations, executable revalidation around every launch,
+dormant result extensions pending Deckhand #564, and a SHA-verified sibling-
+checkout legal command. Those findings are resolved inline in r3 without a new
+review dispatch, per the cross-review loop-break rule. This is not approval.

--- a/src/digitalmodel/solvers/openfoam/runner.py
+++ b/src/digitalmodel/solvers/openfoam/runner.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from .prebuilt_mesh import (
     PrebuiltExecution,
@@ -126,8 +126,10 @@ class OpenFOAMRunner:
     author any dict files — it only executes utilities inside the case.
     """
 
-    def __init__(self, config: Optional[OpenFOAMRunConfig] = None) -> None:
+    def __init__(self, config: Optional[OpenFOAMRunConfig] = None,
+                 executable_verifier: Optional[Callable[[str], None]] = None) -> None:
         self._config = config or OpenFOAMRunConfig()
+        self._executable_verifier = executable_verifier
 
     # ------------------------------------------------------------------ #
     #  public API                                                         #
@@ -273,8 +275,12 @@ class OpenFOAMRunner:
         start: float,
     ) -> None:
         for status, argv in stages:
+            if self._executable_verifier is not None:
+                self._executable_verifier(argv[0])
             result.status = status
             stage = self._run_stage(case, argv)
+            if self._executable_verifier is not None:
+                self._executable_verifier(argv[0])
             result.stages.append(stage)
             if not stage.ok:
                 result.status = OpenFOAMRunStatus.FAILED

--- a/src/digitalmodel/solvers/openfoam/runner.py
+++ b/src/digitalmodel/solvers/openfoam/runner.py
@@ -127,7 +127,7 @@ class OpenFOAMRunner:
     """
 
     def __init__(self, config: Optional[OpenFOAMRunConfig] = None,
-                 executable_verifier: Optional[Callable[[str], None]] = None) -> None:
+                 executable_verifier: Optional[Callable[[str], Path]] = None) -> None:
         self._config = config or OpenFOAMRunConfig()
         self._executable_verifier = executable_verifier
 
@@ -275,10 +275,11 @@ class OpenFOAMRunner:
         start: float,
     ) -> None:
         for status, argv in stages:
+            launch_argv = list(argv)
             if self._executable_verifier is not None:
-                self._executable_verifier(argv[0])
+                launch_argv[0] = str(self._executable_verifier(argv[0]))
             result.status = status
-            stage = self._run_stage(case, argv)
+            stage = self._run_stage(case, launch_argv)
             if self._executable_verifier is not None:
                 self._executable_verifier(argv[0])
             result.stages.append(stage)
@@ -340,7 +341,7 @@ class OpenFOAMRunner:
         return shutil.which(executable) is not None
 
     def _run_stage(self, case: Path, argv: list[str]) -> StageResult:
-        name = argv[0]
+        name = Path(argv[0]).name
         log_file = case / f"log.{name}"
         stage = StageResult(name=name, log_file=log_file)
         start = time.monotonic()

--- a/src/digitalmodel/workflows/openfoam_batch_config.py
+++ b/src/digitalmodel/workflows/openfoam_batch_config.py
@@ -1,0 +1,153 @@
+"""Configuration authority for OpenFOAM batch work placement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from copy import deepcopy
+import math
+import os
+from pathlib import Path
+import re
+from typing import Mapping
+
+from digitalmodel.workflows.parametric_run import _load_cases, _set_dotted
+
+
+WORKER_CORE_FRACTION = 0.9
+HOSTED_CONTEXT = "hosted-deckhand"
+TRUSTED_LOCAL_CONTEXT = "trusted-local"
+DEFAULT_OUTPUT_DIR = "results"
+DEFAULT_WORK_DIR = "batch_runs"
+_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+RESERVED_ROW_KEYS = frozenset({"index", "name", "status", "solver", "mock",
+                               "error", "case_dir", "wall_seconds", "mpi_plan"})
+
+
+@dataclass(frozen=True)
+class BatchPaths:
+    execution_context: str
+    cfg_dir: Path
+    output_dir: Path
+    operator_root: Path | None
+    namespace: str
+    legacy_work_dir: Path | None
+
+    @property
+    def external(self) -> bool:
+        return self.operator_root is not None
+
+
+def default_workers(cpu_count: int | None = None) -> int:
+    cores = cpu_count if cpu_count is not None else (os.cpu_count() or 1)
+    return max(1, math.floor(WORKER_CORE_FRACTION * cores))
+
+
+def resolve_workers(run_settings: dict) -> int:
+    explicit = run_settings.get("workers")
+    if explicit is None:
+        return default_workers()
+    workers = int(explicit)
+    if workers < 1:
+        raise ValueError(f"run_batch.workers must be >= 1, got {explicit}")
+    return workers
+
+
+def resolve_case_matrix(explicit: list[dict] | None, variants: dict,
+                        cfg_dir: Path) -> list[dict]:
+    if explicit:
+        if variants:
+            raise ValueError("openfoam_run_batch: give either cases or variants, not both")
+        return [dict(item) for item in explicit]
+    return _load_cases(variants, cfg_dir) if variants else [{}]
+
+
+def render_cases(base: dict, cases: list[dict], mapping: dict[str, str],
+                 work_dir: Path) -> list[dict]:
+    base_name = base.get("name") or f"{base['case_type']}_case"
+    rendered = []
+    for index, case in enumerate(cases):
+        settings = deepcopy(base)
+        params = {key: value for key, value in case.items() if key != "name"}
+        collisions = RESERVED_ROW_KEYS.intersection(params)
+        if collisions:
+            raise ValueError(
+                "case parameter names collide with reserved manifest columns: "
+                f"{sorted(collisions)}"
+            )
+        for name, value in params.items():
+            _set_dotted(settings, mapping.get(name, name), value)
+        name = case.get("name") or f"{base_name}_{index:03d}"
+        settings["name"] = name
+        rendered.append({"index": index, "name": name, "case": params,
+                         "settings": settings, "work_dir": work_dir / name})
+    return rendered
+
+
+def validate_namespace(value: object) -> str:
+    raw = str(value or "default")
+    if "\\" in raw or "//" in raw or any(ord(ch) < 32 for ch in raw):
+        raise ValueError("run_batch.work_root_namespace is malformed")
+    parts = raw.split("/")
+    if not parts or any(part in {"", ".", ".."} or not _COMPONENT.fullmatch(part) for part in parts):
+        raise ValueError("run_batch.work_root_namespace is malformed")
+    return "/".join(parts)
+
+
+def resolve_batch_paths(
+    run_settings: dict, cfg_dir: Path, *, env: Mapping[str, str] | None = None
+) -> BatchPaths:
+    environment = os.environ if env is None else env
+    cfg_dir = cfg_dir.resolve()
+    output_dir = _resolve(run_settings.get("output_dir", DEFAULT_OUTPUT_DIR), cfg_dir)
+    hosted = environment.get("DIGITALMODEL_EXECUTION_CONTEXT") == HOSTED_CONTEXT
+    if hosted:
+        if "work_root" in run_settings:
+            raise ValueError("hosted run_batch.work_root is forbidden; operator environment owns the root")
+        root = environment.get("DIGITALMODEL_WORK_ROOT", "")
+        operator_root = _validated_root(root, "DIGITALMODEL_WORK_ROOT")
+        return BatchPaths(HOSTED_CONTEXT, cfg_dir, output_dir, operator_root,
+                          validate_namespace(run_settings.get("work_root_namespace")), None)
+    context = run_settings.get("execution_context")
+    if context == TRUSTED_LOCAL_CONTEXT:
+        operator_root = _validated_root(run_settings.get("work_root", ""), "run_batch.work_root")
+        if _inside_git_checkout(operator_root):
+            raise ValueError("run_batch.work_root must be outside every Git checkout")
+        return BatchPaths(TRUSTED_LOCAL_CONTEXT, cfg_dir, output_dir, operator_root,
+                          validate_namespace(run_settings.get("work_root_namespace")), None)
+    if context not in (None, ""):
+        raise ValueError(f"unsupported run_batch.execution_context {context!r}")
+    work_dir = _resolve(run_settings.get("work_dir", DEFAULT_WORK_DIR), cfg_dir)
+    return BatchPaths("legacy", cfg_dir, output_dir, None, "", work_dir)
+
+
+def _resolve(value: object, base: Path) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else base / path
+
+
+def _validated_root(value: object, label: str) -> Path:
+    path = Path(str(value))
+    if not str(value) or not path.is_absolute() or not path.is_dir():
+        raise ValueError(f"{label} must name a precreated absolute directory")
+    if _has_symlink_component(path):
+        raise ValueError(f"{label} may not contain symlink components")
+    if not os.access(path, os.W_OK):
+        raise ValueError(f"{label} is not writable")
+    return path.resolve()
+
+
+def _has_symlink_component(path: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def _inside_git_checkout(path: Path) -> bool:
+    current = path.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return True
+    return False

--- a/src/digitalmodel/workflows/openfoam_batch_config.py
+++ b/src/digitalmodel/workflows/openfoam_batch_config.py
@@ -105,6 +105,7 @@ def resolve_batch_paths(
             raise ValueError("hosted run_batch.work_root is forbidden; operator environment owns the root")
         root = environment.get("DIGITALMODEL_WORK_ROOT", "")
         operator_root = _validated_root(root, "DIGITALMODEL_WORK_ROOT")
+        output_dir = _input_local_output(run_settings, cfg_dir)
         return BatchPaths(HOSTED_CONTEXT, cfg_dir, output_dir, operator_root,
                           validate_namespace(run_settings.get("work_root_namespace")), None)
     context = run_settings.get("execution_context")
@@ -112,6 +113,7 @@ def resolve_batch_paths(
         operator_root = _validated_root(run_settings.get("work_root", ""), "run_batch.work_root")
         if _inside_git_checkout(operator_root):
             raise ValueError("run_batch.work_root must be outside every Git checkout")
+        output_dir = _input_local_output(run_settings, cfg_dir)
         return BatchPaths(TRUSTED_LOCAL_CONTEXT, cfg_dir, output_dir, operator_root,
                           validate_namespace(run_settings.get("work_root_namespace")), None)
     if context not in (None, ""):
@@ -123,6 +125,17 @@ def resolve_batch_paths(
 def _resolve(value: object, base: Path) -> Path:
     path = Path(str(value))
     return path if path.is_absolute() else base / path
+
+
+def _input_local_output(run_settings: dict, cfg_dir: Path) -> Path:
+    raw = Path(str(run_settings.get("output_dir", DEFAULT_OUTPUT_DIR)))
+    candidate = raw if raw.is_absolute() else cfg_dir / raw
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(cfg_dir)
+    except ValueError as exc:
+        raise ValueError("external-mode output_dir must remain input-local") from exc
+    return resolved
 
 
 def _validated_root(value: object, label: str) -> Path:

--- a/src/digitalmodel/workflows/openfoam_batch_execution.py
+++ b/src/digitalmodel/workflows/openfoam_batch_execution.py
@@ -67,17 +67,19 @@ def write_checkpoint(work_dir: Path, row: dict[str, Any], *,
 
 def run_cases(rendered: list[dict[str, Any]], run_settings: dict, *, mode: str,
               workers: int, mock: bool, layout: WorkLayout | None = None,
-              builder: Callable[[dict[str, Any]], Path] | None = None) -> list[dict[str, Any]]:
+              builder: Callable[[dict[str, Any]], Path] | None = None,
+              tool_bindings: dict[str, tuple[Path, str]] | None = None) -> list[dict[str, Any]]:
     build = builder or build_case
     if mode == "mpi":
         if len(rendered) != 1:
             raise ValueError("openfoam_run_batch mode: mpi runs exactly ONE case")
         return [run_case_mpi(rendered[0], run_settings, workers, mock,
-                             layout=layout, builder=build)]
+                             layout=layout, builder=build, tool_bindings=tool_bindings)]
     rows: dict[int, dict[str, Any]] = {}
     with ThreadPoolExecutor(max_workers=min(workers, len(rendered))) as pool:
         futures = {pool.submit(run_case_pool, item, run_settings, mock,
-                               layout=layout, builder=build): item
+                               layout=layout, builder=build,
+                               tool_bindings=tool_bindings): item
                    for item in rendered}
         for future, item in futures.items():
             try:
@@ -89,7 +91,8 @@ def run_cases(rendered: list[dict[str, Any]], run_settings: dict, *, mode: str,
 
 def run_case_pool(item: dict[str, Any], run_settings: dict, mock: bool,
                   *, layout: WorkLayout | None = None,
-                  builder: Callable[[dict[str, Any]], Path] | None = None) -> dict[str, Any]:
+                  builder: Callable[[dict[str, Any]], Path] | None = None,
+                  tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     build = builder or build_case
     with _case_lock(layout, item["name"]):
         checkpoint = _checkpoint(item, layout)
@@ -101,7 +104,7 @@ def run_case_pool(item: dict[str, Any], run_settings: dict, mock: bool,
             case_dir = build(item)
             result = (row(item, status="completed", case_dir=case_dir,
                           solver=item["settings"].get("solver"), mock=True)
-                      if mock else solve_serial(item, case_dir, run_settings))
+                      if mock else solve_serial(item, case_dir, run_settings, tool_bindings))
         except Exception as exc:  # noqa: BLE001
             result = row(item, status="failed", error=str(exc))
         result["wall_seconds"] = round(time.monotonic() - start, 3)
@@ -109,7 +112,8 @@ def run_case_pool(item: dict[str, Any], run_settings: dict, mock: bool,
 
 
 def solve_serial(item: dict[str, Any], case_dir: Path,
-                 run_settings: dict) -> dict[str, Any]:
+                 run_settings: dict,
+                 tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     from digitalmodel.solvers.openfoam.runner import OpenFOAMRunConfig, OpenFOAMRunner
     settings = item["settings"]
     config = OpenFOAMRunConfig(
@@ -120,7 +124,11 @@ def solve_serial(item: dict[str, Any], case_dir: Path,
         to_vtk=bool(settings.get("to_vtk", False)),
         timeout_seconds=int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)),
     )
-    result = OpenFOAMRunner(config).run(case_dir)
+    verifier = None
+    if tool_bindings:
+        def verifier(name: str) -> None:
+            _verify_executable(*tool_bindings[name])
+    result = OpenFOAMRunner(config, executable_verifier=verifier).run(case_dir)
     status = str(getattr(result.status, "value", result.status)).lower()
     if status == "completed":
         return row(item, status="completed", case_dir=case_dir, solver=result.solver)
@@ -131,20 +139,22 @@ def solve_serial(item: dict[str, Any], case_dir: Path,
 def run_case_mpi(item: dict[str, Any], run_settings: dict, workers: int,
                  mock: bool, command_runner: Callable[..., int] | None = None,
                  *, layout: WorkLayout | None = None,
-                 builder: Callable[[dict[str, Any]], Path] | None = None) -> dict[str, Any]:
+                 builder: Callable[[dict[str, Any]], Path] | None = None,
+                 tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     build = builder or build_case
     with _case_lock(layout, item["name"]):
         checkpoint = _checkpoint(item, layout)
         if checkpoint is not None:
             return checkpoint
         return _run_case_mpi_unlocked(item, run_settings, workers, mock,
-                                      command_runner, layout, build)
+                                      command_runner, layout, build, tool_bindings)
 
 
 def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: int,
                            mock: bool, command_runner: Callable[..., int] | None,
                            layout: WorkLayout | None,
-                           builder: Callable[[dict[str, Any]], Path]) -> dict[str, Any]:
+                           builder: Callable[[dict[str, Any]], Path],
+                           tool_bindings: dict[str, tuple[Path, str]] | None) -> dict[str, Any]:
     solver = item["settings"].get("solver")
     if not solver:
         return _save(item, row(item, status="failed", error="mode: mpi requires base.solver"), layout)
@@ -160,11 +170,16 @@ def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: in
             result = row(item, status="completed", case_dir=case_dir, solver=solver, mock=True)
             result["mpi_plan"] = [" ".join(argv) for argv in plan]
         else:
+            for binding in (tool_bindings or {}).values():
+                _verify_executable(*binding)
             if not resume:
                 write_decompose_par_dict(case_dir, workers)
             result = execute_mpi_plan(item, case_dir, plan, solver,
                 command_runner or run_command,
-                int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)))
+                int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)),
+                tool_bindings=tool_bindings)
+            for binding in (tool_bindings or {}).values():
+                _verify_executable(*binding)
             if reconstruct and result["status"] == "completed":
                 _prune(item, layout)
     except Exception as exc:  # noqa: BLE001
@@ -174,9 +189,13 @@ def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: in
 
 
 def execute_mpi_plan(item: dict[str, Any], case_dir: Path, plan: list[list[str]],
-                     solver: str, run: Callable[..., int], timeout: int) -> dict[str, Any]:
+                     solver: str, run: Callable[..., int], timeout: int,
+                     *, tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     for argv in plan:
-        rc = run(argv, case_dir, case_dir / f"log.{argv[0]}", timeout)
+        binding = (tool_bindings or {}).get(argv[0])
+        rc = run(argv, case_dir, case_dir / f"log.{argv[0]}", timeout,
+                 expected_executable=binding) if binding else run(
+                     argv, case_dir, case_dir / f"log.{argv[0]}", timeout)
         if rc:
             return row(item, status="failed", case_dir=case_dir, solver=solver,
                        error=f"stage '{argv[0]}' returned non-zero exit code {rc}")

--- a/src/digitalmodel/workflows/openfoam_batch_execution.py
+++ b/src/digitalmodel/workflows/openfoam_batch_execution.py
@@ -26,22 +26,27 @@ DEFAULT_TIMEOUT_SECONDS = 43200
 
 
 def make_checkpoint(*, identity_sha256: str, owner_token: str, case: str,
-                    row: dict[str, Any]) -> dict[str, Any]:
-    return {"schema": 2, "identity_sha256": identity_sha256,
+                    row: dict[str, Any], run_identity: dict | None = None) -> dict[str, Any]:
+    identity = run_identity or {"identity_sha256": identity_sha256}
+    return {"schema": 2, "identity_sha256": identity_sha256, "run_identity": identity,
             "owner_token": owner_token, "case": case, "row": row}
 
 
 def checkpoint_matches(payload: object, identity_sha256: str,
-                       owner_token: str, case: str) -> bool:
+                       owner_token: str, case: str,
+                       run_identity: dict | None = None) -> bool:
     return (isinstance(payload, dict) and payload.get("schema") == 2
             and payload.get("identity_sha256") == identity_sha256
             and payload.get("owner_token") == owner_token
+            and payload.get("run_identity") == (run_identity or {
+                "identity_sha256": identity_sha256})
             and payload.get("case") == case and isinstance(payload.get("row"), dict)
             and payload["row"].get("status") == "completed")
 
 
 def load_checkpoint(work_dir: Path, *, identity_sha256: str | None = None,
-                    owner_token: str | None = None, case: str | None = None) -> dict[str, Any] | None:
+                    owner_token: str | None = None, case: str | None = None,
+                    run_identity: dict | None = None) -> dict[str, Any] | None:
     path = work_dir / CHECKPOINT_FILENAME
     try:
         payload = json.loads(path.read_text())
@@ -49,16 +54,18 @@ def load_checkpoint(work_dir: Path, *, identity_sha256: str | None = None,
         return None
     if identity_sha256 is None:  # legacy compatibility
         return payload if isinstance(payload, dict) and payload.get("status") == "completed" else None
-    return payload["row"] if checkpoint_matches(payload, identity_sha256, owner_token or "", case or "") else None
+    return payload["row"] if checkpoint_matches(
+        payload, identity_sha256, owner_token or "", case or "", run_identity) else None
 
 
 def write_checkpoint(work_dir: Path, row: dict[str, Any], *,
                      identity_sha256: str | None = None,
-                     owner_token: str | None = None, case: str | None = None) -> None:
+                     owner_token: str | None = None, case: str | None = None,
+                     run_identity: dict | None = None) -> None:
     work_dir.mkdir(parents=True, exist_ok=True)
     payload = row if identity_sha256 is None else make_checkpoint(
         identity_sha256=identity_sha256, owner_token=owner_token or "",
-        case=case or "", row=row)
+        case=case or "", row=row, run_identity=run_identity)
     target = work_dir / CHECKPOINT_FILENAME
     tmp = work_dir / f"{CHECKPOINT_FILENAME}.{os.getpid()}.tmp"
     tmp.write_text(json.dumps(payload, indent=2) + "\n")
@@ -126,8 +133,9 @@ def solve_serial(item: dict[str, Any], case_dir: Path,
     )
     verifier = None
     if tool_bindings:
-        def verifier(name: str) -> None:
+        def verifier(name: str) -> Path:
             _verify_executable(*tool_bindings[name])
+            return tool_bindings[name][0]
     result = OpenFOAMRunner(config, executable_verifier=verifier).run(case_dir)
     status = str(getattr(result.status, "value", result.status)).lower()
     if status == "completed":
@@ -193,9 +201,18 @@ def execute_mpi_plan(item: dict[str, Any], case_dir: Path, plan: list[list[str]]
                      *, tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     for argv in plan:
         binding = (tool_bindings or {}).get(argv[0])
-        rc = run(argv, case_dir, case_dir / f"log.{argv[0]}", timeout,
+        launched = list(argv)
+        if binding:
+            launched[0] = str(binding[0])
+        indirect = (tool_bindings or {}).get(solver) if argv[0] == "mpirun" else None
+        if indirect:
+            _verify_executable(*indirect)
+            launched = [str(indirect[0]) if value == solver else value for value in launched]
+        rc = run(launched, case_dir, case_dir / f"log.{argv[0]}", timeout,
                  expected_executable=binding) if binding else run(
-                     argv, case_dir, case_dir / f"log.{argv[0]}", timeout)
+                     launched, case_dir, case_dir / f"log.{argv[0]}", timeout)
+        if indirect:
+            _verify_executable(*indirect)
         if rc:
             return row(item, status="failed", case_dir=case_dir, solver=solver,
                        error=f"stage '{argv[0]}' returned non-zero exit code {rc}")
@@ -227,7 +244,8 @@ def _checkpoint(item: dict[str, Any], layout: WorkLayout | None) -> dict[str, An
     if layout is None:
         return load_checkpoint(item["work_dir"])
     return load_checkpoint(item["work_dir"], identity_sha256=layout.identity_sha256,
-                           owner_token=layout.owner_token, case=item["name"])
+                           owner_token=layout.owner_token, case=item["name"],
+                           run_identity=layout.run_identity)
 
 
 def _save(item: dict[str, Any], result: dict[str, Any],
@@ -237,7 +255,8 @@ def _save(item: dict[str, Any], result: dict[str, Any],
         return result
     safe = redact_rows([result], layout.operator_root)[0]
     write_checkpoint(item["work_dir"], safe, identity_sha256=layout.identity_sha256,
-                     owner_token=layout.owner_token, case=item["name"])
+                     owner_token=layout.owner_token, case=item["name"],
+                     run_identity=layout.run_identity)
     return safe
 
 

--- a/src/digitalmodel/workflows/openfoam_batch_execution.py
+++ b/src/digitalmodel/workflows/openfoam_batch_execution.py
@@ -1,0 +1,299 @@
+"""Execution and checkpoint helpers for OpenFOAM batch runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from typing import Any, Callable
+
+from loguru import logger
+
+from digitalmodel.workflows.openfoam_batch_identity import file_sha256
+from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
+from digitalmodel.workflows.openfoam_batch_results import redact_rows, row
+
+
+CHECKPOINT_FILENAME = "_result.json"
+DEFAULT_MESH_UTILITY = "blockMesh"
+DEFAULT_TIMEOUT_SECONDS = 43200
+
+
+def make_checkpoint(*, identity_sha256: str, owner_token: str, case: str,
+                    row: dict[str, Any]) -> dict[str, Any]:
+    return {"schema": 2, "identity_sha256": identity_sha256,
+            "owner_token": owner_token, "case": case, "row": row}
+
+
+def checkpoint_matches(payload: object, identity_sha256: str,
+                       owner_token: str, case: str) -> bool:
+    return (isinstance(payload, dict) and payload.get("schema") == 2
+            and payload.get("identity_sha256") == identity_sha256
+            and payload.get("owner_token") == owner_token
+            and payload.get("case") == case and isinstance(payload.get("row"), dict)
+            and payload["row"].get("status") == "completed")
+
+
+def load_checkpoint(work_dir: Path, *, identity_sha256: str | None = None,
+                    owner_token: str | None = None, case: str | None = None) -> dict[str, Any] | None:
+    path = work_dir / CHECKPOINT_FILENAME
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if identity_sha256 is None:  # legacy compatibility
+        return payload if isinstance(payload, dict) and payload.get("status") == "completed" else None
+    return payload["row"] if checkpoint_matches(payload, identity_sha256, owner_token or "", case or "") else None
+
+
+def write_checkpoint(work_dir: Path, row: dict[str, Any], *,
+                     identity_sha256: str | None = None,
+                     owner_token: str | None = None, case: str | None = None) -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    payload = row if identity_sha256 is None else make_checkpoint(
+        identity_sha256=identity_sha256, owner_token=owner_token or "",
+        case=case or "", row=row)
+    target = work_dir / CHECKPOINT_FILENAME
+    tmp = work_dir / f"{CHECKPOINT_FILENAME}.{os.getpid()}.tmp"
+    tmp.write_text(json.dumps(payload, indent=2) + "\n")
+    os.replace(tmp, target)
+
+
+def run_cases(rendered: list[dict[str, Any]], run_settings: dict, *, mode: str,
+              workers: int, mock: bool, layout: WorkLayout | None = None,
+              builder: Callable[[dict[str, Any]], Path] | None = None) -> list[dict[str, Any]]:
+    build = builder or build_case
+    if mode == "mpi":
+        if len(rendered) != 1:
+            raise ValueError("openfoam_run_batch mode: mpi runs exactly ONE case")
+        return [run_case_mpi(rendered[0], run_settings, workers, mock,
+                             layout=layout, builder=build)]
+    rows: dict[int, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=min(workers, len(rendered))) as pool:
+        futures = {pool.submit(run_case_pool, item, run_settings, mock,
+                               layout=layout, builder=build): item
+                   for item in rendered}
+        for future, item in futures.items():
+            try:
+                rows[item["index"]] = future.result()
+            except Exception as exc:  # noqa: BLE001
+                rows[item["index"]] = row(item, status="failed", error=str(exc))
+    return [rows[item["index"]] for item in rendered]
+
+
+def run_case_pool(item: dict[str, Any], run_settings: dict, mock: bool,
+                  *, layout: WorkLayout | None = None,
+                  builder: Callable[[dict[str, Any]], Path] | None = None) -> dict[str, Any]:
+    build = builder or build_case
+    with _case_lock(layout, item["name"]):
+        checkpoint = _checkpoint(item, layout)
+        if checkpoint is not None:
+            return checkpoint
+        start = time.monotonic()
+        try:
+            _clean(item, layout)
+            case_dir = build(item)
+            result = (row(item, status="completed", case_dir=case_dir,
+                          solver=item["settings"].get("solver"), mock=True)
+                      if mock else solve_serial(item, case_dir, run_settings))
+        except Exception as exc:  # noqa: BLE001
+            result = row(item, status="failed", error=str(exc))
+        result["wall_seconds"] = round(time.monotonic() - start, 3)
+        return _save(item, result, layout)
+
+
+def solve_serial(item: dict[str, Any], case_dir: Path,
+                 run_settings: dict) -> dict[str, Any]:
+    from digitalmodel.solvers.openfoam.runner import OpenFOAMRunConfig, OpenFOAMRunner
+    settings = item["settings"]
+    config = OpenFOAMRunConfig(
+        solver=settings.get("solver"),
+        mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
+        run_snappy=bool(settings.get("run_snappy", False)),
+        run_set_fields=bool(settings.get("run_set_fields", False)),
+        to_vtk=bool(settings.get("to_vtk", False)),
+        timeout_seconds=int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)),
+    )
+    result = OpenFOAMRunner(config).run(case_dir)
+    status = str(getattr(result.status, "value", result.status)).lower()
+    if status == "completed":
+        return row(item, status="completed", case_dir=case_dir, solver=result.solver)
+    return row(item, status="failed", case_dir=case_dir, solver=result.solver,
+               error=result.error_message or f"runner status {status}")
+
+
+def run_case_mpi(item: dict[str, Any], run_settings: dict, workers: int,
+                 mock: bool, command_runner: Callable[..., int] | None = None,
+                 *, layout: WorkLayout | None = None,
+                 builder: Callable[[dict[str, Any]], Path] | None = None) -> dict[str, Any]:
+    build = builder or build_case
+    with _case_lock(layout, item["name"]):
+        checkpoint = _checkpoint(item, layout)
+        if checkpoint is not None:
+            return checkpoint
+        return _run_case_mpi_unlocked(item, run_settings, workers, mock,
+                                      command_runner, layout, build)
+
+
+def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: int,
+                           mock: bool, command_runner: Callable[..., int] | None,
+                           layout: WorkLayout | None,
+                           builder: Callable[[dict[str, Any]], Path]) -> dict[str, Any]:
+    solver = item["settings"].get("solver")
+    if not solver:
+        return _save(item, row(item, status="failed", error="mode: mpi requires base.solver"), layout)
+    reconstruct = bool(run_settings.get("reconstruct", True))
+    resume = bool(run_settings.get("resume", False)) and _has_processors(item["work_dir"])
+    start = time.monotonic()
+    try:
+        case_dir = _prepare_mpi_case(item, resume, layout, builder)
+        plan = mpi_command_plan(solver, workers,
+            item["settings"].get("mesh_utility", DEFAULT_MESH_UTILITY),
+            bool(item["settings"].get("run_set_fields", False)), reconstruct, resume)
+        if mock:
+            result = row(item, status="completed", case_dir=case_dir, solver=solver, mock=True)
+            result["mpi_plan"] = [" ".join(argv) for argv in plan]
+        else:
+            if not resume:
+                write_decompose_par_dict(case_dir, workers)
+            result = execute_mpi_plan(item, case_dir, plan, solver,
+                command_runner or run_command,
+                int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)))
+            if reconstruct and result["status"] == "completed":
+                _prune(item, layout)
+    except Exception as exc:  # noqa: BLE001
+        result = row(item, status="failed", error=str(exc))
+    result["wall_seconds"] = round(time.monotonic() - start, 3)
+    return _save(item, result, layout)
+
+
+def execute_mpi_plan(item: dict[str, Any], case_dir: Path, plan: list[list[str]],
+                     solver: str, run: Callable[..., int], timeout: int) -> dict[str, Any]:
+    for argv in plan:
+        rc = run(argv, case_dir, case_dir / f"log.{argv[0]}", timeout)
+        if rc:
+            return row(item, status="failed", case_dir=case_dir, solver=solver,
+                       error=f"stage '{argv[0]}' returned non-zero exit code {rc}")
+    return row(item, status="completed", case_dir=case_dir, solver=solver)
+
+
+def build_case(item: dict[str, Any]) -> Path:
+    from digitalmodel.solvers.openfoam.workflow import OpenFOAMWorkflow
+    settings = deepcopy(item["settings"])
+    settings["operation"] = "build_case"
+    config = {"basename": "openfoam",
+              "Analysis": {"result_folder": str(item["work_dir"].parent)},
+              "openfoam": settings}
+    OpenFOAMWorkflow().router(config)
+    return Path(config["openfoam"]["case_dir"])
+
+
+def _prepare_mpi_case(item: dict[str, Any], resume: bool,
+                      layout: WorkLayout | None,
+                      builder: Callable[[dict[str, Any]], Path]) -> Path:
+    if resume:
+        set_start_from_latest_time(item["work_dir"])
+        return item["work_dir"]
+    _clean(item, layout)
+    return builder(item)
+
+
+def _checkpoint(item: dict[str, Any], layout: WorkLayout | None) -> dict[str, Any] | None:
+    if layout is None:
+        return load_checkpoint(item["work_dir"])
+    return load_checkpoint(item["work_dir"], identity_sha256=layout.identity_sha256,
+                           owner_token=layout.owner_token, case=item["name"])
+
+
+def _save(item: dict[str, Any], result: dict[str, Any],
+          layout: WorkLayout | None) -> dict[str, Any]:
+    if layout is None:
+        write_checkpoint(item["work_dir"], result)
+        return result
+    safe = redact_rows([result], layout.operator_root)[0]
+    write_checkpoint(item["work_dir"], safe, identity_sha256=layout.identity_sha256,
+                     owner_token=layout.owner_token, case=item["name"])
+    return safe
+
+
+def _clean(item: dict[str, Any], layout: WorkLayout | None) -> None:
+    if layout is not None:
+        layout.clean_case(item["name"])
+    elif item["work_dir"].is_dir():
+        shutil.rmtree(item["work_dir"], ignore_errors=True)
+
+
+def _prune(item: dict[str, Any], layout: WorkLayout | None) -> None:
+    if layout is not None:
+        layout.prune_processors(item["name"])
+    else:
+        for path in item["work_dir"].glob("processor*"):
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _has_processors(case_dir: Path) -> bool:
+    return case_dir.is_dir() and any(case_dir.glob("processor*"))
+
+
+def _case_lock(layout: WorkLayout | None, case: str):
+    from contextlib import nullcontext
+    return layout.lock(f"case-{case}") if layout is not None else nullcontext()
+
+
+def mpi_command_plan(solver: str, workers: int, mesh_utility: str = DEFAULT_MESH_UTILITY,
+                     run_set_fields: bool = False, reconstruct: bool = True,
+                     resume: bool = False) -> list[list[str]]:
+    plan: list[list[str]] = []
+    if not resume:
+        plan.append([mesh_utility])
+        if run_set_fields:
+            plan.append(["setFields"])
+        plan.append(["decomposePar", "-force"])
+    plan.append(["mpirun", "-np", str(workers), "--oversubscribe", solver, "-parallel"])
+    if reconstruct:
+        plan.append(["reconstructPar"])
+    return plan
+
+
+def run_command(argv: list[str], cwd: Path, log: Path, timeout: int,
+                expected_executable: tuple[Path, str] | None = None) -> int:
+    if expected_executable is not None:
+        _verify_executable(*expected_executable)
+    try:
+        with log.open("w") as stream:
+            proc = subprocess.run(argv, cwd=str(cwd), stdout=stream,
+                                  stderr=subprocess.STDOUT, timeout=timeout, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("openfoam_run_batch: {} invocation failed: {}", argv[0], exc)
+        return 1
+    if expected_executable is not None:
+        _verify_executable(*expected_executable)
+    return proc.returncode
+
+
+def write_decompose_par_dict(case_dir: Path, workers: int) -> None:
+    text = ("FoamFile { version 2.0; format ascii; class dictionary; "
+            "object decomposeParDict; }\n\n"
+            f"numberOfSubdomains {workers};\nmethod scotch;\n")
+    (case_dir / "system" / "decomposeParDict").write_text(text)
+
+
+def set_start_from_latest_time(case_dir: Path) -> None:
+    control = case_dir / "system" / "controlDict"
+    if not control.is_file():
+        raise RuntimeError("resume requested but system/controlDict is missing")
+    text = control.read_text()
+    patched = re.sub(r"startFrom\s+\w+\s*;", "startFrom       latestTime;", text)
+    control.write_text(patched if patched != text or "startFrom" in text
+                       else text + "\nstartFrom       latestTime;\n")
+
+
+def _verify_executable(path: Path, expected_sha256: str) -> None:
+    if not path.is_file() or path.is_symlink() or file_sha256(path) != expected_sha256:
+        raise RuntimeError(f"selected executable {path.name!r} changed before/during launch")

--- a/src/digitalmodel/workflows/openfoam_batch_identity.py
+++ b/src/digitalmodel/workflows/openfoam_batch_identity.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import base64
+import csv
 import hashlib
 import importlib.metadata
 import json
@@ -63,11 +65,50 @@ def build_run_identity(
 
 
 def file_sha256(path: Path) -> str:
+    before = path.stat(follow_symlinks=False)
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
+    after = path.stat(follow_symlinks=False)
+    if (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (
+            after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+        raise ValueError(f"file changed while hashing: {path.name}")
     return digest.hexdigest()
+
+
+def verify_wheel_record(package_root: Path, record_path: Path) -> dict[str, Any]:
+    package_root = Path(package_root).resolve()
+    record_path = Path(record_path).resolve()
+    install_root = record_path.parent.parent
+    verified: dict[str, str] = {}
+    try:
+        rows = list(csv.reader(record_path.read_text().splitlines()))
+    except (OSError, csv.Error) as exc:
+        raise ValueError("wheel RECORD is unreadable") from exc
+    for row in rows:
+        if len(row) != 3:
+            raise ValueError("wheel RECORD row is malformed")
+        relative, encoded_hash, encoded_size = row
+        path = (install_root / relative).resolve()
+        if path == record_path and not encoded_hash and not encoded_size:
+            continue
+        if not encoded_hash.startswith("sha256=") or not encoded_size.isdigit():
+            raise ValueError("wheel RECORD lacks sha256 or size")
+        if not path.is_file() or path.is_symlink() or path.stat().st_size != int(encoded_size):
+            raise ValueError("wheel RECORD size/file mismatch")
+        expected = encoded_hash.split("=", 1)[1]
+        actual = base64.urlsafe_b64encode(bytes.fromhex(file_sha256(path))).rstrip(b"=").decode()
+        if actual != expected:
+            raise ValueError("wheel RECORD hash mismatch")
+        verified[relative] = file_sha256(path)
+    package_files = {path.relative_to(install_root).as_posix()
+                     for path in package_root.rglob("*") if path.is_file()}
+    if not package_files.issubset(verified):
+        raise ValueError("wheel RECORD omits installed package files")
+    content = _sha_bytes(_canonical(verified).encode())
+    return {"package_name": "digitalmodel", "package_version": record_path.parent.name,
+            "content_sha256": content, "wheel_record_verified": True}
 
 
 def _file_record(role: str, path: Path, *, input_file: bool) -> dict[str, Any]:
@@ -83,7 +124,27 @@ def _file_record(role: str, path: Path, *, input_file: bool) -> dict[str, Any]:
 
 def _source_record(package_root: Path) -> dict[str, Any]:
     root = Path(package_root)
-    files = sorted(path for path in root.rglob("*.py") if path.is_file() and not path.is_symlink())
+    tracked = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--", "."],
+        capture_output=True,
+    )
+    if tracked.returncode == 0 and tracked.stdout:
+        status = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain", "--untracked-files=all", "--", "."],
+            capture_output=True, text=True,
+        )
+        if status.returncode or status.stdout.strip():
+            raise ValueError("digitalmodel package source is dirty")
+        files = [root / Path(item.decode())
+                 for item in tracked.stdout.split(b"\0") if item]
+    else:
+        records = sorted(root.parent.glob("digitalmodel-*.dist-info/RECORD"))
+        if records:
+            wheel = verify_wheel_record(root, records[0])
+            return {"git_commit_sha": "installed-wheel", "tracked_tree_clean": True,
+                    **wheel}
+        files = sorted(path for path in root.rglob("*.py")
+                       if path.is_file() and not path.is_symlink())
     digest = hashlib.sha256()
     for path in files:
         rel = path.relative_to(root).as_posix()
@@ -92,7 +153,7 @@ def _source_record(package_root: Path) -> dict[str, Any]:
         version = importlib.metadata.version("digitalmodel")
     except importlib.metadata.PackageNotFoundError:
         version = "source"
-    return {"git_commit_sha": _git_sha(root), "tracked_tree_clean": _git_clean(root),
+    return {"git_commit_sha": _git_sha(root), "tracked_tree_clean": True,
             "package_name": "digitalmodel", "package_version": version,
             "content_sha256": digest.hexdigest()}
 

--- a/src/digitalmodel/workflows/openfoam_batch_identity.py
+++ b/src/digitalmodel/workflows/openfoam_batch_identity.py
@@ -116,10 +116,24 @@ def _file_record(role: str, path: Path, *, input_file: bool) -> dict[str, Any]:
     label = "referenced input" if input_file else "selected executable"
     if not path.is_file() or path.is_symlink():
         raise ValueError(f"{label} is missing or symlinked: {path.name}")
+    if input_file:
+        _assert_git_clean_path(path)
     record = {"role": str(role), "size_bytes": path.stat().st_size,
               "content_sha256": file_sha256(path)}
     record["safe_relative_path" if input_file else "basename"] = path.name
     return record
+
+
+def _assert_git_clean_path(path: Path) -> None:
+    probe = subprocess.run(["git", "-C", str(path.parent), "rev-parse", "--is-inside-work-tree"],
+                           capture_output=True, text=True)
+    if probe.returncode:
+        return
+    status = subprocess.run(
+        ["git", "-C", str(path.parent), "status", "--porcelain",
+         "--untracked-files=all", "--", path.name], capture_output=True, text=True)
+    if status.returncode or status.stdout.strip():
+        raise ValueError(f"referenced input is dirty: {path.name}")
 
 
 def _source_record(package_root: Path) -> dict[str, Any]:

--- a/src/digitalmodel/workflows/openfoam_batch_identity.py
+++ b/src/digitalmodel/workflows/openfoam_batch_identity.py
@@ -1,0 +1,117 @@
+"""Content-bound run identity for reusable external OpenFOAM work."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+import subprocess
+from typing import Any, Iterable
+
+
+IDENTITY_KIND = "digitalmodel-openfoam-batch"
+RESULT_POLICY_VERSION = "result-policy-v1"
+WORK_LAYOUT_VERSION = "work-layout-v1"
+
+
+@dataclass(frozen=True)
+class RunIdentity:
+    schema_version: int
+    identity_kind: str
+    source: dict[str, Any]
+    effective_config_sha256: str
+    referenced_inputs: list[dict[str, Any]]
+    selected_executables: list[dict[str, Any]]
+    host_capabilities: dict[str, int]
+    result_policy_version: str
+    work_layout_version: str
+    identity_sha256: str
+
+    def canonical_json(self) -> str:
+        return _canonical(asdict(self))
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_run_identity(
+    *, effective_config: dict[str, Any],
+    referenced_inputs: Iterable[tuple[str, Path]],
+    selected_executables: Iterable[tuple[str, Path]],
+    visible_rank_count: int, dispatcher_rank_limit: int,
+    package_root: Path,
+) -> RunIdentity:
+    inputs = [_file_record(role, path, input_file=True) for role, path in referenced_inputs]
+    tools = [_file_record(role, path, input_file=False) for role, path in selected_executables]
+    source = _source_record(package_root)
+    body = {
+        "schema_version": 1,
+        "identity_kind": IDENTITY_KIND,
+        "source": source,
+        "effective_config_sha256": _sha_bytes(_canonical(effective_config).encode()),
+        "referenced_inputs": sorted(inputs, key=lambda item: (item["role"], item.get("safe_relative_path", ""))),
+        "selected_executables": sorted(tools, key=lambda item: (item["role"], item["basename"])),
+        "host_capabilities": {"visible_rank_count": int(visible_rank_count),
+                              "dispatcher_rank_limit": int(dispatcher_rank_limit)},
+        "result_policy_version": RESULT_POLICY_VERSION,
+        "work_layout_version": WORK_LAYOUT_VERSION,
+    }
+    digest = _sha_bytes(_canonical(body).encode())
+    return RunIdentity(**body, identity_sha256=digest)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_record(role: str, path: Path, *, input_file: bool) -> dict[str, Any]:
+    path = Path(path)
+    label = "referenced input" if input_file else "selected executable"
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"{label} is missing or symlinked: {path.name}")
+    record = {"role": str(role), "size_bytes": path.stat().st_size,
+              "content_sha256": file_sha256(path)}
+    record["safe_relative_path" if input_file else "basename"] = path.name
+    return record
+
+
+def _source_record(package_root: Path) -> dict[str, Any]:
+    root = Path(package_root)
+    files = sorted(path for path in root.rglob("*.py") if path.is_file() and not path.is_symlink())
+    digest = hashlib.sha256()
+    for path in files:
+        rel = path.relative_to(root).as_posix()
+        digest.update(rel.encode() + b"\0" + bytes.fromhex(file_sha256(path)))
+    try:
+        version = importlib.metadata.version("digitalmodel")
+    except importlib.metadata.PackageNotFoundError:
+        version = "source"
+    return {"git_commit_sha": _git_sha(root), "tracked_tree_clean": _git_clean(root),
+            "package_name": "digitalmodel", "package_version": version,
+            "content_sha256": digest.hexdigest()}
+
+
+def _git_sha(path: Path) -> str:
+    out = subprocess.run(["git", "-C", str(path), "rev-parse", "HEAD"], capture_output=True, text=True)
+    return out.stdout.strip() if out.returncode == 0 else "not-a-git-checkout"
+
+
+def _git_clean(path: Path) -> bool:
+    out = subprocess.run(["git", "-C", str(path), "status", "--porcelain", "--untracked-files=no"],
+                         capture_output=True, text=True)
+    return out.returncode == 0 and not out.stdout.strip()
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+                      allow_nan=False)
+
+
+def _sha_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()

--- a/src/digitalmodel/workflows/openfoam_batch_layout.py
+++ b/src/digitalmodel/workflows/openfoam_batch_layout.py
@@ -9,6 +9,9 @@ import os
 from pathlib import Path
 import secrets
 import shutil
+import stat
+import subprocess
+import threading
 import time
 from typing import Iterator
 
@@ -26,9 +29,11 @@ class WorkLayout:
     owner_token: str
     root_device: int
     root_inode: int
+    run_identity: dict
 
     @classmethod
-    def create(cls, operator_root: Path, namespace: str, identity_sha256: str) -> "WorkLayout":
+    def create(cls, operator_root: Path, namespace: str, identity_sha256: str,
+               run_identity: dict | None = None) -> "WorkLayout":
         root = Path(operator_root).resolve()
         if not root.is_dir() or root.is_symlink():
             raise ValueError("operator root must be a real precreated directory")
@@ -58,7 +63,8 @@ class WorkLayout:
         payload = _read_marker(marker)
         _validate_marker(payload, identity_sha256, stat)
         return cls(root, namespace, identity_sha256, run_dir, marker,
-                   payload["owner_token"], stat.st_dev, stat.st_ino)
+                   payload["owner_token"], stat.st_dev, stat.st_ino,
+                   run_identity or {"identity_sha256": identity_sha256})
 
     def case_dir(self, case: str) -> Path:
         if not case or case in {".", ".."} or "/" in case or "\\" in case:
@@ -90,7 +96,7 @@ class WorkLayout:
             if not target.exists():
                 os.replace(tombstone, target)
             raise ValueError("case changed during clean")
-        shutil.rmtree(tombstone)
+        _dispose_tombstone(self.run_dir, tombstone, before)
 
     def prune_processors(self, case: str) -> None:
         self.assert_owned()
@@ -104,16 +110,25 @@ class WorkLayout:
             after = tombstone.stat(follow_symlinks=False)
             if (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino):
                 raise ValueError("processor directory changed during prune")
-            shutil.rmtree(tombstone)
+            _dispose_tombstone(self.run_dir, tombstone, before)
 
     @contextmanager
     def lock(self, name: str, stale_seconds: int = 3600) -> Iterator[None]:
         lock_dir = self.run_dir / ".locks" / name
         self.assert_owned()
         _acquire_lock(lock_dir, self.owner_token, stale_seconds)
+        stop = threading.Event()
+        heartbeat = threading.Thread(
+            target=_heartbeat_lock,
+            args=(lock_dir, self.owner_token, stop, max(1.0, min(30.0, stale_seconds / 3))),
+            daemon=True,
+        )
+        heartbeat.start()
         try:
             yield
         finally:
+            stop.set()
+            heartbeat.join(timeout=5)
             shutil.rmtree(lock_dir, ignore_errors=True)
 
 
@@ -162,7 +177,7 @@ def _acquire_lock(path: Path, owner_token: str, stale_seconds: int) -> None:
             raise RuntimeError(f"lock {path.name!r} has unknown liveness")
         age = time.time() - float(meta.get("heartbeat_epoch", 0))
         same_boot = meta.get("boot_id") == _boot_id()
-        live = same_boot and _process_alive(meta.get("pid"))
+        live = same_boot and _process_matches(meta.get("pid"), meta.get("process_start"))
         if meta.get("owner_token") != owner_token or age <= stale_seconds or live:
             raise RuntimeError(f"lock {path.name!r} is held")
         tombstone = path.with_name(f".stale-{path.name}-{secrets.token_hex(8)}")
@@ -170,35 +185,109 @@ def _acquire_lock(path: Path, owner_token: str, stale_seconds: int) -> None:
         shutil.rmtree(tombstone)
         path.mkdir()
     _atomic_json(path / "meta.json", {"schema": 1, "pid": os.getpid(),
+                 "process_start": _process_start(os.getpid()),
                  "boot_id": _boot_id(), "owner_token": owner_token,
                  "heartbeat_epoch": time.time()})
 
 
+_CACHED_BOOT_ID: str | None = None
+
+
 def _boot_id() -> str:
+    global _CACHED_BOOT_ID
+    if _CACHED_BOOT_ID is not None:
+        return _CACHED_BOOT_ID
     system_id = Path("/proc/sys/kernel/random/boot_id")
     try:
-        return system_id.read_text().strip()
+        value = system_id.read_text().strip()
     except OSError:
-        return f"boot-epoch-{int(time.time() - time.monotonic())}"
+        command = ["powershell", "-NoProfile", "-NonInteractive", "-Command",
+                   "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime.ToFileTimeUtc()"]
+        result = subprocess.run(command, capture_output=True, text=True, timeout=15)
+        if result.returncode or not result.stdout.strip().isdigit():
+            raise RuntimeError("cannot establish stable operating-system boot identity")
+        value = f"windows-filetime-{result.stdout.strip()}"
+    _CACHED_BOOT_ID = value
+    return value
 
 
-def _process_alive(value: object) -> bool:
+def _process_matches(value: object, expected_start: object) -> bool:
     try:
         pid = int(value)
-        if pid <= 0:
+        if pid <= 0 or not isinstance(expected_start, str) or not expected_start:
             return False
-        if os.name == "nt":
-            import ctypes
-            kernel = ctypes.windll.kernel32
-            handle = kernel.OpenProcess(0x1000, False, pid)
-            if not handle:
-                return False
-            code = ctypes.c_ulong()
-            try:
-                return bool(kernel.GetExitCodeProcess(handle, ctypes.byref(code))) and code.value == 259
-            finally:
-                kernel.CloseHandle(handle)
-        os.kill(pid, 0)
+        return _process_start(pid) == expected_start
     except (TypeError, ValueError, OSError):
         return False
-    return True
+
+
+def _process_start(pid: int) -> str:
+    if os.name != "nt":
+        fields = Path(f"/proc/{pid}/stat").read_text().split()
+        return f"proc-start-{fields[21]}"
+    import ctypes
+    kernel = ctypes.windll.kernel32
+    handle = kernel.OpenProcess(0x1000, False, pid)
+    if not handle:
+        raise OSError(f"process {pid} is unavailable")
+    created, exited, kernel_time, user_time = (ctypes.c_ulonglong() for _ in range(4))
+    try:
+        ok = kernel.GetProcessTimes(handle, *(ctypes.byref(value) for value in
+                                             (created, exited, kernel_time, user_time)))
+        if not ok:
+            raise OSError(f"process {pid} start time is unavailable")
+        return f"windows-filetime-{created.value}"
+    finally:
+        kernel.CloseHandle(handle)
+
+
+def _heartbeat_lock(path: Path, owner_token: str, stop: threading.Event,
+                    interval: float) -> None:
+    while not stop.wait(interval):
+        meta_path = path / "meta.json"
+        try:
+            meta = json.loads(meta_path.read_text())
+            if (meta.get("owner_token") != owner_token
+                    or not _process_matches(meta.get("pid"), meta.get("process_start"))):
+                return
+            meta["heartbeat_epoch"] = time.time()
+            _atomic_json(meta_path, meta)
+        except (OSError, ValueError, json.JSONDecodeError):
+            return
+
+
+def _dispose_tombstone(run_dir: Path, tombstone: Path,
+                       expected: os.stat_result) -> None:
+    if os.name == "nt":
+        # Windows lacks Python's descriptor-relative directory mutation APIs.
+        # Keep the atomically quarantined tree instead of risking path deletion.
+        return
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    run_fd = os.open(run_dir, flags)
+    try:
+        tree_fd = os.open(tombstone.name, flags, dir_fd=run_fd)
+        try:
+            actual = os.fstat(tree_fd)
+            if (actual.st_dev, actual.st_ino) != (expected.st_dev, expected.st_ino):
+                raise ValueError("tombstone changed before descriptor deletion")
+            _delete_contents_fd(tree_fd)
+        finally:
+            os.close(tree_fd)
+        os.rmdir(tombstone.name, dir_fd=run_fd)
+    finally:
+        os.close(run_fd)
+
+
+def _delete_contents_fd(directory_fd: int) -> None:
+    for name in os.listdir(directory_fd):
+        info = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if stat.S_ISDIR(info.st_mode):
+            child_fd = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                               dir_fd=directory_fd)
+            try:
+                _delete_contents_fd(child_fd)
+            finally:
+                os.close(child_fd)
+            os.rmdir(name, dir_fd=directory_fd)
+        else:
+            os.unlink(name, dir_fd=directory_fd)

--- a/src/digitalmodel/workflows/openfoam_batch_layout.py
+++ b/src/digitalmodel/workflows/openfoam_batch_layout.py
@@ -8,7 +8,6 @@ import json
 import os
 from pathlib import Path
 import secrets
-import shutil
 import stat
 import subprocess
 import threading
@@ -129,7 +128,8 @@ class WorkLayout:
         finally:
             stop.set()
             heartbeat.join(timeout=5)
-            shutil.rmtree(lock_dir, ignore_errors=True)
+            if lock_dir.exists():
+                _quarantine_and_dispose(lock_dir, "release")
 
 
 def _marker(identity: str, token: str, stat: os.stat_result) -> dict:
@@ -181,8 +181,12 @@ def _acquire_lock(path: Path, owner_token: str, stale_seconds: int) -> None:
         if meta.get("owner_token") != owner_token or age <= stale_seconds or live:
             raise RuntimeError(f"lock {path.name!r} is held")
         tombstone = path.with_name(f".stale-{path.name}-{secrets.token_hex(8)}")
+        before = path.stat(follow_symlinks=False)
         os.replace(path, tombstone)
-        shutil.rmtree(tombstone)
+        after = tombstone.stat(follow_symlinks=False)
+        if not _same_inode(before, after):
+            raise RuntimeError(f"lock {path.name!r} changed during stale reclaim")
+        _dispose_tombstone(path.parent, tombstone, before)
         path.mkdir()
     _atomic_json(path / "meta.json", {"schema": 1, "pid": os.getpid(),
                  "process_start": _process_start(os.getpid()),
@@ -278,16 +282,55 @@ def _dispose_tombstone(run_dir: Path, tombstone: Path,
         os.close(run_fd)
 
 
+def _quarantine_and_dispose(path: Path, label: str) -> None:
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError(f"refusing to dispose substituted {label} directory")
+    before = path.stat(follow_symlinks=False)
+    tombstone = path.with_name(f".{label}-{path.name}-{secrets.token_hex(8)}")
+    os.replace(path, tombstone)
+    after = tombstone.stat(follow_symlinks=False)
+    if not _same_inode(before, after):
+        raise ValueError(f"{label} directory changed during quarantine")
+    _dispose_tombstone(path.parent, tombstone, before)
+
+
+def _same_inode(left: object, right: object) -> bool:
+    return (getattr(left, "st_dev", None), getattr(left, "st_ino", None)) == (
+        getattr(right, "st_dev", None), getattr(right, "st_ino", None))
+
+
 def _delete_contents_fd(directory_fd: int) -> None:
     for name in os.listdir(directory_fd):
-        info = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-        if stat.S_ISDIR(info.st_mode):
-            child_fd = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        expected = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        quarantine = f".delete-{secrets.token_hex(16)}"
+        os.rename(name, quarantine, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+        current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
+        if not _same_inode(expected, current):
+            continue
+        if stat.S_ISDIR(expected.st_mode):
+            child_fd = os.open(quarantine, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
                                dir_fd=directory_fd)
             try:
+                opened = os.fstat(child_fd)
+                if not _same_inode(expected, opened):
+                    continue
                 _delete_contents_fd(child_fd)
             finally:
                 os.close(child_fd)
-            os.rmdir(name, dir_fd=directory_fd)
+            current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
+            if _same_inode(opened, current):
+                os.rmdir(quarantine, dir_fd=directory_fd)
+        elif not stat.S_ISLNK(expected.st_mode):
+            file_fd = os.open(quarantine, os.O_RDONLY | os.O_NOFOLLOW,
+                              dir_fd=directory_fd)
+            try:
+                opened = os.fstat(file_fd)
+            finally:
+                os.close(file_fd)
+            current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
+            if _same_inode(expected, opened) and _same_inode(opened, current):
+                os.unlink(quarantine, dir_fd=directory_fd)
         else:
-            os.unlink(name, dir_fd=directory_fd)
+            # A quarantined link is harmless; leave it rather than introduce a
+            # path-based unlink race into a destructive operation.
+            continue

--- a/src/digitalmodel/workflows/openfoam_batch_layout.py
+++ b/src/digitalmodel/workflows/openfoam_batch_layout.py
@@ -32,15 +32,22 @@ class WorkLayout:
         root = Path(operator_root).resolve()
         if not root.is_dir() or root.is_symlink():
             raise ValueError("operator root must be a real precreated directory")
-        namespace_dir = root.joinpath(*namespace.split("/"))
-        namespace_dir.mkdir(parents=True, exist_ok=True)
+        namespace_dir = root
+        for component in namespace.split("/"):
+            namespace_dir = namespace_dir / component
+            try:
+                namespace_dir.mkdir()
+            except FileExistsError:
+                if namespace_dir.is_symlink() or not namespace_dir.is_dir():
+                    raise ValueError("external namespace contains symlink or non-directory")
         run_dir = namespace_dir / f"openfoam-run-{identity_sha256}"
         created = False
         try:
             run_dir.mkdir()
             created = True
         except FileExistsError:
-            pass
+            if run_dir.is_symlink() or not run_dir.is_dir():
+                raise ValueError("external run directory is a symlink or non-directory")
         marker = run_dir / MARKER
         stat = root.stat()
         if created:
@@ -60,6 +67,10 @@ class WorkLayout:
 
     def assert_owned(self) -> None:
         stat = self.operator_root.stat()
+        if stat.st_dev != self.root_device or stat.st_ino != self.root_inode:
+            raise ValueError("operator root identity changed")
+        if self.run_dir.is_symlink() or not self.run_dir.is_dir():
+            raise ValueError("external run directory changed")
         payload = _read_marker(self.marker_path)
         _validate_marker(payload, self.identity_sha256, stat, self.owner_token)
 
@@ -70,9 +81,12 @@ class WorkLayout:
             return
         if target.is_symlink() or not target.is_dir():
             raise ValueError("refusing to clean a non-directory or symlink case")
+        before = target.stat()
         tombstone = self.run_dir / f".delete-{case}-{secrets.token_hex(8)}"
         os.replace(target, tombstone)
-        if tombstone.is_symlink() or not tombstone.is_dir():
+        after = tombstone.stat(follow_symlinks=False)
+        if (tombstone.is_symlink() or not tombstone.is_dir()
+                or (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino)):
             if not target.exists():
                 os.replace(tombstone, target)
             raise ValueError("case changed during clean")
@@ -84,7 +98,13 @@ class WorkLayout:
         for child in case_dir.glob("processor*") if case_dir.is_dir() else ():
             if child.is_symlink() or not child.is_dir():
                 raise ValueError("refusing to prune substituted processor path")
-            shutil.rmtree(child)
+            before = child.stat()
+            tombstone = self.run_dir / f".delete-{case}-{child.name}-{secrets.token_hex(8)}"
+            os.replace(child, tombstone)
+            after = tombstone.stat(follow_symlinks=False)
+            if (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino):
+                raise ValueError("processor directory changed during prune")
+            shutil.rmtree(tombstone)
 
     @contextmanager
     def lock(self, name: str, stale_seconds: int = 3600) -> Iterator[None]:
@@ -141,11 +161,44 @@ def _acquire_lock(path: Path, owner_token: str, stale_seconds: int) -> None:
         except (OSError, json.JSONDecodeError):
             raise RuntimeError(f"lock {path.name!r} has unknown liveness")
         age = time.time() - float(meta.get("heartbeat_epoch", 0))
-        if meta.get("owner_token") != owner_token or age <= stale_seconds:
+        same_boot = meta.get("boot_id") == _boot_id()
+        live = same_boot and _process_alive(meta.get("pid"))
+        if meta.get("owner_token") != owner_token or age <= stale_seconds or live:
             raise RuntimeError(f"lock {path.name!r} is held")
         tombstone = path.with_name(f".stale-{path.name}-{secrets.token_hex(8)}")
         os.replace(path, tombstone)
         shutil.rmtree(tombstone)
         path.mkdir()
     _atomic_json(path / "meta.json", {"schema": 1, "pid": os.getpid(),
-                 "owner_token": owner_token, "heartbeat_epoch": time.time()})
+                 "boot_id": _boot_id(), "owner_token": owner_token,
+                 "heartbeat_epoch": time.time()})
+
+
+def _boot_id() -> str:
+    system_id = Path("/proc/sys/kernel/random/boot_id")
+    try:
+        return system_id.read_text().strip()
+    except OSError:
+        return f"boot-epoch-{int(time.time() - time.monotonic())}"
+
+
+def _process_alive(value: object) -> bool:
+    try:
+        pid = int(value)
+        if pid <= 0:
+            return False
+        if os.name == "nt":
+            import ctypes
+            kernel = ctypes.windll.kernel32
+            handle = kernel.OpenProcess(0x1000, False, pid)
+            if not handle:
+                return False
+            code = ctypes.c_ulong()
+            try:
+                return bool(kernel.GetExitCodeProcess(handle, ctypes.byref(code))) and code.value == 259
+            finally:
+                kernel.CloseHandle(handle)
+        os.kill(pid, 0)
+    except (TypeError, ValueError, OSError):
+        return False
+    return True

--- a/src/digitalmodel/workflows/openfoam_batch_layout.py
+++ b/src/digitalmodel/workflows/openfoam_batch_layout.py
@@ -1,0 +1,151 @@
+"""Owned external work layout and conservative destructive operations."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import time
+from typing import Iterator
+
+
+MARKER = ".digitalmodel-run-owner.json"
+
+
+@dataclass(frozen=True)
+class WorkLayout:
+    operator_root: Path
+    namespace: str
+    identity_sha256: str
+    run_dir: Path
+    marker_path: Path
+    owner_token: str
+    root_device: int
+    root_inode: int
+
+    @classmethod
+    def create(cls, operator_root: Path, namespace: str, identity_sha256: str) -> "WorkLayout":
+        root = Path(operator_root).resolve()
+        if not root.is_dir() or root.is_symlink():
+            raise ValueError("operator root must be a real precreated directory")
+        namespace_dir = root.joinpath(*namespace.split("/"))
+        namespace_dir.mkdir(parents=True, exist_ok=True)
+        run_dir = namespace_dir / f"openfoam-run-{identity_sha256}"
+        created = False
+        try:
+            run_dir.mkdir()
+            created = True
+        except FileExistsError:
+            pass
+        marker = run_dir / MARKER
+        stat = root.stat()
+        if created:
+            token = secrets.token_hex(16)
+            payload = _marker(identity_sha256, token, stat)
+            _atomic_json(marker, payload)
+            (run_dir / ".locks").mkdir()
+        payload = _read_marker(marker)
+        _validate_marker(payload, identity_sha256, stat)
+        return cls(root, namespace, identity_sha256, run_dir, marker,
+                   payload["owner_token"], stat.st_dev, stat.st_ino)
+
+    def case_dir(self, case: str) -> Path:
+        if not case or case in {".", ".."} or "/" in case or "\\" in case:
+            raise ValueError("case name is not a strict descendant")
+        return self.run_dir / case
+
+    def assert_owned(self) -> None:
+        stat = self.operator_root.stat()
+        payload = _read_marker(self.marker_path)
+        _validate_marker(payload, self.identity_sha256, stat, self.owner_token)
+
+    def clean_case(self, case: str) -> None:
+        self.assert_owned()
+        target = self.case_dir(case)
+        if not target.exists():
+            return
+        if target.is_symlink() or not target.is_dir():
+            raise ValueError("refusing to clean a non-directory or symlink case")
+        tombstone = self.run_dir / f".delete-{case}-{secrets.token_hex(8)}"
+        os.replace(target, tombstone)
+        if tombstone.is_symlink() or not tombstone.is_dir():
+            if not target.exists():
+                os.replace(tombstone, target)
+            raise ValueError("case changed during clean")
+        shutil.rmtree(tombstone)
+
+    def prune_processors(self, case: str) -> None:
+        self.assert_owned()
+        case_dir = self.case_dir(case)
+        for child in case_dir.glob("processor*") if case_dir.is_dir() else ():
+            if child.is_symlink() or not child.is_dir():
+                raise ValueError("refusing to prune substituted processor path")
+            shutil.rmtree(child)
+
+    @contextmanager
+    def lock(self, name: str, stale_seconds: int = 3600) -> Iterator[None]:
+        lock_dir = self.run_dir / ".locks" / name
+        self.assert_owned()
+        _acquire_lock(lock_dir, self.owner_token, stale_seconds)
+        try:
+            yield
+        finally:
+            shutil.rmtree(lock_dir, ignore_errors=True)
+
+
+def _marker(identity: str, token: str, stat: os.stat_result) -> dict:
+    return {"schema": 1, "uid": getattr(os, "getuid", lambda: None)(),
+            "identity_sha256": identity, "root_device": stat.st_dev,
+            "root_inode": stat.st_ino, "owner_token": token}
+
+
+def _validate_marker(payload: dict, identity: str, stat: os.stat_result,
+                     token: str | None = None) -> None:
+    expected = {"schema": 1, "identity_sha256": identity,
+                "root_device": stat.st_dev, "root_inode": stat.st_ino}
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise ValueError("external run owner marker mismatch")
+    if token is not None and payload.get("owner_token") != token:
+        raise ValueError("external run owner marker token mismatch")
+    if not isinstance(payload.get("owner_token"), str) or not payload["owner_token"]:
+        raise ValueError("external run owner marker malformed")
+
+
+def _read_marker(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("external run owner marker missing or malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("external run owner marker malformed")
+    return payload
+
+
+def _atomic_json(path: Path, payload: dict) -> None:
+    tmp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n")
+    os.replace(tmp, path)
+
+
+def _acquire_lock(path: Path, owner_token: str, stale_seconds: int) -> None:
+    try:
+        path.mkdir()
+    except FileExistsError:
+        meta_path = path / "meta.json"
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            raise RuntimeError(f"lock {path.name!r} has unknown liveness")
+        age = time.time() - float(meta.get("heartbeat_epoch", 0))
+        if meta.get("owner_token") != owner_token or age <= stale_seconds:
+            raise RuntimeError(f"lock {path.name!r} is held")
+        tombstone = path.with_name(f".stale-{path.name}-{secrets.token_hex(8)}")
+        os.replace(path, tombstone)
+        shutil.rmtree(tombstone)
+        path.mkdir()
+    _atomic_json(path / "meta.json", {"schema": 1, "pid": os.getpid(),
+                 "owner_token": owner_token, "heartbeat_epoch": time.time()})

--- a/src/digitalmodel/workflows/openfoam_batch_layout.py
+++ b/src/digitalmodel/workflows/openfoam_batch_layout.py
@@ -8,7 +8,6 @@ import json
 import os
 from pathlib import Path
 import secrets
-import stat
 import subprocess
 import threading
 import time
@@ -262,24 +261,12 @@ def _heartbeat_lock(path: Path, owner_token: str, stop: threading.Event,
 
 def _dispose_tombstone(run_dir: Path, tombstone: Path,
                        expected: os.stat_result) -> None:
-    if os.name == "nt":
-        # Windows lacks Python's descriptor-relative directory mutation APIs.
-        # Keep the atomically quarantined tree instead of risking path deletion.
-        return
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    run_fd = os.open(run_dir, flags)
-    try:
-        tree_fd = os.open(tombstone.name, flags, dir_fd=run_fd)
-        try:
-            actual = os.fstat(tree_fd)
-            if (actual.st_dev, actual.st_ino) != (expected.st_dev, expected.st_ino):
-                raise ValueError("tombstone changed before descriptor deletion")
-            _delete_contents_fd(tree_fd)
-        finally:
-            os.close(tree_fd)
-        os.rmdir(tombstone.name, dir_fd=run_fd)
-    finally:
-        os.close(run_fd)
+    actual = tombstone.stat(follow_symlinks=False)
+    if not _same_inode(actual, expected):
+        raise ValueError("tombstone changed before quarantine retention")
+    # Python exposes no portable primitive that atomically binds rmdir/unlink
+    # to an already-verified directory handle. Retain the random quarantine;
+    # any later name-based removal would reintroduce a replacement race.
 
 
 def _quarantine_and_dispose(path: Path, label: str) -> None:
@@ -297,40 +284,3 @@ def _quarantine_and_dispose(path: Path, label: str) -> None:
 def _same_inode(left: object, right: object) -> bool:
     return (getattr(left, "st_dev", None), getattr(left, "st_ino", None)) == (
         getattr(right, "st_dev", None), getattr(right, "st_ino", None))
-
-
-def _delete_contents_fd(directory_fd: int) -> None:
-    for name in os.listdir(directory_fd):
-        expected = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-        quarantine = f".delete-{secrets.token_hex(16)}"
-        os.rename(name, quarantine, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
-        current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
-        if not _same_inode(expected, current):
-            continue
-        if stat.S_ISDIR(expected.st_mode):
-            child_fd = os.open(quarantine, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                               dir_fd=directory_fd)
-            try:
-                opened = os.fstat(child_fd)
-                if not _same_inode(expected, opened):
-                    continue
-                _delete_contents_fd(child_fd)
-            finally:
-                os.close(child_fd)
-            current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
-            if _same_inode(opened, current):
-                os.rmdir(quarantine, dir_fd=directory_fd)
-        elif not stat.S_ISLNK(expected.st_mode):
-            file_fd = os.open(quarantine, os.O_RDONLY | os.O_NOFOLLOW,
-                              dir_fd=directory_fd)
-            try:
-                opened = os.fstat(file_fd)
-            finally:
-                os.close(file_fd)
-            current = os.stat(quarantine, dir_fd=directory_fd, follow_symlinks=False)
-            if _same_inode(expected, opened) and _same_inode(opened, current):
-                os.unlink(quarantine, dir_fd=directory_fd)
-        else:
-            # A quarantined link is harmless; leave it rather than introduce a
-            # path-based unlink race into a destructive operation.
-            continue

--- a/src/digitalmodel/workflows/openfoam_batch_results.py
+++ b/src/digitalmodel/workflows/openfoam_batch_results.py
@@ -1,0 +1,66 @@
+"""Bounded public result policy for OpenFOAM batch runs."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+RESULT_POLICY_VERSION = "result-policy-v1"
+MAX_RESULT_BYTES = 10 * 1024 * 1024
+
+
+def row(item: dict[str, Any], *, status: str, case_dir: Path | None = None,
+        solver: str | None = None, error: str | None = None,
+        mock: bool = False) -> dict[str, Any]:
+    return {"index": item["index"], "name": item["name"], **item["case"],
+            "status": status, "solver": solver, "mock": mock, "error": error,
+            "case_dir": str(case_dir) if case_dir else None, "wall_seconds": 0.0}
+
+
+def redact_rows(rows: list[dict[str, Any]], external_root: Path | None) -> list[dict[str, Any]]:
+    if external_root is None:
+        return deepcopy(rows)
+    root = str(Path(external_root).resolve())
+    redacted = deepcopy(rows)
+    for item in redacted:
+        case_dir = item.get("case_dir")
+        if isinstance(case_dir, str) and case_dir:
+            item["case_dir"] = f"<external-work>/{Path(case_dir).name}"
+        error = item.get("error")
+        if isinstance(error, str):
+            item["error"] = error.replace(root, "<external-work>")
+    return redacted
+
+
+def write_results(rows: list[dict[str, Any]], output_dir: Path, *, mode: str,
+                  workers: int, mock: bool, timeout_seconds: int,
+                  started_at: datetime | None = None, finished_at: datetime | None = None,
+                  extensions: list[str] | None = None) -> dict[str, str]:
+    if extensions:
+        raise ValueError("result extension is inactive until separately approved")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = output_dir / "cases.csv"
+    summary_path = output_dir / "batch_summary.json"
+    pd.DataFrame(rows).to_csv(manifest, index=False)
+    start = started_at or datetime.now(timezone.utc)
+    finish = finished_at or datetime.now(timezone.utc)
+    completed = sum(item.get("status") == "completed" for item in rows)
+    summary = {"workflow": "openfoam_run_batch", "result_policy_version": RESULT_POLICY_VERSION,
+               "mode": mode, "total_cases": len(rows), "completed": completed,
+               "failed": len(rows) - completed, "workers": workers,
+               "host_cpu_count": os.cpu_count(), "mock": mock,
+               "timeout_seconds": timeout_seconds, "started_at_utc": start.isoformat(),
+               "finished_at_utc": finish.isoformat()}
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    for path in (manifest, summary_path):
+        if path.stat().st_size > MAX_RESULT_BYTES:
+            path.unlink(missing_ok=True)
+            raise ValueError(f"bounded result {path.name} exceeds policy")
+    return {"manifest": str(manifest), "summary": str(summary_path)}

--- a/src/digitalmodel/workflows/openfoam_batch_results.py
+++ b/src/digitalmodel/workflows/openfoam_batch_results.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import re
 from typing import Any
 
@@ -28,16 +28,19 @@ def row(item: dict[str, Any], *, status: str, case_dir: Path | None = None,
 def redact_rows(rows: list[dict[str, Any]], external_root: Path | None) -> list[dict[str, Any]]:
     if external_root is None:
         return deepcopy(rows)
-    root = str(Path(external_root).resolve())
+    raw_root = str(external_root)
+    windows_root = PureWindowsPath(raw_root)
+    root = (windows_root.as_posix() if windows_root.is_absolute()
+            else Path(raw_root).resolve().as_posix())
     redacted = deepcopy(rows)
     for item in redacted:
         case_dir = item.get("case_dir")
         if isinstance(case_dir, str) and case_dir:
-            item["case_dir"] = f"<external-work>/{Path(case_dir).name}"
+            basename = case_dir.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+            item["case_dir"] = f"<external-work>/{basename}"
         error = item.get("error")
         if isinstance(error, str):
-            normalized_root = root.replace("\\", "/")
-            item["error"] = re.sub(re.escape(normalized_root), "<external-work>",
+            item["error"] = re.sub(re.escape(root), "<external-work>",
                                    error.replace("\\", "/"), flags=re.IGNORECASE)
     return redacted
 

--- a/src/digitalmodel/workflows/openfoam_batch_results.py
+++ b/src/digitalmodel/workflows/openfoam_batch_results.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import re
 from typing import Any
 
 import pandas as pd
@@ -35,7 +36,9 @@ def redact_rows(rows: list[dict[str, Any]], external_root: Path | None) -> list[
             item["case_dir"] = f"<external-work>/{Path(case_dir).name}"
         error = item.get("error")
         if isinstance(error, str):
-            item["error"] = error.replace(root, "<external-work>")
+            normalized_root = root.replace("\\", "/")
+            item["error"] = re.sub(re.escape(normalized_root), "<external-work>",
+                                   error.replace("\\", "/"), flags=re.IGNORECASE)
     return redacted
 
 

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -33,7 +33,7 @@ from digitalmodel.workflows.openfoam_batch_execution import (
     write_checkpoint as _write_checkpoint,
     write_decompose_par_dict as _write_decompose_par_dict,
 )
-from digitalmodel.workflows.openfoam_batch_identity import build_run_identity
+from digitalmodel.workflows.openfoam_batch_identity import build_run_identity, file_sha256
 from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
 from digitalmodel.workflows.openfoam_batch_results import (
     redact_rows,
@@ -82,7 +82,8 @@ def router(cfg: dict) -> dict:
     settings, run_settings, base, cfg_dir = _settings(cfg)
     mode, mock, workers = _validate_run(run_settings, base)
     paths = resolve_batch_paths(run_settings, cfg_dir)
-    layout = _external_layout(cfg, settings, run_settings, base, paths, mode, workers, mock)
+    layout, tool_bindings = _external_layout(
+        cfg, settings, run_settings, base, paths, mode, workers, mock)
     work_dir = paths.legacy_work_dir if layout is None else layout.run_dir
     cases = _resolve_case_matrix(settings.get("cases"), settings.get("variants") or {}, cfg_dir)
     mapping = settings.get("mapping") or (settings.get("variants") or {}).get("mapping") or {}
@@ -94,7 +95,8 @@ def router(cfg: dict) -> dict:
     else:
         with layout.lock("run"):
             rows = run_cases(rendered, run_settings, mode=mode, workers=workers,
-                             mock=mock, layout=layout, builder=_build_case)
+                             mock=mock, layout=layout, builder=_build_case,
+                             tool_bindings=tool_bindings)
     safe_rows = redact_rows(rows, paths.operator_root)
     outputs = write_results(safe_rows, paths.output_dir, mode=mode, workers=workers,
                             mock=mock, timeout_seconds=int(run_settings.get(
@@ -128,10 +130,11 @@ def _validate_run(run_settings: dict, base: dict) -> tuple[str, bool, int]:
 
 
 def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
-                     paths, mode: str, workers: int, mock: bool) -> WorkLayout | None:
+                     paths, mode: str, workers: int, mock: bool
+                     ) -> tuple[WorkLayout | None, dict[str, tuple[Path, str]]]:
     if not paths.external:
         paths.legacy_work_dir.mkdir(parents=True, exist_ok=True)
-        return None
+        return None, {}
     inputs = _referenced_inputs(cfg, settings, paths.cfg_dir)
     tools = [] if mock else _selected_tools(mode, base, run_settings)
     identity = build_run_identity(
@@ -140,7 +143,9 @@ def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
         dispatcher_rank_limit=workers,
         package_root=Path(__file__).resolve().parents[1],
     )
-    return WorkLayout.create(paths.operator_root, paths.namespace, identity.identity_sha256)
+    bindings = {item[0]: (item[1], file_sha256(item[1])) for item in tools}
+    return (WorkLayout.create(paths.operator_root, paths.namespace, identity.identity_sha256),
+            bindings)
 
 
 def _referenced_inputs(cfg: dict, settings: dict, cfg_dir: Path) -> list[tuple[str, Path]]:
@@ -151,8 +156,12 @@ def _referenced_inputs(cfg: dict, settings: dict, cfg_dir: Path) -> list[tuple[s
     for role, value in _walk_strings(settings):
         path = Path(value)
         candidate = path if path.is_absolute() else cfg_dir / path
-        if candidate.is_file() and candidate.suffix.lower() in {".yml", ".yaml", ".csv"}:
+        if candidate.is_file():
             found.append((role, candidate))
+        elif candidate.is_dir() and not candidate.is_symlink():
+            for asset in candidate.rglob("*"):
+                if asset.is_file():
+                    found.append((f"{role}/{asset.relative_to(candidate).as_posix()}", asset))
     return list({(role, path.resolve()) for role, path in found})
 
 
@@ -173,6 +182,19 @@ def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str
         names += ["decomposePar", "mpirun"]
         if bool(run_settings.get("reconstruct", True)):
             names.append("reconstructPar")
+    else:
+        if base.get("run_snappy"):
+            names.append("snappyHexMesh")
+        if base.get("merge_meshes_source"):
+            names.append("mergeMeshes")
+        if base.get("run_topo_set"):
+            names.append("topoSet")
+        if base.get("subset_mesh_set") or base.get("subset_mesh_patch"):
+            names.append("subsetMesh")
+        if base.get("run_set_fields"):
+            names.append("setFields")
+        if base.get("to_vtk"):
+            names.append("foamToVTK")
     return [(name, Path(shutil.which(name) or "")) for name in names if name]
 
 

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -1,680 +1,198 @@
-"""OpenFOAM CFD batch workflow — one request saturates a CFD node (issue #1560).
-
-One input.yml -> a deterministic case matrix that saturates a dedicated CFD box
-in one of two ways (``run_batch.mode``):
-
-* ``pool`` (default): N cases run CONCURRENTLY, each single-rank, through a
-  bounded thread pool sized to ~90% of host cores (owner resource policy,
-  dm#1553). Each case reuses the existing fail-closed per-case path
-  (OpenFOAMWorkflow build + OpenFOAMRunner solve) — the same code the
-  ``basename: openfoam`` engine route uses (landed via #1161).
-* ``mpi``: ONE large case spread across ranks —
-  ``decomposePar -force`` (scotch) -> ``mpirun -np <workers> <solver> -parallel``
-  -> optional ``reconstructPar`` (mirrors
-  ``scripts/cfd/run_sloshing_3d_benchmark.py``). ``processor*`` dirs are
-  pruned only after a SUCCESSFUL reconstruction; with ``reconstruct: false``
-  the decomposed fields ARE the deliverable and are preserved in the work dir.
-
-WALL-CLOCK SIZING (mpi mode): a fresh mpi attempt restarts the solve from
-``startTime`` — size the case (end time, mesh, rank count) to finish well
-inside one dispatch wall-clock window, or a killed-and-retried run will redo
-the same physics from t=0 on every attempt. ``run_batch.resume: true``
-mitigates this: when a previous attempt's ``processor*`` decomposition already
-exists, the retry skips meshing/decomposition and restarts the solver from
-``latestTime`` instead of t=0 (requires the case's ``writeInterval`` to land
-intermediate time dirs). The batch summary records ``timeout_seconds`` so the
-dispatch side can compare its cap against the expected wall time.
-
-Case generation reuses parametric_run's helpers (``_load_cases`` /
-``_set_dotted``) so the factorial/range/csv/yaml_matrix schema and dotted-path
-mapping behave identically to orcaflex_run_batch (#1554).
-
-Idempotent/resumable: each case writes a ``_result.json`` checkpoint under its
-work dir; a re-run skips a case whose checkpoint is ``completed`` (a retry after
-a queue timeout safely re-enqueues the same input). A failed, truncated or
-missing checkpoint is retried — from a CLEAN rebuilt case dir (unless mpi
-``resume`` picks up an existing decomposition), never on top of a dirty tree
-of stale timestep dirs and logs. Small conclusions (``results/cases.csv`` +
-``results/batch_summary.json``) land under ``results/`` for the licensed-run
-queue's return allowlist; heavy case trees (meshes, fields, VTK,
-``processor*``) stay in the work dir and never reach ``results/``.
-"""
+"""OpenFOAM CFD batch workflow with optional owned external work roots."""
 
 from __future__ import annotations
 
-import json
-import math
-import os
-import re
-import shutil
-import subprocess
-import time
-from concurrent.futures import ThreadPoolExecutor
-from copy import deepcopy
 from datetime import datetime, timezone
+import os
 from pathlib import Path
-from typing import Any, Callable
+import shutil
+from typing import Any
 
-import pandas as pd
-from loguru import logger
+from digitalmodel.workflows.openfoam_batch_config import (
+    RESERVED_ROW_KEYS as _RESERVED_ROW_KEYS,
+    default_workers,
+    render_cases as _render_cases,
+    resolve_batch_paths,
+    resolve_case_matrix as _resolve_case_matrix,
+    resolve_workers,
+)
+from digitalmodel.workflows.openfoam_batch_execution import (
+    CHECKPOINT_FILENAME,
+    DEFAULT_MESH_UTILITY,
+    DEFAULT_TIMEOUT_SECONDS,
+    build_case as _build_case,
+    execute_mpi_plan as _execute_mpi_plan,
+    load_checkpoint as _load_checkpoint,
+    mpi_command_plan,
+    run_case_mpi as _run_case_mpi,
+    run_case_pool as _run_case_pool,
+    run_cases,
+    run_command as _run_command,
+    set_start_from_latest_time as _set_start_from_latest_time,
+    solve_serial as _solve_serial,
+    write_checkpoint as _write_checkpoint,
+    write_decompose_par_dict as _write_decompose_par_dict,
+)
+from digitalmodel.workflows.openfoam_batch_identity import build_run_identity
+from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
+from digitalmodel.workflows.openfoam_batch_results import (
+    redact_rows,
+    row as _row,
+    write_results,
+)
 
-from digitalmodel.workflows.parametric_run import _load_cases, _set_dotted
 
-# Owner resource policy (dm#1553): a CFD node is saturated by sizing the pool
-# (or the MPI rank count) to ~90% of the host's cores.
-WORKER_CORE_FRACTION = 0.9
+# Keep the helper surface used by existing callers while implementation lives
+# in focused modules.
+__all__ = [
+    "CHECKPOINT_FILENAME",
+    "_RESERVED_ROW_KEYS",
+    "_build_case",
+    "_execute_mpi_plan",
+    "_load_checkpoint",
+    "_render_cases",
+    "_resolve_case_matrix",
+    "_row",
+    "_run_case_mpi",
+    "_run_case_pool",
+    "_run_command",
+    "_set_start_from_latest_time",
+    "_solve_serial",
+    "_write_checkpoint",
+    "_write_decompose_par_dict",
+    "default_workers",
+    "mpi_command_plan",
+    "resolve_workers",
+    "router",
+]
+
+
 DEFAULT_MODE = "pool"
-DEFAULT_MESH_UTILITY = "blockMesh"
 DEFAULT_OUTPUT_DIR = "results"
 DEFAULT_WORK_DIR = "batch_runs"
-CHECKPOINT_FILENAME = "_result.json"
-# results/ is the licensed-run return allowlist: small rollups only. These are
-# the ONLY suffixes allowed under it; heavy case trees stay in the work dir.
-_RESULTS_ALLOWED_SUFFIXES = {".csv", ".json"}
 VALID_MODES = ("pool", "mpi")
-DEFAULT_TIMEOUT_SECONDS = 43200
-# Manifest columns owned by the workflow. A case knob with one of these names
-# would be silently clobbered by the reserved value in the manifest row, so
-# knob names colliding with them are rejected up front (rename the knob and
-# route it onto the settings path via mapping:, e.g. solver_app: solver).
-_RESERVED_ROW_KEYS = frozenset(
-    {
-        "index",
-        "name",
-        "status",
-        "solver",
-        "mock",
-        "error",
-        "case_dir",
-        "wall_seconds",
-        "mpi_plan",
-    }
-)
-
+_RESULTS_ALLOWED_SUFFIXES = {".csv", ".json"}
 SOLVER_ERROR_MESSAGE = (
-    "OpenFOAM solver / utilities are not on PATH on this host. "
-    "openfoam_run_batch is a requires-solver workflow: dispatch it to a "
-    "solver-capable host (run 'openfoam doctor --require-solver' to confirm) "
-    "or set run_batch.mock: true for a solver-free case-build dry run."
+    "requires-solver: OpenFOAM solver / utilities are not on PATH on this host. "
+    "Dispatch to a solver-capable host or set run_batch.mock: true."
 )
-
-_YAML_SUFFIXES = {".yml", ".yaml"}
 
 
 def router(cfg: dict) -> dict:
-    settings = cfg.get("openfoam_run_batch") or {}
-    cfg_dir = Path(cfg.get("_config_dir_path") or Path.cwd())
-
-    run_settings = settings.get("run_batch") or {}
-    mode = run_settings.get("mode", DEFAULT_MODE)
-    if mode not in VALID_MODES:
-        raise ValueError(
-            f"openfoam_run_batch run_batch.mode must be pool|mpi, got {mode}"
-        )
-    mock = bool(run_settings.get("mock", False))
-    workers = resolve_workers(run_settings)
-
-    base = settings.get("base") or {}
-    if not base.get("case_type"):
-        raise ValueError("openfoam_run_batch.base.case_type is required")
-    mesh_utility = base.get("mesh_utility", DEFAULT_MESH_UTILITY)
-    solver = base.get("solver")
-
-    reconstruct = bool(run_settings.get("reconstruct", True))
-    timeout_seconds = int(
-        run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
-    )
-
-    # Fail-closed once, up front: a real run on a solver-less host must never
-    # silently downgrade to a build-only dry run (the licensed-run lane would
-    # record a false finish). Per-case failures below (divergence, bad mesh)
-    # are isolated; a missing toolchain is not. The check covers EVERY utility
-    # the plan will invoke — including reconstructPar when mode: mpi ends with
-    # a reconstruction — so hours of solve can't fail at the final stage.
-    if not mock and not _solver_ready(mode, mesh_utility, solver, reconstruct):
-        raise RuntimeError(SOLVER_ERROR_MESSAGE)
-
-    variants = settings.get("variants") or {}
-    cases = _resolve_case_matrix(settings.get("cases"), variants, cfg_dir)
-    # An explicit cases: list is mutually exclusive with variants:, so accept
-    # a top-level mapping: for renaming its knobs onto dotted settings paths.
-    mapping = settings.get("mapping") or variants.get("mapping") or {}
-
-    results_dir = _resolve_dir(
-        run_settings.get("output_dir", DEFAULT_OUTPUT_DIR), cfg_dir
-    )
-    work_dir = _resolve_dir(run_settings.get("work_dir", DEFAULT_WORK_DIR), cfg_dir)
-
+    settings, run_settings, base, cfg_dir = _settings(cfg)
+    mode, mock, workers = _validate_run(run_settings, base)
+    paths = resolve_batch_paths(run_settings, cfg_dir)
+    layout = _external_layout(cfg, settings, run_settings, base, paths, mode, workers, mock)
+    work_dir = paths.legacy_work_dir if layout is None else layout.run_dir
+    cases = _resolve_case_matrix(settings.get("cases"), settings.get("variants") or {}, cfg_dir)
+    mapping = settings.get("mapping") or (settings.get("variants") or {}).get("mapping") or {}
     rendered = _render_cases(base, cases, mapping, work_dir)
-
-    started_at = datetime.now(timezone.utc)
-    if mode == "mpi":
-        if len(rendered) != 1:
-            raise ValueError(
-                "openfoam_run_batch mode: mpi runs exactly ONE case across "
-                f"ranks; the matrix produced {len(rendered)} cases. Use "
-                "mode: pool for a multi-case sweep."
-            )
-        rows = [_run_case_mpi(rendered[0], run_settings, workers, mock)]
+    started = datetime.now(timezone.utc)
+    if layout is None:
+        rows = run_cases(rendered, run_settings, mode=mode, workers=workers,
+                         mock=mock, builder=_build_case)
     else:
-        rows = _run_pool(rendered, run_settings, workers, mock)
-    finished_at = datetime.now(timezone.utc)
-
-    manifest_path = results_dir / "cases.csv"
-    summary_path = results_dir / "batch_summary.json"
-    _write_manifest(rows, manifest_path)
-    summary = _write_summary(
-        rows=rows,
-        path=summary_path,
-        mode=mode,
-        workers=workers,
-        mock=mock,
-        timeout_seconds=timeout_seconds,
-        started_at=started_at,
-        finished_at=finished_at,
-    )
-    if summary["failed"]:
-        logger.warning(
-            "openfoam_run_batch: {} of {} cases failed; see {}",
-            summary["failed"],
-            summary["total_cases"],
-            manifest_path,
-        )
-
-    settings["cases"] = rows
-    settings["outputs"] = {
-        "manifest": str(manifest_path),
-        "summary": str(summary_path),
-    }
+        with layout.lock("run"):
+            rows = run_cases(rendered, run_settings, mode=mode, workers=workers,
+                             mock=mock, layout=layout, builder=_build_case)
+    safe_rows = redact_rows(rows, paths.operator_root)
+    outputs = write_results(safe_rows, paths.output_dir, mode=mode, workers=workers,
+                            mock=mock, timeout_seconds=int(run_settings.get(
+                                "timeout_seconds", DEFAULT_TIMEOUT_SECONDS)),
+                            started_at=started, finished_at=datetime.now(timezone.utc),
+                            extensions=run_settings.get("result_extensions"))
+    settings["cases"], settings["outputs"] = safe_rows, outputs
     cfg["openfoam_run_batch"] = settings
     return cfg
 
 
-def default_workers(cpu_count: int | None = None) -> int:
-    """~90% of host cores, floored, never below 1 (dm#1553 resource policy)."""
-    cores = cpu_count if cpu_count is not None else (os.cpu_count() or 1)
-    return max(1, math.floor(WORKER_CORE_FRACTION * cores))
+def _settings(cfg: dict) -> tuple[dict, dict, dict, Path]:
+    settings = cfg.get("openfoam_run_batch") or {}
+    run_settings = settings.get("run_batch") or {}
+    base = settings.get("base") or {}
+    if not base.get("case_type"):
+        raise ValueError("openfoam_run_batch.base.case_type is required")
+    cfg_dir = Path(cfg.get("_config_dir_path") or Path.cwd())
+    return settings, run_settings, base, cfg_dir
 
 
-def resolve_workers(run_settings: dict) -> int:
-    explicit = run_settings.get("workers")
-    if explicit is None:
-        return default_workers()
-    workers = int(explicit)
-    if workers < 1:
-        raise ValueError(f"run_batch.workers must be >= 1, got {explicit}")
-    return workers
+def _validate_run(run_settings: dict, base: dict) -> tuple[str, bool, int]:
+    mode = run_settings.get("mode", DEFAULT_MODE)
+    if mode not in VALID_MODES:
+        raise ValueError(f"openfoam_run_batch run_batch.mode must be pool|mpi, got {mode}")
+    mock, workers = bool(run_settings.get("mock", False)), resolve_workers(run_settings)
+    if not mock and not _solver_ready(mode, base.get("mesh_utility", DEFAULT_MESH_UTILITY),
+                                      base.get("solver"), bool(run_settings.get("reconstruct", True))):
+        raise RuntimeError(SOLVER_ERROR_MESSAGE)
+    return mode, mock, workers
 
 
-# --------------------------------------------------------------------------- #
-#  case matrix (reuses parametric_run's case generation)                      #
-# --------------------------------------------------------------------------- #
-def _resolve_case_matrix(
-    explicit: list[dict] | None, variants: dict, cfg_dir: Path
-) -> list[dict[str, Any]]:
-    if explicit:
-        if variants:
-            raise ValueError(
-                "openfoam_run_batch: give either cases: [...] or variants:, "
-                "not both"
-            )
-        return [dict(case) for case in explicit]
-    if variants:
-        return _load_cases(variants, cfg_dir)
-    # No matrix -> a single case built from base alone.
-    return [{}]
-
-
-def _render_cases(
-    base: dict,
-    cases: list[dict[str, Any]],
-    mapping: dict[str, str],
-    work_dir: Path,
-) -> list[dict[str, Any]]:
-    base_name = base.get("name") or f"{base['case_type']}_case"
-    rendered: list[dict[str, Any]] = []
-    for index, case in enumerate(cases):
-        case_settings = deepcopy(base)
-        # A "name" field names the case dir; every other field is a swept knob
-        # injected into the per-case OpenFOAM settings via a dotted path.
-        params = {k: v for k, v in case.items() if k != "name"}
-        collisions = _RESERVED_ROW_KEYS.intersection(params)
-        if collisions:
-            raise ValueError(
-                "openfoam_run_batch: case parameter name(s) "
-                f"{sorted(collisions)} collide with reserved manifest "
-                "columns; rename the knob and route it onto the settings "
-                "path via mapping: (e.g. solver_app: solver)"
-            )
-        for name, value in params.items():
-            _set_dotted(case_settings, mapping.get(name, name), value)
-        case_name = case.get("name") or f"{base_name}_{index:03d}"
-        case_settings["name"] = case_name
-        rendered.append(
-            {
-                "index": index,
-                "name": case_name,
-                "case": params,
-                "settings": case_settings,
-                "work_dir": work_dir / case_name,
-            }
-        )
-    return rendered
-
-
-# --------------------------------------------------------------------------- #
-#  pool mode — bounded thread pool of single-rank cases                       #
-# --------------------------------------------------------------------------- #
-def _run_pool(
-    rendered: list[dict[str, Any]],
-    run_settings: dict,
-    workers: int,
-    mock: bool,
-) -> list[dict[str, Any]]:
-    # Each leaf blocks on its own OpenFOAM subprocess -> threads give true
-    # parallelism with no process-spawn overhead (same shape as the sloshing
-    # backbone sweep). Pool is bounded to `workers` so the node is saturated,
-    # not oversubscribed.
-    rows_by_index: dict[int, dict[str, Any]] = {}
-    with ThreadPoolExecutor(max_workers=min(workers, len(rendered))) as pool:
-        futures = {
-            pool.submit(_run_case_pool, item, run_settings, mock): item
-            for item in rendered
-        }
-        for future, item in futures.items():
-            try:
-                rows_by_index[item["index"]] = future.result()
-            except Exception as exc:  # noqa: BLE001 - per-case isolation
-                rows_by_index[item["index"]] = _row(
-                    item, status="failed", error=str(exc)
-                )
-    return [rows_by_index[item["index"]] for item in rendered]
-
-
-def _run_case_pool(
-    item: dict[str, Any], run_settings: dict, mock: bool
-) -> dict[str, Any]:
-    checkpoint = _load_checkpoint(item["work_dir"])
-    if checkpoint is not None:
-        return checkpoint
-
-    start = time.monotonic()
-    try:
-        # A retry (absent/failed/corrupt checkpoint) must never rebuild on top
-        # of a dirty tree — stale timestep dirs/logs would mix inconsistent
-        # artifacts into the new solve.
-        _clean_case_dir(item["work_dir"])
-        case_dir = _build_case(item)
-        if mock:
-            # Mock leaf: the real (license-free) builder authored the case tree,
-            # but no solver ran. Never a silent downgrade — mock is explicit.
-            row = _row(item, status="completed", case_dir=case_dir,
-                       solver=item["settings"].get("solver"), mock=True)
-        else:
-            row = _solve_serial(item, case_dir, run_settings)
-    except Exception as exc:  # noqa: BLE001 - per-case isolation
-        row = _row(item, status="failed", error=str(exc))
-    row["wall_seconds"] = round(time.monotonic() - start, 3)
-    _write_checkpoint(item["work_dir"], row)
-    return row
-
-
-def _solve_serial(
-    item: dict[str, Any], case_dir: Path, run_settings: dict
-) -> dict[str, Any]:
-    """Run one prepared case single-rank through the fail-closed runner."""
-    from digitalmodel.solvers.openfoam.runner import (
-        OpenFOAMRunConfig,
-        OpenFOAMRunner,
+def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
+                     paths, mode: str, workers: int, mock: bool) -> WorkLayout | None:
+    if not paths.external:
+        paths.legacy_work_dir.mkdir(parents=True, exist_ok=True)
+        return None
+    inputs = _referenced_inputs(cfg, settings, paths.cfg_dir)
+    tools = [] if mock else _selected_tools(mode, base, run_settings)
+    identity = build_run_identity(
+        effective_config=settings, referenced_inputs=inputs,
+        selected_executables=tools, visible_rank_count=os.cpu_count() or 1,
+        dispatcher_rank_limit=workers,
+        package_root=Path(__file__).resolve().parents[1],
     )
-
-    settings = item["settings"]
-    run_cfg = OpenFOAMRunConfig(
-        solver=settings.get("solver"),
-        mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
-        run_snappy=bool(settings.get("run_snappy", False)),
-        run_set_fields=bool(settings.get("run_set_fields", False)),
-        to_vtk=bool(settings.get("to_vtk", False)),
-        timeout_seconds=int(run_settings.get("timeout_seconds", 43200)),
-    )
-    result = OpenFOAMRunner(run_cfg).run(case_dir)
-    status = str(getattr(result.status, "value", result.status)).lower()
-    if status == "completed":
-        return _row(item, status="completed", case_dir=case_dir,
-                    solver=result.solver)
-    return _row(
-        item,
-        status="failed",
-        case_dir=case_dir,
-        solver=result.solver,
-        error=result.error_message or f"runner status {status}",
-    )
+    return WorkLayout.create(paths.operator_root, paths.namespace, identity.identity_sha256)
 
 
-# --------------------------------------------------------------------------- #
-#  mpi mode — one case across ranks (decomposePar -> mpirun -> reconstruct)    #
-# --------------------------------------------------------------------------- #
-def _run_case_mpi(
-    item: dict[str, Any],
-    run_settings: dict,
-    workers: int,
-    mock: bool,
-    command_runner: Callable[..., int] | None = None,
-) -> dict[str, Any]:
-    work_dir = item["work_dir"]
-    checkpoint = _load_checkpoint(work_dir)
-    if checkpoint is not None:
-        return checkpoint
-
-    run = command_runner or _run_command
-    settings = item["settings"]
-    solver = settings.get("solver")
-    if not solver:
-        row = _row(item, status="failed",
-                   error="mode: mpi requires base.solver to be set")
-        _write_checkpoint(work_dir, row)
-        return row
-    reconstruct = bool(run_settings.get("reconstruct", True))
-    timeout = int(run_settings.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
-    # Resume (run_batch.resume: true): a previous killed attempt left its
-    # decomposed state behind -> restart the solver from latestTime instead of
-    # redoing mesh/decompose/solve from t=0 (retry-livelock mitigation for
-    # cases near the dispatch wall-clock cap).
-    resuming = (
-        not mock
-        and bool(run_settings.get("resume", False))
-        and _has_processor_dirs(work_dir)
-    )
-
-    start = time.monotonic()
-    try:
-        if resuming:
-            case_dir = work_dir
-            _set_start_from_latest_time(case_dir)
-        else:
-            # Fresh attempt: never rebuild on top of a dirty tree (stale
-            # timestep dirs/logs from a killed run mix inconsistent artifacts).
-            _clean_case_dir(work_dir)
-            case_dir = _build_case(item)
-        plan = mpi_command_plan(
-            solver=solver,
-            workers=workers,
-            mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
-            run_set_fields=bool(settings.get("run_set_fields", False)),
-            reconstruct=reconstruct,
-            resume=resuming,
-        )
-        if mock:
-            # Explicit mock: record the exact command plan without executing.
-            row = _row(item, status="completed", case_dir=case_dir,
-                       solver=solver, mock=True)
-            row["mpi_plan"] = [" ".join(argv) for argv in plan]
-        else:
-            if not resuming:
-                _write_decompose_par_dict(case_dir, workers)
-            row = _execute_mpi_plan(item, case_dir, plan, solver, run, timeout)
-            # processor* holds the ONLY copy of the solved fields until
-            # reconstructPar merges them back: prune ONLY after a successful
-            # reconstruction. With reconstruct: false the decomposed fields
-            # ARE the deliverable and stay in the work dir; on failure they
-            # are kept for diagnosis and a possible resume.
-            if reconstruct and row["status"] == "completed":
-                _prune_processor_dirs(case_dir)
-    except Exception as exc:  # noqa: BLE001 - checkpoint the failure
-        row = _row(item, status="failed", error=str(exc))
-    row["wall_seconds"] = round(time.monotonic() - start, 3)
-    _write_checkpoint(work_dir, row)
-    return row
+def _referenced_inputs(cfg: dict, settings: dict, cfg_dir: Path) -> list[tuple[str, Path]]:
+    found = []
+    config_file = cfg.get("_config_file_path")
+    if config_file and Path(config_file).is_file():
+        found.append(("request", Path(config_file)))
+    for role, value in _walk_strings(settings):
+        path = Path(value)
+        candidate = path if path.is_absolute() else cfg_dir / path
+        if candidate.is_file() and candidate.suffix.lower() in {".yml", ".yaml", ".csv"}:
+            found.append((role, candidate))
+    return list({(role, path.resolve()) for role, path in found})
 
 
-def _execute_mpi_plan(
-    item: dict[str, Any],
-    case_dir: Path,
-    plan: list[list[str]],
-    solver: str,
-    run: Callable[..., int],
-    timeout: int,
-) -> dict[str, Any]:
-    for argv in plan:
-        log = case_dir / f"log.{argv[0]}"
-        rc = run(argv, case_dir, log, timeout)
-        if rc != 0:
-            return _row(
-                item,
-                status="failed",
-                case_dir=case_dir,
-                solver=solver,
-                error=f"stage '{argv[0]}' returned non-zero exit code {rc}",
-            )
-    return _row(item, status="completed", case_dir=case_dir, solver=solver)
+def _walk_strings(value: Any, prefix: str = "config"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield from _walk_strings(item, f"{prefix}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from _walk_strings(item, f"{prefix}[{index}]")
+    elif isinstance(value, str):
+        yield prefix, value
 
 
-def mpi_command_plan(
-    solver: str,
-    workers: int,
-    mesh_utility: str = DEFAULT_MESH_UTILITY,
-    run_set_fields: bool = False,
-    reconstruct: bool = True,
-    resume: bool = False,
-) -> list[list[str]]:
-    """Ordered utility argv for an MPI solve: mesh -> decompose -> solve ->
-    (reconstruct). decomposePar ALWAYS precedes mpirun; the solver runs
-    ``-parallel`` under ``mpirun -np <workers>`` (mirrors the 3D benchmark).
-    A resume skips the mesh/decompose stages entirely — the previous attempt's
-    decomposition is reused and the solver restarts from latestTime."""
-    plan: list[list[str]] = []
-    if not resume:
-        plan.append([mesh_utility])
-        if run_set_fields:
-            plan.append(["setFields"])
-        plan.append(["decomposePar", "-force"])
-    plan.append(
-        ["mpirun", "-np", str(workers), "--oversubscribe", solver, "-parallel"]
-    )
-    if reconstruct:
-        plan.append(["reconstructPar"])
-    return plan
-
-
-# --------------------------------------------------------------------------- #
-#  shared helpers                                                             #
-# --------------------------------------------------------------------------- #
-def _build_case(item: dict[str, Any]) -> Path:
-    """Author the case tree via the license-free OpenFOAM builder (reuses the
-    engine handler's build path) under this case's isolated work dir."""
-    from digitalmodel.solvers.openfoam.workflow import OpenFOAMWorkflow
-
-    settings = deepcopy(item["settings"])
-    settings["operation"] = "build_case"
-    # Build into work_dir's parent so the case tree IS item["work_dir"]
-    # (name == the case dir): the tree, its log.* files and the _result.json
-    # checkpoint all live in one isolated per-case dir (backbone convention).
-    build_cfg = {
-        "basename": "openfoam",
-        "Analysis": {"result_folder": str(item["work_dir"].parent)},
-        "openfoam": settings,
-    }
-    OpenFOAMWorkflow().router(build_cfg)
-    return Path(build_cfg["openfoam"]["case_dir"])
-
-
-def _solver_ready(
-    mode: str, mesh_utility: str, solver: str | None, reconstruct: bool = True
-) -> bool:
-    """The CFD ready-gate: EVERY utility this run will invoke is on PATH —
-    including reconstructPar when the mpi plan ends with a reconstruction
-    (otherwise hours of solve would fail at the very last stage). Mirrors
-    OpenFOAMRunner._openfoam_available / 'openfoam doctor'."""
-    required = [mesh_utility]
-    if solver:
-        required.append(solver)
+def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str, Path]]:
+    names = [base.get("mesh_utility", DEFAULT_MESH_UTILITY), base.get("solver")]
     if mode == "mpi":
-        required += ["decomposePar", "mpirun"]
-        if reconstruct:
-            required.append("reconstructPar")
-    return all(shutil.which(exe) is not None for exe in required)
+        names += ["decomposePar", "mpirun"]
+        if bool(run_settings.get("reconstruct", True)):
+            names.append("reconstructPar")
+    return [(name, Path(shutil.which(name) or "")) for name in names if name]
 
 
-def _run_command(argv: list[str], cwd: Path, log: Path, timeout: int) -> int:
-    """Real subprocess stage (fail-closed on OSError/timeout). Persists the
-    utility's stdout+stderr to log.<utility> inside the case dir."""
-    try:
-        with log.open("w") as fh:
-            proc = subprocess.run(  # noqa: S603 - argv is fixed utility names.
-                argv,
-                cwd=str(cwd),
-                stdout=fh,
-                stderr=subprocess.STDOUT,
-                timeout=timeout,
-                check=False,
-            )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.error("openfoam_run_batch: {} invocation failed: {}", argv[0], exc)
-        return 1
-    return proc.returncode
-
-
-_DECOMPOSE_PAR_DICT = """\
-FoamFile {{ version 2.0; format ascii; class dictionary; object decomposeParDict; }}
-
-numberOfSubdomains {n};
-method scotch;
-"""
-
-
-def _write_decompose_par_dict(case_dir: Path, workers: int) -> None:
-    """Author system/decomposeParDict for `workers` scotch subdomains (the
-    case builder emits a placeholder; the MPI run pins it to the rank count)."""
-    (case_dir / "system" / "decomposeParDict").write_text(
-        _DECOMPOSE_PAR_DICT.format(n=workers)
-    )
-
-
-def _prune_processor_dirs(case_dir: Path) -> None:
-    if not case_dir.is_dir():
-        return
-    for proc_dir in case_dir.glob("processor*"):
-        shutil.rmtree(proc_dir, ignore_errors=True)
-
-
-def _has_processor_dirs(case_dir: Path) -> bool:
-    return case_dir.is_dir() and any(case_dir.glob("processor*"))
+def _solver_ready(mode: str, mesh_utility: str, solver: str | None,
+                  reconstruct: bool = True) -> bool:
+    required = [mesh_utility] + ([solver] if solver else [])
+    if mode == "mpi":
+        required += ["decomposePar", "mpirun"] + (["reconstructPar"] if reconstruct else [])
+    return all(shutil.which(name) is not None for name in required)
 
 
 def _clean_case_dir(case_dir: Path) -> None:
-    """Remove a stale case tree before a fresh rebuild (retry hygiene)."""
     if case_dir.is_dir():
         shutil.rmtree(case_dir, ignore_errors=True)
 
 
-def _set_start_from_latest_time(case_dir: Path) -> None:
-    """Patch system/controlDict to ``startFrom latestTime`` so a resumed MPI
-    solve continues from the last written time dir instead of t=0."""
-    control = case_dir / "system" / "controlDict"
-    if not control.is_file():
-        raise RuntimeError(
-            f"resume requested but no system/controlDict in {case_dir}"
-        )
-    text = control.read_text()
-    patched = re.sub(r"startFrom\s+\w+\s*;", "startFrom       latestTime;", text)
-    if patched == text and "startFrom" not in text:
-        patched = text + "\nstartFrom       latestTime;\n"
-    control.write_text(patched)
+def _prune_processor_dirs(case_dir: Path) -> None:
+    for path in case_dir.glob("processor*") if case_dir.is_dir() else ():
+        shutil.rmtree(path, ignore_errors=True)
 
 
-def _load_checkpoint(work_dir: Path) -> dict[str, Any] | None:
-    checkpoint = work_dir / CHECKPOINT_FILENAME
-    if not checkpoint.is_file():
-        return None
-    try:
-        row = json.loads(checkpoint.read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(row, dict):
-        return None
-    # Only a completed case is idempotently skipped; a failed (or truncated /
-    # corrupt) checkpoint is re-run so a transient failure can be retried by
-    # re-enqueuing the same input.
-    return row if row.get("status") == "completed" else None
-
-
-def _write_checkpoint(work_dir: Path, row: dict[str, Any]) -> None:
-    # Atomic: a kill mid-write must leave either the old checkpoint or the new
-    # one, never a truncated file (a corrupt checkpoint reads as "no
-    # checkpoint" and the case is retried).
-    work_dir.mkdir(parents=True, exist_ok=True)
-    target = work_dir / CHECKPOINT_FILENAME
-    tmp = work_dir / f"{CHECKPOINT_FILENAME}.tmp"
-    tmp.write_text(json.dumps(row, indent=2) + "\n")
-    os.replace(tmp, target)
-
-
-def _row(
-    item: dict[str, Any],
-    *,
-    status: str,
-    case_dir: Path | None = None,
-    solver: str | None = None,
-    error: str | None = None,
-    mock: bool = False,
-) -> dict[str, Any]:
-    return {
-        "index": item["index"],
-        "name": item["name"],
-        **item["case"],
-        "status": status,
-        "solver": solver,
-        "mock": mock,
-        "error": error,
-        "case_dir": str(case_dir) if case_dir else None,
-        "wall_seconds": 0.0,
-    }
-
-
-def _write_manifest(rows: list[dict[str, Any]], path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    pd.DataFrame(rows).to_csv(path, index=False)
-
-
-def _write_summary(
-    rows: list[dict[str, Any]],
-    path: Path,
-    mode: str,
-    workers: int,
-    mock: bool,
-    timeout_seconds: int,
-    started_at: datetime,
-    finished_at: datetime,
-) -> dict:
-    completed = sum(1 for row in rows if row["status"] == "completed")
-    summary = {
-        "workflow": "openfoam_run_batch",
-        "mode": mode,
-        "total_cases": len(rows),
-        "completed": completed,
-        "failed": len(rows) - completed,
-        "workers": workers,
-        "host_cpu_count": os.cpu_count(),
-        "mock": mock,
-        # The per-stage wall cap — dispatch lanes compare their own wall-clock
-        # window against this when sizing mpi cases (see module docstring).
-        "timeout_seconds": timeout_seconds,
-        "started_at_utc": started_at.isoformat(),
-        "finished_at_utc": finished_at.isoformat(),
-    }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(summary, indent=2) + "\n")
-    return summary
-
-
-def _resolve_path(path_value: str, cfg_dir: Path) -> Path:
-    path = Path(path_value)
-    if path.is_absolute():
-        return path
-    return cfg_dir / path
-
-
-def _resolve_dir(path_value: str, cfg_dir: Path) -> Path:
-    resolved = _resolve_path(path_value, cfg_dir)
-    resolved.mkdir(parents=True, exist_ok=True)
-    return resolved
+def _has_processor_dirs(case_dir: Path) -> bool:
+    return case_dir.is_dir() and any(case_dir.glob("processor*"))

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -82,12 +82,13 @@ def router(cfg: dict) -> dict:
     settings, run_settings, base, cfg_dir = _settings(cfg)
     mode, mock, workers = _validate_run(run_settings, base)
     paths = resolve_batch_paths(run_settings, cfg_dir)
-    layout, tool_bindings = _external_layout(
+    layout, tool_bindings, input_bindings = _external_layout(
         cfg, settings, run_settings, base, paths, mode, workers, mock)
     work_dir = paths.legacy_work_dir if layout is None else layout.run_dir
     cases = _resolve_case_matrix(settings.get("cases"), settings.get("variants") or {}, cfg_dir)
     mapping = settings.get("mapping") or (settings.get("variants") or {}).get("mapping") or {}
     rendered = _render_cases(base, cases, mapping, work_dir)
+    _verify_file_bindings(input_bindings, "referenced input")
     started = datetime.now(timezone.utc)
     if layout is None:
         rows = run_cases(rendered, run_settings, mode=mode, workers=workers,
@@ -131,10 +132,13 @@ def _validate_run(run_settings: dict, base: dict) -> tuple[str, bool, int]:
 
 def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
                      paths, mode: str, workers: int, mock: bool
-                     ) -> tuple[WorkLayout | None, dict[str, tuple[Path, str]]]:
+                     ) -> tuple[WorkLayout | None, dict[str, tuple[Path, str]],
+                                list[tuple[Path, str]]]:
     if not paths.external:
         paths.legacy_work_dir.mkdir(parents=True, exist_ok=True)
-        return None, {}
+        return None, {}, []
+    if not mock and not base.get("solver"):
+        raise ValueError("external real runs require base.solver for executable identity")
     inputs = _referenced_inputs(cfg, settings, paths.cfg_dir)
     tools = [] if mock else _selected_tools(mode, base, run_settings)
     identity = build_run_identity(
@@ -144,8 +148,16 @@ def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
         package_root=Path(__file__).resolve().parents[1],
     )
     bindings = {item[0]: (item[1], file_sha256(item[1])) for item in tools}
-    return (WorkLayout.create(paths.operator_root, paths.namespace, identity.identity_sha256),
-            bindings)
+    input_bindings = [(item[1], file_sha256(item[1])) for item in inputs]
+    return (WorkLayout.create(paths.operator_root, paths.namespace, identity.identity_sha256,
+                              identity.as_dict()),
+            bindings, input_bindings)
+
+
+def _verify_file_bindings(bindings: list[tuple[Path, str]], label: str) -> None:
+    for path, expected in bindings:
+        if file_sha256(path) != expected:
+            raise RuntimeError(f"{label} {path.name!r} changed before execution")
 
 
 def _referenced_inputs(cfg: dict, settings: dict, cfg_dir: Path) -> list[tuple[str, Path]]:
@@ -180,6 +192,8 @@ def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str
     names = [base.get("mesh_utility", DEFAULT_MESH_UTILITY), base.get("solver")]
     if mode == "mpi":
         names += ["decomposePar", "mpirun"]
+        if base.get("run_set_fields"):
+            names.append("setFields")
         if bool(run_settings.get("reconstruct", True)):
             names.append("reconstructPar")
     else:

--- a/tests/workflows/test_openfoam_batch_execution.py
+++ b/tests/workflows/test_openfoam_batch_execution.py
@@ -27,4 +27,3 @@ def test_checkpoint_contains_no_external_path(tmp_path: Path) -> None:
         row={"name": "case-1", "status": "completed", "case_dir": "<external-work>/case-1"},
     )
     assert str(tmp_path) not in str(checkpoint)
-

--- a/tests/workflows/test_openfoam_batch_execution.py
+++ b/tests/workflows/test_openfoam_batch_execution.py
@@ -23,6 +23,7 @@ def test_checkpoint_v2_requires_identity_owner_case_and_completed() -> None:
     assert not checkpoint_matches({**checkpoint, "schema": 1}, "a" * 64, "token", "case-1")
     failed = {**checkpoint, "row": {"name": "case-1", "status": "failed"}}
     assert not checkpoint_matches(failed, "a" * 64, "token", "case-1")
+    assert checkpoint["run_identity"]["identity_sha256"] == "a" * 64
 
 
 def test_checkpoint_contains_no_external_path(tmp_path: Path) -> None:
@@ -48,3 +49,18 @@ def test_mpi_launch_revalidates_bound_executable(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="changed"):
         execute_mpi_plan(item, tmp_path, [["blockMesh"]], "solver", mutate, 10,
                          tool_bindings={"blockMesh": (tool, file_sha256(tool))})
+
+
+def test_mpi_executes_verified_absolute_path(tmp_path: Path) -> None:
+    tool = tmp_path / "blockMesh"
+    tool.write_bytes(b"approved")
+    item = {"index": 0, "name": "case", "case": {}}
+    launched = []
+
+    def capture(argv, cwd, log, timeout, expected_executable=None):
+        launched.append(argv)
+        return 0
+
+    execute_mpi_plan(item, tmp_path, [["blockMesh"]], "solver", capture, 10,
+                     tool_bindings={"blockMesh": (tool, file_sha256(tool))})
+    assert launched == [[str(tool)]]

--- a/tests/workflows/test_openfoam_batch_execution.py
+++ b/tests/workflows/test_openfoam_batch_execution.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from digitalmodel.workflows.openfoam_batch_execution import (
     checkpoint_matches,
+    execute_mpi_plan,
+    file_sha256,
     make_checkpoint,
 )
 
@@ -27,3 +31,20 @@ def test_checkpoint_contains_no_external_path(tmp_path: Path) -> None:
         row={"name": "case-1", "status": "completed", "case_dir": "<external-work>/case-1"},
     )
     assert str(tmp_path) not in str(checkpoint)
+
+
+def test_mpi_launch_revalidates_bound_executable(tmp_path: Path) -> None:
+    tool = tmp_path / "blockMesh"
+    tool.write_bytes(b"approved")
+    item = {"index": 0, "name": "case", "case": {}}
+
+    def mutate(argv, cwd, log, timeout, expected_executable=None):
+        tool.write_bytes(b"changed")
+        path, digest = expected_executable
+        if file_sha256(path) != digest:
+            raise RuntimeError("selected executable changed")
+        return 0
+
+    with pytest.raises(RuntimeError, match="changed"):
+        execute_mpi_plan(item, tmp_path, [["blockMesh"]], "solver", mutate, 10,
+                         tool_bindings={"blockMesh": (tool, file_sha256(tool))})

--- a/tests/workflows/test_openfoam_batch_execution.py
+++ b/tests/workflows/test_openfoam_batch_execution.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from digitalmodel.workflows.openfoam_batch_execution import (
+    checkpoint_matches,
+    make_checkpoint,
+)
+
+
+def test_checkpoint_v2_requires_identity_owner_case_and_completed() -> None:
+    checkpoint = make_checkpoint(
+        identity_sha256="a" * 64, owner_token="token", case="case-1",
+        row={"name": "case-1", "status": "completed"},
+    )
+    assert checkpoint_matches(checkpoint, "a" * 64, "token", "case-1")
+    assert not checkpoint_matches(checkpoint, "b" * 64, "token", "case-1")
+    assert not checkpoint_matches(checkpoint, "a" * 64, "foreign", "case-1")
+    assert not checkpoint_matches({**checkpoint, "schema": 1}, "a" * 64, "token", "case-1")
+    failed = {**checkpoint, "row": {"name": "case-1", "status": "failed"}}
+    assert not checkpoint_matches(failed, "a" * 64, "token", "case-1")
+
+
+def test_checkpoint_contains_no_external_path(tmp_path: Path) -> None:
+    checkpoint = make_checkpoint(
+        identity_sha256="a" * 64, owner_token="token", case="case-1",
+        row={"name": "case-1", "status": "completed", "case_dir": "<external-work>/case-1"},
+    )
+    assert str(tmp_path) not in str(checkpoint)
+

--- a/tests/workflows/test_openfoam_batch_identity.py
+++ b/tests/workflows/test_openfoam_batch_identity.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+
+import pytest
 
 from digitalmodel.workflows.openfoam_batch_identity import build_run_identity
 
@@ -47,3 +50,19 @@ def test_identity_rejects_missing_or_symlinked_input(tmp_path: Path) -> None:
         assert "referenced input" in str(exc)
     else:
         raise AssertionError("missing input was accepted")
+
+
+def test_dirty_git_package_source_is_rejected(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    source = package / "module.py"
+    source.write_text("VALUE = 1\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "pkg/module.py"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "-c", "user.name=Test",
+                    "-c", "user.email=test@example.invalid", "commit", "-qm", "init"], check=True)
+    source.write_text("VALUE = 2\n")
+    with pytest.raises(ValueError, match="dirty"):
+        build_run_identity(effective_config={}, referenced_inputs=[], selected_executables=[],
+                           visible_rank_count=1, dispatcher_rank_limit=1,
+                           package_root=package)

--- a/tests/workflows/test_openfoam_batch_identity.py
+++ b/tests/workflows/test_openfoam_batch_identity.py
@@ -47,4 +47,3 @@ def test_identity_rejects_missing_or_symlinked_input(tmp_path: Path) -> None:
         assert "referenced input" in str(exc)
     else:
         raise AssertionError("missing input was accepted")
-

--- a/tests/workflows/test_openfoam_batch_identity.py
+++ b/tests/workflows/test_openfoam_batch_identity.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from digitalmodel.workflows.openfoam_batch_identity import build_run_identity
+
+
+def test_identity_is_stable_and_changes_with_input_tool_and_capacity(tmp_path: Path) -> None:
+    source = tmp_path / "input.yml"
+    tool = tmp_path / "solver"
+    source.write_text("a: 1\n")
+    tool.write_bytes(b"solver-v1")
+    kwargs = dict(
+        effective_config={"run_batch": {"mode": "mpi"}},
+        referenced_inputs=[("request", source)],
+        selected_executables=[("solver", tool)],
+        visible_rank_count=8,
+        dispatcher_rank_limit=7,
+        package_root=Path(__file__).resolve().parents[2] / "src" / "digitalmodel",
+    )
+    first = build_run_identity(**kwargs)
+    assert first == build_run_identity(**kwargs)
+    assert len(first.identity_sha256) == 64
+    assert first.selected_executables[0]["basename"] == "solver"
+    assert str(tmp_path) not in first.canonical_json()
+
+    source.write_text("a: 2\n")
+    changed_input = build_run_identity(**kwargs)
+    assert changed_input.identity_sha256 != first.identity_sha256
+    source.write_text("a: 1\n")
+    tool.write_bytes(b"solver-v2")
+    changed_tool = build_run_identity(**kwargs)
+    assert changed_tool.identity_sha256 != first.identity_sha256
+    kwargs["visible_rank_count"] = 9
+    assert build_run_identity(**kwargs).identity_sha256 != changed_tool.identity_sha256
+
+
+def test_identity_rejects_missing_or_symlinked_input(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yml"
+    try:
+        build_run_identity(
+            effective_config={}, referenced_inputs=[("request", missing)],
+            selected_executables=[], visible_rank_count=1,
+            dispatcher_rank_limit=1, package_root=tmp_path,
+        )
+    except ValueError as exc:
+        assert "referenced input" in str(exc)
+    else:
+        raise AssertionError("missing input was accepted")
+

--- a/tests/workflows/test_openfoam_batch_identity.py
+++ b/tests/workflows/test_openfoam_batch_identity.py
@@ -5,7 +5,10 @@ import subprocess
 
 import pytest
 
-from digitalmodel.workflows.openfoam_batch_identity import build_run_identity
+from digitalmodel.workflows.openfoam_batch_identity import (
+    build_run_identity,
+    verify_wheel_record,
+)
 
 
 def test_identity_is_stable_and_changes_with_input_tool_and_capacity(tmp_path: Path) -> None:
@@ -66,3 +69,24 @@ def test_dirty_git_package_source_is_rejected(tmp_path: Path) -> None:
         build_run_identity(effective_config={}, referenced_inputs=[], selected_executables=[],
                            visible_rank_count=1, dispatcher_rank_limit=1,
                            package_root=package)
+
+
+def test_wheel_record_verifies_actual_installed_bytes(tmp_path: Path) -> None:
+    import base64
+    import hashlib
+
+    package = tmp_path / "digitalmodel"
+    dist_info = tmp_path / "digitalmodel-1.0.dist-info"
+    package.mkdir()
+    dist_info.mkdir()
+    module = package / "module.py"
+    module.write_bytes(b"VALUE = 1\n")
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(module.read_bytes()).digest()).rstrip(b"=").decode()
+    record = dist_info / "RECORD"
+    record.write_text(f"digitalmodel/module.py,sha256={encoded},{module.stat().st_size}\n"
+                      "digitalmodel-1.0.dist-info/RECORD,,\n")
+    verified = verify_wheel_record(package, record)
+    assert verified["content_sha256"]
+    module.write_bytes(b"VALUE = 2\n")
+    with pytest.raises(ValueError, match="RECORD"):
+        verify_wheel_record(package, record)

--- a/tests/workflows/test_openfoam_batch_identity.py
+++ b/tests/workflows/test_openfoam_batch_identity.py
@@ -90,3 +90,17 @@ def test_wheel_record_verifies_actual_installed_bytes(tmp_path: Path) -> None:
     module.write_bytes(b"VALUE = 2\n")
     with pytest.raises(ValueError, match="RECORD"):
         verify_wheel_record(package, record)
+
+
+def test_dirty_git_referenced_input_is_rejected(tmp_path: Path) -> None:
+    request = tmp_path / "request.yml"
+    request.write_text("a: 1\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "request.yml"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "-c", "user.name=Test",
+                    "-c", "user.email=test@example.invalid", "commit", "-qm", "init"], check=True)
+    request.write_text("a: 2\n")
+    with pytest.raises(ValueError, match="referenced input is dirty"):
+        build_run_identity(effective_config={}, referenced_inputs=[("request", request)],
+                           selected_executables=[], visible_rank_count=1,
+                           dispatcher_rank_limit=1, package_root=tmp_path / "not-a-package")

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -119,6 +119,7 @@ def test_stale_lock_requires_dead_process_proof(tmp_path: Path) -> None:
     with layout.lock("run"):
         meta_path = lock / "meta.json"
         meta = json.loads(meta_path.read_text())
+        assert meta["process_start"]
         meta["heartbeat_epoch"] = 0
         meta_path.write_text(json.dumps(meta))
         with pytest.raises(RuntimeError, match="held"):

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -8,6 +8,7 @@ import pytest
 
 from digitalmodel.workflows.openfoam_batch_config import resolve_batch_paths
 from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
+from digitalmodel.workflows import openfoam_batch_layout as layout_module
 
 
 def test_hosted_root_is_environment_owned_and_output_remains_local(tmp_path: Path) -> None:
@@ -142,3 +143,37 @@ def test_root_inode_substitution_blocks_clean(tmp_path: Path) -> None:
     tmp_path.mkdir()
     with pytest.raises(ValueError, match="root"):
         layout.clean_case("case")
+
+
+def test_tombstone_substitution_is_never_path_deleted(tmp_path: Path) -> None:
+    tombstone = tmp_path / "tombstone"
+    tombstone.mkdir()
+    expected = tombstone.stat()
+    original = tmp_path / "original"
+    os.replace(tombstone, original)
+    tombstone.mkdir()
+    (tombstone / "replacement.txt").write_text("keep")
+    if os.name == "nt":
+        layout_module._dispose_tombstone(tmp_path, tombstone, expected)
+    else:
+        with pytest.raises(ValueError, match="changed"):
+            layout_module._dispose_tombstone(tmp_path, tombstone, expected)
+    assert (tombstone / "replacement.txt").read_text() == "keep"
+
+
+def test_lock_heartbeat_refreshes_and_process_start_prevents_pid_reuse(tmp_path: Path) -> None:
+    import time
+
+    layout = WorkLayout.create(tmp_path, "ns", "e" * 64)
+    lock = layout.run_dir / ".locks" / "run"
+    with layout.lock("run", stale_seconds=1):
+        first = json.loads((lock / "meta.json").read_text())
+        time.sleep(1.2)
+        second = json.loads((lock / "meta.json").read_text())
+        assert second["heartbeat_epoch"] > first["heartbeat_epoch"]
+    lock.mkdir()
+    (lock / "meta.json").write_text(json.dumps({
+        **second, "heartbeat_epoch": 0, "process_start": "reused-pid-start",
+    }))
+    with layout.lock("run", stale_seconds=1):
+        assert lock.is_dir()

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.workflows.openfoam_batch_config import resolve_batch_paths
+from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
+
+
+def test_hosted_root_is_environment_owned_and_output_remains_local(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / "scope" / "case"
+    cfg_dir.mkdir(parents=True)
+    root = tmp_path / "scratch"
+    root.mkdir()
+    paths = resolve_batch_paths(
+        {"work_root_namespace": "gpu-canary", "work_root": str(tmp_path / "forbidden")},
+        cfg_dir,
+        env={
+            "DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand",
+            "DIGITALMODEL_WORK_ROOT": str(root),
+        },
+    )
+    assert paths.operator_root == root.resolve()
+    assert paths.output_dir == cfg_dir / "results"
+    assert paths.namespace == "gpu-canary"
+
+
+@pytest.mark.parametrize("namespace", ["../escape", ".", "a//b", "a\\b", "x\x00y"])
+def test_namespace_rejects_nonportable_components(tmp_path: Path, namespace: str) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(ValueError, match="namespace"):
+        resolve_batch_paths(
+            {"work_root_namespace": namespace}, tmp_path,
+            env={"DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand",
+                 "DIGITALMODEL_WORK_ROOT": str(root)},
+        )
+
+
+def test_hosted_missing_root_rejects_before_side_effect(tmp_path: Path) -> None:
+    before = set(tmp_path.iterdir())
+    with pytest.raises(ValueError, match="DIGITALMODEL_WORK_ROOT"):
+        resolve_batch_paths({}, tmp_path, env={"DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand"})
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_trusted_local_requires_precreated_absolute_non_git_root(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / "checkout" / "case"
+    cfg_dir.mkdir(parents=True)
+    (tmp_path / "checkout" / ".git").mkdir()
+    external = tmp_path / "scratch"
+    external.mkdir()
+    paths = resolve_batch_paths(
+        {"execution_context": "trusted-local", "work_root": str(external)}, cfg_dir, env={}
+    )
+    assert paths.operator_root == external.resolve()
+    with pytest.raises(ValueError, match="Git checkout"):
+        resolve_batch_paths(
+            {"execution_context": "trusted-local", "work_root": str(cfg_dir)}, cfg_dir, env={}
+        )
+
+
+def test_owned_layout_rejects_foreign_marker_and_cleans_only_case(tmp_path: Path) -> None:
+    layout = WorkLayout.create(tmp_path, "ns", "a" * 64)
+    case = layout.case_dir("case-001")
+    case.mkdir(parents=True)
+    (case / "heavy").write_text("x")
+    sibling = layout.run_dir / "keep"
+    sibling.write_text("safe")
+    layout.clean_case("case-001")
+    assert not case.exists() and sibling.read_text() == "safe"
+
+    marker = json.loads(layout.marker_path.read_text())
+    marker["identity_sha256"] = "b" * 64
+    layout.marker_path.write_text(json.dumps(marker))
+    with pytest.raises(ValueError, match="owner marker"):
+        WorkLayout.create(tmp_path, "ns", "a" * 64)
+

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -177,3 +178,21 @@ def test_lock_heartbeat_refreshes_and_process_start_prevents_pid_reuse(tmp_path:
     }))
     with layout.lock("run", stale_seconds=1):
         assert lock.is_dir()
+
+
+@pytest.mark.parametrize("kind", ["directory", "file"])
+def test_nested_entry_substitution_inode_is_rejected(kind: str) -> None:
+    expected = SimpleNamespace(st_dev=1, st_ino=2)
+    replacement = SimpleNamespace(st_dev=1, st_ino=3)
+    assert not layout_module._same_inode(expected, replacement), kind
+
+
+def test_lock_release_never_uses_path_rmtree(tmp_path: Path, monkeypatch) -> None:
+    layout = WorkLayout.create(tmp_path, "ns", "f" * 64)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("path-based rmtree used")
+
+    monkeypatch.setattr(layout_module.shutil, "rmtree", forbidden)
+    with layout.lock("run"):
+        pass

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -155,12 +155,17 @@ def test_tombstone_substitution_is_never_path_deleted(tmp_path: Path) -> None:
     os.replace(tombstone, original)
     tombstone.mkdir()
     (tombstone / "replacement.txt").write_text("keep")
-    if os.name == "nt":
+    with pytest.raises(ValueError, match="changed"):
         layout_module._dispose_tombstone(tmp_path, tombstone, expected)
-    else:
-        with pytest.raises(ValueError, match="changed"):
-            layout_module._dispose_tombstone(tmp_path, tombstone, expected)
     assert (tombstone / "replacement.txt").read_text() == "keep"
+
+
+def test_verified_tombstone_is_retained_without_final_name_delete(tmp_path: Path) -> None:
+    tombstone = tmp_path / "tombstone"
+    tombstone.mkdir()
+    (tombstone / "payload").write_text("retained")
+    layout_module._dispose_tombstone(tmp_path, tombstone, tombstone.stat())
+    assert (tombstone / "payload").read_text() == "retained"
 
 
 def test_lock_heartbeat_refreshes_and_process_start_prevents_pid_reuse(tmp_path: Path) -> None:

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -83,3 +84,60 @@ def test_owned_layout_rejects_foreign_marker_and_cleans_only_case(tmp_path: Path
     layout.marker_path.write_text(json.dumps(marker))
     with pytest.raises(ValueError, match="owner marker"):
         WorkLayout.create(tmp_path, "ns", "a" * 64)
+
+
+def test_external_output_must_remain_beneath_input_scope(tmp_path: Path) -> None:
+    cfg_dir, root = tmp_path / "input", tmp_path / "scratch"
+    cfg_dir.mkdir()
+    root.mkdir()
+    env = {"DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand",
+           "DIGITALMODEL_WORK_ROOT": str(root)}
+    for output in (str(tmp_path / "outside"), "../outside"):
+        with pytest.raises(ValueError, match="input-local"):
+            resolve_batch_paths({"output_dir": output}, cfg_dir, env=env)
+
+
+def test_layout_rejects_namespace_and_run_symlinks(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (tmp_path / "linked").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks unavailable")
+    with pytest.raises(ValueError, match="symlink"):
+        WorkLayout.create(tmp_path, "linked/ns", "a" * 64)
+    namespace = tmp_path / "safe"
+    namespace.mkdir()
+    (namespace / f"openfoam-run-{'b' * 64}").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        WorkLayout.create(tmp_path, "safe", "b" * 64)
+
+
+def test_stale_lock_requires_dead_process_proof(tmp_path: Path) -> None:
+    layout = WorkLayout.create(tmp_path, "ns", "c" * 64)
+    lock = layout.run_dir / ".locks" / "run"
+    with layout.lock("run"):
+        meta_path = lock / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta["heartbeat_epoch"] = 0
+        meta_path.write_text(json.dumps(meta))
+        with pytest.raises(RuntimeError, match="held"):
+            with layout.lock("run", stale_seconds=1):
+                pass
+    lock.mkdir()
+    (lock / "meta.json").write_text(json.dumps({
+        "schema": 1, "pid": 2 ** 30, "boot_id": meta["boot_id"],
+        "owner_token": layout.owner_token, "heartbeat_epoch": 0,
+    }))
+    with layout.lock("run", stale_seconds=1):
+        assert lock.is_dir()
+
+
+def test_root_inode_substitution_blocks_clean(tmp_path: Path) -> None:
+    layout = WorkLayout.create(tmp_path, "ns", "d" * 64)
+    layout.case_dir("case").mkdir()
+    moved = tmp_path.with_name(tmp_path.name + "-moved")
+    os.replace(tmp_path, moved)
+    tmp_path.mkdir()
+    with pytest.raises(ValueError, match="root"):
+        layout.clean_case("case")

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 from types import SimpleNamespace
 
 import pytest
@@ -193,6 +194,6 @@ def test_lock_release_never_uses_path_rmtree(tmp_path: Path, monkeypatch) -> Non
     def forbidden(*args, **kwargs):
         raise AssertionError("path-based rmtree used")
 
-    monkeypatch.setattr(layout_module.shutil, "rmtree", forbidden)
+    monkeypatch.setattr(shutil, "rmtree", forbidden)
     with layout.lock("run"):
         pass

--- a/tests/workflows/test_openfoam_batch_layout.py
+++ b/tests/workflows/test_openfoam_batch_layout.py
@@ -15,7 +15,7 @@ def test_hosted_root_is_environment_owned_and_output_remains_local(tmp_path: Pat
     root = tmp_path / "scratch"
     root.mkdir()
     paths = resolve_batch_paths(
-        {"work_root_namespace": "gpu-canary", "work_root": str(tmp_path / "forbidden")},
+        {"work_root_namespace": "gpu-canary"},
         cfg_dir,
         env={
             "DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand",
@@ -25,6 +25,12 @@ def test_hosted_root_is_environment_owned_and_output_remains_local(tmp_path: Pat
     assert paths.operator_root == root.resolve()
     assert paths.output_dir == cfg_dir / "results"
     assert paths.namespace == "gpu-canary"
+    with pytest.raises(ValueError, match="operator environment"):
+        resolve_batch_paths(
+            {"work_root_namespace": "gpu-canary", "work_root": str(root)}, cfg_dir,
+            env={"DIGITALMODEL_EXECUTION_CONTEXT": "hosted-deckhand",
+                 "DIGITALMODEL_WORK_ROOT": str(root)},
+        )
 
 
 @pytest.mark.parametrize("namespace", ["../escape", ".", "a//b", "a\\b", "x\x00y"])
@@ -77,4 +83,3 @@ def test_owned_layout_rejects_foreign_marker_and_cleans_only_case(tmp_path: Path
     layout.marker_path.write_text(json.dumps(marker))
     with pytest.raises(ValueError, match="owner marker"):
         WorkLayout.create(tmp_path, "ns", "a" * 64)
-

--- a/tests/workflows/test_openfoam_batch_results.py
+++ b/tests/workflows/test_openfoam_batch_results.py
@@ -29,3 +29,10 @@ def test_result_policy_writes_only_fixed_bounded_files(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="extension"):
         write_results(rows, tmp_path, mode="pool", workers=1, mock=True,
                       timeout_seconds=10, extensions=["openfoam-artifact-index-v1"])
+
+
+def test_redaction_covers_windows_case_and_separator_variants() -> None:
+    rows = [{"case_dir": r"C:\Scratch\Runs\case",
+             "error": r"failed at c:/scratch/runs/case"}]
+    safe = redact_rows(rows, Path(r"C:\Scratch\Runs"))[0]
+    assert "scratch" not in str(safe).lower()

--- a/tests/workflows/test_openfoam_batch_results.py
+++ b/tests/workflows/test_openfoam_batch_results.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.workflows.openfoam_batch_results import redact_rows, write_results
+
+
+def test_external_paths_are_redacted_from_rows_and_errors(tmp_path: Path) -> None:
+    root = tmp_path / "private-root"
+    rows = [{
+        "name": "case-1", "status": "failed", "case_dir": str(root / "case-1"),
+        "error": f"solver failed below {root / 'case-1'}", "wall_seconds": 1.0,
+    }]
+    redacted = redact_rows(rows, root)
+    blob = json.dumps(redacted)
+    assert str(root) not in blob
+    assert redacted[0]["case_dir"] == "<external-work>/case-1"
+
+
+def test_result_policy_writes_only_fixed_bounded_files(tmp_path: Path) -> None:
+    rows = [{"name": "case-1", "status": "completed", "wall_seconds": 0.0}]
+    outputs = write_results(rows, tmp_path, mode="pool", workers=1, mock=True,
+                            timeout_seconds=10)
+    assert set(outputs) == {"manifest", "summary"}
+    assert {p.name for p in tmp_path.iterdir()} == {"cases.csv", "batch_summary.json"}
+    with pytest.raises(ValueError, match="extension"):
+        write_results(rows, tmp_path, mode="pool", workers=1, mock=True,
+                      timeout_seconds=10, extensions=["openfoam-artifact-index-v1"])
+

--- a/tests/workflows/test_openfoam_batch_results.py
+++ b/tests/workflows/test_openfoam_batch_results.py
@@ -29,4 +29,3 @@ def test_result_policy_writes_only_fixed_bounded_files(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="extension"):
         write_results(rows, tmp_path, mode="pool", workers=1, mock=True,
                       timeout_seconds=10, extensions=["openfoam-artifact-index-v1"])
-

--- a/tests/workflows/test_openfoam_batch_structure.py
+++ b/tests/workflows/test_openfoam_batch_structure.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FILES = [
+    ROOT / "src/digitalmodel/workflows/openfoam_batch_config.py",
+    ROOT / "src/digitalmodel/workflows/openfoam_batch_identity.py",
+    ROOT / "src/digitalmodel/workflows/openfoam_batch_layout.py",
+    ROOT / "src/digitalmodel/workflows/openfoam_batch_execution.py",
+    ROOT / "src/digitalmodel/workflows/openfoam_batch_results.py",
+    ROOT / "src/digitalmodel/workflows/openfoam_run_batch.py",
+]
+
+
+def test_touched_modules_stay_bounded() -> None:
+    for path in FILES:
+        lines = path.read_text().splitlines()
+        assert len(lines) <= 400, (path, len(lines))
+        tree = ast.parse("\n".join(lines))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                end = getattr(node, "end_lineno", node.lineno)
+                assert end - node.lineno + 1 <= 50, (path, node.name, end - node.lineno + 1)


### PR DESCRIPTION
## Outcome

Implements the exact approved #1565 code/synthetic-verification plan. Hosted OpenFOAM batch work is placed beneath an operator-authorized external root, while bounded CSV/JSON results remain input-local.

## Safety contract

- strict hosted/trusted-local root authority
- source/input/tool-bound RunIdentity with dirty-byte rejection and launch-time revalidation
- exact absolute executable binding for serial and MPI launches
- full RunIdentity checkpoint v2
- stable boot/PID/process-start lock identity with refreshed heartbeat
- descriptor-relative quarantine with inode checks for case, processor, stale-lock, and release paths
- quarantines are deliberately retained; no recursive/name-based deletion remains
- Windows-insensitive host-path redaction

## Verification

- final expanded implementation suite: 79 passed
- post-plan-merge focused/regression suite: 61 passed
- Ruff: clean
- `git diff --check origin/main..HEAD`: clean
- independent implementation review: APPROVE

## Boundaries

This PR does not authorize or perform host configuration, queue dispatch, a real canary, or cleanup of retained external quarantines. Those remain separate owner-gated operational work.