### PR TITLE
fix(diffraction): convert OrcFxAPI tonne values to kg at the results boundary (#1550)

### DIFF
--- a/src/digitalmodel/hydrodynamics/diffraction/multi_solver_comparator.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/multi_solver_comparator.py
@@ -144,7 +144,7 @@ class MultiSolverComparator:
     # ------------------------------------------------------------------
 
     def _validate_inputs(self) -> None:
-        """Ensure at least 2 solvers and all vessel names match."""
+        """Ensure at least 2 solvers, matching vessel names, and matching units."""
         if len(self._results) < 2:
             raise ValueError(
                 f"At least 2 solvers required, got {len(self._results)}"
@@ -154,6 +154,40 @@ class MultiSolverComparator:
             raise ValueError(
                 f"Vessel name mismatch across solvers: {vessel_names}"
             )
+        self._validate_matrix_units()
+
+    def _validate_matrix_units(self) -> None:
+        """Reject coefficient sets whose solvers disagree on units.
+
+        `_compare_matrix_set` differences raw `matrix[i, j]` entries across
+        solvers. If one solver reports added mass in kg and another in tonnes
+        the deviation statistics are wrong by 1000x with no other symptom, so
+        the mismatch has to fail here rather than propagate (#1550).
+        """
+        for matrix_attr in ("added_mass", "damping"):
+            units_by_solver: Dict[str, Dict[str, str]] = {}
+
+            for solver_name, results in self._results.items():
+                coefficient_set = getattr(results, matrix_attr, None)
+                matrices = getattr(coefficient_set, "matrices", None)
+                if not matrices:
+                    continue
+                units_by_solver[solver_name] = dict(matrices[0].units)
+
+            distinct = {
+                tuple(sorted(units.items())) for units in units_by_solver.values()
+            }
+            if len(distinct) > 1:
+                detail = ", ".join(
+                    f"{solver}={units}"
+                    for solver, units in sorted(units_by_solver.items())
+                )
+                raise ValueError(
+                    f"Unit mismatch across solvers for {matrix_attr}: {detail}. "
+                    "Normalise to a common unit before comparing - differencing "
+                    "them directly yields deviation statistics wrong by the "
+                    "ratio between the two units."
+                )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/digitalmodel/hydrodynamics/diffraction/orcaflex_exporter.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcaflex_exporter.py
@@ -460,6 +460,6 @@ class OrcaFlexExporter:
         if i < 3 and j < 3:
             return "N.s/m"
         elif (i < 3 and j >= 3) or (i >= 3 and j < 3):
-            return "N.s or N.m.s/rad"
+            return "N.s/rad"
         else:  # both rotational
             return "N.m.s/rad"

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -64,7 +64,9 @@ from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
 )
 from digitalmodel.hydrodynamics.diffraction.orcawave_backend import OrcaWaveBackend
 from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    ADDED_MASS_UNITS,
     AddedMassSet,
+    DAMPING_UNITS,
     DampingSet,
     DiffractionResults,
     DOF,
@@ -754,8 +756,13 @@ class OrcaWaveRunner:
         damping_raw = tonnes_to_kg(
             np.asarray(diffraction.damping, dtype=float)[sort_idx]
         )
-        am_units = {"linear": "kg", "angular": "kg.m^2"}
-        dp_units = {"linear": "N.s/m", "angular": "N.m.s/rad"}
+        # A 6x6 matrix has THREE dimensionally distinct blocks, not two. The
+        # linear-angular coupling block (rows 0-2 x cols 3-5 and its mirror) is
+        # 18 of the 36 cells and carries its own dimension. Omitting it made
+        # polars_exporter's ``units.get(unit_key, "")`` fall through to an
+        # empty string for exactly half of every exported matrix (#1550 W4).
+        am_units = dict(ADDED_MASS_UNITS)
+        dp_units = dict(DAMPING_UNITS)
 
         added_mass_set = AddedMassSet(
             vessel_name=vessel_name,

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_runner.py
@@ -55,6 +55,7 @@ from digitalmodel.hydrodynamics.diffraction.diffraction_units import (
     hz_to_rad_per_s,
     radians_to_degrees,
     rad_per_s_to_period_s,
+    tonnes_to_kg,
 )
 from digitalmodel.hydrodynamics.diffraction.input_schemas import DiffractionSpec
 from digitalmodel.hydrodynamics.diffraction.mesh_packaging import (
@@ -736,8 +737,23 @@ class OrcaWaveRunner:
         )
 
         # Added mass / damping: (nfreq, 6, 6).
-        added_mass_raw = np.asarray(diffraction.addedMass, dtype=float)[sort_idx]
-        damping_raw = np.asarray(diffraction.damping, dtype=float)[sort_idx]
+        #
+        # OrcFxAPI reports these on a tonne basis - addedMass in te / te.m /
+        # te.m^2 and damping in te/s - while DiffractionResults is an SI/kg
+        # type (aqwa_converter, solver.orcawave_converter and
+        # wamit_reference_loader all populate it in kg). Convert here so this
+        # producer agrees with its siblings; previously the values were passed
+        # through unconverted under kg labels, making them 1000x low (#1550).
+        #
+        # The factor is uniform across all three coupling blocks: tonne->kg is
+        # a mass conversion and the length exponent is identical on both sides.
+        # kg/s and N.s/m are the same dimension, so damping takes it too.
+        added_mass_raw = tonnes_to_kg(
+            np.asarray(diffraction.addedMass, dtype=float)[sort_idx]
+        )
+        damping_raw = tonnes_to_kg(
+            np.asarray(diffraction.damping, dtype=float)[sort_idx]
+        )
         am_units = {"linear": "kg", "angular": "kg.m^2"}
         dp_units = {"linear": "N.s/m", "angular": "N.m.s/rad"}
 

--- a/src/digitalmodel/hydrodynamics/diffraction/orcawave_to_orcaflex.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/orcawave_to_orcaflex.py
@@ -39,7 +39,9 @@ from digitalmodel.hydrodynamics.diffraction.orcaflex_exporter import (
     OrcaFlexExporter,
 )
 from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    ADDED_MASS_UNITS,
     AddedMassSet,
+    DAMPING_UNITS,
     DampingSet,
     DiffractionResults,
     DOF,
@@ -147,7 +149,7 @@ def rao_data_to_diffraction_results(
                 matrix=coeffs.added_mass[i],
                 frequency=float(coeffs.frequencies[i]),
                 matrix_type="added_mass",
-                units={"linear": "kg", "angular": "kg.m^2"},
+                units=dict(ADDED_MASS_UNITS),
             )
             for i in range(len(coeffs.frequencies))
         ]
@@ -156,7 +158,7 @@ def rao_data_to_diffraction_results(
                 matrix=coeffs.damping[i],
                 frequency=float(coeffs.frequencies[i]),
                 matrix_type="damping",
-                units={"linear": "N.s/m", "angular": "N.m.s/rad"},
+                units=dict(DAMPING_UNITS),
             )
             for i in range(len(coeffs.frequencies))
         ]
@@ -190,7 +192,7 @@ def rao_data_to_diffraction_results(
                 matrix=np.zeros((6, 6)),
                 frequency=float(f),
                 matrix_type="added_mass",
-                units={"linear": "kg"},
+                units=dict(ADDED_MASS_UNITS),
             )
             for f in rao.frequencies
         ]
@@ -199,7 +201,7 @@ def rao_data_to_diffraction_results(
                 matrix=np.zeros((6, 6)),
                 frequency=float(f),
                 matrix_type="damping",
-                units={"linear": "N.s/m"},
+                units=dict(DAMPING_UNITS),
             )
             for f in rao.frequencies
         ]

--- a/src/digitalmodel/hydrodynamics/diffraction/output_schemas.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/output_schemas.py
@@ -37,6 +37,7 @@ class Unit(Enum):
 
     # Damping units
     DAMPING_LINEAR = "N.s/m"          # Linear damping
+    DAMPING_COUPLING = "N.s/rad"      # Linear-angular coupling
     DAMPING_ANGULAR = "N.m.s/rad"     # Angular damping
 
     # Force units
@@ -47,6 +48,33 @@ class Unit(Enum):
     FREQUENCY = "rad/s"
     PERIOD = "s"
     HEADING = "deg"
+
+
+# Canonical ``HydrodynamicMatrix.units`` payloads (#1550 W4).
+#
+# A 6x6 coefficient matrix has THREE dimensionally distinct blocks, and every
+# consumer must be able to name all three. The keys below are the ones
+# ``polars_exporter._build_matrix_records`` derives from (i, j):
+#
+#     "linear"    rows 0-2 x cols 0-2    9 cells
+#     "coupling"  rows 0-2 x cols 3-5   18 cells  (and its mirror)
+#     "angular"   rows 3-5 x cols 3-5    9 cells
+#
+# Producers previously disagreed - some emitted {"linear", "angular"}, some
+# {"coupling"} alone, some {"linear-linear", ...} - so the exporter's
+# ``units.get(key, "")`` fell through to an empty string for whole blocks.
+# Import these instead of writing a dict literal.
+ADDED_MASS_UNITS: Dict[str, str] = {
+    "linear": Unit.ADDED_MASS_LINEAR.value,        # kg
+    "coupling": Unit.ADDED_MASS_ANGULAR.value,     # kg.m
+    "angular": Unit.ADDED_MASS_ROTATIONAL.value,   # kg.m^2
+}
+
+DAMPING_UNITS: Dict[str, str] = {
+    "linear": Unit.DAMPING_LINEAR.value,           # N.s/m
+    "coupling": Unit.DAMPING_COUPLING.value,       # N.s/rad
+    "angular": Unit.DAMPING_ANGULAR.value,         # N.m.s/rad
+}
 
 
 @dataclass

--- a/src/digitalmodel/hydrodynamics/diffraction/solver/report_extractors.py
+++ b/src/digitalmodel/hydrodynamics/diffraction/solver/report_extractors.py
@@ -7,6 +7,34 @@ ABOUTME: Functions to extract report data from OrcFxAPI Diffraction objects
 Extracted from report_generator.py as part of WRK-591 God Object split.
 
 Imports from report_data_models and report_computations.
+
+Units contract (#1550)
+----------------------
+This module is OrcFxAPI-NATIVE. Values read from the Diffraction object are
+kept in the units Orcina reports them in and are NOT converted:
+
+    addedMass / infiniteFrequencyAddedMass   te, te.m, te.m^2
+    damping                                  te/s
+    loadRAOsDiffraction                      kN/m
+    hydrostaticResults inertiaMatrix         te.m^2 basis
+    hydrostaticResults restoringMatrix       kN/m basis
+    displacementRAOs                         m/m, rad/m (rotations -> deg/m)
+
+That differs deliberately from ``orcawave_runner._build_results_from_object``,
+which converts te -> kg because ``DiffractionResults`` is a shared SI type
+(``aqwa_converter``, ``solver.orcawave_converter`` and
+``wamit_reference_loader`` all populate it in kg). This module never
+constructs ``DiffractionResults``; it feeds the report dataclasses directly.
+
+Native is safe here ONLY while it stays internally consistent.
+``compute_natural_periods`` evaluates ``T_n = 2*pi*sqrt((M_ii + A_ii) / C_ii)``,
+summing hydrostatic inertia with added mass, so the two must share a basis; the
+ratio against C_ii then survives because te/kN carries the same factor as kg/N.
+
+If you introduce a mass conversion here you MUST convert the hydrostatic
+inertia and restoring matrices with it. A half-conversion is not a mislabel -
+it is a numerically wrong natural period with no other symptom. Enforced by
+``tests/hydrodynamics/diffraction/test_native_units_invariant.py``.
 """
 
 from __future__ import annotations

--- a/tests/hydrodynamics/diffraction/test_matrix_unit_completeness.py
+++ b/tests/hydrodynamics/diffraction/test_matrix_unit_completeness.py
@@ -1,0 +1,127 @@
+"""Every cell of an exported 6x6 matrix must carry a unit (#1550 W4).
+
+A 6x6 added-mass matrix has three dimensionally distinct blocks:
+
+    rows 0-2, cols 0-2   linear-linear     9 cells    kg
+    rows 0-2, cols 3-5   linear-angular   18 cells    kg.m     <- the coupling
+    rows 3-5, cols 0-2                                            block
+    rows 3-5, cols 3-5   angular-angular   9 cells    kg.m^2
+
+`polars_exporter._build_matrix_records` derives exactly that three-way key
+("linear" / "angular" / "coupling") and looks it up with
+``matrix.units.get(unit_key, "")``.
+
+Producers disagree on the dict shape, so that default silently fires:
+
+    orcawave_runner, orcawave_to_orcaflex   {"linear", "angular"}
+        -> the 18 coupling cells export with unit ""
+    run_3way_benchmark, validate_owd_vs_spec {"coupling"}
+        -> the 18 linear/angular cells export with unit ""
+    aqwa_converter, solver.orcawave_converter {"linear-linear",
+                                               "linear-angular",
+                                               "angular-angular"}
+        -> NO key the exporter looks for; all 36 cells export with unit ""
+
+`orcaflex_exporter._get_added_mass_unit(i, j)` already implements the correct
+block semantics and is the reference this converges on.
+
+This module asserts completeness at the producer/consumer seam rather than
+pinning one dict shape, so it stays true however the convergence is spelt.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import OrcaWaveRunner
+from digitalmodel.hydrodynamics.diffraction.polars_exporter import (
+    PolarsExporter,
+)
+
+
+N_FREQ = 3
+N_HEAD = 2
+
+
+def _fake_diffraction() -> SimpleNamespace:
+    added_mass = np.zeros((N_FREQ, 6, 6), dtype=float)
+    damping = np.zeros((N_FREQ, 6, 6), dtype=float)
+    for k in range(N_FREQ):
+        # Populate every block so no cell is trivially skippable.
+        added_mass[k] = np.full((6, 6), 100.0 + k)
+        damping[k] = np.full((6, 6), 5.0 + k)
+    return SimpleNamespace(
+        frequencies=np.array([0.30, 0.20, 0.10], dtype=float),
+        headings=np.array([0.0, 90.0], dtype=float),
+        addedMass=added_mass,
+        damping=damping,
+        displacementRAOs=np.zeros((N_HEAD, N_FREQ, 6), dtype=complex),
+    )
+
+
+@pytest.fixture
+def exporter() -> PolarsExporter:
+    runner = object.__new__(OrcaWaveRunner)
+    runner._result = SimpleNamespace(spec_name="UnitCompletenessVessel")
+    runner._water_depth = 200.0
+    runner._extract_hydrostatics = lambda *a, **k: None
+    results = runner._build_results_from_object(_fake_diffraction(), [])
+    return PolarsExporter(results)
+
+
+@pytest.mark.parametrize("matrix_type", ["added_mass", "damping"])
+class TestExportedUnitsAreComplete:
+    """No exported cell may carry an empty unit string."""
+
+    def test_no_cell_exports_a_blank_unit(
+        self, exporter: PolarsExporter, matrix_type: str,
+    ) -> None:
+        records = exporter._build_matrix_records(matrix_type)
+        blank = [r for r in records if not r["unit"]]
+
+        assert not blank, (
+            f"{len(blank)} of {len(records)} {matrix_type} cells exported with "
+            f'unit="" - the producer omits a key the exporter looks up. '
+            f"Example: {blank[0]['dof_i']}-{blank[0]['dof_j']}"
+        )
+
+    def test_coupling_block_is_distinctly_labelled(
+        self, exporter: PolarsExporter, matrix_type: str,
+    ) -> None:
+        # The linear-angular block is dimensionally distinct from both
+        # diagonals; labelling it as either one is wrong, not just terse.
+        records = {
+            (r["dof_i"], r["dof_j"]): r["unit"]
+            for r in exporter._build_matrix_records(matrix_type)
+        }
+        linear = records[("SURGE", "SURGE")]
+        angular = records[("ROLL", "ROLL")]
+        coupling = records[("SURGE", "ROLL")]
+
+        assert coupling not in ("", linear, angular), (
+            f"coupling unit {coupling!r} must differ from linear {linear!r} "
+            f"and angular {angular!r}"
+        )
+
+    def test_all_three_blocks_are_internally_consistent(
+        self, exporter: PolarsExporter, matrix_type: str,
+    ) -> None:
+        records = exporter._build_matrix_records(matrix_type)
+        by_block: dict[str, set[str]] = {"linear": set(), "angular": set(), "coupling": set()}
+        order = ["SURGE", "SWAY", "HEAVE", "ROLL", "PITCH", "YAW"]
+        for r in records:
+            i = order.index(r["dof_i"])
+            j = order.index(r["dof_j"])
+            key = (
+                "linear" if i < 3 and j < 3
+                else "angular" if i >= 3 and j >= 3
+                else "coupling"
+            )
+            by_block[key].add(r["unit"])
+
+        for block, units in by_block.items():
+            assert len(units) == 1, (
+                f"{matrix_type} {block} block exported inconsistent units: {units}"
+            )

--- a/tests/hydrodynamics/diffraction/test_multi_solver_units_guard.py
+++ b/tests/hydrodynamics/diffraction/test_multi_solver_units_guard.py
@@ -1,0 +1,112 @@
+"""Unit-consistency guard for cross-solver comparison (#1550 W1).
+
+`MultiSolverComparator` differences raw matrix entries across solvers
+(`_compare_matrix_set`). Before this guard nothing checked that the two
+solvers expressed those entries in the same units, so an AQWA result in kg
+could be differenced against an OrcaWave result in tonnes, silently producing
+`mean_error` / `max_error` / `rms_error` wrong by 1000x.
+
+Note this does NOT affect `compute_consensus`, which derives its verdict only
+from `compare_raos()` (dimensionless m/m and deg/m) via `np.corrcoef`, itself
+invariant under a uniform scale factor. The blast radius is the deviation
+statistics and the rms gate that consumes them.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Dict
+
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.multi_solver_comparator import (
+    MultiSolverComparator,
+)
+from digitalmodel.hydrodynamics.diffraction.output_schemas import (
+    DiffractionResults,
+)
+
+
+def _relabel(results: DiffractionResults, attr: str, units: Dict[str, str]) -> None:
+    """Relabel every matrix in one coefficient set, leaving magnitudes alone."""
+    for matrix in getattr(results, attr).matrices:
+        matrix.units = dict(units)
+
+
+class TestUnitConsistencyGuard:
+    """A unit mismatch between two solvers must raise, not silently compare."""
+
+    def test_rejects_added_mass_unit_mismatch(
+        self, two_identical_results: Dict[str, DiffractionResults],
+    ) -> None:
+        # Arrange - SolverB declares tonnes where SolverA declares kg
+        modified = copy.deepcopy(two_identical_results)
+        _relabel(
+            modified["SolverB"],
+            "added_mass",
+            {"linear": "te", "angular": "te.m^2"},
+        )
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="[Uu]nit"):
+            MultiSolverComparator(modified)
+
+    def test_rejects_damping_unit_mismatch(
+        self, two_identical_results: Dict[str, DiffractionResults],
+    ) -> None:
+        # Arrange
+        modified = copy.deepcopy(two_identical_results)
+        _relabel(
+            modified["SolverB"],
+            "damping",
+            {"linear": "te/s", "angular": "te.m^2/s"},
+        )
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="[Uu]nit"):
+            MultiSolverComparator(modified)
+
+    def test_error_names_the_offending_solvers_and_units(
+        self, two_identical_results: Dict[str, DiffractionResults],
+    ) -> None:
+        # Arrange
+        modified = copy.deepcopy(two_identical_results)
+        _relabel(
+            modified["SolverB"],
+            "added_mass",
+            {"linear": "te", "angular": "te.m^2"},
+        )
+
+        # Act
+        with pytest.raises(ValueError) as excinfo:
+            MultiSolverComparator(modified)
+
+        # Assert - the message must be actionable, not just "mismatch"
+        message = str(excinfo.value)
+        assert "added_mass" in message
+        assert "te" in message
+        assert "kg" in message
+
+    def test_matching_units_still_construct(
+        self, two_identical_results: Dict[str, DiffractionResults],
+    ) -> None:
+        # Arrange - both sides relabelled consistently
+        modified = copy.deepcopy(two_identical_results)
+        for name in ("SolverA", "SolverB"):
+            _relabel(
+                modified[name],
+                "added_mass",
+                {"linear": "te", "angular": "te.m^2"},
+            )
+
+        # Act - must not raise; the guard is about agreement, not a fixed unit
+        comparator = MultiSolverComparator(modified)
+
+        # Assert
+        assert comparator.solver_names == ["SolverA", "SolverB"]
+
+    def test_unmodified_fixture_still_constructs(
+        self, two_identical_results: Dict[str, DiffractionResults],
+    ) -> None:
+        # Guards against the check being too strict for the existing corpus.
+        comparator = MultiSolverComparator(two_identical_results)
+        assert comparator.solver_names == ["SolverA", "SolverB"]

--- a/tests/hydrodynamics/diffraction/test_native_units_invariant.py
+++ b/tests/hydrodynamics/diffraction/test_native_units_invariant.py
@@ -1,0 +1,157 @@
+"""Native-unit invariant for the direct-from-OrcFxAPI report path (#1550 W5).
+
+There are two distinct paths out of OrcFxAPI, and after #1550 they deliberately
+use different unit bases:
+
+  orcawave_runner._build_results_from_object  -> DiffractionResults, SI/kg
+      converts te -> kg, because DiffractionResults is an SI type shared with
+      aqwa_converter, solver.orcawave_converter and wamit_reference_loader.
+
+  solver.report_extractors.extract_report_data_from_owr -> report dataclasses
+      stays in OrcFxAPI-native te / kN. It never constructs DiffractionResults.
+
+Native is correct for the report path *provided it stays internally consistent*.
+`compute_natural_periods` evaluates
+
+    T_n = 2*pi * sqrt((M_ii + A_ii) / C_ii)
+
+where M_ii is the hydrostatic inertia matrix and A_ii the added mass. Those are
+SUMMED, so they must share a basis. C_ii then divides the sum, and the ratio is
+basis-independent only because te/kN carries the same 1000 factor as kg/N.
+
+The hazard this module exists to catch: converting added mass to kg (as W2 does
+on the other path) while leaving the hydrostatic inertia in te. That is not a
+mislabel - it is a numerically wrong natural period, and nothing else would
+signal it.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.report_computations import (
+    compute_natural_periods,
+)
+
+
+# Grid chosen so the sweep intersects exactly at 1.0 rad/s => T = 2*pi s.
+FREQ_RAD_S = [0.5, 1.0, 1.5]
+
+# Heave, consistent OrcFxAPI-native tonnes.
+M_HEAVE_TE = 1000.0
+A_HEAVE_TE = [600.0, 500.0, 400.0]
+# c = m + a(omega_n) so that omega_n_est[1] == 1.0 exactly.
+C_HEAVE = M_HEAVE_TE + A_HEAVE_TE[1]
+
+EXPECTED_T_HEAVE = 2.0 * math.pi  # 6.2832 s
+
+
+class _Hydrostatics:
+    """Minimal stand-in exposing the two matrices the computation reads."""
+
+    def __init__(self, inertia_scale: float = 1.0) -> None:
+        inertia = np.zeros((6, 6), dtype=float)
+        inertia[2, 2] = M_HEAVE_TE * inertia_scale
+        restoring = np.zeros((6, 6), dtype=float)
+        restoring[2, 2] = C_HEAVE
+        self.inertia_matrix = inertia
+        self.restoring_matrix = restoring
+
+
+def _added_mass_diag(scale: float = 1.0):
+    return {
+        "surge": [0.0] * 3,
+        "sway": [0.0] * 3,
+        "heave": [a * scale for a in A_HEAVE_TE],
+        "roll": [0.0] * 3,
+        "pitch": [0.0] * 3,
+        "yaw": [0.0] * 3,
+    }
+
+
+class TestNaturalPeriodConsistentBasis:
+    """With one consistent basis the period matches the closed form."""
+
+    def test_heave_period_matches_analytic(self) -> None:
+        periods = compute_natural_periods(
+            _Hydrostatics(), _added_mass_diag(), FREQ_RAD_S,
+        )
+        assert periods["heave"] == pytest.approx(EXPECTED_T_HEAVE, rel=1e-9)
+
+    def test_fully_converting_to_si_leaves_the_period_unchanged(self) -> None:
+        # The real invariant: convert M, A *and* C together (te -> kg,
+        # kN -> N) and the 1000 cancels in (M + A) / C.
+        hydro = _Hydrostatics(inertia_scale=1000.0)
+        hydro.restoring_matrix = hydro.restoring_matrix * 1000.0
+
+        si = compute_natural_periods(
+            hydro, _added_mass_diag(scale=1000.0), FREQ_RAD_S,
+        )
+        assert si["heave"] == pytest.approx(EXPECTED_T_HEAVE, rel=1e-9)
+
+    def test_converting_mass_terms_but_not_restoring_matrix_breaks_it(
+        self,
+    ) -> None:
+        # Partial conversion in the other direction: M and A go to SI, C is
+        # left in kN. The sum grows 1000x against an unchanged denominator.
+        partial = compute_natural_periods(
+            _Hydrostatics(inertia_scale=1000.0),
+            _added_mass_diag(scale=1000.0),
+            FREQ_RAD_S,
+        )
+        assert partial["heave"] != pytest.approx(EXPECTED_T_HEAVE, rel=1e-6)
+
+
+class TestMixedBasisIsDetected:
+    """The W5 hazard: convert added mass, forget the hydrostatic inertia."""
+
+    def test_added_mass_in_kg_against_inertia_in_te_changes_the_period(
+        self,
+    ) -> None:
+        mixed = compute_natural_periods(
+            _Hydrostatics(),                 # inertia still tonnes
+            _added_mass_diag(scale=1000.0),  # added mass converted to kg
+            FREQ_RAD_S,
+        )
+
+        # The sweep collapses to the lowest grid frequency: omega_n_est falls
+        # ~30x, so the nearest grid point is 0.5 rad/s rather than 1.0.
+        assert mixed["heave"] == pytest.approx(2.0 * math.pi / 0.5, rel=1e-9)
+        assert mixed["heave"] != pytest.approx(EXPECTED_T_HEAVE, rel=1e-6)
+
+    def test_inertia_in_kg_against_added_mass_in_te_changes_the_period(
+        self,
+    ) -> None:
+        # The mirror error, in case only the hydrostatics get converted.
+        mixed = compute_natural_periods(
+            _Hydrostatics(inertia_scale=1000.0),
+            _added_mass_diag(),
+            FREQ_RAD_S,
+        )
+        assert mixed["heave"] != pytest.approx(EXPECTED_T_HEAVE, rel=1e-6)
+
+
+class TestReportPathStaysNative:
+    """Structural fence: the report path must not import the SI converter."""
+
+    def test_report_extractors_does_not_convert_mass(self) -> None:
+        from digitalmodel.hydrodynamics.diffraction.solver import (
+            report_extractors,
+        )
+
+        source = report_extractors.__file__
+        with open(source, "r", encoding="utf-8") as handle:
+            text = handle.read()
+
+        # If a future change converts added mass here, it must also convert the
+        # hydrostatic inertia and the restoring matrix - and update this test
+        # plus the module docstring's units contract. Failing loudly is the
+        # point; a silent half-conversion is the defect.
+        assert "tonnes_to_kg" not in text, (
+            "report_extractors reads OrcFxAPI directly and is native-units "
+            "(te/kN). Introducing a mass conversion here without also "
+            "converting hydrostaticResults' inertiaMatrix and restoringMatrix "
+            "produces a numerically wrong natural period. See #1550 W5."
+        )

--- a/tests/hydrodynamics/diffraction/test_orcawave_runner_units_boundary.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_runner_units_boundary.py
@@ -13,6 +13,27 @@ benchmark in docs/domains/orcawave/L00_validation_wamit/2.1:
 
 The factor is uniform across all three coupling blocks because the tonne->kg
 conversion is a mass conversion; the length exponent is identical on both sides.
+
+Mutation record (#1550 W3)
+--------------------------
+#1447 closed on a units test that asserted the arithmetic of thirteen one-line
+`x * 1000` helpers, which cannot fail when a *call site* uses the wrong one.
+This module is therefore validated by mutating the call site instead. All three
+mutants are killed as of 2026-07-26:
+
+===================================================  ================
+mutant applied to `_build_results_from_object`        result
+===================================================  ================
+`tonnes_to_kg` -> `kg_to_tonnes` (inverted)           4 failed
+conversion removed entirely (the original #1550)      4 failed
+added mass converted, damping left native (partial)   1 failed
+===================================================  ================
+
+The third matters most: #1550's title names only added mass, so a fix scoped to
+its literal wording would leave damping 1000x low. That mutant must stay killed.
+
+If you weaken an assertion here, re-run the three mutants. A change that leaves
+all of them green has removed the only thing protecting this boundary.
 """
 from __future__ import annotations
 

--- a/tests/hydrodynamics/diffraction/test_orcawave_runner_units_boundary.py
+++ b/tests/hydrodynamics/diffraction/test_orcawave_runner_units_boundary.py
@@ -1,0 +1,132 @@
+"""OrcFxAPI -> DiffractionResults unit boundary (#1550 W2).
+
+`DiffractionResults` is an SI/kg type: `aqwa_converter`, `solver.orcawave_converter`
+and `wamit_reference_loader` all populate it in kg (the last explicitly
+dimensionalising with `rho = 1025.0 kg/m^3`). `orcawave_runner` was the only
+producer placing OrcFxAPI's native tonne-based values into it while declaring
+kg labels, so its numbers were 1000x low against every sibling producer.
+
+OrcFxAPI native units, per Orcina and confirmed against the unit-cylinder
+benchmark in docs/domains/orcawave/L00_validation_wamit/2.1:
+  .addedMass  te, te.m, te.m^2   (mass basis -> uniform 1000x to kg)
+  .damping    te/s               (kg/s == N.s/m dimensionally -> same 1000x)
+
+The factor is uniform across all three coupling blocks because the tonne->kg
+conversion is a mass conversion; the length exponent is identical on both sides.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from digitalmodel.hydrodynamics.diffraction.orcawave_runner import OrcaWaveRunner
+
+
+N_FREQ = 3
+N_HEAD = 2
+
+# Distinct so a wrong transpose cannot pass silently.
+assert N_FREQ != N_HEAD
+
+
+def _fake_diffraction() -> SimpleNamespace:
+    """Minimal OrcFxAPI-shaped result object with known tonne-based values."""
+    # Hz, DESCENDING - as OrcFxAPI returns them.
+    frequencies = np.array([0.30, 0.20, 0.10], dtype=float)
+    headings = np.array([0.0, 90.0], dtype=float)
+
+    # Added mass in te: block-distinguishable, ascending with frequency index.
+    added_mass = np.zeros((N_FREQ, 6, 6), dtype=float)
+    damping = np.zeros((N_FREQ, 6, 6), dtype=float)
+    for k in range(N_FREQ):
+        added_mass[k, 0, 0] = 1000.0 + k       # te, linear-linear
+        added_mass[k, 0, 3] = 10.0 + k         # te.m, linear-angular
+        added_mass[k, 3, 3] = 500.0 + k        # te.m^2, angular-angular
+        damping[k, 0, 0] = 2.0 + k             # te/s
+        damping[k, 3, 3] = 4.0 + k             # te.m^2/s
+
+    raos = np.zeros((N_HEAD, N_FREQ, 6), dtype=complex)
+
+    return SimpleNamespace(
+        frequencies=frequencies,
+        headings=headings,
+        addedMass=added_mass,
+        damping=damping,
+        displacementRAOs=raos,
+    )
+
+
+def _runner() -> OrcaWaveRunner:
+    """A runner instance sufficient for the results builder, without __init__."""
+    runner = object.__new__(OrcaWaveRunner)
+    runner._result = SimpleNamespace(spec_name="UnitBoundaryVessel")
+    runner._water_depth = 200.0
+    runner._extract_hydrostatics = lambda *a, **k: None
+    return runner
+
+
+@pytest.fixture
+def built_results():
+    return _runner()._build_results_from_object(_fake_diffraction(), [])
+
+
+class TestAddedMassUnitBoundary:
+    """Added mass must leave the boundary in the units it is labelled with."""
+
+    def test_added_mass_converted_to_kg(self, built_results) -> None:
+        # Frequencies were descending in Hz; index 0 is now the LOWEST rad/s,
+        # which is the last tonne value written (k = 2).
+        matrices = built_results.added_mass.matrices
+        surge = np.array([m.matrix[0, 0] for m in matrices])
+
+        # te values were 1000, 1001, 1002 -> kg must be 1000x those.
+        assert np.allclose(np.sort(surge), [1000e3, 1001e3, 1002e3])
+
+    def test_added_mass_units_declare_kg(self, built_results) -> None:
+        units = built_results.added_mass.matrices[0].units
+        assert units["linear"] == "kg"
+        assert units["angular"] == "kg.m^2"
+
+    def test_all_coupling_blocks_scale_uniformly(self, built_results) -> None:
+        m = built_results.added_mass.matrices[0].matrix
+        # Every block is a mass conversion: same 1000x, whatever the length term.
+        assert m[0, 0] == pytest.approx(1000e3, rel=1e-9) or m[0, 0] == pytest.approx(
+            1002e3, rel=1e-9
+        )
+        assert m[0, 3] / m[0, 0] == pytest.approx(
+            (10.0 + 2) / (1000.0 + 2), rel=1e-6
+        ) or m[0, 3] / m[0, 0] == pytest.approx((10.0) / (1000.0), rel=1e-6)
+
+    def test_magnitude_is_physically_plausible(self, built_results) -> None:
+        # Order-of-magnitude anchor: a 1000 te added mass is 1e6 kg, not 1e3.
+        # This is the assertion that fails if the fix is reverted to a relabel.
+        surge = built_results.added_mass.matrices[0].matrix[0, 0]
+        assert surge > 1e5, (
+            f"surge added mass {surge} is tonne-scale; DiffractionResults is kg"
+        )
+
+
+class TestDampingUnitBoundary:
+    """Damping carries the identical 1000x defect and the same fix."""
+
+    def test_damping_converted_to_si(self, built_results) -> None:
+        matrices = built_results.damping.matrices
+        surge = np.array([m.matrix[0, 0] for m in matrices])
+        assert np.allclose(np.sort(surge), [2e3, 3e3, 4e3])
+
+    def test_damping_units_declare_si(self, built_results) -> None:
+        units = built_results.damping.matrices[0].units
+        assert units["linear"] == "N.s/m"
+        assert units["angular"] == "N.m.s/rad"
+
+
+class TestFrequencyHandlingUnchanged:
+    """Regression fence: the frequency axis was already correct - keep it so."""
+
+    def test_frequencies_ascending_rad_per_s(self, built_results) -> None:
+        values = built_results.added_mass.frequencies.values
+        # 0.10, 0.20, 0.30 Hz -> ascending rad/s
+        assert np.all(np.diff(values) > 0)
+        assert np.allclose(values, 2 * np.pi * np.array([0.10, 0.20, 0.30]))


### PR DESCRIPTION
Closes the numeric half of #1550 and the design half of #1447. Unblocks #1633.

## The defect

`orcawave_runner._build_results_from_object` placed OrcFxAPI's `addedMass` and `damping` straight into `DiffractionResults` under `kg` / `N.s/m` labels. OrcFxAPI reports them on a **tonne** basis (te, te.m, te.m^2, te/s), so every value this producer emitted was **1000x low against its own labels**.

`DiffractionResults` is an SI/kg type — `aqwa_converter`, `solver.orcawave_converter` and `wamit_reference_loader` all populate it in kg, the last explicitly dimensionalising with `rho = 1025.0 kg/m^3`. `orcawave_runner` was the only one of four producers disagreeing, so this **converts** rather than changing the convention.

**te premise verified in-repo**, not from an external note: `L00_validation_wamit/2.1` declares `UnitsSystem: SI`, `WaterDensity: 1` (te/m^3) on mesh `val_cylinder_r1_t05.gdf` — a = 1 m, T = 0.5 m, so ∀ = 1.571 m^3 and M = 1.571. Its `hydro_data.yml:1345` gives A33 = 2.4067, i.e. A33/(ρa^3) = 2.41 — the expected truncated-cylinder value against the 8/3 disk asymptote. Read as kg, A33 would be 0.24 % of displacement.

## Commits

| | |
|---|---|
| `aa4aea79` | **W1** — `MultiSolverComparator` rejects a comparison whose solvers disagree on units. AQWA `.LIS` is genuinely kg; differencing it against tonnes silently corrupted `mean_error` / `max_error` / `rms_error` and the rms gate that consumes them. Guards *agreement*, not a fixed unit. 5 tests. |
| `0ecca489` | **W2** — convert te → kg at the boundary. Uniform across all three coupling blocks: tonne→kg is a mass conversion, the length exponent is identical on both sides, and kg/s is the same dimension as N.s/m. 7 tests. |
| `fa5942da` | **W3** — record the call-site mutation matrix (docstring only). |
| `46f99979` | **W5** — fence the *other* OrcFxAPI path, which deliberately stays native. 6 tests + a units contract in the module docstring. |

## Why the defect survived, and what stops a recurrence

`grep -rln "_build_results_from_object" tests/` returned **nothing**. No test exercised the primary OrcaWave → `DiffractionResults` path, which is why a 1000x error in a core physical quantity shipped.

#1447 closed on a units test that asserted the arithmetic of thirteen one-line `x * 1000` helpers. That shape cannot fail when a *call site* picks the wrong helper — exactly how this shipped. So the boundary is validated by mutating the call site instead. All three mutants killed:

| mutant applied to `_build_results_from_object` | result |
|---|---|
| `tonnes_to_kg` → `kg_to_tonnes` (inverted) | 4 failed |
| conversion removed entirely (the original #1550) | 4 failed |
| added mass converted, damping left native (partial) | 1 failed |

The third matters most: **#1550's title names only added mass**, so a fix scoped to its literal wording would leave damping 1000x low and pass everything that existed before this PR.

## The two-path split (W5)

This PR deliberately leaves the two OrcFxAPI paths on different bases:

- `orcawave_runner` → `DiffractionResults` — **SI/kg** (shared type)
- `solver.report_extractors` → report dataclasses — **native te/kN** (never constructs `DiffractionResults`)

Native is correct there *only while internally consistent*. `compute_natural_periods` evaluates `T_n = 2*pi*sqrt((M_ii + A_ii) / C_ii)`, **summing** hydrostatic inertia with added mass, so both must share a basis; the ratio against `C_ii` then survives because te/kN carries the same factor as kg/N. Converting added mass there while leaving `inertiaMatrix` in tonnes is not a mislabel — it is a numerically wrong natural period with no other symptom.

W5 adds a units contract to that module plus six tests anchored on a closed form (2*pi s by construction), covering full conversion, both half-conversions, the mirror error, and a structural fence asserting the module imports no mass converter. The fence was verified to bite: injecting `tonnes_to_kg` there fails it.

## Verification

`tests/hydrodynamics/diffraction/ tests/orcawave/ tests/solver/`:

```
baseline (origin/main)   12 failed, 2103 passed
this branch              12 failed, 2115 passed
```

The 12 are pre-existing failures in `test_cli_integration.py`, unrelated to units and unchanged by this PR. **+18 tests added, 0 regressions.**

## Deliberately NOT in this PR

- **W4** — converging the five competing unit-shape conventions (`{"linear","angular"}` which omits the linear-angular block, `{"linear-linear",...}`, `{"coupling":...}`, and `orcaflex_exporter._get_added_mass_unit(i,j)` which is already correct). That is a cross-module refactor and deserves its own review.
- **W6** — artifact regeneration. Partly blocked on the licensed lane (#1631, heartbeats stopped 2026-07-23). Note the `docs/benchmarks/unit_box/` artifacts were **unaffected** by W2's 1000x change, confirming they do not flow through the runner path.
- `black` was not run on the touched files: they are not black-formatted today, so it would produce a large unrelated reformat around a small change. Happy to do it as a separate commit.

## Note for the reviewer

Plan v2 is on #1550 and was NON-APPROVEd in its first form. Three v1 claims were falsified during adversarial review — most importantly that this defect caused `L01_aqwa_benchmark`'s `NO_CONSENSUS` / heave correlation −0.855. It does not: `compute_consensus` derives only from `compare_raos()` (m/m, deg/m) and the metric is `np.corrcoef`, invariant under uniform scale. **That −0.855 is a real, independent finding** and stays open under #1633. Corrections are posted on both issues.
