### PR TITLE
fix(ci): separate the full-matrix sweep from the gated PR lane (#1863)

### DIFF
--- a/.github/workflows/full-matrix-sweep.yml
+++ b/.github/workflows/full-matrix-sweep.yml
@@ -1,0 +1,184 @@
+# Full Matrix Sweep (issue #1863)
+#
+# `Quality Gates by Domain` dispatches only the shards a change touches, so an
+# untouched-but-broken shard reports nothing rather than red and `main` can show
+# green indefinitely. This workflow is the counterweight: it runs EVERY domain
+# shard, ignoring touched-domain detection entirely, on
+#
+#   * every push to `main`  -> main's green is earned, not assumed
+#   * a nightly cron        -> drift is caught within a day even without merges
+#   * manual dispatch       -> on-demand "what is the true state of the matrix?"
+#
+# Job names here are deliberately distinct from the PR-gating workflow's
+# (`sweep-tests-*` / `Full matrix sweep result` vs `tests-*` / `Domain test
+# aggregate`) so a diagnostic sweep failure is never confused with, and can
+# never be mistaken for, a required pull-request context.
+name: Full Matrix Sweep
+
+"on":
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # Rapid merges to main supersede each other: the newest commit on main is the
+  # one whose sweep must complete. Nightly and dispatch share the group so a
+  # push does not race a cron run over the same tree.
+  group: full-matrix-sweep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-matrix:
+    name: Build full shard matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      total: ${{ steps.matrix.outputs.total }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build matrix
+        id: matrix
+        run: |
+          matrix=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
+            --mode full \
+            --domains-file tests/DOMAINS.md \
+            --output-format json-matrix)
+          total=$(uv run --no-sources python -c 'import json,sys; print(len(json.loads(sys.argv[1])["include"]))' "$matrix")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Full matrix sweep"
+            echo
+            echo "Dispatching all $total domain shards (no touched-domain gating)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if the matrix is empty
+        env:
+          TOTAL: ${{ steps.matrix.outputs.total }}
+        run: |
+          if [ "$TOTAL" -lt 1 ]; then
+            echo "Full matrix is empty; tests/DOMAINS.md parsed to zero domains."
+            exit 1
+          fi
+          echo "Full matrix contains $TOTAL shards."
+
+  sweep-tests:
+    name: sweep-tests-${{ matrix.domain }}
+    needs: full-matrix
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.full-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Gmsh runtime libraries
+        if: matrix.domain == 'solver-smoke'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libglu1-mesa
+
+      - name: Create reports directory
+        run: mkdir -p reports
+
+      - name: Read domain gate command
+        id: gate
+        env:
+          GATE_NAME: tests-${{ matrix.domain }}
+        run: |
+          command=$(uv run --no-sources --with pyyaml python - <<'PY'
+          import os
+          import yaml
+
+          with open(".claude/quality-gates.yaml", encoding="utf-8") as handle:
+              gates = yaml.safe_load(handle)["gates"]
+          print(gates[os.environ["GATE_NAME"]]["command"])
+          PY
+          )
+          {
+            echo "command<<EOF"
+            echo "$command"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run domain gate
+        run: ${{ steps.gate.outputs.command }}
+
+      - name: Upload domain artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-sweep-${{ matrix.domain }}
+          path: |
+            reports/
+            coverage.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+  sweep-result:
+    name: Full matrix sweep result
+    needs: [full-matrix, sweep-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize shard results
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ needs.full-matrix.outputs.total }}
+        run: |
+          {
+            echo "## Full matrix sweep result"
+            echo
+            echo "Every shard in tests/DOMAINS.md was dispatched ($TOTAL total)."
+            echo
+            echo "| Shard | Result |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # tee so the per-shard table is in the job log too, not only the
+          # rendered summary -- `gh run view` then shows the true matrix state.
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[] | select(.name | startswith("sweep-tests-")) | "| \(.name) | \(.conclusion // .status) |"' \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce full sweep result
+        env:
+          MATRIX_RESULT: ${{ needs.full-matrix.result }}
+          SWEEP_RESULT: ${{ needs.sweep-tests.result }}
+        run: |
+          if [ "$MATRIX_RESULT" != "success" ]; then
+            echo "Full matrix construction did not succeed: $MATRIX_RESULT"
+            exit 1
+          fi
+
+          if [ "$SWEEP_RESULT" != "success" ]; then
+            echo "At least one shard failed in the full sweep: $SWEEP_RESULT"
+            echo "See the per-shard table in this job's summary."
+            exit 1
+          fi
+
+          echo "All domain shards passed the full sweep."

--- a/.github/workflows/quality-gates-by-domain.yml
+++ b/.github/workflows/quality-gates-by-domain.yml
@@ -1,3 +1,17 @@
+# Quality Gates by Domain
+#
+# This workflow is the FAST, touched-domain-gated lane: pull requests and pushes
+# dispatch only the shards their diff touches. That scoping is deliberate, but it
+# means a green result here says "the shards we ran passed", not "all shards
+# passed" (issue #1863). Two things keep that honest:
+#
+#   1. Every run reports its own scope -- how many shards ran, how many did not,
+#      and which -- in the "Detect touched test domains" and "Domain test
+#      aggregate" job summaries.
+#   2. `.github/workflows/full-matrix-sweep.yml` runs EVERY shard on every push
+#      to `main` and nightly, under its own distinct check names. The nightly
+#      cron formerly lived here; it moved there so that a full-sweep failure is
+#      never posted under the same check names as the gated pull-request lane.
 name: Quality Gates by Domain
 
 "on":
@@ -5,8 +19,6 @@ name: Quality Gates by Domain
     branches: [main, develop]
   push:
     branches: [main, develop]
-  schedule:
-    - cron: "17 7 * * *"
   workflow_dispatch:
 
 jobs:
@@ -16,6 +28,11 @@ jobs:
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
       has-domains: ${{ steps.detect.outputs.has_domains }}
+      selected-count: ${{ steps.scope.outputs.selected-count }}
+      total-count: ${{ steps.scope.outputs.total-count }}
+      skipped-count: ${{ steps.scope.outputs.skipped-count }}
+      skipped-domains: ${{ steps.scope.outputs.skipped-domains }}
+      scope-line: ${{ steps.scope.outputs.scope-line }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,7 +76,8 @@ jobs:
               --domains-file tests/DOMAINS.md \
               --output-format json-matrix)
           else
-            # schedule (nightly cron) + workflow_dispatch run the full sweep.
+            # workflow_dispatch runs the full sweep on demand. The nightly cron
+            # now lives in full-matrix-sweep.yml.
             matrix=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
               --mode full \
               --domains-file tests/DOMAINS.md \
@@ -69,6 +87,24 @@ jobs:
           has_domains=$(uv run --no-sources python -c 'import json,sys; print("true" if json.loads(sys.argv[1])["include"] else "false")' "$matrix")
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "has_domains=$has_domains" >> "$GITHUB_OUTPUT"
+
+      - name: Report shard scope
+        id: scope
+        # Reporting only -- never gates. Everything new lives inside this step,
+        # behind continue-on-error, so scope reporting can never fail a PR or
+        # change which shards run. The second detector call (--mode full) is the
+        # denominator: the shards that exist, versus the ones dispatched above.
+        continue-on-error: true
+        env:
+          SELECTED_MATRIX: ${{ steps.detect.outputs.matrix }}
+          SCOPE_EVENT: ${{ github.event_name }}
+        run: |
+          FULL_MATRIX=$(uv run --no-sources python scripts/ci/detect_touched_domains.py \
+            --mode full \
+            --domains-file tests/DOMAINS.md \
+            --output-format json-matrix)
+          export FULL_MATRIX
+          uv run --no-sources python scripts/ci/report_shard_scope.py
 
   ci-harness-tests:
     name: CI harness and compliance tests
@@ -161,6 +197,46 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Report scope of this result
+        # States what this check actually covered, so a green aggregate cannot be
+        # read as "all shards passed" when only a subset was dispatched (#1863).
+        continue-on-error: true
+        env:
+          SCOPE_LINE: ${{ needs.detect-domains.outputs.scope-line }}
+          SELECTED_COUNT: ${{ needs.detect-domains.outputs.selected-count }}
+          TOTAL_COUNT: ${{ needs.detect-domains.outputs.total-count }}
+          SKIPPED_COUNT: ${{ needs.detect-domains.outputs.skipped-count }}
+          SKIPPED_DOMAINS: ${{ needs.detect-domains.outputs.skipped-domains }}
+        run: |
+          scope="${SCOPE_LINE:-Shard scope: unavailable (scope reporting did not run).}"
+          echo "$scope"
+          {
+            echo "## Scope of this result"
+            echo
+            echo "$scope"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$SKIPPED_DOMAINS" ]; then
+            echo "Shards NOT run in this check: $SKIPPED_DOMAINS"
+            {
+              echo "A pass here means **${SELECTED_COUNT:-?} of ${TOTAL_COUNT:-?} shards**"
+              echo "passed. The other ${SKIPPED_COUNT:-?} were not executed by this run;"
+              echo "they run in full on every push to \`main\` and nightly via the"
+              echo "\`Full Matrix Sweep\` workflow."
+              echo
+              echo "Not run: \`${SKIPPED_DOMAINS}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ -n "$TOTAL_COUNT" ]; then
+            echo "All ${TOTAL_COUNT} shards were dispatched in this run."
+            echo "All ${TOTAL_COUNT} shards were dispatched: a pass here covers the whole matrix." \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Shard scope could not be determined for this run."
+            echo "Shard scope could not be determined for this run; treat a pass as scoped." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Enforce required domain result
         env:
           HAS_DOMAINS: ${{ needs.detect-domains.outputs.has-domains }}

--- a/scripts/ci/report_shard_scope.py
+++ b/scripts/ci/report_shard_scope.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Report the shard scope of a Quality Gates by Domain run (issue #1863).
+
+Domain gating means an untouched shard is never dispatched, so a green run can
+mean "the shards we ran passed" rather than "all shards passed". This script
+makes that distinction explicit: it compares the matrix the run will execute
+against the full matrix and reports the difference.
+
+Inputs (environment variables):
+  SELECTED_MATRIX  JSON emitted by detect_touched_domains.py for this run.
+  FULL_MATRIX      JSON emitted by detect_touched_domains.py --mode full.
+  SCOPE_EVENT      Optional event name, used only in the human-readable text.
+
+Outputs:
+  GITHUB_OUTPUT        selected-count, total-count, skipped-count,
+                       skipped-domains, scope-line
+  GITHUB_STEP_SUMMARY  a markdown block stating the scope of the run
+
+This is reporting only and never gates: it exits 0 unless its own inputs are
+unparseable, and it deliberately makes no judgement about whether skipping is
+acceptable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def domain_names(raw: str) -> list[str]:
+    """Extract ordered domain names from a detect_touched_domains.py matrix."""
+    payload = json.loads(raw)
+    include = payload.get("include", [])
+    return [str(entry["domain"]) for entry in include if "domain" in entry]
+
+
+def scope_line(selected: list[str], total: list[str], event: str) -> str:
+    skipped = [name for name in total if name not in set(selected)]
+    if not total:
+        return "No test domains are defined; shard scope is empty."
+    if not skipped:
+        return f"Shard scope: all {len(total)} shards dispatched."
+    return (
+        f"Shard scope: {len(selected)} of {len(total)} shards dispatched"
+        f" ({len(skipped)} not run) for event '{event}'."
+    )
+
+
+def summary_markdown(selected: list[str], total: list[str], event: str) -> str:
+    skipped = [name for name in total if name not in set(selected)]
+    lines = [
+        "## Domain shard scope",
+        "",
+        scope_line(selected, total, event),
+        "",
+    ]
+    if skipped:
+        lines += [
+            "A green result on this run means **the dispatched shards passed**,",
+            "not that every shard passed. The shards below were not executed",
+            "here; they run in full on every push to `main` and nightly via",
+            "`.github/workflows/full-matrix-sweep.yml`.",
+            "",
+            f"<details><summary>Shards not run ({len(skipped)})</summary>",
+            "",
+        ]
+        lines += [f"- `tests-{name}`" for name in skipped]
+        lines += ["", "</details>", ""]
+    if selected:
+        lines += [
+            f"<details><summary>Shards dispatched ({len(selected)})</summary>",
+            "",
+        ]
+        lines += [f"- `tests-{name}`" for name in selected]
+        lines += ["", "</details>", ""]
+    return "\n".join(lines)
+
+
+def write_outputs(path: str | None, pairs: dict[str, str]) -> None:
+    if not path:
+        for key, value in pairs.items():
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def append_summary(path: str | None, text: str) -> None:
+    if not path:
+        print(text)
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(text + "\n")
+
+
+def main() -> int:
+    try:
+        selected = domain_names(os.environ.get("SELECTED_MATRIX", '{"include":[]}'))
+        total = domain_names(os.environ.get("FULL_MATRIX", '{"include":[]}'))
+    except (ValueError, TypeError, KeyError) as exc:
+        print(
+            f"report_shard_scope.py: unparseable matrix input: {exc}", file=sys.stderr
+        )
+        return 1
+
+    event = os.environ.get("SCOPE_EVENT", "unknown")
+    skipped = [name for name in total if name not in set(selected)]
+    line = scope_line(selected, total, event)
+
+    write_outputs(
+        os.environ.get("GITHUB_OUTPUT"),
+        {
+            "selected-count": str(len(selected)),
+            "total-count": str(len(total)),
+            "skipped-count": str(len(skipped)),
+            "skipped-domains": ",".join(skipped),
+            "scope-line": line,
+        },
+    )
+    append_summary(
+        os.environ.get("GITHUB_STEP_SUMMARY"),
+        summary_markdown(selected, total, event),
+    )
+    print(line)
+    if skipped:
+        print("Shards not run: " + ", ".join(f"tests-{name}" for name in skipped))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1863.

## The problem

`Quality Gates by Domain` is a touched-domain-gated lane: a PR dispatches only the shards its diff touches. That scoping is deliberate and worth keeping — but it means **a green result says "the shards we ran passed", not "all shards passed"**. A docs-only push runs 0 of 22 and reports success.

Worse, the nightly full sweep lived in the *same* workflow and posted under the *same check names*. So a full-sweep failure and a gated-lane pass were indistinguishable from the outside — which is how three shards stayed red on `main` without anyone seeing it.

## The fix

**Separate the lanes.** `full-matrix-sweep.yml` now runs every shard on every push to `main` and nightly, under its own distinct check names. The cron moved out of the gated workflow, so a full-sweep failure can never be posted under the PR lane's names again.

**Make the scope legible.** Every run reports how many shards ran, how many did not, and which — in the `Detect touched test domains` and `Domain test aggregate` job summaries. A reader can now tell "22 of 22 passed" from "0 of 22 ran" without opening the matrix.

`scripts/ci/report_shard_scope.py` is **reporting only and never gates** — the whole addition lives inside one step, so a bug in it cannot change any pass/fail verdict.

## Why this matters now

Everything else merged today (#1879, #1882, #1883, #1886, #1887) turned the last red shards green. This is what makes that state *mean* something: without it, `main` being green is compatible with most shards never having run.

Complements #1883, which put `tests-capabilities` into the `Domain test aggregate` roll-up — a gate outside the aggregate was invisible for the same reason a shard that never runs is invisible.

Rebased onto `d0b3f154`; no overlap with #1886 (which touched `.claude/quality-gates.yaml` and the capabilities test — this touches the two workflow files and one new script).
