### PR TITLE
fix(visualization): handle constant input in group comparison statistic

### DIFF
--- a/src/digitalmodel/visualization/orcaflex_dashboard/backend/app/services/comparative_analysis.py
+++ b/src/digitalmodel/visualization/orcaflex_dashboard/backend/app/services/comparative_analysis.py
@@ -434,22 +434,28 @@ class ComparativeAnalysisService:
     ) -> GroupComparisonResult:
         """Perform multi-group comparison"""
         groups = list(data.keys())
-        values = list(data.values())
-        
+        values = [np.asarray(group_data) for group_data in data.values()]
+
         # Choose appropriate test
         if test_type == "auto":
             # Simple heuristic: use Kruskal-Wallis for robustness
             use_parametric = False
         else:
             use_parametric = test_type == "parametric"
-        
-        if use_parametric:
+
+        # Constant input makes the usual test statistics undefined; resolve
+        # those cases analytically instead of letting scipy warn or raise.
+        degenerate = self._constant_input_statistic(values, use_parametric, metric)
+
+        if degenerate is not None:
+            stat, p_value = degenerate
+        elif use_parametric:
             # One-way ANOVA
             stat, p_value = stats.f_oneway(*values)
         else:
             # Kruskal-Wallis test
             stat, p_value = kruskal(*values)
-        
+
         is_significant = p_value < (1 - confidence_level)
         
         # Calculate effect size (eta-squared approximation)
@@ -474,7 +480,71 @@ class ComparativeAnalysisService:
             effect_size=effect_size,
             confidence_level=confidence_level
         )
-    
+
+    def _constant_input_statistic(
+        self,
+        values: List[np.ndarray],
+        use_parametric: bool,
+        metric: str
+    ) -> Optional[Tuple[float, float]]:
+        """
+        Resolve group-comparison statistics for constant (zero-variance) input.
+
+        The one-way ANOVA F ratio is MS_between / MS_within. When every group is
+        constant the within-group mean square is exactly zero, so the ratio is
+        either 0/0 or x/0 and ``scipy.stats.f_oneway`` cannot compute it: it
+        emits a ``ConstantInputWarning`` and substitutes nan/inf after the fact.
+        ``scipy.stats.kruskal`` is worse - it raises
+        ``ValueError("All numbers are identical in kruskal")`` when the pooled
+        sample has no variance, which is the default ("auto") code path here.
+
+        Rather than relying on those side effects, the degenerate cases are
+        decided here:
+
+        * Pooled variance is zero (every observation in every group is the same
+          value): there is no between-group and no within-group variation, the
+          statistic is genuinely undefined, and there is zero evidence of any
+          difference. Reported as ``(nan, nan)`` -> not significant.
+        * Every group is constant but the constants differ, parametric test:
+          within-group variance is zero while between-group variance is not, so
+          the F ratio diverges. Reported as ``(inf, 0.0)``, which is the same
+          convention ``f_oneway`` itself documents for this case.
+        * Every group is constant but the constants differ, non-parametric test:
+          Kruskal-Wallis is rank based and handles this perfectly well, so no
+          substitution is made.
+
+        Returns:
+            ``(test_statistic, p_value)`` for a degenerate case, or None when
+            the data is not degenerate and the normal test should be run.
+        """
+        if not values or any(group_data.size == 0 for group_data in values):
+            return None
+
+        all_groups_constant = all(
+            bool(np.all(group_data == group_data.flat[0])) for group_data in values
+        )
+        if not all_groups_constant:
+            return None
+
+        pooled = np.concatenate(values)
+        if bool(np.all(pooled == pooled.flat[0])):
+            self.logger.warning(
+                f"All groups for metric '{metric}' contain the identical constant "
+                f"value {pooled.flat[0]}; the group comparison statistic is "
+                "undefined (no between-group or within-group variance)"
+            )
+            return float('nan'), float('nan')
+
+        if use_parametric:
+            self.logger.warning(
+                f"Every group for metric '{metric}' is constant with differing "
+                "values; within-group variance is zero so the F statistic is "
+                "infinite"
+            )
+            return float('inf'), 0.0
+
+        return None
+
     def _calculate_descriptive_statistics(
         self,
         data: Dict[str, np.ndarray]

--- a/tests/visualization/test_comparative_analysis.py
+++ b/tests/visualization/test_comparative_analysis.py
@@ -697,6 +697,45 @@ class TestPerformGroupComparison:
         result = service._perform_group_comparison(data, "m", 0.95, "parametric")
         assert result.effect_size == 0.0
 
+    def test_zero_total_variance_statistic_undefined(self, service):
+        """All groups identical -> statistic undefined, nothing significant."""
+        data = {
+            "a": np.array([5.0, 5.0, 5.0]),
+            "b": np.array([5.0, 5.0, 5.0]),
+            "c": np.array([5.0, 5.0, 5.0]),
+        }
+        result = service._perform_group_comparison(data, "m", 0.95, "parametric")
+        assert np.isnan(result.test_statistic)
+        assert np.isnan(result.p_value)
+        assert result.is_significant is False
+        assert result.post_hoc_results == []
+
+    def test_zero_total_variance_non_parametric(self, service):
+        """Kruskal-Wallis raises on identical input; must be handled too."""
+        data = {
+            "a": np.array([5.0, 5.0, 5.0]),
+            "b": np.array([5.0, 5.0, 5.0]),
+        }
+        result = service._perform_group_comparison(data, "m", 0.95, "auto")
+        assert np.isnan(result.p_value)
+        assert result.effect_size == 0.0
+
+    def test_constant_groups_with_different_means(self, service):
+        """Zero within-group variance but differing means -> F is infinite."""
+        import warnings
+        data = {
+            "a": np.array([5.0, 5.0, 5.0]),
+            "b": np.array([7.0, 7.0, 7.0]),
+        }
+        with warnings.catch_warnings():
+            # post-hoc t-tests still warn about precision loss on constant data
+            warnings.simplefilter("ignore", RuntimeWarning)
+            result = service._perform_group_comparison(data, "m", 0.95, "parametric")
+        assert np.isinf(result.test_statistic)
+        assert result.p_value == 0.0
+        assert result.is_significant
+        assert result.effect_size == 1.0
+
 
 # ===========================================================================
 # compare_loading_conditions (integration)


### PR DESCRIPTION
Stacked on #1916 (`fix/1632-revive-dashboard-tests`) — that branch is what re-enables `tests/visualization/test_comparative_analysis.py`, so this PR targets it, not `main`. Merge #1916 first.

## The bug

`tests/visualization/test_comparative_analysis.py::TestPerformGroupComparison::test_zero_total_variance` fails:

```
scipy.stats._warnings_errors.ConstantInputWarning: Each of the input arrays is constant;
the F statistic is not defined or infinite
```

`ComparativeAnalysisService._perform_group_comparison()` handed its groups straight to `scipy.stats.f_oneway` / `scipy.stats.kruskal`. Neither can compute a statistic when every group is constant:

| input | `f_oneway` | `kruskal` |
|---|---|---|
| all groups identical constant (`[5,5,5]`×3) | `ConstantInputWarning`, then nan/nan | **raises** `ValueError("All numbers are identical in kruskal")` |
| each group constant, different values | `ConstantInputWarning`, then inf/0.0 | fine (rank based) |

Under this repo's `filterwarnings = error` the warning is an exception, which is what the test caught. The Kruskal path is worse than a warning: `test_type="auto"` (the default for `compare_loading_conditions`) selects Kruskal-Wallis, so identical input was a hard `ValueError` in production, not just noisy output.

The effect-size line already had a `total_var != 0` guard — the statistic itself never did.

## The fix

New `_constant_input_statistic()` detects the degenerate cases before any scipy call and resolves them analytically:

- **Pooled variance zero** (every observation identical): the F ratio is 0/0 — genuinely undefined, and there is zero evidence of any difference. Returns `(nan, nan)` → `is_significant` False, `effect_size` 0.0, no post-hoc. Nothing fabricated: no statistic is quoted because none exists.
- **Every group constant, values differ, parametric**: within-group variance is zero so F diverges. Returns `(inf, 0.0)` — the same convention `f_oneway` itself documents for this case, just without the warning.
- **Every group constant, values differ, non-parametric**: unchanged; Kruskal-Wallis handles it correctly.
- Non-degenerate input and empty groups: unchanged, straight through to scipy.

Each degenerate case is logged. **No warning is suppressed** — `warnings.filterwarnings` would have hidden the condition instead of answering it, and would have left the `kruskal` `ValueError` crash in place.

## Tests

```
uv run --no-sources --with 'assetutilities @ git+https://github.com/vamseeachanta/assetutilities.git@main' \
  --with-editable '.[test]' --extra orcaflex-dashboard \
  python -m pytest tests/visualization/ -p no:asyncio -p no:randomly -p no:sugar --no-header -q
```

- before: `1 failed, 96 passed` (test_comparative_analysis.py)
- after: `100 passed` (test_comparative_analysis.py), `822 passed, 3 skipped` (whole `tests/visualization/`)

Three regression tests added, one per branch: statistic/p-value undefined, the non-parametric (`auto`) path that used to raise, and the perfectly-separated constant case.

## Same pattern elsewhere (found, not fixed here)

The unguarded-constant-input pattern recurs in the same `services/` directory. None of it is covered by a currently failing test, so it is left alone rather than changed blind:

- `sensitivity_analysis.py:220` — `stats.linregress(param_values, response_values)`; **raises** `ValueError("Cannot calculate a linear regression if all x values are identical")` for a parameter swept at a single value.
- `sensitivity_analysis.py:424`, `:572` — `stats.pearsonr(...)` with no constant check (only a length check at :569). `ConstantInputWarning` → nan correlation.
- `statistical_analysis.py:109/111` — `pearsonr` / `spearmanr` over a correlation matrix; a constant column warns and yields nan.
- `comparative_analysis.py:230` — `stats.pearsonr(env_values, response_array)`: the **x** side is guarded (`np.std(env_values) == 0` → skip) but a constant **response** array is not.
- `comparative_analysis.py:324`, `:390` (`ttest_ind`), `:566-567` (`skew`/`kurtosis`) — emit `RuntimeWarning` (precision loss) on constant data. The existing tests deliberately suppress `RuntimeWarning` at the call site for these, so the current expectation is that they tolerate it.

The `linregress` one is a real crash and is the strongest follow-up candidate.