### PR TITLE
fix(dynacard): make the rod-buckling load datum explicit (#1893)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_buckling.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_buckling.py
@@ -105,6 +105,7 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         loads = self._normalise_load_datum(
             loads,
             load_datum=load_datum,
+            has_downhole_card=downhole_card is not None,
             vendor_downstroke_load=vendor_downstroke_load,
             vendor_upstroke_load=vendor_upstroke_load,
             vendor_fluid_load=vendor_fluid_load,
@@ -150,6 +151,7 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         loads: np.ndarray,
         *,
         load_datum: LoadDatum,
+        has_downhole_card: bool,
         vendor_downstroke_load: Optional[float],
         vendor_upstroke_load: Optional[float],
         vendor_fluid_load: Optional[float],
@@ -164,6 +166,33 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
                 details={"value": load_datum},
             )
 
+        downstroke = self._validated_vendor_offset(
+            vendor_downstroke_load,
+            vendor_upstroke_load,
+            vendor_fluid_load,
+        )
+        if not has_downhole_card:
+            raise ValidationError(
+                "Vendor datum correction requires the corresponding "
+                "vendor downhole card",
+                field="downhole_card",
+            )
+        with np.errstate(over="ignore", invalid="ignore"):
+            normalised = loads - downstroke
+        if not np.all(np.isfinite(normalised)):
+            raise ValidationError(
+                "Datum-corrected load data must contain finite values",
+                field="load_data",
+            )
+        return normalised
+
+    def _validated_vendor_offset(
+        self,
+        vendor_downstroke_load: Optional[float],
+        vendor_upstroke_load: Optional[float],
+        vendor_fluid_load: Optional[float],
+    ) -> float:
+        """Validate vendor metadata and return its downstroke datum."""
         metadata = {
             "downstroke": vendor_downstroke_load,
             "upstroke": vendor_upstroke_load,
@@ -193,8 +222,9 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
                 details={"fluid_load": float(fluid_load)},
             )
         verified_fluid_load = upstroke - downstroke
-        scale = max(abs(fluid_load), 1.0)
-        relative_error = abs(verified_fluid_load - fluid_load) / scale
+        relative_error = (
+            abs(verified_fluid_load - fluid_load) / abs(fluid_load)
+        )
         if relative_error > self.VENDOR_FLUID_LOAD_REL_TOL:
             raise ValidationError(
                 "Vendor load metadata is inconsistent: upstroke minus "
@@ -203,7 +233,7 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
                 details={"relative_error": relative_error},
             )
 
-        return loads - downstroke
+        return float(downstroke)
 
     def _estimate_downhole_loads(self) -> np.ndarray:
         """
@@ -351,6 +381,11 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         if profile is None:
             if inclination_deg is None:
                 return None
+            if not 0.0 <= inclination_deg <= 180.0:
+                raise ValidationError(
+                    "Inclination must be between 0 and 180 degrees",
+                    field="inclination_deg",
+                )
             return np.asarray([inclination_deg], dtype=float)
         if len(profile) < 2:
             raise ValidationError(
@@ -365,6 +400,11 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
                 field="inclination_profile",
             )
         depths = points[:, 0]
+        if np.any((points[:, 1] < 0.0) | (points[:, 1] > 180.0)):
+            raise ValidationError(
+                "Inclinations must be between 0 and 180 degrees",
+                field="inclination_profile",
+            )
         if np.any(np.diff(depths) <= 0.0):
             raise ValidationError(
                 "inclination_profile depths must be strictly increasing",
@@ -387,11 +427,6 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
             points[:, 1],
         )
         inclinations = np.concatenate(([endpoints[0]], inside, [endpoints[1]]))
-        if np.any((inclinations < 0.0) | (inclinations > 180.0)):
-            raise ValidationError(
-                "inclinations must be between 0 and 180 degrees",
-                field="inclination_profile",
-            )
         return inclinations
 
     def _calculate_buckling_tendency(self, loads: np.ndarray) -> np.ndarray:
@@ -625,6 +660,31 @@ def calculate_critical_buckling_load(
     """
     if inclination_deg is None or tubing_id is None:
         return (None, None)
+
+    scalar_inputs = {
+        "rod_diameter": rod_diameter,
+        "modulus": modulus,
+        "weight_per_foot": weight_per_foot,
+        "fluid_density": fluid_density,
+        "inclination_deg": inclination_deg,
+        "tubing_id": tubing_id,
+    }
+    non_finite = [
+        name
+        for name, value in scalar_inputs.items()
+        if not np.isfinite(value)
+    ]
+    if non_finite:
+        raise ValidationError(
+            "Critical-load inputs must contain finite values",
+            field=non_finite[0],
+            details={"non_finite": non_finite},
+        )
+    if not 0.0 <= inclination_deg <= 180.0:
+        raise ValidationError(
+            "Inclination must be between 0 and 180 degrees",
+            field="inclination_deg",
+        )
 
     # Calculate rod properties
     r = rod_diameter / 2.0

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_buckling.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_buckling.py
@@ -1,7 +1,7 @@
 # ABOUTME: Rod buckling analysis for sucker rod pump diagnostics.
 # ABOUTME: Detects sinusoidal and helical buckling based on axial load distribution.
 
-from typing import Optional, List, Tuple
+from typing import Literal, Optional, Sequence, Tuple
 import numpy as np
 
 from .models import (
@@ -12,6 +12,9 @@ from .models import (
 from .base import BaseCalculator
 from .constants import STEEL_DENSITY_LB_PER_FT3
 from .exceptions import DynacardException, ValidationError
+
+LoadDatum = Literal["net_pump_load", "vendor_analysis"]
+InclinationProfile = Sequence[Tuple[float, float]]
 
 
 class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
@@ -34,9 +37,8 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
     so no depth can be recovered from it (see _summarise_compression).
     """
 
-    # Physical constants
-    POISSON_RATIO = 0.30  # Steel Poisson's ratio
     STEEL_DENSITY = STEEL_DENSITY_LB_PER_FT3
+    VENDOR_FLUID_LOAD_REL_TOL = 0.01
 
     def _create_result(self) -> RodBucklingAnalysis:
         return RodBucklingAnalysis()
@@ -46,6 +48,12 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         downhole_card: Optional[CardData] = None,
         inclination_deg: Optional[float] = None,
         tubing_id: Optional[float] = None,
+        *,
+        load_datum: LoadDatum,
+        inclination_profile: Optional[InclinationProfile] = None,
+        vendor_downstroke_load: Optional[float] = None,
+        vendor_upstroke_load: Optional[float] = None,
+        vendor_fluid_load: Optional[float] = None,
     ) -> RodBucklingAnalysis:
         """
         Perform rod buckling analysis.
@@ -61,6 +69,12 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
             tubing_id: Tubing inside diameter in inches, used with the rod
                           diameter to obtain the radial clearance the
                           Paslay-Dawson formula needs.
+            load_datum: Explicit convention for the supplied/estimated loads.
+            inclination_profile: ``(measured_depth_ft, inclination_deg)``
+                          points covering the bottom rod section.
+            vendor_downstroke_load: Vendor downstroke load datum, lb.
+            vendor_upstroke_load: Vendor upstroke load, lb.
+            vendor_fluid_load: Vendor fluid load (Fo), lb.
 
         Returns:
             RodBucklingAnalysis with buckling detection results.
@@ -81,6 +95,21 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
             # Estimate downhole loads from surface card
             loads = self._estimate_downhole_loads()
 
+        loads = np.asarray(loads, dtype=float)
+        if not np.all(np.isfinite(loads)):
+            raise ValidationError(
+                "Load data must contain finite values",
+                field="load_data",
+            )
+
+        loads = self._normalise_load_datum(
+            loads,
+            load_datum=load_datum,
+            vendor_downstroke_load=vendor_downstroke_load,
+            vendor_upstroke_load=vendor_upstroke_load,
+            vendor_fluid_load=vendor_fluid_load,
+        )
+
         if len(loads) == 0:
             raise ValidationError(
                 "No load data available for buckling analysis",
@@ -98,7 +127,11 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
             )
 
         # Calculate critical buckling loads
-        self._calculate_critical_loads(inclination_deg, tubing_id)
+        self._calculate_critical_loads(
+            inclination_deg,
+            tubing_id,
+            inclination_profile,
+        )
 
         # Calculate buckling tendency along the rod
         buckling_tendency = self._calculate_buckling_tendency(loads)
@@ -111,6 +144,66 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         self._detect_buckling(buckling_tendency)
 
         return self.result
+
+    def _normalise_load_datum(
+        self,
+        loads: np.ndarray,
+        *,
+        load_datum: LoadDatum,
+        vendor_downstroke_load: Optional[float],
+        vendor_upstroke_load: Optional[float],
+        vendor_fluid_load: Optional[float],
+    ) -> np.ndarray:
+        """Return loads on the physical net-pump-load datum."""
+        if load_datum == "net_pump_load":
+            return loads
+        if load_datum != "vendor_analysis":
+            raise ValidationError(
+                "load_datum must be 'net_pump_load' or 'vendor_analysis'",
+                field="load_datum",
+                details={"value": load_datum},
+            )
+
+        metadata = {
+            "downstroke": vendor_downstroke_load,
+            "upstroke": vendor_upstroke_load,
+            "fluid_load": vendor_fluid_load,
+        }
+        missing = [name for name, value in metadata.items() if value is None]
+        if missing:
+            raise ValidationError(
+                "Vendor datum correction requires downstroke, upstroke, "
+                f"and fluid-load metadata; missing: {', '.join(missing)}",
+                field="vendor_load_metadata",
+                details={"missing": missing},
+            )
+
+        values = np.asarray(list(metadata.values()), dtype=float)
+        if not np.all(np.isfinite(values)):
+            raise ValidationError(
+                "Vendor load metadata must contain finite values",
+                field="vendor_load_metadata",
+            )
+
+        downstroke, upstroke, fluid_load = values
+        if fluid_load <= 0.0:
+            raise ValidationError(
+                "Vendor fluid load (Fo) must be positive",
+                field="vendor_load_metadata",
+                details={"fluid_load": float(fluid_load)},
+            )
+        verified_fluid_load = upstroke - downstroke
+        scale = max(abs(fluid_load), 1.0)
+        relative_error = abs(verified_fluid_load - fluid_load) / scale
+        if relative_error > self.VENDOR_FLUID_LOAD_REL_TOL:
+            raise ValidationError(
+                "Vendor load metadata is inconsistent: upstroke minus "
+                "downstroke does not agree with fluid load (Fo)",
+                field="vendor_load_metadata",
+                details={"relative_error": relative_error},
+            )
+
+        return loads - downstroke
 
     def _estimate_downhole_loads(self) -> np.ndarray:
         """
@@ -140,6 +233,7 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         self,
         inclination_deg: Optional[float] = None,
         tubing_id: Optional[float] = None,
+        inclination_profile: Optional[InclinationProfile] = None,
     ) -> None:
         """
         Calculate Paslay-Dawson critical buckling loads for the rod string.
@@ -164,22 +258,40 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         if len(self.ctx.rod_string) == 0:
             return
 
-        if inclination_deg is None or tubing_id is None:
+        scalar_inputs = {
+            "inclination_deg": inclination_deg,
+            "tubing_id": tubing_id,
+        }
+        non_finite = [
+            name
+            for name, value in scalar_inputs.items()
+            if value is not None and not np.isfinite(value)
+        ]
+        if non_finite:
+            raise ValidationError(
+                "Wellbore inputs must contain finite values",
+                field=non_finite[0],
+                details={"non_finite": non_finite},
+            )
+
+        inclinations = self._bottom_section_inclinations(
+            inclination_deg,
+            inclination_profile,
+        )
+        if inclinations is None or tubing_id is None:
             self.result.warning_message = (
                 "Critical buckling loads not computed: the Paslay-Dawson "
-                "formula requires hole inclination and rod/tubing radial "
-                "clearance (tubing ID), neither of which is available from "
-                "card data alone."
+                "formula requires bottom-section inclination and rod/tubing "
+                "radial clearance (tubing ID), which card data does not supply."
             )
             return
 
-        # Use the smallest (weakest) rod section for critical load calculation
-        min_diameter = min(s.diameter for s in self.ctx.rod_string)
-        section = next(s for s in self.ctx.rod_string if s.diameter == min_diameter)
+        # Compression occurs adjacent to the pump, in the bottom rod section.
+        section = self.ctx.rod_string[-1]
 
         # Rod geometry
-        d = min_diameter  # inches
-        I = np.pi * d ** 4 / 64.0  # in^4 (moment of inertia)
+        d = section.diameter  # inches
+        inertia = np.pi * d ** 4 / 64.0  # in^4
 
         # Material properties
         E = section.modulus_of_elasticity  # psi
@@ -191,7 +303,7 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         # Radial clearance between rod body and tubing wall, inches
         r_c = (tubing_id - d) / 2.0
 
-        sin_alpha = float(np.sin(np.radians(inclination_deg)))
+        sin_alpha = float(np.min(np.sin(np.radians(inclinations))))
 
         if r_c <= 0.0:
             self.result.warning_message = (
@@ -215,7 +327,9 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
             )
             return
 
-        F_cr_sinusoidal = 2.0 * np.sqrt(E * I * W_b * sin_alpha / r_c)
+        F_cr_sinusoidal = 2.0 * np.sqrt(
+            E * inertia * W_b * sin_alpha / r_c
+        )
 
         # Helical buckling threshold = 2*sqrt(2) x sinusoidal (Chen-Lin-Cheatham)
         F_cr_helical = 2.0 * np.sqrt(2.0) * F_cr_sinusoidal
@@ -223,44 +337,72 @@ class RodBucklingCalculator(BaseCalculator[RodBucklingAnalysis]):
         self.result.sinusoidal_critical_load = float(F_cr_sinusoidal)
         self.result.helical_critical_load = float(F_cr_helical)
 
+    def _bottom_section_inclinations(
+        self,
+        inclination_deg: Optional[float],
+        profile: Optional[InclinationProfile],
+    ) -> Optional[np.ndarray]:
+        """Return inclinations sampled across the bottom rod's depth interval."""
+        if inclination_deg is not None and profile is not None:
+            raise ValidationError(
+                "Supply either inclination_deg or inclination_profile, not both",
+                field="inclination_profile",
+            )
+        if profile is None:
+            if inclination_deg is None:
+                return None
+            return np.asarray([inclination_deg], dtype=float)
+        if len(profile) < 2:
+            raise ValidationError(
+                "inclination_profile requires at least two depth points",
+                field="inclination_profile",
+            )
+
+        points = np.asarray(profile, dtype=float)
+        if points.ndim != 2 or points.shape[1] != 2 or not np.all(np.isfinite(points)):
+            raise ValidationError(
+                "inclination_profile must contain finite (depth, inclination) pairs",
+                field="inclination_profile",
+            )
+        depths = points[:, 0]
+        if np.any(np.diff(depths) <= 0.0):
+            raise ValidationError(
+                "inclination_profile depths must be strictly increasing",
+                field="inclination_profile",
+            )
+
+        section_end = self.ctx.pump.depth
+        section_start = section_end - self.ctx.rod_string[-1].length
+        if depths[0] > section_start or depths[-1] < section_end:
+            raise ValidationError(
+                "inclination_profile must cover the bottom rod depth interval",
+                field="inclination_profile",
+                details={"section_start": section_start, "section_end": section_end},
+            )
+
+        inside = points[(depths > section_start) & (depths < section_end), 1]
+        endpoints = np.interp(
+            [section_start, section_end],
+            depths,
+            points[:, 1],
+        )
+        inclinations = np.concatenate(([endpoints[0]], inside, [endpoints[1]]))
+        if np.any((inclinations < 0.0) | (inclinations > 180.0)):
+            raise ValidationError(
+                "inclinations must be between 0 and 180 degrees",
+                field="inclination_profile",
+            )
+        return inclinations
+
     def _calculate_buckling_tendency(self, loads: np.ndarray) -> np.ndarray:
-        """
-        Calculate buckling tendency (effective axial load).
-
-        Buckling tendency includes the effect of internal pressure
-        and Poisson's ratio on the effective compressive load.
-
-        For a submerged rod:
-        F_eff = F_axial + 2 * ν * P * A
-
-        where:
-        - F_axial = actual axial load
-        - ν = Poisson's ratio
-        - P = hydrostatic pressure
-        - A = cross-sectional area
-        """
+        """Calculate effective axial load for a solid submerged rod."""
         if len(loads) == 0:
             return np.array([])
 
-        # Calculate average rod area
-        total_area_length = sum(
-            np.pi * (s.diameter / 2) ** 2 * s.length
-            for s in self.ctx.rod_string
-        )
-        rod_length = self.ctx.rod_length
-        avg_area = total_area_length / rod_length if rod_length > 0 else 0.0  # in^2
-
-        # Estimate hydrostatic pressure at pump depth
-        pump_depth = self.ctx.pump.depth  # feet
-        fluid_gradient = self.ctx.fluid_density / 144.0  # psi/ft
-        pressure_at_pump = fluid_gradient * pump_depth  # psi
-
-        # Buckling tendency correction
-        # This is an approximation for average conditions
-        pressure_correction = 2.0 * self.POISSON_RATIO * pressure_at_pump * avg_area
-
-        # Calculate buckling tendency
-        buckling_tendency = loads + pressure_correction
+        # A solid rod has no bore on which an internal-pressure ballooning term
+        # can act. The fully submerged external pressure is already represented
+        # through buoyant weight in the Paslay-Dawson threshold.
+        buckling_tendency = loads.copy()
 
         self.result.min_buckling_tendency = float(np.min(buckling_tendency))
         self.result.max_buckling_tendency = float(np.max(buckling_tendency))
@@ -342,6 +484,12 @@ def calculate_rod_buckling(
     raise_on_error: bool = False,
     inclination_deg: Optional[float] = None,
     tubing_id: Optional[float] = None,
+    *,
+    load_datum: LoadDatum,
+    inclination_profile: Optional[InclinationProfile] = None,
+    vendor_downstroke_load: Optional[float] = None,
+    vendor_upstroke_load: Optional[float] = None,
+    vendor_fluid_load: Optional[float] = None,
 ) -> RodBucklingAnalysis:
     """
     Convenience function to calculate rod buckling analysis.
@@ -354,6 +502,11 @@ def calculate_rod_buckling(
         inclination_deg: Hole inclination from vertical (degrees). Required,
                        with tubing_id, for the Paslay-Dawson critical loads.
         tubing_id: Tubing inside diameter (inches).
+        load_datum: ``net_pump_load`` or ``vendor_analysis``.
+        inclination_profile: Depth/inclination points covering the bottom rod.
+        vendor_downstroke_load: Vendor downstroke datum, lb.
+        vendor_upstroke_load: Vendor upstroke load, lb.
+        vendor_fluid_load: Vendor fluid load (Fo), lb.
 
     Returns:
         RodBucklingAnalysis with buckling detection results. Critical loads and
@@ -364,11 +517,28 @@ def calculate_rod_buckling(
         ValidationError: If raise_on_error=True and validation fails.
     """
     calculator = RodBucklingCalculator(context)
+    keyword_args = {
+        "load_datum": load_datum,
+        "inclination_profile": inclination_profile,
+        "vendor_downstroke_load": vendor_downstroke_load,
+        "vendor_upstroke_load": vendor_upstroke_load,
+        "vendor_fluid_load": vendor_fluid_load,
+    }
     if raise_on_error:
-        return calculator.calculate(downhole_card, inclination_deg, tubing_id)
+        return calculator.calculate(
+            downhole_card,
+            inclination_deg,
+            tubing_id,
+            **keyword_args,
+        )
 
     try:
-        return calculator.calculate(downhole_card, inclination_deg, tubing_id)
+        return calculator.calculate(
+            downhole_card,
+            inclination_deg,
+            tubing_id,
+            **keyword_args,
+        )
     except DynacardException as e:
         calculator.result.warning_message = e.message
         return calculator.result
@@ -458,7 +628,7 @@ def calculate_critical_buckling_load(
 
     # Calculate rod properties
     r = rod_diameter / 2.0
-    I = np.pi * rod_diameter ** 4 / 64.0  # in^4
+    inertia = np.pi * rod_diameter ** 4 / 64.0  # in^4
 
     # Calculate weight if not provided
     if weight_per_foot == 0.0:
@@ -476,7 +646,9 @@ def calculate_critical_buckling_load(
     if W_b <= 0.0 or r_c <= 0.0 or sin_alpha <= 0.0:
         return (None, None)
 
-    F_cr_sinusoidal = 2.0 * np.sqrt(modulus * I * W_b * sin_alpha / r_c)
+    F_cr_sinusoidal = 2.0 * np.sqrt(
+        modulus * inertia * W_b * sin_alpha / r_c
+    )
     F_cr_helical = 2.0 * np.sqrt(2.0) * F_cr_sinusoidal
 
     return (float(F_cr_sinusoidal), float(F_cr_helical))

--- a/tests/marine_ops/artificial_lift/dynacard/test_rod_buckling.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_rod_buckling.py
@@ -98,6 +98,44 @@ class TestRodBucklingCalculator:
                 load_datum="net_pump_load",
             )
 
+    def test_vendor_datum_rejects_sub_pound_relative_mismatch(self):
+        """The 1% consistency tolerance remains relative below one pound."""
+        context = self._create_test_context()
+
+        with pytest.raises(ValidationError, match="inconsistent"):
+            RodBucklingCalculator(context).calculate(
+                load_datum="vendor_analysis",
+                vendor_downstroke_load=0.0,
+                vendor_upstroke_load=-0.001,
+                vendor_fluid_load=0.001,
+            )
+
+    def test_vendor_correction_overflow_is_rejected(self):
+        """Finite inputs that overflow during datum correction remain invalid."""
+        context = self._create_test_context()
+        card = CardData(position=[0, 1], load=[1e308, 0.0])
+
+        with pytest.raises(ValidationError, match="finite"):
+            RodBucklingCalculator(context).calculate(
+                downhole_card=card,
+                load_datum="vendor_analysis",
+                vendor_downstroke_load=-1e308,
+                vendor_upstroke_load=0.0,
+                vendor_fluid_load=1e308,
+            )
+
+    def test_vendor_datum_requires_vendor_downhole_card(self):
+        """A vendor-card offset cannot be applied to estimated surface loads."""
+        context = self._create_test_context()
+
+        with pytest.raises(ValidationError, match="downhole card"):
+            RodBucklingCalculator(context).calculate(
+                load_datum="vendor_analysis",
+                vendor_downstroke_load=-100.0,
+                vendor_upstroke_load=900.0,
+                vendor_fluid_load=1000.0,
+            )
+
     @pytest.mark.parametrize(
         ("inclination_deg", "tubing_id"),
         [(math.nan, TUBING_ID_IN), (30.0, math.inf)],
@@ -114,6 +152,21 @@ class TestRodBucklingCalculator:
             RodBucklingCalculator(context).calculate(
                 inclination_deg=inclination_deg,
                 tubing_id=tubing_id,
+                load_datum="net_pump_load",
+            )
+
+    @pytest.mark.parametrize("inclination_deg", [-1.0, 181.0])
+    def test_scalar_inclination_outside_physical_range_is_rejected(
+        self,
+        inclination_deg,
+    ):
+        """Scalar inclination obeys the same physical range as a profile."""
+        context = self._create_test_context()
+
+        with pytest.raises(ValidationError, match="between 0 and 180"):
+            RodBucklingCalculator(context).calculate(
+                inclination_deg=inclination_deg,
+                tubing_id=TUBING_ID_IN,
                 load_datum="net_pump_load",
             )
 
@@ -705,6 +758,39 @@ class TestCalculateCriticalBucklingLoad:
         assert calculate_critical_buckling_load(
             rod_diameter=2.5, inclination_deg=30.0, tubing_id=TUBING_ID_IN
         ) == (None, None)
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("rod_diameter", math.nan),
+            ("modulus", math.inf),
+            ("weight_per_foot", math.nan),
+            ("fluid_density", math.inf),
+            ("inclination_deg", math.nan),
+            ("tubing_id", math.inf),
+        ],
+    )
+    def test_non_finite_inputs_are_rejected(self, field, value):
+        """The public helper must not return NaN critical loads."""
+        inputs = {
+            "rod_diameter": 0.875,
+            "inclination_deg": DEVIATED_INCLINATION_DEG,
+            "tubing_id": TUBING_ID_IN,
+        }
+        inputs[field] = value
+
+        with pytest.raises(ValidationError, match="finite"):
+            calculate_critical_buckling_load(**inputs)
+
+    @pytest.mark.parametrize("inclination_deg", [-1.0, 181.0])
+    def test_out_of_range_inclination_is_rejected(self, inclination_deg):
+        """The public helper rejects non-physical inclination angles."""
+        with pytest.raises(ValidationError, match="between 0 and 180"):
+            calculate_critical_buckling_load(
+                rod_diameter=0.875,
+                inclination_deg=inclination_deg,
+                tubing_id=TUBING_ID_IN,
+            )
 
     def test_positive_critical_loads(self):
         """Test that critical loads are positive."""

--- a/tests/marine_ops/artificial_lift/dynacard/test_rod_buckling.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_rod_buckling.py
@@ -1,9 +1,9 @@
 # ABOUTME: Unit tests for rod buckling analysis module.
 # ABOUTME: Validates buckling detection, neutral point, and critical load calculations.
 
+import json
 import math
 import pytest
-import numpy as np
 from pathlib import Path
 
 from digitalmodel.marine_ops.artificial_lift.dynacard.data_loader import (
@@ -28,6 +28,7 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.exceptions import Validati
 
 # Test data directory
 TEST_DATA_DIR = Path(__file__).parent / "testdata"
+REAL_CARD_DIR = Path(__file__).parents[1] / "test_data"
 
 # Wellbore inputs the Paslay-Dawson critical-load formula requires. They are
 # properties of the hole, not of the card, so they must be supplied explicitly.
@@ -49,8 +50,166 @@ class TestRodBucklingCalculator:
         """Test that calculate returns RodBucklingAnalysis."""
         context = self._create_test_context()
         calculator = RodBucklingCalculator(context)
-        result = calculator.calculate()
+        result = calculator.calculate(load_datum="net_pump_load")
         assert isinstance(result, RodBucklingAnalysis)
+
+    def test_load_datum_is_required_and_keyword_only(self):
+        """A card's zero convention must never be inferred."""
+        context = self._create_test_context()
+        calculator = RodBucklingCalculator(context)
+
+        with pytest.raises(TypeError):
+            calculator.calculate()
+        with pytest.raises(TypeError):
+            calculator.calculate(None, None, None, "net_pump_load")
+
+    def test_vendor_datum_requires_complete_consistent_metadata(self):
+        """Vendor-datum loads without a verified offset must be rejected."""
+        context = self._create_test_context()
+        calculator = RodBucklingCalculator(context)
+
+        with pytest.raises(ValidationError, match="downstroke"):
+            calculator.calculate(load_datum="vendor_analysis")
+
+        with pytest.raises(ValidationError, match="inconsistent"):
+            calculator.calculate(
+                load_datum="vendor_analysis",
+                vendor_downstroke_load=-100.0,
+                vendor_upstroke_load=900.0,
+                vendor_fluid_load=700.0,
+            )
+
+        with pytest.raises(ValidationError, match="positive"):
+            calculator.calculate(
+                load_datum="vendor_analysis",
+                vendor_downstroke_load=-100.0,
+                vendor_upstroke_load=-200.0,
+                vendor_fluid_load=-100.0,
+            )
+
+    def test_non_finite_loads_are_rejected(self):
+        """NaN loads must not fall through to a false not-buckled verdict."""
+        context = self._create_test_context()
+        card = CardData(position=[0, 1], load=[math.nan, 100.0])
+
+        with pytest.raises(ValidationError, match="finite"):
+            RodBucklingCalculator(context).calculate(
+                downhole_card=card,
+                load_datum="net_pump_load",
+            )
+
+    @pytest.mark.parametrize(
+        ("inclination_deg", "tubing_id"),
+        [(math.nan, TUBING_ID_IN), (30.0, math.inf)],
+    )
+    def test_non_finite_scalar_wellbore_inputs_are_rejected(
+        self,
+        inclination_deg,
+        tubing_id,
+    ):
+        """NaN/Inf geometry must not create NaN thresholds and false verdicts."""
+        context = self._create_test_context()
+
+        with pytest.raises(ValidationError, match="finite"):
+            RodBucklingCalculator(context).calculate(
+                inclination_deg=inclination_deg,
+                tubing_id=tubing_id,
+                load_datum="net_pump_load",
+            )
+
+    def test_net_pump_load_has_no_solid_rod_pressure_shift(self):
+        """A solid submerged rod has no bore ballooning correction."""
+        context = self._create_test_context()
+        card = CardData(
+            position=[0, 1, 2],
+            load=[-700.0, 100.0, 3000.0],
+        )
+
+        result = RodBucklingCalculator(context).calculate(
+            downhole_card=card,
+            load_datum="net_pump_load",
+        )
+
+        assert result.min_buckling_tendency == -700.0
+        assert result.max_buckling_tendency == 3000.0
+        assert result.max_compressive_load == 700.0
+
+    def test_vendor_analysis_datum_zeros_the_downstroke_leg(self):
+        """The vendor downstroke load is the card's datum offset."""
+        context = self._create_test_context()
+        card = CardData(
+            position=[0, 1, 2],
+            load=[-1755.0, 2210.0, -1200.0],
+        )
+
+        result = RodBucklingCalculator(context).calculate(
+            downhole_card=card,
+            load_datum="vendor_analysis",
+            vendor_downstroke_load=-1755.0,
+            vendor_upstroke_load=2210.0,
+            vendor_fluid_load=3965.0,
+        )
+
+        assert result.min_buckling_tendency == 0.0
+        assert result.max_buckling_tendency == 3965.0
+
+    def test_bottom_section_controls_critical_load(self):
+        """A smaller rod above a bottom sinker bar must not set the threshold."""
+        context = self._create_test_context()
+        context.rod_string = [
+            RodSection(diameter=0.625, length=4000.0),
+            RodSection(diameter=1.5, length=1000.0),
+        ]
+
+        result = RodBucklingCalculator(context).calculate(
+            inclination_deg=DEVIATED_INCLINATION_DEG,
+            tubing_id=2.5,
+            load_datum="net_pump_load",
+        )
+
+        bottom = context.rod_string[-1]
+        diameter = bottom.diameter
+        inertia = math.pi * diameter ** 4 / 64.0
+        weight = bottom.weight_per_foot * (
+            1.0 - context.fluid_density / 490.0
+        ) / 12.0
+        clearance = (2.5 - diameter) / 2.0
+        expected = 2.0 * math.sqrt(
+            bottom.modulus_of_elasticity
+            * inertia
+            * weight
+            * math.sin(math.radians(DEVIATED_INCLINATION_DEG))
+            / clearance
+        )
+        assert result.sinusoidal_critical_load == pytest.approx(expected)
+
+    def test_bottom_section_is_evaluated_across_inclination_profile(self):
+        """The weakest point across a varying bottom taper sets the threshold."""
+        context = self._create_test_context()
+        context.pump.depth = 5500.0
+        profile = [(0.0, 10.0), (4500.0, 42.0), (5500.0, 77.0)]
+
+        result = RodBucklingCalculator(context).calculate(
+            tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
+            inclination_profile=profile,
+        )
+
+        bottom = context.rod_string[-1]
+        diameter = bottom.diameter
+        inertia = math.pi * diameter ** 4 / 64.0
+        weight = bottom.weight_per_foot * (
+            1.0 - context.fluid_density / 490.0
+        ) / 12.0
+        clearance = (TUBING_ID_IN - diameter) / 2.0
+        expected = 2.0 * math.sqrt(
+            bottom.modulus_of_elasticity
+            * inertia
+            * weight
+            * math.sin(math.radians(42.0))
+            / clearance
+        )
+        assert result.sinusoidal_critical_load == pytest.approx(expected)
 
     def test_critical_loads_calculated(self):
         """Test that critical buckling loads are calculated when inputs allow."""
@@ -59,6 +218,7 @@ class TestRodBucklingCalculator:
         result = calculator.calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         # Should have positive critical loads
@@ -72,16 +232,24 @@ class TestRodBucklingCalculator:
         dimensionally lb*in^0.5 - not a force - and was reported unconditionally.
         """
         context = self._create_test_context()
-        result = RodBucklingCalculator(context).calculate()
+        result = RodBucklingCalculator(context).calculate(
+            load_datum="net_pump_load"
+        )
 
         assert result.sinusoidal_critical_load is None
         assert result.helical_critical_load is None
         assert "inclination" in result.warning_message.lower()
 
         # Missing either one alone is still not enough
-        only_inc = RodBucklingCalculator(context).calculate(inclination_deg=30.0)
+        only_inc = RodBucklingCalculator(context).calculate(
+            inclination_deg=30.0,
+            load_datum="net_pump_load",
+        )
         assert only_inc.sinusoidal_critical_load is None
-        only_id = RodBucklingCalculator(context).calculate(tubing_id=TUBING_ID_IN)
+        only_id = RodBucklingCalculator(context).calculate(
+            tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
+        )
         assert only_id.sinusoidal_critical_load is None
 
     def test_critical_load_is_a_force_in_pounds(self):
@@ -90,18 +258,19 @@ class TestRodBucklingCalculator:
         result = RodBucklingCalculator(context).calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
-        # Reproduce the formula independently for the weakest (0.625 in) section
+        # Reproduce the formula independently for the bottom (0.625 in) section
         d = 0.625
         section = next(s for s in context.rod_string if s.diameter == d)
-        I = math.pi * d ** 4 / 64.0
+        inertia = math.pi * d ** 4 / 64.0
         buoyancy = 1.0 - context.fluid_density / 490.0
         w = section.weight_per_foot * buoyancy / 12.0
         r_c = (TUBING_ID_IN - d) / 2.0
         expected = 2.0 * math.sqrt(
             section.modulus_of_elasticity
-            * I
+            * inertia
             * w
             * math.sin(math.radians(DEVIATED_INCLINATION_DEG))
             / r_c
@@ -113,10 +282,12 @@ class TestRodBucklingCalculator:
         shallow = RodBucklingCalculator(context).calculate(
             inclination_deg=math.degrees(math.asin(0.25)),
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
         steeper = RodBucklingCalculator(context).calculate(
             inclination_deg=math.degrees(math.asin(0.50)),
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
         ratio = steeper.sinusoidal_critical_load / shallow.sinusoidal_critical_load
         assert abs(ratio - math.sqrt(2.0)) < 1e-6
@@ -127,6 +298,7 @@ class TestRodBucklingCalculator:
         result = RodBucklingCalculator(context).calculate(
             inclination_deg=0.0,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
         assert result.sinusoidal_critical_load is None
         assert result.helical_critical_load is None
@@ -139,6 +311,7 @@ class TestRodBucklingCalculator:
         result = calculator.calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         # Helical buckling requires higher load than sinusoidal
@@ -151,6 +324,7 @@ class TestRodBucklingCalculator:
         result = calculator.calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         ratio = result.helical_critical_load / result.sinusoidal_critical_load
@@ -164,7 +338,9 @@ class TestRodBucklingCalculator:
         index onto a depth is a category error. These fields must be None.
         """
         context = self._create_test_context()
-        result = RodBucklingCalculator(context).calculate()
+        result = RodBucklingCalculator(context).calculate(
+            load_datum="net_pump_load"
+        )
 
         assert result.neutral_point_depth is None
         assert result.neutral_point_fraction is None
@@ -176,7 +352,10 @@ class TestRodBucklingCalculator:
             position=[0, 50, 100, 50],
             load=[-1000, 2000, 5000, 2000],
         )
-        result = RodBucklingCalculator(context).calculate(downhole_card=downhole_card)
+        result = RodBucklingCalculator(context).calculate(
+            downhole_card=downhole_card,
+            load_datum="net_pump_load",
+        )
         assert result.neutral_point_depth is None
         assert result.compression_length is None
 
@@ -184,14 +363,19 @@ class TestRodBucklingCalculator:
         """analysis_method must be assigned, not left at a default string."""
         context = self._create_test_context()
 
-        estimated = RodBucklingCalculator(context).calculate()
+        estimated = RodBucklingCalculator(context).calculate(
+            load_datum="net_pump_load"
+        )
         assert estimated.analysis_method == "surface_card_estimate"
 
         downhole_card = CardData(
             position=[0, 50, 100, 50],
             load=[1000, 2000, 3000, 2000],
         )
-        measured = RodBucklingCalculator(context).calculate(downhole_card=downhole_card)
+        measured = RodBucklingCalculator(context).calculate(
+            downhole_card=downhole_card,
+            load_datum="net_pump_load",
+        )
         assert measured.analysis_method == "downhole_card"
 
     def test_no_buckling_with_tensile_loads(self):
@@ -206,6 +390,7 @@ class TestRodBucklingCalculator:
         result = calculator.calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         # With high tensile loads, no buckling expected
@@ -227,6 +412,7 @@ class TestRodBucklingCalculator:
             downhole_card=downhole_card,
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         # Should detect buckling with significant compression
@@ -240,7 +426,10 @@ class TestRodBucklingCalculator:
             position=[0, 50, 100, 50],
             load=[-5000, 1000, 3000, 1000],  # Strong compression
         )
-        result = RodBucklingCalculator(context).calculate(downhole_card=downhole_card)
+        result = RodBucklingCalculator(context).calculate(
+            downhole_card=downhole_card,
+            load_datum="net_pump_load",
+        )
 
         assert result.sinusoidal_buckling_detected is None
         assert result.helical_buckling_detected is None
@@ -250,24 +439,21 @@ class TestRodBucklingCalculator:
     def test_buckling_verdict_follows_threshold_not_raw_load_rule(self):
         """A compression below the critical threshold must NOT trip buckling.
 
-        Regression test for the hard-coded ``min_load < -500`` rule, which
-        tested RAW loads while the threshold branch tested buckling TENDENCY,
-        so a tendency safely under the critical load still returned True.
+        The verdict compares the compressive pump load to the critical load,
+        not merely to zero.
         """
         context = self._create_test_context()
-        # Raw loads far below -500 lb, but the effective axial load (tendency)
-        # after the buoyancy/pressure correction stays modest.
         downhole_card = CardData(
             position=[0, 50, 100, 50],
-            load=[-700, 1000, 3000, 1000],
+            load=[-100, 1000, 3000, 1000],
         )
         result = RodBucklingCalculator(context).calculate(
             downhole_card=downhole_card,
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
-        assert min(downhole_card.load) < -500  # the old rule would have tripped
         assert result.max_compressive_load < result.sinusoidal_critical_load
         assert result.sinusoidal_buckling_detected is False
         assert result.helical_buckling_detected is False
@@ -278,6 +464,7 @@ class TestRodBucklingCalculator:
         result_ref = RodBucklingCalculator(context).calculate(
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
         critical = result_ref.sinusoidal_critical_load
 
@@ -290,6 +477,7 @@ class TestRodBucklingCalculator:
             downhole_card=downhole_card,
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         assert result.max_compressive_load > critical
@@ -299,7 +487,7 @@ class TestRodBucklingCalculator:
         """Test that buckling tendency min/max are calculated."""
         context = self._create_test_context()
         calculator = RodBucklingCalculator(context)
-        result = calculator.calculate()
+        result = calculator.calculate(load_datum="net_pump_load")
 
         # Buckling tendency should be calculated
         assert result.min_buckling_tendency != 0 or result.max_buckling_tendency != 0
@@ -311,7 +499,7 @@ class TestRodBucklingCalculator:
         calculator = RodBucklingCalculator(context)
 
         with pytest.raises(ValidationError) as exc_info:
-            calculator.calculate()
+            calculator.calculate(load_datum="net_pump_load")
 
         assert "load" in exc_info.value.message.lower() or "data" in exc_info.value.message.lower()
 
@@ -322,7 +510,7 @@ class TestRodBucklingCalculator:
         calculator = RodBucklingCalculator(context)
 
         with pytest.raises(ValidationError) as exc_info:
-            calculator.calculate()
+            calculator.calculate(load_datum="net_pump_load")
 
         assert "rod" in exc_info.value.message.lower() or "length" in exc_info.value.message.lower()
 
@@ -332,7 +520,11 @@ class TestRodBucklingCalculator:
         context.surface_card = CardData(position=[], load=[])
 
         # Use convenience function with raise_on_error=False (default)
-        result = calculate_rod_buckling(context, raise_on_error=False)
+        result = calculate_rod_buckling(
+            context,
+            raise_on_error=False,
+            load_datum="net_pump_load",
+        )
 
         # Should return result with warning message set
         assert result.warning_message != ""
@@ -345,7 +537,10 @@ class TestRodBucklingCalculator:
             load=[2000, 3000, 4000, 5000, 4000, 3000, 2000, 1000],
         )
         calculator = RodBucklingCalculator(context)
-        result = calculator.calculate(downhole_card=custom_card)
+        result = calculator.calculate(
+            downhole_card=custom_card,
+            load_datum="net_pump_load",
+        )
 
         # Should complete analysis, recording that a downhole card was used
         assert result.analysis_method == "downhole_card"
@@ -377,7 +572,10 @@ class TestConvenienceFunction:
     def test_returns_rod_buckling_analysis(self):
         """Test that convenience function returns RodBucklingAnalysis."""
         context = self._create_test_context()
-        result = calculate_rod_buckling(context)
+        result = calculate_rod_buckling(
+            context,
+            load_datum="net_pump_load",
+        )
         assert isinstance(result, RodBucklingAnalysis)
 
     def test_with_downhole_card(self):
@@ -387,7 +585,11 @@ class TestConvenienceFunction:
             position=[0, 50, 100, 50],
             load=[1000, 2000, 3000, 2000],
         )
-        result = calculate_rod_buckling(context, downhole_card=downhole_card)
+        result = calculate_rod_buckling(
+            context,
+            downhole_card=downhole_card,
+            load_datum="net_pump_load",
+        )
         assert isinstance(result, RodBucklingAnalysis)
 
     def _create_test_context(self) -> DynacardAnalysisContext:
@@ -632,9 +834,65 @@ class TestRodBucklingWithRealData:
             return load_from_json_file(filepath)
         pytest.skip("Test data file 7699227.json not found")
 
+    def test_real_card_verdict_changes_between_load_datums(self):
+        """The cleansed well 005 card is safe only after datum correction."""
+        filepath = REAL_CARD_DIR / "cleansed_well_005.json"
+        raw = json.loads(filepath.read_text())
+        context = load_from_json_file(filepath)
+        downhole_raw = raw["downholeCard"]
+        downhole_card = CardData(
+            position=downhole_raw["Position"],
+            load=downhole_raw["Load"],
+        )
+        vendor = raw["downholeCardAnalysis"]
+        profile = [
+            (point["MD"], point["Inclination"])
+            for point in raw["surveyData"]
+        ]
+
+        uncorrected = calculate_rod_buckling(
+            context,
+            downhole_card=downhole_card,
+            tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
+            inclination_profile=profile,
+            raise_on_error=True,
+        )
+        corrected = calculate_rod_buckling(
+            context,
+            downhole_card=downhole_card,
+            tubing_id=TUBING_ID_IN,
+            load_datum="vendor_analysis",
+            inclination_profile=profile,
+            vendor_downstroke_load=float(vendor["Fluid Load Downstroke"]),
+            vendor_upstroke_load=float(vendor["Fluid Load Upstroke"]),
+            vendor_fluid_load=float(vendor["Fluid Load"]),
+            raise_on_error=True,
+        )
+
+        assert uncorrected.max_compressive_load == pytest.approx(2032.21176)
+        # Datum correction: -2032.21176 - (-1755) = -277.21176 lb.
+        assert corrected.max_compressive_load == pytest.approx(277.21176)
+        # Bottom 0.75-in section at the minimum 35.94-degree inclination:
+        # 2*sqrt(30.5e6*(pi*0.75^4/64)
+        #        *(1.634*(1-62.4025742248/490)/12)
+        #        *sin(35.94deg)/((2.441-0.75)/2))
+        # = 395.3498 lb.
+        assert corrected.sinusoidal_critical_load == pytest.approx(
+            395.3498,
+            abs=0.0001,
+        )
+        assert uncorrected.sinusoidal_buckling_detected is True
+        assert corrected.sinusoidal_buckling_detected is False
+        assert corrected.neutral_point_depth is None
+        assert corrected.compression_length is None
+
     def test_buckling_calculation_7699227(self, well_7699227):
         """Test buckling calculation with well 7699227 data."""
-        result = calculate_rod_buckling(well_7699227)
+        result = calculate_rod_buckling(
+            well_7699227,
+            load_datum="net_pump_load",
+        )
 
         # Should complete analysis
         assert result.analysis_method == "surface_card_estimate"
@@ -645,6 +903,7 @@ class TestRodBucklingWithRealData:
             well_7699227,
             inclination_deg=DEVIATED_INCLINATION_DEG,
             tubing_id=TUBING_ID_IN,
+            load_datum="net_pump_load",
         )
 
         assert result.sinusoidal_critical_load > 0
@@ -652,7 +911,10 @@ class TestRodBucklingWithRealData:
 
     def test_no_neutral_point_depth_from_real_card_7699227(self, well_7699227):
         """Real card data still cannot yield a neutral-point depth."""
-        result = calculate_rod_buckling(well_7699227)
+        result = calculate_rod_buckling(
+            well_7699227,
+            load_datum="net_pump_load",
+        )
 
         assert result.neutral_point_depth is None
         assert result.neutral_point_fraction is None
@@ -661,7 +923,10 @@ class TestRodBucklingWithRealData:
 
     def test_buckling_tendency_calculated_7699227(self, well_7699227):
         """Test buckling tendency is calculated."""
-        result = calculate_rod_buckling(well_7699227)
+        result = calculate_rod_buckling(
+            well_7699227,
+            load_datum="net_pump_load",
+        )
 
         # Should have buckling tendency values
         assert (


### PR DESCRIPTION
Closes #1893.

## The buckling verdict was an artefact of where the card's zero sits

Reproduced from an **in-repo fixture**, `cleansed_well_005.json`:

| | value |
|---|---:|
| raw compression | 2032.21176 lb |
| corrected by +1755 lb | **277.21176 lb** |
| bottom-section threshold | 395.3498 lb |
| **verdict** | **BUCKLED → NOT BUCKLED** |

A factor of ~7 in compressive load — the difference between telling an operator their string is helically buckled over half its length and telling them it sits at 60–90% of threshold.

The vendor's own `Fluid Load Downstroke` **is** the datum offset: in a physically-zeroed pump card the downstroke leg sits at zero net pump load. Two independent confirmations:

- vendor `Fluid Load` 3965 lb vs `(PDP−PIP)·A_plunger` = 3959.094 lb → **0.149%**
- after the shift, the upstroke leg lands on `Fo` exactly

Nothing in the pipeline asserted what a downhole card's zero meant, so any card whose datum differed from our assumption produced a verdict that was not merely imprecise but **inverted**. Synthetic vertical cards could never surface this — our generators and solver share a datum convention, so the error cancels.

## What changed

1. **Explicit keyword-only `load_datum`** — `net_pump_load` or `vendor_analysis`. No implicit assumption about a card's zero.
2. **Vendor correction requires complete, consistent metadata**, and rejects it loudly otherwise. The upstroke-vs-`Fo` agreement is the verification step — 0.149% is sharp enough to serve as a guard.
3. **Bottom rod section, evaluated across its depth interval.** Replaces `min(s.diameter for s in ctx.rod_string)`, which picks the smallest rod *anywhere* — simply the wrong section when a string carries a sinker bar at the bottom. F_cr scales with √(sin α) and one real taper spans 42°→77°, so a scalar inclination cannot represent it.
4. **Removed the solid-rod Poisson pressure shift.** A solid rod fully submerged has no bore, so the ballooning term doesn't apply in this form, and it mixed bottom-hole pressure with a whole-string *average* area. It added **+562.778 lb** against a ~395 lb threshold — it decided the verdict on its own.

## Verified by hand

The regression test spells out Paslay–Dawson in full rather than pasting output:

```
2*sqrt(30.5e6*(pi*0.75^4/64)*(1.634*(1-62.4025742248/490)/12)*sin(35.94deg)/((2.441-0.75)/2))
```

I recomputed this independently — I = 0.0155317 in⁴, buoyant w = 0.118826 lb/in, sin(35.94°) = 0.58705, r_c = 0.8455 in → **395.4 lb**, matching the asserted 395.3498.

## Two judgement calls preserved

- The Shutdown fixture is **unusable** — its vendor analysis failed and its minimum load is positive. Not forced into a test.
- Neutral-point depth and compressed length stay `None`. A card is load-vs-position *at the pump*; stroke-phase samples cannot determine a depth profile. Deriving one needs the rod string and survey, not the card.

## Verification

- buckling tests **65 passed**
- `tests/marine_ops/artificial_lift/` — **931 passed, 1 skipped**

## Found but not fixed

- The README example omits the now-required `load_datum` (outside the two-file scope).
- A pre-existing dispute over the helical/sinusoidal threshold ratio, preserved pending a separately reviewed physics change.

Authored by Codex; the by-hand arithmetic was recomputed independently before landing.