### PR TITLE
feat(hydrodynamics): connected-tank (U-tube) anti-roll capability — validated inertia, quadratic loss, closed-form moment and coupled roll

### DIFF
--- a/src/digitalmodel/hydrodynamics/utube_tank.py
+++ b/src/digitalmodel/hydrodynamics/utube_tank.py
@@ -1,0 +1,513 @@
+# ABOUTME: CFD-validated analytical model for a prismatic U-tube anti-roll tank.
+
+"""Analytical U-tube anti-roll tank dynamics.
+
+The model is calibrated for conduit form loss and rigid-column inertia.  Its
+moment correlation has 4.3 percent RMS error for forcing periods of 20 seconds
+and longer.  Below about 16 seconds it degrades as the legs' own longitudinal
+(6.25 s) and transverse (2.79 s) sloshing modes begin to participate.
+
+The effective conduit length must be anchored to a measured *natural* period,
+never to the amplitude peak of a forced sweep.  The peak is loss-controlled and
+moves with roll amplitude, whereas the natural period does not.  Using the peak
+for the reference calibration inflates the effective length by 2.76 times.
+
+Conduit loss scales approximately with the inverse square of area, not with
+``1 / area``.  The latter follows from a naive derivation but fails in opposite
+directions on either side of the calibration area.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+DEFAULT_EFFECTIVE_CONDUIT_LENGTH = 5.2004
+DEFAULT_LOSS_COEFFICIENT = 2.3894
+DEFAULT_AREA_EXPONENT = 2.138
+CALIBRATED_AREA_EXPONENT_RMS_PERCENT = 8.6
+LINEAR_AREA_EXPONENT_RMS_PERCENT = 36.5
+DEFAULT_GRAVITY = 9.81
+DEFAULT_DENSITY = 1025.0
+
+
+@dataclass(frozen=True)
+class UTubeGeometry:
+    """Prismatic tank geometry, in metres.
+
+    ``centroid_offset`` is the transverse distance from the vessel centreline
+    to either leg centroid.  Each leg has plan area
+    ``leg_length * leg_width``.  The bottom conduit has rectangular section
+    ``conduit_area`` and joins the leg centroids.
+    """
+
+    leg_length: float
+    leg_width: float
+    fill_depth: float
+    centroid_offset: float
+    effective_conduit_length: float = DEFAULT_EFFECTIVE_CONDUIT_LENGTH
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("leg_length", self.leg_length),
+            ("leg_width", self.leg_width),
+            ("fill_depth", self.fill_depth),
+            ("centroid_offset", self.centroid_offset),
+            ("effective_conduit_length", self.effective_conduit_length),
+        ):
+            if value <= 0.0:
+                raise ValueError(f"{name} must be positive")
+
+    @property
+    def leg_area(self) -> float:
+        return self.leg_length * self.leg_width
+
+
+@dataclass(frozen=True)
+class TankMoment:
+    """Tank moment phasor and transferred-volume response."""
+
+    in_phase: float
+    quadrature: float
+    q_in_phase: float
+    q_quadrature: float
+
+    @property
+    def magnitude(self) -> float:
+        return math.hypot(self.in_phase, self.quadrature)
+
+
+@dataclass(frozen=True)
+class ConduitOptimum:
+    """Result of a bounded conduit-area design search."""
+
+    conduit_area: float
+    tank_natural_period: float
+    peak_roll_reduction: float
+
+
+def _positive(name: str, value: float) -> None:
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+
+
+def natural_period(
+    *,
+    leg_area: float,
+    conduit_area: float,
+    fill_depth: float,
+    effective_conduit_length: float = DEFAULT_EFFECTIVE_CONDUIT_LENGTH,
+    gravity: float = DEFAULT_GRAVITY,
+) -> float:
+    """Return the rigid-column natural period."""
+
+    for name, value in (
+        ("leg_area", leg_area),
+        ("conduit_area", conduit_area),
+        ("fill_depth", fill_depth),
+        ("effective_conduit_length", effective_conduit_length),
+        ("gravity", gravity),
+    ):
+        _positive(name, value)
+    inertia_length = (
+        effective_conduit_length / conduit_area + 2.0 * fill_depth / leg_area
+    )
+    omega_n = math.sqrt((2.0 * gravity / leg_area) / inertia_length)
+    return 2.0 * math.pi / omega_n
+
+
+def calibrate_effective_conduit_length(
+    *,
+    measured_period: float,
+    leg_area: float,
+    conduit_area: float,
+    fill_depth: float,
+    gravity: float = DEFAULT_GRAVITY,
+) -> float:
+    """Infer the single conduit-inertia parameter from a natural period."""
+
+    for name, value in (
+        ("measured_period", measured_period),
+        ("leg_area", leg_area),
+        ("conduit_area", conduit_area),
+        ("fill_depth", fill_depth),
+        ("gravity", gravity),
+    ):
+        _positive(name, value)
+    omega_n = 2.0 * math.pi / measured_period
+    inertia_length = (2.0 * gravity / leg_area) / omega_n**2
+    effective_length = conduit_area * (inertia_length - 2.0 * fill_depth / leg_area)
+    if effective_length <= 0.0:
+        raise ValueError("measured period implies a non-positive effective length")
+    return effective_length
+
+
+def equivalent_damping(
+    *,
+    geometry: UTubeGeometry,
+    conduit_area: float,
+    forcing_period: float,
+    level_difference_amplitude: float,
+    loss_coefficient: float = DEFAULT_LOSS_COEFFICIENT,
+    area_exponent: float = DEFAULT_AREA_EXPONENT,
+    gravity: float = DEFAULT_GRAVITY,
+) -> float:
+    """Return harmonic-balance equivalent damping for quadratic form loss."""
+
+    for name, value in (
+        ("conduit_area", conduit_area),
+        ("forcing_period", forcing_period),
+        ("loss_coefficient", loss_coefficient),
+        ("area_exponent", area_exponent),
+        ("gravity", gravity),
+    ):
+        _positive(name, value)
+    if level_difference_amplitude < 0.0:
+        raise ValueError("level_difference_amplitude must be non-negative")
+
+    leg_area = geometry.leg_area
+    inertia_length = (
+        geometry.effective_conduit_length / conduit_area
+        + 2.0 * geometry.fill_depth / leg_area
+    )
+    omega_n = math.sqrt((2.0 * gravity / leg_area) / inertia_length)
+    omega = 2.0 * math.pi / forcing_period
+    q_amplitude = leg_area * level_difference_amplitude / 2.0
+    return (
+        (4.0 / (3.0 * math.pi))
+        * loss_coefficient
+        * omega
+        * q_amplitude
+        / (2.0 * conduit_area**area_exponent * inertia_length * omega_n)
+    )
+
+
+def _forced_volume_response(
+    *,
+    geometry: UTubeGeometry,
+    conduit_area: float,
+    forcing_period: float,
+    roll_amplitude: float,
+    loss_coefficient: float,
+    area_exponent: float,
+    gravity: float,
+) -> tuple[float, float]:
+    """Solve the harmonic-balance transferred-volume response."""
+
+    leg_area = geometry.leg_area
+    inertia_length = (
+        geometry.effective_conduit_length / conduit_area
+        + 2.0 * geometry.fill_depth / leg_area
+    )
+    omega_n = math.sqrt((2.0 * gravity / leg_area) / inertia_length)
+    omega = 2.0 * math.pi / forcing_period
+    gravity_forcing = (
+        2.0
+        * gravity
+        * geometry.centroid_offset
+        * math.tan(roll_amplitude)
+        / inertia_length
+    )
+    quadrature_forcing = (
+        2.0
+        * gravity
+        * geometry.centroid_offset
+        * math.sin(roll_amplitude)
+        / inertia_length
+    )
+    inertia_forcing = (
+        2.0
+        * (
+            geometry.fill_depth
+            + geometry.effective_conduit_length
+            + conduit_area / (2.0 * geometry.leg_length)
+        )
+        * geometry.centroid_offset
+        * omega**2
+        * roll_amplitude
+        / inertia_length
+    )
+    forcing = gravity_forcing + inertia_forcing
+    detuning = omega_n**2 - omega**2
+
+    q_amplitude = abs(forcing) / max(abs(detuning), 1.0e-12)
+    for _ in range(100):
+        level_amplitude = 2.0 * q_amplitude / leg_area
+        zeta = equivalent_damping(
+            geometry=geometry,
+            conduit_area=conduit_area,
+            forcing_period=forcing_period,
+            level_difference_amplitude=level_amplitude,
+            loss_coefficient=loss_coefficient,
+            area_exponent=area_exponent,
+            gravity=gravity,
+        )
+        damping = 2.0 * zeta * omega_n * omega
+        updated = abs(forcing) / math.hypot(detuning, damping)
+        if math.isclose(updated, q_amplitude, rel_tol=1.0e-10, abs_tol=1.0e-12):
+            q_amplitude = updated
+            break
+        q_amplitude = 0.5 * (q_amplitude + updated)
+
+    level_amplitude = 2.0 * q_amplitude / leg_area
+    zeta = equivalent_damping(
+        geometry=geometry,
+        conduit_area=conduit_area,
+        forcing_period=forcing_period,
+        level_difference_amplitude=level_amplitude,
+        loss_coefficient=loss_coefficient,
+        area_exponent=area_exponent,
+        gravity=gravity,
+    )
+    damping = 2.0 * zeta * omega_n * omega
+    denominator = detuning**2 + damping**2
+    return (
+        forcing * detuning / denominator,
+        -quadrature_forcing * damping / denominator,
+    )
+
+
+def _prismatic_properties(
+    geometry: UTubeGeometry, conduit_area: float
+) -> tuple[float, float, float, float]:
+    """Return volume, vertical centroid, frozen volume inertia, and surface inertia."""
+
+    length = geometry.leg_length
+    width = geometry.leg_width
+    depth = geometry.fill_depth
+    offset = geometry.centroid_offset
+    leg_area = geometry.leg_area
+    conduit_height = conduit_area / length
+    conduit_span = 2.0 * offset
+
+    leg_volume = 2.0 * leg_area * depth
+    conduit_volume = conduit_span * conduit_area
+    volume = leg_volume + conduit_volume
+    leg_first_z = 2.0 * leg_area * depth * (conduit_height + depth / 2.0)
+    conduit_first_z = conduit_volume * conduit_height / 2.0
+    vertical_centroid = (leg_first_z + conduit_first_z) / volume
+
+    leg_y2 = 2.0 * length * depth * (width**3 / 12.0 + width * offset**2)
+    conduit_y2 = conduit_area * conduit_span**3 / 12.0
+    leg_z2 = 2.0 * leg_area * ((conduit_height + depth) ** 3 - conduit_height**3) / 3.0
+    conduit_z2 = conduit_span * length * conduit_height**3 / 3.0
+    frozen_volume_inertia = leg_y2 + conduit_y2 + leg_z2 + conduit_z2
+    free_surface_inertia = 2.0 * length * width**3 / 12.0
+    return volume, vertical_centroid, frozen_volume_inertia, free_surface_inertia
+
+
+def tank_moment(
+    *,
+    geometry: UTubeGeometry,
+    conduit_area: float,
+    forcing_period: float,
+    roll_amplitude: float,
+    density: float = DEFAULT_DENSITY,
+    gravity: float = DEFAULT_GRAVITY,
+    loss_coefficient: float = DEFAULT_LOSS_COEFFICIENT,
+    area_exponent: float = DEFAULT_AREA_EXPONENT,
+) -> TankMoment:
+    """Return the tank-on-vessel moment phasor for sinusoidal roll."""
+
+    for name, value in (
+        ("conduit_area", conduit_area),
+        ("forcing_period", forcing_period),
+        ("density", density),
+        ("gravity", gravity),
+        ("loss_coefficient", loss_coefficient),
+        ("area_exponent", area_exponent),
+    ):
+        _positive(name, value)
+    if roll_amplitude < 0.0:
+        raise ValueError("roll_amplitude must be non-negative")
+
+    q_s, q_c = _forced_volume_response(
+        geometry=geometry,
+        conduit_area=conduit_area,
+        forcing_period=forcing_period,
+        roll_amplitude=roll_amplitude,
+        loss_coefficient=loss_coefficient,
+        area_exponent=area_exponent,
+        gravity=gravity,
+    )
+    volume, z_c, frozen_volume_inertia, free_surface_inertia = _prismatic_properties(
+        geometry, conduit_area
+    )
+    omega = 2.0 * math.pi / forcing_period
+    in_phase = (
+        (density * volume * gravity * z_c + density * gravity * free_surface_inertia)
+        * math.sin(roll_amplitude)
+        - density * frozen_volume_inertia * omega**2 * roll_amplitude
+        + 2.0 * density * gravity * geometry.centroid_offset * q_s
+    )
+    quadrature = 2.0 * density * gravity * geometry.centroid_offset * q_c
+    return TankMoment(in_phase, quadrature, q_s, q_c)
+
+
+def _quasi_static_moment_per_radian(
+    geometry: UTubeGeometry,
+    conduit_area: float,
+    density: float,
+    gravity: float,
+) -> float:
+    volume, z_c, _, free_surface_inertia = _prismatic_properties(geometry, conduit_area)
+    fixed = density * gravity * (volume * z_c + free_surface_inertia)
+    redistribution = (
+        density * gravity * geometry.leg_area * geometry.centroid_offset**2 * 2.0
+    )
+    return fixed + redistribution
+
+
+def coupled_roll_response(
+    *,
+    forcing_period: float,
+    vessel_roll_period: float,
+    hull_damping_ratio: float,
+    tank_authority: float,
+    geometry: UTubeGeometry,
+    conduit_area: float,
+    tank_enabled: bool = True,
+    density: float = DEFAULT_DENSITY,
+    gravity: float = DEFAULT_GRAVITY,
+    loss_coefficient: float = DEFAULT_LOSS_COEFFICIENT,
+    area_exponent: float = DEFAULT_AREA_EXPONENT,
+) -> complex:
+    """Return roll per unit wave moment for the normalized coupled system."""
+
+    for name, value in (
+        ("forcing_period", forcing_period),
+        ("vessel_roll_period", vessel_roll_period),
+        ("conduit_area", conduit_area),
+        ("density", density),
+        ("gravity", gravity),
+    ):
+        _positive(name, value)
+    if hull_damping_ratio < 0.0:
+        raise ValueError("hull_damping_ratio must be non-negative")
+    if tank_authority < 0.0:
+        raise ValueError("tank_authority must be non-negative")
+
+    omega = 2.0 * math.pi / forcing_period
+    vessel_omega = 2.0 * math.pi / vessel_roll_period
+    vessel_inertia = 1.0 / vessel_omega**2
+    hull_damping = 2.0 * hull_damping_ratio / vessel_omega
+    bare_denominator = 1.0 - omega**2 * vessel_inertia + 1j * omega * hull_damping
+    if not tank_enabled or tank_authority == 0.0:
+        return 1.0 / bare_denominator
+
+    # Set the forcing level by a five-degree bare-roll reference.  The returned
+    # value remains theta/M_wave; the finite reference is needed only because a
+    # quadratic-loss system has no amplitude-independent transfer function.
+    wave_moment = max(2.0 * hull_damping_ratio, 1.0e-6) * math.radians(5.0)
+    response = wave_moment / bare_denominator
+    static_moment = _quasi_static_moment_per_radian(
+        geometry, conduit_area, density, gravity
+    )
+    scale = tank_authority / static_moment
+    for _ in range(100):
+        amplitude = abs(response)
+        moment = tank_moment(
+            geometry=geometry,
+            conduit_area=conduit_area,
+            forcing_period=forcing_period,
+            roll_amplitude=amplitude,
+            density=density,
+            gravity=gravity,
+            loss_coefficient=loss_coefficient,
+            area_exponent=area_exponent,
+        )
+        impedance = (
+            scale
+            * complex(moment.in_phase, moment.quadrature)
+            / max(amplitude, 1.0e-15)
+        )
+        updated = wave_moment / (bare_denominator - impedance)
+        if abs(updated - response) <= 1.0e-9 * max(1.0, abs(updated)):
+            return updated / wave_moment
+        response = 0.5 * (response + updated)
+    return response / wave_moment
+
+
+def optimize_conduit_area(
+    *,
+    vessel_roll_period: float,
+    hull_damping_ratio: float,
+    tank_authority: float,
+    geometry: UTubeGeometry,
+    area_bounds: tuple[float, float],
+    samples: int = 121,
+) -> ConduitOptimum:
+    """Optimize conduit area over a bounded deterministic grid search."""
+
+    lower, upper = area_bounds
+    if lower <= 0.0 or upper <= lower:
+        raise ValueError("area_bounds must be positive and increasing")
+    if samples < 2:
+        raise ValueError("samples must be at least two")
+
+    forcing_periods = [
+        0.7 * vessel_roll_period + index * (0.6 * vessel_roll_period / 80.0)
+        for index in range(81)
+    ]
+    bare_peak = max(
+        abs(
+            coupled_roll_response(
+                forcing_period=period,
+                vessel_roll_period=vessel_roll_period,
+                hull_damping_ratio=hull_damping_ratio,
+                tank_authority=tank_authority,
+                geometry=geometry,
+                conduit_area=lower,
+                tank_enabled=False,
+            )
+        )
+        for period in forcing_periods
+    )
+
+    best_area = lower
+    best_peak = math.inf
+    for index in range(samples):
+        area = lower + index * (upper - lower) / (samples - 1)
+        coupled_peak = max(
+            abs(
+                coupled_roll_response(
+                    forcing_period=period,
+                    vessel_roll_period=vessel_roll_period,
+                    hull_damping_ratio=hull_damping_ratio,
+                    tank_authority=tank_authority,
+                    geometry=geometry,
+                    conduit_area=area,
+                )
+            )
+            for period in forcing_periods
+        )
+        if coupled_peak < best_peak:
+            best_area = area
+            best_peak = coupled_peak
+
+    period = natural_period(
+        leg_area=geometry.leg_area,
+        conduit_area=best_area,
+        fill_depth=geometry.fill_depth,
+        effective_conduit_length=geometry.effective_conduit_length,
+    )
+    return ConduitOptimum(best_area, period, 1.0 - best_peak / bare_peak)
+
+
+__all__ = [
+    "CALIBRATED_AREA_EXPONENT_RMS_PERCENT",
+    "ConduitOptimum",
+    "DEFAULT_AREA_EXPONENT",
+    "DEFAULT_EFFECTIVE_CONDUIT_LENGTH",
+    "DEFAULT_LOSS_COEFFICIENT",
+    "LINEAR_AREA_EXPONENT_RMS_PERCENT",
+    "TankMoment",
+    "UTubeGeometry",
+    "calibrate_effective_conduit_length",
+    "coupled_roll_response",
+    "equivalent_damping",
+    "natural_period",
+    "optimize_conduit_area",
+    "tank_moment",
+]

--- a/tests/hydrodynamics/test_utube_tank.py
+++ b/tests/hydrodynamics/test_utube_tank.py
@@ -1,0 +1,204 @@
+# ABOUTME: CFD-validated tests for the analytical U-tube anti-roll tank model.
+
+"""Tests for digitalmodel.hydrodynamics.utube_tank."""
+
+import math
+
+import pytest
+
+from digitalmodel.hydrodynamics import utube_tank as u
+
+
+LEG_LENGTH = 20.0
+LEG_WIDTH = 6.0
+LEG_AREA = LEG_LENGTH * LEG_WIDTH
+CENTROID_OFFSET = 5.0
+FILL_DEPTH = 5.0
+RHO = 1025.0
+GRAVITY = 9.81
+EFFECTIVE_CONDUIT_LENGTH = 5.2004
+LOSS_COEFFICIENT = 2.3894
+LOSS_AREA_EXPONENT = 2.138
+
+
+def reference_geometry():
+    return u.UTubeGeometry(
+        leg_length=LEG_LENGTH,
+        leg_width=LEG_WIDTH,
+        fill_depth=FILL_DEPTH,
+        centroid_offset=CENTROID_OFFSET,
+        effective_conduit_length=EFFECTIVE_CONDUIT_LENGTH,
+    )
+
+
+@pytest.mark.parametrize(
+    ("conduit_area", "fill_depth", "predicted_period", "cfd_period"),
+    [
+        (3.4, 5.0, 19.73, 19.27),
+        (13.5, 5.0, 10.64, 10.97),
+        (6.8, 2.5, 13.95, 13.45),
+        (6.8, 7.0, 14.59, 14.38),
+    ],
+)
+def test_natural_period_matches_cfd(
+    conduit_area, fill_depth, predicted_period, cfd_period
+):
+    period = u.natural_period(
+        leg_area=LEG_AREA,
+        conduit_area=conduit_area,
+        fill_depth=fill_depth,
+        effective_conduit_length=EFFECTIVE_CONDUIT_LENGTH,
+        gravity=GRAVITY,
+    )
+    assert period == pytest.approx(predicted_period, rel=0.004)
+    assert period == pytest.approx(cfd_period, rel=0.04)
+
+
+def test_effective_conduit_length_calibration_round_trips():
+    calibrated = u.calibrate_effective_conduit_length(
+        measured_period=14.31,
+        leg_area=LEG_AREA,
+        conduit_area=6.8,
+        fill_depth=FILL_DEPTH,
+        gravity=GRAVITY,
+    )
+    assert calibrated == pytest.approx(EFFECTIVE_CONDUIT_LENGTH, rel=1e-3)
+    period = u.natural_period(
+        leg_area=LEG_AREA,
+        conduit_area=6.8,
+        fill_depth=FILL_DEPTH,
+        effective_conduit_length=calibrated,
+        gravity=GRAVITY,
+    )
+    assert period == pytest.approx(14.31, rel=1e-3)
+
+
+def test_equivalent_damping_rises_with_roll_amplitude():
+    common = dict(
+        geometry=reference_geometry(),
+        conduit_area=6.8,
+        forcing_period=20.0,
+        loss_coefficient=LOSS_COEFFICIENT,
+        area_exponent=LOSS_AREA_EXPONENT,
+        gravity=GRAVITY,
+    )
+    low = u.equivalent_damping(level_difference_amplitude=0.10, **common)
+    high = u.equivalent_damping(level_difference_amplitude=0.50, **common)
+    assert high > low
+    # Quadratic head loss produces equivalent linear damping proportional to amplitude.
+    assert high / low == pytest.approx(5.0)
+
+
+def test_equivalent_damping_falls_with_conduit_area():
+    common = dict(
+        geometry=reference_geometry(),
+        forcing_period=20.0,
+        level_difference_amplitude=0.10,
+        loss_coefficient=LOSS_COEFFICIENT,
+        area_exponent=LOSS_AREA_EXPONENT,
+        gravity=GRAVITY,
+    )
+    small = u.equivalent_damping(conduit_area=3.4, **common)
+    large = u.equivalent_damping(conduit_area=13.5, **common)
+    assert large < small
+
+
+@pytest.mark.parametrize(
+    ("conduit_area", "cfd_damping"),
+    [(3.4, 0.13598), (13.5, 0.01323)],
+)
+def test_linear_area_loss_scaling_is_materially_worse(conduit_area, cfd_damping):
+    common = dict(
+        geometry=reference_geometry(),
+        conduit_area=conduit_area,
+        forcing_period=20.0,
+        level_difference_amplitude=0.10,
+        loss_coefficient=LOSS_COEFFICIENT,
+        gravity=GRAVITY,
+    )
+    calibrated = u.equivalent_damping(area_exponent=LOSS_AREA_EXPONENT, **common)
+    linear_area = u.equivalent_damping(area_exponent=1.0, **common)
+    calibrated_error = abs(calibrated - cfd_damping)
+    linear_error = abs(linear_area - cfd_damping)
+    assert calibrated == pytest.approx(cfd_damping, rel=0.01)
+    assert linear_error > 10.0 * calibrated_error
+
+
+@pytest.mark.parametrize(
+    ("forcing_period", "cfd_moment_mnm"),
+    [
+        (60.0, 8.807),
+        (40.0, 9.206),
+        (26.0, 9.683),
+        (24.0, 9.673),
+        (22.0, 9.498),
+        (20.0, 9.103),
+    ],
+)
+def test_in_phase_tank_moment_matches_cfd(forcing_period, cfd_moment_mnm):
+    moment = u.tank_moment(
+        geometry=reference_geometry(),
+        conduit_area=6.8,
+        forcing_period=forcing_period,
+        roll_amplitude=math.radians(5.0),
+        density=RHO,
+        gravity=GRAVITY,
+        loss_coefficient=LOSS_COEFFICIENT,
+        area_exponent=LOSS_AREA_EXPONENT,
+    )
+    assert moment.in_phase / 1e6 == pytest.approx(cfd_moment_mnm, rel=0.07)
+
+
+def test_static_moment_terms_cannot_be_dropped():
+    moment = u.tank_moment(
+        geometry=reference_geometry(),
+        conduit_area=6.8,
+        forcing_period=60.0,
+        roll_amplitude=math.radians(5.0),
+        density=RHO,
+        gravity=GRAVITY,
+        loss_coefficient=LOSS_COEFFICIENT,
+        area_exponent=LOSS_AREA_EXPONENT,
+    )
+    redistribution_only = 2.0 * RHO * GRAVITY * CENTROID_OFFSET * moment.q_in_phase
+    assert moment.in_phase / redistribution_only == pytest.approx(1.45, rel=0.08)
+
+
+def test_tank_reduces_peak_roll_near_resonance():
+    common = dict(
+        vessel_roll_period=20.0,
+        hull_damping_ratio=0.05,
+        tank_authority=0.12,
+        geometry=reference_geometry(),
+        conduit_area=4.8,
+    )
+    bare = u.coupled_roll_response(forcing_period=20.0, tank_enabled=False, **common)
+    coupled = u.coupled_roll_response(forcing_period=20.0, tank_enabled=True, **common)
+    assert abs(coupled) < abs(bare)
+
+
+def test_tank_increases_long_period_roll_from_free_surface_penalty():
+    common = dict(
+        vessel_roll_period=20.0,
+        hull_damping_ratio=0.05,
+        tank_authority=0.12,
+        geometry=reference_geometry(),
+        conduit_area=4.8,
+    )
+    bare = u.coupled_roll_response(forcing_period=60.0, tank_enabled=False, **common)
+    coupled = u.coupled_roll_response(forcing_period=60.0, tank_enabled=True, **common)
+    assert abs(coupled) > abs(bare)
+
+
+@pytest.mark.parametrize("vessel_roll_period", [18.0, 19.5, 21.0])
+def test_optimum_conduit_is_bounded_and_detuned(vessel_roll_period):
+    optimum = u.optimize_conduit_area(
+        vessel_roll_period=vessel_roll_period,
+        hull_damping_ratio=0.05,
+        tank_authority=0.12,
+        geometry=reference_geometry(),
+        area_bounds=(2.0, 14.0),
+    )
+    assert 4.0 <= optimum.conduit_area <= 6.0
+    tuning_ratio = optimum.tank_natural_period / vessel_roll_period
+    assert 0.75 <= tuning_ratio <= 0.95

--- a/tests/hydrodynamics/test_utube_tank.py
+++ b/tests/hydrodynamics/test_utube_tank.py
@@ -147,11 +147,14 @@ def test_calibrated_area_exponent_fit_is_materially_better_than_linear():
     changes its dimensions, so the fair comparison is the published result from
     refitting the full 35-case dataset at each exponent.
     """
-    assert CALIBRATED_AREA_EXPONENT_RMS_PERCENT == pytest.approx(8.6)
-    assert LINEAR_AREA_EXPONENT_RMS_PERCENT == pytest.approx(36.5)
+    assert u.DEFAULT_AREA_EXPONENT == pytest.approx(2.138)
+    assert u.DEFAULT_LOSS_COEFFICIENT == pytest.approx(2.3894)
+    assert u.DEFAULT_EFFECTIVE_CONDUIT_LENGTH == pytest.approx(5.2004)
+    assert u.CALIBRATED_AREA_EXPONENT_RMS_PERCENT == pytest.approx(8.6)
+    assert u.LINEAR_AREA_EXPONENT_RMS_PERCENT == pytest.approx(36.5)
     assert (
-        LINEAR_AREA_EXPONENT_RMS_PERCENT
-        > 4.0 * CALIBRATED_AREA_EXPONENT_RMS_PERCENT
+        u.LINEAR_AREA_EXPONENT_RMS_PERCENT
+        > 4.0 * u.CALIBRATED_AREA_EXPONENT_RMS_PERCENT
     )
 
 

--- a/tests/hydrodynamics/test_utube_tank.py
+++ b/tests/hydrodynamics/test_utube_tank.py
@@ -9,6 +9,7 @@ import pytest
 from digitalmodel.hydrodynamics import utube_tank as u
 
 
+# Reference tank geometry and fluid properties used by the CFD measurements.
 LEG_LENGTH = 20.0
 LEG_WIDTH = 6.0
 LEG_AREA = LEG_LENGTH * LEG_WIDTH
@@ -16,9 +17,13 @@ CENTROID_OFFSET = 5.0
 FILL_DEPTH = 5.0
 RHO = 1025.0
 GRAVITY = 9.81
+# Documented calibration outputs from the measured CFD dataset.
 EFFECTIVE_CONDUIT_LENGTH = 5.2004
 LOSS_COEFFICIENT = 2.3894
 LOSS_AREA_EXPONENT = 2.138
+# Published 35-case fit outputs, not individual CFD measurements.
+CALIBRATED_AREA_EXPONENT_RMS_PERCENT = 8.6
+LINEAR_AREA_EXPONENT_RMS_PERCENT = 36.5
 
 
 def reference_geometry():
@@ -32,7 +37,7 @@ def reference_geometry():
 
 
 @pytest.mark.parametrize(
-    ("conduit_area", "fill_depth", "predicted_period", "cfd_period"),
+    ("conduit_area", "fill_depth", "fit_period", "measured_period"),
     [
         (3.4, 5.0, 19.73, 19.27),
         (13.5, 5.0, 10.64, 10.97),
@@ -41,7 +46,7 @@ def reference_geometry():
     ],
 )
 def test_natural_period_matches_cfd(
-    conduit_area, fill_depth, predicted_period, cfd_period
+    conduit_area, fill_depth, fit_period, measured_period
 ):
     period = u.natural_period(
         leg_area=LEG_AREA,
@@ -50,8 +55,8 @@ def test_natural_period_matches_cfd(
         effective_conduit_length=EFFECTIVE_CONDUIT_LENGTH,
         gravity=GRAVITY,
     )
-    assert period == pytest.approx(predicted_period, rel=0.004)
-    assert period == pytest.approx(cfd_period, rel=0.04)
+    assert period == pytest.approx(fit_period, rel=0.004)
+    assert period == pytest.approx(measured_period, rel=0.04)
 
 
 def test_effective_conduit_length_calibration_round_trips():
@@ -104,38 +109,72 @@ def test_equivalent_damping_falls_with_conduit_area():
 
 
 @pytest.mark.parametrize(
-    ("conduit_area", "cfd_damping"),
-    [(3.4, 0.13598), (13.5, 0.01323)],
+    (
+        "conduit_area",
+        "forcing_period",
+        "measured_level_amplitude",
+        "measured_equivalent_damping",
+    ),
+    [
+        (3.4, 19.73, 0.5755, 0.775),
+        (3.4, 17.00, 0.4847, 0.783),
+        (13.5, 10.64, 1.2471, 0.338),
+        (13.5, 13.00, 1.4211, 0.280),
+    ],
 )
-def test_linear_area_loss_scaling_is_materially_worse(conduit_area, cfd_damping):
-    common = dict(
+def test_equivalent_damping_matches_measured_cases(
+    conduit_area,
+    forcing_period,
+    measured_level_amplitude,
+    measured_equivalent_damping,
+):
+    damping = u.equivalent_damping(
         geometry=reference_geometry(),
         conduit_area=conduit_area,
-        forcing_period=20.0,
-        level_difference_amplitude=0.10,
+        forcing_period=forcing_period,
+        level_difference_amplitude=measured_level_amplitude,
         loss_coefficient=LOSS_COEFFICIENT,
+        area_exponent=LOSS_AREA_EXPONENT,
         gravity=GRAVITY,
     )
-    calibrated = u.equivalent_damping(area_exponent=LOSS_AREA_EXPONENT, **common)
-    linear_area = u.equivalent_damping(area_exponent=1.0, **common)
-    calibrated_error = abs(calibrated - cfd_damping)
-    linear_error = abs(linear_area - cfd_damping)
-    assert calibrated == pytest.approx(cfd_damping, rel=0.01)
-    assert linear_error > 10.0 * calibrated_error
+    assert damping == pytest.approx(measured_equivalent_damping, rel=0.10)
+
+
+def test_calibrated_area_exponent_fit_is_materially_better_than_linear():
+    """Published refits avoid an invalid fixed-coefficient exponent substitution.
+
+    Holding the calibrated coefficient fixed while changing the area exponent
+    changes its dimensions, so the fair comparison is the published result from
+    refitting the full 35-case dataset at each exponent.
+    """
+    assert CALIBRATED_AREA_EXPONENT_RMS_PERCENT == pytest.approx(8.6)
+    assert LINEAR_AREA_EXPONENT_RMS_PERCENT == pytest.approx(36.5)
+    assert (
+        LINEAR_AREA_EXPONENT_RMS_PERCENT
+        > 4.0 * CALIBRATED_AREA_EXPONENT_RMS_PERCENT
+    )
 
 
 @pytest.mark.parametrize(
-    ("forcing_period", "cfd_moment_mnm"),
+    (
+        "forcing_period",
+        "measured_in_phase_moment_mnm",
+        "measured_quadrature_moment_mnm",
+    ),
     [
-        (60.0, 8.807),
-        (40.0, 9.206),
-        (26.0, 9.683),
-        (24.0, 9.673),
-        (22.0, 9.498),
-        (20.0, 9.103),
+        (20.0, 7.659, -4.919),
+        (22.0, 8.469, -4.300),
+        (24.0, 8.980, -3.596),
+        (26.0, 9.243, -2.886),
+        (40.0, 9.161, -0.906),
+        (60.0, 8.800, -0.354),
     ],
 )
-def test_in_phase_tank_moment_matches_cfd(forcing_period, cfd_moment_mnm):
+def test_tank_moment_components_match_measurements(
+    forcing_period,
+    measured_in_phase_moment_mnm,
+    measured_quadrature_moment_mnm,
+):
     moment = u.tank_moment(
         geometry=reference_geometry(),
         conduit_area=6.8,
@@ -146,7 +185,12 @@ def test_in_phase_tank_moment_matches_cfd(forcing_period, cfd_moment_mnm):
         loss_coefficient=LOSS_COEFFICIENT,
         area_exponent=LOSS_AREA_EXPONENT,
     )
-    assert moment.in_phase / 1e6 == pytest.approx(cfd_moment_mnm, rel=0.07)
+    assert moment.in_phase / 1e6 == pytest.approx(
+        measured_in_phase_moment_mnm, rel=0.07
+    )
+    assert moment.quadrature / 1e6 == pytest.approx(
+        measured_quadrature_moment_mnm, rel=0.15
+    )
 
 
 def test_static_moment_terms_cannot_be_dropped():
@@ -161,7 +205,8 @@ def test_static_moment_terms_cannot_be_dropped():
         area_exponent=LOSS_AREA_EXPONENT,
     )
     redistribution_only = 2.0 * RHO * GRAVITY * CENTROID_OFFSET * moment.q_in_phase
-    assert moment.in_phase / redistribution_only == pytest.approx(1.45, rel=0.08)
+    # Measured quasi-static ratio at T = 60 s.
+    assert moment.in_phase / redistribution_only == pytest.approx(1.588, rel=0.03)
 
 
 def test_tank_reduces_peak_roll_near_resonance():


### PR DESCRIPTION
Closes #1909.

Promotes the connected-tank sloshing method from private analysis scripts into source-neutral library code. This is the outstanding deliverable for the capability lane: the validated method publishes here, client geometry and calibration stay private.

## What lands

`src/digitalmodel/hydrodynamics/utube_tank.py` (513 lines) + `tests/hydrodynamics/test_utube_tank.py` (24 tests), matching the existing `sloshing.py` / `test_sloshing.py` convention.

API: `UTubeGeometry`, `TankMoment`, `ConduitOptimum`, `natural_period`, `calibrate_effective_conduit_length`, `equivalent_damping`, `tank_moment`, `coupled_roll_response`, `optimize_conduit_area`.

Four links, each validated against CFD:

| link | validation |
|---|---|
| inertia — one calibrated conduit length | exchange period to ±3 % across conduit areas 3.4–13.5 m² and fills 25–70 % |
| quadratic conduit loss, `B = C rho / (2 Ac^n)` | 35 measured cases, 8.6 % rms |
| closed-form tank moment | 4.3 % rms for forcing periods ≥ 20 s |
| coupled roll RAO with/without tank | qualitative: reduces roll near resonance, worsens it at long period |

## Two traps encoded, because both were made and cost real time

**Anchor the conduit length to the natural period, not the amplitude peak.** The peak is loss-controlled and moves with roll amplitude while the natural period does not; anchoring to it inflates the inertia parameter by 2.76×.

**The loss scales as 1/Ac², not 1/Ac.** The naive form-drag derivation gives 1/Ac and fails in *opposite directions* either side of the calibration area — under by 55 % at 3.4 m², over by 108 % at 13.5 m². That signature is what exposed it.

Both are in module docstrings and pinned by tests.

## Development order

TDD per the repo gate — four commits: spec tests, test corrections, provenance fix, implementation. Tests were written and reviewed against measured data *before* any implementation existed to be tuned against them, and the review caught three defects in the first test draft, two of which would have forced a wrong implementation:

- in-phase moment asserted against moment *amplitude* — coincides at long period, 19 % wrong at T = 20 s;
- a quasi-static ratio asserted at 1.45 when the measured value is 1.588, so a correct model would have failed;
- constants named `cfd_damping` that were the formula's own output to five decimal places, asserting the implementation equals itself.

## Verification beyond the suite

The suite alone proves little, so the model was checked out-of-sample against measured data the tests never see: ζ within 0.7 % at A_c = 3.4/T = 23 s and 3.7 % at A_c = 13.5/T = 9 s, and the 90 %-fill natural period reproduces an independently computed value.

Notably it *fails in the right place*: at T = 18 s the in-phase moment is 11 % off, outside the tolerance the tests demand at T ≥ 20 s. That is below the documented validity band, where the legs' own sloshing modes (6.25 s longitudinal, 2.79 s transverse) begin to participate. A model overfitted to its tests would have been accurate everywhere checked and silently wrong elsewhere.

## Caveat to carry forward

**The loss exponent n = 2.138 is now a library default, but it rests on only two off-calibration conduit areas.** The A_c = 6.8 m² dataset cannot constrain it — any exponent is absorbed into the coefficient there. A third conduit area should test it before this is used for real sizing decisions rather than after. Tracked as follow-up to #1909.

Source-neutral: no client identifiers, no scratch-tree reads, all constants documented defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
