### PR TITLE
fix(dynacard): order card corners by cycle phase, not by position (#1897)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -15,6 +15,13 @@ from .corners import calculate_corners, get_corner_loads
 # FLUID LOAD CALCULATION
 # =============================================================================
 
+def _cyclic_phase(load: np.ndarray, start: int, stop: int) -> np.ndarray:
+    """Return load samples in forward traversal, excluding the stop corner."""
+    count = (stop - start) % len(load)
+    indices = (start + np.arange(count)) % len(load)
+    return load[indices]
+
+
 def calculate_fluid_load(
     downhole_card: CardData,
     method: str = 'avg'
@@ -37,16 +44,10 @@ def calculate_fluid_load(
     position, load, _ = canonicalize_card_direction(
         position, load, clockwise=True
     )
-    n = len(load)
 
     # Detect corners
     canonical_card = CardData(position=position.tolist(), load=load.tolist())
     corners, _ = calculate_corners(canonical_card)
-
-    def phase_loads(start: int, stop: int) -> np.ndarray:
-        count = (stop - start) % n
-        indices = (start + np.arange(count)) % n
-        return load[indices]
 
     if method == '2pt':
         # Use corner loads directly
@@ -54,12 +55,12 @@ def calculate_fluid_load(
         downstroke_load = load[corners[0]]  # Bottom left
     elif method == 'avg':
         # Average loads in each region
-        upstroke_load = np.mean(phase_loads(corners[1], corners[2]))
-        downstroke_load = np.mean(phase_loads(corners[3], corners[0]))
+        upstroke_load = np.mean(_cyclic_phase(load, corners[1], corners[2]))
+        downstroke_load = np.mean(_cyclic_phase(load, corners[3], corners[0]))
     elif method == 'med':
         # Median loads in each region
-        upstroke_load = np.median(phase_loads(corners[1], corners[2]))
-        downstroke_load = np.median(phase_loads(corners[3], corners[0]))
+        upstroke_load = np.median(_cyclic_phase(load, corners[1], corners[2]))
+        downstroke_load = np.median(_cyclic_phase(load, corners[3], corners[0]))
     else:
         raise ValueError(f"Unknown method: {method}")
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -50,6 +50,8 @@ def calculate_fluid_load(
     # Detect corners
     canonical_card = CardData(position=position.tolist(), load=load.tolist())
     corners, _ = calculate_corners(canonical_card)
+    if len(set(corners)) < 4:
+        raise ValueError("fluid load requires distinct corner phases")
 
     if method == '2pt':
         # Use corner loads directly

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -7,6 +7,7 @@ from .models import (
     DynacardAnalysisContext, CardData, AnalysisResults,
     FluidLoadAnalysis, CPIPAnalysis, PumpFillageAnalysis, ProductionAnalysis
 )
+from .comparison import canonicalize_card_direction
 from .corners import calculate_corners, get_corner_loads
 
 
@@ -31,12 +32,21 @@ def calculate_fluid_load(
     Returns:
         FluidLoadAnalysis with upstroke, downstroke, and fluid load
     """
-    load = np.array(downhole_card.load)
+    position = np.asarray(downhole_card.position, dtype=np.float64)
+    load = np.asarray(downhole_card.load, dtype=np.float64)
+    position, load, _ = canonicalize_card_direction(
+        position, load, clockwise=True
+    )
     n = len(load)
 
     # Detect corners
-    corners, _ = calculate_corners(downhole_card)
-    corners = sorted(corners)
+    canonical_card = CardData(position=position.tolist(), load=load.tolist())
+    corners, _ = calculate_corners(canonical_card)
+
+    def phase_loads(start: int, stop: int) -> np.ndarray:
+        count = (stop - start) % n
+        indices = (start + np.arange(count)) % n
+        return load[indices]
 
     if method == '2pt':
         # Use corner loads directly
@@ -44,12 +54,12 @@ def calculate_fluid_load(
         downstroke_load = load[corners[0]]  # Bottom left
     elif method == 'avg':
         # Average loads in each region
-        upstroke_load = np.mean(load[corners[1]:corners[2]])
-        downstroke_load = np.mean(load[corners[3]:])
+        upstroke_load = np.mean(phase_loads(corners[1], corners[2]))
+        downstroke_load = np.mean(phase_loads(corners[3], corners[0]))
     elif method == 'med':
         # Median loads in each region
-        upstroke_load = np.median(load[corners[1]:corners[2]])
-        downstroke_load = np.median(load[corners[3]:])
+        upstroke_load = np.median(phase_loads(corners[1], corners[2]))
+        downstroke_load = np.median(phase_loads(corners[3], corners[0]))
     else:
         raise ValueError(f"Unknown method: {method}")
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -47,7 +47,6 @@ def calculate_fluid_load(
         position, load, clockwise=True
     )
 
-    # Detect corners
     canonical_card = CardData(position=position.tolist(), load=load.tolist())
     corners, _ = calculate_corners(canonical_card)
     if len(set(corners)) < 4:

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/calculations.py
@@ -18,6 +18,8 @@ from .corners import calculate_corners, get_corner_loads
 def _cyclic_phase(load: np.ndarray, start: int, stop: int) -> np.ndarray:
     """Return load samples in forward traversal, excluding the stop corner."""
     count = (stop - start) % len(load)
+    if count == 0:
+        raise ValueError("fluid load requires distinct corner phases")
     indices = (start + np.arange(count)) % len(load)
     return load[indices]
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/comparison.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/comparison.py
@@ -46,11 +46,25 @@ def _signed_area(position: np.ndarray, load: np.ndarray) -> float:
     )
 
 
+def canonicalize_card_direction(
+    position: np.ndarray,
+    load: np.ndarray,
+    *,
+    clockwise: bool = False,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return card arrays and source indices in one signed-area direction."""
+    source_indices = np.arange(len(position))
+    area = _signed_area(position, load)
+    reverse = area > 0.0 if clockwise else area < 0.0
+    if reverse:
+        return position[::-1], load[::-1], source_indices[::-1]
+    return position, load, source_indices
+
+
 def _canonical_direction(
     position: np.ndarray, load: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
-    if _signed_area(position, load) < 0.0:
-        return position[::-1], load[::-1]
+    position, load, _ = canonicalize_card_direction(position, load)
     return position, load
 
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -55,27 +55,14 @@ class CornerDetector:
         """
         Use convex hull to find corner candidates.
         """
-        # Stack position and load as 2D points
         points = np.column_stack((self.position, self.load))
-
         try:
             hull = ConvexHull(points)
             hull_vertices = hull.vertices
         except Exception:
-            # Fallback to simple extrema detection
             return self._detect_via_extrema()
 
-        # Find the 4 most extreme points on the hull
-        # Sort hull vertices by position
         hull_pos = self.position[hull_vertices]
-        hull_load = self.load[hull_vertices]
-
-        # Find corners based on position and load extrema
-        # BL: minimum position, low load
-        # TL: minimum position, high load
-        # TR: maximum position, high load
-        # BR: maximum position, low load
-
         min_pos_mask = hull_pos <= np.percentile(hull_pos, 25)
         max_pos_mask = hull_pos >= np.percentile(hull_pos, 75)
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -142,10 +142,17 @@ class CornerDetector:
             self.load[downstroke] - np.min(self.load)
         ) / load_span
         knee_offset = int(np.argmax(retained_stroke - remaining_load))
+        branch_start = self._find_lower_branch_start(
+            retained_stroke, remaining_load
+        )
+        branch_stroke = retained_stroke[branch_start]
+        knee_stroke = retained_stroke[knee_offset]
+        if knee_stroke - 0.45 <= branch_stroke <= knee_stroke:
+            return int(downstroke[branch_start])
 
-        # A discretised taper can leave the knee one material load step before
-        # transfer finishes. Include that endpoint without chasing gradual
-        # lower-branch load variation.
+        # A noisy, curved lower branch can appear linear all the way through
+        # the bottom turnaround. In that case retain the geometric knee, while
+        # including one material endpoint of its discretised transfer taper.
         if knee_offset + 1 < len(downstroke):
             taper_drop = (
                 self.load[downstroke[knee_offset]]
@@ -154,6 +161,27 @@ class CornerDetector:
             if taper_drop > 0.01 * load_span:
                 knee_offset += 1
         return int(downstroke[knee_offset])
+
+    @staticmethod
+    def _find_lower_branch_start(
+        retained_stroke: np.ndarray, remaining_load: np.ndarray
+    ) -> int:
+        """Find the earliest point on the terminal, near-linear lower branch."""
+        branch_start = len(retained_stroke) - 2
+        tolerance = 0.005
+        for candidate in range(branch_start - 1, -1, -1):
+            stroke = retained_stroke[candidate:]
+            load = remaining_load[candidate:]
+            stroke_span = stroke[0] - stroke[-1]
+            if stroke_span <= np.finfo(np.float64).eps:
+                break
+            expected = load[-1] + (load[0] - load[-1]) * (
+                stroke - stroke[-1]
+            ) / stroke_span
+            if np.max(np.abs(load - expected)) > tolerance:
+                break
+            branch_start = candidate
+        return branch_start
 
     def _order_corners(self, corners: List[int]) -> List[int]:
         """

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -126,29 +126,34 @@ class CornerDetector:
             bottom_candidates[np.argmin(self.load[bottom_candidates])]
         )
         downstroke = self._cyclic_indices(top_idx, bottom_idx, include_stop=True)
-        load_drop = np.diff(self.load[downstroke])
-        if len(load_drop) == 0:
+        position_span = float(np.ptp(self.position))
+        load_span = float(np.ptp(self.load))
+        if (
+            len(downstroke) < 2
+            or position_span <= np.finfo(np.float64).eps
+            or load_span <= np.finfo(np.float64).eps
+        ):
             return top_idx
 
-        peak_drop_offset = int(np.argmin(load_drop))
-        peak_drop = abs(float(load_drop[peak_drop_offset]))
-        if peak_drop <= np.finfo(np.float64).eps:
-            return int(downstroke[peak_drop_offset + 1])
+        retained_stroke = (
+            self.position[downstroke] - np.min(self.position)
+        ) / position_span
+        remaining_load = (
+            self.load[downstroke] - np.min(self.load)
+        ) / load_span
+        knee_offset = int(np.argmax(retained_stroke - remaining_load))
 
-        # BR is after the sharp drop, where load transfer has substantially
-        # subsided. Returning the largest-drop sample itself locates the middle
-        # of the transfer and systematically overstates incomplete fillage.
-        completion_rate = 0.25 * peak_drop
-        for offset in range(peak_drop_offset + 1, len(load_drop) - 1):
-            current_drop = float(load_drop[offset])
-            next_drop = float(load_drop[offset + 1])
-            current_rate = abs(min(current_drop, 0.0))
-            next_rate = abs(min(next_drop, 0.0))
-            if current_rate < completion_rate and next_rate < completion_rate:
-                if current_drop >= -np.finfo(np.float64).eps:
-                    return int(downstroke[offset])
-                return int(downstroke[offset + 1])
-        return int(downstroke[peak_drop_offset + 1])
+        # A discretised taper can leave the knee one material load step before
+        # transfer finishes. Include that endpoint without chasing gradual
+        # lower-branch load variation.
+        if knee_offset + 1 < len(downstroke):
+            taper_drop = (
+                self.load[downstroke[knee_offset]]
+                - self.load[downstroke[knee_offset + 1]]
+            )
+            if taper_drop > 0.01 * load_span:
+                knee_offset += 1
+        return int(downstroke[knee_offset])
 
     def _order_corners(self, corners: List[int]) -> List[int]:
         """

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -132,8 +132,12 @@ class CornerDetector:
         Find the bottom right corner (traveling valve opening point).
         This is where the load drops sharply during downstroke.
         """
-        top_idx = int(np.argmax(self.position))
-        bottom_idx = int(np.argmin(self.position))
+        top_candidates = np.flatnonzero(self.position == np.max(self.position))
+        bottom_candidates = np.flatnonzero(self.position == np.min(self.position))
+        top_idx = int(top_candidates[np.argmax(self.load[top_candidates])])
+        bottom_idx = int(
+            bottom_candidates[np.argmin(self.load[bottom_candidates])]
+        )
         downstroke = self._cyclic_indices(top_idx, bottom_idx, include_stop=True)
         load_drop = np.diff(self.load[downstroke])
         if len(load_drop) == 0:
@@ -148,8 +152,14 @@ class CornerDetector:
         # subsided. Returning the largest-drop sample itself locates the middle
         # of the transfer and systematically overstates incomplete fillage.
         completion_rate = 0.25 * peak_drop
-        for offset in range(peak_drop_offset + 1, len(load_drop)):
-            if abs(min(float(load_drop[offset]), 0.0)) < completion_rate:
+        for offset in range(peak_drop_offset + 1, len(load_drop) - 1):
+            current_drop = float(load_drop[offset])
+            next_drop = float(load_drop[offset + 1])
+            current_rate = abs(min(current_drop, 0.0))
+            next_rate = abs(min(next_drop, 0.0))
+            if current_rate < completion_rate and next_rate < completion_rate:
+                if current_drop >= -np.finfo(np.float64).eps:
+                    return int(downstroke[offset])
                 return int(downstroke[offset + 1])
         return int(downstroke[peak_drop_offset + 1])
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -142,17 +142,10 @@ class CornerDetector:
             self.load[downstroke] - np.min(self.load)
         ) / load_span
         knee_offset = int(np.argmax(retained_stroke - remaining_load))
-        branch_start = self._find_lower_branch_start(
-            retained_stroke, remaining_load
-        )
-        branch_stroke = retained_stroke[branch_start]
-        knee_stroke = retained_stroke[knee_offset]
-        if knee_stroke - 0.45 <= branch_stroke <= knee_stroke:
-            return int(downstroke[branch_start])
 
-        # A noisy, curved lower branch can appear linear all the way through
-        # the bottom turnaround. In that case retain the geometric knee, while
-        # including one material endpoint of its discretised transfer taper.
+        # A discretised taper can leave the knee one material load step before
+        # transfer finishes. Include that endpoint without chasing gradual
+        # lower-branch load variation.
         if knee_offset + 1 < len(downstroke):
             taper_drop = (
                 self.load[downstroke[knee_offset]]
@@ -161,27 +154,6 @@ class CornerDetector:
             if taper_drop > 0.01 * load_span:
                 knee_offset += 1
         return int(downstroke[knee_offset])
-
-    @staticmethod
-    def _find_lower_branch_start(
-        retained_stroke: np.ndarray, remaining_load: np.ndarray
-    ) -> int:
-        """Find the earliest point on the terminal, near-linear lower branch."""
-        branch_start = len(retained_stroke) - 2
-        tolerance = 0.005
-        for candidate in range(branch_start - 1, -1, -1):
-            stroke = retained_stroke[candidate:]
-            load = remaining_load[candidate:]
-            stroke_span = stroke[0] - stroke[-1]
-            if stroke_span <= np.finfo(np.float64).eps:
-                break
-            expected = load[-1] + (load[0] - load[-1]) * (
-                stroke - stroke[-1]
-            ) / stroke_span
-            if np.max(np.abs(load - expected)) > tolerance:
-                break
-            branch_start = candidate
-        return branch_start
 
     def _order_corners(self, corners: List[int]) -> List[int]:
         """

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/corners.py
@@ -3,7 +3,8 @@
 
 import numpy as np
 from scipy.spatial import ConvexHull
-from typing import List, Tuple, Optional
+from typing import List, Tuple
+from .comparison import canonicalize_card_direction
 from .models import CardData
 
 
@@ -28,8 +29,13 @@ class CornerDetector:
         Args:
             card: Dynamometer card containing position and load arrays.
         """
-        self.position = np.array(card.position)
-        self.load = np.array(card.load)
+        position = np.asarray(card.position, dtype=np.float64)
+        load = np.asarray(card.load, dtype=np.float64)
+        (
+            self.position,
+            self.load,
+            self._source_indices,
+        ) = canonicalize_card_direction(position, load, clockwise=True)
         self.n_points = len(self.position)
 
     def detect_corners(self) -> List[int]:
@@ -43,7 +49,7 @@ class CornerDetector:
         # Validate and order corners
         corners = self._order_corners(corners)
 
-        return corners
+        return [int(self._source_indices[index]) for index in corners]
 
     def _detect_via_convex_hull(self) -> List[int]:
         """
@@ -94,12 +100,9 @@ class CornerDetector:
         else:
             tr_idx = np.argmax(self.position)
 
-        # Bottom Right: max position, min load in that region
-        br_candidates = hull_vertices[max_pos_mask]
-        if len(br_candidates) > 0:
-            br_idx = br_candidates[np.argmin(self.load[br_candidates])]
-        else:
-            br_idx = self._find_bottom_right_corner()
+        # Bottom Right: end of fluid-load transfer on the downstroke. It can
+        # sit well below maximum position when fillage is incomplete.
+        br_idx = self._find_bottom_right_corner()
 
         return [int(bl_idx), int(tl_idx), int(tr_idx), int(br_idx)]
 
@@ -129,52 +132,45 @@ class CornerDetector:
         Find the bottom right corner (traveling valve opening point).
         This is where the load drops sharply during downstroke.
         """
-        # Look in second half of stroke
-        mid_idx = self.n_points // 2
-        second_half = self.load[mid_idx:]
+        top_idx = int(np.argmax(self.position))
+        bottom_idx = int(np.argmin(self.position))
+        downstroke = self._cyclic_indices(top_idx, bottom_idx, include_stop=True)
+        load_drop = np.diff(self.load[downstroke])
+        if len(load_drop) == 0:
+            return top_idx
 
-        # Find maximum rate of load decrease
-        load_diff = np.diff(second_half)
+        peak_drop_offset = int(np.argmin(load_drop))
+        peak_drop = abs(float(load_drop[peak_drop_offset]))
+        if peak_drop <= np.finfo(np.float64).eps:
+            return int(downstroke[peak_drop_offset + 1])
 
-        # Find the point with largest negative slope
-        min_slope_idx = np.argmin(load_diff)
-
-        # The corner is where the slope changes (after the drop)
-        br_idx = mid_idx + min_slope_idx + 1
-
-        # Clamp to valid range
-        br_idx = min(br_idx, self.n_points - 1)
-
-        return br_idx
+        # BR is after the sharp drop, where load transfer has substantially
+        # subsided. Returning the largest-drop sample itself locates the middle
+        # of the transfer and systematically overstates incomplete fillage.
+        completion_rate = 0.25 * peak_drop
+        for offset in range(peak_drop_offset + 1, len(load_drop)):
+            if abs(min(float(load_drop[offset]), 0.0)) < completion_rate:
+                return int(downstroke[offset + 1])
+        return int(downstroke[peak_drop_offset + 1])
 
     def _order_corners(self, corners: List[int]) -> List[int]:
         """
         Ensure corners are in proper order: BL, TL, TR, BR.
         """
-        # Sort by position first
-        pos_at_corners = self.position[corners]
-        load_at_corners = self.load[corners]
+        # The detector identifies BL first. In canonical clockwise traversal,
+        # the remaining phases follow BL -> TL -> TR -> BR even when BR is not
+        # one of the two highest-position candidates.
+        bl_idx = corners[0]
+        return sorted(corners, key=lambda index: (index - bl_idx) % self.n_points)
 
-        # Identify left side (min position) and right side (max position)
-        sorted_by_pos = np.argsort(pos_at_corners)
-
-        # Left corners (indices 0,1 in sorted)
-        left_corners = [corners[sorted_by_pos[0]], corners[sorted_by_pos[1]]]
-        right_corners = [corners[sorted_by_pos[2]], corners[sorted_by_pos[3]]]
-
-        # Sort left by load (BL is lower, TL is higher)
-        if self.load[left_corners[0]] > self.load[left_corners[1]]:
-            bl_idx, tl_idx = left_corners[1], left_corners[0]
-        else:
-            bl_idx, tl_idx = left_corners[0], left_corners[1]
-
-        # Sort right by load (BR is lower, TR is higher)
-        if self.load[right_corners[0]] > self.load[right_corners[1]]:
-            br_idx, tr_idx = right_corners[1], right_corners[0]
-        else:
-            br_idx, tr_idx = right_corners[0], right_corners[1]
-
-        return [bl_idx, tl_idx, tr_idx, br_idx]
+    def _cyclic_indices(
+        self, start: int, stop: int, *, include_stop: bool = False
+    ) -> np.ndarray:
+        """Return forward traversal indices across an arbitrary array origin."""
+        count = (stop - start) % self.n_points
+        if include_stop:
+            count += 1
+        return (start + np.arange(count)) % self.n_points
 
 
 def calculate_corners(card: CardData) -> Tuple[List[int], np.ndarray]:

--- a/tests/marine_ops/artificial_lift/dynacard/test_calculations.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_calculations.py
@@ -100,12 +100,13 @@ class TestFluidLoad:
 
         assert result.upstroke_load > result.downstroke_load
 
-    def test_fluid_load_rejects_degenerate_corner_phases(self):
+    @pytest.mark.parametrize("method", ["avg", "med", "2pt"])
+    def test_fluid_load_rejects_degenerate_corner_phases(self, method):
         """Identical corner phases have no defined upstroke or downstroke."""
         card = CardData(position=[50.0] * 20, load=[100.0] * 20)
 
         with pytest.raises(ValueError, match="distinct corner phases"):
-            calculate_fluid_load(card)
+            calculate_fluid_load(card, method=method)
 
 
 # =============================================================================

--- a/tests/marine_ops/artificial_lift/dynacard/test_calculations.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_calculations.py
@@ -100,6 +100,13 @@ class TestFluidLoad:
 
         assert result.upstroke_load > result.downstroke_load
 
+    def test_fluid_load_rejects_degenerate_corner_phases(self):
+        """Identical corner phases have no defined upstroke or downstroke."""
+        card = CardData(position=[50.0] * 20, load=[100.0] * 20)
+
+        with pytest.raises(ValueError, match="distinct corner phases"):
+            calculate_fluid_load(card)
+
 
 # =============================================================================
 # PLUNGER TRAVEL TESTS

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -9,6 +9,9 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.corners import (
     calculate_corners,
     get_corner_loads,
 )
+from digitalmodel.marine_ops.artificial_lift.dynacard.calculations import (
+    calculate_pump_fillage,
+)
 from digitalmodel.marine_ops.artificial_lift.dynacard.models import CardData
 
 
@@ -42,6 +45,28 @@ def _make_degenerate_card() -> CardData:
     return CardData(
         position=[0.0, 0.0, 0.0],
         load=[100.0, 100.0, 100.0],
+    )
+
+
+def _make_partial_fillage_card() -> CardData:
+    """Build a card whose downstroke load transfer finishes at 60% stroke."""
+    points = [
+        (0.0, 0.0),   # BL
+        (0.0, 10.0),  # TL
+        (25.0, 10.0),
+        (50.0, 10.0),
+        (75.0, 10.0),
+        (100.0, 10.0),  # TR
+        (90.0, 8.0),
+        (80.0, 4.0),
+        (70.0, 0.5),
+        (60.0, 0.0),  # BR: load transfer has finished
+        (40.0, 0.0),
+        (20.0, 0.0),
+    ]
+    return CardData(
+        position=[point[0] for point in points],
+        load=[point[1] for point in points],
     )
 
 
@@ -131,6 +156,30 @@ class TestCornerDetector:
         n = len(card.position)
         for idx in corners:
             assert 0 <= idx < n, f"Index {idx} out of range [0, {n - 1}]"
+
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            lambda values: np.roll(values, 4).tolist(),
+            lambda values: list(reversed(np.roll(values, 4).tolist())),
+        ],
+        ids=["shifted-origin", "shifted-origin-reversed-direction"],
+    )
+    def test_partial_fillage_uses_phase_order_not_position_extrema(
+        self, transform
+    ):
+        """BR remains the end of load transfer regardless of card storage."""
+        card = _make_partial_fillage_card()
+        stored_card = CardData(
+            position=transform(card.position),
+            load=transform(card.load),
+        )
+
+        result = calculate_pump_fillage(stored_card)
+
+        # Gross stroke = 100 - 0 = 100; load transfer finishes at position 60.
+        assert result.net_stroke == pytest.approx(60.0)
+        assert result.fillage == pytest.approx(60.0)
 
 
 class TestCalculateCorners:

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -284,59 +284,6 @@ class TestCornerDetector:
 
                 assert result.fillage == pytest.approx(70.0)
 
-    @pytest.mark.parametrize(
-        ("position", "load"),
-        [
-            (
-                [0, 0, 50, 100, 70, 60, 40, 20],
-                [0, 10, 10, 10, 0.5, 0, 0, 0],
-            ),
-            (
-                [0, 0, 50, 100, 70, 65, 60, 40, 20],
-                [0, 10, 10, 10, 0.5, 0.25, 0, 0, 0],
-            ),
-            (
-                [0, 0, 50, 100, 70, 67.5, 65, 62.5, 60, 40, 20],
-                [0, 10, 10, 10, 0.5, 0.375, 0.25, 0.125, 0, 0, 0],
-            ),
-        ],
-        ids=["coarse", "one-midpoint", "four-subdivisions"],
-    )
-    def test_br_is_invariant_to_collinear_taper_sampling(self, position, load):
-        """Subdividing the same transfer taper cannot move its endpoint."""
-        result = calculate_pump_fillage(CardData(position=position, load=load))
-
-        assert result.fillage == pytest.approx(60.0)
-
-    @pytest.mark.parametrize(
-        ("position", "load", "expected_fillage"),
-        [
-            (
-                [0, 0, 50, 100, 90, 80, 70, 60, 50, 25],
-                [0, 10, 10, 10, 2, 2, 2, 1.5, 0, 0],
-                50.0,
-            ),
-            (
-                [0, 0, 50, 100, 80, 60, 40, 20],
-                [0, 10, 10, 10, 6, 2, 1.333, 0.667],
-                60.0,
-            ),
-            (
-                [0, 0, 50, 100, 100, 75, 50, 25],
-                [0, 10, 10, 10, 2, 1.5, 1, 0.5],
-                100.0,
-            ),
-        ],
-        ids=["two-stage-pause", "partial-sloped-branch", "full-sloped-branch"],
-    )
-    def test_br_separates_transfer_from_lower_branch(
-        self, position, load, expected_fillage
-    ):
-        """BR starts the terminal lower branch, even when that branch slopes."""
-        result = calculate_pump_fillage(CardData(position=position, load=load))
-
-        assert result.fillage == pytest.approx(expected_fillage)
-
 
 class TestCalculateCorners:
     """Tests for the calculate_corners helper function."""

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -304,18 +304,9 @@ class TestCornerDetector:
     )
     def test_br_is_invariant_to_collinear_taper_sampling(self, position, load):
         """Subdividing the same transfer taper cannot move its endpoint."""
-        for reverse in (False, True):
-            for shift in range(len(position)):
-                stored_position = np.roll(position, shift)
-                stored_load = np.roll(load, shift)
-                if reverse:
-                    stored_position = stored_position[::-1]
-                    stored_load = stored_load[::-1]
-                result = calculate_pump_fillage(
-                    CardData(position=stored_position, load=stored_load)
-                )
+        result = calculate_pump_fillage(CardData(position=position, load=load))
 
-                assert result.fillage == pytest.approx(60.0)
+        assert result.fillage == pytest.approx(60.0)
 
     @pytest.mark.parametrize(
         ("position", "load", "expected_fillage"),
@@ -342,18 +333,9 @@ class TestCornerDetector:
         self, position, load, expected_fillage
     ):
         """BR starts the terminal lower branch, even when that branch slopes."""
-        for reverse in (False, True):
-            for shift in range(len(position)):
-                stored_position = np.roll(position, shift)
-                stored_load = np.roll(load, shift)
-                if reverse:
-                    stored_position = stored_position[::-1]
-                    stored_load = stored_load[::-1]
-                result = calculate_pump_fillage(
-                    CardData(position=stored_position, load=stored_load)
-                )
+        result = calculate_pump_fillage(CardData(position=position, load=load))
 
-                assert result.fillage == pytest.approx(expected_fillage)
+        assert result.fillage == pytest.approx(expected_fillage)
 
 
 class TestCalculateCorners:

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -10,6 +10,7 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.corners import (
     get_corner_loads,
 )
 from digitalmodel.marine_ops.artificial_lift.dynacard.calculations import (
+    calculate_fluid_load,
     calculate_pump_fillage,
 )
 from digitalmodel.marine_ops.artificial_lift.dynacard.models import CardData
@@ -61,6 +62,26 @@ def _make_partial_fillage_card() -> CardData:
         (80.0, 4.0),
         (70.0, 0.5),
         (60.0, 0.0),  # BR: load transfer has finished
+        (40.0, 0.0),
+        (20.0, 0.0),
+    ]
+    return CardData(
+        position=[point[0] for point in points],
+        load=[point[1] for point in points],
+    )
+
+
+def _make_multistage_transfer_card() -> CardData:
+    """Build a partial card with a brief lull inside its downstroke drop."""
+    points = [
+        (0.0, 0.0),
+        (0.0, 10.0),
+        (50.0, 10.0),
+        (100.0, 10.0),
+        (90.0, 6.0),
+        (80.0, 5.5),  # brief lull; load transfer is not complete
+        (70.0, 2.5),
+        (60.0, 0.0),  # BR
         (40.0, 0.0),
         (20.0, 0.0),
     ]
@@ -178,6 +199,31 @@ class TestCornerDetector:
         result = calculate_pump_fillage(stored_card)
 
         # Gross stroke = 100 - 0 = 100; load transfer finishes at position 60.
+        assert result.net_stroke == pytest.approx(60.0)
+        assert result.fillage == pytest.approx(60.0)
+        assert calculate_fluid_load(stored_card).fluid_load == pytest.approx(10.0)
+
+    def test_full_card_stays_full_at_every_origin_and_direction(self):
+        """A flat lower branch starts at BR, not one sample after it."""
+        card = _make_rectangular_card()
+
+        for reverse in (False, True):
+            for shift in range(len(card.position)):
+                position = np.roll(card.position, shift)
+                load = np.roll(card.load, shift)
+                if reverse:
+                    position = position[::-1]
+                    load = load[::-1]
+                stored_card = CardData(position=position, load=load)
+
+                assert calculate_pump_fillage(stored_card).fillage == pytest.approx(
+                    100.0
+                )
+
+    def test_br_requires_sustained_end_of_load_transfer(self):
+        """A one-sample lull does not terminate a multi-stage load drop."""
+        result = calculate_pump_fillage(_make_multistage_transfer_card())
+
         assert result.net_stroke == pytest.approx(60.0)
         assert result.fillage == pytest.approx(60.0)
 

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -284,6 +284,59 @@ class TestCornerDetector:
 
                 assert result.fillage == pytest.approx(70.0)
 
+    @pytest.mark.parametrize(
+        ("position", "load"),
+        [
+            (
+                [0, 0, 50, 100, 70, 60, 40, 20],
+                [0, 10, 10, 10, 0.5, 0, 0, 0],
+            ),
+            (
+                [0, 0, 50, 100, 70, 65, 60, 40, 20],
+                [0, 10, 10, 10, 0.5, 0.25, 0, 0, 0],
+            ),
+            (
+                [0, 0, 50, 100, 70, 67.5, 65, 62.5, 60, 40, 20],
+                [0, 10, 10, 10, 0.5, 0.375, 0.25, 0.125, 0, 0, 0],
+            ),
+        ],
+        ids=["coarse", "one-midpoint", "four-subdivisions"],
+    )
+    def test_br_is_invariant_to_collinear_taper_sampling(self, position, load):
+        """Subdividing the same transfer taper cannot move its endpoint."""
+        result = calculate_pump_fillage(CardData(position=position, load=load))
+
+        assert result.fillage == pytest.approx(60.0)
+
+    @pytest.mark.parametrize(
+        ("position", "load", "expected_fillage"),
+        [
+            (
+                [0, 0, 50, 100, 90, 80, 70, 60, 50, 25],
+                [0, 10, 10, 10, 2, 2, 2, 1.5, 0, 0],
+                50.0,
+            ),
+            (
+                [0, 0, 50, 100, 80, 60, 40, 20],
+                [0, 10, 10, 10, 6, 2, 1.333, 0.667],
+                60.0,
+            ),
+            (
+                [0, 0, 50, 100, 100, 75, 50, 25],
+                [0, 10, 10, 10, 2, 1.5, 1, 0.5],
+                100.0,
+            ),
+        ],
+        ids=["two-stage-pause", "partial-sloped-branch", "full-sloped-branch"],
+    )
+    def test_br_separates_transfer_from_lower_branch(
+        self, position, load, expected_fillage
+    ):
+        """BR starts the terminal lower branch, even when that branch slopes."""
+        result = calculate_pump_fillage(CardData(position=position, load=load))
+
+        assert result.fillage == pytest.approx(expected_fillage)
+
 
 class TestCalculateCorners:
     """Tests for the calculate_corners helper function."""

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -91,6 +91,26 @@ def _make_multistage_transfer_card() -> CardData:
     )
 
 
+def _make_two_lull_transfer_card() -> CardData:
+    """Build a card with two quiet samples before load transfer resumes."""
+    points = [
+        (0.0, 0.0),
+        (0.0, 10.0),
+        (50.0, 10.0),
+        (100.0, 10.0),
+        (90.0, 6.0),
+        (80.0, 5.6),
+        (70.0, 5.2),
+        (60.0, 2.2),
+        (50.0, 0.0),  # BR
+        (25.0, 0.0),
+    ]
+    return CardData(
+        position=[point[0] for point in points],
+        load=[point[1] for point in points],
+    )
+
+
 class TestCornerDetector:
     """Tests for the CornerDetector class."""
 
@@ -226,6 +246,43 @@ class TestCornerDetector:
 
         assert result.net_stroke == pytest.approx(60.0)
         assert result.fillage == pytest.approx(60.0)
+
+    def test_br_is_independent_of_multiple_transfer_lulls(self):
+        """Quiet samples inside a drop do not become false BR corners."""
+        card = _make_two_lull_transfer_card()
+
+        for reverse in (False, True):
+            for shift in range(len(card.position)):
+                position = np.roll(card.position, shift)
+                load = np.roll(card.load, shift)
+                if reverse:
+                    position = position[::-1]
+                    load = load[::-1]
+                result = calculate_pump_fillage(
+                    CardData(position=position, load=load)
+                )
+
+                assert result.fillage == pytest.approx(50.0)
+
+    def test_closed_partial_card_is_origin_and_direction_invariant(self):
+        """A duplicated BL closure sample does not change the downstroke."""
+        card = CardData(
+            position=[0.0, 0.0, 50.0, 100.0, 90.0, 80.0, 70.0, 0.0],
+            load=[0.0, 10.0, 10.0, 10.0, 6.0, 2.0, 0.0, 0.0],
+        )
+
+        for reverse in (False, True):
+            for shift in range(len(card.position)):
+                position = np.roll(card.position, shift)
+                load = np.roll(card.load, shift)
+                if reverse:
+                    position = position[::-1]
+                    load = load[::-1]
+                result = calculate_pump_fillage(
+                    CardData(position=position, load=load)
+                )
+
+                assert result.fillage == pytest.approx(70.0)
 
 
 class TestCalculateCorners:

--- a/tests/marine_ops/artificial_lift/dynacard/test_corners.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_corners.py
@@ -304,9 +304,18 @@ class TestCornerDetector:
     )
     def test_br_is_invariant_to_collinear_taper_sampling(self, position, load):
         """Subdividing the same transfer taper cannot move its endpoint."""
-        result = calculate_pump_fillage(CardData(position=position, load=load))
+        for reverse in (False, True):
+            for shift in range(len(position)):
+                stored_position = np.roll(position, shift)
+                stored_load = np.roll(load, shift)
+                if reverse:
+                    stored_position = stored_position[::-1]
+                    stored_load = stored_load[::-1]
+                result = calculate_pump_fillage(
+                    CardData(position=stored_position, load=stored_load)
+                )
 
-        assert result.fillage == pytest.approx(60.0)
+                assert result.fillage == pytest.approx(60.0)
 
     @pytest.mark.parametrize(
         ("position", "load", "expected_fillage"),
@@ -333,9 +342,18 @@ class TestCornerDetector:
         self, position, load, expected_fillage
     ):
         """BR starts the terminal lower branch, even when that branch slopes."""
-        result = calculate_pump_fillage(CardData(position=position, load=load))
+        for reverse in (False, True):
+            for shift in range(len(position)):
+                stored_position = np.roll(position, shift)
+                stored_load = np.roll(load, shift)
+                if reverse:
+                    stored_position = stored_position[::-1]
+                    stored_load = stored_load[::-1]
+                result = calculate_pump_fillage(
+                    CardData(position=stored_position, load=stored_load)
+                )
 
-        assert result.fillage == pytest.approx(expected_fillage)
+                assert result.fillage == pytest.approx(expected_fillage)
 
 
 class TestCalculateCorners:

--- a/tests/marine_ops/artificial_lift/test_solver_parity.py
+++ b/tests/marine_ops/artificial_lift/test_solver_parity.py
@@ -2,6 +2,10 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
+from digitalmodel.marine_ops.artificial_lift.dynacard.calculations import (
+    calculate_fluid_load,
+)
 from digitalmodel.marine_ops.artificial_lift.dynacard.comparison import (
     compare_cards,
 )
@@ -55,3 +59,40 @@ def test_solver_parity_with_vendor_downhole_cards():
     assert np.median(load_nrmse) < 0.95
     assert np.median(position_nrmse) < 0.2
     assert np.max(load_nrmse) < 2.20
+
+
+def test_corner_metrics_match_available_vendor_analyses():
+    """Corner-derived metrics remain close to the four usable vendor results."""
+    vendor_values = {
+        2: (88.37, 6127.0),
+        3: (97.52, 6557.0),
+        4: (97.92, 7682.0),
+        5: (95.40, 3965.0),
+    }
+    fillage_errors = []
+    fluid_load_errors_pct = []
+
+    for well_number, (vendor_fillage, vendor_fluid_load) in vendor_values.items():
+        context = load_from_json_file(
+            DATA_DIR / f"cleansed_well_{well_number:03d}.json"
+        )
+        results = DynacardWorkflow(context).run_full_analysis()
+        fluid_load = calculate_fluid_load(results.downhole_card).fluid_load
+        fillage_errors.append(results.pump_fillage - vendor_fillage)
+        fluid_load_errors_pct.append(
+            100.0 * (fluid_load - vendor_fluid_load) / vendor_fluid_load
+        )
+
+    # The lowest-fillage fixture is the regression that exposes the old bias.
+    # The two near-full wells retain their pre-fix accuracy instead of paying
+    # for the improvement on wells 002 and 005.
+    assert abs(fillage_errors[0]) < 3.0
+    assert abs(fillage_errors[1]) < 0.7
+    assert abs(fillage_errors[2]) < 1.0
+    assert abs(fillage_errors[3]) < 1.0
+    assert np.mean(np.abs(fillage_errors)) < 1.0
+    assert np.mean(np.abs(fluid_load_errors_pct)) < 6.0
+
+    # Honest coverage limit: these fixtures span 88.37-97.92% vendor fillage.
+    # No trustworthy severe fluid-pound card is available here, so this test
+    # does not establish accuracy near the unusable previous-project 54% card.

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -889,7 +889,7 @@ def test_workflow_registry(workflow, monkeypatch):
         # rod-string round trip.
         #
         # NOTE this is the metric's reading, not the barrel's true fill. A
-        # tagging pump is mechanically full; 70.24% is the corner detector
+        # tagging pump is mechanically full; 67.27% is the corner detector
         # being fooled by a *late load transfer*, which is exactly what it
         # does to a real tagging card too. The old 99.589501 came from the
         # pre-#1878 generator, which released the load at the turnaround.

--- a/tests/workflows/test_durable_workflows.py
+++ b/tests/workflows/test_durable_workflows.py
@@ -882,9 +882,10 @@ def test_workflow_registry(workflow, monkeypatch):
         # fluid load *through* the top turnaround (the plunger is jammed
         # against the barrel top, so the load has nowhere to go) and releasing
         # it only once the plunger backs away. At seed 711 the generator's
-        # release point is position fraction 0.715101; the corner detector
-        # reads the resulting bottom-right corner at 70.24% of gross stroke.
-        # The 1.3% shortfall is the smoothstep transition width plus the
+        # release point is position fraction 0.715101. The phase-ordered corner
+        # detector follows that drop until the load-transfer rate subsides and
+        # reads the resulting bottom-right corner at 67.27% of gross stroke.
+        # The remaining offset includes the smoothstep transition width and the
         # rod-string round trip.
         #
         # NOTE this is the metric's reading, not the barrel's true fill. A
@@ -892,15 +893,17 @@ def test_workflow_registry(workflow, monkeypatch):
         # being fooled by a *late load transfer*, which is exactly what it
         # does to a real tagging card too. The old 99.589501 came from the
         # pre-#1878 generator, which released the load at the turnaround.
-        assert results["pump_fillage"] == pytest.approx(70.239167)
+        assert results["pump_fillage"] == pytest.approx(67.268253)
         # Displacement of a 1.75 in plunger over the recovered 117.34 in gross
         # downhole stroke at 6 SPM, times that fillage:
-        #   pi/4 * 1.75^2 * 117.34115335 * 6 * 1440 / 9702 = 251.344 bbl/d gross
-        #   251.344 * 0.70239167                           = 176.542 bbl/d net
+        #   pi/4 * 1.75^2 * 117.3411533513 * 6 * 1440 / 9702
+        #       = 251.344162726472 bbl/d gross
+        #   251.344162726472 * 0.6726825272107905
+        #       = 169.074826582523 bbl/d net
         # The recovered gross stroke matches the generator's own drawn stroke
         # (117.34 in) to 7 significant figures, so the forward model and the
         # everitt_jennings inverse agree on the plunger travel.
-        assert results["inferred_production"] == pytest.approx(176.542047)
+        assert results["inferred_production"] == pytest.approx(169.074827)
         # PUMP_TAGGING_UP is in field_health.CRITICAL_CLASSIFICATIONS, and a
         # critical classification fails the screen.
         assert cfg["screening_status"] == "fail"


### PR DESCRIPTION
Closes #1897.

## Fillage — mean absolute error 3.23 pp → 0.40 pp

| well | before | after | vendor | before err | after err |
|---|---:|---:|---:|---:|---:|
| 002 | 95.481% | 88.496% | 88.370% | +7.111 pp | **+0.126 pp** |
| 003 | 98.127% | 98.127% | 97.520% | +0.607 pp | +0.607 pp |
| 004 | 96.876% | 98.770% | 97.920% | −1.044 pp | +0.850 pp |
| 005 | 99.575% | 95.389% | 95.400% | +4.175 pp | **−0.011 pp** |

The two worst wells — the lowest-fillage ones, where the defect predicted the largest error — are now within 0.13 pp. Well 004 moved by a similar magnitude in the other direction.

## Fluid load — the bigger repair

Fluid load is corner-driven, and it was badly wrong in a way nobody had measured:

| well | before | after | vendor | before err | after err |
|---|---:|---:|---:|---:|---:|
| 002 | 3916.05 | 6236.86 | 6127 | −36.09% | **+1.79%** |
| 003 | **−124.66** | 6701.78 | 6557 | **−101.90%** | **+2.21%** |
| 004 | 6625.25 | 7715.25 | 7682 | −13.76% | **+0.43%** |
| 005 | 1694.87 | 4023.37 | 3965 | −57.25% | **+1.47%** |

Well 003 was returning a **negative fluid load** — physically impossible — against a vendor 6557 lb.

## Why the obvious fix fails

I attempted this directly first and **regressed** it: mean error 3.25 pp → 27.44 pp, well 003 to 2.42% against a vendor 97.52%. Reverted.

The cause is that the assumption lives in **two** places. `_order_corners` sorts the four corners by position, takes the two highest-position ones as "right", and assigns BR to the lower-load of those — so **BR is always among the two highest-position corners, by construction**. Fixing the detector alone causes `_order_corners` to reshuffle all four by extrema and corrupt the assignment.

**Corners are phases of a cycle, not extrema of a scatter plot.** They are now ordered by traversal along the loop, using the direction canonicalisation from `comparison.py` (#1908) rather than a second implementation — which is why that PR was a hard prerequisite rather than a convenience.

## Honest limitations, preserved rather than papered over

- **The fixtures span 88.37–97.92% vendor fillage.** There is no severe fluid-pound card among them; the 54% one is previous-project data and unusable (its vendor analysis failed, its minimum load is positive). These tests show the bias shrinking across that band — they **cannot** show a 54% card reads 54%. Stated in the test comments.
- **The synthetic `PUMP_TAGGING_UP` card moved 70.24% → 67.27%**, i.e. *farther* from its mechanically correct ~100%. Documented explicitly as a remaining limitation, **not** claimed as repair. Production re-derived accordingly, with arithmetic in the test:

```
gross = π/4 × 1.75² × 117.3411533513 × 6 × 1440 / 9702 = 251.344162726472 bbl/d
net   = 251.344162726472 × 0.6726825272107905          = 169.074826582523 bbl/d
```

- Adversarial review found BR remains ambiguous for densely resampled tapers and curved lower branches. A refinement attempted for it introduced an indefensible discontinuity and was reverted rather than shipped.

## Verification

- **1,456 passed, 3 skipped**
- artificial-lift only: **929 passed**

Authored by Codex, briefed with my own failed attempt and its diagnosis.