### PR TITLE
fix(dynacard): correct the curvature force dimensions in the marching kernel (#1894)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
@@ -410,6 +410,19 @@ def initial_matrix(sim: Simulation, coeff: Coefficients) -> np.ndarray:
 
 
 @_njit(cache=True)
+def _normal_force_per_length(
+    rho_a, gravity, phi, d_phi, d_psi, axial_force
+):
+    """Return borehole normal load per measured length, N/m."""
+    gravity_normal = rho_a * gravity * np.sin(phi)
+    curvature_normal = axial_force * d_phi
+    azimuth_normal = axial_force * d_psi * np.sin(phi)
+    return np.sqrt(
+        (gravity_normal - curvature_normal) ** 2 + azimuth_normal ** 2
+    )
+
+
+@_njit(cache=True)
 def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi, muteg):
     """March the damped wave equation down the rod string.
 
@@ -435,14 +448,18 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
 
             c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
             c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
-            c3 = (rho_a_ij / ea_plus) * lam * sign * dx
+            c3 = (lam * sign / ea_plus) * dx ** 2
             c4 = (rho_a_ij / ea_plus) * dx ** 2
 
-            # Normal force from gravity plus borehole curvature.
-            mg_sin = rho_a[i, j] * g * np.sin(phi[i, j])
-            s1 = mg_sin * dx - d_phi[i, j] * (u[i, j] - u[i - 1, j])
-            s2 = d_psi[i, j] * np.sin(phi[i, j]) * (u[i, j] - u[i - 1, j])
-            q_n = np.sqrt(s1 ** 2 + s2 ** 2)
+            axial_force = ea_minus * (u[i, j] - u[i - 1, j]) / dx
+            q_n = _normal_force_per_length(
+                rho_a_ij,
+                g,
+                phi[i, j],
+                d_phi[i, j],
+                d_psi[i, j],
+                axial_force,
+            )
 
             u[i + 1, j] = (
                 u[i, j]
@@ -464,13 +481,18 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
 
         c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
         c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
-        c3 = (rho_a_ij / ea_plus) * lam * dx
+        c3 = (lam / ea_plus) * dx ** 2
         c4 = (rho_a_ij / ea_plus) * dx ** 2
 
-        mg_sin = rho_a[i, 0] * g * np.sin(phi[i, 0])
-        s1 = mg_sin * dx - d_phi[i, 0] * (u[i, 0] - u[i - 1, 0])
-        s2 = d_psi[i, 0] * np.sin(phi[i, 0]) * (u[i, 0] - u[i - 1, 0])
-        q_n = np.sqrt(s1 ** 2 + s2 ** 2)
+        axial_force = ea_minus * (u[i, 0] - u[i - 1, 0]) / dx
+        q_n = _normal_force_per_length(
+            rho_a_ij,
+            g,
+            phi[i, 0],
+            d_phi[i, 0],
+            d_psi[i, 0],
+            axial_force,
+        )
 
         u[i + 1, 0] = (
             u[i, 0]

--- a/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
@@ -23,6 +23,9 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
 from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
     units as U,
 )
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings.solver import (
+    _march,
+)
 
 FIXTURE = Path(__file__).parent / "testdata" / "7699227.json"
 
@@ -216,6 +219,41 @@ def test_rod_string_rejects_mismatched_section_arrays():
             diameters=np.array([0.0222, 0.0190]),
             lengths=np.array([290.0]),
         )
+
+
+def test_curvature_friction_uses_axial_force_per_unit_length():
+    """The curvature term must be a force/length before PDE integration."""
+    n_x, n_t = 3, 4
+    displacement = np.zeros((n_x, n_t))
+    displacement[1] = np.array([0.01, 0.01, 0.02, 0.01])
+    shape = (n_x, n_t)
+    elastic_modulus = np.full(shape, 1_000.0)
+    area = np.ones(shape)
+    zeros = np.zeros(shape)
+    inclination_gradient = np.full(shape, 3.0)
+
+    solution, _, _ = _march(
+        displacement,
+        n_x,
+        n_t,
+        1.0,
+        0.5,
+        0.2,
+        zeros,
+        0.0,
+        zeros,
+        elastic_modulus,
+        area,
+        zeros,
+        inclination_gradient,
+        zeros,
+        1.0,
+    )
+
+    # F = EA * du/dx = 1,000 N * 0.01 m / 0.5 m = 20 N.
+    # N' = F * d_phi/ds = 20 N * 3 /m = 60 N/m.
+    # du_f = mu * N' * dx^2 / EA = 0.2 * 60 * 0.5^2 / 1,000 = 0.003 m.
+    assert solution[2, 1] == pytest.approx(0.02 + 0.003)
 
 
 class TestEffectiveRodDensity:


### PR DESCRIPTION
Part of #1894, landing on its own because it is a defect regardless of whether deviation is ever enabled.

## The bug

The Everitt–Jennings marching kernel computed its curvature contribution as:

```python
d_phi * (u[i,j] - u[i-1,j])
```

That is a **displacement difference** where the axial force `EA·du/dx` belongs — so `s1` was adding newtons to a dimensionless quantity. Dimensionally incoherent, and invisible today only because the whole term is multiplied by `muteg = 0` (`include_gravity` defaults to `False`).

Fixed, with a test whose expected value is derived independently rather than observed: **20 N axial force, 60 N/m curvature normal load**.

## Why it lands alone

The rest of #1894 — parsing `surveyData`, enabling gravity, supplying a friction coefficient — **regressed real-card agreement** and is deliberately not merged. On the one deviated well, load nRMSE went 0.534% → 6.438% (gravity) → 11.372% (with catalog friction μ=0.2, untuned). The four vertical wells were bit-for-bit unchanged.

That may not mean the physics got worse. The vendor reference we validate against was itself computed **without a survey** — `SurveyData: []`, `TVD: data is nan`, and a buckling threshold that back-solves to 0.76° on a well whose bottom taper spans 42°→77°. A correctly deviation-aware solver *must* disagree with a vertical-assumption reference on a deviated well. This data cannot distinguish the two claims; see the [analysis on #1894](https://github.com/vamseeachanta/digitalmodel/issues/1894#issuecomment-5117752306).

This commit carries none of that. It corrects an expression that is wrong on its own terms.

## Verification

`tests/marine_ops/artificial_lift/` — **909 passed, 1 skipped**.

Authored by Codex during the deviation work; extractable cleanly because its commits were incremental and single-purpose.