### PR TITLE
ci(capabilities): make the capabilities gate able to block (#1637 follow-up)

### DIFF
--- a/.claude/quality-gates.yaml
+++ b/.claude/quality-gates.yaml
@@ -29,6 +29,11 @@ gates:
     domain: "capabilities"
     test_roots: ["tests/capabilities/"]
     command: "uv run --no-sources --with 'assetutilities @ git+https://github.com/vamseeachanta/assetutilities.git@main' --with-editable . python -m pytest tests/capabilities/ -rfE -p no:asyncio -p no:randomly -p no:sugar --no-header -q --tb=line"
+    # Added #1637: this was the ONLY gate of 27 with no failure_action, so its
+    # result carried no verdict even once it was inside the tests-all roll-up.
+    failure_action: "block"
+    warning_action: "report"
+
   tests-cathodic-protection:
     enabled: true
     order: 1

--- a/tests/capabilities/test_capabilities_inventory.py
+++ b/tests/capabilities/test_capabilities_inventory.py
@@ -334,6 +334,7 @@ def test_specs_standards_grounded():
         return False
 
     ungrounded = []
+    checked = 0
     for entry in bo.SPECS:
         if entry.get("kind") != "section":
             continue
@@ -343,8 +344,20 @@ def test_specs_standards_grounded():
             continue  # covered by the bijection test
         files = _section_linked_files(section)
         for token in _STD_TOKEN_RE.findall(entry["std"]):
+            checked += 1
             if not evidence(token, files):
                 ungrounded.append((entry["id"], token))
+    # LIVENESS. The `section is None -> continue` above is safe only while SOME
+    # anchors resolve. Between #1573 and #1637 the census resolved NONE: every
+    # anchor missed, all 42 standards claims skipped their evidence check, and
+    # this test reported PASS for 15 days while verifying nothing. It was one of
+    # the 4 "passing" tests in a shard that was 8/12 red. Assert we checked
+    # something, so the vacuous case is loud instead of green.
+    assert checked, (
+        "standards-grounding guard checked ZERO tokens -- the census resolved no "
+        "anchors, or its sections declare no hrefs. A green result here would be "
+        "meaningless (dm#1637)"
+    )
     assert not ungrounded, (
         f"standards named in `std` lines with zero grep evidence in the "
         f"section's linked files (overclaim per dm#1391): {ungrounded}"


### PR DESCRIPTION
Follow-up to **PR #1882** (#1637, #1639). Refs #1234, #1634.

#1882 fixed *why* `tests-capabilities` was red. This fixes *why nobody noticed for 15 days* — which is the part #1640 actually cares about.

## Three independent mechanisms, none of them in the code #1882 touched

| # | mechanism | effect |
|---|---|---|
| 1 | **only** domain gate absent from `tests-all.depends_on` (21 of 22 listed) | outside the roll-up = invisible by construction |
| 2 | **only** gate of 27 with no `failure_action`/`warning_action` | it ran, but its result carried no verdict |
| 3 | `docs/capability-map/` + `scripts/capabilities/` mapped to no domain | editing the census triggered **no shard at all** |

Any one alone would have hidden the breakage. Together they meant the shard could fail every nightly for two weeks and change nothing.

Mechanism 3 deserves emphasis: it now points at `capabilities-sections.yml`, the file #1882 introduced to *replace* the deleted page. Without this change, the successor to the thing that broke is exactly as unguarded as the original was — you could edit the census and no test would run.

Mechanism 2 is pre-existing, not from #1882 — I checked `c451803c^`. It has presumably been true since the gate was added.

## Re-arming the standards guard against going vacuous

`test_specs_standards_grounded` (the dm#1391 overclaim guard) does:

```python
section = sections.get(anchor)
if section is None:
    continue   # covered by the bijection test
```

That skip is safe only while *some* anchors resolve. When the page was stubbed, **none** did — all 42 standards claims skipped their evidence check and the test reported PASS throughout the 15 days. A guard that cannot fail is worse than no guard.

A `checked` counter now fails the test if it evaluates zero tokens. Measured today: **42 tokens checked**, so the assert is load-bearing rather than decorative.

## What this PR deliberately does not touch

Census behaviour is #1882's, and it is good — `test_census_failure_fixtures` (empty / duplicate / bad-anchor / untitled) and `test_census_does_not_read_rendered_html` are left exactly as merged. `registered_site_paths()` resolving hrefs to real site paths is a better join than the substring match I had drafted.

## Verification

```
tests/capabilities                            13 passed
tests/scripts/test_detect_touched_domains.py  20 passed
ruff check                                    All checks passed
tests-all depends_on                          21 -> 22 domains
tests-capabilities failure_action             block
```

The two new `DOMAIN_PATHS` entries get regression coverage for free: `test_all_domain_path_mappings_have_regression_coverage` derives its cases from `DOMAIN_PATHS` itself.

Note this PR edits `.claude/quality-gates.yaml`, which is in `FULL_MATRIX_PATHS`, so it runs all 22 shards — appropriate, since it changes which gates the aggregate depends on.

## Bearing on #1634

With #1879, #1882 and this, all three of #1234's shards are green **and** the capabilities gate can finally block. That was the stated precondition for arming `required_status_checks`. #1634 remains an owner decision, not an agent action.