### PR TITLE
fix(capabilities): close the gate gaps that hid #1637 for 15 days (#1637)

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -233,7 +233,11 @@ gates:
     enabled: true
     order: 1
     description: "Aggregator for all domain test gates"
-    depends_on: ["tests-asset-integrity", "tests-cathodic-protection", "tests-citations", "tests-contracts", "tests-field-development", "tests-hydrodynamics-diffraction", "tests-hydrodynamics-passing-ship", "tests-hydrodynamics-other", "tests-infrastructure-core", "tests-infrastructure-other", "tests-marine-engineering", "tests-marine-ops-other", "tests-naval-architecture", "tests-orcaflex", "tests-orcaflex-solver", "tests-solver-smoke", "tests-specialized", "tests-structural", "tests-subsea", "tests-workflows", "tests-misc"]
+    # tests-capabilities added #1637: it was the only domain gate absent from
+    # this list, so 8 tests failed every nightly for 15 days without ever
+    # surfacing in the aggregate. A gate outside the roll-up is invisible by
+    # construction -- if a domain is deliberately advisory, say so here.
+    depends_on: ["tests-asset-integrity", "tests-capabilities", "tests-cathodic-protection", "tests-citations", "tests-contracts", "tests-field-development", "tests-hydrodynamics-diffraction", "tests-hydrodynamics-passing-ship", "tests-hydrodynamics-other", "tests-infrastructure-core", "tests-infrastructure-other", "tests-marine-engineering", "tests-marine-ops-other", "tests-naval-architecture", "tests-orcaflex", "tests-orcaflex-solver", "tests-solver-smoke", "tests-specialized", "tests-structural", "tests-subsea", "tests-workflows", "tests-misc"]
     aggregate: true
     command: "uv run --no-sources --with-editable . python -c 'print(\"domain test gates complete\")'"
     failure_action: "block"

--- a/docs/capability-map/capabilities-ia-spec-1444.md
+++ b/docs/capability-map/capabilities-ia-spec-1444.md
@@ -12,7 +12,7 @@ Sections declared: **22** · clusters: **7** · PDF coverage gaps: **0** · unli
 *Strength, fatigue and remaining-life decisions for plates, panels and aging assets — field measurement to code verdict, with the validation table anchoring every engine to a published golden case.*
 
 - [`#structural`](https://www.aceengineer.com/capabilities/#structural) — Ship structural strength
-- [`#fatigue`](https://www.aceengineer.com/capabilities/#fatigue) — Fatigue &amp; fracture &mdash; S-N life and crack growth
+- [`#fatigue`](https://www.aceengineer.com/capabilities/#fatigue) — Fatigue & fracture — S-N life and crack growth
 - [`#ffs`](https://www.aceengineer.com/capabilities/#ffs) — Fitness-for-service
 - [`#cathodic`](https://www.aceengineer.com/capabilities/#cathodic) — Cathodic protection
 - [`#validation`](https://www.aceengineer.com/capabilities/#validation) — Validated against published references
@@ -20,37 +20,37 @@ Sections declared: **22** · clusters: **7** · PDF coverage gaps: **0** · unli
 ### Pipelines & Risers (`pipelines-risers`)
 *Wall sizing, code checks and vortex-induced-vibration screening for flowlines, pipelines and riser systems across 10+ design codes.*
 
-- [`#risers`](https://www.aceengineer.com/capabilities/#risers) — Risers &amp; pipelines
-- [`#wall-thickness`](https://www.aceengineer.com/capabilities/#wall-thickness) — Wall thickness &mdash; sizing &amp; code checks
-- [`#viv`](https://www.aceengineer.com/capabilities/#viv) — Vortex-induced vibration &mdash; screening, frequency &amp; fatigue
+- [`#risers`](https://www.aceengineer.com/capabilities/#risers) — Risers & pipelines
+- [`#wall-thickness`](https://www.aceengineer.com/capabilities/#wall-thickness) — Wall thickness — sizing & code checks
+- [`#viv`](https://www.aceengineer.com/capabilities/#viv) — Vortex-induced vibration — screening, frequency & fatigue
 
 ### Moorings, Anchors & Subsea (`moorings-stationkeeping`)
 *Stationkeeping design and subsea hardware — mooring strength and fatigue, anchor holding capacity, and foundation geotechnics.*
 
 - [`#subsea`](https://www.aceengineer.com/capabilities/#subsea) — Subsea
-- [`#geotechnical`](https://www.aceengineer.com/capabilities/#geotechnical) — Geotechnical &mdash; pile, anchor &amp; foundation capacity
+- [`#geotechnical`](https://www.aceengineer.com/capabilities/#geotechnical) — Geotechnical — pile, anchor & foundation capacity
 
 ### Hydrodynamics & Naval Architecture (`hydro-naval`)
 *Vessel and floating-body behaviour — diffraction, seakeeping, CFD, manoeuvring and ship-form performance from hull lines to RAOs.*
 
-- [`#hydro`](https://www.aceengineer.com/capabilities/#hydro) — Hydrodynamics &amp; diffraction
+- [`#hydro`](https://www.aceengineer.com/capabilities/#hydro) — Hydrodynamics & diffraction
 - [`#cfd`](https://www.aceengineer.com/capabilities/#cfd) — Computational fluid dynamics (CFD)
-- [`#manoeuvring`](https://www.aceengineer.com/capabilities/#manoeuvring) — Manoeuvring &amp; station-keeping
-- [`#naval-architecture`](https://www.aceengineer.com/capabilities/#naval-architecture) — Naval architecture &mdash; stability, resistance &amp; hull strength
+- [`#manoeuvring`](https://www.aceengineer.com/capabilities/#manoeuvring) — Manoeuvring & station-keeping
+- [`#naval-architecture`](https://www.aceengineer.com/capabilities/#naval-architecture) — Naval architecture — stability, resistance & hull strength
 
 ### Wells, Drilling & Production (`wells-drilling-production`)
 *The well axis end-to-end — casing and drilling engineering, pore pressure, artificial lift, production chemistry and flow assurance.*
 
-- [`#well`](https://www.aceengineer.com/capabilities/#well) — Well construction &mdash; casing &amp; tubulars
-- [`#drilling-engineering`](https://www.aceengineer.com/capabilities/#drilling-engineering) — Drilling engineering &mdash; pore pressure, hydraulics &amp; well control
-- [`#artificial-lift`](https://www.aceengineer.com/capabilities/#artificial-lift) — Artificial lift &mdash; rod-pump diagnostics
-- [`#production-engineering`](https://www.aceengineer.com/capabilities/#production-engineering) — Production engineering &mdash; nodal analysis &amp; well deliverability
-- [`#corrosion-production`](https://www.aceengineer.com/capabilities/#corrosion-production) — Corrosion &amp; production chemistry
+- [`#well`](https://www.aceengineer.com/capabilities/#well) — Well construction — casing & tubulars
+- [`#drilling-engineering`](https://www.aceengineer.com/capabilities/#drilling-engineering) — Drilling engineering — pore pressure, hydraulics & well control
+- [`#artificial-lift`](https://www.aceengineer.com/capabilities/#artificial-lift) — Artificial lift — rod-pump diagnostics
+- [`#production-engineering`](https://www.aceengineer.com/capabilities/#production-engineering) — Production engineering — nodal analysis & well deliverability
+- [`#corrosion-production`](https://www.aceengineer.com/capabilities/#corrosion-production) — Corrosion & production chemistry
 
 ### Field Development & Economics (`field-dev-economics`)
 *Concept-to-cashflow screening — field development options, floating wind TOTEX/LCOE and NPV levers over real project structures.*
 
-- [`#field-development`](https://www.aceengineer.com/capabilities/#field-development) — Field development &mdash; concept screening, cost &amp; economics
+- [`#field-development`](https://www.aceengineer.com/capabilities/#field-development) — Field development — concept screening, cost & economics
 - [`#wind`](https://www.aceengineer.com/capabilities/#wind) — Floating wind
 
 ### Installation & Marine Operations (`installation-ops`)

--- a/docs/capability-map/capabilities-inventory.json
+++ b/docs/capability-map/capabilities-inventory.json
@@ -144,7 +144,7 @@
       "explorers": [],
       "id": "fatigue",
       "pdf": "docs/api/capabilities/pdf/sec-fatigue.pdf",
-      "title": "Fatigue &amp; fracture &mdash; S-N life and crack growth"
+      "title": "Fatigue & fracture — S-N life and crack growth"
     },
     {
       "added": "unknown",
@@ -154,7 +154,7 @@
       ],
       "id": "hydro",
       "pdf": "docs/api/capabilities/pdf/sec-hydro.pdf",
-      "title": "Hydrodynamics &amp; diffraction"
+      "title": "Hydrodynamics & diffraction"
     },
     {
       "added": {
@@ -177,7 +177,7 @@
       ],
       "id": "risers",
       "pdf": "docs/api/capabilities/pdf/sec-risers.pdf",
-      "title": "Risers &amp; pipelines"
+      "title": "Risers & pipelines"
     },
     {
       "added": {
@@ -190,7 +190,7 @@
       ],
       "id": "wall-thickness",
       "pdf": "docs/api/capabilities/pdf/sec-wall-thickness.pdf",
-      "title": "Wall thickness &mdash; sizing &amp; code checks"
+      "title": "Wall thickness — sizing & code checks"
     },
     {
       "added": "unknown",
@@ -211,7 +211,7 @@
       ],
       "id": "viv",
       "pdf": "docs/api/capabilities/pdf/sec-viv.pdf",
-      "title": "Vortex-induced vibration &mdash; screening, frequency &amp; fatigue"
+      "title": "Vortex-induced vibration — screening, frequency & fatigue"
     },
     {
       "added": "unknown",
@@ -240,7 +240,7 @@
       ],
       "id": "field-development",
       "pdf": "docs/api/capabilities/pdf/sec-field-development.pdf",
-      "title": "Field development &mdash; concept screening, cost &amp; economics"
+      "title": "Field development — concept screening, cost & economics"
     },
     {
       "added": "unknown",
@@ -250,7 +250,7 @@
       ],
       "id": "manoeuvring",
       "pdf": "docs/api/capabilities/pdf/sec-manoeuvring.pdf",
-      "title": "Manoeuvring &amp; station-keeping"
+      "title": "Manoeuvring & station-keeping"
     },
     {
       "added": {
@@ -263,7 +263,7 @@
       ],
       "id": "naval-architecture",
       "pdf": "docs/api/capabilities/pdf/sec-naval-architecture.pdf",
-      "title": "Naval architecture &mdash; stability, resistance &amp; hull strength"
+      "title": "Naval architecture — stability, resistance & hull strength"
     },
     {
       "added": {
@@ -276,7 +276,7 @@
       ],
       "id": "geotechnical",
       "pdf": "docs/api/capabilities/pdf/sec-geotechnical.pdf",
-      "title": "Geotechnical &mdash; pile, anchor &amp; foundation capacity"
+      "title": "Geotechnical — pile, anchor & foundation capacity"
     },
     {
       "added": "unknown",
@@ -284,7 +284,7 @@
       "explorers": [],
       "id": "artificial-lift",
       "pdf": "docs/api/capabilities/pdf/sec-artificial-lift.pdf",
-      "title": "Artificial lift &mdash; rod-pump diagnostics"
+      "title": "Artificial lift — rod-pump diagnostics"
     },
     {
       "added": {
@@ -297,7 +297,7 @@
       ],
       "id": "production-engineering",
       "pdf": "docs/api/capabilities/pdf/sec-production-engineering.pdf",
-      "title": "Production engineering &mdash; nodal analysis &amp; well deliverability"
+      "title": "Production engineering — nodal analysis & well deliverability"
     },
     {
       "added": "unknown",
@@ -307,7 +307,7 @@
       ],
       "id": "well",
       "pdf": "docs/api/capabilities/pdf/sec-well.pdf",
-      "title": "Well construction &mdash; casing &amp; tubulars"
+      "title": "Well construction — casing & tubulars"
     },
     {
       "added": {
@@ -320,7 +320,7 @@
       ],
       "id": "drilling-engineering",
       "pdf": "docs/api/capabilities/pdf/sec-drilling-engineering.pdf",
-      "title": "Drilling engineering &mdash; pore pressure, hydraulics &amp; well control"
+      "title": "Drilling engineering — pore pressure, hydraulics & well control"
     },
     {
       "added": {
@@ -344,7 +344,7 @@
       ],
       "id": "corrosion-production",
       "pdf": "docs/api/capabilities/pdf/sec-corrosion-production.pdf",
-      "title": "Corrosion &amp; production chemistry"
+      "title": "Corrosion & production chemistry"
     },
     {
       "added": "unknown",

--- a/docs/capability-map/capabilities-sections.yml
+++ b/docs/capability-map/capabilities-sections.yml
@@ -10,7 +10,10 @@
 #
 # `id`     -- URL anchor. STABLE: external links cite these (see the
 #             anchor-stability contract in capabilities-ia-spec-1444.md).
-# `title`  -- human label used in the generated spec tables.
+# `title`  -- human label used in the generated spec tables. Plain text, NOT
+#             HTML: the entities the extraction inherited (&amp;, &mdash;)
+#             were an artefact of the markup this data used to live in, and
+#             are decoded here. test_titles_are_plain_text keeps them out.
 # `hrefs`  -- every link the section owns, page-relative to
 #             docs/api/capabilities/. These drive the explorer<->section
 #             join, `unlinked_explorers`, and the standards-grounding
@@ -50,7 +53,7 @@ sections:
       - "api/buckling-panel.html"
 
   - id: fatigue
-    title: "Fatigue &amp; fracture &mdash; S-N life and crack growth"
+    title: "Fatigue & fracture — S-N life and crack growth"
     hrefs:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/sn_library.py"
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/scf_library.py"
@@ -59,7 +62,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/fatigue/crack_growth.py"
 
   - id: hydro
-    title: "Hydrodynamics &amp; diffraction"
+    title: "Hydrodynamics & diffraction"
     hrefs:
       - "pdf/sec-hydro.pdf"
       - "../hydro/rao-comparison/"
@@ -111,7 +114,7 @@ sections:
       - "../cfd/naca0012-airfoil-verification.html"
 
   - id: risers
-    title: "Risers &amp; pipelines"
+    title: "Risers & pipelines"
     hrefs:
       - "pdf/sec-risers.pdf"
       - "../orcaflex/riser-validation-report.html"
@@ -128,7 +131,7 @@ sections:
       - "api/drilling-riser-operability-monitor.html"
 
   - id: wall-thickness
-    title: "Wall thickness &mdash; sizing &amp; code checks"
+    title: "Wall thickness — sizing & code checks"
     hrefs:
       - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/structural/analysis/wall_thickness_codes"
       - "../structural/wall-thickness-explorer.html"
@@ -146,7 +149,7 @@ sections:
       - "api/subsea-xsection.html"
 
   - id: viv
-    title: "Vortex-induced vibration &mdash; screening, frequency &amp; fatigue"
+    title: "Vortex-induced vibration — screening, frequency & fatigue"
     hrefs:
       - "../structural/viv-explorer.html"
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/subsea/viv_analysis/vortex_shedding.py"
@@ -179,7 +182,7 @@ sections:
       - "api/wind-economics.html"
 
   - id: field-development
-    title: "Field development &mdash; concept screening, cost &amp; economics"
+    title: "Field development — concept screening, cost & economics"
     hrefs:
       - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/field_development"
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/field_development/capex_estimator.py"
@@ -187,7 +190,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/tree/main/docs/domains/references/field_development/catalog"
 
   - id: manoeuvring
-    title: "Manoeuvring &amp; station-keeping"
+    title: "Manoeuvring & station-keeping"
     hrefs:
       - "pdf/sec-manoeuvring.pdf"
       - "../hydro/rudder-maneuvering-explorer.html"
@@ -204,7 +207,7 @@ sections:
       - "api/short-horizon-motion-forecast.html"
 
   - id: naval-architecture
-    title: "Naval architecture &mdash; stability, resistance &amp; hull strength"
+    title: "Naval architecture — stability, resistance & hull strength"
     hrefs:
       - "../structural/ship-resistance-explorer.html"
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/damage_stability.py"
@@ -212,7 +215,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/floating_platform_stability.py"
 
   - id: geotechnical
-    title: "Geotechnical &mdash; pile, anchor &amp; foundation capacity"
+    title: "Geotechnical — pile, anchor & foundation capacity"
     hrefs:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/geotechnical/piles.py"
       - "../structural/anchor-holding-explorer.html"
@@ -220,7 +223,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/tree/main/src/digitalmodel/geotechnical"
 
   - id: artificial-lift
-    title: "Artificial lift &mdash; rod-pump diagnostics"
+    title: "Artificial lift — rod-pump diagnostics"
     hrefs:
       - "pdf/sec-artificial-lift.pdf"
       - "../artificial-lift/dynacard-troubleshooting.html"
@@ -231,7 +234,7 @@ sections:
       - "api/dynacard-field-health.html"
 
   - id: production-engineering
-    title: "Production engineering &mdash; nodal analysis &amp; well deliverability"
+    title: "Production engineering — nodal analysis & well deliverability"
     hrefs:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/production_engineering/nodal_solver.py"
       - "../structural/ipr-explorer.html"
@@ -239,7 +242,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/production_engineering/reconciliation_workflow.py"
 
   - id: well
-    title: "Well construction &mdash; casing &amp; tubulars"
+    title: "Well construction — casing & tubulars"
     hrefs:
       - "pdf/sec-well.pdf"
       - "../well/casing-design-explorer.html"
@@ -247,7 +250,7 @@ sections:
       - "api/casing-design.html"
 
   - id: drilling-engineering
-    title: "Drilling engineering &mdash; pore pressure, hydraulics &amp; well control"
+    title: "Drilling engineering — pore pressure, hydraulics & well control"
     hrefs:
       - "../structural/pore-pressure-explorer.html"
       - "https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/swab-surge"
@@ -265,7 +268,7 @@ sections:
       - "https://github.com/vamseeachanta/digitalmodel/blob/main/docs/domains/articles/dnv_rp_f106_coating_selection.md"
 
   - id: corrosion-production
-    title: "Corrosion &amp; production chemistry"
+    title: "Corrosion & production chemistry"
     hrefs:
       - "pdf/sec-corrosion-production.pdf"
       - "../corrosion/galvanic-compatibility-explorer.html"

--- a/scripts/ci/detect_touched_domains.py
+++ b/scripts/ci/detect_touched_domains.py
@@ -34,6 +34,11 @@ DOMAIN_PATHS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("src/digitalmodel/orcaflex/", ("orcaflex",)),
     ("src/digitalmodel/visualization/agent_dashboard.py", ("workflows",)),
     ("src/digitalmodel/workflows/", ("workflows",)),
+    # The capabilities census SSOT and its builder live outside src/ and tests/,
+    # so without these two entries an edit to the census would trigger no shard
+    # at all -- the gap that let #1637 sit red for 15 days.
+    ("docs/capability-map/", ("capabilities",)),
+    ("scripts/capabilities/", ("capabilities",)),
     ("tests/benchmarks/test_cp_benchmarks.py", ("cathodic-protection",)),
     (
         "tests/marine_ops/marine_engineering/test_cathodic_protection_dnv.py",

--- a/tests/capabilities/test_capabilities_inventory.py
+++ b/tests/capabilities/test_capabilities_inventory.py
@@ -2,6 +2,7 @@
 # ABOUTME: census schema, cluster totality, joins with gaps, freshness gate.
 
 import ast
+import html
 import importlib.util
 import json
 import re
@@ -32,6 +33,26 @@ def test_section_census_schema():
     for s in sections:
         assert s["title"]
         assert isinstance(s["hrefs"], list)
+
+
+# 1a — titles are data, not markup.
+#
+# The census was extracted from HTML, so titles arrived carrying &amp; and
+# &mdash;. Those entities are meaningless in YAML and leak into every consumer
+# that is not an HTML renderer — the generated spec tables, the one-pagers, any
+# future API. Decoded once in #1637; this keeps them from creeping back with
+# the next hand-added section.
+
+
+def test_titles_are_plain_text():
+    offenders = [
+        (s["id"], s["title"])
+        for s in ci.load_sections(REPO)
+        if html.unescape(s["title"]) != s["title"]
+    ]
+    assert not offenders, (
+        f"section titles must be plain text, not HTML entities: {offenders}"
+    )
 
 
 # 1b — the IA is declared in YAML, not scraped out of rendered markup.


### PR DESCRIPTION
Supersedes #1880 — this ports the three things that PR got right and #1882 missed. **Credit is #1880's**; #1882 landed first only because it also carried #1639.

## The gate gaps (the important part)

#1880 found the real reason nobody noticed #1637 for 15 days, and it is not about the census at all:

- **`tests-capabilities` was the only domain gate absent from the `Domain test aggregate` `depends_on` list.** Eight tests failed every nightly and the aggregate stayed green. A gate outside the roll-up is invisible by construction.
- **`detect_touched_domains.py` had no entry for `docs/capability-map/` or `scripts/capabilities/`.** Both live outside `src/` and `tests/`, so editing the census SSOT triggered *no shard at all* — the census could drift from its builder with nothing to catch it.

Together, the capabilities domain could be arbitrarily broken and CI would report success twice over.

Verified functionally rather than by reading the diff:

```
docs/capability-map/capabilities-sections.yml   -> [('capabilities',)]
scripts/capabilities/build_capabilities_inventory.py -> [('capabilities',)]
capabilities in aggregate: True
```

## Titles are data, not markup

Section titles arrived carrying `&amp;` and `&mdash;` because the census was extracted from HTML. #1882 preserved them verbatim — faithful to the previous output, but the entities are an artefact of the markup the data used to live in, and they leak into every consumer that is not an HTML renderer (the generated spec tables, the one-pagers, any future API).

```diff
- "title": "Risers &amp; pipelines"
+ "title": "Risers & pipelines"
```

All 22 titles decoded, with `test_titles_are_plain_text` to stop them creeping back on the next hand-added section.

## Verification

- `tests/capabilities/` + `tests/subsea/` + `tests/drilling_riser/` — **793 passed**
- `--check` freshness gate — `fresh`
- `ruff` clean on both changed Python files

The 18 local `drilling_riser` failures are the known stale-`llm-wiki`-clone set; CI has no clone and skips them.
