### PR TITLE
feat(dynacard): phase-invariant card comparison, and a parity test that runs (#1896)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/comparison.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/comparison.py
@@ -1,0 +1,147 @@
+# ABOUTME: Phase-invariant comparison metrics for closed dynamometer cards.
+# ABOUTME: Traversal direction and sample origin are canonicalized before scoring.
+"""Compare dynamometer cards without assigning meaning to storage phase."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .models import CardData
+
+
+@dataclass(frozen=True)
+class CardComparison:
+    """Percentage errors for an actual card against a reference card."""
+
+    load_nrmse_pct: float
+    position_nrmse_pct: float
+    peak_load_error_pct: float
+    minimum_load_error_pct: float
+    stroke_error_pct: float
+    enclosed_area_error_pct: float
+
+
+def _card_arrays(card: CardData, name: str) -> tuple[np.ndarray, np.ndarray]:
+    position = np.asarray(card.position, dtype=np.float64)
+    load = np.asarray(card.load, dtype=np.float64)
+    if position.ndim != 1 or load.ndim != 1:
+        raise ValueError(f"{name} card position and load must be one-dimensional")
+    if len(position) != len(load):
+        raise ValueError(
+            f"{name} card position ({len(position)}) and load ({len(load)}) "
+            "must have equal length"
+        )
+    if len(position) < 3:
+        raise ValueError(f"{name} card needs at least 3 points; got {len(position)}")
+    if not np.all(np.isfinite(position)) or not np.all(np.isfinite(load)):
+        raise ValueError(f"{name} card contains non-finite values")
+    return position, load
+
+
+def _signed_area(position: np.ndarray, load: np.ndarray) -> float:
+    return 0.5 * float(
+        np.sum(position * np.roll(load, -1) - np.roll(position, -1) * load)
+    )
+
+
+def _canonical_direction(
+    position: np.ndarray, load: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    if _signed_area(position, load) < 0.0:
+        return position[::-1], load[::-1]
+    return position, load
+
+
+def _positive_reference_scale(value: float, metric: str) -> float:
+    if value <= np.finfo(np.float64).eps:
+        raise ValueError(f"reference card has zero {metric}; percentage is undefined")
+    return value
+
+
+def _relative_error_pct(actual: float, reference: float, metric: str) -> float:
+    scale = _positive_reference_scale(abs(reference), metric)
+    return 100.0 * abs(actual - reference) / scale
+
+
+def compare_cards(actual: CardData, reference: CardData) -> CardComparison:
+    """Compare two equal-sample closed cards independent of direction and phase.
+
+    Both loops are oriented by the sign of their signed shoelace area. The
+    actual card is then circularly shifted to minimise the sum of squared
+    position and load errors after each axis is normalised by the corresponding
+    reference range.
+    """
+    actual_position, actual_load = _card_arrays(actual, "actual")
+    reference_position, reference_load = _card_arrays(reference, "reference")
+    if len(actual_position) != len(reference_position):
+        raise ValueError(
+            f"actual ({len(actual_position)}) and reference "
+            f"({len(reference_position)}) cards must have equal sample counts"
+        )
+
+    actual_position, actual_load = _canonical_direction(
+        actual_position, actual_load
+    )
+    reference_position, reference_load = _canonical_direction(
+        reference_position, reference_load
+    )
+    position_range = _positive_reference_scale(
+        float(np.ptp(reference_position)), "stroke"
+    )
+    load_range = _positive_reference_scale(
+        float(np.ptp(reference_load)), "load range"
+    )
+
+    best_score = np.inf
+    aligned_position = actual_position
+    aligned_load = actual_load
+    for shift in range(len(actual_position)):
+        shifted_position = np.roll(actual_position, shift)
+        shifted_load = np.roll(actual_load, shift)
+        position_error = (shifted_position - reference_position) / position_range
+        load_error = (shifted_load - reference_load) / load_range
+        score = float(np.mean(position_error**2 + load_error**2))
+        if score < best_score:
+            best_score = score
+            aligned_position = shifted_position
+            aligned_load = shifted_load
+
+    load_nrmse_pct = (
+        100.0
+        * float(np.sqrt(np.mean((aligned_load - reference_load) ** 2)))
+        / load_range
+    )
+    position_nrmse_pct = (
+        100.0
+        * float(np.sqrt(np.mean((aligned_position - reference_position) ** 2)))
+        / position_range
+    )
+    actual_area = abs(_signed_area(aligned_position, aligned_load))
+    reference_area = abs(_signed_area(reference_position, reference_load))
+
+    return CardComparison(
+        load_nrmse_pct=load_nrmse_pct,
+        position_nrmse_pct=position_nrmse_pct,
+        peak_load_error_pct=_relative_error_pct(
+            float(np.max(actual_load)),
+            float(np.max(reference_load)),
+            "peak load",
+        ),
+        minimum_load_error_pct=_relative_error_pct(
+            float(np.min(actual_load)),
+            float(np.min(reference_load)),
+            "minimum load",
+        ),
+        stroke_error_pct=_relative_error_pct(
+            float(np.ptp(actual_position)),
+            position_range,
+            "stroke",
+        ),
+        enclosed_area_error_pct=_relative_error_pct(
+            actual_area,
+            reference_area,
+            "enclosed area",
+        ),
+    )

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/data_loader.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/data_loader.py
@@ -49,11 +49,13 @@ def parse_legacy_json(data: Dict[str, Any]) -> DynacardAnalysisContext:
     # Extract input parameters
     input_params_raw = data.get('InputParameters', {})
     spm = input_params_raw.get('StrokesPerMinute', 6.0)
+    runtime_raw = input_params_raw.get('RunTime')
+    runtime = 24.0 if runtime_raw is None else runtime_raw
 
     input_params = InputParameters(
         strokes_per_minute=spm,
         tubing_pressure=input_params_raw.get('TubingPressure', 100.0),
-        runtime=input_params_raw.get('RunTime', 24.0),
+        runtime=runtime,
         load_max_sp=input_params_raw.get('LoadMaxSP'),
         load_min_sp=input_params_raw.get('LoadMinSP'),
         fluid_density=input_params_raw.get('FluidDensity'),
@@ -128,9 +130,6 @@ def parse_legacy_json(data: Dict[str, Any]) -> DynacardAnalysisContext:
         voltage=motor_raw.get('Voltage') or 0.0,
         manufacturer=motor_raw.get('Manufacturer') or '',
     )
-
-    # Get runtime from input parameters
-    runtime = input_params_raw.get('RunTime', 24.0)
 
     # Parse well test data
     well_test_raw = data.get('WellTestData', {})

--- a/tests/marine_ops/artificial_lift/dynacard/test_comparison.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_comparison.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.models import CardData
+
+
+def _card(position, load):
+    return CardData(position=position, load=load)
+
+
+def _assert_zero_error(comparison):
+    assert comparison.load_nrmse_pct == pytest.approx(0.0, abs=1.0e-12)
+    assert comparison.position_nrmse_pct == pytest.approx(0.0, abs=1.0e-12)
+    assert comparison.peak_load_error_pct == pytest.approx(0.0, abs=1.0e-12)
+    assert comparison.minimum_load_error_pct == pytest.approx(0.0, abs=1.0e-12)
+    assert comparison.stroke_error_pct == pytest.approx(0.0, abs=1.0e-12)
+    assert comparison.enclosed_area_error_pct == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_compare_cards_is_invariant_to_traversal_direction():
+    from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
+        compare_cards,
+    )
+
+    card = _card(
+        position=[0.0, 2.0, 3.0, 1.0, -1.0],
+        load=[10.0, 9.0, 12.0, 15.0, 13.0],
+    )
+    reversed_card = _card(
+        position=list(reversed(card.position)),
+        load=list(reversed(card.load)),
+    )
+
+    _assert_zero_error(compare_cards(reversed_card, card))
+
+
+def test_compare_cards_is_invariant_to_circular_index_origin():
+    from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
+        compare_cards,
+    )
+
+    card = _card(
+        position=[0.0, 2.0, 3.0, 1.0, -1.0],
+        load=[10.0, 9.0, 12.0, 15.0, 13.0],
+    )
+    rotated_card = _card(
+        position=np.roll(card.position, 2).tolist(),
+        load=np.roll(card.load, 2).tolist(),
+    )
+
+    _assert_zero_error(compare_cards(rotated_card, card))
+
+
+def test_compare_cards_reports_a_genuine_shape_difference():
+    from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
+        compare_cards,
+    )
+
+    reference = _card(
+        position=[0.0, 2.0, 2.0, 0.0],
+        load=[10.0, 10.0, 14.0, 14.0],
+    )
+    taller = _card(
+        position=[0.0, 2.0, 2.0, 0.0],
+        load=[10.0, 10.0, 16.0, 16.0],
+    )
+
+    comparison = compare_cards(taller, reference)
+
+    # RMSE = sqrt((0^2 + 0^2 + 2^2 + 2^2) / 4) = sqrt(2).
+    # Normalising by the 4 lb reference range gives 100*sqrt(2)/4.
+    assert comparison.load_nrmse_pct == pytest.approx(35.3553390593)
+    assert comparison.position_nrmse_pct == pytest.approx(0.0)
+    assert comparison.peak_load_error_pct == pytest.approx(100.0 * 2.0 / 14.0)
+    assert comparison.minimum_load_error_pct == pytest.approx(0.0)
+    assert comparison.stroke_error_pct == pytest.approx(0.0)
+    # Reference area = 2*4 = 8; taller area = 2*6 = 12.
+    assert comparison.enclosed_area_error_pct == pytest.approx(
+        100.0 * (12.0 - 8.0) / 8.0
+    )

--- a/tests/marine_ops/artificial_lift/test_dynacard_cleansed.py
+++ b/tests/marine_ops/artificial_lift/test_dynacard_cleansed.py
@@ -1,85 +1,48 @@
-import os
 import json
+from pathlib import Path
+
 import pytest
-import glob
-import numpy as np
-from digitalmodel.marine_ops.artificial_lift.dynacard.models import (
-    DynacardAnalysisContext, CardData, RodSection, PumpProperties, SurfaceUnit
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
+    compare_cards,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.data_loader import (
+    get_expected_downhole_card,
+    load_from_json_file,
 )
 from digitalmodel.marine_ops.artificial_lift.dynacard.solver import DynacardWorkflow
 
-# Path to local cleansed test data
-LOCAL_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
+LOCAL_DATA_DIR = Path(__file__).with_name("test_data")
 
 def get_cleansed_files():
     """Retrieves all anonymized JSON files from the local test data directory."""
-    return glob.glob(os.path.join(LOCAL_DATA_DIR, "*.json"))
-
-def map_cleansed_to_modern(file_path):
-    """Maps anonymized JSON structure to modern DynacardAnalysisContext."""
-    with open(file_path, 'r') as f:
-        data = json.load(f)
-    
-    # Rods mapping
-    rods = []
-    for r in data.get('equipmentData', {}).get('Rods', []):
-        rods.append(RodSection(
-            diameter=r.get('Diameter', 1.0),
-            length=r.get('TotalLength', 0.0),
-            modulus_of_elasticity=r.get('ModulusOfElasticity', 30500000.0),
-            density=490.0
-        ))
-    
-    # Pump mapping
-    pump_raw = data.get('equipmentData', {}).get('Pump', {})
-    pump = PumpProperties(
-        diameter=pump_raw.get('Diameter', 1.5),
-        depth=pump_raw.get('Depth', 5000.0)
-    )
-    
-    # Surface Unit mapping
-    su_raw = data.get('equipmentData', {}).get('SurfaceUnit', {})
-    surface_unit = SurfaceUnit(
-        manufacturer=su_raw.get('PumpingUnitManufacturer', 'Unknown'),
-        unit_type=su_raw.get('PumpingUnitGeometry', 'C'),
-        stroke_length=su_raw.get('StrokeLengthSetting', 144.0),
-        gear_box_rating=su_raw.get('GearBoxRating', 0.0)
-    )
-    
-    # Card Data mapping
-    card_raw = data.get('cardData', {})
-    surface_card = CardData(
-        position=card_raw.get('Position', []),
-        load=card_raw.get('Load', [])
-    )
-    
-    return DynacardAnalysisContext(
-        api14=data.get('CardDetails', {}).get('Api14', 'ANONYMIZED'),
-        surface_card=surface_card,
-        rod_string=rods,
-        pump=pump,
-        surface_unit=surface_unit,
-        spm=data.get('InputParameters', {}).get('StrokesPerMinute', 10.0)
-    )
+    return sorted(LOCAL_DATA_DIR.glob("cleansed_well_*.json"))
 
 @pytest.mark.parametrize("file_path", get_cleansed_files())
 def test_algorithm_robustness_with_cleansed_data(file_path):
     """
     Ensures new algorithms correctly process the permanent anonymized dataset.
     """
-    ctx = map_cleansed_to_modern(file_path)
-    
-    if not ctx.surface_card.position or not ctx.surface_card.load:
-        pytest.skip(f"Skipping {os.path.basename(file_path)}: Empty card data")
-        
+    with file_path.open() as stream:
+        raw_data = json.load(stream)
+    ctx = load_from_json_file(file_path)
+    expected_downhole = get_expected_downhole_card(raw_data)
+    assert expected_downhole is not None
+
     workflow = DynacardWorkflow(ctx)
     results = workflow.run_full_analysis()
-    
+
     assert results is not None
     assert results.downhole_card is not None
     assert len(results.downhole_card.position) == len(ctx.surface_card.position)
     assert results.pump_fillage > 0
     assert "Classification" in results.diagnostic_message
     
-    # Verify Anonymization is maintained
-    assert "API-CLEANSED" in results.ctx.api14 or "cleansed" in file_path.lower()
+    comparison = compare_cards(results.downhole_card, expected_downhole)
+    # Published worst errors are 2.15% load and 0.41% position. Adding
+    # 0.05 percentage point for rounding gives the regression ceilings.
+    assert comparison.load_nrmse_pct < 2.20
+    assert comparison.position_nrmse_pct < 0.46
+
+    # Verify anonymization is maintained.
+    assert "API-CLEANSED" in results.ctx.api14

--- a/tests/marine_ops/artificial_lift/test_solver_parity.py
+++ b/tests/marine_ops/artificial_lift/test_solver_parity.py
@@ -1,92 +1,57 @@
-import os
 import json
 from pathlib import Path
-import pytest
+
 import numpy as np
-from digitalmodel.marine_ops.artificial_lift.dynacard.models import (
-    DynacardAnalysisContext, CardData, RodSection, PumpProperties, SurfaceUnit
+from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
+    compare_cards,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.data_loader import (
+    get_expected_downhole_card,
+    load_from_json_file,
 )
 from digitalmodel.marine_ops.artificial_lift.dynacard.solver import DynacardWorkflow
 
-# Reference data from legacy system
-REFERENCE_FILE = "/mnt/github/workspace-hub/client_projects/energy_firm_data_analytics/dynacard/Code/Oxy.Cipher.DynaCard/tests/testdata/11708328.json"
-
-
-def _reference_file_available() -> bool:
-    """Check if the reference file exists."""
-    return Path(REFERENCE_FILE).exists()
-
-
-def load_reference_data():
-    with open(REFERENCE_FILE, 'r') as f:
-        data = json.load(f)
-    
-    # Legacy Downhole Card (The "Gold Standard")
-    ref_dh_pos = data['downholeCard']['Position']
-    ref_dh_load = data['downholeCard']['Load']
-    
-    # Equipment and Surface Card for our new solver
-    rods = [RodSection(diameter=r['Diameter'], length=r['TotalLength'], 
-                       modulus_of_elasticity=r['ModulusOfElasticity']) 
-            for r in data['equipmentData']['Rods']]
-    
-    ctx = DynacardAnalysisContext(
-        api14=data['CardDetails']['Api14'],
-        surface_card=CardData(position=data['cardData']['Position'], load=data['cardData']['Load']),
-        rod_string=rods,
-        pump=PumpProperties(diameter=data['equipmentData']['Pump']['Diameter'], 
-                            depth=data['equipmentData']['Pump']['Depth']),
-        surface_unit=SurfaceUnit(manufacturer="Ref", unit_type="C", 
-                                 stroke_length=data['InputParameters']['StrokePerMinute4LiftCapacity'], 
-                                 gear_box_rating=0),
-        spm=data['InputParameters']['StrokesPerMinute']
-    )
-    
-    return ctx, ref_dh_pos, ref_dh_load
-
-@pytest.mark.skipif(
-    not _reference_file_available(),
-    reason=f"Reference file not available: {REFERENCE_FILE}"
+DATA_DIR = Path(__file__).with_name("test_data")
+REFERENCE_FILES = tuple(
+    DATA_DIR / f"cleansed_well_{well_number:03d}.json"
+    for well_number in range(1, 6)
 )
-def test_solver_parity_with_legacy_gold_standard():
-    """
-    Test-Driven Update: Compare new solver results with legacy outputs.
-    Ensures mathematical accuracy within defined acceptance criteria.
-    """
-    ctx, ref_pos, ref_load = load_reference_data()
-    
-    # 1. Run New Solver
-    workflow = DynacardWorkflow(ctx)
-    results = workflow.run_full_analysis()
-    
-    new_pos = np.array(results.downhole_card.position)
-    new_load = np.array(results.downhole_card.load)
-    ref_pos = np.array(ref_pos)
-    ref_load = np.array(ref_load)
-    
-    # 2. Compare Metrics
-    # A. Stroke Length (Peak-to-Peak)
-    new_stroke = np.max(new_pos) - np.min(new_pos)
-    ref_stroke = np.max(ref_pos) - np.min(ref_pos)
-    stroke_diff_pct = abs(new_stroke - ref_stroke) / ref_stroke * 100
-    
-    # B. Peak Load
-    new_peak = np.max(new_load)
-    ref_peak = np.max(ref_load)
-    peak_diff_pct = abs(new_peak - ref_peak) / ref_peak * 100
-    
-    # C. Normalized RMS Error (Shape similarity)
-    # Ensure arrays are same length for comparison
-    min_len = min(len(new_load), len(ref_load))
-    rms_error = np.sqrt(np.mean((new_load[:min_len] - ref_load[:min_len])**2))
-    nrmse = (rms_error / (np.max(ref_load) - np.min(ref_load))) * 100
 
-    # 3. Acceptance Assertions
-    print(f"\n--- Parity Results for Well {ctx.api14} ---")
-    print(f"Stroke Difference: {stroke_diff_pct:.2f}% (Limit: 2%)")
-    print(f"Peak Load Difference: {peak_diff_pct:.2f}% (Limit: 10%)")
-    print(f"Shape NRMSE: {nrmse:.2f}% (Limit: 20%)")
-    
-    assert stroke_diff_pct < 2.0, f"Stroke difference too high: {stroke_diff_pct:.2f}%"
-    assert peak_diff_pct < 10.0, f"Peak load difference too high: {peak_diff_pct:.2f}%"
-    assert nrmse < 20.0, f"Card shape error too high: {nrmse:.2f}%"
+
+def test_null_fixture_runtime_uses_loader_default():
+    """A nullable optional runtime must not make a required fixture unloadable."""
+    context = load_from_json_file(DATA_DIR / "cleansed_well_004.json")
+
+    assert context.runtime == 24.0
+    assert context.input_params.runtime == 24.0
+
+
+def test_solver_parity_with_vendor_downhole_cards():
+    """Hold the default solver to its published real-card accuracy."""
+    comparisons = []
+    for reference_file in REFERENCE_FILES:
+        # These are required repository fixtures. Opening them directly makes a
+        # missing fixture fail instead of turning the only parity check into a skip.
+        with reference_file.open() as stream:
+            raw_data = json.load(stream)
+        context = load_from_json_file(reference_file)
+        expected = get_expected_downhole_card(raw_data)
+        assert expected is not None
+
+        results = DynacardWorkflow(context).run_full_analysis()
+        comparisons.append(compare_cards(results.downhole_card, expected))
+
+    load_nrmse = np.array(
+        [comparison.load_nrmse_pct for comparison in comparisons]
+    )
+    position_nrmse = np.array(
+        [comparison.position_nrmse_pct for comparison in comparisons]
+    )
+
+    # The class docstring reports median load nRMSE to one decimal place.
+    # Its 0.9% claim therefore permits values below 0.9 + 0.05 = 0.95%.
+    # The other bounds reproduce the issue's published 0.16% median position
+    # and 2.15% worst load results, rounded upward by 0.05 percentage point.
+    assert np.median(load_nrmse) < 0.95
+    assert np.median(position_nrmse) < 0.2
+    assert np.max(load_nrmse) < 2.20


### PR DESCRIPTION
Closes #1896.

## The only real-card solver test had never executed

`test_solver_parity.py:12` hard-coded `REFERENCE_FILE` under `/mnt/github/`, which exists on no machine here, and was `skipif`-guarded on that path existing. So it **skipped silently** — indistinguishable in a run summary from a test that passed. `solver.py`'s docstring claim of *0.9% median nRMSE* was therefore reproduced by nothing.

It now runs against `tests/marine_ops/artificial_lift/test_data/cleansed_well_*.json` — anonymised real wells that **already shipped in this repo**, complete with vendor downhole cards, sitting unused.

## Why it couldn't just be repointed

The repo had no phase-invariant way to compare two cards, despite the docstring claiming "phase-aligned". A dynamometer card is a **closed loop**: neither the index origin nor the stored traversal direction is physical. **4 of 6 real surface cards are stored in the opposite direction** to the vendor's, and comparing those index-to-index scores a *correct* card at 20–65% nRMSE.

`comparison.py` canonicalises both — traversal direction by the sign of the signed (shoelace) area, index origin by the circular shift minimising normalised RMSE — then reports load and position nRMSE, peak/minimum load error, stroke error and enclosed-area error.

## The test that matters

Three tests: a card against its own **reversal** scores ~0, against its own **rotation** scores ~0, and against a **genuinely different card** must not. A comparison that always returned zero would satisfy the first two.

Its expectations are derived by hand, not observed:

```
RMSE = sqrt((0² + 0² + 2² + 2²)/4) = √2
normalised by the 4 lb reference range → 35.3553%
areas 8 → 12 → +50%
```

I recomputed both independently before landing this.

## This is a prerequisite, not a convenience

An attempt at the pump-fillage fix (#1897) **regressed** the numbers — mean absolute error 3.25 pp → 27.44 pp, one well from 98.1% to **2.42%** against a vendor 97.52% — because corner *ordering* sorts by position and so re-imposes the assumption the detector fix removes. No corner-ordering or card-comparison rule means anything until direction is canonicalised. **#1897 is unblocked by this.**

## Verification

- `tests/marine_ops/artificial_lift/` — **913 passed**
- `test_solver_parity.py` — **2 passed**, not skipped, holding the docstring's numbers to account for the first time

Authored by Codex; salvaged from a session interrupted by my own timeout, then verified here — the by-hand arithmetic was recomputed independently before commit.