### PR TITLE
feat(dynacard): Everitt-Jennings downhole card solver + API RP 11L rod-pump module

### DIFF
--- a/docs/collide_pe/dynacard-undulations/DATA-REQUEST.md
+++ b/docs/collide_pe/dynacard-undulations/DATA-REQUEST.md
@@ -1,0 +1,183 @@
+# Data request — Collide "Dynamometer Discussions" well
+
+What we would need to take this from *"why the undulations?"* (answered) to a
+full pump diagnosis. Ordered by how much each item actually changes the answer,
+not by how easy it is to ask for.
+
+Everything already posted in the thread is listed at the bottom under
+[Already have](#already-have) — no need to resend those.
+
+---
+
+## Already answered without any new data
+
+These follow from stroke, depth, speed and the card alone, and none of them
+move if the items below change:
+
+| Result | Value |
+|---|---|
+| Rod-string natural frequency `No` | 58.3 SPM |
+| Load-peak interval `dt = 60/No'` | 1.03 s |
+| `N/No'` | 0.110 |
+| Predicted undulations per half-stroke | 4.56 (4 clear humps observed) |
+| String spring rate `Kr` | 271.7 lb/in |
+| `Skr` | 11,141 lb |
+| Rod weight in air `Wr` | 6,863 lb |
+| PPRL / MPRL | 12,438 / 9,274 lb |
+| Card area | 5,829 ft-lb/stroke |
+| Polished-rod power | 1.13 hp |
+
+**The undulations are normal.** At `N/No' = 0.11` a 4,200 ft string will always
+ring roughly four times per half-stroke; the absence of undulations is what
+would be surprising.
+
+---
+
+## Tier 1 — blocking. Without these, no diagnosis is defensible.
+
+### 1. Rod string, as actually run
+
+Confirm the string is 4,200 ft of 3/4 in and **nothing else** — specifically
+whether there are sinker bars, weight bars, or a section of larger rod at the
+top.
+
+*Why it's first:* the measured minimum polished-rod load (9,274 lb) is
+**2,412 lb heavier than the entire rod string weighs in air** (6,863 lb). That
+is not possible mechanically. Friction acts upward on the downstroke, so it
+lowers polished-rod load and widens a card — it cannot lift the whole card.
+Only two explanations survive:
+
+1. The load cell has a zero or scale offset.
+2. The string is heavier than recorded.
+
+Until this is settled, every absolute load number from this card is suspect.
+Load *differences* (and therefore the undulation analysis) remain sound.
+
+### 2. Load-cell make, model, and last calibration date
+
+Directly tests explanation (1) above. If the cell reads a fixed offset, the
+whole card shifts and the fix is arithmetic.
+
+### 3. Runtime — hours per day the unit actually pumped
+
+Was the unit running 24 h, or cycling on a pump-off controller / timer?
+
+*Why it matters more than it looks:* a unit on a 50% duty cycle produces half
+the fluid with a perfectly healthy pump. That is indistinguishable from 50%
+fillage if you only look at daily volume. Any efficiency number we quote
+without runtime is not a measurement, it's an assumption — so we report it as
+undetermined rather than guess.
+
+---
+
+## Tier 2 — unlocks the calculated downhole card
+
+This is the piece both commenters in the thread asked for, and the only way to
+separate pump-off from gas interference from a worn pump.
+
+### 4. Tubing ID and anchor status
+
+Tubing size (2-3/8 in, 2-7/8 in …) and whether the tubing is **anchored**.
+Unanchored tubing breathes with the rod string and changes both the card shape
+and the effective plunger stroke.
+
+### 5. Fluid level above the pump
+
+From an acoustic shot if one exists. We currently assume the pump is submerged
+to its setting depth, which is the pessimistic bound.
+
+### 6. Oil gravity (°API) and formation volume factor `Bo`
+
+Needed to convert surface barrels to reservoir barrels before any efficiency
+claim.
+
+### 7. Produced-fluid viscosity, or bottomhole temperature
+
+Sets rod-string damping, which controls how much of the ringing survives down
+to the pump.
+
+> **Note on precision:** items 5 and 6 matter less than they appear. Sweeping
+> specific gravity 0.80–0.90 and fluid level 3,000–4,300 ft moves theoretical
+> displacement only from **38.3 to 41.7 bfpd** — about ±4%. Reasonable
+> estimates are fine; we do not need exact numbers. Runtime (item 3) swings the
+> answer far harder than either.
+
+---
+
+## Tier 3 — unlocks the gearbox / torque / power checks
+
+### 8. Pumping unit API designation
+
+The full nameplate, e.g. `C-228D-200-74`. The `C-66` mentioned in the thread is
+an **Arrow Engine natural-gas engine** — the prime mover — not a pumping-unit
+or gearbox rating, so it doesn't give us a torque limit.
+
+### 9. Unit geometry dimensions and counterbalance
+
+The API 11E dimension sheet for that unit (`A`, `C`, `I`, `K`, `P`, crank
+radius, phase angle), plus counterbalance moment and structural imbalance.
+Without these the torque calculation cannot run at all.
+
+### 10. Motor nameplate
+
+Horsepower, voltage, NEMA class — for the electrical/power side.
+
+---
+
+## Tier 4 — better data beats more data
+
+### 11. The raw card file, not a screenshot
+
+A `.dyn` export or a timestamped CSV of load and position, straight from the
+controller.
+
+*Why this is worth more than several items above:* time read off a
+position-axis card is inherently uncertain, because polished-rod velocity goes
+to zero at both stroke ends. The same ±1.5 in digitizing error costs:
+
+| Peak position | Rod velocity | Time uncertainty |
+|---:|---:|---:|
+| 7.5 in | 10.62 in/s | ±0.14 s |
+| 23.5 in | 13.59 in/s | ±0.11 s |
+| 35.0 in | 9.71 in/s | ±0.15 s |
+
+With uncertainties that size, the apparent peak-to-peak spacings of 1.24 s and
+0.95 s are **not distinguishable from each other**, and both are consistent
+with the predicted 1.03 s. A raw time-series file removes this entirely.
+
+### 12. A downhole card from the controller, if it can produce one
+
+Lets us check our calculated card against the controller's, which is the
+fastest possible validation of both.
+
+### 13. Several consecutive strokes, and a card from a different day
+
+The posted card shows overlaid strokes ("Display all"). Stroke-to-stroke
+variability distinguishes a steady condition from an intermittent one, and a
+second date shows whether anything is trending.
+
+---
+
+## Already have
+
+From the thread, no need to resend:
+
+- Surface stroke 41 in · pump setting depth 4,300 ft · 6.4 SPM
+- 1-1/4 in top-hold-down insert pump
+- Tubing pressure building to 150 psi (Baird valve setpoint) · casing 25 psi
+- Production 23 bbl oil, 0 water, previous day
+- The surface card itself (digitized to ±40 lb / ±0.3 in)
+
+---
+
+## What we'd return
+
+With Tier 1 alone: a defensible statement on whether the card is
+self-consistent, and an honest production check.
+
+With Tier 1 + 2: the calculated downhole pump card, pump fillage, and a
+diagnosis separating pump-off, gas interference and mechanical wear — the
+question the thread actually ended on.
+
+With Tier 3: gearbox torque loading against the unit's rating, counterbalance
+condition, and power consumption.

--- a/docs/domains/artificial_lift/rod-pump-rp11l.md
+++ b/docs/domains/artificial_lift/rod-pump-rp11l.md
@@ -1,0 +1,166 @@
+# Rod-pump surface-card analysis (API RP 11L)
+
+`digitalmodel.marine_ops.artificial_lift.dynacard.rod_pump`
+
+Kinematics and rod-string mechanics for a rod-pumped well: natural frequency,
+card undulations, crank motion, plunger stroke, pump displacement, and the
+dimensionless groups the API RP 11L correlations run on.
+
+This sits **upstream** of the surface-to-downhole card transform. For that, use
+the sibling [`everitt_jennings`](../../../src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/)
+package, which implements the SPE 18189 space-marching finite-difference
+solver.
+
+## Quick start
+
+```python
+from digitalmodel.marine_ops.artificial_lift.dynacard.rod_pump import analyse
+
+result = analyse(
+    rod_diameter_in=0.75,
+    rod_length_ft=4200.0,
+    surface_stroke_in=41.0,
+    strokes_per_minute=6.4,
+    plunger_diameter_in=1.25,
+    fluid_level_ft=4300.0,
+    specific_gravity=0.85,
+    tubing_pressure_psi=150.0,
+    casing_pressure_psi=25.0,
+)
+
+result.natural_frequency_spm          # 58.33  (No = 245,000 / L)
+result.peak_interval_s                # 1.03   (dt = 60 / No')
+result.undulations_per_half_stroke    # 4.56
+result.plunger_stroke_in              # 33.29
+result.pump_displacement_bpd          # 38.80
+result.volumetric_efficiency          # None -- runtime and Bo unknown
+```
+
+## Three things this module is opinionated about
+
+### 1. Pump displacement uses **plunger** stroke, not surface stroke
+
+Rod stretch under fluid load shortens the plunger's travel. On a 4,200 ft
+3/4 in string carrying 2,096 lb of fluid load, the stretch is 7.7 in — so a
+41 in surface stroke drives only a 33.3 in plunger stroke.
+
+Using the surface stroke gives PD = 47.8 bfpd; using the plunger stroke gives
+38.8 bfpd. Against 23 bbl/day measured, that is the difference between a
+reported 48% and 59% efficiency — before runtime is even considered.
+
+### 2. Efficiency is `None` until runtime and `Bo` are known
+
+A unit cycling on a pump-off controller has a duty cycle that looks exactly
+like low fillage, and surface barrels are not reservoir barrels. Rather than
+assume 24 h and `Bo = 1.0`, `volumetric_efficiency` returns `None` and the
+analysis lists what it needs under `result.undetermined`.
+
+### 3. It fails closed outside the RP 11L envelope
+
+| `N/No'` | Behaviour |
+|---|---|
+| < 0.15 | Wave-dominated card, many undulations. Valid, flagged as expected. |
+| 0.15 – 0.35 | Typical RP 11L design range. Valid. |
+| > 0.35 | Resonance. **Raises `ValidityError`** — use a wave-equation solver. |
+
+Also refused: tapered strings without an explicit `Fc`; Mark II, RotaFlex and
+hydraulic long-stroke geometries passed to the Class I correlations; non-steel
+sonic velocity used with the steel-derived 245,000 constant (caught by the
+cross-check that `245,000/L` and `15c/L` agree within 0.5%).
+
+## Peak spacing is not peak phase
+
+The interval between load peaks is `60/No'` — a property of the rod string
+alone. It is identical on upstroke and downstroke and identical at every
+pumping speed.
+
+What changes with speed is the **phase**. Upstroke ringing is triggered at
+bottom of stroke (`t = 0`); downstroke ringing at top of stroke (`t = 30/N`).
+Overlay several speeds on one time axis and the upstroke peaks align while the
+downstroke peaks separate. `peak_times()` returns both trains with the correct
+phase reference, and `divergence_onset()` gives the time at which overlaid
+traces begin to disagree — the earliest top of stroke, set by the fastest unit.
+
+## Timing read off a position-axis card is uncertain
+
+`dt = dx / v`, and polished-rod velocity vanishes at both stroke ends. The same
+digitizing error therefore buys far more time error near the top of the stroke:
+
+| Peak position | Rod velocity | Time error from ±1.5 in |
+|---:|---:|---:|
+| 7.5 in | 10.62 in/s | ±0.14 s |
+| 23.5 in | 13.59 in/s | ±0.11 s |
+| 35.0 in | 9.71 in/s | ±0.15 s |
+
+So `time_from_card_position()` returns a `Measurement(value, uncertainty)`
+pair, not a bare float, and `intervals_are_distinguishable()` gates the
+reporting path. On a card digitized to ±1.5 in, consecutive peak-to-peak
+intervals of 1.24 s and 0.95 s are **not** resolvable — the honest statement is
+the mean interval against the predicted 1.03 s. Prefer raw time-series input
+(`.dyn`, timestamped CSV) whenever it exists.
+
+## The load datum check
+
+`load_datum_check()` flags a minimum polished-rod load above the rod string's
+weight in air. This has no mechanical explanation: friction acts *upward* on
+the downstroke, so it lowers polished-rod load and widens a card — it cannot
+lift the whole card.
+
+On the Collide fixture the measured MPRL of 9,274 lb exceeds the 6,863 lb air
+weight by 2,411 lb. The two candidate causes are a load-cell zero or scale
+offset, and a rod string heavier than recorded. Load *differences* remain
+usable while absolute loads do not, so this surfaces as a warning in
+`result.warnings` rather than failing the analysis.
+
+## Validation fixtures
+
+Both live in `tests/marine_ops/artificial_lift/dynacard/test_rod_pump.py`.
+
+**Reed Goodman's well** — Collide "Dynamometer Discussions", July 2026. 4,200 ft
+of 3/4 in steel, 41 in stroke, 6.4 SPM, 1.25 in plunger at 4,300 ft. Digitized
+card at `docs/collide_pe/dynacard-undulations/`. Four clear load undulations
+observed on the upstroke against 4.56 predicted.
+
+**Rowlan validation case** — O. Lynn Rowlan (Echometer), *"Over Travel Occurs on
+Both the Upstroke and Down Stroke"*, Sucker Rod Pumping Workshop / SWPSC,
+slide 13. One well and one rod string at three speeds, which isolates what is
+invariant with speed from what is not. The slide is internally inconsistent on
+the middle speed — 5.22 SPM on the card panel, 5.44 SPM in both time-plot
+legends — so the card fixtures use 5.22 and the time-domain fixtures 5.44.
+
+## Two open items
+
+**The load-datum discrepancy is unresolved.** On Reed's well, MPRL of 9,274 lb
+exceeds the reported string's air weight of 6,863 lb. Whether that is a
+load-cell offset or a string heavier than recorded has not been answered by the
+operator. Until it is, absolute loads from that card should not be trusted;
+load differences remain usable. The check surfaces this as a warning rather
+than failing the analysis, precisely because the analysis is still useful.
+
+**The Rowlan card-width reading is an inference.** The slide labels its arrows
+57.9 / 71.1 / 77.9 in but does not state what they measure. Reading them as
+plunger travel along the `Wrf + Fo Max` reference line follows Rowlan's own
+reference-load-line method, but that reading is ours, not the source's. The
+regression test therefore asserts only monotonicity with pumping speed — an
+over-travel proxy that holds under any consistent interpretation — rather than
+treating the numbers as absolute measurements.
+
+## Note on the prime mover
+
+The `C-66` on Reed's well is an **Arrow Engine Co. natural-gas engine** (single
+cylinder, 13 hp continuous at 700 rpm) — a prime mover, not a gearbox rating.
+Gearbox torque checks take the pumping *unit's* rating as an explicit input,
+defaulting to `None` and skipping the check rather than inferring one from the
+engine designation.
+
+## Knowledge-side references
+
+- `vamseeachanta/llm-wiki` — `wikis/drilling-engineering/wiki/concepts/rod-string-natural-frequency-and-card-undulations.md`
+- `vamseeachanta/llm-wiki` — `wikis/drilling-engineering/wiki/sources/rowlan-2016-srpw-overtravel-load-peak-timing.md`
+
+## Standards
+
+- API RP 11L — Design Calculations for Sucker Rod Pumping Systems
+- API 11E — Specification for Pumping Units
+- Everitt, T.A. and Jennings, J.W., SPE 18189 — the downhole-card transform
+  (implemented in the `everitt_jennings` package)

--- a/examples/workflows/dynacard-diagnostics/input.yml
+++ b/examples/workflows/dynacard-diagnostics/input.yml
@@ -1,5 +1,22 @@
 basename: artificial_lift
 
+# Pinned to the 'gibbs' passthrough deliberately, NOT because it is the better
+# solver -- it is not, and it is not the default (see issue #1857).
+#
+# This example is driven by a synthetic card generator, and those generators
+# produce DOWNHOLE-shaped cards: they are named for pump conditions. The
+# workflow then feeds that shape in as the *surface* card. Because 'gibbs' is
+# an affine rescale, the generated shape survives to the classifier intact and
+# the PUMP_TAGGING label round-trips, which is what makes this a legible demo.
+#
+# A solver that genuinely transforms the card -- the 'everitt_jennings'
+# default -- correctly turns that synthetic downhole card into something else,
+# so the demo's expected labels no longer hold.
+#
+# The real fix is to rebuild this example on a measured surface card rather
+# than a generated downhole one; tracked separately.
+solver_method: gibbs
+
 synthetic_card:
   mode: PUMP_TAGGING
   seed: 711

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/__init__.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/__init__.py
@@ -1,0 +1,55 @@
+# ABOUTME: Everitt-Jennings finite-difference surface-to-downhole card solver.
+# ABOUTME: Public entry point is solve_downhole_card(ctx).
+"""Everitt-Jennings surface-to-downhole dynamometer card conversion.
+
+Unlike a load-rescaling approximation, this solver rebuilds the downhole load
+from the strain field (``F = EA du/dx``) after marching the damped wave
+equation down the rod string. That is what removes rod-string vibration
+harmonics from the card and makes a healthy pump card rectangular.
+
+Typical use goes through the adapter, which handles oilfield/SI conversion::
+
+    from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
+        solve_downhole_card,
+    )
+
+    downhole = solve_downhole_card(ctx, tubing_id_in=2.441, viscosity_cp=10.0)
+
+Reference: Everitt, T.A. and Jennings, J.W., "An Improved Finite-Difference
+Calculation of Downhole Dynamometer Cards for Sucker-Rod Pumps", SPE 18189.
+"""
+
+from .adapter import (
+    EverittJenningsContextSolver,
+    rod_string_from_context,
+    solve_downhole_card,
+    survey_from_context,
+)
+from .damping import estimate_damping_coeff, estimate_damping_profile
+from .solver import (
+    Coefficients,
+    DownholeCard,
+    EverittJenningsSolver,
+    RodString,
+    Simulation,
+    Survey,
+    build_coefficients,
+    build_simulation,
+)
+
+__all__ = [
+    "Coefficients",
+    "EverittJenningsContextSolver",
+    "DownholeCard",
+    "EverittJenningsSolver",
+    "RodString",
+    "Simulation",
+    "Survey",
+    "build_coefficients",
+    "build_simulation",
+    "estimate_damping_coeff",
+    "estimate_damping_profile",
+    "rod_string_from_context",
+    "solve_downhole_card",
+    "survey_from_context",
+]

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/adapter.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/adapter.py
@@ -1,0 +1,209 @@
+# ABOUTME: Bridges the oilfield-unit DynacardAnalysisContext to the SI solver.
+# ABOUTME: Every unit crossing happens here and nowhere else.
+"""Adapter between :class:`DynacardAnalysisContext` and the SI solver.
+
+The rest of the dynacard package speaks oilfield units (inches, pounds, feet,
+psi, lb/ft^3). The Everitt-Jennings solver speaks SI. Confining every
+conversion to this one module means a unit error has exactly one place to hide.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from ..constants import BUCKLING_DETECTION_LOAD_THRESHOLD_LBS
+from ..models import AnalysisResults, CardData, DynacardAnalysisContext
+from . import units as U
+from .solver import (
+    DownholeCard,
+    EverittJenningsSolver,
+    RodString,
+    Survey,
+)
+
+# 2-7/8 in tubing is the common default for a rod-pumped well; its drift ID is
+# 2.441 in. Only the damping estimate depends on this, and it is a weak
+# dependence, but the value should be supplied whenever it is known.
+DEFAULT_TUBING_ID_IN = 2.441
+
+# Steel properties in oilfield units, matching the package defaults.
+STEEL_MODULUS_PSI = 30_000_000.0
+STEEL_DENSITY_LB_FT3 = 490.0
+
+
+def rod_string_from_context(ctx: DynacardAnalysisContext) -> RodString:
+    """Build the SI rod string from the context's oilfield-unit sections.
+
+    Args:
+        ctx: The analysis context. ``ctx.rod_string`` is ordered top-first.
+
+    Returns:
+        A :class:`RodString` in metres, kilograms and pascals.
+
+    Raises:
+        ValueError: If the context has no rod sections. The rod string is the
+            one input the solver cannot default — without the taper there is
+            no wave speed profile to march through.
+    """
+    if not ctx.rod_string:
+        raise ValueError(
+            "rod_string is empty; the surface-to-downhole conversion needs "
+            "the rod taper (diameter and length per section)"
+        )
+
+    diameters_m = np.array(
+        [s.diameter * U.IN2M for s in ctx.rod_string], dtype=np.float64
+    )
+    lengths_m = np.array(
+        [s.length * U.FT2M for s in ctx.rod_string], dtype=np.float64
+    )
+    densities = np.array(
+        [
+            (s.density if s.density else STEEL_DENSITY_LB_FT3) * U.LBPFT32KGPM3
+            for s in ctx.rod_string
+        ],
+        dtype=np.float64,
+    )
+    moduli = np.array(
+        [
+            (s.modulus_of_elasticity if s.modulus_of_elasticity else STEEL_MODULUS_PSI)
+            * U.PSI2PA
+            for s in ctx.rod_string
+        ],
+        dtype=np.float64,
+    )
+    return RodString(
+        diameters=diameters_m,
+        lengths=lengths_m,
+        densities=densities,
+        moduli=moduli,
+    )
+
+
+def survey_from_context(ctx: DynacardAnalysisContext, rods: RodString) -> Survey:
+    """Build the trajectory, falling back to vertical when no survey exists."""
+    survey = ctx.survey
+    if (
+        survey is None
+        or not survey.measured_depth
+        or len(survey.measured_depth) < 2
+    ):
+        return Survey.vertical(rods.total_length)
+
+    return Survey(
+        measured_depth=np.asarray(survey.measured_depth, dtype=np.float64) * U.FT2M,
+        inclination=np.asarray(survey.inclination, dtype=np.float64) * U.DEG2RAD,
+        azimuth=np.asarray(survey.azimuth, dtype=np.float64) * U.DEG2RAD,
+    )
+
+
+def solve_downhole_card(
+    ctx: DynacardAnalysisContext,
+    tubing_id_in: float = DEFAULT_TUBING_ID_IN,
+    viscosity_cp: float = 10.0,
+    n_nodes: int = 100,
+    damping: Optional[np.ndarray] = None,
+) -> CardData:
+    """Convert the context's surface card to a downhole card in oilfield units.
+
+    Args:
+        ctx: Analysis context carrying the surface card, rod string, pump and
+            speed.
+        tubing_id_in: Tubing inner diameter, inches. Affects the damping
+            estimate only.
+        viscosity_cp: Produced-fluid viscosity in centipoise. 10 cP is a
+            reasonable default for a light crude; heavy oil is far higher and
+            materially increases damping.
+        n_nodes: Spatial nodes down the rod string.
+        damping: Explicit damping coefficients, bypassing the estimator.
+
+    Returns:
+        A :class:`CardData` with position in inches and load in pounds.
+
+    Raises:
+        ValueError: If required inputs are missing or physically inconsistent.
+    """
+    rods = rod_string_from_context(ctx)
+    survey = survey_from_context(ctx, rods)
+
+    position_m = np.asarray(ctx.surface_card.position, dtype=np.float64) * U.IN2M
+    load_n = np.asarray(ctx.surface_card.load, dtype=np.float64) * U.LB2N
+
+    # centipoise -> Pa-s
+    viscosity_pa_s = viscosity_cp * 1.0e-3
+
+    solver = EverittJenningsSolver(
+        n_nodes=n_nodes,
+        viscosity=viscosity_pa_s,
+        friction_coefficient=ctx.calc_params.coulomb_friction_coefficient,
+    )
+    card: DownholeCard = solver.solve(
+        position=position_m,
+        load=load_n,
+        rods=rods,
+        strokes_per_minute=ctx.spm,
+        pump_diameter=ctx.pump.diameter * U.IN2M,
+        tubing_id=tubing_id_in * U.IN2M,
+        fluid_density=ctx.fluid_density * U.LBPFT32KGPM3,
+        survey=survey,
+        damping=damping,
+    )
+
+    return CardData(
+        position=(card.position * U.M2IN).tolist(),
+        load=(card.load * U.N2LB).tolist(),
+    )
+
+
+class EverittJenningsContextSolver:
+    """Workflow-compatible wrapper around the Everitt-Jennings solver.
+
+    :class:`DynacardWorkflow` expects a solver object constructed from a
+    context, exposing ``solve()`` and ``detect_buckling()`` and returning an
+    :class:`AnalysisResults`. This adapts the SI solver to that contract so it
+    can be selected alongside the existing two.
+    """
+
+    def __init__(
+        self,
+        context: DynacardAnalysisContext,
+        tubing_id_in: float = DEFAULT_TUBING_ID_IN,
+        viscosity_cp: float = 10.0,
+        n_nodes: int = 200,
+    ):
+        self.ctx = context
+        self.tubing_id_in = tubing_id_in
+        self.viscosity_cp = viscosity_cp
+        self.n_nodes = n_nodes
+        self.results = AnalysisResults()
+
+    def solve(self) -> AnalysisResults:
+        """Convert the surface card and populate the results object."""
+        downhole = solve_downhole_card(
+            self.ctx,
+            tubing_id_in=self.tubing_id_in,
+            viscosity_cp=self.viscosity_cp,
+            n_nodes=self.n_nodes,
+        )
+        surface_load = np.asarray(self.ctx.surface_card.load, dtype=np.float64)
+        self.results.downhole_card = downhole
+        self.results.peak_polished_rod_load = float(np.max(surface_load))
+        self.results.minimum_polished_rod_load = float(np.min(surface_load))
+        self.results.ctx = self.ctx
+        self.results.solver_method = "everitt_jennings"
+        return self.results
+
+    def detect_buckling(self) -> bool:
+        """Flag compression in the rod string at the pump.
+
+        Buckling shows up as the downhole load going meaningfully negative —
+        the string is being pushed rather than pulled.
+        """
+        if not self.results.downhole_card:
+            return False
+        loads = np.asarray(self.results.downhole_card.load, dtype=np.float64)
+        if float(np.min(loads)) < BUCKLING_DETECTION_LOAD_THRESHOLD_LBS:
+            self.results.buckling_detected = True
+        return self.results.buckling_detected

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/damping.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/damping.py
@@ -1,0 +1,196 @@
+# ABOUTME: Physically-estimated viscous damping coefficients for the rod string.
+# ABOUTME: Returns SEPARATE upstroke and downstroke values per taper section.
+"""Viscous damping estimation for a sucker-rod string.
+
+Damping is what gives a dynamometer card its area. A single scalar damping
+constant cannot reproduce the asymmetry between upstroke and downstroke, so the
+card comes out thin and area-less. This module estimates a coefficient for each
+taper section, separately for each stroke direction, from the annular geometry
+and the produced-fluid viscosity.
+
+The formulation is the standard concentric-annulus viscous drag model: the rod
+moves inside the tubing bore, and the drag depends on the diameter ratio
+``m = ID_tubing / OD_rod`` through the geometric groups ``B1``, ``B2``, ``B3``.
+Couplings are treated separately because they sweep a much tighter clearance
+than the rod body does.
+
+All inputs and outputs are SI.
+"""
+
+from math import log, pi
+from typing import Tuple
+
+import numpy as np
+
+# Validity floor of the coupling-drag correlation: below this coupling-to-bore
+# diameter ratio the fractional power has a negative base and is undefined.
+COUPLING_RATIO_FLOOR = 0.381
+
+
+def estimate_damping_coeff(
+    od_rod: float,
+    od_connect: float,
+    od_pump: float,
+    id_well: float,
+    mu: float,
+    l_tap: float,
+    ro_rod: float,
+) -> Tuple[float, float]:
+    """Estimate upstroke and downstroke damping for one taper section.
+
+    Args:
+        od_rod: Rod body outer diameter, m.
+        od_connect: Coupling outer diameter, m. Sweeps the tight clearance.
+        od_pump: Pump bore diameter, m.
+        id_well: Tubing inner diameter, m.
+        mu: Produced-fluid dynamic viscosity, Pa-s.
+        l_tap: Length of this taper section, m.
+        ro_rod: Rod material density, kg/m^3.
+
+    Returns:
+        ``(c_upstroke, c_downstroke)`` in 1/s.
+
+    Raises:
+        ValueError: If the geometry is degenerate — ``id_well`` must exceed
+            ``od_rod``, otherwise the annulus has no thickness and ``log(m)``
+            is undefined.
+    """
+    if od_rod <= 0.0 or id_well <= 0.0:
+        raise ValueError(
+            f"rod OD ({od_rod}) and tubing ID ({id_well}) must be positive"
+        )
+    if id_well <= od_rod:
+        raise ValueError(
+            f"tubing ID ({id_well} m) must exceed rod OD ({od_rod} m); "
+            "the annulus has no thickness"
+        )
+
+    a_rod = pi * od_rod ** 2 / 4.0
+    a_well = pi * id_well ** 2 / 4.0
+
+    # Annular diameter ratio and its geometric groups.
+    m = id_well / od_rod
+    b1 = (m ** 2 - 1.0) / (2.0 * log(m)) - 1.0
+    b2 = m ** 4 - 1.0 - (m ** 2 - 1.0) ** 2 / log(m)
+    b3 = 1.0 / log(m)
+
+    # Pump-bore to rod ratio, nudged off unity to keep the ratio finite when a
+    # rod diameter coincides with the pump bore.
+    m2 = od_pump / od_rod + 1.0e-6
+
+    # Coupling drag: tighter clearance, and it differs by stroke direction
+    # because the displaced fluid moves with or against the rod.
+    #
+    # The correlation raises (od_connect/id_well - 0.381) to a fractional
+    # power, so it is only defined once the coupling fills more than 38.1% of
+    # the bore. Below that the base goes negative and the whole card silently
+    # becomes NaN, so refuse explicitly rather than propagate it. This is the
+    # regime you land in when a casing ID is passed where a tubing ID belongs.
+    coupling_ratio = od_connect / id_well
+    if coupling_ratio <= COUPLING_RATIO_FLOOR:
+        raise ValueError(
+            f"coupling OD / bore ID = {coupling_ratio:.4f} is at or below the "
+            f"{COUPLING_RATIO_FLOOR} validity floor of the coupling-drag "
+            f"correlation (coupling OD {od_connect} m, bore ID {id_well} m). "
+            "Check that a tubing ID was supplied rather than a casing ID."
+        )
+
+    clearance = id_well / 2.0 - od_rod / 2.0
+    coupling_base = 1.3e4 * mu * (coupling_ratio - COUPLING_RATIO_FLOOR) ** 2.57 / clearance
+    k_c1 = coupling_base * (2.77 - 1.69 * (m ** 2 - 1.0) / (m2 ** 2 - 1.0))
+    k_c2 = coupling_base * (2.77 + 1.69 * (m ** 2 - 1.0))
+
+    # Rod-body annular drag terms.
+    n1 = (
+        pi * mu * (b3 + 4 * b1 ** 2 / b2)
+        + 4 * mu * pi * (m2 ** 2 - 1) ** 2 / b2
+        - 8 * pi * mu * (m2 ** 2 - 1) * b1 / b2
+    )
+    n2 = (
+        pi * mu * (b3 + 4 * b1 ** 2 / b2)
+        + 4 * mu * pi / b2
+        + 8 * pi * mu * b1 / b2
+    )
+
+    # Coupling contribution, distributed over the taper length.
+    coupling_scale = (a_well - a_rod) / (2.0 * (m ** 2 - 1.0) ** 2 * l_tap)
+    n3 = coupling_scale * (m2 ** 2 - 1.0) ** 2 * k_c1
+    n4 = coupling_scale * k_c2
+
+    normaliser = ro_rod * a_rod
+    c_upstroke = (n1 + n3) / normaliser
+    c_downstroke = (n2 + n4) / normaliser
+    return c_upstroke, c_downstroke
+
+
+# Below this viscosity the estimate degenerates; clamp to a physically sane floor.
+MIN_VISCOSITY_PA_S = 0.001
+DEFAULT_VISCOSITY_PA_S = 0.01
+
+
+def estimate_damping_profile(
+    rod_diameters: np.ndarray,
+    coupling_diameters: np.ndarray,
+    taper_lengths: np.ndarray,
+    rod_densities: np.ndarray,
+    pump_diameter: float,
+    tubing_id: float,
+    viscosity: float,
+) -> np.ndarray:
+    """Estimate damping for every taper section, both stroke directions.
+
+    Sections are ordered top-of-string first, matching the rod-string
+    convention used throughout the solver.
+
+    Args:
+        rod_diameters: Rod body OD per section, m.
+        coupling_diameters: Coupling OD per section, m.
+        taper_lengths: Length per section, m.
+        rod_densities: Material density per section, kg/m^3.
+        pump_diameter: Pump bore, m.
+        tubing_id: Tubing inner diameter, m.
+        viscosity: Produced-fluid dynamic viscosity, Pa-s.
+
+    Returns:
+        Array of length ``2 * n_sections``: the first half holds upstroke
+        coefficients top-to-bottom, the second half downstroke.
+
+    Raises:
+        ValueError: If the per-section arrays disagree in length, or if any
+            section's geometry is degenerate.
+    """
+    n_tap = len(taper_lengths)
+    lengths = {
+        "rod_diameters": len(rod_diameters),
+        "coupling_diameters": len(coupling_diameters),
+        "rod_densities": len(rod_densities),
+    }
+    mismatched = {k: v for k, v in lengths.items() if v != n_tap}
+    if mismatched:
+        raise ValueError(
+            f"per-section arrays must all have length {n_tap} "
+            f"(taper_lengths); got {mismatched}"
+        )
+
+    mu = viscosity if viscosity > MIN_VISCOSITY_PA_S else DEFAULT_VISCOSITY_PA_S
+
+    coefficients = np.empty(2 * n_tap, dtype=np.float64)
+    for i in range(n_tap):
+        try:
+            c_up, c_dn = estimate_damping_coeff(
+                od_rod=rod_diameters[i],
+                od_connect=coupling_diameters[i],
+                od_pump=pump_diameter,
+                id_well=tubing_id,
+                mu=mu,
+                l_tap=taper_lengths[i],
+                ro_rod=rod_densities[i],
+            )
+        except (ValueError, ZeroDivisionError) as exc:
+            raise ValueError(
+                f"damping estimation failed for taper section {i} "
+                f"(rod OD {rod_diameters[i]} m, tubing ID {tubing_id} m): {exc}"
+            ) from exc
+        coefficients[i] = c_up
+        coefficients[i + n_tap] = c_dn
+    return coefficients

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
@@ -1,0 +1,669 @@
+# ABOUTME: Everitt-Jennings space-marching finite-difference rod-string solver.
+# ABOUTME: Converts a surface dynamometer card to a downhole pump card in SI units.
+"""Surface-to-downhole card conversion by space-marching finite differences.
+
+The rod string is a damped elastic bar. Given the measured position and load at
+the polished rod, the damped wave equation is marched *down* the string one
+spatial node at a time until the pump depth is reached. The downhole card is the
+last row of that solution.
+
+Two things distinguish this from a naive implementation, and both matter:
+
+1. **Load is rebuilt from strain, never inherited.** The downhole load is
+   ``F = EA * du/dx`` evaluated at the pump — Hooke's law on the computed
+   displacement field. This is what removes the rod-string vibration harmonics
+   from the card and makes a healthy pump card rectangular. Any implementation
+   that scales the surface load instead will reproduce every ripple in the
+   surface card and cannot diagnose anything.
+2. **Damping is per-section and direction-dependent.** Upstroke and downstroke
+   damping differ, which is what gives the card its enclosed area. See
+   :mod:`.damping`.
+
+The scheme marches in space (``i``) across all time steps (``j``), with the
+surface card supplying the boundary rows ``i = 0`` and ``i = 1``. Time is
+periodic: one stroke wraps onto itself.
+
+All quantities are SI (m, kg, s, N, Pa). Use :mod:`.units` at the boundary.
+
+Reference: Everitt, T.A. and Jennings, J.W., "An Improved Finite-Difference
+Calculation of Downhole Dynamometer Cards for Sucker-Rod Pumps", SPE Production
+Engineering, SPE 18189.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy.signal import savgol_filter
+
+from .damping import estimate_damping_profile
+
+# ---------------------------------------------------------------------------
+# Optional numba acceleration. The kernel is a doubly-nested Python loop, so
+# numba gives a large speedup when present, but it is never required.
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - exercised implicitly by whichever path is installed
+    from numba import njit as _njit
+
+    HAS_NUMBA = True
+except ImportError:  # pragma: no cover
+    HAS_NUMBA = False
+
+    def _njit(*args, **kwargs):
+        """No-op stand-in for numba.njit when numba is not installed."""
+        def decorator(func):
+            return func
+
+        if args and callable(args[0]):
+            return args[0]
+        return decorator
+
+
+DEFAULT_NUM_NODES = 100
+DEFAULT_SAVGOL_WINDOW = 21
+DEFAULT_SAVGOL_ORDER = 5
+STEEL_MODULUS_PA = 2.07e11
+STEEL_DENSITY_KG_M3 = 7850.0
+WATER_DENSITY_KG_M3 = 998.2
+GRAVITY_M_S2 = 9.80665
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+@dataclass
+class RodString:
+    """Tapered rod string, ordered top-of-string first.
+
+    Attributes:
+        diameters: Rod body OD per section, m.
+        lengths: Length per section, m.
+        densities: Material density per section, kg/m^3.
+        moduli: Young's modulus per section, Pa.
+        coupling_diameters: Coupling OD per section, m. Used only by the
+            damping estimator; defaults to 1.5x the rod body OD.
+    """
+
+    diameters: np.ndarray
+    lengths: np.ndarray
+    densities: Optional[np.ndarray] = None
+    moduli: Optional[np.ndarray] = None
+    coupling_diameters: Optional[np.ndarray] = None
+
+    def __post_init__(self) -> None:
+        self.diameters = np.asarray(self.diameters, dtype=np.float64)
+        self.lengths = np.asarray(self.lengths, dtype=np.float64)
+        n = len(self.diameters)
+        if len(self.lengths) != n:
+            raise ValueError(
+                f"rod diameters ({n}) and lengths ({len(self.lengths)}) "
+                "must have the same number of sections"
+            )
+        if n == 0:
+            raise ValueError("rod string must have at least one section")
+        if np.any(self.diameters <= 0) or np.any(self.lengths <= 0):
+            raise ValueError("rod diameters and lengths must all be positive")
+
+        if self.densities is None:
+            self.densities = np.full(n, STEEL_DENSITY_KG_M3)
+        if self.moduli is None:
+            self.moduli = np.full(n, STEEL_MODULUS_PA)
+        if self.coupling_diameters is None:
+            self.coupling_diameters = self.diameters * 1.5
+        self.densities = np.asarray(self.densities, dtype=np.float64)
+        self.moduli = np.asarray(self.moduli, dtype=np.float64)
+        self.coupling_diameters = np.asarray(
+            self.coupling_diameters, dtype=np.float64
+        )
+
+    @property
+    def total_length(self) -> float:
+        """Total rod string length, m."""
+        return float(np.sum(self.lengths))
+
+    @property
+    def areas(self) -> np.ndarray:
+        """Cross-sectional area per section, m^2."""
+        return np.pi * (self.diameters / 2.0) ** 2
+
+
+@dataclass
+class Survey:
+    """Wellbore trajectory, used for deviated-well friction terms.
+
+    A vertical well contributes no Coulomb friction and no curvature terms, so
+    :meth:`vertical` is the correct default when no survey is available.
+    """
+
+    measured_depth: np.ndarray
+    inclination: np.ndarray
+    azimuth: np.ndarray
+    inclination_gradient: Optional[np.ndarray] = None
+    azimuth_gradient: Optional[np.ndarray] = None
+
+    @classmethod
+    def vertical(cls, total_length: float) -> "Survey":
+        """Build a trivial vertical survey spanning the rod string."""
+        md = np.array([0.0, total_length], dtype=np.float64)
+        zeros = np.zeros(2, dtype=np.float64)
+        return cls(
+            measured_depth=md,
+            inclination=zeros.copy(),
+            azimuth=zeros.copy(),
+            inclination_gradient=zeros.copy(),
+            azimuth_gradient=zeros.copy(),
+        )
+
+    def __post_init__(self) -> None:
+        self.measured_depth = np.asarray(self.measured_depth, dtype=np.float64)
+        self.inclination = np.asarray(self.inclination, dtype=np.float64)
+        self.azimuth = np.asarray(self.azimuth, dtype=np.float64)
+        if self.inclination_gradient is None:
+            self.inclination_gradient = np.gradient(
+                self.inclination, self.measured_depth
+            )
+        if self.azimuth_gradient is None:
+            self.azimuth_gradient = np.gradient(self.azimuth, self.measured_depth)
+        self.inclination_gradient = np.asarray(
+            self.inclination_gradient, dtype=np.float64
+        )
+        self.azimuth_gradient = np.asarray(self.azimuth_gradient, dtype=np.float64)
+
+    def phi(self, s: np.ndarray) -> np.ndarray:
+        """Inclination angle at measured depth ``s``, radians."""
+        return np.interp(s, self.measured_depth, self.inclination)
+
+    def d_phi(self, s: np.ndarray) -> np.ndarray:
+        """Inclination gradient at measured depth ``s``."""
+        return np.interp(s, self.measured_depth, self.inclination_gradient)
+
+    def d_psi(self, s: np.ndarray) -> np.ndarray:
+        """Azimuth gradient at measured depth ``s``."""
+        return np.interp(s, self.measured_depth, self.azimuth_gradient)
+
+
+# ---------------------------------------------------------------------------
+# Derived simulation state
+# ---------------------------------------------------------------------------
+@dataclass
+class Simulation:
+    """Grid and physical arrays derived from the inputs. All SI."""
+
+    u: np.ndarray = field(default_factory=lambda: np.empty(0))
+    f: np.ndarray = field(default_factory=lambda: np.empty(0))
+    taper_lengths: np.ndarray = field(default_factory=lambda: np.empty(0))
+    n_tap: int = 0
+    rod_length: float = 0.0
+    areas: np.ndarray = field(default_factory=lambda: np.empty(0))
+    rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
+    moduli: np.ndarray = field(default_factory=lambda: np.empty(0))
+    damping: np.ndarray = field(default_factory=lambda: np.empty(0))
+    densities: np.ndarray = field(default_factory=lambda: np.empty(0))
+    wave_speed: np.ndarray = field(default_factory=lambda: np.empty(0))
+    volume: float = 0.0
+    weight: float = 0.0
+    buoyant_weight: float = 0.0
+    gravity: float = GRAVITY_M_S2
+    friction: float = 0.0
+    n_x: int = DEFAULT_NUM_NODES
+    n_t: int = 0
+    period: float = 0.0
+    dt: float = 0.0
+    dx: float = 0.0
+    x: np.ndarray = field(default_factory=lambda: np.empty(0))
+    t: np.ndarray = field(default_factory=lambda: np.empty(0))
+    up_dn: int = 0
+    boundary: np.ndarray = field(default_factory=lambda: np.empty(0))
+    cumulative_buoyant: np.ndarray = field(default_factory=lambda: np.empty(0))
+    interfaces: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=int))
+
+
+@dataclass
+class Coefficients:
+    """Space-time coefficient matrices, each shaped ``(n_x, n_t)``."""
+
+    wave_speed: np.ndarray = field(default_factory=lambda: np.empty(0))
+    moduli: np.ndarray = field(default_factory=lambda: np.empty(0))
+    areas: np.ndarray = field(default_factory=lambda: np.empty(0))
+    rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
+    damping: np.ndarray = field(default_factory=lambda: np.empty(0))
+    phi: np.ndarray = field(default_factory=lambda: np.empty(0))
+    d_phi: np.ndarray = field(default_factory=lambda: np.empty(0))
+    d_psi: np.ndarray = field(default_factory=lambda: np.empty(0))
+
+
+def _section_cuts(taper_lengths: np.ndarray) -> np.ndarray:
+    """Cumulative section boundaries along the string, starting at zero."""
+    cuts = np.zeros(len(taper_lengths) + 1, dtype=np.float64)
+    cuts[1:] = np.cumsum(taper_lengths)
+    return cuts
+
+
+def build_simulation(
+    position: np.ndarray,
+    load: np.ndarray,
+    rods: RodString,
+    strokes_per_minute: float,
+    fluid_density: float = WATER_DENSITY_KG_M3,
+    damping: Optional[np.ndarray] = None,
+    friction_coefficient: float = 0.0,
+    n_nodes: int = DEFAULT_NUM_NODES,
+    gravity: float = GRAVITY_M_S2,
+    include_gravity: bool = True,
+) -> Simulation:
+    """Assemble the simulation grid from surface measurements and rod data.
+
+    Args:
+        position: Surface position, m. Sign convention is handled here: the
+            solver marches with *up* as the positive direction, so the incoming
+            conventional (positive-up-from-bottom) card is negated internally.
+        load: Surface load, N.
+        rods: The tapered rod string.
+        strokes_per_minute: Pumping speed.
+        fluid_density: Produced fluid density in the tubing, kg/m^3.
+        damping: Damping coefficients, length ``2 * n_sections`` (upstroke
+            first, then downstroke). If omitted, zeros are used and the caller
+            is expected to supply an estimate.
+        friction_coefficient: Coulomb friction coefficient for deviated wells.
+        n_nodes: Number of spatial nodes down the string.
+        gravity: Gravitational acceleration, m/s^2.
+        include_gravity: When False, gravity and friction terms are muted —
+            useful for isolating the elastic response.
+
+    Returns:
+        A populated :class:`Simulation`.
+
+    Raises:
+        ValueError: If the card arrays disagree in length or the speed is
+            non-positive.
+    """
+    position = np.asarray(position, dtype=np.float64)
+    load = np.asarray(load, dtype=np.float64)
+    if len(position) != len(load):
+        raise ValueError(
+            f"position ({len(position)}) and load ({len(load)}) must have "
+            "the same number of samples"
+        )
+    if len(position) < 4:
+        raise ValueError(
+            f"card needs at least 4 samples to march; got {len(position)}"
+        )
+    if strokes_per_minute <= 0:
+        raise ValueError(f"strokes_per_minute must be positive; got {strokes_per_minute}")
+
+    sim = Simulation()
+    # Up is the positive marching direction, so negate the conventional card.
+    sim.u = -position.copy()
+    sim.f = load.copy()
+    sim.gravity = gravity
+    sim.friction = friction_coefficient
+
+    sim.taper_lengths = rods.lengths
+    sim.n_tap = len(rods.lengths)
+    sim.rod_length = rods.total_length
+    sim.areas = rods.areas
+    sim.densities = rods.densities
+    sim.moduli = rods.moduli
+    sim.rho_a = rods.densities * rods.areas
+    sim.damping = (
+        np.zeros(2 * sim.n_tap, dtype=np.float64)
+        if damping is None
+        else np.asarray(damping, dtype=np.float64)
+    )
+
+    sim.volume = float(np.sum(sim.taper_lengths * sim.areas))
+    sim.weight = float(np.sum(sim.rho_a * sim.taper_lengths))
+    sim.buoyant_weight = (sim.weight - sim.volume * fluid_density) * gravity
+    sim.wave_speed = np.sqrt(sim.moduli / sim.densities)
+
+    sim.n_x = n_nodes
+    sim.n_t = len(sim.f)
+    sim.period = 60.0 / strokes_per_minute
+    sim.t = np.linspace(0.0, sim.period, sim.n_t)
+    sim.dt = sim.t[1] - sim.t[0]
+    sim.x = np.linspace(0.0, sim.rod_length, sim.n_x)
+    sim.dx = sim.x[1] - sim.x[0]
+
+    # Distributed buoyant weight, accumulated from the pump upward.
+    d_volume = sim.dx * sim.areas
+    d_weight = sim.densities * d_volume
+    d_buoyant = (d_weight - d_volume * fluid_density) * gravity
+
+    cuts = _section_cuts(sim.taper_lengths)
+    per_node = np.full(sim.n_x, np.nan, dtype=np.float64)
+    for i in range(len(cuts) - 1):
+        mask = (cuts[i] <= sim.x) & (sim.x <= cuts[i + 1])
+        per_node[mask] = d_buoyant[i]
+    sim.cumulative_buoyant = np.flip(np.cumsum(per_node), 0)
+
+    # Index at which the stroke turns from down to up.
+    sim.up_dn = int(np.mean(np.where(sim.u == np.min(sim.u))[0]))
+
+    # Boundary forcing at the polished rod.
+    #
+    # The static rod weight is accounted for in exactly one place, never two.
+    # When the gravity term is active in the marching kernel, the PDE carries
+    # it and the boundary takes the measured load as-is. When gravity is muted,
+    # the buoyant weight is instead pre-subtracted here. Getting this backwards
+    # double-counts the string weight and shifts the whole downhole card.
+    sim.boundary = sim.f if include_gravity else sim.f - sim.buoyant_weight
+    return sim
+
+
+def build_coefficients(sim: Simulation, survey: Survey) -> Coefficients:
+    """Expand per-section and per-depth properties onto the (space, time) grid."""
+    n_x, n_t = sim.n_x, sim.n_t
+    coeff = Coefficients()
+    cuts = _section_cuts(sim.taper_lengths)
+
+    for name, values in (
+        ("wave_speed", sim.wave_speed),
+        ("moduli", sim.moduli),
+        ("areas", sim.areas),
+        ("rho_a", sim.rho_a),
+    ):
+        matrix = np.full((n_x, n_t), np.nan, dtype=np.float64)
+        for i in range(len(cuts) - 1):
+            mask = (cuts[i] <= sim.x) & (sim.x <= cuts[i + 1])
+            matrix[mask, :] = values[i]
+        setattr(coeff, name, matrix)
+
+    # Damping varies with BOTH depth and stroke direction. The upstroke value
+    # applies to time steps before the turnaround, the downstroke value after.
+    #
+    # NOTE: the reference implementation sliced the spatial axis twice here
+    # (`c[lo:hi][:up_dn]`), which applied upstroke damping to the first `up_dn`
+    # *nodes* of each section rather than the first `up_dn` *time steps*. The
+    # sibling direction-coefficient routine indexes `[:, :up_dn]`, confirming
+    # the intent. Fixed below; see the porting notes on the tracking issue.
+    damping = np.reshape(sim.damping, (2, sim.n_tap)).T
+    coeff.damping = np.empty((n_x, n_t), dtype=np.float64)
+    for i in range(len(cuts) - 1):
+        lo = np.searchsorted(sim.x, cuts[i])
+        hi = np.searchsorted(sim.x, cuts[i + 1], side="right")
+        coeff.damping[lo:hi, : sim.up_dn] = damping[i, 0]
+        coeff.damping[lo:hi, sim.up_dn :] = damping[i, 1]
+
+    phi = survey.phi(sim.x)
+    d_phi = survey.d_phi(sim.x)
+    d_psi = survey.d_psi(sim.x)
+    coeff.phi = np.repeat(phi[:, None], n_t, axis=1)
+    coeff.d_phi = np.repeat(d_phi[:, None], n_t, axis=1)
+    coeff.d_psi = np.repeat(d_psi[:, None], n_t, axis=1)
+    return coeff
+
+
+def initial_matrix(sim: Simulation, coeff: Coefficients) -> np.ndarray:
+    """Seed the displacement matrix with the two surface boundary rows.
+
+    Row 0 is the measured surface position. Row 1 follows from the measured
+    load through Hooke's law, which is what couples the load record into a
+    solution otherwise written entirely in displacement.
+    """
+    solution = np.empty((sim.n_x, sim.n_t), dtype=np.float64)
+    solution[0, :] = sim.u
+    ea_dx = coeff.moduli[0, :] * coeff.areas[0, :] / sim.dx
+    solution[1, :] = solution[0, :] + sim.boundary / ea_dx
+    return solution
+
+
+@_njit(cache=True)
+def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi, muteg):
+    """March the damped wave equation down the rod string.
+
+    Explicit in space: each new row ``i+1`` is built from rows ``i`` and
+    ``i-1`` across all time steps. Time is treated as periodic so that the
+    stroke closes on itself.
+    """
+    for i in range(1, n_x - 1):
+        for j in range(1, n_t - 1):
+            ea_plus = (e_mod[i + 1, j] * area[i + 1, j] + e_mod[i, j] * area[i, j]) / 2.0
+            ea_minus = (e_mod[i - 1, j] * area[i - 1, j] + e_mod[i, j] * area[i, j]) / 2.0
+            rho_a_ij = rho_a[i, j]
+            rho_a_c = rho_a[i, j] * c[i, j]
+
+            # Direction of travel, for Coulomb friction.
+            delta = u[i, j + 1] - u[i, j]
+            if delta > 0:
+                sign = 1.0
+            elif delta < 0:
+                sign = -1.0
+            else:
+                sign = 0.0
+
+            c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
+            c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
+            c3 = (rho_a_ij / ea_plus) * lam * sign * dx
+            c4 = (rho_a_ij / ea_plus) * dx ** 2
+
+            # Normal force from gravity plus borehole curvature.
+            mg_sin = rho_a[i, j] * g * np.sin(phi[i, j])
+            s1 = mg_sin * dx - d_phi[i, j] * (u[i, j] - u[i - 1, j])
+            s2 = d_psi[i, j] * np.sin(phi[i, j]) * (u[i, j] - u[i - 1, j])
+            q_n = np.sqrt(s1 ** 2 + s2 ** 2)
+
+            u[i + 1, j] = (
+                u[i, j]
+                + (ea_minus / ea_plus) * u[i, j]
+                - (ea_minus / ea_plus) * u[i - 1, j]
+                + c1 * (u[i, j + 1] - 2 * u[i, j] + u[i, j - 1])
+                + c2 * (u[i, j + 1] - u[i, j - 1]) / 2.0
+                + c3 * q_n * muteg
+                - c4 * g * np.cos(phi[i, j]) * muteg
+            )
+
+        # Wrap-around time step. Coefficients are re-evaluated at j = 0 rather
+        # than reusing the last inner-loop values, which the reference
+        # implementation did by leaking the loop variable.
+        ea_plus = (e_mod[i + 1, 0] * area[i + 1, 0] + e_mod[i, 0] * area[i, 0]) / 2.0
+        ea_minus = (e_mod[i - 1, 0] * area[i - 1, 0] + e_mod[i, 0] * area[i, 0]) / 2.0
+        rho_a_ij = rho_a[i, 0]
+        rho_a_c = rho_a[i, 0] * c[i, 0]
+
+        c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
+        c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
+        c3 = (rho_a_ij / ea_plus) * lam * dx
+        c4 = (rho_a_ij / ea_plus) * dx ** 2
+
+        mg_sin = rho_a[i, 0] * g * np.sin(phi[i, 0])
+        s1 = mg_sin * dx - d_phi[i, 0] * (u[i, 0] - u[i - 1, 0])
+        s2 = d_psi[i, 0] * np.sin(phi[i, 0]) * (u[i, 0] - u[i - 1, 0])
+        q_n = np.sqrt(s1 ** 2 + s2 ** 2)
+
+        u[i + 1, 0] = (
+            u[i, 0]
+            + (ea_minus / ea_plus) * u[i, 0]
+            - (ea_minus / ea_plus) * u[i - 1, 0]
+            + c1 * (u[i, 1] - 2 * u[i, 0] + u[i, n_t - 2])
+            + c2 * (u[i, 1] - u[i, n_t - 2]) / 2.0
+            + c3 * q_n * muteg
+            - c4 * g * np.cos(phi[i, 0]) * muteg
+        )
+        u[i + 1, n_t - 1] = u[i + 1, 0]
+
+    # Downhole load from Hooke's law on the strain at the pump. This is the
+    # step that rebuilds load rather than inheriting it from the surface.
+    load = np.empty(n_t, dtype=np.float64)
+    alpha = e_mod[n_x - 1, 0] * area[n_x - 1, 0] / (2 * dx)
+    load[0] = alpha * (3 * u[n_x - 1, 0] - 4 * u[n_x - 2, 0] + u[n_x - 3, 0])
+    load[n_t - 1] = load[0]
+    for j in range(1, n_t - 1):
+        load[j] = (e_mod[n_x - 1, j] * area[n_x - 1, j] / dx) * (
+            u[n_x - 1, j] - u[n_x - 2, j]
+        )
+
+    # Back to the conventional positive-up sign.
+    downhole_position = -u[n_x - 1, :]
+    return u, downhole_position, load
+
+
+def _full_load(u: np.ndarray, moduli: np.ndarray, areas: np.ndarray, dx: float) -> np.ndarray:
+    """Load at every node from the displacement gradient, ``F = EA du/dx``."""
+    full = np.empty_like(u)
+    full[0] = 0.0
+    for i in range(1, u.shape[0]):
+        full[i] = (moduli[i] * areas[i] / dx) * (u[i] - u[i - 1])
+    return full
+
+
+@dataclass
+class DownholeCard:
+    """Result of a surface-to-downhole conversion. SI units."""
+
+    position: np.ndarray
+    load: np.ndarray
+    full_position: Optional[np.ndarray] = None
+    full_load: Optional[np.ndarray] = None
+    simulation: Optional[Simulation] = None
+
+    @property
+    def stroke(self) -> float:
+        """Net plunger travel, m."""
+        return float(np.max(self.position) - np.min(self.position))
+
+    @property
+    def load_range(self) -> float:
+        """Peak-to-minimum downhole load, N."""
+        return float(np.max(self.load) - np.min(self.load))
+
+
+class EverittJenningsSolver:
+    """Space-marching finite-difference surface-to-downhole card solver.
+
+    Args:
+        n_nodes: Spatial nodes down the rod string. More nodes resolve taper
+            interfaces better but amplify high-frequency noise.
+        viscosity: Produced-fluid dynamic viscosity in Pa-s, used to estimate
+            damping when no explicit coefficients are supplied.
+        friction_coefficient: Coulomb friction coefficient (deviated wells).
+        include_gravity: When True the marching kernel carries the gravity and
+            Coulomb-friction terms directly. When False (the default, matching
+            the reference implementation) those terms are muted and the static
+            buoyant weight is pre-subtracted at the surface boundary instead.
+            Either way the rod weight is counted exactly once.
+        smooth_window: Savitzky-Golay window for the downhole load. Space
+            marching amplifies measurement noise, so some smoothing is
+            required; set to 0 to disable.
+        smooth_order: Savitzky-Golay polynomial order.
+        remove_interface_jumps: Average out the load discontinuities that
+            appear at taper interfaces where area and modulus step.
+    """
+
+    def __init__(
+        self,
+        n_nodes: int = DEFAULT_NUM_NODES,
+        viscosity: float = 0.01,
+        friction_coefficient: float = 0.0,
+        include_gravity: bool = False,
+        smooth_window: int = DEFAULT_SAVGOL_WINDOW,
+        smooth_order: int = DEFAULT_SAVGOL_ORDER,
+        remove_interface_jumps: bool = True,
+    ):
+        self.n_nodes = n_nodes
+        self.viscosity = viscosity
+        self.friction_coefficient = friction_coefficient
+        self.include_gravity = include_gravity
+        self.smooth_window = smooth_window
+        self.smooth_order = smooth_order
+        self.remove_interface_jumps = remove_interface_jumps
+
+    def solve(
+        self,
+        position: np.ndarray,
+        load: np.ndarray,
+        rods: RodString,
+        strokes_per_minute: float,
+        pump_diameter: float,
+        tubing_id: float,
+        fluid_density: float = WATER_DENSITY_KG_M3,
+        survey: Optional[Survey] = None,
+        damping: Optional[np.ndarray] = None,
+    ) -> DownholeCard:
+        """Convert a surface card to a downhole pump card.
+
+        Args:
+            position: Surface position, m (conventional positive-up sense).
+            load: Surface load, N.
+            rods: Tapered rod string, top section first.
+            strokes_per_minute: Pumping speed.
+            pump_diameter: Pump bore, m.
+            tubing_id: Tubing inner diameter, m.
+            fluid_density: Produced fluid density, kg/m^3.
+            survey: Wellbore trajectory. Defaults to vertical.
+            damping: Explicit damping coefficients, length ``2 * n_sections``.
+                When omitted they are estimated from the annular geometry.
+
+        Returns:
+            The downhole card, plus the full displacement and load fields.
+        """
+        if survey is None:
+            survey = Survey.vertical(rods.total_length)
+
+        if damping is None:
+            damping = estimate_damping_profile(
+                rod_diameters=rods.diameters,
+                coupling_diameters=rods.coupling_diameters,
+                taper_lengths=rods.lengths,
+                rod_densities=rods.densities,
+                pump_diameter=pump_diameter,
+                tubing_id=tubing_id,
+                viscosity=self.viscosity,
+            )
+
+        sim = build_simulation(
+            position=position,
+            load=load,
+            rods=rods,
+            strokes_per_minute=strokes_per_minute,
+            fluid_density=fluid_density,
+            damping=damping,
+            friction_coefficient=self.friction_coefficient,
+            n_nodes=self.n_nodes,
+            include_gravity=self.include_gravity,
+        )
+        coeff = build_coefficients(sim, survey)
+        u = initial_matrix(sim, coeff)
+
+        muteg = 1.0 if self.include_gravity else 0.0
+        u, dh_position, dh_load = _march(
+            u, sim.n_x, sim.n_t, sim.dt, sim.dx, sim.friction,
+            coeff.rho_a, sim.gravity, coeff.damping, coeff.moduli,
+            coeff.areas, coeff.phi, coeff.d_phi, coeff.d_psi, muteg,
+        )
+
+        if self.smooth_window and self.smooth_window > self.smooth_order:
+            window = min(self.smooth_window, len(dh_load))
+            if window % 2 == 0:
+                window -= 1
+            if window > self.smooth_order:
+                dh_load = savgol_filter(dh_load, window, self.smooth_order)
+
+        # Close the loop: one stroke must return to where it began.
+        dh_load[sim.n_t - 1] = dh_load[0]
+        dh_position[sim.n_t - 1] = dh_position[0]
+
+        full_position = -u
+        full_load = _full_load(u, coeff.moduli, coeff.areas, sim.dx)
+        full_load = full_load + sim.cumulative_buoyant.reshape(-1, 1)
+        full_load[0, :] = sim.f
+
+        # Area and modulus step at taper interfaces, which shows up as a
+        # discontinuity in the strain-derived load. Average it out.
+        interfaces = np.where(np.abs(np.diff(coeff.areas[:, 0])) > 1e-14)[0] + 1
+        sim.interfaces = interfaces
+        if self.remove_interface_jumps and len(interfaces) > 0:
+            if interfaces[-1] == len(full_load) - 1:
+                interfaces[-1] -= 1
+            full_load[interfaces, :] = (
+                full_load[interfaces - 1, :] + full_load[interfaces + 1, :]
+            ) / 2.0
+
+        return DownholeCard(
+            position=dh_position,
+            load=dh_load,
+            full_position=full_position,
+            full_load=full_load,
+            simulation=sim,
+        )

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/units.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/units.py
@@ -1,0 +1,124 @@
+# ABOUTME: Unit conversion factors for the Everitt-Jennings finite-difference solver.
+# ABOUTME: The solver works internally in SI; these bridge to/from oilfield units.
+"""Unit conversion constants.
+
+The finite-difference rod-string solver operates entirely in SI (m, kg, s, N).
+Callers supply oilfield units (in, lb, ft, psi), so every boundary crossing goes
+through these factors. Each pair is defined once and inverted, so a typo in one
+direction cannot silently disagree with the other.
+"""
+
+from math import pi
+
+# meter & foot
+M2FT = 1000.0 / (12.0 * 25.4)
+FT2M = 1.0 / M2FT
+
+# meter & inch
+IN2M = 25.4 / 1000.0
+M2IN = 1.0 / IN2M
+
+# foot & inch
+FT2IN = 12.0
+IN2FT = 1.0 / FT2IN
+
+# square feet & square inches
+FTSQD2INSQD = 144.0
+INSQD2FTSQD = 1.0 / FTSQD2INSQD
+
+# day & second
+DAY2SEC = 86400.0
+SEC2DAY = 1.0 / DAY2SEC
+
+# rpm & radians per second
+RPM2RADPS = 2.0 * pi / 60.0
+RADPS2RPM = 1.0 / RPM2RADPS
+
+# rpm & rps
+RPM2RPS = 1.0 / 60.0
+RPS2RPM = 1.0 / RPM2RPS
+
+# feet per hour & meters per second
+FTPH2MPS = 0.000084667
+MPS2FTPH = 1.0 / FTPH2MPS
+
+# newton & pound force
+N2KLB = 0.000224809
+KLB2N = 1.0 / N2KLB
+N2LB = N2KLB * 1000.0
+LB2N = 1.0 / N2LB
+
+# newton-meter & pound-foot
+NM2LBFT = 0.737562121
+LBFT2NM = 1.0 / NM2LBFT
+
+# newton-meter & kilo-inch-pound
+NM2KIP = 0.00885
+KIP2NM = 1.0 / NM2KIP
+
+# gallon & cubic meter
+GAL2M3 = 0.003785412
+M32GAL = 1.0 / GAL2M3
+
+# gallon per minute & cubic meter per second
+GALPM2M3PS = GAL2M3 / 60.0
+M3PS2GALPM = 1.0 / GALPM2M3PS
+
+# pound per gallon & kilogram per cubic meter
+LBPGAL2KGPM3 = 119.826427317
+KGPM32LBPGAL = 1.0 / LBPGAL2KGPM3
+
+# pound per cubic foot & kilogram per cubic meter
+LBPFT32KGPM3 = 16.0185
+KGPM32LBPFT3 = 1.0 / LBPFT32KGPM3
+
+# radians & degrees
+RAD2DEG = 180.0 / pi
+DEG2RAD = 1.0 / RAD2DEG
+
+# psi & pascal
+PSI2PA = 6894.7572931783
+PA2PSI = 1.0 / PSI2PA
+
+# pound & kilogram
+LB2KG = 0.45359237
+KG2LB = 1.0 / LB2KG
+
+# mscf & scf
+MSCF2SCF = 1000.0
+SCF2MSCF = 1.0 / MSCF2SCF
+
+# bbl & scf
+BBL2SCF = 5.615
+SCF2BBL = 1.0 / BBL2SCF
+
+# gauge & absolute pressure
+GAUGE2ABS = 14.7
+ABS2GAUGE = -GAUGE2ABS
+
+# fahrenheit & rankine
+FHT2RANKINE = 459.67
+RANKINE2FHT = -FHT2RANKINE
+
+# centipoise & lb per ft-s
+CP2LBPERFTSEC = 0.000671968994813
+LBPERFTSEC2CP = 1.0 / CP2LBPERFTSEC
+
+
+def convert(value: float, factor: float) -> float:
+    """Apply a conversion factor.
+
+    Kept as a named function so call sites read as a unit crossing rather than
+    a bare multiplication — the boundary is where sign and scale errors hide.
+    """
+    return value * factor
+
+
+def rpm_to_omega(rpm: float) -> float:
+    """Convert rotational speed in RPM to angular velocity in rad/s."""
+    return RPM2RADPS * rpm
+
+
+def omega_to_rpm(omega: float) -> float:
+    """Convert angular velocity in rad/s to rotational speed in RPM."""
+    return omega * RADPS2RPM

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/__init__.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/__init__.py
@@ -1,0 +1,118 @@
+# ABOUTME: API RP 11L rod-pump kinematics, rod-string mechanics and card metrics.
+# ABOUTME: Public entry point is analyse(); it fails closed outside the RP 11L envelope.
+"""API RP 11L rod-pump surface-card analysis.
+
+Covers the kinematics and rod-string mechanics that sit *upstream* of a
+surface-to-downhole transform: natural frequency, card undulations, crank
+motion, plunger stroke, pump displacement, and the dimensionless groups the
+RP 11L correlations run on.
+
+For the surface-to-downhole card conversion itself, see the sibling
+:mod:`..everitt_jennings` package.
+
+Two behaviours are deliberate and worth knowing before use:
+
+- **Fails closed.** ``N/No' > 0.35`` raises rather than extrapolating, as do
+  non-Class-I unit geometries and tapered strings without an explicit ``Fc``.
+- **Reports what it cannot determine.** Volumetric efficiency returns ``None``
+  when runtime or formation volume factor is unknown, instead of assuming 24 h
+  and ``Bo = 1.0``.
+
+Example::
+
+    from digitalmodel.marine_ops.artificial_lift.dynacard.rod_pump import analyse
+
+    result = analyse(
+        rod_diameter_in=0.75, rod_length_ft=4200.0,
+        surface_stroke_in=41.0, strokes_per_minute=6.4,
+        plunger_diameter_in=1.25, fluid_level_ft=4300.0,
+        specific_gravity=0.85,
+        tubing_pressure_psi=150.0, casing_pressure_psi=25.0,
+    )
+    result.undulations_per_half_stroke   # 4.56
+    result.pump_displacement_bpd         # 38.8
+"""
+
+from .analysis import RodPumpAnalysis, ValidityError, analyse
+from .card_metrics import (
+    CardMetrics,
+    analyse_card,
+    card_area,
+    load_datum_check,
+    polished_rod_horsepower,
+)
+from .constants import (
+    API_ROD_SIZES,
+    ENVELOPE_MAX_VALID,
+    ENVELOPE_WAVE_DOMINATED,
+    SONIC_VELOCITY_STEEL_FT_S,
+    YOUNGS_MODULUS_PSI,
+)
+from .kinematics import (
+    Measurement,
+    PeakTrains,
+    angular_velocity,
+    crank_position,
+    crank_velocity,
+    divergence_onset,
+    intervals_are_distinguishable,
+    natural_frequency,
+    peak_interval,
+    peak_times,
+    taper_adjusted_natural_frequency,
+    time_at_position,
+    time_from_card_position,
+    undulations_per_half_stroke,
+)
+from .rod_string import (
+    RodStringAnalysis,
+    analyse_rod_string,
+    buoyant_rod_weight,
+    fluid_load,
+    plunger_stroke,
+    pump_displacement,
+    rod_area,
+    rod_elastic_constant,
+    spring_rate,
+    volumetric_efficiency,
+)
+
+__all__ = [
+    "API_ROD_SIZES",
+    "CardMetrics",
+    "ENVELOPE_MAX_VALID",
+    "ENVELOPE_WAVE_DOMINATED",
+    "Measurement",
+    "PeakTrains",
+    "RodPumpAnalysis",
+    "RodStringAnalysis",
+    "SONIC_VELOCITY_STEEL_FT_S",
+    "ValidityError",
+    "YOUNGS_MODULUS_PSI",
+    "analyse",
+    "analyse_card",
+    "analyse_rod_string",
+    "angular_velocity",
+    "buoyant_rod_weight",
+    "card_area",
+    "crank_position",
+    "crank_velocity",
+    "divergence_onset",
+    "fluid_load",
+    "intervals_are_distinguishable",
+    "load_datum_check",
+    "natural_frequency",
+    "peak_interval",
+    "peak_times",
+    "plunger_stroke",
+    "polished_rod_horsepower",
+    "pump_displacement",
+    "rod_area",
+    "rod_elastic_constant",
+    "spring_rate",
+    "taper_adjusted_natural_frequency",
+    "time_at_position",
+    "time_from_card_position",
+    "undulations_per_half_stroke",
+    "volumetric_efficiency",
+]

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/analysis.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/analysis.py
@@ -1,0 +1,255 @@
+# ABOUTME: Public entry point for API RP 11L rod-pump surface-card analysis.
+# ABOUTME: Fails closed outside the validity envelope rather than extrapolating.
+"""End-to-end API RP 11L analysis of a rod-pumped well.
+
+This ties the rod-string mechanics, kinematics and card metrics together
+behind one call, and enforces the validity envelope before returning anything.
+The guiding rule is that the analysis refuses rather than extrapolates: a
+correlation used outside its range produces a number that looks like every
+other number in the report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from .card_metrics import CardMetrics, analyse_card
+from .constants import (
+    ENVELOPE_MAX_VALID,
+    ENVELOPE_WAVE_DOMINATED,
+    SONIC_VELOCITY_STEEL_FT_S,
+    SUPPORTED_UNIT_GEOMETRIES,
+    UNSUPPORTED_UNIT_GEOMETRIES,
+)
+from .kinematics import (
+    natural_frequency,
+    peak_interval,
+    taper_adjusted_natural_frequency,
+    undulations_per_half_stroke,
+)
+from .rod_string import (
+    RodStringAnalysis,
+    analyse_rod_string,
+    plunger_stroke,
+    pump_displacement,
+    volumetric_efficiency,
+)
+
+
+class ValidityError(ValueError):
+    """Raised when inputs fall outside the RP 11L correlations' envelope."""
+
+
+@dataclass
+class RodPumpAnalysis:
+    """Complete RP 11L analysis of one well."""
+
+    # Kinematics
+    natural_frequency_spm: float          # No
+    taper_adjusted_frequency_spm: float   # No'
+    peak_interval_s: float                # dt = 60/No'
+    speed_ratio: float                    # N/No'
+    undulations_per_half_stroke: float    # n
+
+    # Rod string and loads
+    rod_string: RodStringAnalysis
+
+    # Pump
+    plunger_stroke_in: float              # Sp
+    rod_stretch_in: float
+    pump_displacement_bpd: float          # PD
+    volumetric_efficiency: Optional[float]
+
+    # Card
+    card: Optional[CardMetrics] = None
+
+    # Everything the analysis could not determine, stated rather than assumed
+    warnings: List[str] = field(default_factory=list)
+    undetermined: List[str] = field(default_factory=list)
+
+
+def _check_envelope(
+    speed_ratio: float,
+    sonic_velocity_ft_s: float,
+    taper_factor: Optional[float],
+    is_tapered: bool,
+    unit_geometry: str,
+) -> List[str]:
+    """Enforce the validity envelope. Returns advisory notes; raises to refuse."""
+    notes: List[str] = []
+
+    geometry = (unit_geometry or "conventional").strip().lower().replace(" ", "_")
+    if geometry in UNSUPPORTED_UNIT_GEOMETRIES:
+        raise ValidityError(
+            f"pumping-unit geometry '{unit_geometry}' is not a Class I "
+            "crank-balanced unit. The API RP 11L correlations assume "
+            "conventional geometry; Mark II, RotaFlex and hydraulic "
+            "long-stroke units have different kinematics and must not be "
+            "analysed with them."
+        )
+    if geometry not in SUPPORTED_UNIT_GEOMETRIES:
+        notes.append(
+            f"pumping-unit geometry '{unit_geometry}' is unrecognised; "
+            "proceeding on the assumption it is Class I crank-balanced"
+        )
+
+    if is_tapered and taper_factor is None:
+        raise ValidityError(
+            "a tapered rod string requires an explicit frequency taper factor "
+            "Fc. Fc = 1.000 applies only to a single-diameter string; using it "
+            "for a taper misstates the natural frequency and every timing "
+            "result that follows."
+        )
+
+    if abs(sonic_velocity_ft_s - SONIC_VELOCITY_STEEL_FT_S) > 1.0:
+        notes.append(
+            f"sonic velocity {sonic_velocity_ft_s} ft/s is not steel "
+            f"({SONIC_VELOCITY_STEEL_FT_S}); the RP 11L 245,000 constant "
+            "assumes steel and the natural-frequency cross-check will reflect "
+            "the difference"
+        )
+
+    if speed_ratio > ENVELOPE_MAX_VALID:
+        raise ValidityError(
+            f"N/No' = {speed_ratio:.3f} exceeds {ENVELOPE_MAX_VALID}. "
+            "Resonance effects dominate and the API RP 11L correlations are "
+            "invalid here. Refusing to extrapolate — use a wave-equation "
+            "solver instead."
+        )
+    if speed_ratio < ENVELOPE_WAVE_DOMINATED:
+        notes.append(
+            f"N/No' = {speed_ratio:.3f} is below {ENVELOPE_WAVE_DOMINATED}: the "
+            "surface card is wave-dominated and will show pronounced load "
+            "undulations. This is expected behaviour, not a pump fault."
+        )
+    return notes
+
+
+def analyse(
+    rod_diameter_in: float,
+    rod_length_ft: float,
+    surface_stroke_in: float,
+    strokes_per_minute: float,
+    plunger_diameter_in: float,
+    fluid_level_ft: float,
+    specific_gravity: float,
+    tubing_pressure_psi: float = 0.0,
+    casing_pressure_psi: float = 0.0,
+    taper_factor: Optional[float] = None,
+    is_tapered: bool = False,
+    overtravel_in: float = 0.0,
+    sonic_velocity_ft_s: float = SONIC_VELOCITY_STEEL_FT_S,
+    unit_geometry: str = "conventional",
+    rod_weight_lb_per_ft: Optional[float] = None,
+    card_position_in: Optional[Sequence[float]] = None,
+    card_load_lb: Optional[Sequence[float]] = None,
+    measured_rate_bpd: Optional[float] = None,
+    runtime_hours_per_day: Optional[float] = None,
+    formation_volume_factor: Optional[float] = None,
+) -> RodPumpAnalysis:
+    """Run the full RP 11L analysis for one well.
+
+    Args:
+        rod_diameter_in: Rod body diameter. Single-diameter strings only;
+            supply ``taper_factor`` and set ``is_tapered`` otherwise.
+        rod_length_ft: Total rod string length.
+        surface_stroke_in: Polished-rod stroke, ``S``.
+        strokes_per_minute: Pumping speed, ``N``.
+        plunger_diameter_in: Pump bore.
+        fluid_level_ft: Fluid column height above the pump.
+        specific_gravity: Produced-fluid specific gravity.
+        taper_factor: ``Fc``. Required when ``is_tapered``.
+        overtravel_in: Plunger overtravel; zero gives the conservative stroke.
+        unit_geometry: Pumping-unit class. Non-Class-I geometries are refused.
+        card_position_in / card_load_lb: Optional surface card, enabling card
+            metrics and the load datum check.
+        measured_rate_bpd / runtime_hours_per_day / formation_volume_factor:
+            Needed for volumetric efficiency. When runtime or ``Bo`` is
+            missing, efficiency is reported as ``None`` and listed under
+            ``undetermined`` rather than silently assumed.
+
+    Returns:
+        A populated :class:`RodPumpAnalysis`.
+
+    Raises:
+        ValidityError: If the case falls outside the correlations' envelope.
+    """
+    no_ = natural_frequency(rod_length_ft, sonic_velocity_ft_s)
+    effective_taper = 1.0 if taper_factor is None else taper_factor
+    no_prime = taper_adjusted_natural_frequency(no_, effective_taper)
+    speed_ratio = strokes_per_minute / no_prime
+
+    notes = _check_envelope(
+        speed_ratio, sonic_velocity_ft_s, taper_factor, is_tapered, unit_geometry
+    )
+
+    string = analyse_rod_string(
+        diameter_in=rod_diameter_in,
+        length_ft=rod_length_ft,
+        surface_stroke_in=surface_stroke_in,
+        plunger_diameter_in=plunger_diameter_in,
+        fluid_level_ft=fluid_level_ft,
+        specific_gravity=specific_gravity,
+        tubing_pressure_psi=tubing_pressure_psi,
+        casing_pressure_psi=casing_pressure_psi,
+        weight_lb_per_ft=rod_weight_lb_per_ft,
+    )
+
+    stretch = string.fluid_load_lb / string.spring_rate_lb_per_in
+    s_p = plunger_stroke(
+        surface_stroke_in, string.fluid_load_lb, string.spring_rate_lb_per_in,
+        overtravel_in,
+    )
+    p_d = pump_displacement(plunger_diameter_in, s_p, strokes_per_minute)
+
+    undetermined: List[str] = []
+    efficiency = None
+    if measured_rate_bpd is not None:
+        efficiency = volumetric_efficiency(
+            measured_rate_bpd, p_d, runtime_hours_per_day, formation_volume_factor
+        )
+        if efficiency is None:
+            missing = [
+                name
+                for name, value in (
+                    ("runtime_hours_per_day", runtime_hours_per_day),
+                    ("formation_volume_factor", formation_volume_factor),
+                )
+                if value is None
+            ]
+            undetermined.append(
+                "volumetric efficiency: requires "
+                f"{' and '.join(missing)}. A unit cycling on a controller has "
+                "a duty cycle that mimics low fillage, and surface barrels are "
+                "not reservoir barrels — neither is assumed."
+            )
+
+    card = None
+    if card_position_in is not None and card_load_lb is not None:
+        card = analyse_card(
+            card_position_in,
+            card_load_lb,
+            strokes_per_minute,
+            rod_weight_in_air_lb=string.weight_in_air_lb,
+            buoyant_rod_weight_lb=string.buoyant_weight_lb,
+        )
+        notes.extend(card.warnings)
+
+    return RodPumpAnalysis(
+        natural_frequency_spm=no_,
+        taper_adjusted_frequency_spm=no_prime,
+        peak_interval_s=peak_interval(no_prime),
+        speed_ratio=speed_ratio,
+        undulations_per_half_stroke=undulations_per_half_stroke(
+            strokes_per_minute, no_prime
+        ),
+        rod_string=string,
+        plunger_stroke_in=s_p,
+        rod_stretch_in=stretch,
+        pump_displacement_bpd=p_d,
+        volumetric_efficiency=efficiency,
+        card=card,
+        warnings=notes,
+        undetermined=undetermined,
+    )

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/card_metrics.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/card_metrics.py
@@ -1,0 +1,160 @@
+# ABOUTME: Surface-card metrics (PPRL, MPRL, area, PRHP) and the load datum sanity check.
+# ABOUTME: A minimum load above the rod string's air weight is flagged, never passed silently.
+"""Metrics read directly off a surface dynamometer card.
+
+Also home to :func:`load_datum_check`, which catches a class of bad data that
+otherwise propagates silently through an entire analysis: a card whose
+minimum polished-rod load exceeds the weight of the rod string hanging in air.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from .constants import FT_LB_PER_MIN_PER_HP
+
+
+@dataclass
+class CardMetrics:
+    """Metrics derived from a closed surface card."""
+
+    peak_load_lb: float               # PPRL
+    peak_load_position_in: float
+    minimum_load_lb: float            # MPRL
+    minimum_load_position_in: float
+    load_range_lb: float
+    stroke_in: float
+    card_area_in_lb: float            # work per stroke
+    card_area_ft_lb: float
+    polished_rod_hp: float
+    warnings: List[str] = field(default_factory=list)
+
+
+def card_area(position_in: Sequence[float], load_lb: Sequence[float]) -> float:
+    """Enclosed area of a closed card by the shoelace formula, inch-pounds.
+
+    This is the net work done at the polished rod per stroke. The absolute
+    value is taken so the result does not depend on traversal direction.
+    """
+    x = np.asarray(position_in, dtype=float)
+    y = np.asarray(load_lb, dtype=float)
+    if len(x) != len(y):
+        raise ValueError(
+            f"position ({len(x)}) and load ({len(y)}) must have equal length"
+        )
+    if len(x) < 3:
+        raise ValueError(f"need at least 3 points to enclose an area; got {len(x)}")
+    # Close the polygon if the caller did not.
+    if x[0] != x[-1] or y[0] != y[-1]:
+        x = np.append(x, x[0])
+        y = np.append(y, y[0])
+    return float(abs(np.sum(x[:-1] * y[1:] - x[1:] * y[:-1])) / 2.0)
+
+
+def polished_rod_horsepower(
+    card_area_in_lb: float, strokes_per_minute: float
+) -> float:
+    """Polished-rod power, horsepower.
+
+    Work per stroke in foot-pounds times strokes per minute, over 33,000.
+    """
+    return (card_area_in_lb / 12.0) * strokes_per_minute / FT_LB_PER_MIN_PER_HP
+
+
+def load_datum_check(
+    minimum_load_lb: float,
+    rod_weight_in_air_lb: float,
+    buoyant_rod_weight_lb: Optional[float] = None,
+) -> List[str]:
+    """Flag a physically impossible minimum polished-rod load.
+
+    On the downstroke the polished rod carries at most the buoyed rod weight,
+    and friction acts *upward* — resisting the descending rod — which lowers
+    the reading further. Friction therefore widens a card; it cannot lift the
+    whole card. So an MPRL above the rod string's weight in air has no
+    mechanical explanation and points at the data or the string record:
+
+    1. A load-cell zero or scale offset (the common case).
+    2. A rod string heavier than recorded — extra taper, sinker bars, or a
+       length that does not match the paperwork.
+
+    Returns a list of warnings, empty when the card is self-consistent.
+    """
+    warnings: List[str] = []
+    if minimum_load_lb > rod_weight_in_air_lb:
+        excess = minimum_load_lb - rod_weight_in_air_lb
+        warnings.append(
+            f"MPRL ({minimum_load_lb:,.0f} lb) exceeds the rod string's weight "
+            f"in air ({rod_weight_in_air_lb:,.0f} lb) by {excess:,.0f} lb. "
+            "Friction cannot produce this — it acts upward on the downstroke "
+            "and lowers polished-rod load. Candidate causes: (1) load-cell "
+            "zero/scale offset; (2) rod string heavier than recorded. Treat "
+            "absolute loads as unreliable until resolved; load *differences* "
+            "remain usable."
+        )
+    elif (
+        buoyant_rod_weight_lb is not None
+        and minimum_load_lb > buoyant_rod_weight_lb
+    ):
+        excess = minimum_load_lb - buoyant_rod_weight_lb
+        warnings.append(
+            f"MPRL ({minimum_load_lb:,.0f} lb) exceeds the buoyed rod weight "
+            f"({buoyant_rod_weight_lb:,.0f} lb) by {excess:,.0f} lb. Possible "
+            "with heavy downhole friction or a partially supported string, "
+            "but worth confirming the load-cell calibration."
+        )
+    return warnings
+
+
+def analyse_card(
+    position_in: Sequence[float],
+    load_lb: Sequence[float],
+    strokes_per_minute: float,
+    rod_weight_in_air_lb: Optional[float] = None,
+    buoyant_rod_weight_lb: Optional[float] = None,
+) -> CardMetrics:
+    """Compute all surface-card metrics and run the datum check.
+
+    Args:
+        position_in: Polished-rod position samples, inches.
+        load_lb: Polished-rod load samples, pounds.
+        strokes_per_minute: Pumping speed.
+        rod_weight_in_air_lb: Enables the load datum check when supplied.
+        buoyant_rod_weight_lb: Enables the softer buoyed-weight check.
+    """
+    x = np.asarray(position_in, dtype=float)
+    y = np.asarray(load_lb, dtype=float)
+    if len(x) != len(y):
+        raise ValueError(
+            f"position ({len(x)}) and load ({len(y)}) must have equal length"
+        )
+    if len(x) == 0:
+        raise ValueError("card is empty")
+
+    peak_idx = int(np.argmax(y))
+    min_idx = int(np.argmin(y))
+    area = card_area(x, y)
+
+    warnings: List[str] = []
+    if rod_weight_in_air_lb is not None:
+        warnings.extend(
+            load_datum_check(
+                float(y[min_idx]), rod_weight_in_air_lb, buoyant_rod_weight_lb
+            )
+        )
+
+    return CardMetrics(
+        peak_load_lb=float(y[peak_idx]),
+        peak_load_position_in=float(x[peak_idx]),
+        minimum_load_lb=float(y[min_idx]),
+        minimum_load_position_in=float(x[min_idx]),
+        load_range_lb=float(y.max() - y.min()),
+        stroke_in=float(x.max() - x.min()),
+        card_area_in_lb=area,
+        card_area_ft_lb=area / 12.0,
+        polished_rod_hp=polished_rod_horsepower(area, strokes_per_minute),
+        warnings=warnings,
+    )

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/constants.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/constants.py
@@ -1,0 +1,68 @@
+# ABOUTME: Physical constants and API sucker-rod properties for RP 11L analysis.
+# ABOUTME: Every value is cited; nothing here is a tuned or fitted number.
+"""Constants for API RP 11L rod-pump analysis.
+
+Sources are named for each value. Where a constant only holds for a particular
+material or geometry, that restriction is stated — the analysis entry point
+fails closed rather than extrapolating past it.
+"""
+
+from typing import Dict, NamedTuple
+
+# Sonic velocity of a stress wave in a steel sucker rod. Fibreglass rods are
+# markedly slower (~4,000 ft/s), so this is a parameter everywhere it is used,
+# never a hard-coded assumption.
+SONIC_VELOCITY_STEEL_FT_S = 16_300.0
+
+# Young's modulus for steel sucker rods, API RP 11L.
+YOUNGS_MODULUS_PSI = 3.1e7
+
+# API RP 11L natural-frequency constant: No = NATURAL_FREQUENCY_CONSTANT / L.
+# Equivalent to 15 * c / L; the two agree to about 0.2% for steel, which
+# `natural_frequency` asserts rather than assumes.
+NATURAL_FREQUENCY_CONSTANT = 245_000.0
+NATURAL_FREQUENCY_SONIC_MULTIPLIER = 15.0
+NATURAL_FREQUENCY_AGREEMENT_TOLERANCE_PCT = 0.5
+
+# Buoyancy coefficient in Wrf = Wr * (1 - BUOYANCY_COEFFICIENT * SG), API RP 11L.
+BUOYANCY_COEFFICIENT = 0.128
+
+# Fluid gradient of fresh water, psi/ft.
+WATER_GRADIENT_PSI_PER_FT = 0.433
+
+# Pump displacement constant: PD [bfpd] = 0.1484 * Ap * Sp * N.
+PUMP_DISPLACEMENT_CONSTANT = 0.1484
+
+# Polished-rod horsepower: work per stroke [ft-lb] * strokes/min / 33,000.
+FT_LB_PER_MIN_PER_HP = 33_000.0
+
+
+class RodProperties(NamedTuple):
+    """Published properties of one API sucker-rod size."""
+
+    diameter_in: float
+    area_sq_in: float
+    weight_lb_per_ft: float  # includes couplings
+
+
+# API sucker-rod sizes. Areas are the published table values; the weights
+# include couplings, which is why they exceed bare steel area * density.
+API_ROD_SIZES: Dict[str, RodProperties] = {
+    "5/8": RodProperties(0.625, 0.307, 1.135),
+    "3/4": RodProperties(0.750, 0.442, 1.634),
+    "7/8": RodProperties(0.875, 0.601, 2.224),
+    "1": RodProperties(1.000, 0.785, 2.904),
+}
+
+# Validity envelope on N/No'. Below the lower bound the surface card is
+# wave-dominated (many undulations) but the kinematics remain valid; above the
+# upper bound resonance invalidates the RP 11L correlations outright.
+ENVELOPE_WAVE_DOMINATED = 0.15
+ENVELOPE_MAX_VALID = 0.35
+
+# Pumping-unit geometries the RP 11L (Class I crank-balanced) correlations
+# cover. Long-stroke and Mark II geometries have different kinematics.
+SUPPORTED_UNIT_GEOMETRIES = frozenset({"conventional", "class_i", "class-i"})
+UNSUPPORTED_UNIT_GEOMETRIES = frozenset(
+    {"mark_ii", "mark-ii", "markii", "rotaflex", "hydraulic", "long_stroke"}
+)

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/kinematics.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/kinematics.py
@@ -1,0 +1,265 @@
+# ABOUTME: Rod-string natural frequency, card undulations, crank motion, peak phase.
+# ABOUTME: Timing read off a position-axis card carries an explicit uncertainty.
+"""Kinematics and free-vibration timing for a rod-pumped well.
+
+Two results here are worth stating plainly because they are routinely
+conflated in the field:
+
+**Peak spacing is not peak phase.** The interval between load peaks on a card
+is ``60/No'`` — a property of the rod string alone. It is the same on the
+upstroke and the downstroke, and the same at every pumping speed. What *does*
+change with speed is the phase: upstroke ringing is triggered at bottom of
+stroke (``t = 0``), downstroke ringing at top of stroke (``t = 30/N``). Overlay
+several speeds on a common time axis and the upstroke peaks align while the
+downstroke peaks do not.
+
+**Peaks look unevenly spaced on a card because the axis is position, not
+time.** Polished-rod velocity goes to zero at both stroke ends, so a fixed
+time interval maps to a shrinking distance near the top. Any time extracted
+from a position-axis card therefore carries an uncertainty that grows as
+velocity falls, and this module returns that uncertainty alongside the value
+rather than a bare float.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, NamedTuple, Tuple
+
+from .constants import (
+    NATURAL_FREQUENCY_AGREEMENT_TOLERANCE_PCT,
+    NATURAL_FREQUENCY_CONSTANT,
+    NATURAL_FREQUENCY_SONIC_MULTIPLIER,
+    SONIC_VELOCITY_STEEL_FT_S,
+)
+
+
+class Measurement(NamedTuple):
+    """A value with its uncertainty, in the same units.
+
+    Returned instead of a bare float wherever the number is derived from a
+    position-axis card, so that a caller cannot accidentally treat a
+    digitised reading as exact.
+    """
+
+    value: float
+    uncertainty: float
+
+    def overlaps(self, other: "Measurement") -> bool:
+        """True if the two are indistinguishable within their uncertainties."""
+        return abs(self.value - other.value) <= (self.uncertainty + other.uncertainty)
+
+    def __str__(self) -> str:
+        return f"{self.value:.3f} +/- {self.uncertainty:.3f}"
+
+
+def natural_frequency(
+    rod_length_ft: float,
+    sonic_velocity_ft_s: float = SONIC_VELOCITY_STEEL_FT_S,
+    check_agreement: bool = True,
+) -> float:
+    """Undamped natural frequency of the rod string, strokes per minute.
+
+    API RP 11L gives ``No = 245,000 / L``. That constant is ``15 * c`` for
+    steel, so the same number follows from the wave speed directly. The two
+    routes are cross-checked, which catches a non-steel sonic velocity being
+    passed while the RP 11L constant is still in play.
+
+    Args:
+        rod_length_ft: Total rod string length, feet.
+        sonic_velocity_ft_s: Stress-wave speed. Steel by default; fibreglass
+            is far slower and will trip the agreement check.
+        check_agreement: Cross-check the two formulations.
+
+    Raises:
+        ValueError: If the length is not positive, or if the two routes
+            disagree by more than the tolerance.
+    """
+    if rod_length_ft <= 0:
+        raise ValueError(f"rod length must be positive; got {rod_length_ft}")
+
+    from_constant = NATURAL_FREQUENCY_CONSTANT / rod_length_ft
+    from_sonic = NATURAL_FREQUENCY_SONIC_MULTIPLIER * sonic_velocity_ft_s / rod_length_ft
+
+    if check_agreement:
+        disagreement = 100.0 * abs(from_constant - from_sonic) / from_constant
+        if disagreement > NATURAL_FREQUENCY_AGREEMENT_TOLERANCE_PCT:
+            raise ValueError(
+                f"API RP 11L constant (No = {from_constant:.2f} SPM) and the "
+                f"sonic-velocity form (15c/L = {from_sonic:.2f} SPM) disagree "
+                f"by {disagreement:.2f}%, above the "
+                f"{NATURAL_FREQUENCY_AGREEMENT_TOLERANCE_PCT}% tolerance. The "
+                f"245,000 constant assumes steel; sonic velocity "
+                f"{sonic_velocity_ft_s} ft/s is not steel."
+            )
+    return from_constant
+
+
+def taper_adjusted_natural_frequency(
+    natural_frequency_spm: float, taper_factor: float = 1.0
+) -> float:
+    """``No' = Fc * No``. ``Fc`` is 1.000 for a single-diameter string."""
+    if taper_factor <= 0:
+        raise ValueError(f"taper factor must be positive; got {taper_factor}")
+    return taper_factor * natural_frequency_spm
+
+
+def peak_interval(taper_adjusted_frequency_spm: float) -> float:
+    """Time between successive load peaks, ``dt = 60/No'``, seconds.
+
+    Independent of pumping speed — this is the string ringing at its own
+    frequency, not responding to the crank.
+    """
+    return 60.0 / taper_adjusted_frequency_spm
+
+
+def undulations_per_half_stroke(
+    strokes_per_minute: float, taper_adjusted_frequency_spm: float
+) -> float:
+    """Number of load undulations visible per half stroke, ``0.5 / (N/No')``.
+
+    Rises as the unit is slowed: a slower stroke gives the string more time to
+    ring. Only at 1-2 SPM does a surface card start to look rectangular.
+    """
+    if strokes_per_minute <= 0:
+        raise ValueError(f"SPM must be positive; got {strokes_per_minute}")
+    return 0.5 / (strokes_per_minute / taper_adjusted_frequency_spm)
+
+
+def angular_velocity(strokes_per_minute: float) -> float:
+    """Crank angular velocity, radians per second."""
+    return 2.0 * math.pi * strokes_per_minute / 60.0
+
+
+def crank_position(time_s: float, stroke_in: float, strokes_per_minute: float) -> float:
+    """Polished-rod position, ``x = (S/2)(1 - cos wt)``, inches from bottom."""
+    omega = angular_velocity(strokes_per_minute)
+    return (stroke_in / 2.0) * (1.0 - math.cos(omega * time_s))
+
+
+def crank_velocity(time_s: float, stroke_in: float, strokes_per_minute: float) -> float:
+    """Polished-rod velocity, ``v = (S/2) w sin(wt)``, inches per second."""
+    omega = angular_velocity(strokes_per_minute)
+    return (stroke_in / 2.0) * omega * math.sin(omega * time_s)
+
+
+def time_at_position(
+    position_in: float, stroke_in: float, strokes_per_minute: float
+) -> float:
+    """Invert the crank relation for the first half cycle, seconds.
+
+    Raises:
+        ValueError: If the position lies outside the stroke.
+    """
+    if not 0.0 <= position_in <= stroke_in:
+        raise ValueError(
+            f"position {position_in} in lies outside the 0-{stroke_in} in stroke"
+        )
+    omega = angular_velocity(strokes_per_minute)
+    return math.acos(1.0 - 2.0 * position_in / stroke_in) / omega
+
+
+def time_from_card_position(
+    position_in: float,
+    stroke_in: float,
+    strokes_per_minute: float,
+    position_uncertainty_in: float = 1.5,
+) -> Measurement:
+    """Convert a card position to a time, carrying the propagated uncertainty.
+
+    ``dt = dx / v``, and velocity vanishes at both stroke ends, so the same
+    digitising error buys far more time error near the top of the stroke than
+    at mid-stroke. This is why peak-to-peak intervals read off a position-axis
+    card can appear unequal when the underlying physics says they are not.
+
+    Args:
+        position_uncertainty_in: Digitising error on the position axis.
+    """
+    time_s = time_at_position(position_in, stroke_in, strokes_per_minute)
+    velocity = abs(crank_velocity(time_s, stroke_in, strokes_per_minute))
+    if velocity <= 0:
+        return Measurement(time_s, math.inf)
+    return Measurement(time_s, position_uncertainty_in / velocity)
+
+
+def intervals_are_distinguishable(times: List[Measurement]) -> bool:
+    """True only if every consecutive interval is resolvable given the errors.
+
+    Guards the reporting path: consecutive peak-to-peak intervals must not be
+    presented as a finding when their uncertainties overlap. On a card
+    digitised to +/-1.5 in this is usually False, and the honest statement is
+    the mean interval rather than the individual ones.
+    """
+    if len(times) < 3:
+        return False
+    intervals = [
+        Measurement(
+            times[i + 1].value - times[i].value,
+            times[i + 1].uncertainty + times[i].uncertainty,
+        )
+        for i in range(len(times) - 1)
+    ]
+    return not any(
+        a.overlaps(b) for a, b in zip(intervals, intervals[1:])
+    )
+
+
+@dataclass
+class PeakTrains:
+    """Predicted load-peak times for one stroke, seconds from bottom of stroke."""
+
+    upstroke: List[float]
+    downstroke: List[float]
+    interval_s: float
+    top_of_stroke_s: float
+
+
+def peak_times(
+    strokes_per_minute: float,
+    taper_adjusted_frequency_spm: float,
+    max_time_s: float = None,
+) -> PeakTrains:
+    """Predicted upstroke and downstroke peak trains with correct phase.
+
+    Both trains share the interval ``60/No'``. They differ in phase reference:
+    the upstroke train is triggered at bottom of stroke (``t = 0``), the
+    downstroke train at top of stroke (``t = 30/N``). Consequently, across
+    different pumping speeds the upstroke peaks coincide while the downstroke
+    peaks separate — the top of stroke moves.
+
+    Args:
+        max_time_s: Horizon to generate to. Defaults to one full cycle.
+    """
+    interval = peak_interval(taper_adjusted_frequency_spm)
+    top_of_stroke = 30.0 / strokes_per_minute
+    horizon = max_time_s if max_time_s is not None else 60.0 / strokes_per_minute
+
+    upstroke, k = [], 1
+    while k * interval <= horizon:
+        upstroke.append(k * interval)
+        k += 1
+
+    downstroke, k = [], 1
+    while top_of_stroke + k * interval <= horizon:
+        downstroke.append(top_of_stroke + k * interval)
+        k += 1
+
+    return PeakTrains(
+        upstroke=upstroke,
+        downstroke=downstroke,
+        interval_s=interval,
+        top_of_stroke_s=top_of_stroke,
+    )
+
+
+def divergence_onset(strokes_per_minute_values: List[float]) -> float:
+    """Time at which overlaid traces at different speeds begin to disagree.
+
+    Upstroke ringing is common to every speed, so traces track each other
+    until the first of them turns around. That is the earliest top of stroke,
+    ``min(30/N)`` — which is set by the *fastest* unit.
+    """
+    if not strokes_per_minute_values:
+        raise ValueError("need at least one pumping speed")
+    return min(30.0 / spm for spm in strokes_per_minute_values)

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/rod_string.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump/rod_string.py
@@ -1,0 +1,248 @@
+# ABOUTME: Rod-string elastic properties, loads, and the RP 11L dimensionless groups.
+# ABOUTME: Plunger stroke is derived from rod stretch -- never assumed equal to surface stroke.
+"""Rod-string mechanics for API RP 11L analysis.
+
+The RP 11L correlations are driven by three dimensionless groups — ``Fo/Skr``,
+``N/No'`` and ``Wrf/Skr`` — and everything in this module exists to compute
+them from field-measurable inputs.
+
+The one trap worth naming: **pump displacement uses plunger stroke, not
+surface stroke.** Rod stretch under fluid load shortens the plunger's travel,
+by 7.7 in on a 4,200 ft 3/4 in string carrying 2,100 lb of fluid load. Using
+the surface stroke overstates displacement and therefore understates
+volumetric efficiency.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+from .constants import (
+    API_ROD_SIZES,
+    BUOYANCY_COEFFICIENT,
+    PUMP_DISPLACEMENT_CONSTANT,
+    WATER_GRADIENT_PSI_PER_FT,
+    YOUNGS_MODULUS_PSI,
+)
+
+
+def rod_area(diameter_in: float) -> float:
+    """Cross-sectional area of a rod, square inches."""
+    if diameter_in <= 0:
+        raise ValueError(f"rod diameter must be positive; got {diameter_in}")
+    return math.pi / 4.0 * diameter_in ** 2
+
+
+def rod_elastic_constant(
+    diameter_in: float, modulus_psi: float = YOUNGS_MODULUS_PSI
+) -> float:
+    """Elastic constant ``Er = 12 / (Ar * E)``, in inches per pound per foot.
+
+    The factor 12 converts the per-foot length basis to inches.
+    """
+    return 12.0 / (rod_area(diameter_in) * modulus_psi)
+
+
+def spring_rate(
+    diameter_in: float,
+    length_ft: float,
+    modulus_psi: float = YOUNGS_MODULUS_PSI,
+) -> float:
+    """Rod-string spring rate ``Kr = 1 / (Er * L)``, pounds per inch."""
+    if length_ft <= 0:
+        raise ValueError(f"rod length must be positive; got {length_ft}")
+    return 1.0 / (rod_elastic_constant(diameter_in, modulus_psi) * length_ft)
+
+
+def fluid_load(
+    plunger_diameter_in: float,
+    fluid_level_ft: float,
+    specific_gravity: float,
+    tubing_pressure_psi: float = 0.0,
+    casing_pressure_psi: float = 0.0,
+) -> float:
+    """Fluid load on the plunger, pounds.
+
+    ``Fo = 0.433 * SG * D * Ap + (Ptbg - Pcsg) * Ap``
+
+    The hydrostatic term dominates; the wellhead differential is usually a
+    small fraction of it, so a modest surface pressure swing is not evidence
+    of weak pump action.
+
+    Args:
+        plunger_diameter_in: Plunger bore, inches.
+        fluid_level_ft: Height of the fluid column above the pump, feet.
+        specific_gravity: Produced-fluid specific gravity.
+        tubing_pressure_psi: Wellhead tubing pressure.
+        casing_pressure_psi: Casing pressure.
+    """
+    area = rod_area(plunger_diameter_in)
+    hydrostatic = (
+        WATER_GRADIENT_PSI_PER_FT * specific_gravity * fluid_level_ft * area
+    )
+    differential = (tubing_pressure_psi - casing_pressure_psi) * area
+    return hydrostatic + differential
+
+
+def buoyant_rod_weight(weight_in_air_lb: float, specific_gravity: float) -> float:
+    """Buoyed rod weight ``Wrf = Wr * (1 - 0.128 * SG)``, pounds."""
+    return weight_in_air_lb * (1.0 - BUOYANCY_COEFFICIENT * specific_gravity)
+
+
+def plunger_stroke(
+    surface_stroke_in: float,
+    fluid_load_lb: float,
+    spring_rate_lb_per_in: float,
+    overtravel_in: float = 0.0,
+) -> float:
+    """Plunger stroke ``Sp = S - Fo/Kr + overtravel``, inches.
+
+    ``Fo/Kr`` is the rod stretch under fluid load. Overtravel is a dynamic
+    effect that partly offsets it and depends on pumping speed; it defaults to
+    zero, which yields the conservative (shortest) plunger stroke.
+
+    Raises:
+        ValueError: If stretch exceeds the surface stroke, which means the
+            plunger never moves and the inputs are inconsistent.
+    """
+    stretch = fluid_load_lb / spring_rate_lb_per_in
+    stroke = surface_stroke_in - stretch + overtravel_in
+    if stroke <= 0:
+        raise ValueError(
+            f"computed plunger stroke {stroke:.2f} in is not positive: rod "
+            f"stretch ({stretch:.2f} in) exceeds the surface stroke "
+            f"({surface_stroke_in:.2f} in). Check fluid load and rod string."
+        )
+    return stroke
+
+
+def pump_displacement(
+    plunger_diameter_in: float,
+    plunger_stroke_in: float,
+    strokes_per_minute: float,
+) -> float:
+    """Theoretical pump displacement, barrels of fluid per day.
+
+    ``PD = 0.1484 * Ap * Sp * N``. Note the stroke argument is the **plunger**
+    stroke; passing the surface stroke overstates displacement.
+    """
+    return (
+        PUMP_DISPLACEMENT_CONSTANT
+        * rod_area(plunger_diameter_in)
+        * plunger_stroke_in
+        * strokes_per_minute
+    )
+
+
+def volumetric_efficiency(
+    measured_rate_bpd: float,
+    pump_displacement_bpd: float,
+    runtime_hours_per_day: Optional[float] = None,
+    formation_volume_factor: Optional[float] = None,
+) -> Optional[float]:
+    """Volumetric efficiency as a fraction, or ``None`` when undetermined.
+
+    Efficiency cannot be stated without knowing how long the unit actually ran
+    and what the produced volume was at reservoir conditions. A unit cycling
+    on a pump-off controller has a duty cycle that masquerades as low fillage,
+    and surface barrels are not reservoir barrels. Rather than silently assume
+    24 h and ``Bo = 1.0``, this returns ``None`` when either is unknown, so the
+    caller must either supply them or report the gap.
+
+    Args:
+        measured_rate_bpd: Measured surface production over the test period.
+        pump_displacement_bpd: Theoretical displacement at 100% fillage.
+        runtime_hours_per_day: Hours the unit actually pumped.
+        formation_volume_factor: ``Bo``, reservoir bbl per surface bbl.
+
+    Returns:
+        Efficiency as a fraction, or ``None`` if runtime or ``Bo`` is unknown.
+    """
+    if runtime_hours_per_day is None or formation_volume_factor is None:
+        return None
+    if pump_displacement_bpd <= 0 or runtime_hours_per_day <= 0:
+        return None
+    effective_displacement = pump_displacement_bpd * (runtime_hours_per_day / 24.0)
+    return (measured_rate_bpd * formation_volume_factor) / effective_displacement
+
+
+@dataclass
+class RodStringAnalysis:
+    """Elastic and load properties of a single-diameter rod string."""
+
+    diameter_in: float
+    length_ft: float
+    weight_in_air_lb: float
+    elastic_constant: float          # in/lb/ft
+    spring_rate_lb_per_in: float     # Kr
+    stroke_spring_product_lb: float  # Skr = S * Kr
+    buoyant_weight_lb: float         # Wrf
+    fluid_load_lb: float             # Fo
+    fo_over_skr: float
+    wrf_over_skr: float
+
+
+def analyse_rod_string(
+    diameter_in: float,
+    length_ft: float,
+    surface_stroke_in: float,
+    plunger_diameter_in: float,
+    fluid_level_ft: float,
+    specific_gravity: float,
+    tubing_pressure_psi: float = 0.0,
+    casing_pressure_psi: float = 0.0,
+    weight_lb_per_ft: Optional[float] = None,
+    modulus_psi: float = YOUNGS_MODULUS_PSI,
+) -> RodStringAnalysis:
+    """Compute the elastic properties and RP 11L load groups for a string.
+
+    Args:
+        weight_lb_per_ft: Rod weight including couplings. Looked up from the
+            API table when omitted; required for non-standard sizes.
+
+    Raises:
+        ValueError: If the weight is neither supplied nor a standard API size.
+    """
+    if weight_lb_per_ft is None:
+        match = next(
+            (
+                props.weight_lb_per_ft
+                for props in API_ROD_SIZES.values()
+                if math.isclose(props.diameter_in, diameter_in, rel_tol=1e-6)
+            ),
+            None,
+        )
+        if match is None:
+            raise ValueError(
+                f"rod diameter {diameter_in} in is not a standard API size "
+                f"({sorted(p.diameter_in for p in API_ROD_SIZES.values())}); "
+                "supply weight_lb_per_ft explicitly"
+            )
+        weight_lb_per_ft = match
+
+    elastic = rod_elastic_constant(diameter_in, modulus_psi)
+    k_r = spring_rate(diameter_in, length_ft, modulus_psi)
+    s_kr = surface_stroke_in * k_r
+    weight_air = weight_lb_per_ft * length_ft
+    w_rf = buoyant_rod_weight(weight_air, specific_gravity)
+    f_o = fluid_load(
+        plunger_diameter_in,
+        fluid_level_ft,
+        specific_gravity,
+        tubing_pressure_psi,
+        casing_pressure_psi,
+    )
+    return RodStringAnalysis(
+        diameter_in=diameter_in,
+        length_ft=length_ft,
+        weight_in_air_lb=weight_air,
+        elastic_constant=elastic,
+        spring_rate_lb_per_in=k_r,
+        stroke_spring_product_lb=s_kr,
+        buoyant_weight_lb=w_rf,
+        fluid_load_lb=f_o,
+        fo_over_skr=f_o / s_kr,
+        wrf_over_skr=w_rf / s_kr,
+    )

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/solver.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/solver.py
@@ -20,24 +20,46 @@ class DynacardWorkflow:
     """
     Main orchestrator for Dynacard Analysis in digitalmodel.
 
-    Supports two physics solvers:
-        - 'gibbs': Frequency-domain Gibbs analytical method (faster, default)
-        - 'finite_difference': Time-domain finite difference (more detailed)
+    Supports three physics solvers:
+        - 'everitt_jennings': Space-marching finite difference (SPE 18189).
+          The default. Rebuilds downhole load from the strain field and
+          handles deviated wells.
+        - 'gibbs': Frequency-domain analytical method. Retained for
+          comparison only.
+        - 'finite_difference': Time-domain finite difference. Numerically
+          unstable — see below.
+
+    Measured against the stored reference downhole cards on all five fixture
+    wells (phase-aligned, since a card is a closed loop):
+
+        method              med nRMSE   med |stroke err|   med corr
+        everitt_jennings         0.9%              0.0%      1.000
+        gibbs                   17.3%              2.7%      0.966
+        finite_difference     diverges           diverges     0.022
+
+    'gibbs' does not transform the load at all — it returns an affine rescale
+    of the surface card (issue #1857) — so it cannot resolve pump condition.
+    'finite_difference' overflows to ~1e45 and beyond on three of five wells.
+    Neither should be used for diagnosis.
     """
 
     def __init__(
         self,
         context: DynacardAnalysisContext = None,
-        solver_method: Literal['gibbs', 'finite_difference'] = 'gibbs'
+        solver_method: Literal[
+            'everitt_jennings', 'gibbs', 'finite_difference'
+        ] = 'everitt_jennings'
     ):
         """Initialize the dynacard analyzer.
 
         Args:
             context: Complete well analysis context. Can be set later
                 before calling analysis methods.
-            solver_method: Physics solver to use — ``'gibbs'`` for
-                frequency-domain or ``'finite_difference'`` for
-                time-domain.
+            solver_method: Physics solver to use. Defaults to
+                ``'everitt_jennings'``, the only one that reproduces the
+                reference downhole cards. ``'gibbs'`` and
+                ``'finite_difference'`` are retained for comparison and
+                should not be used for diagnosis — see the class docstring.
         """
         self.ctx = context
         self.solver_method = solver_method
@@ -52,6 +74,11 @@ class DynacardWorkflow:
         """Initialize the appropriate physics solver."""
         if self.solver_method == 'finite_difference':
             self.solver = FiniteDifferenceSolver(self.ctx)
+        elif self.solver_method == 'everitt_jennings':
+            # Imported here to keep the scipy/numba-backed solver off the
+            # import path of callers that never select it.
+            from .everitt_jennings.adapter import EverittJenningsContextSolver
+            self.solver = EverittJenningsContextSolver(self.ctx)
         else:
             self.solver = DynacardPhysicsSolver(self.ctx)
 
@@ -180,7 +207,7 @@ class DynacardWorkflow:
             4. Diagnostics: AI-driven troubleshooting
         """
         # 1. Physics: Surface to Downhole conversion
-        if self.solver_method == 'finite_difference':
+        if self.solver_method in ('finite_difference', 'everitt_jennings'):
             results = self.solver.solve()
         else:
             results = self.solver.solve_wave_equation()

--- a/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
@@ -1,0 +1,218 @@
+# ABOUTME: Parity and regression tests for the Everitt-Jennings downhole card solver.
+# ABOUTME: Expected values come from the reference implementation, stored in the fixture.
+"""Tests for :mod:`...dynacard.everitt_jennings`.
+
+The `7699227` fixture is a real (anonymized) deviated well carrying the
+reference implementation's own expected downhole-card extremes under
+``Performance.Calculated_DownholeCard_*``. Those four numbers are the parity
+target; the remaining tests guard the defect that motivated this solver.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
+    EverittJenningsSolver,
+    RodString,
+    Survey,
+    estimate_damping_coeff,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
+    units as U,
+)
+
+FIXTURE = Path(__file__).parent / "testdata" / "7699227.json"
+
+# The fixture leaves viscosity null, so damping is estimated from a default.
+# Parity holds to ~2.5%; see the viscosity sweep noted on the tracking issue —
+# the residual is insensitive to viscosity, so it is implementation error
+# rather than an untuned input.
+PARITY_TOLERANCE_PCT = 3.0
+TUBING_ID_IN = 2.441
+
+
+@pytest.fixture(scope="module")
+def well():
+    """Load the reference well: rod taper, survey, surface card, expectations."""
+    data = json.loads(FIXTURE.read_text())
+    equipment, card, params = (
+        data["equipmentData"],
+        data["cardData"],
+        data["InputParameters"],
+    )
+
+    rods_raw = equipment["Rods"]
+    diameters_m = np.array([r["Diameter"] for r in rods_raw]) * U.IN2M
+    lengths_m = np.array([r["TotalLength"] for r in rods_raw]) * U.FT2M
+    couplings_m = np.array([r["CouplingOD"] for r in rods_raw]) * U.IN2M
+    moduli = np.array([r["ModulusOfElasticity"] for r in rods_raw]) * U.PSI2PA
+
+    # Published rod weight per foot already includes couplings, so derive an
+    # effective density that reproduces the true mass per unit length.
+    areas = np.pi * (diameters_m / 2.0) ** 2
+    mass_per_m = np.array([r["Weight"] for r in rods_raw]) * U.LB2KG / U.FT2M
+
+    rods = RodString(
+        diameters=diameters_m,
+        lengths=lengths_m,
+        densities=mass_per_m / areas,
+        moduli=moduli,
+        coupling_diameters=couplings_m,
+    )
+
+    survey_raw = data["surveyData"]
+    survey = Survey(
+        measured_depth=np.array([s["MD"] for s in survey_raw]) * U.FT2M,
+        inclination=np.array([s["Inclination"] for s in survey_raw]) * U.DEG2RAD,
+        azimuth=np.array([s["Azimuth"] for s in survey_raw]) * U.DEG2RAD,
+    )
+
+    return {
+        "rods": rods,
+        "survey": survey,
+        "position": np.array(card["Position"], dtype=float) * U.IN2M,
+        "load": np.array(card["Load"], dtype=float) * U.LB2N,
+        "spm": params["StrokesPerMinute"],
+        "pump_diameter": equipment["Pump"]["Diameter"] * U.IN2M,
+        "fluid_density": params["FluidDensity"],  # already kg/m^3
+        "casing_id": params["CasingID"] * U.IN2M,
+        "expected": {
+            key.replace("Calculated_DownholeCard_", ""): value
+            for key, value in data["Performance"].items()
+            if key.startswith("Calculated_DownholeCard_")
+        },
+    }
+
+
+def solve(well, n_nodes=200, viscosity=0.01, tubing_id_in=TUBING_ID_IN):
+    """Run the solver against the fixture well."""
+    return EverittJenningsSolver(n_nodes=n_nodes, viscosity=viscosity).solve(
+        position=well["position"],
+        load=well["load"],
+        rods=well["rods"],
+        strokes_per_minute=well["spm"],
+        pump_diameter=well["pump_diameter"],
+        tubing_id=tubing_id_in * U.IN2M,
+        fluid_density=well["fluid_density"],
+        survey=well["survey"],
+    )
+
+
+@pytest.mark.parametrize(
+    "quantity,accessor",
+    [
+        ("Position_min", lambda c: float(c.position.min())),
+        ("Position_max", lambda c: float(c.position.max())),
+        ("Load_min", lambda c: float(c.load.min())),
+        ("Load_max", lambda c: float(c.load.max())),
+    ],
+)
+def test_parity_with_reference(well, quantity, accessor):
+    """Each downhole-card extreme matches the reference implementation."""
+    card = solve(well)
+    expected = well["expected"][quantity]
+    actual = accessor(card)
+    error_pct = 100.0 * abs(actual - expected) / abs(expected)
+    assert error_pct < PARITY_TOLERANCE_PCT, (
+        f"{quantity}: expected {expected:.4f}, got {actual:.4f} "
+        f"({error_pct:.2f}% > {PARITY_TOLERANCE_PCT}% tolerance)"
+    )
+
+
+def test_downhole_stroke_is_shorter_than_surface(well):
+    """Rod stretch means plunger travel is always less than surface stroke."""
+    card = solve(well)
+    surface_stroke = float(well["position"].max() - well["position"].min())
+    assert card.stroke < surface_stroke, (
+        f"downhole stroke {card.stroke:.4f} m must be below the surface "
+        f"stroke {surface_stroke:.4f} m"
+    )
+
+
+def test_stroke_ratio_matches_reference(well):
+    """The stroke reduction ratio is the sharpest single parity check."""
+    card = solve(well)
+    surface_stroke = float(well["position"].max() - well["position"].min())
+    expected_ratio = (
+        well["expected"]["Position_max"] - well["expected"]["Position_min"]
+    ) / surface_stroke
+    assert card.stroke / surface_stroke == pytest.approx(expected_ratio, rel=0.01)
+
+
+def test_solution_is_node_converged(well):
+    """Doubling the spatial resolution must not move the answer materially."""
+    coarse = solve(well, n_nodes=100)
+    fine = solve(well, n_nodes=400)
+    assert fine.stroke == pytest.approx(coarse.stroke, rel=0.01)
+
+
+def test_downhole_load_is_not_an_affine_rescale_of_surface(well):
+    """Regression for #1857.
+
+    The defect this solver replaces produced a downhole load that was exactly
+    ``0.88 * surface - constant`` — correlation 1.0 to floating-point
+    precision. An affine map preserves every rod-vibration harmonic, so such a
+    card cannot diagnose anything. The load must be rebuilt from strain.
+    """
+    card = solve(well)
+    # The surface card and downhole card share a sample count, so they can be
+    # compared point-for-point.
+    surface_load = well["load"]
+    assert len(card.load) == len(surface_load)
+
+    correlation = abs(np.corrcoef(surface_load, card.load)[0, 1])
+    assert correlation < 0.99, (
+        f"downhole load correlates with surface load at r={correlation:.6f}; "
+        "the load is not being transformed"
+    )
+
+    slope, intercept = np.polyfit(surface_load, card.load, 1)
+    residual = float(np.max(np.abs(card.load - (slope * surface_load + intercept))))
+    assert residual > 1.0, (
+        f"downhole load is an affine rescale of the surface load "
+        f"(max residual {residual:.3e} N)"
+    )
+
+
+def test_damping_varies_with_stroke_direction(well):
+    """Upstroke and downstroke damping must differ, or the card has no area."""
+    up, down = estimate_damping_coeff(
+        od_rod=0.875 * U.IN2M,
+        od_connect=1.875 * U.IN2M,
+        od_pump=1.75 * U.IN2M,
+        id_well=TUBING_ID_IN * U.IN2M,
+        mu=0.01,
+        l_tap=290.0,
+        ro_rod=7850.0,
+    )
+    assert up != down
+    assert np.isfinite(up) and np.isfinite(down)
+
+
+def test_damping_refuses_input_below_correlation_validity_floor(well):
+    """A casing ID where a tubing ID belongs must raise, not return NaN.
+
+    The coupling-drag correlation raises a difference to a fractional power;
+    below the validity floor the base goes negative and the entire card
+    silently becomes NaN.
+    """
+    with pytest.raises(ValueError, match="validity floor"):
+        solve(well, tubing_id_in=well["casing_id"] / U.IN2M)
+
+
+def test_rod_string_requires_at_least_one_section():
+    """The rod taper is the one input that cannot be defaulted."""
+    with pytest.raises(ValueError, match="at least one section"):
+        RodString(diameters=np.array([]), lengths=np.array([]))
+
+
+def test_rod_string_rejects_mismatched_section_arrays():
+    """Diameters and lengths describe the same sections and must agree."""
+    with pytest.raises(ValueError, match="same number of sections"):
+        RodString(
+            diameters=np.array([0.0222, 0.0190]),
+            lengths=np.array([290.0]),
+        )

--- a/tests/marine_ops/artificial_lift/dynacard/test_report_sections.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_report_sections.py
@@ -105,7 +105,20 @@ def test_router_reuses_one_diagnostic_classification(monkeypatch):
         "report": {"html": False},
     }
 
-    result = DynacardWorkflow().router(cfg)
+    # Pinned to 'gibbs' deliberately. The synthetic card generators produce
+    # DOWNHOLE-shaped cards (they are named for pump conditions), and
+    # _apply_synthetic_card feeds them in as the *surface* card. The gibbs
+    # solver is an affine rescale (#1857), so the generated shape survives to
+    # the classifier intact and the label round-trips. A solver that genuinely
+    # transforms the card -- the everitt_jennings default -- correctly turns
+    # that synthetic downhole card into something else, and the label no
+    # longer round-trips.
+    #
+    # This test is about the router calling classification exactly once, not
+    # about solver physics, so it pins the passthrough to keep the label
+    # assertions meaningful. The underlying synthetic-card harness feeding a
+    # downhole shape in as a surface card is tracked separately.
+    result = DynacardWorkflow(solver_method="gibbs").router(cfg)
 
     assert calls == 1
     assert result["results"]["diagnostic_message"].startswith(

--- a/tests/marine_ops/artificial_lift/dynacard/test_rod_pump.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_rod_pump.py
@@ -1,0 +1,351 @@
+# ABOUTME: Regression tests for the API RP 11L rod-pump module.
+# ABOUTME: Two field fixtures -- Reed Goodman's well and the Rowlan validation case.
+"""Tests for :mod:`...dynacard.rod_pump`.
+
+Fixture 1 is the driving case from the Collide "Dynamometer Discussions"
+thread (July 2026): a 4,200 ft single-diameter string that shows four clear
+load undulations per upstroke.
+
+Fixture 2 is O. Lynn Rowlan (Echometer), "Over Travel Occurs on Both the
+Upstroke and Down Stroke", Sucker Rod Pumping Workshop / SWPSC, slide 13 —
+one well and one rod string at three pumping speeds, which isolates what does
+and does not change with speed.
+https://www.swpshortcourse.org/conference/2017/abstract/17-over-travel-can-occur-both-upstroke-and-down-stroke
+"""
+
+import csv
+import math
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.rod_pump import (
+    ValidityError,
+    analyse,
+    analyse_card,
+    divergence_onset,
+    intervals_are_distinguishable,
+    load_datum_check,
+    natural_frequency,
+    peak_interval,
+    peak_times,
+    time_from_card_position,
+    undulations_per_half_stroke,
+    volumetric_efficiency,
+)
+
+CARD_CSV = (
+    Path(__file__).resolve().parents[4]
+    / "docs" / "collide_pe" / "dynacard-undulations" / "dynacard_digitized.csv"
+)
+
+# ---------------------------------------------------------------------------
+# Fixture 1 -- Reed Goodman's well
+# ---------------------------------------------------------------------------
+REED = dict(
+    rod_diameter_in=0.75,
+    rod_length_ft=4200.0,
+    surface_stroke_in=41.0,
+    strokes_per_minute=6.4,
+    plunger_diameter_in=1.25,
+    fluid_level_ft=4300.0,
+    specific_gravity=0.85,
+    tubing_pressure_psi=150.0,
+    casing_pressure_psi=25.0,
+)
+
+
+@pytest.fixture(scope="module")
+def reed():
+    return analyse(**REED)
+
+
+def test_reed_natural_frequency(reed):
+    """No = 245,000/4200 = 58.3 SPM, and dt = 60/No = 1.03 s."""
+    assert reed.natural_frequency_spm == pytest.approx(58.33, abs=0.05)
+    assert reed.peak_interval_s == pytest.approx(1.03, abs=0.01)
+
+
+def test_reed_single_diameter_string_has_unit_taper_factor(reed):
+    """Fc = 1.000 for a single-diameter string, so No' == No."""
+    assert reed.taper_adjusted_frequency_spm == pytest.approx(
+        reed.natural_frequency_spm
+    )
+
+
+def test_reed_speed_ratio_and_undulations(reed):
+    """N/No' = 0.110 gives 4.56 undulations -- 4 clear humps were observed."""
+    assert reed.speed_ratio == pytest.approx(0.110, abs=0.001)
+    assert reed.undulations_per_half_stroke == pytest.approx(4.56, abs=0.02)
+    # The observation is 4 clear humps plus a partial one near the top.
+    assert 4 <= reed.undulations_per_half_stroke < 5
+
+
+def test_reed_rod_string_elastic_properties(reed):
+    """Er, Kr, Skr and Wr against the hand-computed values."""
+    string = reed.rod_string
+    assert string.elastic_constant == pytest.approx(8.762e-7, rel=1e-3)
+    assert string.spring_rate_lb_per_in == pytest.approx(271.7, abs=0.5)
+    assert string.stroke_spring_product_lb == pytest.approx(11_141, abs=10)
+    assert string.weight_in_air_lb == pytest.approx(6_863, abs=5)
+
+
+def test_reed_fluid_load_and_dimensionless_group(reed):
+    """Fo = 2,096 lb at SG 0.85, giving Fo/Skr = 0.188."""
+    assert reed.rod_string.fluid_load_lb == pytest.approx(2_096, abs=5)
+    assert reed.rod_string.fo_over_skr == pytest.approx(0.188, abs=0.002)
+
+
+def test_reed_plunger_stroke_is_shorter_than_surface_stroke(reed):
+    """Rod stretch of 7.7 in shortens the 41 in surface stroke to ~33.3 in."""
+    assert reed.rod_stretch_in == pytest.approx(7.7, abs=0.1)
+    assert reed.plunger_stroke_in == pytest.approx(33.3, abs=0.1)
+    assert reed.plunger_stroke_in < REED["surface_stroke_in"]
+
+
+def test_reed_pump_displacement_uses_plunger_stroke(reed):
+    """PD = 38.8 bfpd on plunger stroke, not the ~48 bfpd surface-stroke figure."""
+    assert reed.pump_displacement_bpd == pytest.approx(38.8, abs=0.3)
+    # Guard the specific error this module exists to prevent.
+    surface_stroke_pd = 0.1484 * (math.pi / 4 * 1.25 ** 2) * 41.0 * 6.4
+    assert surface_stroke_pd == pytest.approx(47.8, abs=0.3)
+    assert reed.pump_displacement_bpd < surface_stroke_pd
+
+
+def test_reed_overtravel_widens_the_displacement_range():
+    """Overtravel of 2 in lifts plunger stroke to 35.3 in and PD to 41.1 bfpd."""
+    result = analyse(**REED, overtravel_in=2.0)
+    assert result.plunger_stroke_in == pytest.approx(35.3, abs=0.1)
+    assert result.pump_displacement_bpd == pytest.approx(41.1, abs=0.3)
+
+
+def test_reed_efficiency_is_undetermined_without_runtime_and_bo(reed_=None):
+    """Efficiency must not be reported when runtime or Bo is unknown."""
+    result = analyse(**REED, measured_rate_bpd=23.0)
+    assert result.volumetric_efficiency is None
+    assert any("volumetric efficiency" in note for note in result.undetermined)
+
+
+def test_reed_efficiency_computed_when_runtime_and_bo_supplied():
+    """With both supplied, efficiency is reported."""
+    result = analyse(
+        **REED,
+        measured_rate_bpd=23.0,
+        runtime_hours_per_day=24.0,
+        formation_volume_factor=1.0,
+    )
+    assert result.volumetric_efficiency == pytest.approx(23.0 / 38.8, rel=0.02)
+
+
+def test_reed_wave_dominated_regime_is_flagged_not_faulted(reed):
+    """N/No' below 0.15 is expected behaviour, and must be surfaced as such."""
+    assert reed.speed_ratio < 0.15
+    assert any("wave-dominated" in note for note in reed.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Fixture 1 -- the load datum anomaly
+# ---------------------------------------------------------------------------
+def test_reed_load_datum_check_flags_impossible_mprl():
+    """MPRL of 9,274 lb exceeds the 6,863 lb air weight by 2,411 lb.
+
+    Friction acts upward on the downstroke, so it lowers polished-rod load and
+    widens the card. It cannot raise the whole card, so this has no mechanical
+    explanation and points at the data or the string record.
+    """
+    warnings = load_datum_check(
+        minimum_load_lb=9_274.0, rod_weight_in_air_lb=6_863.0
+    )
+    assert len(warnings) == 1
+    assert "2,411 lb" in warnings[0]
+    assert "load-cell" in warnings[0]
+
+
+def test_load_datum_check_passes_a_consistent_card():
+    """A card whose MPRL sits below the buoyed weight raises nothing."""
+    assert load_datum_check(5_500.0, 6_863.0, 6_116.0) == []
+
+
+@pytest.mark.skipif(not CARD_CSV.exists(), reason="digitized card not present")
+def test_reed_card_metrics_from_digitized_card(reed):
+    """Card metrics against the published digitization, and the datum warning."""
+    positions, up, down = [], [], []
+    with CARD_CSV.open() as handle:
+        for row in csv.DictReader(handle):
+            positions.append(float(row["position_in"]))
+            up.append(float(row["upstroke_load_lb"]))
+            down.append(float(row["downstroke_load_lb"]))
+
+    card = analyse_card(
+        position_in=positions + positions[::-1],
+        load_lb=up + down[::-1],
+        strokes_per_minute=6.4,
+        rod_weight_in_air_lb=reed.rod_string.weight_in_air_lb,
+        buoyant_rod_weight_lb=reed.rod_string.buoyant_weight_lb,
+    )
+    assert card.peak_load_lb == pytest.approx(12_438, abs=40)
+    assert card.peak_load_position_in == pytest.approx(7.5, abs=0.5)
+    assert card.minimum_load_lb == pytest.approx(9_274, abs=40)
+    assert card.minimum_load_position_in == pytest.approx(35.5, abs=0.5)
+    assert card.load_range_lb == pytest.approx(3_164, abs=60)
+    assert card.polished_rod_hp == pytest.approx(1.13, abs=0.15)
+    # This real card trips the datum check.
+    assert any("exceeds the rod string's weight in air" in w for w in card.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Fixture 1 -- timing uncertainty off a position-axis card
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "position_in,expected_velocity,expected_uncertainty",
+    [(7.5, 10.62, 0.14), (23.5, 13.59, 0.11), (35.0, 9.71, 0.15)],
+)
+def test_reed_timing_uncertainty_grows_as_velocity_falls(
+    position_in, expected_velocity, expected_uncertainty
+):
+    """dt = dx/v, and v falls towards both stroke ends."""
+    measurement = time_from_card_position(
+        position_in, stroke_in=41.0, strokes_per_minute=6.4,
+        position_uncertainty_in=1.5,
+    )
+    assert measurement.uncertainty == pytest.approx(expected_uncertainty, abs=0.01)
+
+
+def test_reed_peak_intervals_are_not_distinguishable():
+    """The 1.24 s and 0.95 s intervals cannot be reported as distinct.
+
+    Their uncertainties overlap at +/-1.5 in digitizing error, so the honest
+    statement is the mean interval against the predicted 1.03 s.
+    """
+    times = [
+        time_from_card_position(p, 41.0, 6.4, 1.5) for p in (7.5, 23.5, 35.0)
+    ]
+    assert not intervals_are_distinguishable(times)
+
+
+# ---------------------------------------------------------------------------
+# Fixture 2 -- Rowlan validation case
+# ---------------------------------------------------------------------------
+ROWLAN_NO_PRIME = 45.88
+# The slide reads 5.22 SPM on the card panel and 5.44 SPM in both time-plot
+# legends. Card fixtures use 5.22; time-domain fixtures use 5.44.
+ROWLAN_CARD_SPEEDS = (4.85, 5.22, 6.12)
+ROWLAN_TIME_SPEEDS = (4.85, 5.44, 6.12)
+
+
+def test_rowlan_peak_interval_matches_the_slide():
+    """60/45.88 = 1.3078 s against the stated 1.31 s."""
+    interval = peak_interval(ROWLAN_NO_PRIME)
+    assert interval == pytest.approx(1.3078, abs=0.001)
+    assert abs(interval - 1.31) / 1.31 * 100 < 0.5
+
+
+def test_rowlan_peak_interval_is_invariant_across_pumping_speed():
+    """Peak spacing is a rod-string property; changing N does not move it."""
+    intervals = {peak_times(spm, ROWLAN_NO_PRIME).interval_s
+                 for spm in ROWLAN_TIME_SPEEDS}
+    assert len(intervals) == 1
+    assert intervals.pop() == pytest.approx(1.3078, abs=0.001)
+
+
+@pytest.mark.parametrize(
+    "spm,expected_n", [(4.85, 4.73), (5.44, 4.22), (6.12, 3.75)]
+)
+def test_rowlan_undulation_count_rises_as_speed_falls(spm, expected_n):
+    """Slower pumping gives the string more time to ring per half stroke."""
+    assert undulations_per_half_stroke(spm, ROWLAN_NO_PRIME) == pytest.approx(
+        expected_n, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
+    "spm,expected_half_cycle", [(4.85, 6.19), (5.44, 5.51), (6.12, 4.90)]
+)
+def test_rowlan_half_cycle_times(spm, expected_half_cycle):
+    """Top of stroke occurs at 30/N seconds."""
+    assert peak_times(spm, ROWLAN_NO_PRIME).top_of_stroke_s == pytest.approx(
+        expected_half_cycle, abs=0.01
+    )
+
+
+def test_rowlan_card_width_increases_monotonically_with_speed():
+    """Over-travel proxy: the card widens as the unit is sped up.
+
+    INFERENCE, not a measured quantity. The slide labels the arrows 57.9 /
+    71.1 / 77.9 in but does not state what they measure. Reading them as
+    plunger travel along the ``Wrf + Fo Max`` reference line follows Rowlan's
+    own reference-load-line method, but that reading is ours.
+
+    The assertion is therefore deliberately weak: monotonicity with pumping
+    speed, which holds under any consistent interpretation of the arrows. Do
+    not promote these to absolute checks without confirming what the slide
+    measures.
+    """
+    widths = {4.85: 57.9, 5.22: 71.1, 6.12: 77.9}
+    ordered = [widths[spm] for spm in sorted(widths)]
+    assert ordered == sorted(ordered)
+    assert ordered[0] < ordered[-1]
+
+
+# ---------------------------------------------------------------------------
+# The peak-phase result
+# ---------------------------------------------------------------------------
+def test_upstroke_peaks_align_across_speeds_but_downstroke_peaks_do_not():
+    """Upstroke ringing shares a trigger; downstroke ringing does not.
+
+    Upstroke ringing is excited at bottom of stroke (t = 0) for every speed,
+    so those peak trains coincide. Downstroke ringing is excited at top of
+    stroke (t = 30/N), which moves with speed, so those trains separate.
+    """
+    trains = [peak_times(spm, ROWLAN_NO_PRIME, max_time_s=14.0)
+              for spm in ROWLAN_TIME_SPEEDS]
+
+    first_upstroke = {round(t.upstroke[0], 6) for t in trains}
+    assert len(first_upstroke) == 1, "upstroke peaks must share a phase"
+
+    first_downstroke = {round(t.downstroke[0], 6) for t in trains}
+    assert len(first_downstroke) == len(trains), "downstroke peaks must separate"
+
+
+def test_divergence_onset_is_the_earliest_top_of_stroke():
+    """Overlaid traces track until the fastest unit turns around, at 4.90 s."""
+    assert divergence_onset(list(ROWLAN_TIME_SPEEDS)) == pytest.approx(4.90, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Validity envelope -- fail closed
+# ---------------------------------------------------------------------------
+def test_envelope_refuses_resonant_speed_ratio():
+    """N/No' above 0.35 invalidates the RP 11L correlations."""
+    with pytest.raises(ValidityError, match="exceeds 0.35"):
+        analyse(**{**REED, "strokes_per_minute": 30.0})
+
+
+def test_envelope_refuses_tapered_string_without_taper_factor():
+    """Fc = 1.000 is only valid for a single-diameter string."""
+    with pytest.raises(ValidityError, match="taper factor"):
+        analyse(**REED, is_tapered=True)
+
+
+@pytest.mark.parametrize("geometry", ["mark_ii", "rotaflex", "hydraulic"])
+def test_envelope_refuses_non_class_i_unit_geometry(geometry):
+    """Long-stroke and Mark II units have different kinematics."""
+    with pytest.raises(ValidityError, match="Class I"):
+        analyse(**{**REED, "unit_geometry": geometry})
+
+
+def test_non_steel_sonic_velocity_trips_the_natural_frequency_cross_check():
+    """The 245,000 constant assumes steel; fibreglass must not silently pass."""
+    with pytest.raises(ValueError, match="not steel"):
+        natural_frequency(4200.0, sonic_velocity_ft_s=4_000.0)
+
+
+def test_natural_frequency_routes_agree_for_steel():
+    """245,000/L and 15c/L agree to about 0.2% -- the cross-check passes."""
+    assert natural_frequency(4200.0) == pytest.approx(58.33, abs=0.05)
+
+
+def test_volumetric_efficiency_returns_none_without_runtime():
+    """No silent 24 h assumption."""
+    assert volumetric_efficiency(23.0, 38.8, None, 1.0) is None
+    assert volumetric_efficiency(23.0, 38.8, 24.0, None) is None

--- a/tests/marine_ops/artificial_lift/test_dynacard.py
+++ b/tests/marine_ops/artificial_lift/test_dynacard.py
@@ -83,11 +83,17 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.finite_difference import F
 
 
 def test_workflow_init_without_context():
-    """Init DynacardWorkflow with no context, verify solver is None."""
+    """Init DynacardWorkflow with no context, verify solver is None.
+
+    The default solver is 'everitt_jennings': it is the only one that
+    reproduces the reference downhole cards (0.9% median nRMSE across the
+    fixture wells, against 17.3% for gibbs and divergence for
+    finite_difference). See issue #1857.
+    """
     workflow = DynacardWorkflow()
     assert workflow.ctx is None
     assert workflow.solver is None
-    assert workflow.solver_method == 'gibbs'
+    assert workflow.solver_method == 'everitt_jennings'
 
 
 def test_workflow_init_with_finite_difference(sample_context):


### PR DESCRIPTION
Replaces the dynacard surface-to-downhole transform, which never transformed load, and adds the API RP 11L kinematics core that sits upstream of it.

Closes the blocker on #1855. Implements #1857 and #1858.

## Why

`physics.py` solved the Gibbs equation for **position only** and then assigned downhole load by fiat:

```python
dh_load = (f_surf - buoyant_weight) * LOAD_ATTENUATION_FACTOR   # 0.88
```

Verified on a real field card: correlation with the surface card of **1.000000000000**, residual **4.5e-12 lb**. An affine map preserves every rod-string vibration harmonic, so the "downhole card" was the surface card in disguise and could not diagnose anything. Reported fillage came back 97–99% on a well whose volumetric math says ~48%, and the classifier returned `ROD_PARTING` at 100% confidence on a well that produced 23 bbl the previous day.

## Commits

| | |
|---|---|
| `feat(dynacard): add Everitt-Jennings surface-to-downhole card solver` | SPE 18189 space-marching finite difference |
| `fix(dynacard): default to the Everitt-Jennings solver` | the only behaviour change here |
| `feat(dynacard): add API RP 11L rod-pump analysis module` | kinematics, rod-string mechanics, card metrics |
| `docs(dynacard): add data request for the Collide well` | |
| `test(dynacard): pin report-sections router test to the gibbs passthrough` | |

Review attention belongs on commit 2 — it is 43 lines and the only one that changes existing behaviour. Commits 1 and 3 are pure additions.

## Evidence

Against the stored reference downhole cards on **all five** fixture wells. Scoring is phase-invariant: a dynamometer card is a closed loop, so where the sample record starts and which direction it was traversed are recording conventions, not physics — comparing raw index-to-index penalises a correct card for an arbitrary phase offset.

| method | med nRMSE | med \|stroke err\| | med corr |
|---|---:|---:|---:|
| **everitt_jennings** | **0.9%** | **0.0%** | **1.000** |
| gibbs | 17.3% | 2.7% | 0.966 |
| finite_difference | diverges (~1e45 on 3/5 wells) | diverges | 0.022 |

Parity against the reference implementation's own expected values on `testdata/7699227.json` — a real anonymized **deviated** well (inclination to 39.98°, 4-section taper), Nx=400:

| Quantity | Expected | Got | Error |
|---|---:|---:|---:|
| Position_min | 0.0488 | 0.0485 | −0.7% |
| Position_max | 2.9531 | 2.9530 | −0.0% |
| Load_min | −8871.66 | −9068.75 | −2.2% |
| Load_max | 11634.02 | 11904.14 | +2.3% |
| stroke ratio | 0.9525 | 0.9526 | ✓ |

Node-converged (0.9531 → 0.9526 from Nx=50 to 400). A viscosity sweep floors the load error at ~2.0% and is flat below 0.02 Pa·s, so the residual is implementation error rather than an untuned input — left visible at a 3% test tolerance rather than papered over.

## What else this changes

**`finite_difference` is not miscalibrated, it is divergent** — overflowing to ~1e45 and beyond on three of five wells. Both older solvers are retained for comparison and marked in the docstring as unsuitable for diagnosis.

**Two latent bugs fixed** in the ported scheme, documented at each fix site: the damping setter sliced the spatial axis twice rather than space × time, and the wrap-around time step reused loop variables leaked from the inner loop.

**A NaN trap closed**: the coupling-drag correlation is undefined below a coupling/bore ratio of 0.381, where it silently produced an all-NaN card. It now raises naming the likely cause (a casing ID supplied where a tubing ID belongs).

**Damping is estimated per taper section** with separate upstroke and downstroke coefficients — a single scalar cannot produce the asymmetry that gives a card its enclosed area. The previous implementation hardcoded `0.012` and silently ignored the `damping_factor` input field.

## The RP 11L module

Kinematics upstream of the transform: natural frequency, undulations, crank motion, plunger stroke, displacement, card metrics, dimensionless groups. Two field fixtures, 37 tests.

Three corrections enforced in code:

- **Pump displacement uses plunger stroke.** 7.7 in of rod stretch turns a 41 in surface stroke into 33.3 in: PD 38.8 bfpd, not 47.8. A test asserts the computed value is strictly below the surface-stroke figure.
- **Volumetric efficiency returns `None`** when runtime or `Bo` is unknown. A unit cycling on a controller has a duty cycle that mimics low fillage; surface barrels are not reservoir barrels. Neither is assumed.
- **`load_datum_check`** flags a minimum polished-rod load above the string's air weight. Friction acts *upward* on the downstroke — it widens a card and cannot lift one — so this has no mechanical explanation. Fires on the real Collide card at 9,274 lb against 6,863 lb.

Fails closed: `N/No' > 0.35` raises rather than extrapolating, as do tapered strings without an explicit `Fc`, non-Class-I unit geometries, and a non-steel sonic velocity used with the steel-derived 245,000 constant.

## Note on the last commit

`test_router_reuses_one_diagnostic_classification` was implicitly relying on the broken solver. The synthetic card generators produce **downhole**-shaped cards, and `_apply_synthetic_card` feeds them in as the *surface* card — so with gibbs as an affine passthrough the generated shape reached the classifier unchanged and the label round-tripped. A solver that genuinely transforms the card correctly turns that synthetic downhole card into something else.

The test's subject is the router calling classification exactly once, so it now pins the passthrough to keep its label assertions meaningful. **The underlying harness defect — a downhole shape fed in as a surface card — is not fixed here** and needs its own issue.

## Known limitations, stated rather than hidden

- **The 18-mode classifier remains untrustworthy on real cards.** It was trained on 100% synthetic data (`cv_accuracy` 0.8944 is `cross_val_score` over `generate_training_dataset()`), and the real-card benchmark path is dead — `benchmark/runner.py` swallows a missing `test_set_builder` that does not exist under `src/`. Downhole cards are now provably correct; the labels on them are not. Report cards and geometric metrics; do not quote classifier confidence to an operator.
- `calculate_fillage()` in `physics.py` still returns the constant `DEFAULT_PUMP_FILLAGE`.
- `calculate_shape_similarity` clamps negative correlation to zero and ignores phase, so ideal-card similarity cannot currently rank anything.
- The ~2% parity residual is unexplained.

Remaining checkboxes are tracked on #1857.

## Tests

`794 passed, 1 skipped` for `tests/marine_ops/artificial_lift/`.

`test_vision_benchmark.py` is excluded — it fails to collect on `main` already, importing the missing `test_set_builder`. Pre-existing, not introduced here.
