### PR TITLE
feat: vessel stability screening workflow (intact criteria + KG limits)

### DIFF
--- a/docs/domains/ship-design/vessel-stability-screening.md
+++ b/docs/domains/ship-design/vessel-stability-screening.md
@@ -1,0 +1,120 @@
+# Vessel intact stability screening (criteria + KG limits)
+
+## What this is
+
+`digitalmodel.naval_architecture.vessel_stability_screening` and the routed
+workflow basename `vessel_stability_screening` run a deterministic intact
+stability screen from config: a draft-indexed hydrostatic table, a loading
+condition with per-tank free-surface correction, a GZ curve from a GZ table
+or KN cross-curves, cited stability criteria (IMO IS Code 2008 Part A
+intact set, 46 CFR 170.170 weather criterion, 46 CFR 173.005-series style
+lifting/crane-heel criteria) and a max-KG (KG-limit) screen per criterion.
+
+This is the L1 slice of the stability/hydrostatics/T&S-booklet lane:
+hydrostatics come in as a *table* (from GHS, a curves-of-form sheet, or a
+published example) — geometry-based hydrostatics, damage stability and the
+T&S booklet report assembly are later slices.
+
+## Governance — screening tier only
+
+**This is a screening tool.** It ranks and gates intact loading conditions
+(e.g. across a T&S-booklet condition set or a lift plan) so attention goes
+to the governing cases. **The PE-stamped stability booklet / class or USCG
+submittal governs**; GHS remains the licensed cross-check. Criteria
+thresholds are *cited config inputs* (foam_system Citation pattern —
+standard/edition/clause mandatory): the IMO IS Code 2008 defaults are baked
+in with their citation and are overridable; the 46 CFR weather-criterion
+wind pressure and the lifting criteria must be supplied and cited by the
+user against the governing edition.
+
+## Method
+
+1. **Hydrostatic-table interface.** Draft-indexed rows (draft,
+   displacement, KM, and optionally LCB, LCF, MCT1cm, TPC) from inline YAML
+   or CSV; linear interpolation in displacement (or draft); no
+   extrapolation — out-of-range queries raise.
+2. **Loading-condition builder.** Lightship + tank/cargo weight items sum
+   to displacement, KG and LCG. Free-surface correction is the standard
+   virtual rise `FSC = sum(FSM_i) / W` from per-tank free-surface moments,
+   given directly (t·m) or as rectangular tank dimensions
+   (`FSM = rho·l·b³/12`); `KG_fluid = KG + FSC`.
+3. **Equilibrium estimate.** Mean draft at the condition displacement;
+   `GM = KM − KG` (solid and fluid); trim (positive by the stern) from
+   `trim_cm = W·(LCB − LCG)/MCT1cm`, distributed about the LCF to end
+   drafts when LBP is given. Longitudinal positions from the aft
+   perpendicular.
+4. **GZ curve.** From a pre-corrected GZ table, a KN cross-curve at the
+   condition displacement, or a KN grid interpolated linearly in
+   displacement: `GZ = KN − KG_fluid·sin(phi)`. Areas by trapezoidal
+   integration (shared with the validated IS-Code helpers in
+   `naval_architecture.damage_stability`).
+5. **Criteria table (all rows cited).**
+   * IMO IS Code 2008 (Res. MSC.267(85)) Part A 2.2: areas 0–30°, 0–40°
+     (capped at the downflooding angle), 30–40°, GZ at 30°, angle of max
+     GZ, initial GM0 — evaluated on the fluid GM.
+   * 46 CFR 170.170 weather criterion:
+     `GM ≥ P·A·H / (W·tan(T))`, `T = min(14°, deck-edge immersion)`; the
+     wind pressure `P` (service- and edition-dependent) is a cited config
+     input.
+   * Lifting/crane heel (46 CFR 173.005-series style): heeling arm
+     `HA(phi) = HM·cos(phi)/W` from a hook load × transverse outreach (or
+     a direct heeling moment); static equilibrium heel at the first
+     GZ/HA intersection (bisection); criteria are a cited maximum
+     equilibrium heel (capped by deck-edge immersion) and an optional
+     residual-righting-energy / heeling-energy ratio over the residual
+     range (to the least of the configured limit, downflooding angle and
+     the tabulated GZ range). A lift whose heeling arm exceeds GZ over the
+     whole range has no static equilibrium and fails hard.
+6. **Max-KG screening.** For each criterion, bisect the fluid KG on
+   [0, KM] for the largest value that still passes at the condition
+   displacement → KG-limit table with the governing (lowest) criterion.
+   Criteria that still pass at KG = KM are flagged `limited_by_km`;
+   criteria failing even at KG = 0 report no limit.
+
+Units: SI marine practice — m, t, degrees, m·rad; MCT in t·m/cm.
+
+## Outputs
+
+Loading-condition, equilibrium, GZ-curve (with heeling-arm columns when a
+lift is configured), criteria (with a citation column), KG-limit and
+one-row summary CSVs — all report_pack-ready — plus the same content in
+the returned config; `screening_status` is stamped pass/fail from the
+evaluated criteria.
+
+## Validation
+
+`tests/naval_architecture/test_vessel_stability_screening.py` (+ the
+workflow tests) pin the implementation to a synthetic box-barge golden
+fixture in the standard published closed forms (Barrass & Derrett box-barge
+hydrostatics/trim; PNA Vol. I; wall-sided GZ formula) — synthetic fixtures
+only, no client-derived values:
+
+* Box barge 100 m × 20 m, W = 8200 t → T = 4.0 m, KM = 10.3333 m,
+  KG = 4.9024 m, FSC = 0.0500 m exactly, GM_fluid = 5.3809 m; trim
+  0.2341 m by the stern from a 4000 t·m trimming moment
+  (MCT1cm = 170.833 t·m/cm).
+* Wall-sided KN cross-curve: GZ(30°) = 3.3849 m; analytic GZ areas
+  (0–30° = 0.8073 m·rad, 0–40° = 1.5567 m·rad) recovered by the
+  trapezoidal table integration to ~0.3 %.
+* 46 CFR 170.170 hand value: GM_required = 165/2044.49 = 0.0807 m.
+* Crane lift 100 t × 15 m: equilibrium heel 1.9377° (closed-form
+  intersection on the tabulated curve); a heeling arm exceeding max GZ
+  reports no static equilibrium and fails.
+* Max-KG hand values: GM0 criterion gives KG_limit = KM − 0.15
+  = 10.1833 m; weather gives KM − 0.0807 = 10.2526 m; the 5° lift-heel
+  limit gives 8.2744 m and governs.
+* Edge cases: negative GM (GM0 fails), FSM dominance (FSC = 10 m flips
+  GM_fluid negative), out-of-range hydrostatics, uncited criteria
+  rejected.
+
+A GHS golden fixture (run file + output listing) is the planned
+cross-check once the extraction lane lands (llm-wiki-acma#227/#262);
+damage stability and T&S-booklet assembly via `report_pack` are the next
+slices (llm-wiki-acma#239).
+
+## Config
+
+See the module docstring of
+`src/digitalmodel/vessel_stability_screening/workflow.py` for the full
+YAML schema and `src/digitalmodel/base_configs/modules/vessel_stability_screening/vessel_stability_screening.yml`
+for the base config.

--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -84,6 +84,7 @@ of duplicating its detailed issue history.
 | `uncertainty` | `src/digitalmodel/uncertainty/` | `tests/uncertainty/` | `docs/domains/README.md` | Monte Carlo uncertainty quantification: priors, LHS DoE, evaluator harness, sensitivity ranking, percentile analytics | NumPy, pandas, SciPy, PyYAML, pydantic |
 | `usecase_registry` | `src/digitalmodel/usecase_registry/` | `tests/test_usecase_registry.py` | `docs/domains/README.md` | Registry of runnable use cases and routing metadata | PyYAML |
 | `vessel_seakeeping` | `src/digitalmodel/vessel_seakeeping/` | `tests/` | `docs/domains/README.md` | Vessel seakeeping response and operability analysis | hydrodynamics standards |
+| `vessel_stability_screening` | `src/digitalmodel/vessel_stability_screening/` | `tests/naval_architecture/test_vessel_stability_screening.py` | `docs/domains/ship-design/vessel-stability-screening.md` | Intact stability screening: hydrostatic-table loading condition (KG + free-surface correction, trim), GZ/KN criteria (IMO IS Code 2008 Part A, 46 CFR 170.170 weather, 46 CFR 173 lifting heel), max-KG limits | cited criteria config (IMO IS Code / 46 CFR), stability fundamentals |
 | `weather_window` | `src/digitalmodel/weather_window/` | `tests/` | `docs/domains/README.md` | Weather-window/operability assessment for marine operations | metocean data, statistics |
 | `well_access` | `src/digitalmodel/well_access/` | `tests/well_access/` | `docs/domains/README.md` | Well-access/intervention analysis and operability | well engineering standards |
 

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -386,6 +386,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#vessel_seakeeping
+  - module: vessel_stability_screening
+    entry_point: src/digitalmodel/vessel_stability_screening/
+    maturity: development
+    owner_wiki: docs/domains/ship-design/vessel-stability-screening.md
+    key_tests: [tests/naval_architecture/test_vessel_stability_screening.py, tests/naval_architecture/test_vessel_stability_screening_workflow.py]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#vessel_stability_screening
   - module: weather_window
     entry_point: src/digitalmodel/weather_window/
     maturity: development

--- a/src/digitalmodel/base_configs/modules/vessel_stability_screening/vessel_stability_screening.yml
+++ b/src/digitalmodel/base_configs/modules/vessel_stability_screening/vessel_stability_screening.yml
@@ -1,0 +1,16 @@
+basename: vessel_stability_screening
+
+# Intact vessel stability SCREENING: hydrostatic-table loading condition
+# (displacement, KG with free-surface correction, trim via MTC/LCF), GZ
+# curve from a GZ table or KN cross-curves, IMO IS Code 2008 Part A intact
+# criteria + 46 CFR 170.170 weather criterion + optional lifting/crane-heel
+# load case (46 CFR 173.005-series style), and max-KG (KG-limit) screening.
+# Screening tier only — the PE-stamped stability booklet / class or USCG
+# submittal governs; criteria thresholds are cited config inputs. See
+# docs/domains/ship-design/vessel-stability-screening.md.
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -502,6 +502,12 @@ def engine(
         )
 
         cfg_base = hull_girder_screening(cfg_base)
+    elif basename == "vessel_stability_screening":
+        from digitalmodel.vessel_stability_screening.workflow import (
+            router as vessel_stability_screening,
+        )
+
+        cfg_base = vessel_stability_screening(cfg_base)
     elif basename == "von_mises":
         from digitalmodel.structural.fe.von_mises_workflow import router as von_mises
 

--- a/src/digitalmodel/naval_architecture/vessel_stability_screening.py
+++ b/src/digitalmodel/naval_architecture/vessel_stability_screening.py
@@ -1,0 +1,983 @@
+# ABOUTME: Intact vessel stability screening core — hydrostatic-table interface,
+# ABOUTME: loading condition + FSC, GZ/KN criteria (IMO IS 2008, 46 CFR), max-KG.
+"""Vessel intact-stability screening — deterministic core (L1 slice).
+
+Pure functions and dataclasses for:
+
+1. **Hydrostatic-table interface**: a draft-indexed table (displacement, KM,
+   LCB, LCF, MTC, TPC) supplied by the user (from GHS, a curves-of-form
+   sheet, or a published example) — geometry-based hydrostatics is a later
+   slice.
+2. **Loading-condition builder**: lightship + tank/cargo weight items ->
+   displacement, KG and LCG, with a free-surface correction from per-tank
+   free-surface moments (FSM) or rectangular tank dimensions
+   (``FSM = rho * l * b^3 / 12``).
+3. **Equilibrium estimate**: mean draft at displacement, KM/GM (solid and
+   fluid), trim from ``trim = W * (LCB - LCG) / MTC`` distributed about the
+   LCF.
+4. **GZ-curve analysis** from a supplied GZ table or cross-curves (KN):
+   ``GZ = KN - KG_fluid * sin(phi)``.
+5. **Criteria checks** — IMO IS Code 2008 Part A intact criteria (areas
+   0-30 / 0-40 / 30-40, GZ at 30, angle of max GZ, GM0) and the
+   46 CFR 170.170 weather criterion ``GM >= P*A*H / (W * tan(T))``. Every
+   criterion row carries a :class:`Citation` (standard/edition/clause —
+   foam_system pattern); default IMO values are cited to IS Code 2008
+   (Res. MSC.267(85)) and are config-overridable.
+6. **Lifting/crane-heel load case**: cosine heeling-arm curve from a hook
+   load x transverse outreach (or a direct heeling moment), static
+   equilibrium heel angle, and 46 CFR 173.005-series style criteria
+   (max equilibrium heel, residual righting-energy ratio) — thresholds are
+   config-supplied and MUST be cited.
+7. **Max-KG screening**: iterate the fluid KG to the limiting value per
+   criterion at a given displacement -> KG-limit table.
+
+SCREENING POSTURE: this is the deterministic screen. The PE-stamped
+stability booklet / class or USCG submittal governs; criteria thresholds
+here are traceability-cited config inputs, not a substitute for the
+approved calculation (GHS remains the licensed cross-check).
+
+Units: SI marine practice — metres, tonnes, degrees at the API surface
+(m*rad for GZ areas), MTC in t*m per cm of trim. Longitudinal positions
+are measured from the aft perpendicular, positive forward. Trim is
+positive by the stern.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from digitalmodel.naval_architecture.damage_stability import (
+    gz_area_under_curve,
+    interpolate_gz,
+)
+
+RHO_SEAWATER_T_M3 = 1.025
+"""Standard seawater density [t/m3]."""
+
+
+# -- citations (foam_system pattern) ------------------------------------------
+
+
+@dataclass(frozen=True)
+class Citation:
+    """Traceability record for a criteria value.
+
+    All three of ``standard``, ``edition`` and ``clause`` are mandatory —
+    a criterion threshold without them is not usable in a deliverable.
+    """
+
+    standard: str
+    edition: str
+    clause: str
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        for name in ("standard", "edition", "clause"):
+            if not str(getattr(self, name)).strip():
+                raise ValueError(f"citation.{name} must be a non-empty string")
+
+    def label(self) -> str:
+        text = f"{self.standard} ({self.edition}) {self.clause}"
+        return f"{text} — {self.note}" if self.note else text
+
+
+# -- hydrostatic-table interface ----------------------------------------------
+
+
+@dataclass(frozen=True)
+class HydroRow:
+    """One draft-indexed row of a vessel hydrostatic table."""
+
+    draft_m: float
+    displacement_t: float
+    km_m: float
+    lcb_m: float | None = None
+    lcf_m: float | None = None
+    mct_t_m_per_cm: float | None = None
+    tpc_t_per_cm: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.draft_m <= 0.0:
+            raise ValueError("hydrostatic row: draft_m must be > 0")
+        if self.displacement_t <= 0.0:
+            raise ValueError("hydrostatic row: displacement_t must be > 0")
+        if self.km_m <= 0.0:
+            raise ValueError("hydrostatic row: km_m must be > 0")
+
+
+@dataclass(frozen=True)
+class HydrostaticProperties:
+    """Hydrostatic properties interpolated at one displacement."""
+
+    draft_m: float
+    displacement_t: float
+    km_m: float
+    lcb_m: float | None
+    lcf_m: float | None
+    mct_t_m_per_cm: float | None
+    tpc_t_per_cm: float | None
+
+
+@dataclass(frozen=True)
+class HydrostaticTable:
+    """Draft-indexed hydrostatic table with linear interpolation.
+
+    Rows must be strictly increasing in both draft and displacement.
+    Interpolation is linear in displacement (the loading-condition entry
+    point) or draft. Queries outside the tabulated range raise — a
+    screening run must not silently extrapolate the hull.
+    """
+
+    rows: tuple[HydroRow, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.rows) < 2:
+            raise ValueError("hydrostatic table needs >= 2 rows")
+        rows = tuple(sorted(self.rows, key=lambda r: r.draft_m))
+        object.__setattr__(self, "rows", rows)
+        for prev, cur in zip(rows, rows[1:]):
+            if cur.draft_m <= prev.draft_m:
+                raise ValueError("hydrostatic table drafts must be strictly increasing")
+            if cur.displacement_t <= prev.displacement_t:
+                raise ValueError(
+                    "hydrostatic table displacements must increase with draft"
+                )
+
+    def at_displacement(self, displacement_t: float) -> HydrostaticProperties:
+        return self._interpolate(
+            displacement_t, [r.displacement_t for r in self.rows], "displacement_t"
+        )
+
+    def at_draft(self, draft_m: float) -> HydrostaticProperties:
+        return self._interpolate(draft_m, [r.draft_m for r in self.rows], "draft_m")
+
+    def _interpolate(
+        self, target: float, keys: list[float], label: str
+    ) -> HydrostaticProperties:
+        if target < keys[0] or target > keys[-1]:
+            raise ValueError(
+                f"{label}={target:g} outside hydrostatic table range "
+                f"[{keys[0]:g}, {keys[-1]:g}] — no extrapolation in screening"
+            )
+        hi = next(i for i, k in enumerate(keys) if k >= target)
+        if keys[hi] == target:
+            row = self.rows[hi]
+            return HydrostaticProperties(
+                draft_m=row.draft_m,
+                displacement_t=row.displacement_t,
+                km_m=row.km_m,
+                lcb_m=row.lcb_m,
+                lcf_m=row.lcf_m,
+                mct_t_m_per_cm=row.mct_t_m_per_cm,
+                tpc_t_per_cm=row.tpc_t_per_cm,
+            )
+        lo = hi - 1
+        frac = (target - keys[lo]) / (keys[hi] - keys[lo])
+        a, b = self.rows[lo], self.rows[hi]
+
+        def lerp(x: float | None, y: float | None) -> float | None:
+            if x is None or y is None:
+                return None
+            return x + frac * (y - x)
+
+        return HydrostaticProperties(
+            draft_m=lerp(a.draft_m, b.draft_m),
+            displacement_t=lerp(a.displacement_t, b.displacement_t),
+            km_m=lerp(a.km_m, b.km_m),
+            lcb_m=lerp(a.lcb_m, b.lcb_m),
+            lcf_m=lerp(a.lcf_m, b.lcf_m),
+            mct_t_m_per_cm=lerp(a.mct_t_m_per_cm, b.mct_t_m_per_cm),
+            tpc_t_per_cm=lerp(a.tpc_t_per_cm, b.tpc_t_per_cm),
+        )
+
+
+# -- loading condition ----------------------------------------------------------
+
+
+def rectangular_fsm_t_m(
+    length_m: float, breadth_m: float, density_t_m3: float
+) -> float:
+    """Free-surface moment of a slack rectangular tank: ``rho * l * b^3 / 12``."""
+    if length_m <= 0.0 or breadth_m <= 0.0 or density_t_m3 <= 0.0:
+        raise ValueError("rectangular tank FSM needs positive l, b and density")
+    return density_t_m3 * length_m * breadth_m**3 / 12.0
+
+
+@dataclass(frozen=True)
+class WeightItem:
+    """One loading-condition weight item (lightship, tank, cargo, hook load).
+
+    ``fsm_t_m`` is the free-surface moment of the item when it is a slack
+    tank (t*m); zero for solid weights and pressed-full/empty tanks.
+    """
+
+    name: str
+    weight_t: float
+    vcg_m: float
+    lcg_m: float
+    fsm_t_m: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.weight_t <= 0.0:
+            raise ValueError(f"weight item '{self.name}': weight_t must be > 0")
+        if self.fsm_t_m < 0.0:
+            raise ValueError(f"weight item '{self.name}': fsm_t_m must be >= 0")
+
+
+@dataclass(frozen=True)
+class LoadingCondition:
+    """Summed loading condition with free-surface correction."""
+
+    name: str
+    items: tuple[WeightItem, ...]
+    displacement_t: float
+    kg_m: float
+    lcg_m: float
+    fsm_total_t_m: float
+    fsc_m: float
+    kg_fluid_m: float
+
+
+def build_loading_condition(name: str, items: list[WeightItem]) -> LoadingCondition:
+    """Sum weight items into displacement, KG, LCG and the fluid (FSC) KG.
+
+    ``FSC = sum(FSM_i) / displacement``; ``KG_fluid = KG + FSC`` — the
+    standard virtual-rise-of-G free-surface correction.
+    """
+    if not items:
+        raise ValueError("loading condition needs at least one weight item")
+    displacement = sum(item.weight_t for item in items)
+    kg = sum(item.weight_t * item.vcg_m for item in items) / displacement
+    lcg = sum(item.weight_t * item.lcg_m for item in items) / displacement
+    fsm = sum(item.fsm_t_m for item in items)
+    fsc = fsm / displacement
+    return LoadingCondition(
+        name=name,
+        items=tuple(items),
+        displacement_t=displacement,
+        kg_m=kg,
+        lcg_m=lcg,
+        fsm_total_t_m=fsm,
+        fsc_m=fsc,
+        kg_fluid_m=kg + fsc,
+    )
+
+
+@dataclass(frozen=True)
+class Equilibrium:
+    """Upright equilibrium estimate at the condition displacement."""
+
+    draft_m: float
+    km_m: float
+    gm_solid_m: float
+    gm_fluid_m: float
+    lcb_m: float | None
+    lcf_m: float | None
+    mct_t_m_per_cm: float | None
+    trim_m: float | None
+    draft_aft_m: float | None
+    draft_fwd_m: float | None
+
+
+def solve_equilibrium(
+    condition: LoadingCondition,
+    table: HydrostaticTable,
+    lbp_m: float | None = None,
+) -> Equilibrium:
+    """Draft, GM and trim estimate at the condition displacement.
+
+    Trim (positive by the stern) from ``trim_cm = W * (LCB - LCG) / MTC``;
+    end drafts distribute the trim about the LCF when ``lbp_m`` is given.
+    The mean draft from the table is taken as the draft at the LCF
+    (standard hydrostatic-table convention).
+    """
+    props = table.at_displacement(condition.displacement_t)
+    gm_solid = props.km_m - condition.kg_m
+    gm_fluid = props.km_m - condition.kg_fluid_m
+
+    trim_m = draft_aft = draft_fwd = None
+    if props.lcb_m is not None and props.mct_t_m_per_cm is not None:
+        trim_cm = (
+            condition.displacement_t
+            * (props.lcb_m - condition.lcg_m)
+            / props.mct_t_m_per_cm
+        )
+        trim_m = trim_cm / 100.0
+        if lbp_m is not None and props.lcf_m is not None:
+            if lbp_m <= 0.0:
+                raise ValueError("lbp_m must be > 0")
+            draft_aft = props.draft_m + trim_m * (props.lcf_m / lbp_m)
+            draft_fwd = props.draft_m - trim_m * (1.0 - props.lcf_m / lbp_m)
+
+    return Equilibrium(
+        draft_m=props.draft_m,
+        km_m=props.km_m,
+        gm_solid_m=gm_solid,
+        gm_fluid_m=gm_fluid,
+        lcb_m=props.lcb_m,
+        lcf_m=props.lcf_m,
+        mct_t_m_per_cm=props.mct_t_m_per_cm,
+        trim_m=trim_m,
+        draft_aft_m=draft_aft,
+        draft_fwd_m=draft_fwd,
+    )
+
+
+# -- GZ curve -------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GZCurve:
+    """Righting-arm curve, tabulated at increasing heel angles from 0."""
+
+    heel_deg: tuple[float, ...]
+    gz_m: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.heel_deg) != len(self.gz_m):
+            raise ValueError("GZ curve: heel_deg and gz_m lengths differ")
+        if len(self.heel_deg) < 3:
+            raise ValueError("GZ curve needs >= 3 points")
+        if any(b <= a for a, b in zip(self.heel_deg, self.heel_deg[1:])):
+            raise ValueError("GZ curve heel angles must be strictly increasing")
+        if self.heel_deg[0] != 0.0:
+            raise ValueError("GZ curve must start at 0 deg heel")
+
+    def gz_at(self, heel_deg: float) -> float:
+        return interpolate_gz(list(self.heel_deg), list(self.gz_m), heel_deg)
+
+    def area_m_rad(self, from_deg: float, to_deg: float) -> float:
+        """Area under the curve between two heel angles [m*rad]."""
+        if to_deg < from_deg:
+            raise ValueError("GZ area: to_deg must be >= from_deg")
+        angles, values = list(self.heel_deg), list(self.gz_m)
+        return gz_area_under_curve(angles, values, to_deg) - gz_area_under_curve(
+            angles, values, from_deg
+        )
+
+    def max_gz(self) -> tuple[float, float]:
+        """(angle_deg, gz_m) at the tabulated maximum righting arm."""
+        idx = max(range(len(self.gz_m)), key=lambda i: self.gz_m[i])
+        return self.heel_deg[idx], self.gz_m[idx]
+
+
+def gz_from_kn(
+    heel_deg: list[float], kn_m: list[float], kg_fluid_m: float
+) -> GZCurve:
+    """GZ curve from cross-curves of stability: ``GZ = KN - KG * sin(phi)``.
+
+    ``kg_fluid_m`` is the free-surface-corrected KG (KG + FSC).
+    """
+    if len(heel_deg) != len(kn_m):
+        raise ValueError("KN table: heel_deg and kn_m lengths differ")
+    gz = [
+        kn - kg_fluid_m * math.sin(math.radians(phi))
+        for phi, kn in zip(heel_deg, kn_m)
+    ]
+    return GZCurve(heel_deg=tuple(heel_deg), gz_m=tuple(gz))
+
+
+def kn_at_displacement(
+    heel_deg: list[float],
+    displacements_t: list[float],
+    kn_grid_m: list[list[float]],
+    displacement_t: float,
+) -> list[float]:
+    """Interpolate a KN cross-curve grid (rows = displacements) linearly in
+    displacement. No extrapolation."""
+    if len(displacements_t) != len(kn_grid_m):
+        raise ValueError("KN grid: displacements_t and kn_grid_m lengths differ")
+    if any(len(row) != len(heel_deg) for row in kn_grid_m):
+        raise ValueError("KN grid: every row must match heel_deg length")
+    if any(b <= a for a, b in zip(displacements_t, displacements_t[1:])):
+        raise ValueError("KN grid displacements must be strictly increasing")
+    if not displacements_t[0] <= displacement_t <= displacements_t[-1]:
+        raise ValueError(
+            f"displacement {displacement_t:g} outside KN grid range "
+            f"[{displacements_t[0]:g}, {displacements_t[-1]:g}]"
+        )
+    hi = next(i for i, d in enumerate(displacements_t) if d >= displacement_t)
+    if displacements_t[hi] == displacement_t:
+        return list(kn_grid_m[hi])
+    lo = hi - 1
+    frac = (displacement_t - displacements_t[lo]) / (
+        displacements_t[hi] - displacements_t[lo]
+    )
+    return [
+        a + frac * (b - a) for a, b in zip(kn_grid_m[lo], kn_grid_m[hi])
+    ]
+
+
+# -- criteria engine --------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CriterionResult:
+    """One evaluated criteria-table row (report_pack-ready)."""
+
+    key: str
+    description: str
+    value: float | None
+    required: float
+    unit: str
+    comparison: str  # ">=" or "<="
+    passed: bool
+    citation: str  # Citation.label()
+
+    @property
+    def margin(self) -> float | None:
+        if self.value is None:
+            return None
+        if self.comparison == ">=":
+            return self.value - self.required
+        return self.required - self.value
+
+
+def _evaluate(
+    key: str,
+    description: str,
+    value: float | None,
+    required: float,
+    unit: str,
+    comparison: str,
+    citation: Citation,
+) -> CriterionResult:
+    if value is None:
+        passed = False
+    elif comparison == ">=":
+        passed = value >= required
+    elif comparison == "<=":
+        passed = value <= required
+    else:
+        raise ValueError(f"criterion '{key}': comparison must be >= or <=")
+    return CriterionResult(
+        key=key,
+        description=description,
+        value=value,
+        required=required,
+        unit=unit,
+        comparison=comparison,
+        passed=passed,
+        citation=citation.label(),
+    )
+
+
+# -- IMO IS Code 2008 Part A intact criteria ---------------------------------------
+
+
+@dataclass(frozen=True)
+class ImoIntactCriteria:
+    """IMO IS Code 2008 Part A 2.2 intact-criteria thresholds, cited.
+
+    Defaults carry the published IS Code 2008 (Res. MSC.267(85)) values;
+    override values and citations from config for other flag/edition sets.
+    """
+
+    area_0_30_min_m_rad: float = 0.055
+    area_0_40_min_m_rad: float = 0.09
+    area_30_40_min_m_rad: float = 0.03
+    gz_30_min_m: float = 0.20
+    angle_max_gz_min_deg: float = 25.0
+    gm0_min_m: float = 0.15
+    citation: Citation = field(
+        default_factory=lambda: Citation(
+            standard="IMO IS Code 2008 (Res. MSC.267(85))",
+            edition="2008",
+            clause="Part A 2.2.1-2.2.4",
+            note="general intact criteria — verify against the governing edition",
+        )
+    )
+
+
+def imo_intact_criteria(
+    curve: GZCurve,
+    gm0_m: float,
+    criteria: ImoIntactCriteria | None = None,
+    downflooding_angle_deg: float | None = None,
+) -> list[CriterionResult]:
+    """Evaluate the six IS Code 2008 Part A 2.2 intact criteria.
+
+    The 0-40 and 30-40 areas cap at the downflooding angle when it is less
+    than 40 deg (IS Code 2008 Part A 2.2.1). Angle of maximum GZ uses the
+    tabulated maximum.
+    """
+    c = criteria or ImoIntactCriteria()
+    cap_40 = 40.0
+    if downflooding_angle_deg is not None:
+        if downflooding_angle_deg <= 0.0:
+            raise ValueError("downflooding_angle_deg must be > 0")
+        cap_40 = min(40.0, downflooding_angle_deg)
+    angle_max, _ = curve.max_gz()
+    cite = c.citation
+    return [
+        _evaluate(
+            "imo_area_0_30",
+            "Area under GZ, 0-30 deg",
+            curve.area_m_rad(0.0, 30.0),
+            c.area_0_30_min_m_rad,
+            "m*rad",
+            ">=",
+            cite,
+        ),
+        _evaluate(
+            "imo_area_0_40",
+            f"Area under GZ, 0-{cap_40:g} deg (40 deg or downflooding)",
+            curve.area_m_rad(0.0, cap_40),
+            c.area_0_40_min_m_rad,
+            "m*rad",
+            ">=",
+            cite,
+        ),
+        _evaluate(
+            "imo_area_30_40",
+            f"Area under GZ, 30-{cap_40:g} deg",
+            curve.area_m_rad(30.0, cap_40) if cap_40 > 30.0 else 0.0,
+            c.area_30_40_min_m_rad,
+            "m*rad",
+            ">=",
+            cite,
+        ),
+        _evaluate(
+            "imo_gz_30",
+            "Righting arm GZ at 30 deg",
+            curve.gz_at(30.0),
+            c.gz_30_min_m,
+            "m",
+            ">=",
+            cite,
+        ),
+        _evaluate(
+            "imo_angle_max_gz",
+            "Angle of maximum GZ",
+            angle_max,
+            c.angle_max_gz_min_deg,
+            "deg",
+            ">=",
+            cite,
+        ),
+        _evaluate(
+            "imo_gm0",
+            "Initial metacentric height GM0 (fluid)",
+            gm0_m,
+            c.gm0_min_m,
+            "m",
+            ">=",
+            cite,
+        ),
+    ]
+
+
+# -- 46 CFR 170.170 weather criterion -----------------------------------------------
+
+
+@dataclass(frozen=True)
+class WeatherCriterion:
+    """46 CFR 170.170 weather-criterion inputs — all config-supplied, cited.
+
+    ``GM_required = P * A * H / (W * tan(T))`` with T the lesser of
+    ``max_heel_deg`` (14 deg in the rule) and the deck-edge immersion
+    angle. The wind pressure ``P`` depends on service (ocean / partially
+    protected / protected) and the rule edition — it is a cited config
+    input, never a baked-in value.
+    """
+
+    wind_pressure_t_m2: float
+    windage_area_m2: float
+    windage_lever_m: float
+    citation: Citation
+    max_heel_deg: float = 14.0
+
+    def __post_init__(self) -> None:
+        for name in ("wind_pressure_t_m2", "windage_area_m2", "windage_lever_m"):
+            if getattr(self, name) <= 0.0:
+                raise ValueError(f"weather criterion: {name} must be > 0")
+        if not 0.0 < self.max_heel_deg < 90.0:
+            raise ValueError("weather criterion: max_heel_deg must be in (0, 90)")
+
+
+def weather_criterion_cfr_170_170(
+    weather: WeatherCriterion,
+    displacement_t: float,
+    gm_fluid_m: float,
+    deck_edge_immersion_deg: float | None = None,
+) -> CriterionResult:
+    """46 CFR 170.170 weather criterion: GM (fluid) >= P*A*H / (W*tan(T))."""
+    if displacement_t <= 0.0:
+        raise ValueError("weather criterion: displacement_t must be > 0")
+    heel = weather.max_heel_deg
+    if deck_edge_immersion_deg is not None and deck_edge_immersion_deg > 0.0:
+        heel = min(heel, deck_edge_immersion_deg)
+    required = (
+        weather.wind_pressure_t_m2
+        * weather.windage_area_m2
+        * weather.windage_lever_m
+        / (displacement_t * math.tan(math.radians(heel)))
+    )
+    return _evaluate(
+        "cfr_170_170_weather_gm",
+        f"Weather criterion GM >= PAH/(W tan T), T = {heel:g} deg",
+        gm_fluid_m,
+        required,
+        "m",
+        ">=",
+        weather.citation,
+    )
+
+
+# -- lifting / crane-heel load case ---------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CraneHeelingCase:
+    """Crane/davit lifting heeling-moment input.
+
+    Either a direct ``heeling_moment_t_m`` or ``hook_load_t`` x
+    ``transverse_outreach_m`` (moment about centreline at zero heel).
+    The heeling arm varies as ``HA(phi) = HM * cos(phi) / W`` — the
+    standard 46 CFR 173 Subpart B heeling-moment form.
+    """
+
+    name: str
+    heeling_moment_t_m: float
+
+    def __post_init__(self) -> None:
+        if self.heeling_moment_t_m <= 0.0:
+            raise ValueError(
+                f"crane case '{self.name}': heeling_moment_t_m must be > 0"
+            )
+
+    @classmethod
+    def from_hook_load(
+        cls, name: str, hook_load_t: float, transverse_outreach_m: float
+    ) -> CraneHeelingCase:
+        if hook_load_t <= 0.0 or transverse_outreach_m <= 0.0:
+            raise ValueError(
+                f"crane case '{name}': hook_load_t and transverse_outreach_m "
+                "must be > 0"
+            )
+        return cls(name=name, heeling_moment_t_m=hook_load_t * transverse_outreach_m)
+
+    def heeling_arm_m(self, displacement_t: float, heel_deg: float) -> float:
+        return (
+            self.heeling_moment_t_m
+            * math.cos(math.radians(heel_deg))
+            / displacement_t
+        )
+
+
+@dataclass(frozen=True)
+class LiftingCriteria:
+    """46 CFR 173.005-series style lifting criteria — thresholds cited.
+
+    ``max_equilibrium_heel_deg``: static heel under the lift must not
+    exceed this angle (and never the deck-edge immersion angle when one
+    is supplied). ``residual_area_ratio_min``: ratio of the residual
+    righting energy (area between GZ and the heeling arm from the
+    equilibrium heel to the residual-range limit) to the heeling energy
+    (area under the heeling arm to the equilibrium heel).
+    """
+
+    max_equilibrium_heel_deg: float
+    citation: Citation
+    residual_area_ratio_min: float | None = None
+    residual_range_limit_deg: float = 40.0
+
+    def __post_init__(self) -> None:
+        if self.max_equilibrium_heel_deg <= 0.0:
+            raise ValueError("lifting criteria: max_equilibrium_heel_deg must be > 0")
+        if self.residual_area_ratio_min is not None and self.residual_area_ratio_min <= 0.0:
+            raise ValueError("lifting criteria: residual_area_ratio_min must be > 0")
+        if self.residual_range_limit_deg <= 0.0:
+            raise ValueError("lifting criteria: residual_range_limit_deg must be > 0")
+
+
+@dataclass(frozen=True)
+class LiftingResult:
+    """Evaluated crane-heel load case."""
+
+    case_name: str
+    heeling_moment_t_m: float
+    heeling_arm_0_m: float
+    equilibrium_heel_deg: float | None
+    residual_range_to_deg: float | None
+    residual_area_m_rad: float | None
+    heeling_area_m_rad: float | None
+    residual_area_ratio: float | None
+    criteria: tuple[CriterionResult, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(c.passed for c in self.criteria)
+
+
+def equilibrium_heel_deg(
+    curve: GZCurve, case: CraneHeelingCase, displacement_t: float
+) -> float | None:
+    """First static equilibrium: smallest heel where GZ(phi) = HA(phi).
+
+    Returns None when the heeling arm exceeds GZ over the whole tabulated
+    range (no static equilibrium — the lift capsizes the screen).
+    Solved by scanning the residual ``GZ - HA`` for its first sign change
+    and bisecting to 1e-4 deg.
+    """
+
+    def residual(phi: float) -> float:
+        return curve.gz_at(phi) - case.heeling_arm_m(displacement_t, phi)
+
+    lo, hi = None, None
+    steps = 2000
+    span = curve.heel_deg[-1]
+    prev_phi = 0.0
+    if residual(0.0) >= 0.0:
+        return 0.0
+    for i in range(1, steps + 1):
+        phi = span * i / steps
+        if residual(phi) >= 0.0:
+            lo, hi = prev_phi, phi
+            break
+        prev_phi = phi
+    if lo is None:
+        return None
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        if hi - lo < 1e-4:
+            break
+        if residual(mid) >= 0.0:
+            hi = mid
+        else:
+            lo = mid
+    return 0.5 * (lo + hi)
+
+
+def lifting_check(
+    curve: GZCurve,
+    case: CraneHeelingCase,
+    displacement_t: float,
+    criteria: LiftingCriteria,
+    downflooding_angle_deg: float | None = None,
+    deck_edge_immersion_deg: float | None = None,
+) -> LiftingResult:
+    """Evaluate a crane-heel load case against the cited lifting criteria.
+
+    The residual range runs from the equilibrium heel to the least of the
+    configured limit, the downflooding angle and the tabulated GZ range.
+    """
+    if displacement_t <= 0.0:
+        raise ValueError("lifting check: displacement_t must be > 0")
+    eq = equilibrium_heel_deg(curve, case, displacement_t)
+    cite = criteria.citation
+
+    heel_limit = criteria.max_equilibrium_heel_deg
+    if deck_edge_immersion_deg is not None and deck_edge_immersion_deg > 0.0:
+        heel_limit = min(heel_limit, deck_edge_immersion_deg)
+
+    results = [
+        _evaluate(
+            "lifting_equilibrium_heel",
+            f"Equilibrium heel under lift '{case.name}'"
+            + ("" if eq is not None else " (no static equilibrium)"),
+            eq,
+            heel_limit,
+            "deg",
+            "<=",
+            cite,
+        )
+    ]
+
+    residual_to = residual_area = heeling_area = ratio = None
+    if criteria.residual_area_ratio_min is not None:
+        if eq is not None:
+            residual_to = min(
+                criteria.residual_range_limit_deg,
+                curve.heel_deg[-1],
+                *(
+                    [downflooding_angle_deg]
+                    if downflooding_angle_deg is not None
+                    else []
+                ),
+            )
+            if residual_to > eq:
+                residual_area = _net_area_m_rad(
+                    curve, case, displacement_t, eq, residual_to
+                )
+                heeling_area = _arm_area_m_rad(case, displacement_t, 0.0, eq)
+                ratio = (
+                    residual_area / heeling_area if heeling_area > 0.0 else math.inf
+                )
+            else:
+                residual_area, heeling_area, ratio = 0.0, None, 0.0
+        results.append(
+            _evaluate(
+                "lifting_residual_area_ratio",
+                "Residual righting energy / heeling energy ratio",
+                None if ratio is None else (ratio if ratio != math.inf else 1e9),
+                criteria.residual_area_ratio_min,
+                "-",
+                ">=",
+                cite,
+            )
+        )
+
+    return LiftingResult(
+        case_name=case.name,
+        heeling_moment_t_m=case.heeling_moment_t_m,
+        heeling_arm_0_m=case.heeling_arm_m(displacement_t, 0.0),
+        equilibrium_heel_deg=eq,
+        residual_range_to_deg=residual_to,
+        residual_area_m_rad=residual_area,
+        heeling_area_m_rad=heeling_area,
+        residual_area_ratio=ratio,
+        criteria=tuple(results),
+    )
+
+
+def _net_area_m_rad(
+    curve: GZCurve,
+    case: CraneHeelingCase,
+    displacement_t: float,
+    from_deg: float,
+    to_deg: float,
+    steps: int = 400,
+) -> float:
+    """Trapezoidal area of max(GZ - HA, 0) between two heel angles [m*rad]."""
+    total = 0.0
+    prev_phi = from_deg
+    prev_v = max(
+        curve.gz_at(from_deg) - case.heeling_arm_m(displacement_t, from_deg), 0.0
+    )
+    for i in range(1, steps + 1):
+        phi = from_deg + (to_deg - from_deg) * i / steps
+        v = max(curve.gz_at(phi) - case.heeling_arm_m(displacement_t, phi), 0.0)
+        total += 0.5 * (prev_v + v) * math.radians(phi - prev_phi)
+        prev_phi, prev_v = phi, v
+    return total
+
+
+def _arm_area_m_rad(
+    case: CraneHeelingCase,
+    displacement_t: float,
+    from_deg: float,
+    to_deg: float,
+) -> float:
+    """Exact area under HA(phi) = (HM/W) cos(phi): (HM/W)(sin(b) - sin(a))."""
+    scale = case.heeling_moment_t_m / displacement_t
+    return scale * (
+        math.sin(math.radians(to_deg)) - math.sin(math.radians(from_deg))
+    )
+
+
+# -- max-KG screening -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KgLimit:
+    """Limiting fluid KG for one criterion at a fixed displacement."""
+
+    key: str
+    description: str
+    kg_limit_m: float | None
+    limited_by_km: bool
+    citation: str
+
+
+def max_kg_screening(
+    heel_deg: list[float],
+    kn_m: list[float],
+    km_m: float,
+    displacement_t: float,
+    imo: ImoIntactCriteria | None = None,
+    weather: WeatherCriterion | None = None,
+    lifting_case: CraneHeelingCase | None = None,
+    lifting: LiftingCriteria | None = None,
+    downflooding_angle_deg: float | None = None,
+    deck_edge_immersion_deg: float | None = None,
+    tolerance_m: float = 1e-4,
+) -> list[KgLimit]:
+    """Limiting fluid KG per criterion at one displacement (KG-limit row).
+
+    For each criterion, bisects the fluid KG on [0, KM] for the largest
+    value that still passes (criteria margins decrease monotonically with
+    rising KG for the intact set screened here). ``kg_limit_m`` is None
+    when the criterion fails even at KG = 0; ``limited_by_km`` marks
+    criteria that still pass at KG = KM (not limiting below KM).
+    """
+    if km_m <= 0.0:
+        raise ValueError("max KG screening: km_m must be > 0")
+
+    def criteria_at(kg: float) -> list[CriterionResult]:
+        curve = gz_from_kn(heel_deg, kn_m, kg)
+        results = imo_intact_criteria(
+            curve, km_m - kg, imo, downflooding_angle_deg
+        )
+        if weather is not None:
+            results.append(
+                weather_criterion_cfr_170_170(
+                    weather, displacement_t, km_m - kg, deck_edge_immersion_deg
+                )
+            )
+        if lifting_case is not None and lifting is not None:
+            results.extend(
+                lifting_check(
+                    curve,
+                    lifting_case,
+                    displacement_t,
+                    lifting,
+                    downflooding_angle_deg,
+                    deck_edge_immersion_deg,
+                ).criteria
+            )
+        return results
+
+    base = criteria_at(0.0)
+    limits: list[KgLimit] = []
+    for idx, criterion in enumerate(base):
+        if not criterion.passed:
+            limits.append(
+                KgLimit(
+                    key=criterion.key,
+                    description=criterion.description,
+                    kg_limit_m=None,
+                    limited_by_km=False,
+                    citation=criterion.citation,
+                )
+            )
+            continue
+        if criteria_at(km_m)[idx].passed:
+            limits.append(
+                KgLimit(
+                    key=criterion.key,
+                    description=criterion.description,
+                    kg_limit_m=km_m,
+                    limited_by_km=True,
+                    citation=criterion.citation,
+                )
+            )
+            continue
+        lo, hi = 0.0, km_m  # passes at lo, fails at hi
+        while hi - lo > tolerance_m:
+            mid = 0.5 * (lo + hi)
+            if criteria_at(mid)[idx].passed:
+                lo = mid
+            else:
+                hi = mid
+        limits.append(
+            KgLimit(
+                key=criterion.key,
+                description=criterion.description,
+                kg_limit_m=lo,
+                limited_by_km=False,
+                citation=criterion.citation,
+            )
+        )
+    return limits
+
+
+def governing_kg_limit(limits: list[KgLimit]) -> KgLimit | None:
+    """The lowest KG limit (the governing criterion); None when any
+    criterion fails even at KG = 0 or the list is empty."""
+    if not limits:
+        return None
+    if any(limit.kg_limit_m is None for limit in limits):
+        return next(limit for limit in limits if limit.kg_limit_m is None)
+    return min(limits, key=lambda limit: limit.kg_limit_m)

--- a/src/digitalmodel/vessel_stability_screening/__init__.py
+++ b/src/digitalmodel/vessel_stability_screening/__init__.py
@@ -1,0 +1,5 @@
+"""Routed workflow for intact vessel stability screening."""
+
+from digitalmodel.vessel_stability_screening.workflow import router
+
+__all__ = ["router"]

--- a/src/digitalmodel/vessel_stability_screening/workflow.py
+++ b/src/digitalmodel/vessel_stability_screening/workflow.py
@@ -1,0 +1,676 @@
+"""Durable workflow: intact vessel stability screening.
+
+Wires :mod:`digitalmodel.naval_architecture.vessel_stability_screening`
+into a registry workflow: hydrostatic-table lookup (draft-indexed, CSV or
+inline YAML) -> loading condition with per-tank free-surface correction ->
+draft/trim/GM equilibrium -> GZ curve from a GZ table or KN cross-curves ->
+IMO IS Code 2008 Part A intact criteria + 46 CFR 170.170 weather criterion
+-> optional lifting/crane-heel load case (46 CFR 173.005-series style) ->
+optional max-KG (KG-limit) screening.
+
+SCREENING TIER ONLY: the PE-stamped stability booklet / class or USCG
+submittal governs. GHS remains the licensed cross-check; criteria
+thresholds are cited config inputs (foam_system Citation pattern), with
+the IMO IS Code 2008 defaults baked in and overridable.
+
+Config schema (YAML basename ``vessel_stability_screening``)::
+
+    basename: vessel_stability_screening
+    vessel_stability_screening:
+      vessel:
+        name: synthetic box barge        # public/synthetic label only
+        lbp_m: 100.0
+        deck_edge_immersion_deg: 30.96   # optional
+        downflooding_angle_deg: 35.0     # optional
+      hydrostatics:
+        table:                           # draft-indexed rows, or csv: path
+          - {draft_m: 2.0, displacement_t: 4100.0, km_m: 17.67,
+             lcb_m: 50.0, lcf_m: 50.0, mct_t_m_per_cm: 170.83,
+             tpc_t_per_cm: 20.5}
+        # csv: hydrostatics.csv          # same column names as above
+      loading_condition:
+        name: departure
+        items:
+          - {name: lightship, weight_t: 4000.0, vcg_m: 5.0, lcg_m: 50.0}
+          - {name: fuel, weight_t: 1000.0, vcg_m: 2.0, lcg_m: 40.0,
+             fsm_t_m: 410.0}             # or free_surface: {length_m,
+                                         #   breadth_m, density_t_m3}
+      gz:                                # optional; enables GZ criteria
+        heel_deg: [0, 10, 20, 30, 40]
+        kn_m: [0.0, 1.87, 3.72, 5.51, 7.18]        # at the condition
+        # or gz_m: [...]                 # pre-corrected righting arms
+        # or cross_curves:               # KN grid, interpolated in W
+        #   displacements_t: [4100.0, 8200.0]
+        #   kn_m: [[...], [...]]
+      criteria:
+        imo_intact:                      # optional value/citation overrides
+          enabled: true
+          # area_0_30_min_m_rad: 0.055 ... gm0_min_m: 0.15
+          # citation: {standard: ..., edition: ..., clause: ...}
+        weather_cfr_170_170:             # optional; ALL cited
+          wind_pressure_t_m2: 0.055     # P per service/edition (config)
+          windage_area_m2: 600.0
+          windage_lever_m: 5.0
+          max_heel_deg: 14.0             # rule value; deck edge caps it
+          citation: {standard: "46 CFR 170.170", edition: "2024",
+                     clause: "170.170(a)"}
+      lifting:                           # optional crane-heel load case
+        name: main crane lift
+        hook_load_t: 100.0
+        transverse_outreach_m: 15.0
+        # or heeling_moment_t_m: 1500.0
+        criteria:                        # thresholds cited (46 CFR 173)
+          max_equilibrium_heel_deg: 5.0
+          residual_area_ratio_min: 1.4   # optional
+          residual_range_limit_deg: 40.0 # optional
+          citation: {standard: "46 CFR Part 173 Subpart B", edition: "2024",
+                     clause: "173.005-series"}
+      max_kg:                            # optional KG-limit screening
+        enabled: true
+        tolerance_m: 0.0001
+      output_dir: results
+
+Outputs: loading-condition, equilibrium, GZ-curve, criteria (with citation
+column), optional lifting and KG-limit CSVs plus a one-row summary CSV —
+all report_pack-ready — and the same content in the returned config under
+``vessel_stability_screening``; ``screening_status`` is stamped pass/fail.
+
+Units: SI marine practice — m, t, deg, m*rad; MTC in t*m/cm; longitudinal
+positions from the aft perpendicular; trim positive by the stern.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from digitalmodel.naval_architecture.vessel_stability_screening import (
+    Citation,
+    CraneHeelingCase,
+    Equilibrium,
+    GZCurve,
+    HydroRow,
+    HydrostaticTable,
+    ImoIntactCriteria,
+    LiftingCriteria,
+    LiftingResult,
+    LoadingCondition,
+    WeatherCriterion,
+    WeightItem,
+    build_loading_condition,
+    governing_kg_limit,
+    gz_from_kn,
+    imo_intact_criteria,
+    kn_at_displacement,
+    lifting_check,
+    max_kg_screening,
+    rectangular_fsm_t_m,
+    solve_equilibrium,
+    weather_criterion_cfr_170_170,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+GOVERNANCE_NOTE = (
+    "Screening tier only: ranks and gates intact loading conditions. The "
+    "PE-stamped stability booklet / class or USCG submittal governs; "
+    "criteria thresholds are cited config inputs and GHS remains the "
+    "licensed cross-check."
+)
+
+_HYDRO_FIELDS = (
+    "draft_m",
+    "displacement_t",
+    "km_m",
+    "lcb_m",
+    "lcf_m",
+    "mct_t_m_per_cm",
+    "tpc_t_per_cm",
+)
+
+
+def router(cfg: dict) -> dict:
+    settings = cfg.get("vessel_stability_screening") or {}
+    vessel = settings.get("vessel") or {}
+    lbp_m = _opt_float(vessel, "lbp_m")
+    downflooding = _opt_float(vessel, "downflooding_angle_deg")
+    deck_edge = _opt_float(vessel, "deck_edge_immersion_deg")
+
+    table = _hydrostatics(cfg, settings)
+    condition = _loading_condition(settings)
+    equilibrium = solve_equilibrium(condition, table, lbp_m)
+
+    curve, kn_pairs = _gz_curve(settings, condition)
+
+    imo_cfg = (settings.get("criteria") or {}).get("imo_intact") or {}
+    imo = _imo_criteria(imo_cfg)
+    weather = _weather(settings)
+    lifting_case, lifting_criteria = _lifting(settings)
+
+    criteria_results = []
+    lifting_result: LiftingResult | None = None
+    if curve is not None and _enabled(imo_cfg, default=True):
+        criteria_results.extend(
+            imo_intact_criteria(curve, equilibrium.gm_fluid_m, imo, downflooding)
+        )
+    if weather is not None:
+        criteria_results.append(
+            weather_criterion_cfr_170_170(
+                weather, condition.displacement_t, equilibrium.gm_fluid_m, deck_edge
+            )
+        )
+    if lifting_case is not None:
+        if curve is None:
+            raise ValueError(
+                "vessel_stability_screening lifting requires gz input "
+                "(gz table or KN cross-curves)"
+            )
+        lifting_result = lifting_check(
+            curve,
+            lifting_case,
+            condition.displacement_t,
+            lifting_criteria,
+            downflooding,
+            deck_edge,
+        )
+        criteria_results.extend(lifting_result.criteria)
+
+    if not criteria_results:
+        raise ValueError(
+            "vessel_stability_screening evaluated no criteria — supply gz "
+            "input and/or criteria.weather_cfr_170_170 and/or lifting"
+        )
+
+    kg_limits, governing = _max_kg(
+        settings,
+        condition,
+        equilibrium,
+        kn_pairs,
+        imo,
+        weather,
+        lifting_case,
+        lifting_criteria,
+        downflooding,
+        deck_edge,
+    )
+
+    status = "pass" if all(c.passed for c in criteria_results) else "fail"
+
+    # -- rows / CSVs ---------------------------------------------------------
+    condition_rows = _condition_rows(condition)
+    equilibrium_row = _equilibrium_row(condition, equilibrium)
+    criteria_rows = [_criterion_row(c) for c in criteria_results]
+    gz_rows = _gz_rows(curve, lifting_case, condition.displacement_t)
+    kg_rows = [asdict(limit) for limit in kg_limits]
+
+    outputs: dict[str, str] = {}
+    condition_csv = _output_path(cfg, settings, "loading_condition.csv")
+    _write_csv(condition_csv, condition_rows)
+    outputs["loading_condition_csv"] = _display_path(condition_csv)
+    equilibrium_csv = _output_path(cfg, settings, "equilibrium.csv")
+    _write_csv(equilibrium_csv, [equilibrium_row])
+    outputs["equilibrium_csv"] = _display_path(equilibrium_csv)
+    criteria_csv = _output_path(cfg, settings, "criteria.csv")
+    _write_csv(criteria_csv, criteria_rows)
+    outputs["criteria_csv"] = _display_path(criteria_csv)
+    if gz_rows:
+        gz_csv = _output_path(cfg, settings, "gz_curve.csv")
+        _write_csv(gz_csv, gz_rows)
+        outputs["gz_curve_csv"] = _display_path(gz_csv)
+    if kg_rows:
+        kg_csv = _output_path(cfg, settings, "kg_limits.csv")
+        _write_csv(kg_csv, kg_rows)
+        outputs["kg_limits_csv"] = _display_path(kg_csv)
+
+    summary = {
+        "method": "vessel_stability_screening_intact_v1",
+        "vessel": str(vessel.get("name", "unnamed")),
+        "condition": condition.name,
+        "displacement_t": condition.displacement_t,
+        "draft_m": equilibrium.draft_m,
+        "trim_m": equilibrium.trim_m,
+        "kg_m": condition.kg_m,
+        "fsc_m": condition.fsc_m,
+        "kg_fluid_m": condition.kg_fluid_m,
+        "km_m": equilibrium.km_m,
+        "gm_solid_m": equilibrium.gm_solid_m,
+        "gm_fluid_m": equilibrium.gm_fluid_m,
+        "criteria_evaluated": len(criteria_results),
+        "criteria_failed": sum(1 for c in criteria_results if not c.passed),
+        "lifting_equilibrium_heel_deg": (
+            None if lifting_result is None else lifting_result.equilibrium_heel_deg
+        ),
+        "governing_kg_limit_m": (
+            None if governing is None else governing.kg_limit_m
+        ),
+        "governing_kg_criterion": (None if governing is None else governing.key),
+        "screening_status": status,
+    }
+    summary_csv = _output_path(cfg, settings, "summary.csv")
+    _write_csv(summary_csv, [summary])
+    outputs["summary_csv"] = _display_path(summary_csv)
+
+    cfg["vessel_stability_screening"] = {
+        **settings,
+        **summary,
+        "loading_condition_result": condition_rows,
+        "equilibrium_result": equilibrium_row,
+        "criteria_results": criteria_rows,
+        "gz_curve_result": gz_rows,
+        "lifting_result": None if lifting_result is None else _lifting_row(lifting_result),
+        "kg_limits": kg_rows,
+        **outputs,
+        "governance": GOVERNANCE_NOTE,
+    }
+    cfg["screening_status"] = status
+    return cfg
+
+
+# --------------------------------------------------------------------------- #
+# Input parsing
+# --------------------------------------------------------------------------- #
+def _hydrostatics(cfg: dict, settings: dict) -> HydrostaticTable:
+    raw = settings.get("hydrostatics")
+    if not isinstance(raw, dict):
+        raise ValueError("vessel_stability_screening hydrostatics mapping is required")
+    rows_raw: list[dict[str, Any]]
+    if raw.get("csv"):
+        csv_path = Path(str(raw["csv"]))
+        if not csv_path.is_absolute():
+            csv_path = _config_dir(cfg) / csv_path
+        with csv_path.open(newline="") as stream:
+            rows_raw = list(csv.DictReader(stream))
+        if not rows_raw:
+            raise ValueError(f"hydrostatics csv {csv_path} is empty")
+    else:
+        rows_raw = raw.get("table") or []
+        if not isinstance(rows_raw, list) or not rows_raw:
+            raise ValueError(
+                "vessel_stability_screening hydrostatics needs table rows or csv"
+            )
+    rows = []
+    for i, item in enumerate(rows_raw):
+        unknown = set(item) - set(_HYDRO_FIELDS)
+        if unknown and not raw.get("csv"):
+            raise ValueError(
+                f"hydrostatics.table[{i}] unknown fields: {sorted(unknown)}"
+            )
+        kwargs: dict[str, float] = {}
+        for name in _HYDRO_FIELDS:
+            value = item.get(name)
+            if value is None or value == "":
+                continue
+            kwargs[name] = float(value)
+        for name in ("draft_m", "displacement_t", "km_m"):
+            if name not in kwargs:
+                raise ValueError(f"hydrostatics row {i}: {name} is required")
+        rows.append(HydroRow(**kwargs))
+    return HydrostaticTable(rows=tuple(rows))
+
+
+def _loading_condition(settings: dict) -> LoadingCondition:
+    raw = settings.get("loading_condition")
+    if not isinstance(raw, dict):
+        raise ValueError(
+            "vessel_stability_screening loading_condition mapping is required"
+        )
+    items_raw = raw.get("items")
+    if not isinstance(items_raw, list) or not items_raw:
+        raise ValueError(
+            "vessel_stability_screening loading_condition.items must be a "
+            "non-empty list"
+        )
+    items = []
+    for i, item in enumerate(items_raw):
+        label = f"loading_condition.items[{i}]"
+        fsm = float(item.get("fsm_t_m", 0.0))
+        fs = item.get("free_surface")
+        if fs is not None:
+            if fsm:
+                raise ValueError(f"{label}: give fsm_t_m or free_surface, not both")
+            fsm = rectangular_fsm_t_m(
+                length_m=_req_float(fs, "length_m", f"{label}.free_surface.length_m"),
+                breadth_m=_req_float(
+                    fs, "breadth_m", f"{label}.free_surface.breadth_m"
+                ),
+                density_t_m3=_req_float(
+                    fs, "density_t_m3", f"{label}.free_surface.density_t_m3"
+                ),
+            )
+        items.append(
+            WeightItem(
+                name=str(item.get("name", f"item_{i + 1}")),
+                weight_t=_req_float(item, "weight_t", f"{label}.weight_t"),
+                vcg_m=_req_float(item, "vcg_m", f"{label}.vcg_m"),
+                lcg_m=_req_float(item, "lcg_m", f"{label}.lcg_m"),
+                fsm_t_m=fsm,
+            )
+        )
+    return build_loading_condition(str(raw.get("name", "condition")), items)
+
+
+def _gz_curve(
+    settings: dict, condition: LoadingCondition
+) -> tuple[GZCurve | None, tuple[list[float], list[float]] | None]:
+    """Returns (curve, (heel_deg, kn_m)) — KN pairs only when KN was input
+    (max-KG screening needs KN, not a pre-corrected GZ table)."""
+    raw = settings.get("gz")
+    if raw is None:
+        return None, None
+    if not isinstance(raw, dict):
+        raise ValueError("vessel_stability_screening gz must be a mapping")
+    heels = [float(v) for v in raw.get("heel_deg") or []]
+    if not heels:
+        raise ValueError("vessel_stability_screening gz.heel_deg is required")
+    sources = [k for k in ("kn_m", "gz_m", "cross_curves") if raw.get(k) is not None]
+    if len(sources) != 1:
+        raise ValueError(
+            "vessel_stability_screening gz needs exactly one of kn_m, gz_m "
+            "or cross_curves"
+        )
+    if raw.get("gz_m") is not None:
+        gz = [float(v) for v in raw["gz_m"]]
+        return GZCurve(heel_deg=tuple(heels), gz_m=tuple(gz)), None
+    if raw.get("kn_m") is not None:
+        kn = [float(v) for v in raw["kn_m"]]
+    else:
+        grid = raw["cross_curves"]
+        kn = kn_at_displacement(
+            heels,
+            [float(v) for v in grid.get("displacements_t") or []],
+            [[float(v) for v in row] for row in grid.get("kn_m") or []],
+            condition.displacement_t,
+        )
+    return gz_from_kn(heels, kn, condition.kg_fluid_m), (heels, kn)
+
+
+def _enabled(raw: dict, default: bool) -> bool:
+    return bool(raw.get("enabled", default))
+
+
+def _imo_criteria(raw: dict) -> ImoIntactCriteria:
+    kwargs: dict[str, Any] = {}
+    for name in (
+        "area_0_30_min_m_rad",
+        "area_0_40_min_m_rad",
+        "area_30_40_min_m_rad",
+        "gz_30_min_m",
+        "angle_max_gz_min_deg",
+        "gm0_min_m",
+    ):
+        if raw.get(name) is not None:
+            kwargs[name] = float(raw[name])
+    if raw.get("citation") is not None:
+        kwargs["citation"] = _citation(raw.get("citation"), "criteria.imo_intact")
+    return ImoIntactCriteria(**kwargs)
+
+
+def _weather(settings: dict) -> WeatherCriterion | None:
+    raw = (settings.get("criteria") or {}).get("weather_cfr_170_170")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            "vessel_stability_screening criteria.weather_cfr_170_170 must be "
+            "a mapping"
+        )
+    label = "criteria.weather_cfr_170_170"
+    return WeatherCriterion(
+        wind_pressure_t_m2=_req_float(
+            raw, "wind_pressure_t_m2", f"{label}.wind_pressure_t_m2"
+        ),
+        windage_area_m2=_req_float(raw, "windage_area_m2", f"{label}.windage_area_m2"),
+        windage_lever_m=_req_float(
+            raw, "windage_lever_m", f"{label}.windage_lever_m"
+        ),
+        max_heel_deg=float(raw.get("max_heel_deg", 14.0)),
+        citation=_citation(raw.get("citation"), label),
+    )
+
+
+def _lifting(settings: dict) -> tuple[CraneHeelingCase | None, LiftingCriteria | None]:
+    raw = settings.get("lifting")
+    if raw is None:
+        return None, None
+    if not isinstance(raw, dict):
+        raise ValueError("vessel_stability_screening lifting must be a mapping")
+    name = str(raw.get("name", "lift"))
+    if raw.get("heeling_moment_t_m") is not None:
+        case = CraneHeelingCase(
+            name=name, heeling_moment_t_m=float(raw["heeling_moment_t_m"])
+        )
+    else:
+        case = CraneHeelingCase.from_hook_load(
+            name,
+            _req_float(raw, "hook_load_t", "lifting.hook_load_t"),
+            _req_float(
+                raw, "transverse_outreach_m", "lifting.transverse_outreach_m"
+            ),
+        )
+    crit_raw = raw.get("criteria")
+    if not isinstance(crit_raw, dict):
+        raise ValueError(
+            "vessel_stability_screening lifting.criteria mapping is required "
+            "(cited thresholds)"
+        )
+    ratio = crit_raw.get("residual_area_ratio_min")
+    criteria = LiftingCriteria(
+        max_equilibrium_heel_deg=_req_float(
+            crit_raw,
+            "max_equilibrium_heel_deg",
+            "lifting.criteria.max_equilibrium_heel_deg",
+        ),
+        residual_area_ratio_min=None if ratio is None else float(ratio),
+        residual_range_limit_deg=float(
+            crit_raw.get("residual_range_limit_deg", 40.0)
+        ),
+        citation=_citation(crit_raw.get("citation"), "lifting.criteria"),
+    )
+    return case, criteria
+
+
+def _max_kg(
+    settings: dict,
+    condition: LoadingCondition,
+    equilibrium: Equilibrium,
+    kn_pairs: tuple[list[float], list[float]] | None,
+    imo: ImoIntactCriteria,
+    weather: WeatherCriterion | None,
+    lifting_case: CraneHeelingCase | None,
+    lifting_criteria: LiftingCriteria | None,
+    downflooding: float | None,
+    deck_edge: float | None,
+):
+    raw = settings.get("max_kg")
+    if raw is None or not _enabled(raw if isinstance(raw, dict) else {}, default=True):
+        return [], None
+    if not isinstance(raw, dict):
+        raise ValueError("vessel_stability_screening max_kg must be a mapping")
+    if kn_pairs is None:
+        raise ValueError(
+            "vessel_stability_screening max_kg requires KN input (gz.kn_m or "
+            "gz.cross_curves) — a pre-corrected gz_m table cannot be re-based"
+        )
+    heels, kn = kn_pairs
+    limits = max_kg_screening(
+        heels,
+        kn,
+        equilibrium.km_m,
+        condition.displacement_t,
+        imo=imo,
+        weather=weather,
+        lifting_case=lifting_case,
+        lifting=lifting_criteria,
+        downflooding_angle_deg=downflooding,
+        deck_edge_immersion_deg=deck_edge,
+        tolerance_m=float(raw.get("tolerance_m", 1e-4)),
+    )
+    return limits, governing_kg_limit(limits)
+
+
+def _citation(item: Any, label: str) -> Citation:
+    if not isinstance(item, dict):
+        raise ValueError(
+            f"vessel_stability_screening {label}.citation is required "
+            "(mapping with standard, edition, clause)"
+        )
+    try:
+        return Citation(
+            standard=str(item.get("standard", "")),
+            edition=str(item.get("edition", "")),
+            clause=str(item.get("clause", "")),
+            note=str(item.get("note", "")),
+        )
+    except ValueError as exc:
+        raise ValueError(f"vessel_stability_screening {label}.{exc}") from exc
+
+
+# --------------------------------------------------------------------------- #
+# Output rows
+# --------------------------------------------------------------------------- #
+def _condition_rows(condition: LoadingCondition) -> list[dict[str, Any]]:
+    rows = [
+        {
+            "name": item.name,
+            "weight_t": item.weight_t,
+            "vcg_m": item.vcg_m,
+            "lcg_m": item.lcg_m,
+            "fsm_t_m": item.fsm_t_m,
+        }
+        for item in condition.items
+    ]
+    rows.append(
+        {
+            "name": f"TOTAL ({condition.name})",
+            "weight_t": condition.displacement_t,
+            "vcg_m": condition.kg_m,
+            "lcg_m": condition.lcg_m,
+            "fsm_t_m": condition.fsm_total_t_m,
+        }
+    )
+    return rows
+
+
+def _equilibrium_row(
+    condition: LoadingCondition, equilibrium: Equilibrium
+) -> dict[str, Any]:
+    return {
+        "condition": condition.name,
+        "displacement_t": condition.displacement_t,
+        "draft_m": equilibrium.draft_m,
+        "km_m": equilibrium.km_m,
+        "kg_m": condition.kg_m,
+        "fsc_m": condition.fsc_m,
+        "kg_fluid_m": condition.kg_fluid_m,
+        "gm_solid_m": equilibrium.gm_solid_m,
+        "gm_fluid_m": equilibrium.gm_fluid_m,
+        "lcg_m": condition.lcg_m,
+        "lcb_m": equilibrium.lcb_m,
+        "lcf_m": equilibrium.lcf_m,
+        "mct_t_m_per_cm": equilibrium.mct_t_m_per_cm,
+        "trim_m": equilibrium.trim_m,
+        "draft_aft_m": equilibrium.draft_aft_m,
+        "draft_fwd_m": equilibrium.draft_fwd_m,
+    }
+
+
+def _criterion_row(criterion) -> dict[str, Any]:
+    return {
+        "key": criterion.key,
+        "description": criterion.description,
+        "value": criterion.value,
+        "required": criterion.required,
+        "unit": criterion.unit,
+        "comparison": criterion.comparison,
+        "margin": criterion.margin,
+        "status": "pass" if criterion.passed else "fail",
+        "citation": criterion.citation,
+    }
+
+
+def _gz_rows(
+    curve: GZCurve | None,
+    lifting_case: CraneHeelingCase | None,
+    displacement_t: float,
+) -> list[dict[str, Any]]:
+    if curve is None:
+        return []
+    rows = []
+    for phi, gz in zip(curve.heel_deg, curve.gz_m):
+        row: dict[str, Any] = {"heel_deg": phi, "gz_m": gz}
+        if lifting_case is not None:
+            ha = lifting_case.heeling_arm_m(displacement_t, phi)
+            row["heeling_arm_m"] = ha
+            row["net_arm_m"] = gz - ha
+        rows.append(row)
+    return rows
+
+
+def _lifting_row(result: LiftingResult) -> dict[str, Any]:
+    return {
+        "case_name": result.case_name,
+        "heeling_moment_t_m": result.heeling_moment_t_m,
+        "heeling_arm_0_m": result.heeling_arm_0_m,
+        "equilibrium_heel_deg": result.equilibrium_heel_deg,
+        "residual_range_to_deg": result.residual_range_to_deg,
+        "residual_area_m_rad": result.residual_area_m_rad,
+        "heeling_area_m_rad": result.heeling_area_m_rad,
+        "residual_area_ratio": result.residual_area_ratio,
+        "status": "pass" if result.passed else "fail",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Shared plumbing (sibling-module pattern)
+# --------------------------------------------------------------------------- #
+def _req_float(source: dict, name: str, label: str) -> float:
+    value = source.get(name)
+    if value is None:
+        raise ValueError(f"vessel_stability_screening {label} is required")
+    return float(value)
+
+
+def _opt_float(source: dict, name: str) -> float | None:
+    value = source.get(name)
+    return None if value is None else float(value)
+
+
+def _output_path(cfg: dict, settings: dict, suffix: str) -> Path:
+    output_dir = Path(settings.get("output_dir", "results"))
+    if not output_dir.is_absolute():
+        output_dir = _config_dir(cfg) / output_dir
+    return output_dir / f"{_input_stem(cfg)}_{suffix}"
+
+
+def _config_dir(cfg: dict) -> Path:
+    if cfg.get("_config_dir_path"):
+        return Path(cfg["_config_dir_path"])
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).parent
+    return Path.cwd()
+
+
+def _input_stem(cfg: dict) -> str:
+    if cfg.get("_config_file_path"):
+        return Path(cfg["_config_file_path"]).stem
+    return str(cfg.get("basename", "vessel_stability_screening"))
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("vessel_stability_screening cannot write empty results")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/naval_architecture/test_vessel_stability_screening.py
+++ b/tests/naval_architecture/test_vessel_stability_screening.py
@@ -1,0 +1,505 @@
+# ABOUTME: Core tests for vessel_stability_screening — synthetic box-barge
+# ABOUTME: fixture with closed-form hand checks (Barrass & Derrett / PNA form).
+"""Core tests for :mod:`digitalmodel.naval_architecture.vessel_stability_screening`.
+
+Synthetic box-barge golden fixture (public textbook closed forms — Barrass &
+Derrett "Ship Stability for Masters and Mates" box-barge examples, PNA Vol. I
+hydrostatics; no client-derived values):
+
+* Barge L = 100 m, B = 20 m, depth D = 10 m, seawater rho = 1.025 t/m3.
+* Hydrostatics at draft T: displacement = rho*L*B*T = 2050*T;
+  KB = T/2; BMt = B^2/(12*T); KM = KB + BMt; LCB = LCF = 50.0 m (from AP);
+  MCT1cm = displacement * BML / (100*L) with BML = L^2/(12*T)
+  = 2050*T * (10000/(12*T)) / 10000 = 170.8333 t*m/cm (draft-independent);
+  TPC = rho*L*B/100 = 20.5.
+* Loading condition (chosen for exact hand arithmetic):
+    lightship 4000 t @ vcg 5.0, lcg 50.0
+    cargo     3000 t @ vcg 6.0, lcg 52.0
+    fuel      1000 t @ vcg 2.0, lcg 40.0, FSM 410 t*m
+    ballast    200 t @ vcg 1.0, lcg 50.0
+  Totals: W = 8200 t -> T = 4.0 m exactly; KM = 2 + 400/48 = 10.333333 m;
+  KG = 40200/8200 = 4.9024390 m; FSC = 410/8200 = 0.0500000 m exactly;
+  KG_fluid = 4.9524390 m; GM_solid = 5.4308943 m; GM_fluid = 5.3808943 m;
+  LCG = 406000/8200 = 49.5121951 m; trimming moment = 8200*(50 - LCG)
+  = 4000.0 t*m -> trim = 4000/170.8333 = 23.414634 cm = 0.2341463 m by the
+  stern; T_aft = 4 + 0.5*trim = 4.1170732 m, T_fwd = 3.8829268 m (LCF at
+  midship).
+* KN cross-curves from the wall-sided formula (synthetic fixture, valid to
+  deck-edge immersion atan((D-T)/(B/2)) = 30.96 deg, tabulated to 40 deg as
+  a smooth synthetic extension):
+    KN(phi) = KM*sin(phi) + 0.5*BMt*tan^2(phi)*sin(phi),   BMt = 8.3333333
+  so GZ = KN - KG_f*sin(phi) = GM_f*sin(phi) + 0.5*BMt*tan^2(phi)*sin(phi).
+  Hand values: GZ(30) = 5.3808943*0.5 + 4.1666667*(1/3)*0.5 = 3.3848905 m;
+  analytic areas (integral of the wall-sided GZ):
+    area(0-a) = GM_f*(1-cos a) + 0.5*BMt*[(sec a - 1) - (1 - cos a)]
+    area(0-30) = 0.8072556 m*rad; area(0-40) = 1.5566685 m*rad;
+    area(30-40) = 0.7494129 m*rad (trapezoid on the 5-deg table agrees to
+    ~0.3%).
+* 46 CFR 170.170 weather criterion with config P = 0.055 t/m2, A = 600 m2,
+  H = 5.0 m, T = min(14 deg, deck edge 30.96 deg) = 14 deg:
+    GM_required = 0.055*600*5 / (8200*tan 14) = 165/2044.4896 = 0.0807046 m.
+* Crane lift 100 t at 15 m outreach -> HM = 1500 t*m, HA(0) = 0.1829268 m.
+  On the 5-deg tabulated curve GZ is linear 0-5 deg with slope
+  GZ(5)/5 = (KN(5) - KG_f*sin 5)/5 = 0.4717565/5 = 0.0943513 m/deg, so the
+  static equilibrium solves 0.0943513*phi = 0.1829268*cos(phi)
+  -> phi = 1.9377 deg.
+* Max-KG at W = 8200 t: GM0 >= 0.15 gives KG_limit = KM - 0.15
+  = 10.1833333 m (governing); weather gives KM - 0.0807046 = 10.2526287 m;
+  the GZ-curve criteria still pass at KG = KM (wall-sided term), so they
+  report limited_by_km.
+"""
+
+import math
+
+import pytest
+
+from digitalmodel.naval_architecture.vessel_stability_screening import (
+    Citation,
+    CraneHeelingCase,
+    GZCurve,
+    HydroRow,
+    HydrostaticTable,
+    ImoIntactCriteria,
+    LiftingCriteria,
+    WeatherCriterion,
+    WeightItem,
+    build_loading_condition,
+    equilibrium_heel_deg,
+    governing_kg_limit,
+    gz_from_kn,
+    imo_intact_criteria,
+    kn_at_displacement,
+    lifting_check,
+    max_kg_screening,
+    rectangular_fsm_t_m,
+    solve_equilibrium,
+    weather_criterion_cfr_170_170,
+)
+
+L, B, D = 100.0, 20.0, 10.0
+RHO = 1.025
+MCT = 170.8333333  # t*m/cm, draft-independent for the box barge
+KM_4 = 2.0 + 400.0 / 48.0  # 10.3333333 at T = 4 m
+BMT_4 = 400.0 / 48.0  # 8.3333333 at T = 4 m
+W = 8200.0
+KG_FLUID = 4.9524390
+GM_FLUID = KM_4 - KG_FLUID
+HEELS = [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0]
+
+
+def _hydro_table() -> HydrostaticTable:
+    rows = []
+    for t in (2.0, 3.0, 4.0, 5.0, 6.0, 8.0):
+        rows.append(
+            HydroRow(
+                draft_m=t,
+                displacement_t=RHO * L * B * t,
+                km_m=t / 2.0 + B**2 / (12.0 * t),
+                lcb_m=50.0,
+                lcf_m=50.0,
+                mct_t_m_per_cm=MCT,
+                tpc_t_per_cm=20.5,
+            )
+        )
+    return HydrostaticTable(rows=tuple(rows))
+
+
+def _items() -> list[WeightItem]:
+    return [
+        WeightItem("lightship", 4000.0, 5.0, 50.0),
+        WeightItem("cargo", 3000.0, 6.0, 52.0),
+        WeightItem("fuel", 1000.0, 2.0, 40.0, fsm_t_m=410.0),
+        WeightItem("ballast", 200.0, 1.0, 50.0),
+    ]
+
+
+def _kn(heel_deg: list[float], km: float = KM_4, bmt: float = BMT_4) -> list[float]:
+    """Wall-sided KN: KM*sin + 0.5*BMt*tan^2*sin (synthetic cross-curve)."""
+    out = []
+    for phi in heel_deg:
+        r = math.radians(phi)
+        out.append(km * math.sin(r) + 0.5 * bmt * math.tan(r) ** 2 * math.sin(r))
+    return out
+
+
+def _curve(kg_fluid: float = KG_FLUID) -> GZCurve:
+    return gz_from_kn(HEELS, _kn(HEELS), kg_fluid)
+
+
+def _weather() -> WeatherCriterion:
+    return WeatherCriterion(
+        wind_pressure_t_m2=0.055,
+        windage_area_m2=600.0,
+        windage_lever_m=5.0,
+        max_heel_deg=14.0,
+        citation=Citation("46 CFR 170.170", "2024", "170.170(a)"),
+    )
+
+
+def _lifting_criteria(**overrides) -> LiftingCriteria:
+    kwargs = dict(
+        max_equilibrium_heel_deg=5.0,
+        residual_area_ratio_min=1.4,
+        residual_range_limit_deg=40.0,
+        citation=Citation("46 CFR Part 173 Subpart B", "2024", "173.005-series"),
+    )
+    kwargs.update(overrides)
+    return LiftingCriteria(**kwargs)
+
+
+# -- citations -----------------------------------------------------------------
+
+
+def test_citation_requires_standard_edition_clause():
+    with pytest.raises(ValueError, match="citation.edition"):
+        Citation("46 CFR 170.170", "", "170.170(a)")
+
+
+def test_citation_label_includes_note():
+    cite = Citation("IMO IS Code", "2008", "2.2.1", note="general criteria")
+    assert cite.label() == "IMO IS Code (2008) 2.2.1 — general criteria"
+
+
+# -- hydrostatic table -----------------------------------------------------------
+
+
+def test_table_exact_node_lookup():
+    props = _hydro_table().at_displacement(8200.0)
+    assert props.draft_m == pytest.approx(4.0)
+    assert props.km_m == pytest.approx(10.3333333, abs=1e-6)
+    assert props.mct_t_m_per_cm == pytest.approx(MCT, abs=1e-6)
+
+
+def test_table_interpolates_between_drafts():
+    # Midway between T=4 (8200 t) and T=5 (10250 t): W = 9225 t.
+    props = _hydro_table().at_displacement(9225.0)
+    assert props.draft_m == pytest.approx(4.5)
+    # Linear-in-displacement KM: (10.3333333 + 9.1666667)/2 = 9.75
+    assert props.km_m == pytest.approx(9.75, abs=1e-6)
+
+
+def test_table_rejects_out_of_range():
+    with pytest.raises(ValueError, match="outside hydrostatic table range"):
+        _hydro_table().at_displacement(100.0)
+    with pytest.raises(ValueError, match="outside hydrostatic table range"):
+        _hydro_table().at_draft(9.0)
+
+
+def test_table_rejects_non_monotonic_displacement():
+    rows = (
+        HydroRow(draft_m=2.0, displacement_t=5000.0, km_m=17.0),
+        HydroRow(draft_m=3.0, displacement_t=4000.0, km_m=13.0),
+    )
+    with pytest.raises(ValueError, match="displacements must increase"):
+        HydrostaticTable(rows=rows)
+
+
+def test_table_needs_two_rows():
+    with pytest.raises(ValueError, match=">= 2 rows"):
+        HydrostaticTable(rows=(HydroRow(draft_m=2.0, displacement_t=4100.0, km_m=17.0),))
+
+
+# -- loading condition -----------------------------------------------------------
+
+
+def test_loading_condition_hand_totals():
+    cond = build_loading_condition("departure", _items())
+    assert cond.displacement_t == pytest.approx(8200.0)
+    assert cond.kg_m == pytest.approx(40200.0 / 8200.0, abs=1e-9)
+    assert cond.lcg_m == pytest.approx(406000.0 / 8200.0, abs=1e-9)
+    assert cond.fsm_total_t_m == pytest.approx(410.0)
+    assert cond.fsc_m == pytest.approx(0.05, abs=1e-12)
+    assert cond.kg_fluid_m == pytest.approx(cond.kg_m + 0.05, abs=1e-12)
+
+
+def test_rectangular_fsm_hand_value():
+    # rho*l*b^3/12 = 0.85 * 12 * 8^3 / 12 = 435.2 t*m
+    assert rectangular_fsm_t_m(12.0, 8.0, 0.85) == pytest.approx(435.2)
+
+
+def test_weight_item_rejects_nonpositive_weight():
+    with pytest.raises(ValueError, match="weight_t must be > 0"):
+        WeightItem("bad", 0.0, 1.0, 1.0)
+
+
+def test_empty_condition_rejected():
+    with pytest.raises(ValueError, match="at least one weight item"):
+        build_loading_condition("empty", [])
+
+
+# -- equilibrium (draft / GM / trim) ----------------------------------------------
+
+
+def test_equilibrium_hand_values():
+    cond = build_loading_condition("departure", _items())
+    eq = solve_equilibrium(cond, _hydro_table(), lbp_m=100.0)
+    assert eq.draft_m == pytest.approx(4.0)
+    assert eq.km_m == pytest.approx(10.3333333, abs=1e-6)
+    assert eq.gm_solid_m == pytest.approx(5.4308943, abs=1e-6)
+    assert eq.gm_fluid_m == pytest.approx(5.3808943, abs=1e-6)
+    # trim = W*(LCB-LCG)/MCT = 4000/170.8333 cm = 0.2341463 m by the stern
+    assert eq.trim_m == pytest.approx(0.2341463, abs=1e-6)
+    assert eq.draft_aft_m == pytest.approx(4.1170732, abs=1e-6)
+    assert eq.draft_fwd_m == pytest.approx(3.8829268, abs=1e-6)
+
+
+def test_equilibrium_without_lcb_mct_skips_trim():
+    rows = tuple(
+        HydroRow(draft_m=t, displacement_t=2050.0 * t, km_m=t / 2 + 400.0 / (12 * t))
+        for t in (2.0, 4.0, 6.0)
+    )
+    cond = build_loading_condition("departure", _items())
+    eq = solve_equilibrium(cond, HydrostaticTable(rows=rows))
+    assert eq.trim_m is None
+    assert eq.draft_aft_m is None
+    assert eq.gm_fluid_m == pytest.approx(5.3808943, abs=1e-6)
+
+
+# -- GZ curve ---------------------------------------------------------------------
+
+
+def test_gz_from_kn_hand_value_at_30():
+    curve = _curve()
+    # GZ(30) = KN(30) - KG_f*sin30 = 5.8611111 - 2.4762195 = 3.3848916
+    assert curve.gz_at(30.0) == pytest.approx(3.3848916, abs=1e-5)
+
+
+def test_gz_areas_match_wall_sided_analytic():
+    curve = _curve()
+    assert curve.area_m_rad(0.0, 30.0) == pytest.approx(0.8072556, rel=5e-3)
+    assert curve.area_m_rad(0.0, 40.0) == pytest.approx(1.5566685, rel=5e-3)
+    assert curve.area_m_rad(30.0, 40.0) == pytest.approx(0.7494129, rel=5e-3)
+
+
+def test_gz_curve_validation():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        GZCurve(heel_deg=(0.0, 10.0, 10.0), gz_m=(0.0, 1.0, 2.0))
+    with pytest.raises(ValueError, match="start at 0"):
+        GZCurve(heel_deg=(5.0, 10.0, 15.0), gz_m=(0.0, 1.0, 2.0))
+    with pytest.raises(ValueError, match="lengths differ"):
+        gz_from_kn([0.0, 10.0], [0.0], 5.0)
+
+
+def test_kn_grid_interpolation_in_displacement():
+    heels = [0.0, 10.0, 20.0]
+    grid = [[0.0, 1.0, 2.0], [0.0, 3.0, 4.0]]
+    kn = kn_at_displacement(heels, [4100.0, 8200.0], grid, 6150.0)
+    assert kn == pytest.approx([0.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="outside KN grid range"):
+        kn_at_displacement(heels, [4100.0, 8200.0], grid, 9000.0)
+
+
+# -- IMO IS Code 2008 intact criteria -----------------------------------------------
+
+
+def test_imo_intact_all_pass_with_hand_values():
+    results = imo_intact_criteria(_curve(), GM_FLUID)
+    by_key = {r.key: r for r in results}
+    assert len(results) == 6
+    assert all(r.passed for r in results)
+    assert by_key["imo_area_0_30"].value == pytest.approx(0.8072556, rel=5e-3)
+    assert by_key["imo_area_0_30"].required == 0.055
+    assert by_key["imo_gz_30"].value == pytest.approx(3.3848916, abs=1e-5)
+    assert by_key["imo_angle_max_gz"].value == pytest.approx(40.0)
+    assert by_key["imo_gm0"].value == pytest.approx(GM_FLUID, abs=1e-6)
+    assert "IMO IS Code 2008" in by_key["imo_gm0"].citation
+    assert "MSC.267(85)" in by_key["imo_gm0"].citation
+
+
+def test_imo_intact_caps_areas_at_downflooding_angle():
+    results = imo_intact_criteria(_curve(), GM_FLUID, downflooding_angle_deg=35.0)
+    by_key = {r.key: r for r in results}
+    # area(0-35) analytic = GM_f*(1-cos35) + 4.1666667*((sec35-1)-(1-cos35))
+    #                     = 5.3808943*0.1808479 + 4.1666667*(0.2207745-0.1808479)
+    #                     = 0.9731287 + 0.1663608 = 1.1394895 m*rad
+    assert by_key["imo_area_0_40"].value == pytest.approx(1.1394895, rel=5e-3)
+    assert "35" in by_key["imo_area_0_40"].description
+
+
+def test_imo_intact_negative_gm_fails_gm0_and_overall():
+    # FSM-dominant condition: KG_fluid pushed above KM (free-surface loss).
+    results = imo_intact_criteria(_curve(kg_fluid=10.6), -0.2666667)
+    by_key = {r.key: r for r in results}
+    assert not by_key["imo_gm0"].passed
+    assert by_key["imo_gm0"].margin == pytest.approx(-0.4166667, abs=1e-6)
+    assert not all(r.passed for r in results)
+
+
+def test_imo_intact_criteria_overridable_with_new_citation():
+    custom = ImoIntactCriteria(
+        gm0_min_m=6.0,
+        citation=Citation("Flag criteria", "2020", "annex 1"),
+    )
+    results = imo_intact_criteria(_curve(), GM_FLUID, criteria=custom)
+    by_key = {r.key: r for r in results}
+    assert not by_key["imo_gm0"].passed  # 5.38 < 6.0
+    assert by_key["imo_gm0"].citation == "Flag criteria (2020) annex 1"
+
+
+# -- 46 CFR 170.170 weather criterion ------------------------------------------------
+
+
+def test_weather_criterion_hand_value():
+    result = weather_criterion_cfr_170_170(
+        _weather(), W, GM_FLUID, deck_edge_immersion_deg=30.9637565
+    )
+    # GM_required = 0.055*600*5/(8200*tan14) = 165/2044.4896 = 0.0807046 m
+    assert result.required == pytest.approx(0.0807046, abs=1e-6)
+    assert result.value == pytest.approx(GM_FLUID, abs=1e-6)
+    assert result.passed
+    assert "46 CFR 170.170" in result.citation
+
+
+def test_weather_criterion_deck_edge_caps_heel_angle():
+    # Deck edge at 10 deg < 14 deg: T = 10 deg -> required grows by
+    # tan14/tan10 = 0.2493280/0.1763270 = 1.4140...
+    result = weather_criterion_cfr_170_170(
+        _weather(), W, GM_FLUID, deck_edge_immersion_deg=10.0
+    )
+    assert result.required == pytest.approx(
+        165.0 / (8200.0 * math.tan(math.radians(10.0))), abs=1e-6
+    )
+
+
+def test_weather_criterion_fails_low_gm():
+    result = weather_criterion_cfr_170_170(_weather(), W, 0.05)
+    assert not result.passed
+    assert result.margin == pytest.approx(0.05 - 0.0807046, abs=1e-6)
+
+
+def test_weather_criterion_requires_positive_inputs():
+    with pytest.raises(ValueError, match="wind_pressure_t_m2 must be > 0"):
+        WeatherCriterion(
+            wind_pressure_t_m2=0.0,
+            windage_area_m2=600.0,
+            windage_lever_m=5.0,
+            citation=Citation("46 CFR 170.170", "2024", "170.170(a)"),
+        )
+
+
+# -- lifting / crane heel -------------------------------------------------------------
+
+
+def test_crane_case_from_hook_load():
+    case = CraneHeelingCase.from_hook_load("main crane", 100.0, 15.0)
+    assert case.heeling_moment_t_m == pytest.approx(1500.0)
+    assert case.heeling_arm_m(W, 0.0) == pytest.approx(0.1829268, abs=1e-6)
+    # cosine decay: HA(30) = HA(0)*cos30
+    assert case.heeling_arm_m(W, 30.0) == pytest.approx(
+        0.1829268 * math.cos(math.radians(30.0)), abs=1e-6
+    )
+
+
+def test_equilibrium_heel_hand_value():
+    # Linear GZ 0-5 deg with slope 0.0943513 m/deg (see module docstring):
+    # 0.0943513*phi = 0.1829268*cos(phi) -> phi = 1.9377 deg
+    case = CraneHeelingCase.from_hook_load("main crane", 100.0, 15.0)
+    eq = equilibrium_heel_deg(_curve(), case, W)
+    assert eq == pytest.approx(1.9377, abs=5e-3)
+
+
+def test_lifting_check_passes_criteria():
+    case = CraneHeelingCase.from_hook_load("main crane", 100.0, 15.0)
+    result = lifting_check(
+        _curve(), case, W, _lifting_criteria(), downflooding_angle_deg=None
+    )
+    assert result.passed
+    assert result.equilibrium_heel_deg == pytest.approx(1.9377, abs=5e-3)
+    by_key = {c.key: c for c in result.criteria}
+    assert by_key["lifting_equilibrium_heel"].required == pytest.approx(5.0)
+    # Heeling energy (exact): (HM/W)*sin(eq) = 0.1829268*sin(1.9377 deg)
+    assert result.heeling_area_m_rad == pytest.approx(
+        0.1829268 * math.sin(math.radians(result.equilibrium_heel_deg)), rel=1e-6
+    )
+    assert result.residual_area_ratio > 100.0  # barge GZ dwarfs the lift
+    assert "46 CFR Part 173" in by_key["lifting_residual_area_ratio"].citation
+
+
+def test_lifting_equilibrium_heel_exceeding_limit_fails():
+    # 10x the hook load: HA(0) = 1.8293 m; solve on the tabulated curve.
+    case = CraneHeelingCase.from_hook_load("heavy lift", 1000.0, 15.0)
+    result = lifting_check(_curve(), case, W, _lifting_criteria())
+    by_key = {c.key: c for c in result.criteria}
+    assert result.equilibrium_heel_deg > 5.0
+    assert not by_key["lifting_equilibrium_heel"].passed
+    assert not result.passed
+
+
+def test_lifting_no_static_equilibrium_when_arm_exceeds_gz():
+    # HM/W = 8 m: HA exceeds GZ over the whole tabulated range (max GZ
+    # = 5.344 m at 40 deg < 8*cos40 = 6.13 m) -> no equilibrium, hard fail.
+    case = CraneHeelingCase(name="capsizing lift", heeling_moment_t_m=8.0 * W)
+    result = lifting_check(_curve(), case, W, _lifting_criteria())
+    assert result.equilibrium_heel_deg is None
+    assert not result.passed
+    by_key = {c.key: c for c in result.criteria}
+    assert by_key["lifting_equilibrium_heel"].value is None
+    assert "no static equilibrium" in by_key["lifting_equilibrium_heel"].description
+
+
+def test_lifting_deck_edge_caps_heel_limit():
+    case = CraneHeelingCase.from_hook_load("main crane", 100.0, 15.0)
+    result = lifting_check(
+        _curve(), case, W, _lifting_criteria(), deck_edge_immersion_deg=1.0
+    )
+    by_key = {c.key: c for c in result.criteria}
+    assert by_key["lifting_equilibrium_heel"].required == pytest.approx(1.0)
+    assert not by_key["lifting_equilibrium_heel"].passed
+
+
+def test_lifting_criteria_require_citation():
+    with pytest.raises(TypeError):
+        LiftingCriteria(max_equilibrium_heel_deg=5.0)  # citation is required
+
+
+# -- max-KG screening -----------------------------------------------------------------
+
+
+def test_max_kg_gm0_governs_with_hand_value():
+    limits = max_kg_screening(HEELS, _kn(HEELS), KM_4, W, weather=_weather())
+    by_key = {limit.key: limit for limit in limits}
+    # GM0 >= 0.15 -> KG_limit = KM - 0.15 = 10.1833333 m
+    assert by_key["imo_gm0"].kg_limit_m == pytest.approx(10.1833333, abs=1e-3)
+    assert not by_key["imo_gm0"].limited_by_km
+    # Weather: KG_limit = KM - 0.0807046 = 10.2526287 m
+    assert by_key["cfr_170_170_weather_gm"].kg_limit_m == pytest.approx(
+        10.2526287, abs=1e-3
+    )
+    # Wall-sided GZ criteria still pass at KG = KM -> limited_by_km
+    for key in ("imo_area_0_30", "imo_area_0_40", "imo_area_30_40",
+                "imo_gz_30", "imo_angle_max_gz"):
+        assert by_key[key].limited_by_km, key
+        assert by_key[key].kg_limit_m == pytest.approx(KM_4, abs=1e-9)
+    governing = governing_kg_limit(limits)
+    assert governing.key == "imo_gm0"
+    assert governing.kg_limit_m == pytest.approx(10.1833333, abs=1e-3)
+
+
+def test_max_kg_with_lifting_hand_value():
+    # Equilibrium heel hits the 5-deg limit when GZ(5) = HA(5):
+    # KN(5) - KG*sin5 = 0.1829268*cos5 -> KG = (0.9033889 - 0.1822313)
+    # / 0.0871557 = 8.2744 m -> lifting governs over GM0 (10.18 m).
+    case = CraneHeelingCase.from_hook_load("main crane", 100.0, 15.0)
+    limits = max_kg_screening(
+        HEELS, _kn(HEELS), KM_4, W,
+        lifting_case=case, lifting=_lifting_criteria(),
+    )
+    by_key = {limit.key: limit for limit in limits}
+    assert by_key["lifting_equilibrium_heel"].kg_limit_m == pytest.approx(
+        8.2744, abs=5e-3
+    )
+    governing = governing_kg_limit(limits)
+    assert governing.key == "lifting_equilibrium_heel"
+
+
+def test_max_kg_criterion_failing_at_zero_kg_reports_none():
+    strict = ImoIntactCriteria(
+        gz_30_min_m=100.0,
+        citation=Citation("synthetic", "2026", "edge case"),
+    )
+    limits = max_kg_screening(HEELS, _kn(HEELS), KM_4, W, imo=strict)
+    by_key = {limit.key: limit for limit in limits}
+    assert by_key["imo_gz_30"].kg_limit_m is None
+    governing = governing_kg_limit(limits)
+    assert governing.key == "imo_gz_30"
+    assert governing.kg_limit_m is None

--- a/tests/naval_architecture/test_vessel_stability_screening_workflow.py
+++ b/tests/naval_architecture/test_vessel_stability_screening_workflow.py
@@ -1,0 +1,360 @@
+# ABOUTME: Workflow (router) tests for the vessel_stability_screening basename —
+# ABOUTME: YAML-config driven intact stability screening, CSV outputs, status.
+"""Workflow tests for the ``vessel_stability_screening`` basename.
+
+Fixture: the synthetic box-barge golden fixture derived and hand-verified in
+``test_vessel_stability_screening.py`` (Barrass & Derrett / PNA box-barge
+closed forms — public textbook values only): L = 100 m, B = 20 m, seawater;
+condition W = 8200 t -> T = 4.0 m, KM = 10.3333 m, KG = 4.9024 m,
+FSC = 0.0500 m, GM_fluid = 5.3809 m, trim 0.2341 m by the stern; wall-sided
+KN cross-curve; 46 CFR 170.170 weather GM_required = 0.0807 m; crane lift
+100 t x 15 m -> equilibrium heel 1.9377 deg; governing max-KG = KM - 0.15
+= 10.1833 m (IMO GM0).
+"""
+
+import csv
+import math
+
+import pytest
+
+from digitalmodel.vessel_stability_screening.workflow import router
+
+KM_4 = 2.0 + 400.0 / 48.0
+BMT_4 = 400.0 / 48.0
+HEELS = [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0]
+
+
+def _kn(heel_deg):
+    out = []
+    for phi in heel_deg:
+        r = math.radians(phi)
+        out.append(
+            KM_4 * math.sin(r) + 0.5 * BMT_4 * math.tan(r) ** 2 * math.sin(r)
+        )
+    return out
+
+
+def _hydro_rows():
+    rows = []
+    for t in (2.0, 3.0, 4.0, 5.0, 6.0, 8.0):
+        rows.append(
+            {
+                "draft_m": t,
+                "displacement_t": 1.025 * 100.0 * 20.0 * t,
+                "km_m": t / 2.0 + 400.0 / (12.0 * t),
+                "lcb_m": 50.0,
+                "lcf_m": 50.0,
+                "mct_t_m_per_cm": 170.8333333,
+                "tpc_t_per_cm": 20.5,
+            }
+        )
+    return rows
+
+
+def _settings(**overrides):
+    settings = {
+        "vessel": {
+            "name": "synthetic box barge",
+            "lbp_m": 100.0,
+            "deck_edge_immersion_deg": 30.9637565,
+        },
+        "hydrostatics": {"table": _hydro_rows()},
+        "loading_condition": {
+            "name": "departure",
+            "items": [
+                {"name": "lightship", "weight_t": 4000.0, "vcg_m": 5.0, "lcg_m": 50.0},
+                {"name": "cargo", "weight_t": 3000.0, "vcg_m": 6.0, "lcg_m": 52.0},
+                {"name": "fuel", "weight_t": 1000.0, "vcg_m": 2.0, "lcg_m": 40.0,
+                 "fsm_t_m": 410.0},
+                {"name": "ballast", "weight_t": 200.0, "vcg_m": 1.0, "lcg_m": 50.0},
+            ],
+        },
+        "gz": {"heel_deg": list(HEELS), "kn_m": _kn(HEELS)},
+        "criteria": {
+            "weather_cfr_170_170": {
+                "wind_pressure_t_m2": 0.055,
+                "windage_area_m2": 600.0,
+                "windage_lever_m": 5.0,
+                "max_heel_deg": 14.0,
+                "citation": {
+                    "standard": "46 CFR 170.170",
+                    "edition": "2024",
+                    "clause": "170.170(a)",
+                },
+            },
+        },
+        "lifting": {
+            "name": "main crane lift",
+            "hook_load_t": 100.0,
+            "transverse_outreach_m": 15.0,
+            "criteria": {
+                "max_equilibrium_heel_deg": 5.0,
+                "residual_area_ratio_min": 1.4,
+                "citation": {
+                    "standard": "46 CFR Part 173 Subpart B",
+                    "edition": "2024",
+                    "clause": "173.005-series",
+                },
+            },
+        },
+        "max_kg": {"enabled": True},
+    }
+    settings.update(overrides)
+    return settings
+
+
+def _cfg(tmp_path, **overrides):
+    settings = _settings(**overrides)
+    settings.setdefault("output_dir", str(tmp_path / "results"))
+    return {
+        "basename": "vessel_stability_screening",
+        "vessel_stability_screening": settings,
+        "_config_dir_path": str(tmp_path),
+    }
+
+
+def test_router_matches_golden_fixture(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    result = cfg["vessel_stability_screening"]
+    assert result["displacement_t"] == pytest.approx(8200.0)
+    assert result["draft_m"] == pytest.approx(4.0)
+    assert result["kg_m"] == pytest.approx(4.9024390, abs=1e-6)
+    assert result["fsc_m"] == pytest.approx(0.05, abs=1e-9)
+    assert result["kg_fluid_m"] == pytest.approx(4.9524390, abs=1e-6)
+    assert result["gm_fluid_m"] == pytest.approx(5.3808943, abs=1e-6)
+    assert result["trim_m"] == pytest.approx(0.2341463, abs=1e-6)
+    assert result["equilibrium_result"]["draft_aft_m"] == pytest.approx(
+        4.1170732, abs=1e-6
+    )
+    assert cfg["screening_status"] == "pass"
+    assert "Screening tier only" in result["governance"]
+
+
+def test_router_criteria_table_cited_and_passing(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    rows = cfg["vessel_stability_screening"]["criteria_results"]
+    by_key = {row["key"]: row for row in rows}
+    # 6 IMO + 1 weather + 2 lifting = 9 criteria rows
+    assert len(rows) == 9
+    assert all(row["status"] == "pass" for row in rows)
+    assert all(row["citation"] for row in rows)
+    assert "MSC.267(85)" in by_key["imo_gm0"]["citation"]
+    assert by_key["cfr_170_170_weather_gm"]["required"] == pytest.approx(
+        0.0807046, abs=1e-6
+    )
+    assert "46 CFR 170.170" in by_key["cfr_170_170_weather_gm"]["citation"]
+    assert by_key["imo_gz_30"]["value"] == pytest.approx(3.3848916, abs=1e-5)
+    assert by_key["lifting_equilibrium_heel"]["value"] == pytest.approx(
+        1.9377, abs=5e-3
+    )
+    assert "46 CFR Part 173" in by_key["lifting_equilibrium_heel"]["citation"]
+
+
+def test_router_lifting_result_block(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    lifting = cfg["vessel_stability_screening"]["lifting_result"]
+    assert lifting["heeling_moment_t_m"] == pytest.approx(1500.0)
+    assert lifting["heeling_arm_0_m"] == pytest.approx(0.1829268, abs=1e-6)
+    assert lifting["equilibrium_heel_deg"] == pytest.approx(1.9377, abs=5e-3)
+    assert lifting["status"] == "pass"
+
+
+def test_router_max_kg_limits_and_governing(tmp_path):
+    cfg = router(_cfg(tmp_path))
+    result = cfg["vessel_stability_screening"]
+    by_key = {row["key"]: row for row in result["kg_limits"]}
+    assert by_key["imo_gm0"]["kg_limit_m"] == pytest.approx(10.1833333, abs=1e-3)
+    assert by_key["cfr_170_170_weather_gm"]["kg_limit_m"] == pytest.approx(
+        10.2526287, abs=1e-3
+    )
+    # Lifting equilibrium-heel limit (hand value, see core tests): 8.2744 m
+    assert by_key["lifting_equilibrium_heel"]["kg_limit_m"] == pytest.approx(
+        8.2744, abs=5e-3
+    )
+    assert result["governing_kg_criterion"] == "lifting_equilibrium_heel"
+    assert result["governing_kg_limit_m"] == pytest.approx(8.2744, abs=5e-3)
+
+
+def test_router_writes_report_pack_ready_csvs(tmp_path):
+    router(_cfg(tmp_path))
+    stem = "vessel_stability_screening"
+    results_dir = tmp_path / "results"
+    for suffix in (
+        "loading_condition.csv",
+        "equilibrium.csv",
+        "criteria.csv",
+        "gz_curve.csv",
+        "kg_limits.csv",
+        "summary.csv",
+    ):
+        assert (results_dir / f"{stem}_{suffix}").exists(), suffix
+    with (results_dir / f"{stem}_criteria.csv").open() as stream:
+        rows = list(csv.DictReader(stream))
+    assert {"key", "value", "required", "unit", "status", "citation"} <= set(rows[0])
+    assert len(rows) == 9
+    with (results_dir / f"{stem}_gz_curve.csv").open() as stream:
+        gz_rows = list(csv.DictReader(stream))
+    assert {"heel_deg", "gz_m", "heeling_arm_m", "net_arm_m"} <= set(gz_rows[0])
+    assert len(gz_rows) == len(HEELS)
+    with (results_dir / f"{stem}_summary.csv").open() as stream:
+        summary = list(csv.DictReader(stream))[0]
+    assert summary["screening_status"] == "pass"
+
+
+def test_router_hydrostatics_from_csv(tmp_path):
+    csv_path = tmp_path / "hydrostatics.csv"
+    rows = _hydro_rows()
+    with csv_path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    cfg = router(_cfg(tmp_path, hydrostatics={"csv": "hydrostatics.csv"}))
+    assert cfg["vessel_stability_screening"]["draft_m"] == pytest.approx(4.0)
+    assert cfg["screening_status"] == "pass"
+
+
+def test_router_cross_curve_grid_interpolation(tmp_path):
+    # Sandwich the true KN curve between two grid rows equidistant in W:
+    # linear interpolation at W = 8200 recovers the true curve.
+    kn = _kn(HEELS)
+    grid = {
+        "displacements_t": [6150.0, 10250.0],
+        "kn_m": [
+            [v - 0.5 for v in kn],
+            [v + 0.5 for v in kn],
+        ],
+    }
+    cfg = router(
+        _cfg(tmp_path, gz={"heel_deg": list(HEELS), "cross_curves": grid})
+    )
+    by_key = {
+        row["key"]: row
+        for row in cfg["vessel_stability_screening"]["criteria_results"]
+    }
+    assert by_key["imo_gz_30"]["value"] == pytest.approx(3.3848916, abs=1e-5)
+
+
+def test_router_direct_gz_table_skips_max_kg_requirement(tmp_path):
+    kn = _kn(HEELS)
+    kg_fluid = 4.9524390
+    gz = [k - kg_fluid * math.sin(math.radians(p)) for p, k in zip(HEELS, kn)]
+    cfg = router(
+        _cfg(
+            tmp_path,
+            gz={"heel_deg": list(HEELS), "gz_m": gz},
+            max_kg=None,
+            lifting=None,
+        )
+    )
+    by_key = {
+        row["key"]: row
+        for row in cfg["vessel_stability_screening"]["criteria_results"]
+    }
+    assert by_key["imo_gz_30"]["value"] == pytest.approx(3.3848916, abs=1e-5)
+    assert cfg["vessel_stability_screening"]["kg_limits"] == []
+
+
+def test_router_max_kg_with_gz_table_rejected(tmp_path):
+    gz = [0.0] + [1.0] * (len(HEELS) - 1)
+    cfg = _cfg(tmp_path, gz={"heel_deg": list(HEELS), "gz_m": gz}, lifting=None)
+    with pytest.raises(ValueError, match="max_kg requires KN input"):
+        router(cfg)
+
+
+def test_router_free_surface_tank_dimensions(tmp_path):
+    settings = _settings()
+    settings["loading_condition"]["items"][2] = {
+        "name": "fuel",
+        "weight_t": 1000.0,
+        "vcg_m": 2.0,
+        "lcg_m": 40.0,
+        # rho*l*b^3/12 = 1.025 * 20 * (2.7144176)^3/12 -> pick exact 410:
+        # use l = 12 m, b = 8 m, rho = 0.4270833 -> 0.4270833*12*512/12 = 218.67
+        # keep it simple: l = 12, b = 8, rho = 0.85 -> FSM = 435.2 t*m
+        "free_surface": {"length_m": 12.0, "breadth_m": 8.0, "density_t_m3": 0.85},
+    }
+    settings["output_dir"] = str(tmp_path / "results")
+    cfg = router(
+        {
+            "basename": "vessel_stability_screening",
+            "vessel_stability_screening": settings,
+            "_config_dir_path": str(tmp_path),
+        }
+    )
+    result = cfg["vessel_stability_screening"]
+    assert result["fsc_m"] == pytest.approx(435.2 / 8200.0, abs=1e-9)
+
+
+def test_router_fsm_dominance_fails_gm(tmp_path):
+    # Free-surface loss dominates: FSC = 82000/8200 = 10 m -> GM_fluid < 0.
+    settings = _settings()
+    settings["loading_condition"]["items"][2]["fsm_t_m"] = 82000.0
+    settings["output_dir"] = str(tmp_path / "results")
+    cfg = router(
+        {
+            "basename": "vessel_stability_screening",
+            "vessel_stability_screening": settings,
+            "_config_dir_path": str(tmp_path),
+        }
+    )
+    result = cfg["vessel_stability_screening"]
+    assert result["fsc_m"] == pytest.approx(10.0)
+    assert result["gm_fluid_m"] < 0.0
+    assert cfg["screening_status"] == "fail"
+    by_key = {row["key"]: row for row in result["criteria_results"]}
+    assert by_key["imo_gm0"]["status"] == "fail"
+    assert by_key["cfr_170_170_weather_gm"]["status"] == "fail"
+
+
+def test_router_uncited_weather_criterion_rejected(tmp_path):
+    settings = _settings()
+    del settings["criteria"]["weather_cfr_170_170"]["citation"]
+    settings["output_dir"] = str(tmp_path / "results")
+    cfg = {
+        "basename": "vessel_stability_screening",
+        "vessel_stability_screening": settings,
+        "_config_dir_path": str(tmp_path),
+    }
+    with pytest.raises(ValueError, match="citation is required"):
+        router(cfg)
+
+
+def test_router_uncited_lifting_criteria_rejected(tmp_path):
+    settings = _settings()
+    del settings["lifting"]["criteria"]["citation"]
+    settings["output_dir"] = str(tmp_path / "results")
+    cfg = {
+        "basename": "vessel_stability_screening",
+        "vessel_stability_screening": settings,
+        "_config_dir_path": str(tmp_path),
+    }
+    with pytest.raises(ValueError, match="citation is required"):
+        router(cfg)
+
+
+def test_router_lifting_without_gz_rejected(tmp_path):
+    cfg = _cfg(tmp_path, gz=None, max_kg=None)
+    with pytest.raises(ValueError, match="lifting requires gz input"):
+        router(cfg)
+
+
+def test_router_no_criteria_rejected(tmp_path):
+    cfg = _cfg(tmp_path, gz=None, max_kg=None, lifting=None, criteria=None)
+    with pytest.raises(ValueError, match="evaluated no criteria"):
+        router(cfg)
+
+
+def test_router_requires_hydrostatics_and_condition(tmp_path):
+    cfg = _cfg(tmp_path, hydrostatics=None)
+    with pytest.raises(ValueError, match="hydrostatics mapping is required"):
+        router(cfg)
+    cfg = _cfg(tmp_path, loading_condition=None)
+    with pytest.raises(ValueError, match="loading_condition mapping is required"):
+        router(cfg)
+
+
+def test_router_engine_arm_routes_basename():
+    # The engine arm imports lazily; exercise the routed import path directly.
+    from digitalmodel import vessel_stability_screening as package
+
+    assert package.router is router


### PR DESCRIPTION
## Summary

L1 slice of the vessel stability / hydrostatics deterministic workflow (vamseeachanta/llm-wiki-acma#239, including the 2026-07-13 lifting/crane-heel scope addition): new basename-routed module `vessel_stability_screening` — intact stability only, public math + synthetic textbook fixtures.

### What's in

- **Hydrostatic-table interface**: draft-indexed table (displacement, KM, LCB, LCF, MCT, TPC) from inline YAML or CSV; linear interpolation, no extrapolation. Geometry-based hydrostatics is a later slice.
- **Loading-condition builder**: lightship + tank/cargo items → displacement, KG, LCG with per-tank free-surface correction (`FSM` direct or `rho*l*b^3/12`); trim via `W*(LCB−LCG)/MCT` distributed about the LCF to end drafts.
- **GZ-curve analysis**: from a GZ table or KN cross-curves (grid interpolated in displacement): `GZ = KN − KG_fluid*sin(phi)`.
- **Cited criteria table** (foam_system `Citation` pattern — standard/edition/clause mandatory):
  - IMO IS Code 2008 (Res. MSC.267(85)) Part A 2.2: areas 0–30°/0–40° (downflooding-capped)/30–40°, GZ@30°, angle of max GZ, GM0 — cited defaults, config-overridable;
  - 46 CFR 170.170 weather criterion `GM ≥ PAH/(W tan T)`, `T = min(14°, deck-edge immersion)`, wind pressure P as a cited config input;
  - 46 CFR 173.005-series style lifting/crane-heel: cosine heeling arm from hook load × outreach (or direct moment), equilibrium heel by bisection, cited max-heel + residual-energy-ratio criteria; a heeling arm exceeding GZ over the whole range reports no static equilibrium and fails hard.
- **Max-KG screening**: limiting fluid KG per criterion by bisection on [0, KM] → KG-limit table + governing criterion.
- **Routing surfaces**: `engine.py` arm (basename `vessel_stability_screening`), base_config, `docs/registry/module-routing.yaml` + operator-map rows, docs page `docs/domains/ship-design/vessel-stability-screening.md`.
- **Outputs**: loading-condition / equilibrium / GZ-curve / criteria (citation column) / KG-limit / summary CSVs (report_pack-ready); `screening_status` stamped.

Reuses the validated `naval_architecture.damage_stability` GZ interpolation/area helpers.

### Governance

Screening tier only — the PE-stamped stability booklet / class or USCG submittal governs; GHS remains the licensed cross-check. All criteria thresholds are traceability-cited config inputs.

### Tests

- 52 new tests (`tests/naval_architecture/test_vessel_stability_screening{,_workflow}.py`) on a synthetic box-barge golden fixture (Barrass & Derrett / PNA closed forms; hand-verified values in docstrings): exact hydrostatics/trim/FSC arithmetic, wall-sided KN → analytic GZ areas, 46 CFR 170.170 hand value, crane equilibrium heel closed form, max-KG hand values, plus negative-GM, FSM-dominance, no-static-equilibrium and uncited-criteria edge cases.
- `tests/docs/test_digitalmodel_routing_contract.py`: 8/8 pass.
- End-to-end `python -m digitalmodel <config>.yml` run verified (all hand values reproduced, CSVs written).
- Ruff clean on all new files. Pre-existing environment failures (uv-managed CPython `SRE module mismatch`, docs encoding) unchanged vs origin/main.

### Remaining (next slices)

GHS golden fixtures (llm-wiki-acma#262 manifest), damage stability, T&S-booklet assembly via `report_pack`, geometry-based hydrostatics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
