### PR TITLE
Add end-to-end solver smoke test (OrcaFlex + AQWA licence probe)

### DIFF
--- a/scripts/solver_smoke_test.py
+++ b/scripts/solver_smoke_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""End-to-end solver smoke test for licensed hosts (OrcaFlex + AQWA).
+
+Unlike the readiness ``doctor`` commands (``orcawave-doctor``, ``openfoam
+doctor``), which only report whether a binding imports and an executable
+exists, this *actually solves* a tiny model on each solver. That is the only
+check that proves the licence is reachable and can be checked out, which is the
+failure mode that matters on a licensed run host.
+
+The probes themselves live in ``digitalmodel.solvers.smoke.probes`` so this CLI
+and the engine arm (``basename: solver_smoke_test``, used by the deckhand
+licensed-run lane) run exactly the same checks.
+
+Designed to be run unattended (scheduled task, SSH, deckhand preflight):
+no prompts, machine-readable ``--json``, and an exit code that means
+"this host can solve".
+
+Usage::
+
+    python scripts/solver_smoke_test.py                    # both solvers
+    python scripts/solver_smoke_test.py --solver orcaflex
+    python scripts/solver_smoke_test.py --json             # for automation
+
+Exit codes: ``0`` every selected solver solved; ``1`` at least one failed.
+
+Running this remotely over SSH
+------------------------------
+The Windows licensed host answers SSH with Git bash (MSYS), so use POSIX-style
+paths -- ``D:\\ws\\...`` backslashes are escape characters there::
+
+    ssh <user>@<licensed-host> \\
+      '/d/ws/digitalmodel/.venv/Scripts/python.exe \\
+       /d/ws/digitalmodel/scripts/solver_smoke_test.py --json'
+
+Call the venv interpreter by absolute path; there is no shell activation and
+no ``uv`` on PATH in a non-login SSH session.
+
+**AQWA works over SSH; OrcaFlex does not.** ANSYS licensing is a plain TCP
+checkout against the FlexNet server and is unaffected by session type. OrcaFlex
+checkout fails under SSH *public-key* auth with "could not access the FlexNet
+service. Error 21", even though the environment, the ``ORCINA_LICENSE_FILE``
+registry value and TCP reachability to the licence server are byte-identical to
+a working interactive session -- the key-auth logon token simply cannot
+complete the checkout. Route remote OrcaFlex work through an executor that owns
+a credentialed logon (the deckhand licensed-run lane's ``solver-smoke-test``
+workflow, or a scheduled task) rather than running it in the SSH session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+# Support running straight from a checkout without the package installed.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from digitalmodel.solvers.smoke.probes import CHECKS, run_probes  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--solver",
+        choices=[*CHECKS, "all"],
+        default="all",
+        help="which solver to smoke test (default: all)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="where to write scratch solver output (default: a temp dir)",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the scratch output instead of deleting it",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit a machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--include-host",
+        action="store_true",
+        help="include this machine's name in the report (private deployment data)",
+    )
+    args = parser.parse_args(argv)
+
+    selected = list(CHECKS) if args.solver == "all" else [args.solver]
+
+    if args.output_dir:
+        root = args.output_dir
+        root.mkdir(parents=True, exist_ok=True)
+        ephemeral = False
+    else:
+        root = Path(tempfile.mkdtemp(prefix="solver_smoke_"))
+        ephemeral = not args.keep
+
+    if args.json:
+        # The diffraction stack logs heavily through loguru AND prints a
+        # validation summary with bare print(); keep stdout clean so the JSON
+        # document is the only thing on it.
+        try:
+            from loguru import logger
+
+            logger.remove()
+        except Exception:
+            pass
+
+    try:
+        if args.json:
+            with contextlib.redirect_stdout(io.StringIO()):
+                report = run_probes(selected, root, include_host=args.include_host)
+        else:
+            report = run_probes(selected, root, include_host=args.include_host)
+    finally:
+        if ephemeral:
+            shutil.rmtree(root, ignore_errors=True)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print()
+        for entry in report["results"]:
+            print(f"{entry['solver']:>9}: {'PASS' if entry['ok'] else 'FAIL'}")
+            for key, value in entry.items():
+                if key in ("solver", "ok", "traceback"):
+                    continue
+                print(f"{'':>11}{key} = {value}")
+        print(f"\nRESULT: {'PASS' if report['ok'] else 'FAIL'}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/digitalmodel/base_configs/modules/solver_smoke_test/solver_smoke_test.yml
+++ b/src/digitalmodel/base_configs/modules/solver_smoke_test/solver_smoke_test.yml
@@ -1,0 +1,24 @@
+basename: solver_smoke_test
+
+# End-to-end solver licence-checkout probe. Defaults probe both solvers and fail
+# closed, so an input that only sets `basename` still answers the real question
+# ("can this host solve?") rather than silently degrading to a readiness check.
+solver_smoke_test:
+  solvers:
+    - orcaflex
+    - aqwa
+  # null => write the report straight into Analysis.result_folder. Setting this
+  # to "results" would nest a second results/ inside it.
+  output_directory: null
+  require_all: True
+  keep_scratch: False
+
+file_management:
+  flag: False
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: True
+    cfg_sensitivities: False

--- a/src/digitalmodel/engine.py
+++ b/src/digitalmodel/engine.py
@@ -831,6 +831,13 @@ def engine(
         from digitalmodel.solvers.openfoam.workflow import OpenFOAMWorkflow
 
         cfg_base = OpenFOAMWorkflow().router(cfg_base)
+    elif basename == "solver_smoke_test":
+        # End-to-end OrcaFlex/AQWA licence-checkout probe, so a licensed host can
+        # be asked "can you actually solve right now?" through the same lane
+        # command as a real run. NEW basename; the solver arms are untouched.
+        from digitalmodel.solvers.smoke.workflow import SolverSmokeTestWorkflow
+
+        cfg_base = SolverSmokeTestWorkflow().router(cfg_base)
     else:
         raise (Exception(f"Analysis for basename: {basename} not found. ... FAIL"))
 

--- a/src/digitalmodel/solvers/smoke/__init__.py
+++ b/src/digitalmodel/solvers/smoke/__init__.py
@@ -1,0 +1,1 @@
+"""Solver smoke tests — end-to-end licence-checkout probes for licensed hosts."""

--- a/src/digitalmodel/solvers/smoke/probes.py
+++ b/src/digitalmodel/solvers/smoke/probes.py
@@ -1,0 +1,196 @@
+"""End-to-end solver licence probes shared by the CLI script and the engine arm.
+
+Each probe *solves something small* rather than just checking that a binding
+imports — licence checkout is the failure mode that matters on a licensed host,
+and only an actual solve exercises it.
+
+Kept dependency-light at module import: the solver imports happen inside the
+probe functions so this module is importable on hosts with neither solver.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import time
+import traceback
+from pathlib import Path
+
+# .../src/digitalmodel/solvers/smoke/probes.py -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# The AQWA probe reuses the repo-managed acceptance fixture (5-panel unit box,
+# 3 frequencies x 3 headings) so the deck stays small and self-contained.
+AQWA_SPEC = (
+    REPO_ROOT
+    / "tests"
+    / "hydrodynamics"
+    / "diffraction"
+    / "fixtures"
+    / "acceptance_610"
+    / "spec.yml"
+)
+
+
+def _result(solver: str, ok: bool, **detail) -> dict:
+    return {"solver": solver, "ok": ok, **detail}
+
+
+def check_orcaflex(work_dir: Path) -> dict:
+    """Import OrcFxAPI, solve statics, run a short dynamic sim, round-trip files."""
+    detail: dict = {}
+    start = time.monotonic()
+    try:
+        import OrcFxAPI
+    except Exception as exc:
+        return _result(
+            "orcaflex", False, stage="import", error=f"{type(exc).__name__}: {exc}"
+        )
+
+    detail["module"] = getattr(OrcFxAPI, "__file__", None)
+    try:
+        detail["dll_version"] = OrcFxAPI.DLLVersion()
+    except Exception as exc:  # pragma: no cover - version call is advisory
+        detail["dll_version"] = f"unavailable ({exc})"
+
+    try:
+        model = OrcFxAPI.Model()
+        line = model.CreateObject(OrcFxAPI.otLine, "SmokeTestLine")
+        line.EndAX, line.EndAY, line.EndAZ = 0.0, 0.0, 0.0
+        line.EndBX, line.EndBY, line.EndBZ = 50.0, 0.0, -30.0
+        line.Length[0] = 70.0
+        line.TargetSegmentLength[0] = 5.0
+
+        # Statics proves the solver core and the licence checkout.
+        model.CalculateStatics()
+        detail["statics_state"] = str(model.state)
+        detail["static_tension_kN"] = round(
+            float(line.StaticResult("Effective Tension", OrcFxAPI.oeEndA)), 3
+        )
+
+        # A short dynamic sim exercises the time-domain path as well.
+        model.general.StageDuration = [4.0, 8.0]
+        model.environment.WaveType = "Airy"
+        model.environment.WaveHeight = 2.0
+        model.environment.WavePeriod = 8.0
+        model.RunSimulation()
+        detail["simulation_state"] = str(model.state)
+
+        history = line.TimeHistory(
+            "Effective Tension", OrcFxAPI.Period(1), OrcFxAPI.oeEndA
+        )
+        detail["dynamic_samples"] = int(len(history))
+        detail["dynamic_tension_kN"] = [
+            round(float(history.min()), 3),
+            round(float(history.max()), 3),
+        ]
+
+        # File I/O round trip - catches a broken install that still solves.
+        work_dir.mkdir(parents=True, exist_ok=True)
+        dat = work_dir / "smoke.dat"
+        sim = work_dir / "smoke.sim"
+        model.SaveData(dat)
+        OrcFxAPI.Model(dat)
+        model.SaveSimulation(sim)
+        detail["sim_bytes"] = sim.stat().st_size
+    except Exception as exc:
+        detail.update(
+            stage="solve",
+            error=f"{type(exc).__name__}: {exc}",
+            traceback=traceback.format_exc(limit=5),
+        )
+        return _result("orcaflex", False, **detail)
+
+    detail["elapsed_s"] = round(time.monotonic() - start, 1)
+    return _result("orcaflex", True, **detail)
+
+
+def check_aqwa(work_dir: Path) -> dict:
+    """Run the acceptance diffraction deck through AQWARunner and require rc=0."""
+    detail: dict = {}
+    start = time.monotonic()
+    try:
+        from digitalmodel.hydrodynamics.diffraction.aqwa_runner import (
+            AQWARunConfig,
+            AQWARunner,
+            WINDOWS_AQWA_CANDIDATES,
+        )
+        from digitalmodel.hydrodynamics.diffraction.input_schemas import (
+            DiffractionSpec,
+        )
+    except Exception as exc:
+        return _result(
+            "aqwa", False, stage="import", error=f"{type(exc).__name__}: {exc}"
+        )
+
+    executable = next((p for p in WINDOWS_AQWA_CANDIDATES if Path(p).exists()), None)
+    detail["executable"] = executable
+    detail["licence_env"] = {
+        key: os.environ.get(key)
+        for key in ("ANSYSLMD_LICENSE_FILE", "ANSYSLI_SERVERS")
+    }
+    if executable is None:
+        return _result(
+            "aqwa",
+            False,
+            stage="detect",
+            error="no Aqwa.exe found on any known install path",
+            **detail,
+        )
+
+    if not AQWA_SPEC.exists():
+        return _result(
+            "aqwa",
+            False,
+            stage="fixture",
+            error=f"acceptance spec missing: {AQWA_SPEC}",
+            **detail,
+        )
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        spec = DiffractionSpec.from_yaml(AQWA_SPEC)
+        runner = AQWARunner(
+            AQWARunConfig(output_dir=work_dir, dry_run=False, timeout_seconds=900)
+        )
+        run = runner.run(spec, spec_path=AQWA_SPEC)
+    except Exception as exc:
+        detail.update(
+            stage="solve",
+            error=f"{type(exc).__name__}: {exc}",
+            traceback=traceback.format_exc(limit=5),
+        )
+        return _result("aqwa", False, **detail)
+
+    status = str(getattr(run.status, "name", run.status))
+    detail["status"] = status
+    detail["return_code"] = getattr(run, "return_code", None)
+    detail["error_message"] = run.error_message
+    detail["elapsed_s"] = round(time.monotonic() - start, 1)
+
+    # A DRY_RUN status means the runner silently fell back to not solving - that
+    # is a failure here even though the call itself succeeded.
+    listing = [p.name for p in work_dir.rglob("*") if p.is_file()]
+    detail["produced_lis"] = any(n.upper().endswith(".LIS") for n in listing)
+    ok = status == "COMPLETED" and detail["produced_lis"]
+    return _result("aqwa", ok, **detail)
+
+
+CHECKS = {"orcaflex": check_orcaflex, "aqwa": check_aqwa}
+
+
+def run_probes(solvers, work_root: Path, include_host: bool = False) -> dict:
+    """Run the named probes under ``work_root`` and return the report dict."""
+    results = []
+    for name in solvers:
+        results.append(CHECKS[name](Path(work_root) / name))
+    report = {
+        "python": sys.executable,
+        "results": results,
+        "ok": all(r["ok"] for r in results),
+    }
+    # Hostnames are private deployment data in this fleet - opt in explicitly.
+    if include_host:
+        report["host"] = platform.node()
+    return report

--- a/src/digitalmodel/solvers/smoke/workflow.py
+++ b/src/digitalmodel/solvers/smoke/workflow.py
@@ -1,0 +1,102 @@
+"""Engine router for the solver smoke test (``basename: solver_smoke_test``).
+
+Makes the OrcaFlex/AQWA end-to-end licence probe in
+``scripts/solver_smoke_test.py`` reachable through the fixed licensed-run lane
+command ``uv run python -m digitalmodel <input.yml>``, so a licensed host can be
+asked "can you actually solve right now?" without an operator on the console.
+
+This exists because a *readiness* check is not enough. ``orcawave-doctor`` and
+``openfoam doctor`` confirm a binding imports and an executable exists; neither
+proves the licence can be checked out, which is the failure that actually stops
+a run. It also matters that this runs *inside the agent's session*: OrcaFlex
+licence checkout fails under an SSH public-key logon token even though the
+environment, registry and licence-server reachability are identical, so a
+remote SSH probe cannot answer the question for OrcaFlex. The lane can.
+
+Input contract::
+
+    basename: solver_smoke_test
+    solver_smoke_test:
+      solvers: [orcaflex, aqwa]   # subset to probe; default both
+      output_directory: null      # relative to Analysis.result_folder; null = it
+      require_all: true           # false -> report failures without raising
+      keep_scratch: false         # true -> retain the solve scratch dir for triage
+
+Fail-closed, matching the ANSYS/OpenFOAM routers: any probed solver that cannot
+solve raises, so the lane records a real failure instead of a false finish.
+The report is written as ``solver_smoke_test.json`` under the output directory,
+which is where the lane's ``result_return`` collector picks small JSON up from.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SOLVERS = ("orcaflex", "aqwa")
+
+
+class SolverSmokeTestWorkflow:
+    def router(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        settings = cfg.setdefault("solver_smoke_test", {})
+
+        solvers = settings.get("solvers") or list(DEFAULT_SOLVERS)
+        if isinstance(solvers, str):
+            solvers = [solvers]
+        unknown = [s for s in solvers if s not in DEFAULT_SOLVERS]
+        if unknown:
+            raise ValueError(
+                f"Unknown solver(s) in solver_smoke_test.solvers: {unknown}. "
+                f"Supported: {', '.join(DEFAULT_SOLVERS)}"
+            )
+
+        output_dir = self._resolve_output_dir(cfg, settings)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Lazy import: the probe pulls in OrcFxAPI and the diffraction stack, and
+        # the engine must stay importable on hosts that have neither.
+        from digitalmodel.solvers.smoke.probes import run_probes
+
+        # Solve scratch (.sim/.dat/.LIS, plus the AQWA validator's own JSON) is
+        # deliberately kept OUT of the results folder. The lane's result_return
+        # collector walks that folder recursively and ships small JSON back
+        # through the queue; scratch there would return validator noise as if it
+        # were a result, and strand heavy licensed artifacts in a returned tree.
+        keep_scratch = settings.get("keep_scratch", False)
+        scratch_root = tempfile.mkdtemp(prefix="solver_smoke_")
+        try:
+            report = run_probes(solvers, Path(scratch_root))
+            if keep_scratch:
+                settings["scratch_dir"] = scratch_root
+        finally:
+            if not keep_scratch:
+                shutil.rmtree(scratch_root, ignore_errors=True)
+
+        report_path = output_dir / "solver_smoke_test.json"
+        report_path.write_text(json.dumps(report, indent=2, default=str))
+
+        settings["report_path"] = str(report_path)
+        settings["report"] = report
+
+        if settings.get("require_all", True) and not report["ok"]:
+            failed = [r["solver"] for r in report["results"] if not r["ok"]]
+            raise RuntimeError(
+                f"Solver smoke test FAILED for: {', '.join(failed)}. "
+                f"Report: {report_path}"
+            )
+        return cfg
+
+    @staticmethod
+    def _resolve_output_dir(cfg: dict[str, Any], settings: dict[str, Any]) -> Path:
+        result_folder = cfg.get("Analysis", {}).get("result_folder")
+        base_dir = Path(result_folder) if result_folder else Path.cwd()
+        output = settings.get("output_directory")
+        if output is None:
+            return base_dir.resolve()
+        output_dir = Path(output)
+        if output_dir.is_absolute():
+            return output_dir.resolve()
+        return (base_dir / output_dir).resolve()


### PR DESCRIPTION
Closes #1943.

Adds a licence-**checkout** probe for licensed hosts. The existing readiness diagnostics (`orcawave-doctor`, `openfoam doctor`) only confirm a binding imports and an executable exists, so they pass on a host whose licence server is unreachable — the failure that actually stops a run. There was no OrcaFlex or AQWA equivalent at all.

Each probe solves something small:
- **OrcaFlex** — build a line in memory, `CalculateStatics()`, a short Airy dynamic sim, then a `.dat`/`.sim` round trip.
- **AQWA** — run the repo-managed `acceptance_610` fixture through `AQWARunner`; require `COMPLETED` + rc 0 + a real `.LIS`. A `DRY_RUN` status counts as failure, since the runner falls back to it silently when it finds no executable.

Two entry points share the same probe functions so they cannot drift: `scripts/solver_smoke_test.py` (CLI) and `basename: solver_smoke_test` (engine arm, for the licensed-run lane). The engine arm is fail-closed like the ANSYS/OpenFOAM routers, so the lane cannot record a false finish. Solve scratch goes to a temp dir rather than the results folder — left there, the lane result collector would ship the AQWA validator's own JSON back as if it were a result and strand heavy licensed artifacts in a returned tree.

`engine.py` gains one additive `elif`; no existing arm is touched.

### Verified on a licensed host
- CLI both solvers: PASS, exit 0. Failure path (shimmed broken `OrcFxAPI`): exit 1, clean JSON.
- `python -m digitalmodel input.yml` and the lane's real `uv run` form: exit 0, writes only `results/solver_smoke_test.json`.
- Fail-closed guard raises naming the failed solver.
- `test_aqwa_runner.py` + `test_aqwa_backend.py`: 109 passed.
- Re-run after rebasing onto 118 newer commits: both solvers still PASS, identical values.

OrcaFlex 11.6c statics 45.080 kN, 81-sample dynamic history 44.644–46.092 kN. AQWA v261 `COMPLETED` rc 0, ~20 s.