### PR TITLE
feat(capabilities): sweep tension and bending moment as axes (#1915)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,7 @@ scripts/capabilities/_*_manifest.json
 # Tidy publishing intermediates (scripts/hf/build_capability_datasets.py) — derived from
 # the committed sidecars, regenerated on demand, published to HF rather than committed.
 docs/api/_datasets/
+
+# 3D tension-moment study: 191 MB of JSON that compresses to ~1 MB as parquet.
+# Regenerated on demand and published to Hugging Face; never committed. (#1915)
+docs/api/structural/wall-thickness-3d.json

--- a/.planning/plan-approved/1915.md
+++ b/.planning/plan-approved/1915.md
@@ -1,0 +1,24 @@
+# #1915 wall-thickness 3D (tension × moment axes) — plan recorded
+
+**Authorization:** operator direction in-session, 2026-07-29 — "we should be able to add
+tension and bending moment as axes and come up with 3D plots using 3js or similar", then
+"open gh issues and tackle work as needed" and "delegate to codex as appropriately".
+Not an owner-reviewed written plan; recording what the authorization actually was.
+
+Plan: https://github.com/vamseeachanta/digitalmodel/issues/1915
+
+Scope, this pass: DATA LAYER ONLY. New additive module
+scripts/capabilities/build_wall_thickness_3d.py emitting
+docs/api/structural/wall-thickness-3d.json. No HTML, no change to the existing
+build_wall_thickness_explorer.py, no other docs/ file touched.
+
+Grid: 41 (t) × 31 (T) × 31 (M) × ALL 9 design codes = 354,609 rows. Ranges derived from
+capacity at the 18 mm mid-range wall, not chosen for appearance:
+  A   = 0.017298 m²,  T_y = 7.7496 MN,  T_max = 0.6·T_y = 4.6498 MN
+  M_y = 592.65 kN·m,  M_max = 0.6·M_y = 355.59 kN·m
+Hand-checked against independent calculation before approving.
+
+Codex implements; it cannot run the generator (needs `uv run`, unavailable in its sandbox).
+Verification is Claude running it and checking that the combined check actually varies
+across the grid and that the governing check changes somewhere in the domain — if either
+is flat, the ranges are wrong and the study is still not exercising its own axes.

--- a/scripts/capabilities/build_wall_thickness_3d.py
+++ b/scripts/capabilities/build_wall_thickness_3d.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+"""Build the wall-thickness tension-moment study as tidy JSON rows.
+
+The effective-tension and bending-moment limits are derived at the 18 mm
+midpoint of the 8--28 mm wall sweep.  For pipe area ``A`` and first-yield
+moment ``M_y``:
+
+    T_y = SMYS * A
+    M_y = (pi / 4) * SMYS * (D - t)^2 * t
+
+Both load axes end at 60% of those reference capacities (rounded to the
+nearest N and N*m): 4,649,766 N and 355,591 N*m.  This spans elastic loading
+through near-yield interaction without selecting arbitrary round limits.
+Calculations use SI units; wall thickness is emitted in millimetres.
+
+Output:
+    docs/api/structural/wall-thickness-3d.json
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from digitalmodel.structural.analysis.wall_thickness import (
+    DesignCode,
+    DesignFactors,
+    DesignLoads,
+    PipeGeometry,
+    PipeMaterial,
+    SafetyClass,
+    WallThicknessAnalyzer,
+)
+from digitalmodel.structural.analysis.wall_thickness_codes import CODE_REGISTRY
+
+
+_OD_M = 0.3239
+_GRADE = "X65"
+_SMYS_PA = 448.0e6
+_SMTS_PA = 530.9e6
+_INTERNAL_PRESSURE_PA = 20.0e6
+_EXTERNAL_PRESSURE_PA = 10.0e6
+_SAFETY_CLASS = SafetyClass.MEDIUM
+_FABRICATION_TOLERANCE = 0.125
+
+_REFERENCE_WALL_M = 0.018
+_REFERENCE_AREA_M2 = math.pi / 4 * (
+    _OD_M**2 - (_OD_M - 2 * _REFERENCE_WALL_M) ** 2
+)
+_YIELD_TENSION_N = _SMYS_PA * _REFERENCE_AREA_M2
+_YIELD_MOMENT_NM = (
+    math.pi
+    / 4
+    * _SMYS_PA
+    * (_OD_M - _REFERENCE_WALL_M) ** 2
+    * _REFERENCE_WALL_M
+)
+_TENSION_MAX_N = round(0.6 * _YIELD_TENSION_N)
+_MOMENT_MAX_NM = round(0.6 * _YIELD_MOMENT_NM)
+
+_WALL_THICKNESS_MM = tuple(round(8.0 + 0.5 * index, 1) for index in range(41))
+_EFFECTIVE_TENSION_N = tuple(
+    _TENSION_MAX_N * index / 30 for index in range(31)
+)
+_BENDING_MOMENT_NM = tuple(
+    _MOMENT_MAX_NM * index / 30 for index in range(31)
+)
+_DESIGN_CODES = tuple(DesignCode)
+_CHECK_NAMES = tuple(
+    sorted(
+        {
+            check_name
+            for strategy in CODE_REGISTRY.values()
+            for check_name in strategy.check_names
+        }
+    )
+)
+
+
+def _axis_metadata(values: Sequence[float], unit: str) -> dict:
+    if not values:
+        raise ValueError(f"{unit} grid axis must not be empty")
+    return {
+        "minimum": min(values),
+        "maximum": max(values),
+        "count": len(values),
+        "values": list(values),
+        "unit": unit,
+    }
+
+
+def build_metadata(
+    wall_thickness_mm: Sequence[float] = _WALL_THICKNESS_MM,
+    effective_tension_n: Sequence[float] = _EFFECTIVE_TENSION_N,
+    bending_moment_nm: Sequence[float] = _BENDING_MOMENT_NM,
+    codes: Sequence[DesignCode] = _DESIGN_CODES,
+) -> dict:
+    """Describe the reference case, capacity basis, units, and emitted grid."""
+    grid = {
+        "wall_thickness_mm": _axis_metadata(wall_thickness_mm, "mm"),
+        "effective_tension_n": _axis_metadata(effective_tension_n, "N"),
+        "bending_moment_nm": _axis_metadata(bending_moment_nm, "N*m"),
+        "design_codes": [code.value for code in codes],
+        "code_count": len(codes),
+        "point_count_per_code": (
+            len(wall_thickness_mm)
+            * len(effective_tension_n)
+            * len(bending_moment_nm)
+        ),
+    }
+    grid["row_count"] = grid["point_count_per_code"] * grid["code_count"]
+    grid["iteration_order"] = [
+        "code",
+        "wall_thickness_mm",
+        "effective_tension_n",
+        "bending_moment_nm",
+    ]
+    return {
+        "schema_version": 1,
+        "geometry": {
+            "outer_diameter_m": _OD_M,
+            "corrosion_allowance_m": 0.0,
+            "fabrication_tolerance_fraction": _FABRICATION_TOLERANCE,
+        },
+        "material": {
+            "grade": _GRADE,
+            "smys_pa": _SMYS_PA,
+            "smts_pa": _SMTS_PA,
+            "youngs_modulus_pa": 207e9,
+            "poissons_ratio": 0.3,
+        },
+        "pressures": {
+            "internal_pa": _INTERNAL_PRESSURE_PA,
+            "external_pa": _EXTERNAL_PRESSURE_PA,
+            "net_internal_pa": _INTERNAL_PRESSURE_PA - _EXTERNAL_PRESSURE_PA,
+        },
+        "safety_class": _SAFETY_CLASS.value,
+        "load_range_basis": {
+            "reference_wall_thickness_mm": _REFERENCE_WALL_M * 1000.0,
+            "reference_area_m2": _REFERENCE_AREA_M2,
+            "tension": {
+                "formula": "T_y = SMYS * A",
+                "yield_capacity_n": _YIELD_TENSION_N,
+                "sweep_fraction_of_yield": 0.6,
+                "maximum_n": _TENSION_MAX_N,
+            },
+            "bending_moment": {
+                "formula": "M_y = (pi/4) * SMYS * (D - t)^2 * t",
+                "yield_capacity_nm": _YIELD_MOMENT_NM,
+                "sweep_fraction_of_yield": 0.6,
+                "maximum_nm": _MOMENT_MAX_NM,
+            },
+            "maximum_rounding": "nearest N and N*m",
+        },
+        "grid": grid,
+        "units": {
+            "internal_calculations": "SI: m, Pa, N, N*m",
+            "outer_diameter": "m",
+            "wall_thickness": "mm",
+            "material_strength": "Pa",
+            "pressure": "Pa",
+            "effective_tension": "N",
+            "bending_moment": "N*m",
+            "utilisation": "dimensionless",
+        },
+        "check_utilisation_columns": [
+            f"{name}_utilisation" for name in _CHECK_NAMES
+        ],
+    }
+
+
+def _analyze_point(
+    code: DesignCode,
+    wall_thickness_mm: float,
+    effective_tension_n: float,
+    bending_moment_nm: float,
+) -> dict:
+    geometry = PipeGeometry(
+        outer_diameter=_OD_M,
+        wall_thickness=wall_thickness_mm / 1000.0,
+        corrosion_allowance=0.0,
+        fabrication_tolerance=_FABRICATION_TOLERANCE,
+    )
+    material = PipeMaterial(
+        grade=_GRADE,
+        smys=_SMYS_PA,
+        smts=_SMTS_PA,
+        youngs_modulus=207e9,
+        poissons_ratio=0.3,
+    )
+    loads = DesignLoads(
+        internal_pressure=_INTERNAL_PRESSURE_PA,
+        external_pressure=_EXTERNAL_PRESSURE_PA,
+        bending_moment=bending_moment_nm,
+        effective_tension=effective_tension_n,
+    )
+    result = WallThicknessAnalyzer(
+        geometry,
+        material,
+        loads,
+        DesignFactors(safety_class=_SAFETY_CLASS),
+        code=code,
+    ).perform_analysis()
+    row = {
+        "code": code.value,
+        "wall_thickness_mm": wall_thickness_mm,
+        "effective_tension_n": effective_tension_n,
+        "bending_moment_nm": bending_moment_nm,
+        "utilisation": round(float(result.max_utilisation), 6),
+        "governing_check": result.governing_check,
+        "is_safe": bool(result.is_safe),
+    }
+    row.update({f"{name}_utilisation": None for name in _CHECK_NAMES})
+    row.update(
+        {
+            f"{name}_utilisation": round(float(utilisation), 6)
+            for name, utilisation in result.checks.items()
+        }
+    )
+    return row
+
+
+def build_study(
+    wall_thickness_mm: Sequence[float] = _WALL_THICKNESS_MM,
+    effective_tension_n: Sequence[float] = _EFFECTIVE_TENSION_N,
+    bending_moment_nm: Sequence[float] = _BENDING_MOMENT_NM,
+    codes: Sequence[DesignCode] = _DESIGN_CODES,
+) -> dict:
+    """Run the requested grid and return metadata plus tidy result rows."""
+    rows = [
+        _analyze_point(code, wall_mm, tension_n, moment_nm)
+        for code in codes
+        for wall_mm in wall_thickness_mm
+        for tension_n in effective_tension_n
+        for moment_nm in bending_moment_nm
+    ]
+    return {
+        "meta": build_metadata(
+            wall_thickness_mm,
+            effective_tension_n,
+            bending_moment_nm,
+            codes,
+        ),
+        "rows": rows,
+    }
+
+
+def main() -> None:
+    import json
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    out = repo / "docs" / "api" / "structural" / "wall-thickness-3d.json"
+    study = build_study()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(study, indent=1) + "\n", encoding="utf-8")
+    meta = study["meta"]
+    print(f"wrote {out} ({out.stat().st_size / 1048576:.1f} MB)")
+    print(
+        f"  rows: {meta['grid']['row_count']:,} "
+        f"over {meta['grid']['code_count']} codes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf/build_capability_datasets.py
+++ b/scripts/hf/build_capability_datasets.py
@@ -82,6 +82,14 @@ def cathodic_protection_rows() -> list[dict]:
     return out
 
 
+def wall_thickness_3d_rows() -> list[dict]:
+    """The (t, T, M) study from build_wall_thickness_3d.py — already tidy, so this only
+    reads it. 354,609 rows: 191 MB as JSON, ~1 MB as parquet, which is why the JSON is
+    gitignored and only the published dataset is durable (#1915)."""
+    doc = _load("structural/wall-thickness-3d.json")
+    return doc["rows"]
+
+
 def galvanic_rows() -> list[dict]:
     """environments[env] holds 16x16 matrices indexed by the `metals` list. Unpivot to one
     row per (environment, metal pair) — 16 x 16 x 3 = 768 rows."""
@@ -120,6 +128,7 @@ def galvanic_rows() -> list[dict]:
 DATASETS = {
     "digitalmodel-integrity": {
         "wall_thickness": wall_thickness_rows,
+        "wall_thickness_tension_moment": wall_thickness_3d_rows,
     },
     "digitalmodel-corrosion": {
         "cathodic_protection": cathodic_protection_rows,

--- a/tests/capabilities/test_wall_thickness_3d.py
+++ b/tests/capabilities/test_wall_thickness_3d.py
@@ -1,0 +1,73 @@
+# ABOUTME: Tests the issue #1915 wall-thickness, tension, and moment data sweep.
+# ABOUTME: Verifies tidy rows, capacity-derived axes, and JSON-only output.
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+from digitalmodel.structural.analysis.wall_thickness import DesignCode
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "capabilities" / "build_wall_thickness_3d.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("build_wall_thickness_3d", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_single_grid_point_emits_one_flat_row_per_design_code():
+    generator = _load_module()
+
+    study = generator.build_study(
+        wall_thickness_mm=(18.0,),
+        effective_tension_n=(0.0,),
+        bending_moment_nm=(0.0,),
+    )
+
+    assert len(study["rows"]) == len(DesignCode) == 9
+    assert {row["code"] for row in study["rows"]} == {
+        code.value for code in DesignCode
+    }
+    for row in study["rows"]:
+        assert row["wall_thickness_mm"] == 18.0
+        assert row["effective_tension_n"] == 0.0
+        assert row["bending_moment_nm"] == 0.0
+        assert row["governing_check"]
+        assert isinstance(row["utilisation"], float)
+        assert all(not isinstance(value, (dict, list)) for value in row.values())
+
+
+def test_default_metadata_records_capacity_derived_ranges_and_grid():
+    generator = _load_module()
+
+    meta = generator.build_metadata()
+    basis = meta["load_range_basis"]
+
+    expected_area_m2 = math.pi / 4 * (0.3239**2 - (0.3239 - 2 * 0.018) ** 2)
+    expected_yield_tension_n = 448.0e6 * expected_area_m2
+    expected_yield_moment_nm = (
+        math.pi / 4 * 448.0e6 * (0.3239 - 0.018) ** 2 * 0.018
+    )
+    assert basis["reference_wall_thickness_mm"] == 18.0
+    assert basis["reference_area_m2"] == expected_area_m2
+    assert basis["tension"]["yield_capacity_n"] == expected_yield_tension_n
+    assert basis["tension"]["maximum_n"] == 4_649_766
+    assert basis["bending_moment"]["yield_capacity_nm"] == expected_yield_moment_nm
+    assert basis["bending_moment"]["maximum_nm"] == 355_591
+
+    grid = meta["grid"]
+    assert grid["wall_thickness_mm"]["values"] == [
+        8.0 + 0.5 * index for index in range(41)
+    ]
+    assert grid["effective_tension_n"]["values"][0] == 0.0
+    assert grid["effective_tension_n"]["values"][-1] == 4_649_766
+    assert grid["bending_moment_nm"]["values"][0] == 0.0
+    assert grid["bending_moment_nm"]["values"][-1] == 355_591
+    assert grid["row_count"] == 41 * 31 * 31 * 9 == 354_609
+    assert meta["units"]["wall_thickness"] == "mm"


### PR DESCRIPTION
Data layer for #1915. The 3D renderer is the next pass.

## The problem it fixes

`build_wall_thickness_explorer.py` passes `bending_moment=0.0, effective_tension=0.0`, so the API-STD-2RD combined check was **0.0 on all 41 rows**. Combined tension+bending frequently *governs* wall-thickness selection, so the study was silent about the thing an engineer opens it for.

## What it does

Sweeps (t, T, M) across all **nine** design codes — 41 × 31 × 31 × 9 = **354,609 rows in 2.5 s**.

Load ranges derived from capacity at the 18 mm mid-range wall, not chosen for appearance:

```
A   = 0.017298 m²    T_y = 7.7496 MN    T_max = 0.6·T_y = 4.6498 MN
M_y = 592.65 kN·m                       M_max = 0.6·M_y = 355.59 kN·m
```

I hand-checked that arithmetic independently before accepting it.

## Acceptance — measured, not asserted

| criterion | before | after |
|---|---|---|
| combined utilisation | one value, `0.0` | **0.0000 – 3.8827**, 38,034 distinct across 39,401 points |
| governing check | fixed | **six** limit states vary across the domain |

**The result worth reading: `combined` governs at 30,855 grid points** — roughly 9% of the design space where combined loading is the controlling limit state, and where the pressure-only study showed nothing at all. The axes did not merely make a number non-zero; they exposed a governing regime that was structurally invisible.

## Payload

191 MB as JSON, **1.0 MB as parquet** (191×). So the JSON is gitignored and only the published dataset is durable — same reasoning as the `_datasets` intermediates. Wired into `build_capability_datasets.py` as a second table on `digitalmodel-integrity`.

## Method note

Produced with codex under the plan gate, which it correctly refused to bypass twice. It derived the load ranges and caught that this repo has **nine** design codes, not the six I briefed. It delivered `build_study()` plus tests but no `main()` and an empty `meta`, so the script ran and wrote nothing — I completed those directly rather than spend a fifth round trip. Its 2 tests pass.

## Not in this pass

The renderer. #1915 requires three.js **with a 2D fallback and a usable no-WebGL path** — a 3D-only capability page is unusable on a phone, and this one is destined for a public capability surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)