### PR TITLE
fix(capabilities): replace 8 permanently blank report panels with honest links (#1892)

### DIFF
--- a/.planning/plan-approved/1892.md
+++ b/.planning/plan-approved/1892.md
@@ -1,0 +1,8 @@
+# #1892 blank iframe panels — plan recorded
+
+Authorization: operator direction in-session 2026-07-29 ("continue work using codex
+subagents", with #1892 named as a queued item). Not an owner-reviewed written plan.
+
+Scope: the 8 capability pages whose "Comprehensive report (live output)" iframe points at a
+github.com tree URL, which GitHub serves with `x-frame-options: deny` so the panel is always
+blank. Replace the dead iframe with an honest link to the same location.

--- a/docs/api/capabilities/api/container-utilization.html
+++ b/docs/api/capabilities/api/container-utilization.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="container-utilization.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/structural/offshore_container_utilization">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/structural/offshore_container_utilization" loading="lazy" title="Offshore container utilization — DNV 2.7-1 report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/structural/offshore_container_utilization">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/diffraction-deck-prep.html
+++ b/docs/api/capabilities/api/diffraction-deck-prep.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -172,8 +169,9 @@
       <a class="btn" href="diffraction-deck-prep.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Deterministic registry workflow (docs/registry/workflows.yaml). POST to the Deckhand workflow-API, or run the invocation locally; the embedded page is a representative live output of the workflow.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/aqwa-diffraction-deck-prep">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/aqwa-diffraction-deck-prep" loading="lazy" title="Diffraction deck generation — spec to solver input report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/aqwa-diffraction-deck-prep">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/dynacard-field-health.html
+++ b/docs/api/capabilities/api/dynacard-field-health.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -172,8 +169,9 @@
       <a class="btn" href="dynacard-field-health.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Deterministic registry workflow (docs/registry/workflows.yaml). POST to the Deckhand workflow-API, or run the invocation locally; the embedded page is a representative live output of the workflow.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/artificial-lift-field-health">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/artificial-lift-field-health" loading="lazy" title="Field-wide dynacard health rollup report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/artificial-lift-field-health">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/mooring-resilience.html
+++ b/docs/api/capabilities/api/mooring-resilience.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="mooring-resilience.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/marine_ops/mooring_resilience">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/marine_ops/mooring_resilience" loading="lazy" title="Mooring resilience screen report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/marine_ops/mooring_resilience">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/rudder-database.html
+++ b/docs/api/capabilities/api/rudder-database.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="rudder-database.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/data/rudder_database.yml">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/data/rudder_database.yml" loading="lazy" title="Rudder-type database report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository file.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/blob/main/src/digitalmodel/naval_architecture/data/rudder_database.yml">Open repository file &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/vessel-suitability.html
+++ b/docs/api/capabilities/api/vessel-suitability.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="vessel-suitability.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/data/vessels">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/data/vessels" loading="lazy" title="Installation vessel database &amp; suitability ranking report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/data/vessels">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/wind-economics.html
+++ b/docs/api/capabilities/api/wind-economics.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="wind-economics.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-economics">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-economics" loading="lazy" title="Floating-wind LCOE / TOTEX tradespace report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-economics">Open repository directory &rarr;</a>
   </div>
 </div></body></html>

--- a/docs/api/capabilities/api/wind-sizing.html
+++ b/docs/api/capabilities/api/wind-sizing.html
@@ -18,9 +18,6 @@
   .verb{display:inline-block;font:700 11px ui-monospace,monospace;background:var(--teal);color:#fff;padding:2px 8px;border-radius:6px;margin-bottom:8px}
   a.btn{display:inline-block;margin-top:10px;font-size:12.5px;font-weight:700;color:#fff;
         background:linear-gradient(135deg,#0f8a7e,#0B3D91);padding:8px 14px;border-radius:9px;text-decoration:none}
-  .reportwrap{margin-top:16px;background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
-  .reportwrap .bar{font-size:12px;color:var(--muted);padding:9px 14px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between}
-  iframe{width:100%;height:560px;border:0;display:block;background:#fff}
   .note{color:var(--muted);font-size:12.5px;margin-top:6px}
   a{color:var(--navy)}
   .bigpanel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px 16px;margin-top:16px}
@@ -154,8 +151,9 @@
       <a class="btn" href="wind-sizing.json" download>Download envelope JSON &darr;</a></div>
   </div>
   <p class="note">Published report surface — the deterministic output is served as a self-contained page; GET the report_url to consume it.</p>
-  <div class="reportwrap">
-    <div class="bar"><span>Comprehensive report (live output)</span><a href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-sizing">open full report &rarr;</a></div>
-    <iframe src="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-sizing" loading="lazy" title="Floating-wind sizing &amp; concept screening report"></iframe>
+  <div class="bigpanel">
+    <h2>Deterministic output</h2>
+    <p class="note">The deterministic output is published as a repository directory.</p>
+    <a class="btn" href="https://github.com/vamseeachanta/digitalmodel/tree/main/examples/workflows/floating-wind-sizing">Open repository directory &rarr;</a>
   </div>
 </div></body></html>


### PR DESCRIPTION
Closes #1892.

## The bug

Eight pages embedded their *"Comprehensive report (live output)"* panel as an iframe pointing at a **github.com tree URL**. GitHub serves those with `x-frame-options: deny`, so the browser refuses to render them — the panel was **empty on every one**, under a heading promising a live report. The page returned 200 and looked fine to any check that did not render it.

## The fix

None of the eight has a published report page to point at, so the iframe is replaced with a **visible link to the same location** rather than repointed. An honest link beats a blank frame, and it matches the ecosystem rule that missing output gets a visible placeholder, never a silent gap.

Reuses each page's existing `.bigpanel` / `.note` / `a.btn` classes — no new CSS — and removes the `.reportwrap`, `.reportwrap .bar` and `iframe` rules that became dead on these eight. **The other 28 pages still use that markup and are untouched.**

## Verified in a browser at 375px

No iframe remains, the replacement link is visible on every page, and every href still resolves to its original target.

## Two things the check surfaced that are NOT defects here

- **`rudder-database` says "Open repository file", not "directory"** — its target is a `.yml` file rather than a directory. My assertion looked for the wrong wording; the page was right. Worth noting because it means the generated wording was chosen per target rather than pasted.
- **All four sampled pages overflow horizontally at 375px — and so do the unmodified `ocimf` and `passing-ship`.** That is pre-existing across the capability set, not introduced here, and belongs in its own issue rather than being smuggled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)