### PR TITLE
fix(subsea): quarantine the non-functional lazy-wave analyzer

### DIFF
--- a/src/digitalmodel/subsea/catenary_riser/cli.py
+++ b/src/digitalmodel/subsea/catenary_riser/cli.py
@@ -214,9 +214,15 @@ def lazy_wave_analysis(diameter, thickness, length, water_depth, offset, materia
             buoyancy_modules=[buoy_module],
         )
 
-        # Analyze
+        # Analyze. The analyzer is quarantined — it never solved a lazy-wave catenary and
+        # returned hardcoded geometry that was invariant to buoyancy configuration. Fail
+        # with its explanation rather than an unhandled traceback, so the operator learns
+        # why and where to go instead.
         analyzer = LazyWaveAnalyzer()
-        result = analyzer.analyze(config)
+        try:
+            result = analyzer.analyze(config)
+        except NotImplementedError as exc:
+            raise click.ClickException(str(exc)) from exc
 
         # Output
         click.echo("\n=== Lazy Wave Riser Analysis ===\n")

--- a/src/digitalmodel/subsea/catenary_riser/lazy_wave.py
+++ b/src/digitalmodel/subsea/catenary_riser/lazy_wave.py
@@ -52,7 +52,30 @@ class LazyWaveAnalyzer:
 
         Returns:
             LazyWaveResult with geometry and forces
+
+        Raises:
+            NotImplementedError: always. See the quarantine note below.
         """
+        raise NotImplementedError(
+            "LazyWaveAnalyzer.analyze() is quarantined: it never solved a lazy-wave "
+            "catenary. It returned hardcoded fractions of water depth (sag = 0.35 x "
+            "depth, hog = 0.20 x depth), hardcoded tension ratios (0.4 / 0.6 of baseline "
+            "top tension) and hardcoded bend angles (45 deg / 30 deg). The buoyancy "
+            "weight was computed and never read, so buoyancy configuration had NO effect "
+            "on the result -- three wildly different buoyancy configurations produced "
+            "bit-identical output.\n\n"
+            "Use digitalmodel.marine_ops.marine_analysis.catenary.LazyWaveSolver, which "
+            "implements the 5-segment closed-form construction and is differentially "
+            "tested against the legacy solver.\n\n"
+            "Quarantined rather than deleted so that callers fail loudly with this "
+            "explanation instead of silently receiving invented geometry. See "
+            "tests/subsea/catenary_riser/test_lazy_wave_quarantine.py."
+        )
+
+        # ------------------------------------------------------------------
+        # UNREACHABLE — retained only as the record of what was being returned.
+        # Do not revive. Reimplement against LazyWaveSolver instead.
+        # ------------------------------------------------------------------
         riser = config.riser
 
         # Get effective weight profile

--- a/tests/subsea/catenary_riser/test_catenary_riser_cli.py
+++ b/tests/subsea/catenary_riser/test_catenary_riser_cli.py
@@ -178,10 +178,12 @@ class TestLazyWaveCommand:
             '--buoy-start', '300',
         ])
 
-        assert result.exit_code == 0
-        assert 'Lazy Wave Riser Analysis' in result.output
-        assert 'Sag Bend Depth' in result.output
-        assert 'Hog Bend Depth' in result.output
+        # QUARANTINED: the lazy-wave analyzer returned hardcoded geometry invariant to
+        # buoyancy configuration. The command must now fail cleanly with the explanation
+        # rather than print invented numbers or raise a traceback.
+        assert result.exit_code != 0
+        assert 'quarantined' in result.output.lower()
+        assert 'LazyWaveSolver' in result.output
 
     def test_lazy_wave_output_file(self, runner, temp_output_file):
         """Test lazy wave with JSON output"""
@@ -195,13 +197,15 @@ class TestLazyWaveCommand:
             '--output', temp_output_file,
         ])
 
-        assert result.exit_code == 0
+        # QUARANTINED: must fail before writing anything. Persisting fabricated geometry
+        # to a JSON file is the worst outcome of the three — it outlives the session and
+        # carries no indication that the numbers were invented.
+        assert result.exit_code != 0
+        assert 'quarantined' in result.output.lower()
 
         with open(temp_output_file, 'r') as f:
-            data = json.load(f)
-
-        assert 'sag_bend_depth_m' in data
-        assert 'arch_height_m' in data
+            contents = f.read().strip()
+        assert contents == '', 'no output file should be written when the analysis refuses'
 
 
 # ============================================================================

--- a/tests/subsea/catenary_riser/test_catenary_riser_unit.py
+++ b/tests/subsea/catenary_riser/test_catenary_riser_unit.py
@@ -345,13 +345,13 @@ class TestLazyWave:
             buoyancy_modules=[buoy_module],
         )
 
-        analyzer = LazyWaveAnalyzer()
-        result = analyzer.analyze(config)
-
-        assert result.sag_bend_depth > 0
-        assert result.hog_bend_depth > 0
-        assert result.arch_height > 0
-        assert result.sag_bend_depth > result.hog_bend_depth
+        # QUARANTINED. This previously asserted sag_bend_depth > hog_bend_depth, which
+        # was true by construction: the implementation returned 0.35 * water_depth and
+        # 0.20 * water_depth as literals. The assertion held for any positive depth and
+        # would have passed with the physics deleted -- which, in effect, it was.
+        # Full contract: tests/subsea/catenary_riser/test_lazy_wave_quarantine.py
+        with pytest.raises(NotImplementedError):
+            LazyWaveAnalyzer().analyze(config)
 
     def test_weight_profile(self, basic_riser):
         """Test weight profile with buoyancy"""
@@ -390,10 +390,11 @@ class TestLazyWave:
             buoyancy_modules=[buoy_module],
         )
 
-        analyzer = LazyWaveAnalyzer()
-        result = analyzer.analyze(config)
-
-        assert 0 <= result.buoyancy_utilization <= 1.0
+        # QUARANTINED. This previously asserted 0 <= buoyancy_utilization <= 1.0, which
+        # was guaranteed by a min(1.0, ...) in the implementation -- a tautology, not a
+        # property of any lazy-wave physics.
+        with pytest.raises(NotImplementedError):
+            LazyWaveAnalyzer().analyze(config)
 
 
 # ============================================================================

--- a/tests/subsea/catenary_riser/test_lazy_wave_quarantine.py
+++ b/tests/subsea/catenary_riser/test_lazy_wave_quarantine.py
@@ -1,0 +1,94 @@
+"""Quarantine contract for the non-functional lazy-wave analyzer.
+
+`subsea.catenary_riser.LazyWaveAnalyzer` never solved a lazy-wave catenary. It returned
+hardcoded fractions of water depth (sag = 0.35 x depth, hog = 0.20 x depth), hardcoded
+tension ratios (0.4 / 0.6 of baseline top tension) and hardcoded bend angles
+(45 deg / 30 deg, commented "Rough estimate"). The buoyancy weight was computed and then
+never read, so **buoyancy configuration had no effect whatsoever on the result**.
+
+Its previous tests passed because they asserted properties true by construction --
+`sag_bend_depth > hog_bend_depth` holds for any positive water depth given 0.35 > 0.20,
+and `0 <= buoyancy_utilization <= 1` was guaranteed by a `min(1.0, ...)`. They would have
+passed with the physics deleted, because in effect it was.
+
+Why this matters beyond tidiness: an optimiser searching buoyancy configurations against
+this analyzer sees a perfectly flat objective. It returns whatever it started with and
+reports convergence. That is worse than a crash -- it is a confident wrong answer, and it
+is exactly what the SLWR buoyancy work would have run into.
+
+The real solver is `digitalmodel.marine_ops.marine_analysis.catenary.LazyWaveSolver`.
+"""
+
+import pytest
+
+from digitalmodel.subsea.catenary_riser import (
+    PRODUCTION_OIL,
+    STEEL_API_5L_X65,
+    BuoyancyModule,
+    LazyWaveAnalyzer,
+    LazyWaveConfiguration,
+    RiserConfiguration,
+)
+
+
+@pytest.fixture
+def basic_riser():
+    return RiserConfiguration(
+        name="TestRiser",
+        outer_diameter=0.508,
+        wall_thickness=0.025,
+        length=1500.0,
+        material=STEEL_API_5L_X65,
+        internal_fluid=PRODUCTION_OIL,
+        water_depth=1000.0,
+        horizontal_offset=500.0,
+    )
+
+
+def _config(riser, *, length, outer_diameter, density):
+    return LazyWaveConfiguration(
+        riser=riser,
+        buoyancy_modules=[
+            BuoyancyModule(
+                name="Buoy",
+                length=length,
+                outer_diameter=outer_diameter,
+                buoyancy_material_density=density,
+                start_length=300.0,
+            )
+        ],
+    )
+
+
+def test_analyzer_refuses_rather_than_fabricating(basic_riser):
+    """It must fail loudly, not return numbers it did not compute.
+
+    A caller who gets a populated result object has no way to know the geometry was
+    invented. Raising is the only honest behaviour until a real solve exists here.
+    """
+    config = _config(basic_riser, length=200.0, outer_diameter=1.5, density=500)
+
+    with pytest.raises(NotImplementedError) as exc:
+        LazyWaveAnalyzer().analyze(config)
+
+    # The error must route the caller somewhere useful, not just refuse.
+    assert "LazyWaveSolver" in str(exc.value)
+
+
+def test_buoyancy_invariance_is_no_longer_reachable(basic_riser):
+    """Regression guard on the defect itself.
+
+    Previously these three wildly different buoyancy configurations produced
+    bit-identical output. If `analyze` is ever reimplemented, this test must be rewritten
+    to assert that the results actually DIFFER -- not deleted. Until then, the quarantine
+    is what makes the invariance unreachable.
+    """
+    configs = [
+        _config(basic_riser, length=50.0, outer_diameter=0.35, density=900),
+        _config(basic_riser, length=300.0, outer_diameter=0.65, density=450),
+        _config(basic_riser, length=800.0, outer_diameter=1.50, density=200),
+    ]
+
+    for config in configs:
+        with pytest.raises(NotImplementedError):
+            LazyWaveAnalyzer().analyze(config)


### PR DESCRIPTION
Closes #1949. Prerequisite for #1947.

## The defect

`LazyWaveAnalyzer.analyze()` never solved a lazy-wave catenary. It returned hardcoded fractions of water depth (sag 0.35×, hog 0.20×), hardcoded tension ratios, and hardcoded bend angles commented *"Rough estimate"*. `buoy_weight` was assigned and **never read**, so buoyancy configuration had no effect on the output.

Verified by execution — three configurations spanning OD 0.35→1.50, density 200→900, length 50→800 produced **bit-identical results**.

## Why it survived

Its tests asserted properties true by construction: `sag_bend_depth > hog_bend_depth` holds for any positive depth given 0.35 > 0.20, and `0 <= buoyancy_utilization <= 1` was guaranteed by a `min(1.0, ...)`. Both would have passed with the physics deleted.

## Why now

An optimiser searching buoyancy against this analyzer sees a **perfectly flat objective** — it returns its starting point and reports convergence. A confident wrong answer, not a crash. #1947 would have run straight into it.

## Approach — quarantine, not delete

`analyze()` raises `NotImplementedError` carrying the full explanation and routing to `marine_ops.marine_analysis.catenary.LazyWaveSolver`. Deleting would remove the record and leave callers a bare import error with no explanation.

The CLI converts it to a `ClickException` — clean failure, no traceback, **and no JSON file written**. Persisting fabricated geometry to disk is the worst outcome: it outlives the session carrying no sign the numbers were invented.

Both tautological tests now assert the quarantine, annotated with what they previously claimed and why it was vacuous. The new test carries a regression guard: if `analyze()` is reimplemented, the buoyancy-invariance test must be **rewritten to assert results differ** — not deleted.

## Verification

- **69 passed** — `tests/subsea/catenary_riser/` + `tests/specialized/cli/test_catenary_riser_cli.py`
- **277 passed** across all lazy-wave/catenary selected tests
- 4 `mooring_analysis` CLI failures and 2 `workflow_api` collection errors confirmed **pre-existing** by re-running with the change stashed

## Not in this PR

Three further kernel defects from the same audit, all in `marine_ops/marine_analysis/catenary/lazy_wave.py` and listed in #1949: `abs()` sign-blindness on `weight_with_buoyancy`, dead `vertical_distance` (no water-depth closure), and `hangoff_bend_radius` as an independent input rather than derived (5.5× arc-length divergence in the shipped fixture).