### PR TITLE
fix(dynacard): correct the two largest errors found against real data (#1899, #1897)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -289,13 +289,27 @@ def calculate_theoretical_production(
     fillage_fraction = fillage_analysis.fillage / 100.0
     net_displacement = gross_displacement * fillage_fraction
 
-    # Get runtime (hours)
-    if ctx.well_test is not None:
-        runtime = ctx.well_test.runtime
-    elif ctx.input_params is not None:
+    # Runtime (hours) -- prefer the value recorded WITH the card.
+    #
+    # This priority used to be reversed, and it was the largest single error
+    # term measured against public production records (dm#1899). A well test's
+    # runtime can predate the card by months: one well used 9.12 h from a
+    # January test for an April card whose own runtime was 5.28 h, which alone
+    # inflated production by ~68%. Correcting the order took that card from
+    # +65.5% to -4.2% against the state's filed volumes.
+    #
+    # A well that cycles but is assumed to run 24 h is overstated by exactly
+    # its duty factor. That assumption is reported on the result rather than
+    # made silently -- see ProductionAnalysis.runtime_source.
+    if ctx.input_params is not None and ctx.input_params.runtime:
         runtime = ctx.input_params.runtime
+        runtime_source = "card"
+    elif ctx.well_test is not None and ctx.well_test.runtime:
+        runtime = ctx.well_test.runtime
+        runtime_source = "well_test"
     else:
-        runtime = 24.0  # Assume 24 hours
+        runtime = 24.0
+        runtime_source = "assumed_24h"
 
     # Theoretical production (BPD) adjusted for runtime
     runtime_fraction = runtime / 24.0
@@ -312,7 +326,9 @@ def calculate_theoretical_production(
         gross_displacement=float(gross_displacement),
         net_displacement=float(net_displacement),
         theoretical_production=float(theoretical_production),
-        pump_efficiency=float(pump_efficiency)
+        pump_efficiency=float(pump_efficiency),
+        runtime_hours=float(runtime),
+        runtime_source=runtime_source,
     )
 
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/adapter.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/adapter.py
@@ -33,6 +33,31 @@ STEEL_MODULUS_PSI = 30_000_000.0
 STEEL_DENSITY_LB_FT3 = 490.0
 
 
+def _effective_density_lb_ft3(section) -> float:
+    """Rod density including couplings, derived from measured weight per foot.
+
+    The wave speed the solver marches at is c = sqrt(E/rho), so density is not
+    a cosmetic input. Bare steel is 490 lb/ft3, but a real rod's catalogued
+    weight is coupling-inclusive and works out near 532 lb/ft3 -- couplings add
+    roughly 8% of mass to the same nominal cross-section.
+
+    Using 490 gave 14.01% median nRMSE against measured vendor downhole cards;
+    deriving density from weight gave 0.74% (dm#1897). The error is nearly a
+    pure load offset, so correlation stays above 0.999 either way and it does
+    not look like a defect on a shape comparison.
+
+    The corroboration is sharp: rod catalogues state a sonic velocity of
+    16,300 ft/s, which matches sqrt(E/rho) at 532 lb/ft3 to 0.07%, against
+    16,982 ft/s (+4.2%) at 490.
+    """
+    weight_per_foot = getattr(section, "weight_per_foot", 0.0) or 0.0
+    if weight_per_foot > 0.0 and section.diameter > 0.0:
+        # lb/ft divided by ft^2 of nominal steel area; 576 = 4 * 144 converts
+        # the in^2 area of a round rod to ft^2.
+        return weight_per_foot * 576.0 / (np.pi * section.diameter ** 2)
+    return section.density if section.density else STEEL_DENSITY_LB_FT3
+
+
 def rod_string_from_context(ctx: DynacardAnalysisContext) -> RodString:
     """Build the SI rod string from the context's oilfield-unit sections.
 
@@ -60,10 +85,7 @@ def rod_string_from_context(ctx: DynacardAnalysisContext) -> RodString:
         [s.length * U.FT2M for s in ctx.rod_string], dtype=np.float64
     )
     densities = np.array(
-        [
-            (s.density if s.density else STEEL_DENSITY_LB_FT3) * U.LBPFT32KGPM3
-            for s in ctx.rod_string
-        ],
+        [_effective_density_lb_ft3(s) * U.LBPFT32KGPM3 for s in ctx.rod_string],
         dtype=np.float64,
     )
     moduli = np.array(

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/models.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/models.py
@@ -215,6 +215,19 @@ class ProductionAnalysis(BaseModel):
     theoretical_production: float = 0.0  # BPD
     pump_efficiency: float = 0.0  # percent
 
+    #: Runtime used, and where it came from: ``"card"`` (recorded with the
+    #: card, preferred), ``"well_test"`` (may predate the card by months), or
+    #: ``"assumed_24h"``.
+    #:
+    #: Production scales linearly with this, so which source was used matters
+    #: as much as the value. A stale well-test runtime silently outranking the
+    #: card's own was the largest single error term measured against public
+    #: production records (dm#1899). The assumption is now reported rather
+    #: than inferred by the reader: ``"assumed_24h"`` overstates any cycling
+    #: well by exactly its duty factor.
+    runtime_hours: float = 24.0
+    runtime_source: str = "assumed_24h"
+
 
 class TorqueStatistics(BaseModel):
     """Min/max torque statistics in M-in-lbs (thousands of inch-pounds)."""
@@ -447,6 +460,18 @@ class AnalysisResults(BaseModel):
 
     # Legacy compatibility
     pump_fillage: float = 0.0
+
+    #: Theoretical pump displacement in BPD, NOT a production estimate.
+    #:
+    #: It is gross displacement x fillage x runtime/24 at 100% volumetric
+    #: efficiency: no slippage past the plunger, no valve leakage, and no
+    #: formation volume factor -- and card-derived barrels are downhole
+    #: barrels, while a sales or regulatory figure is stock-tank.
+    #:
+    #: Scored against public New Mexico OCD filings this reads +65% to +82%
+    #: high, on a well whose runtime was unambiguous, implying real volumetric
+    #: efficiency near 55% (dm#1899). The name is retained for compatibility
+    #: with the field-health CSV schema; read it as displacement.
     inferred_production: float = 0.0
     buckling_detected: bool = False
     diagnostic_message: str = "Analysis not yet performed"

--- a/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
@@ -216,3 +216,45 @@ def test_rod_string_rejects_mismatched_section_arrays():
             diameters=np.array([0.0222, 0.0190]),
             lengths=np.array([290.0]),
         )
+
+
+class TestEffectiveRodDensity:
+    """Rod density is derived from measured weight, not assumed bare steel.
+
+    The solver marches at c = sqrt(E/rho), so this is not a cosmetic input.
+    Assuming 490 lb/ft3 gave 14.01% median nRMSE against measured vendor
+    downhole cards; deriving from catalogued weight gave 0.74% (dm#1897).
+    """
+
+    def test_derived_from_weight_matches_catalogue_sonic_velocity(self):
+        """Independent check: the derived density must reproduce 16,300 ft/s.
+
+        Rod catalogues state a sonic velocity our derivation never sees, so
+        agreement is a genuine cross-check rather than a restatement. Bare
+        steel at 490 lb/ft3 gives 16,982 ft/s -- 4.2% off, and the reason the
+        old default was wrong.
+        """
+        from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings.adapter import (
+            _effective_density_lb_ft3,
+        )
+        from digitalmodel.marine_ops.artificial_lift.dynacard.models import RodSection
+
+        # 0.75 in rod, catalogued coupling-inclusive weight 1.63 lb/ft
+        section = RodSection(diameter=0.75, length=1000.0, weight_per_foot=1.63)
+        rho = _effective_density_lb_ft3(section)
+        assert rho == pytest.approx(531.3, abs=1.0)
+
+        E_lbf_ft2 = 30.5e6 * 144.0
+        c_ft_s = np.sqrt(E_lbf_ft2 * 32.174 / rho)
+        assert c_ft_s == pytest.approx(16_300.0, rel=0.005)
+
+    def test_falls_back_to_steel_without_a_measured_weight(self):
+        """No weight supplied is the only case where assuming steel is honest."""
+        from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings.adapter import (
+            _effective_density_lb_ft3,
+        )
+        from digitalmodel.marine_ops.artificial_lift.dynacard.models import RodSection
+
+        assert _effective_density_lb_ft3(
+            RodSection(diameter=0.75, length=1000.0)
+        ) == pytest.approx(490.0)


### PR DESCRIPTION
Closes #1899. Closes #1897 (rod density part).

Two fixes, both measured against external reality rather than our own fixtures.

## Runtime priority was backwards (#1899)

`calculations.py` read `ctx.well_test.runtime` — which can predate the card by **months** — before `ctx.input_params.runtime`, recorded *with* the card. One well used **9.12 h** from a January test for an April card whose own runtime was **5.28 h**.

Scored against public New Mexico OCD filings: that card goes from **+65.5% to −4.2%**, three-card median from **+67.6% to +23.5%**. The vendor's own well test matches those filings to +2.2%, so the error was ours.

The 24 h fallback stays but is no longer silent — `ProductionAnalysis` now carries `runtime_hours` and `runtime_source` (`card`/`well_test`/`assumed_24h`).

I first made the missing case *raise*. That was wrong — it failed an entire analysis over one optional metric and broke 24 legitimate callers. Reporting the assumption is honest and proportionate.

## Rod density fell back to bare steel (#1897)

The adapter used 490 lb/ft³ whenever `RodSection.density` was unset — which is every well loaded from field data. Real catalogued rod weight is coupling-inclusive, ~532 lb/ft³.

The solver marches at c = √(E/ρ), so it matters:

| | median nRMSE | peak-load error |
|---|---:|---:|
| 490 (default) | **14.01%** | +15.6% |
| derived from weight | **0.74%** | +0.7% |

Corroborated by a number the derivation never sees: catalogues state 16,300 ft/s sonic velocity; the derived density gives **16,309 ft/s** (0.06%), bare steel gives 16,982 (+4.2%). `constants.py` already had `WAVE_SPEED_FT_PER_S = 16_300.0` — the right answer was present and unused.

## Still open on #1899

`calculate_theoretical_production` is 100%-volumetric-efficiency displacement — no slippage, leakage or FVF, and downhole rather than stock-tank barrels. On a well with unambiguous runtime we remain +81.8%, implying real volumetric efficiency ~55%.

**1440 passed, 4 skipped.**