### PR TITLE
fix(capabilities): stop all 36 pages scrolling sideways at 375px (#1934)

### DIFF
--- a/.planning/plan-approved/1934.md
+++ b/.planning/plan-approved/1934.md
@@ -1,0 +1,8 @@
+# #1934 capability pages overflow at 375px — plan recorded
+
+Authorization: operator direction in-session 2026-07-29 ("continue work using codex
+subagents"). Not an owner-reviewed written plan.
+
+Scope: CSS only, in the self-contained <style> block of the 36 pages under
+docs/api/capabilities/api/. Acceptance is measured in a browser at 375px:
+document.documentElement.scrollWidth must equal clientWidth.

--- a/docs/api/capabilities/api/buckling-panel.html
+++ b/docs/api/capabilities/api/buckling-panel.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/buckling-plate.html
+++ b/docs/api/capabilities/api/buckling-plate.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/casing-design.html
+++ b/docs/api/capabilities/api/casing-design.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/cathodic-protection-explorer.html
+++ b/docs/api/capabilities/api/cathodic-protection-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/container-utilization.html
+++ b/docs/api/capabilities/api/container-utilization.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/diffraction-deck-prep.html
+++ b/docs/api/capabilities/api/diffraction-deck-prep.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/drilling-riser-operability-monitor.html
+++ b/docs/api/capabilities/api/drilling-riser-operability-monitor.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/drilling-riser-operability.html
+++ b/docs/api/capabilities/api/drilling-riser-operability.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/dynacard-field-health.html
+++ b/docs/api/capabilities/api/dynacard-field-health.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/dynacard-troubleshooting.html
+++ b/docs/api/capabilities/api/dynacard-troubleshooting.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/ffs-field-dashboard.html
+++ b/docs/api/capabilities/api/ffs-field-dashboard.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/ffs-showcase.html
+++ b/docs/api/capabilities/api/ffs-showcase.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/galvanic-explorer.html
+++ b/docs/api/capabilities/api/galvanic-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/installation-bokalift.html
+++ b/docs/api/capabilities/api/installation-bokalift.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/mooring-resilience.html
+++ b/docs/api/capabilities/api/mooring-resilience.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/ocimf.html
+++ b/docs/api/capabilities/api/ocimf.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/passing-ship.html
+++ b/docs/api/capabilities/api/passing-ship.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/rao-comparison.html
+++ b/docs/api/capabilities/api/rao-comparison.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/riser-joint-acceptance.html
+++ b/docs/api/capabilities/api/riser-joint-acceptance.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/riser-mesh.html
+++ b/docs/api/capabilities/api/riser-mesh.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/riser-validation.html
+++ b/docs/api/capabilities/api/riser-validation.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/rudder-database.html
+++ b/docs/api/capabilities/api/rudder-database.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/rudder-explorer.html
+++ b/docs/api/capabilities/api/rudder-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/scale-si-explorer.html
+++ b/docs/api/capabilities/api/scale-si-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/short-horizon-motion-forecast.html
+++ b/docs/api/capabilities/api/short-horizon-motion-forecast.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/sloshing-explorer.html
+++ b/docs/api/capabilities/api/sloshing-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="700" height="220" viewBox="0 0 700 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/subsea-xsection.html
+++ b/docs/api/capabilities/api/subsea-xsection.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/unitbox-amplitude.html
+++ b/docs/api/capabilities/api/unitbox-amplitude.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/unitbox-combined.html
+++ b/docs/api/capabilities/api/unitbox-combined.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/unitbox-heatmap.html
+++ b/docs/api/capabilities/api/unitbox-heatmap.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/unitbox-phase.html
+++ b/docs/api/capabilities/api/unitbox-phase.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/unitbox-report.html
+++ b/docs/api/capabilities/api/unitbox-report.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/vessel-suitability.html
+++ b/docs/api/capabilities/api/vessel-suitability.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/wall-thickness-explorer.html
+++ b/docs/api/capabilities/api/wall-thickness-explorer.html
@@ -30,6 +30,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="690" height="210" viewBox="0 0 690 210" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/wind-economics.html
+++ b/docs/api/capabilities/api/wind-economics.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/api/capabilities/api/wind-sizing.html
+++ b/docs/api/capabilities/api/wind-sizing.html
@@ -27,6 +27,7 @@
   .copy{font:700 12px Arial;color:#fff;background:linear-gradient(135deg,#0f8a7e,#0B3D91);border:0;border-radius:9px;padding:10px 13px;cursor:pointer;white-space:nowrap}
   .how ol{margin:8px 0 0 18px} .how li{font-size:13.5px;margin:7px 0;color:var(--ink)}
   .how code{background:#0e1726;color:#d6e2f5;padding:1px 6px;border-radius:5px;font-size:12px}
+  .prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
 </style></head>
 <body><div class="wrap">
   <div class="top"><a href="../" aria-label="Back to capabilities" style="display:contents"><svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Closes #1934. One rule per page, 36 files:

```css
.prompt .q,.how,.how li,.how code,.bigpanel{overflow-wrap:anywhere}
```

## The cause

Long unbroken URLs in the prompt and *"How to run the API"* blocks — the GitHub tree links and the `curl` command, which contain no space to wrap at.

Measured before fixing: `mooring-resilience` scrolled **651px inside a 375px viewport**; `ocimf` 401px.

## Why it wasn't obvious from the markup

A `getBoundingClientRect` scan found **zero** elements exceeding the viewport. The boxes all fit; their *content* did not. Comparing `scrollWidth` to `clientWidth` per element is what identified `.prompt`, `.how` and `.bigpanel` — worth recording, because the first measurement said "no offenders" while the page was visibly 651px wide.

## Verified the same way

All 36 pages loaded at 375px: **`scrollWidth == clientWidth` on every one.** Was 36 of 36 failing.

## Deliberately not touched

`pre` already carries `white-space:pre-wrap; word-break:break-word` on these pages, so the `ResultEnvelope` block was never the offender. Adding rules there would have been noise dressed as thoroughness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)