### PR TITLE
fix(packaging): declare h5netcdf and PyTables — both addressed by string (#1924)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ dependencies = [
     "urllib3>=2.0.0,<3.0.0",
     "validators==0.22.0",
     "webcolors>=1.13,<2.0",
+    # NOT imported anywhere -- xarray resolves the engine by NAME:
+    # xr.open_dataset(..., engine="h5netcdf") in
+    # data_systems/data_procurement/common/stream_handler.py:112  (#1924)
+    "h5netcdf>=1.3.0,<2.0.0",
+    # NOT imported anywhere -- pandas needs PyTables for HDF5:
+    # pd.read_hdf(...) in
+    # signal_processing/signal_analysis/orcaflex/reader.py:248  (#1924)
+    "tables>=3.9.0,<4.0.0",
     # NOT imported anywhere -- pandas resolves it by NAME:
     # pd.ExcelWriter(..., engine="xlsxwriter"). See DYNAMIC_RUNTIME in
     # tests/contracts/test_runtime_dependencies.py (#1632).

--- a/tests/contracts/test_runtime_dependencies.py
+++ b/tests/contracts/test_runtime_dependencies.py
@@ -75,7 +75,26 @@ DYNAMIC_RUNTIME: dict[str, str] = {
     #   asset_integrity/common/data.py:454
     #   infrastructure/utils/data.py (same helper)
     "xlsxwriter": "pandas ExcelWriter engine, addressed by string not import",
+    # xr.open_dataset(..., engine="h5netcdf") at
+    #   data_systems/data_procurement/common/stream_handler.py:112
+    "h5netcdf": "xarray open_dataset engine, selected by string not import",
+    # pd.read_hdf(...) at
+    #   signal_processing/signal_analysis/orcaflex/reader.py:248
+    # pandas requires PyTables for HDF5; h5py is NOT a substitute.
+    "tables": "pandas HDF5 backend (PyTables), required implicitly by read_hdf",
 }
+
+#: NOTE (#1924): this dict is hand-maintained, and that is a known weakness.
+#: It held exactly ONE entry -- xlsxwriter -- until an independent review found
+#: the two above, both of which broke clean installs. A list of invisible
+#: dependencies curated from memory is a sample, not a set.
+#:
+#: The durable fix is a scan that DERIVES candidates from the known
+#: string-addressing patterns rather than trusting an author to recall them:
+#: engine= / backend= / driver= / dialect= / format= keyword arguments, the
+#: pandas read_*/to_* family (hdf, parquet, excel, sql), matplotlib backends,
+#: and importlib.metadata entry-point lookups. Until that exists, treat this
+#: dict as incomplete rather than authoritative.
 
 #: FROZEN 2026-07-29 (#1632). Module-level imports in shipped code that resolve to
 #: nothing installable. Two kinds, both pre-existing and both out of scope for the


### PR DESCRIPTION
Closes #1924. Two more dependencies that break clean installs today.

## The two breaks

| site | call | needs | was declared |
|---|---|---|---|
| `data_systems/data_procurement/common/stream_handler.py:112` | `xr.open_dataset(buffer, engine='h5netcdf')` | `h5netcdf` | **no** |
| `signal_processing/signal_analysis/orcaflex/reader.py:248` | `pd.read_hdf(filepath)` | `tables` (PyTables) | **no** |

Both selected by **name**, not imported — so no AST scan can see them, both contract tests passed, and every shard stayed green while the package was broken for users.

**`h5py` being declared makes this worse, not better.** It looks like HDF5 is covered. xarray's `h5netcdf` engine is a separate distribution, and pandas requires PyTables for HDF5; `h5py` substitutes for neither.

Runtime deps **55 → 57**. Both added to `DYNAMIC_RUNTIME` with call sites cited, so `test_dynamic_runtime_entries_are_declared_and_still_used` holds them to the two-way check — declared **and** still referenced by name.

## What this PR does not claim

I did not find these. An independent adversarial review of #1922 did, and that is the point worth recording.

`DYNAMIC_RUNTIME` held exactly **one** entry — `xlsxwriter` — added when that identical failure mode broke Excel export (#1906). I created the category, then treated it as complete when it was a sample of size one: I had enumerated the single instance I happened to trip over. Asked the question in the abstract, a reviewer found two more in one pass.

So this fixes two known breaks. **It does not close the class.** The dict now carries that admission in-line:

```python
#: NOTE (#1924): this dict is hand-maintained, and that is a known weakness.
#: It held exactly ONE entry -- xlsxwriter -- until an independent review found
#: the two above, both of which broke clean installs. A list of invisible
#: dependencies curated from memory is a sample, not a set.
```

with the durable fix named: **derive** candidates from the string-addressing patterns — `engine=` / `backend=` / `driver=` / `dialect=` / `format=`, the pandas `read_*`/`to_*` family, matplotlib backends, `importlib.metadata` entry-point lookups — rather than trusting recall. Until that exists the dict should be read as incomplete rather than authoritative.

Given this session's recurring theme, a guard that implies completeness it does not have would be the same failure all over again.

## Verification — read this before merging

**Not verified locally.** The box hit 100% disk (the `uv` cache alone is 33G) and the cache was locked by concurrent jobs, so it could not be pruned without risking their in-flight installs. `tests/contracts/` could not run here.

**CI is the verification for this change.** The contracts shard exercises all six contract tests including the two-way `DYNAMIC_RUNTIME` check, and the full matrix will confirm the two new dependencies resolve. I am flagging this rather than implying a local run I did not complete — please do not merge on a red or partial matrix.

Related: #1632 (the un-merge), #1906 (the `xlsxwriter` regression, same class), #1922 (the review that found these)