### PR TITLE
test(cfd): give the single-tank sloshing study a roll-amplitude axis (#1911)

### DIFF
--- a/docs/api/cfd/single-tank-amplitude-findings.md
+++ b/docs/api/cfd/single-tank-amplitude-findings.md
@@ -1,0 +1,98 @@
+# Single-tank roll-amplitude findings — issue #1911
+
+## Outcome
+
+The nominal amplitude-conditioned reduction **inverts at 2° roll**: the coupled
+peak is 9.0643 for 70% fill versus 9.1024 for 50% fill. The 50% fill remains
+lower at 4° and 8°. However, the 2° difference is only 0.42% and changes sign
+within the existing damping fitter's 0.005 ζ resolution. The four-case study
+therefore does **not** establish that the 50%-fill ranking survives every
+amplitude, but it also does not resolve the 2° ordering decisively. It plainly
+shows that the published fill-only damping interpretation is unsafe.
+
+## Change and safety
+
+`scripts/cfd/run_sloshing_response_sweep.py` now accepts
+`--roll-amplitude-deg`, threads it into case generation, records it in each
+case specification, uses it in moment reduction, and writes it to the collected
+manifest metadata. The default remains 4.0°, so commands without the new option
+retain the previous solver setup and manifest amplitude.
+
+`scripts/cfd/reduce_sloshing_sdof.py` also accepts an optional `--output` path.
+Its default remains `docs/api/cfd/sloshing-sdof.json`; the option allowed this
+study to re-run the published curve fit without overwriting that artifact.
+
+Both changes were made test-first. The seven focused CLI contract tests pass.
+
+## Cases run
+
+The added cases used the existing forced-response resonances:
+
+- h/L = 0.50: 1.12136 s, equal to `resonant_period_cfd_s`; the independent
+  free-decay `natural_period_cfd_s` is 1.11713 s (0.38% lower).
+- h/L = 0.70: 1.08720 s, equal to `resonant_period_cfd_s`; the independent
+  free-decay `natural_period_cfd_s` is 1.08897 s (0.16% higher).
+
+These are the existing ratio-1.00 cases. Each solve used OpenFOAM ESI v2312 and
+ran only after `pgrep -x interFoam` returned no process. Solves were serial.
+
+| Fill h/L | Roll | Period (s) | Runtime (s) | Wall run-up amplitude (m) | Quadrature coefficient | Moment amplitude (N·m) |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0.50 | 2° | 1.12136 | 183.0 | 0.285271 | 2.15650 | 2.15682 |
+| 0.70 | 2° | 1.08720 | 175.0 | 0.338700 | 2.77499 | 2.77756 |
+| 0.50 | 8° | 1.12136 | 198.4 | 0.363559 | 1.41385 | 1.81771 |
+| 0.70 | 8° | 1.08720 | 189.2 | 0.408536 | 2.34572 | 3.53340 |
+
+The run-up, quadrature, moment, and runtime values above are measured/reduced
+directly from the four new CFD cases.
+
+## Equivalent damping and coupled response
+
+Re-running `scripts/cfd/reduce_sloshing_sdof.py` reproduced the published 4°
+wall-run-up curve fits: ζ = 0.180 at h/L = 0.50 and ζ = 0.305 at h/L = 0.70.
+The original raw 4° case tree was not present on this machine, so its A44/B44
+contract rows could not be regenerated; the committed five-point response
+manifest was available and is what determines these ζ fits.
+
+Only resonance cases were requested at 2° and 8°, not new five-period response
+curves. Their equivalent ζ values are therefore **inferred**, not independently
+curve-fitted. At resonance, the SDOF response used by the reducer scales as
+roll amplitude divided by ζ. Using each fill's 4° curve fit as the calibration:
+
+`ζ(A) = ζ(4°) × (A / 4°) × [run-up(4°) / run-up(A)]`.
+
+The coupled peaks are grid-sampled approximations using the same Den Hartog
+reduction as `scripts/cfd/reduce_tld_two_peak.py`: mass ratio μ = 0.05, tuning
+ratio = 1.0, and frequency-ratio grid 0.75–1.30.
+
+| Fill h/L | Roll | ζ | ζ basis | Coupled peak response | Coupled regime |
+|---:|---:|---:|:---|---:|:---|
+| 0.50 | 2° | 0.1153 | inferred from resonant run-up scaling | 9.1024 | two-peak split |
+| 0.70 | 2° | 0.1755 | inferred from resonant run-up scaling | **9.0643** | single peak |
+| 0.50 | 4° | 0.1800 | measured five-period curve fit | **9.1537** | single peak |
+| 0.70 | 4° | 0.3050 | measured five-period curve fit | 13.5225 | single peak |
+| 0.50 | 8° | 0.3618 | inferred from resonant run-up scaling | **15.8752** | single peak |
+| 0.70 | 8° | 0.5819 | inferred from resonant run-up scaling | 25.1613 | single peak |
+
+The measured resonance response is strongly non-proportional to roll amplitude,
+consistent with amplitude-dependent nonlinear free-surface loss. Nominally,
+70% is slightly better at 2°, while 50% is better at 4° and 8°. But the
+published 4° ζ values come from a fitter that searches in 0.005 increments.
+Propagating only the resulting ±0.0025 quantization through the 2° scaling makes
+`peak(50%) - peak(70%)` range from about -0.032 to +0.113. Thus the nominal
+inversion is not robust at the method's own resolution. “70% fill is
+over-damped” remains conditional on excitation amplitude and the stated coupled
+model assumptions; a full frequency sweep (or an uncertainty-aware refined fit)
+is needed to settle the close 2° ranking.
+
+## Recommended wording for PR #1877
+
+> At the tested 4° roll amplitude, 50% fill gives the lowest coupled peak
+> response of the three fills (ζ ≈ 0.18), while 70% fill (ζ ≈ 0.305) lies on the
+> over-damped side of this specific coupled model. These are
+> amplitude-conditioned equivalent damping values, not fill-only properties.
+> Resonance checks at 2° and 8° show nonlinear amplitude dependence. The nominal
+> reduction reverses the 50%/70% ranking slightly at 2° and returns to 50%-best
+> at 8°, but the 2° ordering is unresolved within the damping fit's numerical
+> resolution. A full frequency sweep at each amplitude is required before
+> claiming a general best fill.

--- a/scripts/cfd/reduce_sloshing_sdof.py
+++ b/scripts/cfd/reduce_sloshing_sdof.py
@@ -55,6 +55,12 @@ def _fit_zeta(pairs: List[tuple]) -> float:
 def main(argv: List[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Sloshing SDOF + tuning reduction (#1433)")
     ap.add_argument("--work-dir", type=Path, default=Path("/mnt/local-analysis/sloshing_cfd_work"))
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=_OUT,
+        help="output manifest path (default: docs/api/cfd/sloshing-sdof.json)",
+    )
     args = ap.parse_args(argv)
 
     forced = json.loads(_FORCED.read_text())
@@ -120,9 +126,13 @@ def main(argv: List[str] | None = None) -> int:
         "tuning_basis": {"relation": "omega1^2 = (pi*g/L)*tanh(pi*h/L)",
                          "g": G, "note": "Interactive tuning: for tank length L and target roll period T_roll, the tuning fill is where f1(fill)=1/T_roll."},
     }
-    _OUT.parent.mkdir(parents=True, exist_ok=True)
-    _OUT.write_text(json.dumps(manifest, indent=2) + "\n")
-    print(f"wrote {_OUT.relative_to(_REPO)} ({len(fills_out)} fills, {len(rows)} contract rows)")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(manifest, indent=2) + "\n")
+    try:
+        output_label = args.output.relative_to(_REPO)
+    except ValueError:
+        output_label = args.output
+    print(f"wrote {output_label} ({len(fills_out)} fills, {len(rows)} contract rows)")
     for x in fills_out:
         print(f"  h/L={x['h_over_L']}: T1={x['natural_period_s']}s zeta={x['equivalent_damping_ratio_zeta']} "
               f"coeff={x['resonance_coefficients']}")

--- a/scripts/cfd/run_sloshing_response_sweep.py
+++ b/scripts/cfd/run_sloshing_response_sweep.py
@@ -98,7 +98,12 @@ def _patch_wall_probe(case_dir: Path) -> None:
         cd.write_text(txt.replace(center, wall))
 
 
-def _build(work_dir: Path, spec: Dict[str, Any]) -> Path:
+def _build(
+    work_dir: Path,
+    spec: Dict[str, Any],
+    roll_amplitude_deg: float = ROLL_DEG,
+) -> Path:
+    spec = {**spec, "roll_amplitude_deg": roll_amplitude_deg}
     if spec["kind"] == "free-decay":
         cfg = SloshingFreeDecayConfig(
             breadth=BREADTH, tank_height=TANK_HEIGHT, fill_level=spec["hl"],
@@ -108,7 +113,7 @@ def _build(work_dir: Path, spec: Dict[str, Any]) -> Path:
     else:
         cfg = SloshingForcedRollConfig(
             breadth=BREADTH, tank_height=TANK_HEIGHT, fill_depth=spec["hl"] * BREADTH,
-            roll_amplitude_deg=ROLL_DEG, roll_period=spec["drive_period"],
+            roll_amplitude_deg=roll_amplitude_deg, roll_period=spec["drive_period"],
             cells_per_breadth=FORCED_CPB, n_cycles=N_CYCLES, name=spec["name"],
         )
         case = build_forced_roll_case(cfg, work_dir, with_moment=True)
@@ -126,11 +131,16 @@ def _runup_amplitude(elev: List[float]) -> float:
 
 def _run_one(case_dir: Path) -> Dict[str, Any]:
     spec = json.loads((case_dir / "_spec.json").read_text())
+    roll_amplitude_deg = spec.get("roll_amplitude_deg", ROLL_DEG)
     # Idempotent: skip a case already solved (so a parallel fan-out is re-runnable).
     done = case_dir / "_result.json"
     if done.exists():
         prev = json.loads(done.read_text())
-        if prev.get("status") == "completed":
+        prev_amplitude = prev.get("roll_amplitude_deg", ROLL_DEG)
+        if (
+            prev.get("status") == "completed"
+            and prev_amplitude == roll_amplitude_deg
+        ):
             return prev
     runner = OpenFOAMRunner(OpenFOAMRunConfig(run_set_fields=True, to_vtk=False))
     res = runner.run(case_dir)
@@ -158,7 +168,7 @@ def _run_one(case_dir: Path) -> Dict[str, Any]:
                 mt, mz = parse_roll_moment(case_dir)
                 red = reduce_roll_moment(mt, mz, spec["drive_period"],
                                          fill_level=fill_depth / TANK_HEIGHT,
-                                         roll_amplitude_deg=ROLL_DEG)
+                                         roll_amplitude_deg=roll_amplitude_deg)
                 row.update(quad_coeff=round(red["quad_coeff"], 5),
                            moment_amplitude_nm=round(red["moment_amplitude"], 5))
             except (FileNotFoundError, RuntimeError, ValueError):
@@ -169,12 +179,23 @@ def _run_one(case_dir: Path) -> Dict[str, Any]:
     return row
 
 
-def _collect(work_dir: Path) -> Dict[str, Any]:
+def _collect(
+    work_dir: Path,
+    roll_amplitude_deg: float = ROLL_DEG,
+) -> Dict[str, Any]:
     results: List[Dict[str, Any]] = []
     for spec in _specs():
         rp = work_dir / spec["name"] / "_result.json"
         if rp.exists():
-            results.append(json.loads(rp.read_text()))
+            result = json.loads(rp.read_text())
+            if result.get("kind") == "forced":
+                result_amplitude = result.get("roll_amplitude_deg", ROLL_DEG)
+                if result_amplitude != roll_amplitude_deg:
+                    raise ValueError(
+                        f"{rp} has roll amplitude {result_amplitude}°, "
+                        f"not requested {roll_amplitude_deg}°"
+                    )
+            results.append(result)
     fills: List[Dict[str, Any]] = []
     for hl in FILLS:
         fd = next((r for r in results if r["kind"] == "free-decay" and r["hl"] == hl), {})
@@ -204,7 +225,8 @@ def _collect(work_dir: Path) -> Dict[str, Any]:
     manifest = {
         "meta": {"generated_by": "scripts/cfd/run_sloshing_response_sweep.py",
                  "solver": "interFoam (VOF), OpenFOAM ESI v2312",
-                 "epic": "#1429", "issue": "#1433", "g": G, "roll_amplitude_deg": ROLL_DEG},
+                 "epic": "#1429", "issue": "#1433", "g": G,
+                 "roll_amplitude_deg": roll_amplitude_deg},
         "tank": {"shape": "rectangular", "breadth_m": BREADTH, "tank_height_m": TANK_HEIGHT,
                  "freedecay_cells_per_breadth": FREEDECAY_CPB,
                  "forced_cells_per_breadth": FORCED_CPB, "n_cycles": N_CYCLES},
@@ -220,6 +242,12 @@ def main(argv: List[str] | None = None) -> int:
     ap.add_argument("command", choices=("generate", "run-one", "collect", "all"))
     ap.add_argument("--work-dir", type=Path, default=Path("/mnt/local-analysis/sloshing_cfd_work"))
     ap.add_argument("--case-dir", type=Path, help="case directory for run-one")
+    ap.add_argument(
+        "--roll-amplitude-deg",
+        type=float,
+        default=ROLL_DEG,
+        help=f"forced-roll amplitude in degrees (default: {ROLL_DEG})",
+    )
     args = ap.parse_args(argv)
 
     if args.command == "run-one":
@@ -232,22 +260,25 @@ def main(argv: List[str] | None = None) -> int:
     args.work_dir.mkdir(parents=True, exist_ok=True)
     if args.command == "generate":
         specs = _specs()
-        dirs = [_build(args.work_dir, s) for s in specs]
+        dirs = [
+            _build(args.work_dir, s, args.roll_amplitude_deg)
+            for s in specs
+        ]
         (args.work_dir / "response_plan.json").write_text(
             json.dumps({"n": len(dirs), "cases": [{"name": s["name"], "kind": s["kind"],
                         "dir": str(args.work_dir / s["name"])} for s in specs]}, indent=2) + "\n")
         print(f"generated {len(dirs)} cases under {args.work_dir}")
         return 0
     if args.command == "collect":
-        m = _collect(args.work_dir)
+        m = _collect(args.work_dir, args.roll_amplitude_deg)
         print(f"wrote {_MANIFEST.relative_to(_REPO)} ({len(m['fills'])} fills)")
         return 0
     # all (serial)
     for s in _specs():
-        case = _build(args.work_dir, s)
+        case = _build(args.work_dir, s, args.roll_amplitude_deg)
         r = _run_one(case)
         print(f"[{s['name']}] {r['status']}")
-    m = _collect(args.work_dir)
+    m = _collect(args.work_dir, args.roll_amplitude_deg)
     print(f"wrote {_MANIFEST.relative_to(_REPO)}")
     return 0
 

--- a/tests/solvers/openfoam/validation/test_reduce_sloshing_sdof_script.py
+++ b/tests/solvers/openfoam/validation/test_reduce_sloshing_sdof_script.py
@@ -1,0 +1,63 @@
+"""CLI contract tests for the single-tank SDOF reducer (#1911)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[4]
+    / "scripts"
+    / "cfd"
+    / "reduce_sloshing_sdof.py"
+)
+
+
+def test_reducer_can_write_to_nondefault_output(tmp_path, monkeypatch) -> None:
+    spec = importlib.util.spec_from_file_location("reduce_sloshing_sdof", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    forced_path = tmp_path / "forced.json"
+    forced_path.write_text(
+        json.dumps(
+            {
+                "tank": {"breadth_m": 0.9},
+                "fills": [
+                    {
+                        "h_over_L": 0.5,
+                        "T1_analytical_s": 1.0,
+                        "forced": [
+                            {
+                                "status": "completed",
+                                "period_ratio": 1.0,
+                                "drive_period_s": 1.0,
+                                "runup_amp_m": 0.2,
+                                "quad_coeff": 1.0,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(module, "_FORCED", forced_path)
+    output_path = tmp_path / "reduced.json"
+    default_output_before = module._OUT.read_bytes()
+
+    assert (
+        module.main(
+            [
+                "--work-dir",
+                str(tmp_path / "no-raw-cases"),
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    assert output_path.exists()
+    assert module._OUT.read_bytes() == default_output_before

--- a/tests/solvers/openfoam/validation/test_sloshing_response_sweep_script.py
+++ b/tests/solvers/openfoam/validation/test_sloshing_response_sweep_script.py
@@ -1,0 +1,170 @@
+"""CLI contract tests for the single-tank forced-roll response sweep (#1911)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[4]
+    / "scripts"
+    / "cfd"
+    / "run_sloshing_response_sweep.py"
+)
+
+
+@pytest.fixture()
+def sweep_module():
+    spec = importlib.util.spec_from_file_location("run_sloshing_response_sweep", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_threads_custom_roll_amplitude_into_case_and_spec(
+    tmp_path, sweep_module
+) -> None:
+    case = sweep_module._build(
+        tmp_path,
+        {
+            "kind": "forced",
+            "hl": 0.5,
+            "ratio": 1.0,
+            "drive_period": 1.12136,
+            "t1_analytical": 1.12136,
+            "name": "custom_amplitude",
+        },
+        roll_amplitude_deg=8.0,
+    )
+
+    motion = (case / "constant" / "dynamicMeshDict").read_text()
+    case_spec = json.loads((case / "_spec.json").read_text())
+    assert "amplitude   (0 0 8)" in motion
+    assert case_spec["roll_amplitude_deg"] == 8.0
+
+
+def test_collect_records_custom_roll_amplitude_in_manifest(
+    tmp_path, monkeypatch, sweep_module
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    monkeypatch.setattr(sweep_module, "_MANIFEST", manifest_path)
+
+    manifest = sweep_module._collect(tmp_path, roll_amplitude_deg=2.0)
+
+    assert manifest["meta"]["roll_amplitude_deg"] == 2.0
+    assert json.loads(manifest_path.read_text())["meta"]["roll_amplitude_deg"] == 2.0
+
+
+def test_collect_rejects_result_from_different_roll_amplitude(
+    tmp_path, sweep_module
+) -> None:
+    case = tmp_path / "resp_fr_hl50_r100"
+    case.mkdir()
+    (case / "_result.json").write_text(
+        json.dumps(
+            {
+                "kind": "forced",
+                "hl": 0.5,
+                "ratio": 1.0,
+                "roll_amplitude_deg": 4.0,
+                "status": "completed",
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="roll amplitude"):
+        sweep_module._collect(tmp_path, roll_amplitude_deg=8.0)
+
+
+def test_run_one_does_not_reuse_completed_result_from_different_amplitude(
+    tmp_path, monkeypatch, sweep_module
+) -> None:
+    case = tmp_path / "case"
+    case.mkdir()
+    (case / "_spec.json").write_text(
+        json.dumps(
+            {
+                "kind": "forced",
+                "hl": 0.5,
+                "drive_period": 1.12136,
+                "roll_amplitude_deg": 8.0,
+            }
+        )
+    )
+    (case / "_result.json").write_text(
+        json.dumps(
+            {
+                "kind": "forced",
+                "hl": 0.5,
+                "drive_period": 1.12136,
+                "roll_amplitude_deg": 4.0,
+                "status": "completed",
+            }
+        )
+    )
+
+    class FakeRunner:
+        def __init__(self, config):
+            pass
+
+        def run(self, case_dir):
+            return SimpleNamespace(
+                status=SimpleNamespace(value="failed"),
+                duration_seconds=0.1,
+                error_message="intentional test sentinel",
+            )
+
+    monkeypatch.setattr(sweep_module, "OpenFOAMRunner", FakeRunner)
+    result = sweep_module._run_one(case)
+
+    assert result["status"] == "failed"
+    assert result["roll_amplitude_deg"] == 8.0
+
+
+def test_cli_default_roll_amplitude_remains_four_degrees(
+    tmp_path, monkeypatch, sweep_module
+) -> None:
+    seen = []
+    monkeypatch.setattr(sweep_module, "_specs", lambda: [])
+    monkeypatch.setattr(
+        sweep_module,
+        "_collect",
+        lambda work_dir, roll_amplitude_deg: seen.append(roll_amplitude_deg)
+        or {"fills": []},
+    )
+
+    assert sweep_module.main(["all", "--work-dir", str(tmp_path)]) == 0
+    assert seen == [4.0]
+
+
+def test_cli_forwards_requested_roll_amplitude(
+    tmp_path, monkeypatch, sweep_module
+) -> None:
+    seen = []
+    monkeypatch.setattr(sweep_module, "_specs", lambda: [])
+    monkeypatch.setattr(
+        sweep_module,
+        "_collect",
+        lambda work_dir, roll_amplitude_deg: seen.append(roll_amplitude_deg)
+        or {"fills": []},
+    )
+
+    assert (
+        sweep_module.main(
+            [
+                "all",
+                "--work-dir",
+                str(tmp_path),
+                "--roll-amplitude-deg",
+                "8",
+            ]
+        )
+        == 0
+    )
+    assert seen == [8.0]


### PR DESCRIPTION
Closes #1911. Owner-approved plan (`status:plan-approved`); TDD, tests before behaviour.

## Result: the published fill ranking is amplitude-conditional

PR #1877 publishes *"50% fill gives the best vessel-level response … 70% fill is over-damped"*. The entire single-tank dataset behind it carries `roll_amplitude_deg: 4.0` at the meta level — one amplitude. Four new resonance cases at 2° and 8° show that claim is not unconditional:

| fill | 2° | 4° | 8° |
|---|---:|---:|---:|
| ζ at h/L = 0.50 | 0.115 | 0.180 | 0.362 |
| ζ at h/L = 0.70 | 0.176 | 0.305 | 0.582 |
| coupled peak, 50% | 9.1024 | **9.1537** | **15.8752** |
| coupled peak, 70% | **9.0643** | 13.5225 | 25.1613 |

**70% is lower at 2°; 50% is lower at 4° and 8°.**

The underlying nonlinearity is stark: **doubling roll from 4° to 8° produced no increase in wall run-up at all** (0.36535 → 0.36356 m — saturated), so equivalent damping rises **3.1× across a 4× amplitude range**. That independently matches the connected-tank result of 2.9× across the same range, from a different geometry and a separate reduction path.

## Two caveats, stated because they bound the conclusion

- The 2° and 8° ζ values are **inferred**, not curve-fitted: only resonance points were run, not full five-period response curves. The inference is `zeta(A) = zeta(4deg) * (A/4deg) * [run-up(4deg)/run-up(A)]`, anchored on the published 4° fit.
- The 2° inversion is **0.42 %** — inside any reasonable uncertainty on an inferred quantity.

So this **rejects the unconditional ranking**; it does not establish 70% as generally better. A full frequency sweep at each amplitude is needed before claiming a general best fill.

## Changes

`run_sloshing_response_sweep.py` gains `--roll-amplitude-deg`, threaded into case generation, the case spec, moment reduction, and the collected manifest. `reduce_sloshing_sdof.py` gains an optional `--output`, so this study could re-fit without overwriting the published curve.

**Defaults unchanged** — `ROLL_DEG = 4.0` remains the default, so existing commands reproduce today's results exactly. **No published artifact was modified**: `sloshing-forced-response.json` and `sloshing-sdof.json` are byte-identical to main.

## Verification

7 new CLI-contract tests pass. Solves ran serially behind an `interFoam` idle gate. Every reported run-up, quadrature and moment value is measured; every ζ at 2°/8° is labelled inferred.

## Consequence for #1877

That PR should not merge with the claim as written. Suggested replacement wording is in `docs/api/cfd/single-tank-amplitude-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
