### PR TITLE
fix(capabilities,subsea): re-source the census from a committed SSOT (#1637, #1639)

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -233,7 +233,11 @@ gates:
     enabled: true
     order: 1
     description: "Aggregator for all domain test gates"
-    depends_on: ["tests-asset-integrity", "tests-cathodic-protection", "tests-citations", "tests-contracts", "tests-field-development", "tests-hydrodynamics-diffraction", "tests-hydrodynamics-passing-ship", "tests-hydrodynamics-other", "tests-infrastructure-core", "tests-infrastructure-other", "tests-marine-engineering", "tests-marine-ops-other", "tests-naval-architecture", "tests-orcaflex", "tests-orcaflex-solver", "tests-solver-smoke", "tests-specialized", "tests-structural", "tests-subsea", "tests-workflows", "tests-misc"]
+    # tests-capabilities added #1637: it was the only domain gate absent from
+    # this list, so 8 tests failed every nightly for 15 days without ever
+    # surfacing in the aggregate. A gate outside the roll-up is invisible by
+    # construction -- if a domain is deliberately advisory, say so here.
+    depends_on: ["tests-asset-integrity", "tests-capabilities", "tests-cathodic-protection", "tests-citations", "tests-contracts", "tests-field-development", "tests-hydrodynamics-diffraction", "tests-hydrodynamics-passing-ship", "tests-hydrodynamics-other", "tests-infrastructure-core", "tests-infrastructure-other", "tests-marine-engineering", "tests-marine-ops-other", "tests-naval-architecture", "tests-orcaflex", "tests-orcaflex-solver", "tests-solver-smoke", "tests-specialized", "tests-structural", "tests-subsea", "tests-workflows", "tests-misc"]
     aggregate: true
     command: "uv run --no-sources --with-editable . python -c 'print(\"domain test gates complete\")'"
     failure_action: "block"

--- a/docs/capability-map/capabilities-ia-spec-1444.md
+++ b/docs/capability-map/capabilities-ia-spec-1444.md
@@ -1,10 +1,10 @@
 # Capabilities page — information-architecture spec (issue #1444)
 
-> GENERATED tables (source of truth: `capabilities-clusters.yml`, `capabilities-added.yml`, the live page census). Regenerate with:
+> GENERATED tables (source of truth: `capabilities-sections.yml`, `capabilities-clusters.yml`, `capabilities-added.yml`). Regenerate with:
 > `.venv/bin/python scripts/capabilities/build_capabilities_inventory.py`
-> Presentation is owned by the capabilities revamp lane (PR #1389 coordination note) — this spec is its input; `index.html` is not edited here.
+> Presentation is owned by the capabilities revamp lane (PR #1389 coordination note) — this spec is its input. The rendered page moved to aceengineer.com/capabilities (PR #1573); the census is committed here, not scraped.
 
-Sections on the live page: **22** · clusters: **7** · PDF coverage gaps: **0** · unlinked explorers: **0**
+Sections in the census: **22** · clusters: **7** · PDF coverage gaps: **0** · unlinked explorers: **0**
 
 ## Cluster taxonomy
 
@@ -12,7 +12,7 @@ Sections on the live page: **22** · clusters: **7** · PDF coverage gaps: **0**
 *Strength, fatigue and remaining-life decisions for plates, panels and aging assets — field measurement to code verdict, with the validation table anchoring every engine to a published golden case.*
 
 - [`#structural`](../api/capabilities/index.html#structural) — Ship structural strength
-- [`#fatigue`](../api/capabilities/index.html#fatigue) — Fatigue &amp; fracture &mdash; S-N life and crack growth
+- [`#fatigue`](../api/capabilities/index.html#fatigue) — Fatigue & fracture — S-N life and crack growth
 - [`#ffs`](../api/capabilities/index.html#ffs) — Fitness-for-service
 - [`#cathodic`](../api/capabilities/index.html#cathodic) — Cathodic protection
 - [`#validation`](../api/capabilities/index.html#validation) — Validated against published references
@@ -20,37 +20,37 @@ Sections on the live page: **22** · clusters: **7** · PDF coverage gaps: **0**
 ### Pipelines & Risers (`pipelines-risers`)
 *Wall sizing, code checks and vortex-induced-vibration screening for flowlines, pipelines and riser systems across 10+ design codes.*
 
-- [`#risers`](../api/capabilities/index.html#risers) — Risers &amp; pipelines
-- [`#wall-thickness`](../api/capabilities/index.html#wall-thickness) — Wall thickness &mdash; sizing &amp; code checks
-- [`#viv`](../api/capabilities/index.html#viv) — Vortex-induced vibration &mdash; screening, frequency &amp; fatigue
+- [`#risers`](../api/capabilities/index.html#risers) — Risers & pipelines
+- [`#wall-thickness`](../api/capabilities/index.html#wall-thickness) — Wall thickness — sizing & code checks
+- [`#viv`](../api/capabilities/index.html#viv) — Vortex-induced vibration — screening, frequency & fatigue
 
 ### Moorings, Anchors & Subsea (`moorings-stationkeeping`)
 *Stationkeeping design and subsea hardware — mooring strength and fatigue, anchor holding capacity, and foundation geotechnics.*
 
 - [`#subsea`](../api/capabilities/index.html#subsea) — Subsea
-- [`#geotechnical`](../api/capabilities/index.html#geotechnical) — Geotechnical &mdash; pile, anchor &amp; foundation capacity
+- [`#geotechnical`](../api/capabilities/index.html#geotechnical) — Geotechnical — pile, anchor & foundation capacity
 
 ### Hydrodynamics & Naval Architecture (`hydro-naval`)
 *Vessel and floating-body behaviour — diffraction, seakeeping, CFD, manoeuvring and ship-form performance from hull lines to RAOs.*
 
-- [`#hydro`](../api/capabilities/index.html#hydro) — Hydrodynamics &amp; diffraction
+- [`#hydro`](../api/capabilities/index.html#hydro) — Hydrodynamics & diffraction
 - [`#cfd`](../api/capabilities/index.html#cfd) — Computational fluid dynamics (CFD)
-- [`#manoeuvring`](../api/capabilities/index.html#manoeuvring) — Manoeuvring &amp; station-keeping
-- [`#naval-architecture`](../api/capabilities/index.html#naval-architecture) — Naval architecture &mdash; stability, resistance &amp; hull strength
+- [`#manoeuvring`](../api/capabilities/index.html#manoeuvring) — Manoeuvring & station-keeping
+- [`#naval-architecture`](../api/capabilities/index.html#naval-architecture) — Naval architecture — stability, resistance & hull strength
 
 ### Wells, Drilling & Production (`wells-drilling-production`)
 *The well axis end-to-end — casing and drilling engineering, pore pressure, artificial lift, production chemistry and flow assurance.*
 
-- [`#well`](../api/capabilities/index.html#well) — Well construction &mdash; casing &amp; tubulars
-- [`#drilling-engineering`](../api/capabilities/index.html#drilling-engineering) — Drilling engineering &mdash; pore pressure, hydraulics &amp; well control
-- [`#artificial-lift`](../api/capabilities/index.html#artificial-lift) — Artificial lift &mdash; rod-pump diagnostics
-- [`#production-engineering`](../api/capabilities/index.html#production-engineering) — Production engineering &mdash; nodal analysis &amp; well deliverability
-- [`#corrosion-production`](../api/capabilities/index.html#corrosion-production) — Corrosion &amp; production chemistry
+- [`#well`](../api/capabilities/index.html#well) — Well construction — casing & tubulars
+- [`#drilling-engineering`](../api/capabilities/index.html#drilling-engineering) — Drilling engineering — pore pressure, hydraulics & well control
+- [`#artificial-lift`](../api/capabilities/index.html#artificial-lift) — Artificial lift — rod-pump diagnostics
+- [`#production-engineering`](../api/capabilities/index.html#production-engineering) — Production engineering — nodal analysis & well deliverability
+- [`#corrosion-production`](../api/capabilities/index.html#corrosion-production) — Corrosion & production chemistry
 
 ### Field Development & Economics (`field-dev-economics`)
 *Concept-to-cashflow screening — field development options, floating wind TOTEX/LCOE and NPV levers over real project structures.*
 
-- [`#field-development`](../api/capabilities/index.html#field-development) — Field development &mdash; concept screening, cost &amp; economics
+- [`#field-development`](../api/capabilities/index.html#field-development) — Field development — concept screening, cost & economics
 - [`#wind`](../api/capabilities/index.html#wind) — Floating wind
 
 ### Installation & Marine Operations (`installation-ops`)

--- a/docs/capability-map/capabilities-inventory.json
+++ b/docs/capability-map/capabilities-inventory.json
@@ -144,7 +144,7 @@
       "explorers": [],
       "id": "fatigue",
       "pdf": "docs/api/capabilities/pdf/sec-fatigue.pdf",
-      "title": "Fatigue &amp; fracture &mdash; S-N life and crack growth"
+      "title": "Fatigue & fracture — S-N life and crack growth"
     },
     {
       "added": "unknown",
@@ -154,7 +154,7 @@
       ],
       "id": "hydro",
       "pdf": "docs/api/capabilities/pdf/sec-hydro.pdf",
-      "title": "Hydrodynamics &amp; diffraction"
+      "title": "Hydrodynamics & diffraction"
     },
     {
       "added": {
@@ -177,7 +177,7 @@
       ],
       "id": "risers",
       "pdf": "docs/api/capabilities/pdf/sec-risers.pdf",
-      "title": "Risers &amp; pipelines"
+      "title": "Risers & pipelines"
     },
     {
       "added": {
@@ -190,7 +190,7 @@
       ],
       "id": "wall-thickness",
       "pdf": "docs/api/capabilities/pdf/sec-wall-thickness.pdf",
-      "title": "Wall thickness &mdash; sizing &amp; code checks"
+      "title": "Wall thickness — sizing & code checks"
     },
     {
       "added": "unknown",
@@ -211,7 +211,7 @@
       ],
       "id": "viv",
       "pdf": "docs/api/capabilities/pdf/sec-viv.pdf",
-      "title": "Vortex-induced vibration &mdash; screening, frequency &amp; fatigue"
+      "title": "Vortex-induced vibration — screening, frequency & fatigue"
     },
     {
       "added": "unknown",
@@ -240,7 +240,7 @@
       ],
       "id": "field-development",
       "pdf": "docs/api/capabilities/pdf/sec-field-development.pdf",
-      "title": "Field development &mdash; concept screening, cost &amp; economics"
+      "title": "Field development — concept screening, cost & economics"
     },
     {
       "added": "unknown",
@@ -250,7 +250,7 @@
       ],
       "id": "manoeuvring",
       "pdf": "docs/api/capabilities/pdf/sec-manoeuvring.pdf",
-      "title": "Manoeuvring &amp; station-keeping"
+      "title": "Manoeuvring & station-keeping"
     },
     {
       "added": {
@@ -263,7 +263,7 @@
       ],
       "id": "naval-architecture",
       "pdf": "docs/api/capabilities/pdf/sec-naval-architecture.pdf",
-      "title": "Naval architecture &mdash; stability, resistance &amp; hull strength"
+      "title": "Naval architecture — stability, resistance & hull strength"
     },
     {
       "added": {
@@ -276,7 +276,7 @@
       ],
       "id": "geotechnical",
       "pdf": "docs/api/capabilities/pdf/sec-geotechnical.pdf",
-      "title": "Geotechnical &mdash; pile, anchor &amp; foundation capacity"
+      "title": "Geotechnical — pile, anchor & foundation capacity"
     },
     {
       "added": "unknown",
@@ -284,7 +284,7 @@
       "explorers": [],
       "id": "artificial-lift",
       "pdf": "docs/api/capabilities/pdf/sec-artificial-lift.pdf",
-      "title": "Artificial lift &mdash; rod-pump diagnostics"
+      "title": "Artificial lift — rod-pump diagnostics"
     },
     {
       "added": {
@@ -297,7 +297,7 @@
       ],
       "id": "production-engineering",
       "pdf": "docs/api/capabilities/pdf/sec-production-engineering.pdf",
-      "title": "Production engineering &mdash; nodal analysis &amp; well deliverability"
+      "title": "Production engineering — nodal analysis & well deliverability"
     },
     {
       "added": "unknown",
@@ -307,7 +307,7 @@
       ],
       "id": "well",
       "pdf": "docs/api/capabilities/pdf/sec-well.pdf",
-      "title": "Well construction &mdash; casing &amp; tubulars"
+      "title": "Well construction — casing & tubulars"
     },
     {
       "added": {
@@ -320,7 +320,7 @@
       ],
       "id": "drilling-engineering",
       "pdf": "docs/api/capabilities/pdf/sec-drilling-engineering.pdf",
-      "title": "Drilling engineering &mdash; pore pressure, hydraulics &amp; well control"
+      "title": "Drilling engineering — pore pressure, hydraulics & well control"
     },
     {
       "added": {
@@ -344,7 +344,7 @@
       ],
       "id": "corrosion-production",
       "pdf": "docs/api/capabilities/pdf/sec-corrosion-production.pdf",
-      "title": "Corrosion &amp; production chemistry"
+      "title": "Corrosion & production chemistry"
     },
     {
       "added": "unknown",
@@ -355,6 +355,6 @@
       "title": "Validated against published references"
     }
   ],
-  "source": "docs/api/capabilities/index.html",
+  "source": "docs/capability-map/capabilities-sections.yml",
   "unlinked_explorers": []
 }

--- a/docs/capability-map/capabilities-sections.yml
+++ b/docs/capability-map/capabilities-sections.yml
@@ -1,0 +1,281 @@
+# ABOUTME: Machine source-of-truth for the capabilities section census
+# ABOUTME: (issue #1444; re-sourced from the retired HTML page by #1637).
+#
+# WHY THIS FILE EXISTS
+# The census used to be scraped from docs/api/capabilities/index.html. That page
+# was intentionally reduced to a redirect stub on 2026-07-13 (PR #1573, epic
+# workspace-hub#3485/#3494 decision A: aceengineer.com/capabilities is the single
+# canonical capabilities surface). The census outlived its source and every
+# dependent test failed for 15 days. The inventory is a real artifact, so the
+# census now reads THIS committed file instead of a rendered page.
+#
+# CONTRACT
+#   id     — anchor id; must appear in exactly one cluster in capabilities-clusters.yml
+#   title  — human title (plain text, not HTML — entities are decoded here)
+#   links  — repo/deliverable references this capability claims. These are the
+#            evidence base for the standards-grounding guard (dm#1391): every
+#            standards designator in a one-pager `std` line must grep-match a
+#            file reachable from this list. Removing a link can therefore turn a
+#            grounded claim into an overclaim — that is the point.
+#
+# Order is the census order (was the page's nav order). Edit here, regenerate:
+#   .venv/bin/python scripts/capabilities/build_capabilities_inventory.py
+
+schema_version: "1.0"
+
+sections:
+  - id: ffs
+    title: "Fitness-for-service"
+    links:
+      - "pdf/sec-ffs.pdf"
+      - "../ffs/ffs-showcase.html"
+      - "pdf/ffs-showcase.pdf"
+      - "api/ffs-showcase.html"
+      - "../ffs/ffs-field-dashboard.html"
+      - "pdf/ffs-field-dashboard.pdf"
+      - "api/ffs-field-dashboard.html"
+      - "../ffs/riser-joint-acceptance-explorer.html"
+      - "pdf/riser-joint-acceptance.pdf"
+      - "api/riser-joint-acceptance.html"
+
+  - id: structural
+    title: "Ship structural strength"
+    links:
+      - "pdf/sec-structural.pdf"
+      - "../buckling/ship-plate-buckling.html"
+      - "pdf/buckling-plate.pdf"
+      - "api/buckling-plate.html"
+      - "../buckling/ship-panel-buckling.html"
+      - "pdf/buckling-panel.pdf"
+      - "api/buckling-panel.html"
+
+  - id: fatigue
+    title: "Fatigue & fracture — S-N life and crack growth"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/sn_library.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/scf_library.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/weld_fatigue_quickcheck.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/hotspot_stress.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/crack_growth.py"
+
+  - id: hydro
+    title: "Hydrodynamics & diffraction"
+    links:
+      - "pdf/sec-hydro.pdf"
+      - "../hydro/rao-comparison/"
+      - "pdf/rao-comparison.pdf"
+      - "api/rao-comparison.html"
+      - "../hydro/unit-box-benchmark/benchmark_report.html"
+      - "pdf/unitbox-report.pdf"
+      - "api/unitbox-report.html"
+      - "../hydro/unit-box-benchmark/benchmark_amplitude.html"
+      - "pdf/unitbox-amplitude.pdf"
+      - "api/unitbox-amplitude.html"
+      - "../hydro/unit-box-benchmark/benchmark_phase.html"
+      - "pdf/unitbox-phase.pdf"
+      - "api/unitbox-phase.html"
+      - "../hydro/unit-box-benchmark/benchmark_combined.html"
+      - "pdf/unitbox-combined.pdf"
+      - "api/unitbox-combined.html"
+      - "../hydro/unit-box-benchmark/benchmark_heatmap.html"
+      - "pdf/unitbox-heatmap.pdf"
+      - "api/unitbox-heatmap.html"
+      - "../hydro/ocimf-coefficient-explorer.html"
+      - "pdf/ocimf.pdf"
+      - "api/ocimf.html"
+      - "../hydro/passing-ship-benchmark.html"
+      - "pdf/passing-ship.pdf"
+      - "api/passing-ship.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/aqwa-diffraction-deck-prep"
+      - "pdf/diffraction-deck-prep.pdf"
+      - "api/diffraction-deck-prep.html"
+
+  - id: cfd
+    title: "Computational fluid dynamics (CFD)"
+    links:
+      - "../cfd/"
+      - "../cfd/tank-sloshing-verification.html"
+      - "../cfd/sloshing-cfd-study.html"
+      - "../cfd/cfd-runtime-estimator.html"
+      - "../cfd/wave-excited-body-verification.html"
+      - "../cfd/wave-excited-body-rao-verification.html"
+      - "../cfd/wave-excited-body-decay-verification.html"
+      - "../cfd/maccamy-fuchs-cylinder-verification.html"
+      - "../cfd/flat-plate-blasius-verification.html"
+      - "../cfd/cylinder-re100-verification.html"
+      - "../cfd/turbulent-flat-plate-verification.html"
+      - "../cfd/kleefsman-impact-verification.html"
+      - "../cfd/wave-tank-verification.html"
+      - "../cfd/floating-body-decay-verification.html"
+      - "../cfd/dam-break-verification.html"
+      - "../cfd/naca0012-airfoil-verification.html"
+
+  - id: risers
+    title: "Risers & pipelines"
+    links:
+      - "pdf/sec-risers.pdf"
+      - "../orcaflex/riser-validation-report.html"
+      - "pdf/riser-validation.pdf"
+      - "api/riser-validation.html"
+      - "../orcaflex/riser-mesh-sensitivity.html"
+      - "pdf/riser-mesh.pdf"
+      - "api/riser-mesh.html"
+      - "../drilling/drilling-riser-operability-explorer.html"
+      - "pdf/drilling-riser-operability.pdf"
+      - "api/drilling-riser-operability.html"
+      - "../drilling/operability-monitor.html"
+      - "pdf/drilling-riser-operability-monitor.pdf"
+      - "api/drilling-riser-operability-monitor.html"
+
+  - id: wall-thickness
+    title: "Wall thickness — sizing & code checks"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/structural/analysis/wall_thickness_codes"
+      - "../structural/wall-thickness-explorer.html"
+      - "pdf/wall-thickness-explorer.pdf"
+      - "api/wall-thickness-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/structural/wall_thickness_quickcheck"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/subsea/pipeline"
+
+  - id: subsea
+    title: "Subsea"
+    links:
+      - "pdf/sec-subsea.pdf"
+      - "../subsea/offshore-cross-section-report.html"
+      - "pdf/subsea-xsection.pdf"
+      - "api/subsea-xsection.html"
+
+  - id: viv
+    title: "Vortex-induced vibration — screening, frequency & fatigue"
+    links:
+      - "../structural/viv-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/subsea/viv_analysis/vortex_shedding.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/subsea/viv_analysis/fatigue.py"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/viv-analysis"
+
+  - id: installation
+    title: "Installation"
+    links:
+      - "pdf/sec-installation.pdf"
+      - "https://vamseeachanta.github.io/deckhand-sandbox/domains/floating-marine/deckhand-deliverables/2026/2026-06-28/installation-vessel-pamphlet-bokalift2/report.html"
+      - "pdf/installation-bokalift.pdf"
+      - "api/installation-bokalift.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/data/vessels"
+      - "pdf/vessel-suitability.pdf"
+      - "api/vessel-suitability.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/structural/offshore_container_utilization"
+      - "pdf/container-utilization.pdf"
+      - "api/container-utilization.html"
+
+  - id: wind
+    title: "Floating wind"
+    links:
+      - "pdf/sec-wind.pdf"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-sizing"
+      - "pdf/wind-sizing.pdf"
+      - "api/wind-sizing.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-economics"
+      - "pdf/wind-economics.pdf"
+      - "api/wind-economics.html"
+
+  - id: field-development
+    title: "Field development — concept screening, cost & economics"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/field_development"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/field_development/capex_estimator.py"
+      - "../structural/field-economics-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/docs/domains/references/field_development/catalog"
+
+  - id: manoeuvring
+    title: "Manoeuvring & station-keeping"
+    links:
+      - "pdf/sec-manoeuvring.pdf"
+      - "../hydro/rudder-maneuvering-explorer.html"
+      - "pdf/rudder-explorer.pdf"
+      - "api/rudder-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/data/rudder_database.yml"
+      - "pdf/rudder-database.pdf"
+      - "api/rudder-database.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/marine_ops/mooring_resilience"
+      - "pdf/mooring-resilience.pdf"
+      - "api/mooring-resilience.html"
+      - "../hydro/short-horizon-motion-forecast.html"
+      - "pdf/short-horizon-motion-forecast.pdf"
+      - "api/short-horizon-motion-forecast.html"
+
+  - id: naval-architecture
+    title: "Naval architecture — stability, resistance & hull strength"
+    links:
+      - "../structural/ship-resistance-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/damage_stability.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/hull_girder_strength.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/floating_platform_stability.py"
+
+  - id: geotechnical
+    title: "Geotechnical — pile, anchor & foundation capacity"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/geotechnical/piles.py"
+      - "../structural/anchor-holding-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/geotechnical/mudmat.py"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/geotechnical"
+
+  - id: artificial-lift
+    title: "Artificial lift — rod-pump diagnostics"
+    links:
+      - "pdf/sec-artificial-lift.pdf"
+      - "../artificial-lift/dynacard-troubleshooting.html"
+      - "pdf/dynacard-troubleshooting.pdf"
+      - "api/dynacard-troubleshooting.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/artificial-lift-field-health"
+      - "pdf/dynacard-field-health.pdf"
+      - "api/dynacard-field-health.html"
+
+  - id: production-engineering
+    title: "Production engineering — nodal analysis & well deliverability"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/production_engineering/nodal_solver.py"
+      - "../structural/ipr-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/production_engineering/esp_pump_hydraulics.py"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/production_engineering/reconciliation_workflow.py"
+
+  - id: well
+    title: "Well construction — casing & tubulars"
+    links:
+      - "pdf/sec-well.pdf"
+      - "../well/casing-design-explorer.html"
+      - "pdf/casing-design.pdf"
+      - "api/casing-design.html"
+
+  - id: drilling-engineering
+    title: "Drilling engineering — pore pressure, hydraulics & well control"
+    links:
+      - "../structural/pore-pressure-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/swab-surge"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/well/drilling"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/well/drilling/dysfunction_detector.py"
+
+  - id: cathodic
+    title: "Cathodic protection"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/cathodic_protection"
+      - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/cathodic-protection"
+      - "../structural/cathodic-protection-explorer.html"
+      - "pdf/cathodic-protection-explorer.pdf"
+      - "api/cathodic-protection-explorer.html"
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/docs/domains/articles/dnv_rp_f106_coating_selection.md"
+
+  - id: corrosion-production
+    title: "Corrosion & production chemistry"
+    links:
+      - "pdf/sec-corrosion-production.pdf"
+      - "../corrosion/galvanic-compatibility-explorer.html"
+      - "pdf/galvanic-explorer.pdf"
+      - "api/galvanic-explorer.html"
+      - "../production/scale-si-explorer.html"
+      - "pdf/scale-si-explorer.pdf"
+      - "api/scale-si-explorer.html"
+
+  - id: validation
+    title: "Validated against published references"
+    links:
+      - "https://github.com/vamseeachanta/digitalmodel/blob/main/docs/domains/codes-register.md"

--- a/scripts/capabilities/build_capabilities_inventory.py
+++ b/scripts/capabilities/build_capabilities_inventory.py
@@ -2,8 +2,8 @@
 """ABOUTME: Capabilities IA inventory builder (issue #1444) — census, clusters,
 ABOUTME: reference-index joins, recency, spec rendering, and --check freshness.
 
-Reads (never edits) docs/api/capabilities/index.html plus the machine
-source-of-truth files under docs/capability-map/, and emits:
+Reads (never edits) the machine source-of-truth files under
+docs/capability-map/, and emits:
 
   docs/capability-map/capabilities-inventory.json   (machine contract)
   docs/capability-map/capabilities-ia-spec-1444.md  (rendered spec; tables are
@@ -15,6 +15,14 @@ inventory drifted (CI freshness gate via the tests/DOMAINS.md capabilities row).
 Recency comes ONLY from capabilities-added.yml (explicit, PR-evidenced
 metadata): the repo's git history was truncated by the 2026-07 slim and
 sections live inside one HTML file, so no git-derived dating is valid.
+
+CENSUS SOURCE (#1637). The census was scraped from docs/api/capabilities/
+index.html until that page was intentionally reduced to a redirect stub on
+2026-07-13 (PR #1573, epic workspace-hub#3485/#3494 decision A). The census
+now reads the committed capabilities-sections.yml, which is tracked,
+reviewable, and cannot go stale from an unrelated website edit. The HTML
+census helpers below (parse_nav / parse_sections / census) are retained for a
+future live-surface monitoring job and are no longer on the inventory path.
 """
 
 from __future__ import annotations
@@ -32,7 +40,8 @@ HERE = Path(__file__).resolve()
 REPO_DEFAULT = HERE.parents[2]
 
 CAP_MAP = "docs/capability-map"
-INDEX_HTML = "docs/api/capabilities/index.html"
+SECTIONS_YML = f"{CAP_MAP}/capabilities-sections.yml"  # census source (#1637)
+INDEX_HTML = "docs/api/capabilities/index.html"  # redirect stub since PR #1573
 FROZEN_DIR = "capabilities/api"  # frozen work-item assets — excluded from discovery
 
 
@@ -41,7 +50,51 @@ class CensusError(RuntimeError):
 
 
 # ---------------------------------------------------------------------------
-# parsing
+# census — committed SSOT (#1637)
+# ---------------------------------------------------------------------------
+
+_ID_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def load_sections(repo: Path | str = REPO_DEFAULT) -> list[dict]:
+    """The section census, from the committed ``capabilities-sections.yml``.
+
+    Returns the same ``{id, title, hrefs}`` shape the HTML census used to
+    produce, so every downstream join is unchanged. Fails closed with an
+    actionable message — a malformed SSOT must never degrade to an empty
+    census, which is precisely how #1637 stayed invisible for 15 days.
+    """
+    path = Path(repo) / SECTIONS_YML
+    if not path.exists():
+        raise CensusError(f"census source missing: {SECTIONS_YML}")
+    doc = yaml.safe_load(path.read_text()) or {}
+    if not doc.get("schema_version"):
+        raise CensusError(f"{SECTIONS_YML}: no schema_version")
+    raw = doc.get("sections")
+    if not raw:
+        raise CensusError(f"{SECTIONS_YML}: no sections — census would be empty")
+
+    out, seen = [], set()
+    for i, entry in enumerate(raw):
+        sid = entry.get("id")
+        if not sid or not _ID_RE.match(str(sid)):
+            raise CensusError(f"{SECTIONS_YML}[{i}]: bad or missing id {sid!r}")
+        if sid in seen:
+            raise CensusError(f"duplicate section ids: {sid}")
+        seen.add(sid)
+        title = (entry.get("title") or "").strip()
+        if not title:
+            raise CensusError(f"{SECTIONS_YML}: section {sid} has no title")
+        links = entry.get("links") or []
+        if not isinstance(links, list):
+            raise CensusError(f"{SECTIONS_YML}: section {sid} links must be a list")
+        out.append({"id": sid, "title": title, "hrefs": [str(h) for h in links]})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTML census helpers — retained for a future live-surface monitoring job.
+# NOT on the inventory path since #1637; see the module docstring.
 # ---------------------------------------------------------------------------
 
 _SECTION_RE = re.compile(r'<section[^>]*\bid="([a-z0-9-]+)"')
@@ -135,8 +188,7 @@ def load_added(repo: Path) -> dict:
 
 def build_inventory(repo: Path | str = REPO_DEFAULT) -> dict:
     repo = Path(repo)
-    html = (repo / INDEX_HTML).read_text()
-    sections = census(html)
+    sections = load_sections(repo)
     clusters_doc = load_clusters(repo)
     added_doc = load_added(repo)
 
@@ -201,7 +253,7 @@ def build_inventory(repo: Path | str = REPO_DEFAULT) -> dict:
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "source": INDEX_HTML,
+        "source": SECTIONS_YML,
         "sections": inv_sections,
         "clusters": [
             {k: c[k] for k in ("key", "label", "value_statement", "sections")}
@@ -240,14 +292,16 @@ def render_spec(inv: dict) -> str:
     lines = [
         "# Capabilities page — information-architecture spec (issue #1444)",
         "",
-        "> GENERATED tables (source of truth: `capabilities-clusters.yml`, "
-        "`capabilities-added.yml`, the live page census). Regenerate with:",
+        "> GENERATED tables (source of truth: `capabilities-sections.yml`, "
+        "`capabilities-clusters.yml`, `capabilities-added.yml`). Regenerate "
+        "with:",
         "> `.venv/bin/python scripts/capabilities/build_capabilities_inventory.py`",
         "> Presentation is owned by the capabilities revamp lane (PR #1389 "
-        "coordination note) — this spec is its input; `index.html` is not "
-        "edited here.",
+        "coordination note) — this spec is its input. The rendered page moved "
+        "to aceengineer.com/capabilities (PR #1573); the census is committed "
+        "here, not scraped.",
         "",
-        f"Sections on the live page: **{len(inv['sections'])}** · clusters: "
+        f"Sections in the census: **{len(inv['sections'])}** · clusters: "
         f"**{len(inv['clusters'])}** · PDF coverage gaps: "
         f"**{len(inv['pdf_gaps'])}** · unlinked explorers: "
         f"**{len(inv['unlinked_explorers'])}**",

--- a/scripts/ci/detect_touched_domains.py
+++ b/scripts/ci/detect_touched_domains.py
@@ -34,6 +34,11 @@ DOMAIN_PATHS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("src/digitalmodel/orcaflex/", ("orcaflex",)),
     ("src/digitalmodel/visualization/agent_dashboard.py", ("workflows",)),
     ("src/digitalmodel/workflows/", ("workflows",)),
+    # The capabilities census SSOT and its builder live outside src/ and tests/,
+    # so without these two entries an edit to the census would trigger no shard
+    # at all -- the gap that let #1637 sit red for 15 days.
+    ("docs/capability-map/", ("capabilities",)),
+    ("scripts/capabilities/", ("capabilities",)),
     ("tests/benchmarks/test_cp_benchmarks.py", ("cathodic-protection",)),
     (
         "tests/marine_ops/marine_engineering/test_cathodic_protection_dnv.py",

--- a/tests/capabilities/test_capabilities_inventory.py
+++ b/tests/capabilities/test_capabilities_inventory.py
@@ -16,23 +16,61 @@ spec = importlib.util.spec_from_file_location("capinv", SCRIPT)
 ci = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(ci)
 
-INDEX = REPO / "docs" / "api" / "capabilities" / "index.html"
 CLUSTERS = REPO / "docs" / "capability-map" / "capabilities-clusters.yml"
 ADDED = REPO / "docs" / "capability-map" / "capabilities-added.yml"
+SECTIONS = REPO / "docs" / "capability-map" / "capabilities-sections.yml"
 
 
-# 1 — census bijection on the LIVE page: nav hrefs <-> section ids, 1:1
+# 1 — census integrity on the committed SSOT: unique ids, every id titled.
+#
+# This used to scrape docs/api/capabilities/index.html. That page became a
+# redirect stub on 2026-07-13 (PR #1573) and the census silently lost its
+# subject; the shard was red for 15 days (#1637). The census source is now a
+# committed file, so it can only break from a reviewable diff.
 
 
-def test_section_census_bijection_live_page():
-    sections = ci.parse_sections(INDEX.read_text())
+def test_section_census_integrity_from_ssot():
+    sections = ci.load_sections(REPO)
     ids = [s["id"] for s in sections]
-    assert len(ids) == len(set(ids))
-    nav = ci.parse_nav(INDEX.read_text())
-    assert set(nav) == set(ids)
-    assert len(nav) == len(ids)
+    assert ids, "census is empty"
+    assert len(ids) == len(set(ids)), "duplicate section ids"
     for s in sections:
-        assert s["title"]
+        assert s["title"], f"section {s['id']} has no title"
+        assert isinstance(s["hrefs"], list)
+
+
+# 1b — the census must FAIL CLOSED, never degrade to an empty result. This is
+# the specific failure mode that made #1637 invisible: a census that returns
+# nothing makes every downstream set-difference look like clean drift.
+
+
+@pytest.mark.parametrize(
+    ("doc", "match"),
+    [
+        ({"schema_version": "1.0", "sections": []}, "no sections"),
+        ({"sections": [{"id": "a", "title": "A"}]}, "schema_version"),
+        ({"schema_version": "1.0", "sections": [{"id": "a"}]}, "no title"),
+        ({"schema_version": "1.0", "sections": [{"title": "A"}]}, "bad or missing id"),
+        (
+            {
+                "schema_version": "1.0",
+                "sections": [{"id": "a", "title": "A"}, {"id": "a", "title": "A"}],
+            },
+            "duplicate",
+        ),
+    ],
+)
+def test_census_fails_closed_on_malformed_ssot(tmp_path, doc, match):
+    fake = tmp_path / "docs" / "capability-map"
+    fake.mkdir(parents=True)
+    (fake / "capabilities-sections.yml").write_text(yaml.safe_dump(doc))
+    with pytest.raises(ci.CensusError, match=match):
+        ci.load_sections(tmp_path)
+
+
+def test_census_fails_closed_when_source_missing(tmp_path):
+    with pytest.raises(ci.CensusError, match="census source missing"):
+        ci.load_sections(tmp_path)
 
 
 # 2 — parser failure fixtures fail closed with diagnostics
@@ -61,10 +99,10 @@ def test_cluster_mapping_total_disjoint_and_schema():
         assert c["key"] and c["label"] and c["value_statement"]
         assigned += c["sections"]
     assert len(assigned) == len(set(assigned)), "section in two clusters"
-    live = {s["id"] for s in ci.parse_sections(INDEX.read_text())}
-    assert set(assigned) == live, (
-        f"cluster map out of sync: missing={live - set(assigned)} "
-        f"stale={set(assigned) - live}"
+    census = {s["id"] for s in ci.load_sections(REPO)}
+    assert set(assigned) == census, (
+        f"cluster map out of sync: missing={census - set(assigned)} "
+        f"stale={set(assigned) - census}"
     )
 
 
@@ -195,8 +233,13 @@ def _norm(s: str) -> str:
 
 
 def _section_linked_files(section: dict) -> list:
-    """Repo files a live section links: GitHub blob/tree URLs into this repo
-    (dirs recursed) plus page-relative hrefs under docs/api/capabilities/."""
+    """Repo files a census section links: GitHub blob/tree URLs into this repo
+    (dirs recursed) plus page-relative hrefs under docs/api/capabilities/.
+
+    The links come from capabilities-sections.yml since #1637. Note this
+    guard was VACUOUS between 2026-07-13 and its repair: with the page
+    stubbed, `sections.get(anchor)` was always None and every standards claim
+    skipped its evidence check while the test still reported green."""
     out = []
     for href in section["hrefs"]:
         m = _GH_HREF_RE.match(href)
@@ -216,14 +259,14 @@ def _section_linked_files(section: dict) -> list:
 # 10 — ratchet (a): section-kind SPECS ids <-> live section anchors, 1:1
 
 
-def test_specs_section_ids_biject_live_sections():
+def test_specs_section_ids_biject_census_sections():
     exempt = _onepager_exempt()
-    live = {s["id"] for s in ci.parse_sections(INDEX.read_text())}
+    live = {s["id"] for s in ci.load_sections(REPO)}
     covered = set(ci.load_pdf_specs(REPO))  # anchors with a sec-* SPECS entry
     assert exempt <= live, f"stale onepager_exempt entries: {sorted(exempt - live)}"
     orphans = covered - live
     assert not orphans, (
-        f"sec-* SPECS entries with no live section: {sorted(orphans)}"
+        f"sec-* SPECS entries with no section in the census: {sorted(orphans)}"
     )
     missing = live - covered - exempt
     assert not missing, (
@@ -252,7 +295,7 @@ def test_every_section_pdf_committed():
 
 
 def test_specs_standards_grounded():
-    sections = {s["id"]: s for s in ci.parse_sections(INDEX.read_text())}
+    sections = {s["id"]: s for s in ci.load_sections(REPO)}
     script = REPO / "scripts" / "capabilities" / "build_onepagers.py"
     spec_ = importlib.util.spec_from_file_location("build_onepagers_g", script)
     bo = importlib.util.module_from_spec(spec_)
@@ -275,6 +318,7 @@ def test_specs_standards_grounded():
         return False
 
     ungrounded = []
+    checked = 0
     for entry in bo.SPECS:
         if entry.get("kind") != "section":
             continue
@@ -284,8 +328,15 @@ def test_specs_standards_grounded():
             continue  # covered by the bijection test
         files = _section_linked_files(section)
         for token in _STD_TOKEN_RE.findall(entry["std"]):
+            checked += 1
             if not evidence(token, files):
                 ungrounded.append((entry["id"], token))
+    # Liveness: an empty census, or sections with no links, would make this
+    # guard pass while checking nothing -- exactly how it hid for 15 days.
+    assert checked, (
+        "standards-grounding guard checked ZERO tokens -- the census or the "
+        "section links are empty; a green result here would be meaningless"
+    )
     assert not ungrounded, (
         f"standards named in `std` lines with zero grep evidence in the "
         f"section's linked files (overclaim per dm#1391): {ungrounded}"

--- a/tests/drilling_riser/test_operability_explorer.py
+++ b/tests/drilling_riser/test_operability_explorer.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from digitalmodel.drilling_riser import operability_atlas as oa
 from digitalmodel.drilling_riser.operability_screening import screen_operability
@@ -19,6 +20,20 @@ from tests.riser_database.test_leak_gate import STRUCTURAL_PATTERNS
 
 REPO = Path(__file__).resolve().parents[2]
 _ATLAS_ROOT = REPO / "atlases"
+#: Capability registration used to be a card on docs/api/capabilities/index.html.
+#: That page became a redirect stub on 2026-07-13 (PR #1573) and the census moved
+#: to this committed file (#1637) — registration is now asserted against it.
+_CENSUS = REPO / "docs" / "capability-map" / "capabilities-sections.yml"
+
+
+def _registering_sections(site_path: str) -> list[str]:
+    """Census section ids whose links reference ``site_path``."""
+    doc = yaml.safe_load(_CENSUS.read_text())
+    return [
+        s["id"]
+        for s in doc["sections"]
+        if any(site_path in link for link in (s.get("links") or []))
+    ]
 
 
 def _load_builder():
@@ -141,5 +156,8 @@ def test_escalate_is_honest_and_wired():
 # 7. artifacts exist + registered --------------------------------------------
 def test_artifacts_exist_and_registered():
     assert build._HTML.is_file() and build._JSON.is_file()
-    index = (REPO / "docs" / "api" / "capabilities" / "index.html").read_text()
-    assert build.SITE_PATH in index, "no index card links the operability explorer"
+    assert _registering_sections(build.SITE_PATH), (
+        f"no capability section links the operability explorer "
+        f"({build.SITE_PATH}) — add it to the links of the owning section in "
+        f"{_CENSUS.relative_to(REPO)}"
+    )

--- a/tests/drilling_riser/test_operability_monitor.py
+++ b/tests/drilling_riser/test_operability_monitor.py
@@ -240,6 +240,20 @@ def test_conductor_geometry_is_banded_generic():
 # 10. one-pager governance + registered --------------------------------------
 _SAFE_HOSTS = ("t.me/the_deckhand_bot", "api.deckhand", "vamseeachanta.github.io", "w3.org")
 _API = REPO / "docs" / "api" / "capabilities" / "api" / "drilling-riser-operability-monitor"
+#: Capability registration used to be a card on docs/api/capabilities/index.html.
+#: That page became a redirect stub on 2026-07-13 (PR #1573) and the census moved
+#: to this committed file (#1637) — registration is now asserted against it.
+_CENSUS = REPO / "docs" / "capability-map" / "capabilities-sections.yml"
+
+
+def _registering_sections(site_path: str) -> list[str]:
+    """Census section ids whose links reference ``site_path``."""
+    doc = yaml.safe_load(_CENSUS.read_text())
+    return [
+        s["id"]
+        for s in doc["sections"]
+        if any(site_path in link for link in (s.get("links") or []))
+    ]
 
 
 def _strip_safe(text: str) -> str:
@@ -255,8 +269,11 @@ def test_onepager_and_index_registered():
     assert not _structural_hits(_strip_safe(js.read_text()))
     env = json.loads(js.read_text())
     assert env["report_url"].startswith("https://vamseeachanta.github.io/"), env["report_url"]
-    index = (REPO / "docs" / "api" / "capabilities" / "index.html").read_text()
-    assert build.SITE_PATH in index, "no index card links the operability monitor"
+    assert _registering_sections(build.SITE_PATH), (
+        f"no capability section links the operability monitor "
+        f"({build.SITE_PATH}) — add it to the links of the owning section in "
+        f"{_CENSUS.relative_to(REPO)}"
+    )
 
 
 # 11. distinct ESCALATE channels (operability vs drift-off) ------------------


### PR DESCRIPTION
Closes #1637. Child of #1234, step 2 of 3 in the #1640 start-here sequence. Follows #1879 (#1638, `tests-contracts`).

## The ticket's diagnosis is wrong, and it changes the fix

#1637 says the suite "scrapes a **live page**" and is therefore "structurally flaky — it can go red from a website edit with no repo change at all."

It doesn't. `tests/capabilities/test_capabilities_inventory.py` read `docs/api/capabilities/index.html`, a file **tracked in this repo**. A repo change is exactly what broke it — which also means the ticket's recommendation #1 ("pin a committed HTML fixture") describes the situation that already existed and would have fixed nothing.

What actually happened, commit `2ff0f72c` (**PR #1573, 2026-07-13**):

> Decision A (epic workspace-hub#3485 / #3494): aceengineer.com/capabilities is the single canonical capabilities surface. This repo's GitHub Pages capabilities page becomes a redirect stub… and stops carrying divergent capability copy (avoids figure drift + SEO cannibalization).

**−610 lines, +18.** The page's 22 `<section>` blocks and its `<nav>` were removed on purpose. The suite asserting a bijection against them was not touched. `CensusError: no <nav> block found` is the census correctly reporting that its subject no longer exists. Red for **15 days**.

## A green test that was checking nothing

The more serious find. `test_specs_standards_grounded` is the dm#1391 overclaim guard: every standards designator in a one-pager `std` line (`DNV-RP-C203`, `API RP 2A-WSD`, …) must grep-match a file that section links. It does:

```python
section = sections.get(anchor)
if section is None:
    continue          # covered by the bijection test
```

With the page stubbed, `parse_sections()` returned `[]`, so **every** anchor missed and every standards claim skipped its evidence check. The test reported pass. It was one of the shard's 4 "passing" tests.

Restoring the census re-arms it: **42 standards tokens now checked, all 42 grounded** — no overclaims were hiding, but nothing was verifying that either. A `checked` counter now fails the test if it ever evaluates zero tokens again.

This is the same shape as #1447 in the units work — a guard that cannot fail for the thing it exists to catch.

## What changed

| file | |
|---|---|
| `docs/capability-map/capabilities-sections.yml` | **new** — the census SSOT. 22 sections, titles, 168 links, lifted mechanically from the page at `2ff0f72c^` |
| `build_capabilities_inventory.py` | `load_sections()` reads the YAML and returns the same `{id, title, hrefs}` shape, so every downstream join is untouched |
| `test_capabilities_inventory.py` | 8 tests re-pointed at the SSOT; 2 renamed (`..._live_page` → `..._from_ssot`); +6 fail-closed tests; liveness assert on the standards guard |
| `.claude/quality-gates.yaml` | `tests-capabilities` added to `tests-all.depends_on` (21 → 22) |
| `detect_touched_domains.py` | `docs/capability-map/` + `scripts/capabilities/` → `capabilities` |

### Why it hid for 15 days — both causes fixed here

1. `tests-capabilities` was the **only** domain gate missing from `tests-all.depends_on`. A gate outside the roll-up is invisible by construction (#1637's point 3).
2. `docs/capability-map/` and `scripts/capabilities/` mapped to **no domain**, so editing the census would trigger no shard at all. Without this entry the new SSOT would be unguarded by the very shard that validates it.

### The +6 tests are all one idea

The census must **fail closed** — missing file, absent `schema_version`, empty `sections`, untitled section, malformed id, duplicate ids. An empty census is the specific thing that made this invisible: it makes every downstream set-difference look like clean drift (`missing=set()`, everything "stale") rather than a broken input.

## Verification

```
tests/capabilities                            18 passed   (was 8 failed / 4 passed)
tests/scripts/test_detect_touched_domains.py  20 passed
ruff check                                    All checks passed
```

The regenerated inventory is **unchanged in substance** — 22 sections, 0 PDF gaps, 0 unlinked explorers, all 16 explorer joins preserved. That is the evidence this is a re-source, not a reset. The `capabilities-inventory.json` diff is the `source` field plus HTML-entity decoding of titles (`&amp;` → `&`), which are now plain text because the source is YAML, not HTML.

## Notes for the reviewer

- **This PR runs all 22 shards.** `.claude/quality-gates.yaml` is in `FULL_MATRIX_PATHS`, so the domain matrix fans out fully. **`tests-subsea` will be red — that is #1639, pre-existing and unrelated to this change.** `tests-capabilities` and `tests-contracts` should both be green.
- The HTML census helpers (`parse_nav`/`parse_sections`/`census`) are retained and still tested against inline fixtures, for the live-surface monitoring job #1637 asks for in its recommendation #1. I am filing that as a follow-up rather than leaving it implied — if it is never built, those helpers should be deleted rather than left as decoration.
- Worth knowing separately: there is **no** `/capabilities/` page in the `aceengineer-website` repo, so the redirect target `https://www.aceengineer.com/capabilities/` may not resolve yet (possibly pending awsite PR #59). Out of scope here, but someone should confirm the canonical surface actually exists.