### PR TITLE
fix(packaging): restore xlsxwriter — pandas addresses it by string, not import (#1632)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ dependencies = [
     "urllib3>=2.0.0,<3.0.0",
     "validators==0.22.0",
     "webcolors>=1.13,<2.0",
+    # NOT imported anywhere -- pandas resolves it by NAME:
+    # pd.ExcelWriter(..., engine="xlsxwriter"). See DYNAMIC_RUNTIME in
+    # tests/contracts/test_runtime_dependencies.py (#1632).
+    "xlsxwriter>=3.1.0,<4.0.0",
     "xarray>=2023.1.0,<2026.0.0",
     "xlrd>=2.0.0,<3.0.0",
     "xmltodict>=0.13.0,<1.0.0",

--- a/tests/contracts/test_runtime_dependencies.py
+++ b/tests/contracts/test_runtime_dependencies.py
@@ -58,6 +58,25 @@ IMPORT_TO_DIST = {
     "mpl_toolkits": "matplotlib",  # namespace package shipped BY matplotlib
 }
 
+#: Runtime dependencies that shipped code needs but never `import`s -- so no AST
+#: scan can see them, and `test_no_runtime_dependency_is_unused` would call them
+#: unused. Each entry MUST cite the call site that needs it.
+#:
+#: This category exists because #1632 removed `xlsxwriter` on exactly that
+#: reasoning and broke Excel export: pandas resolves the writer by NAME, and a
+#: dependency expressed as a string is invisible to an import scan.
+#:
+#: Before adding an entry, prefer making the dependency explicit in code. Add
+#: here only when the library's own API is string-addressed (pandas engines,
+#: matplotlib backends, SQLAlchemy dialects, entry-point plugins).
+DYNAMIC_RUNTIME: dict[str, str] = {
+    # pd.ExcelWriter(..., engine="xlsxwriter") at:
+    #   asset_integrity/common/DataFrame_To_xlsx.py:12
+    #   asset_integrity/common/data.py:454
+    #   infrastructure/utils/data.py (same helper)
+    "xlsxwriter": "pandas ExcelWriter engine, addressed by string not import",
+}
+
 #: FROZEN 2026-07-29 (#1632). Module-level imports in shipped code that resolve to
 #: nothing installable. Two kinds, both pre-existing and both out of scope for the
 #: dependency un-merge -- enumerated here so they are visible debt rather than a
@@ -81,7 +100,8 @@ KNOWN_UNDECLARED: frozenset[str] = frozenset({
     "services", "xlsx-to-dataframe",
     # (b) real packages, legacy corners only
     "bokeh", "exchangelib", "flask-cors", "flask-flatpages", "flask-httpauth",
-    "flask-restful", "flask-wtf", "markitdown", "oyaml", "pandas-datareader",
+    "finvizfinance", "flask-restful", "flask-wtf", "markitdown", "oyaml",
+    "pandas-datareader",
     "pdfplumber", "pygame", "sec-edgar-downloader", "webdriver-manager",
     "wtforms", "yahoo-fin", "yfinance",
 })
@@ -115,7 +135,21 @@ def _import_names(node: ast.AST) -> set[str]:
 
 def hard_imports() -> set[str]:
     """Distributions imported at MODULE level, outside try/except and outside any
-    function or class body, by code that ships in the wheel."""
+    function or class body, by code that ships in the wheel.
+
+    Only ``tree.body`` is examined, and that is sufficient: a module-level
+    ``try: import x`` is an ``ast.Try`` node whose children are NOT direct
+    children of ``tree.body``, and a lazy import inside a function is inside an
+    ``ast.FunctionDef``. Both are therefore already excluded.
+
+    An earlier version also subtracted a ``guarded`` set collected by walking
+    every ``Try``/``FunctionDef`` in the file. That was worse than redundant: it
+    CANCELLED a genuine module-level offender whenever the same name was also
+    imported lazily somewhere else in the same file, producing false negatives.
+    It hid two real offenders, one of them live and under test
+    (``structural/pipe_capacity/common/PipeCapacity.py``, 1192 LOC, whose test
+    carries a ``sys.path`` hack to work around the broken import).
+    """
     out: set[str] = set()
     stdlib = set(sys.stdlib_module_names)
     for path in sorted(SRC.rglob("*.py")):
@@ -126,15 +160,10 @@ def hard_imports() -> set[str]:
             tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
         except SyntaxError:  # pragma: no cover - reported by its own guard
             continue
-        guarded: set[str] = set()
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.Try, ast.FunctionDef, ast.AsyncFunctionDef)):
-                for sub in ast.walk(node):
-                    guarded |= _import_names(sub)
         top: set[str] = set()
         for node in tree.body:
             top |= _import_names(node)
-        for mod in top - guarded:
+        for mod in top:
             if mod in stdlib or mod in NOT_A_DEPENDENCY or mod.startswith("_"):
                 continue
             out.add(_dist(mod))
@@ -146,6 +175,33 @@ def declared_runtime() -> set[str]:
     return {_spec_name(s) for s in doc["project"]["dependencies"]}
 
 
+def test_dynamic_runtime_entries_are_declared_and_still_used():
+    """Every DYNAMIC_RUNTIME entry must be a real runtime dependency AND still be
+    referenced by name in shipped code.
+
+    Without the second half, this dict becomes a blanket exemption: an entry
+    whose call site was deleted would keep a dependency alive forever with the
+    contract asserting nothing. Matching on the string literal is the only check
+    available -- that is the whole point of the category.
+    """
+    runtime = declared_runtime()
+    for dist, reason in sorted(DYNAMIC_RUNTIME.items()):
+        assert dist in runtime, (
+            f"{dist} is listed in DYNAMIC_RUNTIME ({reason}) but is not a runtime "
+            "dependency -- either declare it or drop the entry (#1632)"
+        )
+        found = [
+            p.relative_to(SRC).as_posix()
+            for p in SRC.rglob("*.py")
+            if dist in p.read_text(encoding="utf-8", errors="ignore")
+        ]
+        assert found, (
+            f"{dist} is exempted as a dynamic runtime dependency ({reason}) but no "
+            "shipped module mentions it by name any more. Delete the DYNAMIC_RUNTIME "
+            "entry and the dependency together (#1632)."
+        )
+
+
 def test_no_runtime_dependency_is_unused():
     """Every runtime dependency is imported by shipped code.
 
@@ -153,7 +209,7 @@ def test_no_runtime_dependency_is_unused():
     ``[test]`` extra for anything the test runner needs, ``[dev]`` for tooling,
     ``[orcaflex-dashboard]`` for the vendored app.
     """
-    unused = sorted(declared_runtime() - hard_imports())
+    unused = sorted(declared_runtime() - hard_imports() - set(DYNAMIC_RUNTIME))
     assert not unused, (
         "runtime dependencies that no shipped module imports at module level "
         f"({len(unused)}): {unused}\n"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,6 +1125,7 @@ dependencies = [
     { name = "webcolors" },
     { name = "xarray" },
     { name = "xlrd" },
+    { name = "xlsxwriter" },
     { name = "xmltodict" },
 ]
 
@@ -1374,6 +1375,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'test'", specifier = ">=15.0.1,<16.0.0" },
     { name = "xarray", specifier = ">=2023.1.0,<2026.0.0" },
     { name = "xlrd", specifier = ">=2.0.0,<3.0.0" },
+    { name = "xlsxwriter", specifier = ">=3.1.0,<4.0.0" },
     { name = "xlsxwriter", marker = "extra == 'test'", specifier = ">=3.1.0,<4.0.0" },
     { name = "xmltodict", specifier = ">=0.13.0,<1.0.0" },
 ]


### PR DESCRIPTION
Fixes a regression **I introduced** in #1632 (PR #1901), plus a false-negative in the contract test that shipped with it. Refs #1900.

## The regression

Two shipped call sites:

```python
# asset_integrity/common/DataFrame_To_xlsx.py:12
# asset_integrity/common/data.py:454
writer = pd.ExcelWriter(data['FileName'], engine='xlsxwriter')
```

pandas resolves the writer **by name**. So `xlsxwriter` is a genuine runtime dependency that appears nowhere as an `import` — the AST scan couldn't see it, the new contract test agreed it was unused, all 22 shards stayed green, and Excel export was broken for anyone who installed the package.

Runtime deps **54 → 55**.

This is the exact failure mode I flagged as the blind spot when writing the scan, and then walked straight into. An import-based contract cannot see a dependency addressed by string — pandas engines, matplotlib backends, SQLAlchemy dialects, entry-point plugins.

## Making it expressible instead of just fixing it

New `DYNAMIC_RUNTIME: dict[str, str]` — distribution → reason, each entry citing its call site.

Guarded by `test_dynamic_runtime_entries_are_declared_and_still_used`, which asserts **both** directions:

1. the entry is a declared runtime dependency, and
2. shipped code still mentions it by name.

Without (2) the dict rots into a blanket exemption: delete the call site and the dependency lives forever with the contract asserting nothing. Same expiry discipline as `KNOWN_UNDECLARED` and the units `LEGACY_ALLOWLIST`.

## The false negative in `hard_imports()`

Found by the #1900 recon. The scan built a `guarded` set by walking every `Try`/`FunctionDef` in a file and subtracting it from module-level imports. That was worse than redundant — `tree.body` **already** excludes try- and function-wrapped imports, because their children aren't direct children of the module body. All the subtraction did was **cancel a genuine module-level offender whenever the same name was also imported lazily elsewhere in the same file**.

Removing it surfaced a previously-hidden offender, now frozen in class (b):

- **`finvizfinance`** — `specialized/finance/stock_analysis/finance_components_get_data.py:6`, same corner as `yfinance`/`yahoo-fin`

And it means this is no longer invisible to the contract:

- **`structural/pipe_capacity/common/PipeCapacity.py`** — 1192 LOC, **live and under test**, whose `from common.update_deep import ...` fails, and whose test `tests/structural/pipe_capacity/test_pipe_capacity_common.py` carries a `sys.path.insert` hack to work around it. Tracked in #1900; the fix there is to re-root the import to `digitalmodel.infrastructure.common.update_deep` and delete the hack.

## Verification

```
tests/contracts   54 passed  (6 contract tests, was 5)
```

Run with the exact gate command (`--with-editable '.[test]'`). The contract test caught its own defect once the bug was removed — a less honest fix would have left the subtraction in place, since it made the debt list look shorter.

## Note on scope

I did not audit every other removed package for string-addressed use. My grep for removed-package names as string literals in `src/` returned only tool names in `workflows/automation/quality_gates.py` (invoked as subprocesses, correctly not dependencies) and an informational dict in `mcp_server/orcawave/quick_start.py`. `xlsxwriter` was the only true positive, but I want the limit of that check on the record rather than implied.