### PR TITLE
fix(catenary): repair three SLWR geometry-kernel defects (#1949)

### DIFF
--- a/examples/domains/mooring/lazy_wave_example.py
+++ b/examples/domains/mooring/lazy_wave_example.py
@@ -21,16 +21,21 @@ def main():
     """Run lazy-wave catenary analysis example."""
 
     # Define lazy-wave configuration
-    # This represents a typical deep-water riser with buoyancy modules
+    # This represents a typical deep-water riser with buoyancy modules.
+    #
+    # hangoff_bend_radius is deliberately omitted: it is derived from the hang-off
+    # vertical span (vertical_distance - sag_bend_elevation = 350 m) and the
+    # departure angle, and is not a free parameter. Supplying an inconsistent value
+    # is rejected -- earlier revisions of this example passed 2000 m against a
+    # derived 122 m, which silently inflated the horizontal force (issue #1949).
     config = LazyWaveConfiguration(
-        hangoff_angle=15.0,              # Departure angle from vessel [degrees]
-        hangoff_below_msl=50.0,          # Hang-off depth [m]
+        hangoff_angle=15.0,              # Departure angle from vertical [degrees]
+        hangoff_below_msl=50.0,          # Hang-off below MSL [m] (reporting datum)
         hog_bend_above_seabed=300.0,     # Hog bend elevation [m]
         sag_bend_elevation=150.0,        # Sag bend elevation [m]
-        weight_without_buoyancy=1000.0,  # Bare riser weight [N/m]
+        weight_without_buoyancy=1000.0,  # Bare riser weight [N/m] (positive)
         weight_with_buoyancy=-500.0,     # With buoyancy modules [N/m] (negative)
-        vertical_distance=500.0,         # Total vertical span [m]
-        hangoff_bend_radius=2000.0       # Initial bend radius [m]
+        vertical_distance=500.0,         # Hang-off down to seabed [m]
     )
 
     print("="*60)
@@ -38,12 +43,14 @@ def main():
     print("="*60)
     print("\nConfiguration:")
     print(f"  Hang-off angle: {config.hangoff_angle}°")
-    print(f"  Hang-off depth: {config.hangoff_below_msl} m")
+    print(f"  Hang-off below MSL: {config.hangoff_below_msl} m (datum only)")
+    print(f"  Hang-off to seabed: {config.vertical_distance} m")
     print(f"  Hog bend elevation: {config.hog_bend_above_seabed} m")
     print(f"  Sag bend elevation: {config.sag_bend_elevation} m")
     print(f"  Bare riser weight: {config.weight_without_buoyancy} N/m")
     print(f"  With buoyancy: {config.weight_with_buoyancy} N/m")
-    print(f"  Bend radius: {config.hangoff_bend_radius} m")
+    print(f"  Hang-off span: {config.hangoff_vertical_span} m (derived)")
+    print(f"  Bend radius: {config.hangoff_bend_radius:.3f} m (derived)")
 
     # Solve lazy-wave catenary
     solver = LazyWaveSolver()
@@ -63,6 +70,7 @@ def main():
     print("\nOverall Geometry:")
     print(f"  Total arc length:        {results.total_arc_length:,.1f} m")
     print(f"  Total horizontal dist:   {results.total_horizontal_distance:,.1f} m")
+    print(f"  Water-depth closure err: {results.vertical_closure_error:.3e} m")
 
     # Segment breakdown
     print("\nSegment Breakdown:")

--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/__init__.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/__init__.py
@@ -33,8 +33,10 @@ except ImportError:
 from .lazy_wave import (
     LazyWaveSolver,
     LazyWaveConfiguration,
+    LazyWaveConfigurationError,
     LazyWaveResults,
-    LazyWaveSegment
+    LazyWaveSegment,
+    derive_hangoff_bend_radius
 )
 
 # Import legacy compatibility adapter
@@ -53,8 +55,10 @@ __all__ = [
     # Lazy-Wave API
     'LazyWaveSolver',
     'LazyWaveConfiguration',
+    'LazyWaveConfigurationError',
     'LazyWaveResults',
     'LazyWaveSegment',
+    'derive_hangoff_bend_radius',
     # Legacy API (deprecated)
     'catenaryEquation',
     'catenaryForces',

--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/lazy_wave.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/lazy_wave.py
@@ -18,9 +18,48 @@ Lazy-wave risers use buoyancy modules to create a wave-like configuration:
 3. Touchdown: Final catenary section to seabed
 
 The configuration is solved by:
-- Computing bend radii based on weight ratios
+- Deriving the hang-off bend radius from the hang-off vertical span and departure angle
+- Computing the remaining bend radii from weight ratios
 - Calculating arc lengths and horizontal distances for each segment
 - Summing total forces and geometry
+
+Water-depth closure
+-------------------
+The construction closes on the seabed exactly, by definition of the hang-off span
+rather than by iteration. With the hang-off point taken as the vertical datum and
+the seabed ``vertical_distance`` below it, the five segment spans are::
+
+    d1 = vertical_distance - sag_bend_elevation            (down: hang-off -> sag bend)
+    d2 = (hog - sag) * |w_b| / (|w_b| + w)                 (up:   sag bend -> buoyancy)
+    d3 = (hog - sag) * w     / (|w_b| + w)                 (up:   buoyancy -> hog bend)
+    d4 = hog * w     / (|w_b| + w)                         (down: hog bend -> buoyancy)
+    d5 = hog * |w_b| / (|w_b| + w)                         (down: buoyancy -> touchdown)
+
+so that ``d2 + d3 == hog - sag`` and ``d4 + d5 == hog``, and the net descent
+
+    d1 - d2 - d3 + d4 + d5 == vertical_distance
+
+identically. Setting ``d1`` to anything other than ``vertical_distance -
+sag_bend_elevation`` breaks closure and returns a riser that never reaches bottom;
+``LazyWaveResults.vertical_closure_error`` reports the residual and the solver
+refuses to return a configuration that does not close (issue #1949, defect 2).
+
+Sign convention
+---------------
+``weight_without_buoyancy`` (w) is the submerged weight of the bare riser and is
+positive (net downward). ``weight_with_buoyancy`` (w_b) is the net effective weight
+over the buoyed length and must be negative (net upward) -- that is what makes the
+hog bend arc upward. A non-negative w_b describes a "buoyed" section that is still
+net-heavy: no hog bend can form and there is no lazy-wave configuration to report.
+Such a configuration is rejected rather than silently folded onto its mirror image
+by ``abs()`` (issue #1949, defect 1).
+
+Hang-off bend radius
+--------------------
+There is exactly one bend radius at hang-off and it is *derived* from the hang-off
+vertical span and the departure angle. It is reused verbatim for the sag and
+touchdown segments and for the force balance. It is not a free input; supplying an
+inconsistent value is rejected (issue #1949, defect 3).
 
 References:
 ----------
@@ -28,9 +67,64 @@ Legacy implementation: catenaryMethods.py sagHogEquation (lines 93-153)
                       catenaryMethods.py lazyWaveCatenaryEquation (lines 156-194)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 import math
+
+
+#: Relative tolerance when checking a caller-supplied hang-off bend radius against
+#: the value derived from (vertical span, departure angle).
+BEND_RADIUS_REL_TOL = 1e-6
+
+#: Absolute tolerance [m] on the water-depth closure residual. The construction is
+#: exact, so this only guards against future regressions and float accumulation.
+CLOSURE_ABS_TOL = 1e-6
+
+
+class LazyWaveConfigurationError(ValueError):
+    """A lazy-wave configuration is not physically realisable.
+
+    Raised at construction time so that an invalid configuration can never reach
+    the solver. Optimisers searching buoyancy configurations (issue #1947) should
+    catch this and score the candidate infeasible rather than treat it as a crash.
+    """
+
+
+def derive_hangoff_bend_radius(vertical_span: float, hangoff_angle: float) -> float:
+    """Bend radius of the hang-off catenary section.
+
+    The catenary through a departure angle ``q`` from the vertical, descending a
+    vertical span ``d``, has bend radius::
+
+        R = d * cos(90 - q) / (1 - cos(90 - q))
+
+    This is the only bend radius at hang-off; the sag and touchdown segments reuse
+    it and the force balance is built on it.
+
+    Parameters:
+        vertical_span (float): Vertical drop from hang-off to the sag bend [m].
+        hangoff_angle (float): Departure angle from the vertical [degrees].
+
+    Returns:
+        float: Bend radius [m].
+
+    Raises:
+        LazyWaveConfigurationError: If the span or angle is outside the valid range.
+    """
+    if not 0.0 < hangoff_angle < 90.0:
+        raise LazyWaveConfigurationError(
+            f"hangoff_angle must be strictly between 0 and 90 degrees from the "
+            f"vertical, got {hangoff_angle}."
+        )
+    if vertical_span <= 0.0:
+        raise LazyWaveConfigurationError(
+            f"hang-off vertical span must be positive, got {vertical_span}. The "
+            f"hang-off point must sit above the sag bend."
+        )
+
+    angle_rad = math.radians(90.0 - hangoff_angle)
+    cos_angle = math.cos(angle_rad)
+    return vertical_span * cos_angle / (1.0 - cos_angle)
 
 
 @dataclass
@@ -56,16 +150,35 @@ class LazyWaveSegment:
 class LazyWaveConfiguration:
     """Complete lazy-wave riser configuration.
 
+    Validated on construction: an instance of this class is always a physically
+    realisable lazy-wave configuration that closes on the seabed. Invalid input
+    raises :class:`LazyWaveConfigurationError`.
+
     Attributes:
-        hangoff_angle (float): Departure angle from vessel [degrees]
-        hangoff_below_msl (float): Hang-off depth below mean sea level [m]
-        hog_bend_above_seabed (float): Hog bend elevation above seabed [m]
-        sag_bend_elevation (float): Sag bend elevation above seabed [m]
-        weight_without_buoyancy (float): Bare riser weight per length w [N/m]
-        weight_with_buoyancy (float): Effective weight with buoyancy modules w_buoy [N/m]
-                                     (typically negative)
-        vertical_distance (float): Total vertical span (hang-off to seabed) [m]
-        hangoff_bend_radius (float): Initial bend radius at hang-off [m]
+        hangoff_angle (float): Departure angle from the vertical at the vessel
+            [degrees]. Strictly between 0 and 90.
+        hangoff_below_msl (float): Depth of the hang-off point below mean sea level
+            [m]. This is a *reporting datum* used to place the configuration
+            relative to the waterline; it is not a catenary span and does not enter
+            the geometry solve. The vertical span that does is
+            ``vertical_distance``.
+        hog_bend_above_seabed (float): Hog bend elevation above seabed [m]. Must
+            exceed ``sag_bend_elevation``.
+        sag_bend_elevation (float): Sag bend elevation above seabed [m]. Must be
+            positive and below the hang-off point.
+        weight_without_buoyancy (float): Submerged weight per length of the bare
+            riser w [N/m]. Must be positive (net downward).
+        weight_with_buoyancy (float): Net effective weight per length over the
+            buoyed length w_buoy [N/m]. Must be negative (net upward) -- see the
+            module docstring on the sign convention.
+        vertical_distance (float): Vertical span from the hang-off point down to
+            the seabed [m]. Drives the hang-off section and the water-depth
+            closure. Must exceed ``sag_bend_elevation``.
+        hangoff_bend_radius (Optional[float]): Bend radius at hang-off [m].
+            Derived from (``vertical_distance - sag_bend_elevation``,
+            ``hangoff_angle``) when omitted, which is the normal usage. If a value
+            is supplied it is checked against the derived one and an inconsistent
+            value is rejected -- it is a cross-check, not a free parameter.
     """
     hangoff_angle: float
     hangoff_below_msl: float
@@ -74,7 +187,80 @@ class LazyWaveConfiguration:
     weight_without_buoyancy: float
     weight_with_buoyancy: float
     vertical_distance: float
-    hangoff_bend_radius: float
+    hangoff_bend_radius: Optional[float] = None
+
+    @property
+    def hangoff_vertical_span(self) -> float:
+        """Vertical drop from the hang-off point to the sag bend [m].
+
+        This is the closure identity: the hang-off section must descend exactly far
+        enough to land on a sag bend sitting ``sag_bend_elevation`` above a seabed
+        that is ``vertical_distance`` below the hang-off point.
+        """
+        return self.vertical_distance - self.sag_bend_elevation
+
+    def __post_init__(self) -> None:
+        if self.weight_without_buoyancy <= 0.0:
+            raise LazyWaveConfigurationError(
+                f"weight_without_buoyancy must be positive (the submerged bare riser "
+                f"is net-heavy), got {self.weight_without_buoyancy} N/m."
+            )
+
+        if self.weight_with_buoyancy >= 0.0:
+            raise LazyWaveConfigurationError(
+                f"weight_with_buoyancy must be negative (net buoyant) for a lazy-wave "
+                f"configuration, got {self.weight_with_buoyancy} N/m. A non-negative "
+                f"value describes buoyancy modules that leave the section net-heavy, "
+                f"so no upward hog bend can form and there is no lazy-wave "
+                f"configuration to report. Increase the buoyancy until the net "
+                f"effective weight over the buoyed length is negative."
+            )
+
+        if self.sag_bend_elevation <= 0.0:
+            raise LazyWaveConfigurationError(
+                f"sag_bend_elevation must be positive (the sag bend sits above the "
+                f"seabed), got {self.sag_bend_elevation} m."
+            )
+
+        if self.hog_bend_above_seabed <= self.sag_bend_elevation:
+            raise LazyWaveConfigurationError(
+                f"hog_bend_above_seabed ({self.hog_bend_above_seabed} m) must exceed "
+                f"sag_bend_elevation ({self.sag_bend_elevation} m); the hog bend is "
+                f"the crest of the wave and the sag bend its trough."
+            )
+
+        if self.hangoff_below_msl < 0.0:
+            raise LazyWaveConfigurationError(
+                f"hangoff_below_msl must be non-negative, got "
+                f"{self.hangoff_below_msl} m."
+            )
+
+        if self.hangoff_vertical_span <= 0.0:
+            raise LazyWaveConfigurationError(
+                f"vertical_distance ({self.vertical_distance} m) must exceed "
+                f"sag_bend_elevation ({self.sag_bend_elevation} m). The hang-off "
+                f"point sits {self.hangoff_vertical_span} m above the sag bend, so "
+                f"the configuration cannot close on the seabed."
+            )
+
+        derived = derive_hangoff_bend_radius(
+            vertical_span=self.hangoff_vertical_span,
+            hangoff_angle=self.hangoff_angle,
+        )
+
+        if self.hangoff_bend_radius is not None and not math.isclose(
+            self.hangoff_bend_radius, derived, rel_tol=BEND_RADIUS_REL_TOL
+        ):
+            raise LazyWaveConfigurationError(
+                f"supplied hangoff_bend_radius {self.hangoff_bend_radius} m is "
+                f"inconsistent with the {derived} m derived from a "
+                f"{self.hangoff_vertical_span} m hang-off span at "
+                f"{self.hangoff_angle} degrees. The hang-off bend radius is not a "
+                f"free parameter; omit it and it will be derived."
+            )
+
+        # Single source of truth for every downstream segment and the force balance.
+        self.hangoff_bend_radius = derived
 
 
 @dataclass
@@ -93,6 +279,11 @@ class LazyWaveResults:
         vertical_force (float): Vertical force at hang-off Fv [N]
         segments (List[LazyWaveSegment]): All segments for plotting
         summary (Dict[str, Any]): Summary data matching legacy format
+        vertical_closure_error (float): Residual of the water-depth closure [m] --
+            the net descent of the returned geometry minus the configured
+            ``vertical_distance``. Zero to machine precision for any configuration
+            the solver returns; a non-zero value would mean the riser does not
+            reach the seabed.
     """
     hangoff_to_sag: LazyWaveSegment
     sag_to_buoyancy: LazyWaveSegment
@@ -105,6 +296,7 @@ class LazyWaveResults:
     vertical_force: float
     segments: List[LazyWaveSegment]
     summary: Dict[str, Any]
+    vertical_closure_error: float = 0.0
 
 
 class LazyWaveSolver:
@@ -182,6 +374,25 @@ class LazyWaveSolver:
         total_arc = hangoff_to_buoyancy.arc_length + buoyancy_section.arc_length + buoyancy_to_touchdown.arc_length
         total_horizontal = hangoff_to_buoyancy.horizontal_distance + buoyancy_section.horizontal_distance + buoyancy_to_touchdown.horizontal_distance
 
+        # Step 3b: Water-depth closure check (issue #1949, defect 2).
+        # Net descent from the hang-off point: down over the hang-off, hog-to-buoyancy
+        # and touchdown segments, up over the two segments that climb to the hog bend.
+        net_descent = (
+            hangoff_section.vertical_distance
+            - sag_hog_results['sag_to_buoyancy'].vertical_distance
+            - sag_hog_results['buoyancy_to_hog'].vertical_distance
+            + sag_hog_results['hog_to_buoyancy'].vertical_distance
+            + buoyancy_to_touchdown.vertical_distance
+        )
+        closure_error = net_descent - config.vertical_distance
+        if abs(closure_error) > CLOSURE_ABS_TOL:
+            raise LazyWaveConfigurationError(
+                f"lazy-wave geometry does not close on the seabed: net descent "
+                f"{net_descent} m against a vertical_distance of "
+                f"{config.vertical_distance} m (residual {closure_error} m). "
+                f"Refusing to return a riser that never reaches bottom."
+            )
+
         # Create summary dict matching legacy format
         summary = {
             'HangOffToBuoyancy': {
@@ -201,7 +412,8 @@ class LazyWaveSolver:
                 'X': total_horizontal
             },
             'Fh': Fh,
-            'Fv': Fv
+            'Fv': Fv,
+            'VerticalClosureError': closure_error
         }
 
         # Collect all segments
@@ -224,7 +436,8 @@ class LazyWaveSolver:
             horizontal_force=Fh,
             vertical_force=Fv,
             segments=segments,
-            summary=summary
+            summary=summary,
+            vertical_closure_error=closure_error
         )
 
     def _solve_hangoff_section(self, config: LazyWaveConfiguration) -> LazyWaveSegment:
@@ -240,6 +453,12 @@ class LazyWaveSolver:
             S = BendRadius * tanq
             X = BendRadius * asinh(tanq)
 
+        The vertical span ``d`` is the drop from the hang-off point to the sag bend,
+        ``vertical_distance - sag_bend_elevation``. It is *not* ``hangoff_below_msl``,
+        which positions the hang-off relative to the waterline and plays no part in
+        the geometry (issue #1949, defect 2). The bend radius is the single derived
+        value carried on the configuration (issue #1949, defect 3).
+
         Parameters:
             config (LazyWaveConfiguration): Configuration with hangoff_angle
 
@@ -247,16 +466,16 @@ class LazyWaveSolver:
             LazyWaveSegment: Hang-off section geometry
         """
         q = config.hangoff_angle
-        d = config.hangoff_below_msl
+        d = config.hangoff_vertical_span
 
         # Convert to radians and compute complementary angle
         angle_rad = math.radians(90 - q)
 
         tanq = math.tan(angle_rad)
-        cos_angle = math.cos(angle_rad)
 
-        # Bend radius formula
-        BendRadius = d * cos_angle / (1 - cos_angle)
+        # Derived on the configuration; reused by the sag and touchdown segments
+        # and by the force balance so that one radius governs the whole solution.
+        BendRadius = config.hangoff_bend_radius
 
         # Arc length
         S = BendRadius * tanq
@@ -293,8 +512,16 @@ class LazyWaveSolver:
             Dict with keys: 'sag_to_buoyancy', 'buoyancy_to_hog',
                            'hog_to_buoyancy', 'buoyancy_to_touchdown'
         """
+        # Signs are guaranteed by LazyWaveConfiguration.__post_init__: w > 0 (net
+        # heavy) and w_buoy < 0 (net buoyant). The magnitudes below are therefore
+        # unambiguous, where the previous `abs()` calls silently accepted a
+        # net-heavy "buoyed" section and returned its mirror image (issue #1949,
+        # defect 1). For a valid configuration these are numerically identical to
+        # the legacy expressions, so legacy equivalence is preserved exactly.
         w = config.weight_without_buoyancy
         w_buoy = config.weight_with_buoyancy
+        w_mag = w
+        w_buoy_mag = -w_buoy
         hog_elev = config.hog_bend_above_seabed
         sag_elev = config.sag_bend_elevation
         initial_bend_radius = config.hangoff_bend_radius
@@ -303,8 +530,8 @@ class LazyWaveSolver:
         # Legacy: lines 94-106
         BendRadius_sag = initial_bend_radius
         d_sag = (
-            (hog_elev - sag_elev) * abs(w_buoy) /
-            (abs(w_buoy) + abs(w))
+            (hog_elev - sag_elev) * w_buoy_mag /
+            (w_buoy_mag + w_mag)
         )
         X_sag = BendRadius_sag * math.acosh(d_sag / BendRadius_sag + 1)
         S_sag = BendRadius_sag * math.sinh(X_sag / BendRadius_sag)
@@ -320,11 +547,11 @@ class LazyWaveSolver:
         # Buoyancy to Hog Configuration
         # Legacy: lines 108-124
         BendRadius_buoy_to_hog = (
-            BendRadius_sag * w / abs(w_buoy)
+            BendRadius_sag * w_mag / w_buoy_mag
         )
         d_buoy_to_hog = (
-            (hog_elev - sag_elev) * abs(w) /
-            (abs(w_buoy) + abs(w))
+            (hog_elev - sag_elev) * w_mag /
+            (w_buoy_mag + w_mag)
         )
         X_buoy_to_hog = BendRadius_buoy_to_hog * math.acosh(d_buoy_to_hog / BendRadius_buoy_to_hog + 1)
         S_buoy_to_hog = BendRadius_buoy_to_hog * math.sinh(X_buoy_to_hog / BendRadius_buoy_to_hog)
@@ -340,8 +567,8 @@ class LazyWaveSolver:
         # Hog to Buoyancy Configuration
         # Legacy: lines 126-137
         d_hog_to_buoy = (
-            hog_elev * abs(w) /
-            (abs(w_buoy) + abs(w))
+            hog_elev * w_mag /
+            (w_buoy_mag + w_mag)
         )
         X_hog_to_buoy = BendRadius_buoy_to_hog * math.acosh(d_hog_to_buoy / BendRadius_buoy_to_hog + 1)
         S_hog_to_buoy = BendRadius_buoy_to_hog * math.sinh(X_hog_to_buoy / BendRadius_buoy_to_hog)
@@ -358,8 +585,8 @@ class LazyWaveSolver:
         # Legacy: lines 139-151
         BendRadius_touchdown = initial_bend_radius
         d_touchdown = (
-            hog_elev * abs(w_buoy) /
-            (abs(w_buoy) + abs(w))
+            hog_elev * w_buoy_mag /
+            (w_buoy_mag + w_mag)
         )
         X_touchdown = BendRadius_touchdown * math.acosh(d_touchdown / BendRadius_touchdown + 1)
         S_touchdown = BendRadius_touchdown * math.sinh(X_touchdown / BendRadius_touchdown)
@@ -397,7 +624,9 @@ class LazyWaveSolver:
                 'S': results.hangoff_to_sag.arc_length,
                 'X': results.hangoff_to_sag.horizontal_distance,
                 'BendRadius': results.hangoff_to_sag.bend_radius,
-                'd': config.hangoff_below_msl,
+                # The legacy HangOff['d'] is the hang-off -> sag bend span, not the
+                # depth below MSL (issue #1949, defect 2).
+                'd': results.hangoff_to_sag.vertical_distance,
                 'q': config.hangoff_angle
             },
             'SagToBuoyancy': {
@@ -428,5 +657,7 @@ class LazyWaveSolver:
             'WeightPerUnitLengthWithOutBuoyancy': config.weight_without_buoyancy,
             'WeightPerUnitLengthWithBuoyancy': config.weight_with_buoyancy,
             'HogBendAboveSeabed': config.hog_bend_above_seabed,
-            'SagBendElevationAboveSeabed': config.sag_bend_elevation
+            'SagBendElevationAboveSeabed': config.sag_bend_elevation,
+            'VerticalDistance': config.vertical_distance,
+            'HangoffBelowMeanSeaLevel': config.hangoff_below_msl
         }

--- a/src/digitalmodel/marine_ops/marine_analysis/catenary/lazy_wave.py
+++ b/src/digitalmodel/marine_ops/marine_analysis/catenary/lazy_wave.py
@@ -67,7 +67,7 @@ Legacy implementation: catenaryMethods.py sagHogEquation (lines 93-153)
                       catenaryMethods.py lazyWaveCatenaryEquation (lines 156-194)
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 import math
 

--- a/tests/fixtures/test_vectors/metocean_diffraction/lazy_wave_catenary.yaml
+++ b/tests/fixtures/test_vectors/metocean_diffraction/lazy_wave_catenary.yaml
@@ -1,13 +1,27 @@
 source_type: python
 source_description: "Lazy-wave catenary solver test vectors from test_lazy_wave_catenary.py — legacy formula verification"
 extracted_date: "2026-03-16"
+revised_date: "2026-08-02"
+revision_note: >-
+  Revised for issue #1949. The previous entry supplied hangoff_bend_radius = 2000 m
+  alongside a hang-off depth of 50 m, from which the same solver derived 17.5 m —
+  a 115x disagreement that the kernel used simultaneously, and the expected
+  horizontal force of 2000000 N encoded the inconsistent value. The bend radius is
+  now derived from the hang-off vertical span (vertical_distance -
+  sag_bend_elevation = 350 m) and the departure angle, and is no longer an input.
 legal_scan_passed: true
 category: "metocean_diffraction"
 subcategory: "lazy_wave_catenary"
 equations:
+  - name: "Hangoff vertical span (water-depth closure)"
+    latex: "d = V - h_{sag}"
+    description: "Vertical drop from the hang-off point to the sag bend; sets water-depth closure"
   - name: "Hangoff section bend radius"
     latex: "R = d \\cdot \\cos(90-q) / (1 - \\cos(90-q))"
-    description: "Bend radius of the hangoff catenary section from depth and angle"
+    description: "Bend radius of the hangoff catenary section, DERIVED from the hang-off span and angle"
+  - name: "Vertical closure identity"
+    latex: "d_1 - d_2 - d_3 + d_4 + d_5 = V"
+    description: "Net descent of the five segments equals the hang-off to seabed distance exactly"
   - name: "Hangoff arc length"
     latex: "S = R \\cdot \\tan(90-q)"
     description: "Arc length of hangoff section"
@@ -31,8 +45,8 @@ inputs:
     symbol: "q"
     unit: "deg"
     test_value: 15.0
-  - name: "Hangoff depth below MSL"
-    symbol: "d"
+  - name: "Hangoff depth below MSL (reporting datum, not a catenary span)"
+    symbol: "z_ho"
     unit: "m"
     test_value: 50.0
   - name: "Hog bend above seabed"
@@ -51,22 +65,33 @@ inputs:
     symbol: "w_b"
     unit: "N/m"
     test_value: -500.0
-  - name: "Vertical distance"
+  - name: "Vertical distance, hang-off to seabed"
     symbol: "V"
     unit: "m"
     test_value: 500.0
-  - name: "Hangoff bend radius"
+outputs:
+  - name: "Hangoff vertical span"
+    symbol: "d"
+    unit: "m"
+    test_expected: 350.0
+    tolerance: 1.0e-9
+  - name: "Hangoff bend radius (derived)"
     symbol: "R"
     unit: "m"
-    test_value: 2000.0
-outputs:
+    test_expected: 122.21936517299244
+    tolerance: 1.0e-6
   - name: "Horizontal force"
     symbol: "Fh"
     unit: "N"
-    test_expected: 2000000.0
-    tolerance: 1.0
+    test_expected: 122219.36517299245
+    tolerance: 1.0e-3
+  - name: "Vertical closure error"
+    symbol: "eps_V"
+    unit: "m"
+    test_expected: 0.0
+    tolerance: 1.0e-9
 worked_examples:
-  - description: "Typical config: hangoff q=15 deg, d=50m — bend radius, arc, horizontal from legacy catenary equations"
+  - description: "Typical config: q=15 deg, hang-off span 500-150=350 m; bend radius derived, not supplied"
     inputs:
       hangoff_angle: 15.0
       hangoff_below_msl: 50.0
@@ -75,9 +100,11 @@ worked_examples:
       weight_without_buoyancy: 1000.0
       weight_with_buoyancy: -500.0
       vertical_distance: 500.0
-      hangoff_bend_radius: 2000.0
     outputs:
-      horizontal_force: 2000000.0
+      hangoff_vertical_span: 350.0
+      hangoff_bend_radius: 122.21936517299244
+      horizontal_force: 122219.36517299245
+      vertical_closure_error: 0.0
       segment_count: 5
     use_as_test: true
   - description: "Sag-to-buoyancy segment vertical distance: (300-150)*500/(500+1000) = 50.0"
@@ -89,15 +116,15 @@ worked_examples:
     outputs:
       sag_to_buoy_d: 50.0
     use_as_test: true
-  - description: "Buoyancy-to-hog bend radius: R_new = R * w / |w_b| = 2000 * 1000/500 = 4000"
+  - description: "Buoyancy-to-hog bend radius: R_new = R * w / |w_b| = 122.21936517299244 * 1000/500"
     inputs:
-      initial_bend_radius: 2000.0
+      initial_bend_radius: 122.21936517299244
       weight: 1000.0
       buoyancy_weight_abs: 500.0
     outputs:
-      new_bend_radius: 4000.0
+      new_bend_radius: 244.43873034598488
     use_as_test: true
-  - description: "Alternative config: q=20 d=60 — forces positive, arc lengths positive"
+  - description: "Alternative config: q=20 deg, hang-off span 400-120=280 m"
     inputs:
       hangoff_angle: 20.0
       hangoff_below_msl: 60.0
@@ -106,14 +133,28 @@ worked_examples:
       weight_without_buoyancy: 800.0
       weight_with_buoyancy: -400.0
       vertical_distance: 400.0
-      hangoff_bend_radius: 1500.0
     outputs:
       horizontal_force_min: 0.0
       vertical_force_min: 0.0
+      vertical_closure_error: 0.0
+    use_as_test: true
+  - description: "Rejection: insufficient buoyancy (w_b >= 0) has no lazy-wave solution"
+    inputs:
+      hangoff_angle: 15.0
+      hangoff_below_msl: 50.0
+      hog_bend_above_seabed: 300.0
+      sag_bend_elevation: 150.0
+      weight_without_buoyancy: 1000.0
+      weight_with_buoyancy: 500.0
+      vertical_distance: 500.0
+    outputs:
+      raises: "LazyWaveConfigurationError"
     use_as_test: true
 assumptions:
   - "Catenary equations assume uniform weight per unit length"
-  - "Negative buoyancy weight indicates net upward force from buoyancy modules"
+  - "Negative buoyancy weight indicates net upward force from buoyancy modules; a non-negative value has no lazy-wave solution and is rejected"
+  - "hangoff_below_msl positions the configuration against the waterline for reporting; the catenary span is vertical_distance - sag_bend_elevation"
+  - "The hang-off bend radius is derived, never supplied independently"
   - "All segment calculations match legacy sagHogEquation and lazyWaveCatenaryEquation"
   - "Solver tolerance rel_tol=1e-9 for legacy comparison"
 references:

--- a/tests/fixtures/test_vectors/mooring_risers/lazy_wave_reference_cases.yaml
+++ b/tests/fixtures/test_vectors/mooring_risers/lazy_wave_reference_cases.yaml
@@ -1,0 +1,154 @@
+source_type: historical_solver_run
+source_description: >-
+  De-identified parameter -> result pairs from a historical result set produced by the
+  ancestor of this repo's lazy-wave solver. Only numeric engineering parameters and the
+  geometry/force results they produced are reproduced here; no project, client or file
+  identifiers are carried across. Used to pin the water-depth closure identity and the
+  hang-off bend-radius binding that the ported solver had lost (issue #1949).
+extracted_date: "2026-08-02"
+legal_scan_passed: true
+category: "mooring_risers"
+subcategory: "lazy_wave_reference_cases"
+
+# The parameter space spanned below matches the historical sweep: buoyancy factor
+# (net buoyant weight), sag/hog bend elevations, and hang-off declination angle.
+#
+# Two invariants hold across all 64 historical runs and are asserted by the tests:
+#   1. hangoff_d == vertical_distance - sag_bend_elevation   (closure by construction)
+#   2. hangoff_bend_radius is DERIVED from (hangoff_d, hangoff_angle), never supplied
+#      independently, and is reused verbatim for the sag and touchdown segments.
+#
+# Every historical run had weight_with_buoyancy < 0 (net buoyant). The insufficient-
+# buoyancy regime was never exercised by the original, so its abs() handling of that
+# case is untested legacy behaviour, not validated behaviour.
+
+invariants:
+  hangoff_span: "d_hangoff = vertical_distance - sag_bend_elevation"
+  hangoff_bend_radius: "R = d_hangoff * cos(90-q) / (1 - cos(90-q))"
+  vertical_closure: "d1 - d2 - d3 + d4 + d5 == vertical_distance (exactly, by construction)"
+
+cases:
+  - id: A
+    description: "Baseline: net buoyant weight equal and opposite to bare weight, 8 deg declination"
+    inputs:
+      hangoff_angle: 8.0
+      hangoff_below_msl: 0.0
+      vertical_distance: 4000.0
+      sag_bend_elevation: 1200.0
+      hog_bend_above_seabed: 1500.0
+      weight_without_buoyancy: 2456.695439714344
+      weight_with_buoyancy: -2456.695439714344
+    expected:
+      hangoff_d: 2800.0
+      hangoff_bend_radius: 452.68646126508355
+      hangoff_S: 3221.0315402188266
+      hangoff_X: 1204.2845667664897
+      sag_to_buoyancy_d: 150.0
+      sag_to_buoyancy_S: 397.87678793757874
+      sag_to_buoyancy_X: 359.03406247548156
+      buoyancy_to_hog_R: 452.68646126508355
+      buoyancy_to_hog_d: 150.0
+      buoyancy_to_hog_S: 397.87678793757874
+      hog_to_buoyancy_d: 750.0
+      hog_to_buoyancy_S: 1114.2395128057635
+      buoyancy_to_touchdown_d: 750.0
+      buoyancy_to_touchdown_S: 1114.2395128057635
+      total_S: 6245.264141705511
+      total_X: 3400.6427273504437
+      Fh: 1112112.7650103548
+      Fv: 9025206.261042016
+
+  - id: B
+    description: "Higher buoyancy factor; hog bend radius contracts as |w_b| grows"
+    inputs:
+      hangoff_angle: 8.0
+      hangoff_below_msl: 0.0
+      vertical_distance: 4000.0
+      sag_bend_elevation: 1200.0
+      hog_bend_above_seabed: 1500.0
+      weight_without_buoyancy: 2456.695439714344
+      weight_with_buoyancy: -3685.0431595715163
+    expected:
+      hangoff_d: 2800.0
+      hangoff_bend_radius: 452.68646126508355
+      hangoff_S: 3221.0315402188266
+      hangoff_X: 1204.2845667664897
+      sag_to_buoyancy_d: 180.00000000000003
+      sag_to_buoyancy_S: 442.0035362476529
+      sag_to_buoyancy_X: 391.3871813183194
+      buoyancy_to_hog_R: 301.79097417672233
+      buoyancy_to_hog_d: 120.0
+      buoyancy_to_hog_S: 294.66902416510186
+      hog_to_buoyancy_d: 600.0
+      hog_to_buoyancy_S: 849.7936037721552
+      buoyancy_to_touchdown_d: 900.0
+      buoyancy_to_touchdown_S: 1274.6904056582327
+      total_S: 6082.188110061969
+      total_X: 3183.376409945153
+      Fh: 1112112.7650103548
+      Fv: 9025206.261042016
+
+  - id: C
+    description: "Shallower sag/hog elevations with the highest buoyancy factor in the sweep"
+    inputs:
+      hangoff_angle: 8.0
+      hangoff_below_msl: 0.0
+      vertical_distance: 4000.0
+      sag_bend_elevation: 500.0
+      hog_bend_above_seabed: 800.0
+      weight_without_buoyancy: 2456.695439714344
+      weight_with_buoyancy: -6141.73859928586
+    expected:
+      hangoff_d: 3500.0
+      hangoff_bend_radius: 565.8580765813543
+      hangoff_S: 4026.2894252735327
+      hangoff_X: 1505.3557084581118
+      sag_to_buoyancy_d: 214.28571428571428
+      sag_to_buoyancy_S: 537.055836572037
+      sag_to_buoyancy_X: 478.1047885167005
+      buoyancy_to_hog_R: 226.34323063254175
+      buoyancy_to_hog_d: 85.71428571428572
+      buoyancy_to_hog_S: 214.82233462881487
+      hog_to_buoyancy_d: 228.57142857142858
+      hog_to_buoyancy_S: 394.60877981297944
+      buoyancy_to_touchdown_d: 571.4285714285714
+      buoyancy_to_touchdown_S: 986.5219495324485
+      total_S: 6159.298325819812
+      total_X: 3222.4860545848674
+      Fh: 1390140.9562629433
+      Fv: 11281507.826302517
+
+  - id: D
+    description: "Steeper declination angle; isolates the (depth, angle) -> bend radius binding"
+    inputs:
+      hangoff_angle: 14.0
+      hangoff_below_msl: 0.0
+      vertical_distance: 4000.0
+      sag_bend_elevation: 1200.0
+      hog_bend_above_seabed: 1500.0
+      weight_without_buoyancy: 2456.695439714344
+      weight_with_buoyancy: -2456.695439714344
+    expected:
+      hangoff_d: 2800.0
+      hangoff_bend_radius: 893.5508145495153
+      hangoff_S: 3583.83657014062
+      hangoff_X: 1874.0655656430379
+      sag_to_buoyancy_d: 150.0
+      sag_to_buoyancy_S: 539.0410414475456
+      sag_to_buoyancy_X: 510.76793603601595
+      buoyancy_to_hog_R: 893.5508145495154
+      buoyancy_to_hog_d: 150.0
+      buoyancy_to_hog_S: 539.0410414475457
+      hog_to_buoyancy_d: 750.0
+      hog_to_buoyancy_S: 1379.4296726634066
+      buoyancy_to_touchdown_d: 750.0
+      buoyancy_to_touchdown_S: 1379.4296726634063
+      total_S: 7420.777998362524
+      total_X: 5073.712567597819
+      Fh: 2195182.211256832
+      Fv: 10999577.169802789
+
+assumptions:
+  - "Hang-off point is the datum for vertical_distance; the seabed lies vertical_distance below it."
+  - "hangoff_below_msl positions the hang-off relative to mean sea level for reporting and plotting only; it is not a catenary span."
+  - "weight_with_buoyancy is the net effective weight over the buoyed length and is negative (net upward) for every physically realisable lazy-wave configuration."

--- a/tests/test_lazy_wave_catenary.py
+++ b/tests/test_lazy_wave_catenary.py
@@ -28,8 +28,11 @@ class TestLazyWaveSolver:
             sag_bend_elevation=150.0,  # m
             weight_without_buoyancy=1000.0,  # N/m (bare riser)
             weight_with_buoyancy=-500.0,  # N/m (with buoyancy, negative)
-            vertical_distance=500.0,  # m
-            hangoff_bend_radius=2000.0  # m
+            vertical_distance=500.0,  # m (hang-off down to seabed)
+            # hangoff_bend_radius omitted: derived from the hang-off span
+            # (500 - 150 = 350 m) and the departure angle. Earlier revisions of
+            # this fixture supplied 2000 m against a derived 122 m and the solver
+            # used both at once (issue #1949, defect 3).
         )
 
     @pytest.fixture
@@ -39,9 +42,12 @@ class TestLazyWaveSolver:
 
     def test_hangoff_section_calculation(self, solver, typical_config):
         """Test hang-off section matches legacy catenaryEquation with angle."""
-        # Expected values from legacy formula (lines 51-63)
+        # Expected values from legacy formula (lines 51-63).
+        # The legacy driver set the hang-off section's vertical span to
+        # (VerticalDistance - SagBendElevationAboveSeabed), not to the depth below
+        # MSL (issue #1949, defect 2).
         q = typical_config.hangoff_angle
-        d = typical_config.hangoff_below_msl
+        d = typical_config.vertical_distance - typical_config.sag_bend_elevation
 
         angle_rad = math.radians(90 - q)
         tanq = math.tan(angle_rad)
@@ -244,8 +250,7 @@ class TestLazyWaveSolver:
             sag_bend_elevation=120.0,
             weight_without_buoyancy=800.0,
             weight_with_buoyancy=-400.0,  # Negative = buoyancy
-            vertical_distance=400.0,
-            hangoff_bend_radius=1500.0
+            vertical_distance=400.0
         )
 
         results = solver.solve(config)
@@ -268,8 +273,7 @@ class TestLazyWaveSolver:
             sag_bend_elevation=150.0,
             weight_without_buoyancy=500.0,
             weight_with_buoyancy=-1000.0,  # High buoyancy
-            vertical_distance=500.0,
-            hangoff_bend_radius=2000.0
+            vertical_distance=500.0
         )
 
         results = solver.solve(config_high_buoy)
@@ -289,8 +293,7 @@ class TestLazyWaveSolver:
             sag_bend_elevation=140.0,  # m
             weight_without_buoyancy=900.0,  # N/m
             weight_with_buoyancy=-450.0,  # N/m
-            vertical_distance=450.0,  # m
-            hangoff_bend_radius=1800.0  # m
+            vertical_distance=450.0,  # m (hang-off down to seabed)
         )
 
         results = solver.solve(config)
@@ -302,9 +305,18 @@ class TestLazyWaveSolver:
         assert results.hog_to_buoyancy_end is not None
         assert results.buoyancy_to_touchdown is not None
 
-        # Verify forces are reasonable
-        assert 1000000 < results.horizontal_force < 3000000  # Typical range for risers
+        # Verify forces follow the force balance rather than a hardcoded band.
+        # The previous `1000000 < Fh < 3000000` band was only satisfied because the
+        # solver used an unbound 1800 m bend radius; against the radius actually
+        # derived from this geometry it is off by an order of magnitude, so the
+        # band tested the defect, not the physics (issue #1949, defect 3).
+        expected_fh = config.hangoff_bend_radius * config.weight_without_buoyancy
+        assert math.isclose(results.horizontal_force, expected_fh, rel_tol=1e-12)
+        assert results.horizontal_force > 0
         assert results.vertical_force > results.horizontal_force  # Should have vertical component
+
+        # Verify the configuration reaches the seabed.
+        assert abs(results.vertical_closure_error) < 1e-9
 
         # Verify geometry is physically consistent
         total_from_segments = sum(seg.arc_length for seg in results.segments)
@@ -330,8 +342,7 @@ class TestLazyWaveEdgeCases:
             sag_bend_elevation=100.0,
             weight_without_buoyancy=1000.0,
             weight_with_buoyancy=-500.0,
-            vertical_distance=400.0,
-            hangoff_bend_radius=2500.0
+            vertical_distance=400.0
         )
 
         results = solver.solve(config)
@@ -347,8 +358,7 @@ class TestLazyWaveEdgeCases:
             sag_bend_elevation=180.0,
             weight_without_buoyancy=1200.0,
             weight_with_buoyancy=-600.0,
-            vertical_distance=600.0,
-            hangoff_bend_radius=1500.0
+            vertical_distance=600.0
         )
 
         results = solver.solve(config)
@@ -364,8 +374,7 @@ class TestLazyWaveEdgeCases:
             sag_bend_elevation=200.0,  # Very close to hog
             weight_without_buoyancy=1000.0,
             weight_with_buoyancy=-500.0,
-            vertical_distance=500.0,
-            hangoff_bend_radius=2000.0
+            vertical_distance=500.0
         )
 
         results = solver.solve(config)

--- a/tests/test_lazy_wave_kernel_defects.py
+++ b/tests/test_lazy_wave_kernel_defects.py
@@ -1,0 +1,335 @@
+"""
+Regression tests for the three SLWR geometry-kernel defects catalogued in issue #1949.
+
+Each test class pins one defect. Every assertion here failed before the repair and
+is written so that it would fail again if the behaviour regressed — none of them are
+true by construction.
+
+Defect 1 -- sign-blindness on buoyancy
+    ``abs()`` was applied to ``weight_with_buoyancy`` throughout, so a configuration
+    with *insufficient* buoyancy (positive net weight over the buoyed length) returned
+    results bit-identical to a correctly buoyant one. Half of any buoyancy search space
+    was physically invalid and scored as valid.
+
+Defect 2 -- ``vertical_distance`` was dead input
+    Sweeping it 100 m -> 5000 m changed nothing. The solver was an open-loop geometric
+    construction with no water-depth closure, so it could return a configuration that
+    never reached the seabed.
+
+Defect 3 -- ``hangoff_bend_radius`` was an unbound independent input
+    ``_solve_hangoff_section`` derived a bend radius from (depth, angle) while
+    ``_solve_sag_hog_sections`` and the force balance used a separately supplied value.
+    On the shipped fixture the two disagreed by 5.5x in arc length and 115x in
+    horizontal force.
+
+The reference cases in ``tests/fixtures/test_vectors/mooring_risers/
+lazy_wave_reference_cases.yaml`` are de-identified parameter -> result pairs from a
+historical result set produced by the ancestor of this solver. They pin the closure
+identity and the bend-radius binding against real prior output rather than against
+this implementation's own arithmetic.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.marine_ops.marine_analysis.catenary.lazy_wave import (
+    LazyWaveConfigurationError,
+    LazyWaveConfiguration,
+    LazyWaveSolver,
+    derive_hangoff_bend_radius,
+)
+
+
+REFERENCE_CASES_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "test_vectors"
+    / "mooring_risers"
+    / "lazy_wave_reference_cases.yaml"
+)
+
+
+def _reference_cases():
+    data = yaml.safe_load(REFERENCE_CASES_PATH.read_text())
+    return data["cases"]
+
+
+REFERENCE_CASES = _reference_cases()
+
+
+@pytest.fixture
+def solver():
+    return LazyWaveSolver()
+
+
+def make_config(**overrides):
+    """A physically valid lazy-wave configuration, with overrides applied.
+
+    The hang-off sits 50 m below MSL in 500 m of water measured from the hang-off
+    down to the seabed; the sag bend is 150 m above the seabed, so the hang-off
+    section spans 500 - 150 = 350 m vertically.
+    """
+    base = dict(
+        hangoff_angle=15.0,
+        hangoff_below_msl=50.0,
+        hog_bend_above_seabed=300.0,
+        sag_bend_elevation=150.0,
+        weight_without_buoyancy=1000.0,
+        weight_with_buoyancy=-500.0,
+        vertical_distance=500.0,
+    )
+    base.update(overrides)
+    return LazyWaveConfiguration(**base)
+
+
+class TestDefect1SignBlindnessOnBuoyancy:
+    """Insufficient buoyancy must not alias onto correct buoyancy."""
+
+    def test_positive_net_weight_over_buoyed_length_is_rejected(self):
+        """w_buoy > 0 means the 'buoyed' section is still net-heavy.
+
+        No upward hog arc can form, so there is no lazy-wave configuration to
+        report. Previously this returned a result identical to w_buoy = -500.
+        """
+        with pytest.raises(LazyWaveConfigurationError) as exc:
+            make_config(weight_with_buoyancy=+500.0)
+        assert "buoyan" in str(exc.value).lower()
+
+    def test_zero_net_weight_over_buoyed_length_is_rejected(self):
+        """w_buoy == 0 is neutrally buoyant: the hog bend radius diverges."""
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(weight_with_buoyancy=0.0)
+
+    def test_sign_of_buoyancy_is_not_erased_by_magnitude(self, solver):
+        """The +/- pair must not produce the same numbers.
+
+        This is the direct regression on the ``abs()`` defect: previously
+        w_buoy = +500 and w_buoy = -500 gave bit-identical arc length, horizontal
+        distance and forces.
+        """
+        buoyant = solver.solve(make_config(weight_with_buoyancy=-500.0))
+        with pytest.raises(LazyWaveConfigurationError):
+            solver.solve(make_config(weight_with_buoyancy=+500.0))
+        # And the valid branch still produces a usable answer.
+        assert buoyant.total_arc_length > 0
+
+    def test_non_positive_bare_riser_weight_is_rejected(self):
+        """A bare riser that is not net-heavy cannot hang off in a catenary."""
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(weight_without_buoyancy=-1000.0)
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(weight_without_buoyancy=0.0)
+
+    def test_buoyancy_magnitude_still_moves_the_objective(self, solver):
+        """A buoyancy search needs a non-flat objective across the valid range."""
+        arcs = [
+            solver.solve(make_config(weight_with_buoyancy=wb)).total_arc_length
+            for wb in (-400.0, -600.0, -800.0, -1200.0)
+        ]
+        assert len(set(arcs)) == len(arcs), f"objective is flat across buoyancy: {arcs}"
+
+
+class TestDefect2WaterDepthClosure:
+    """``vertical_distance`` must drive the solution and the geometry must close."""
+
+    def test_vertical_distance_changes_the_solution(self, solver):
+        """Previously a 100 m -> 5000 m sweep produced identical output."""
+        results = {
+            vd: solver.solve(make_config(vertical_distance=vd))
+            for vd in (400.0, 500.0, 800.0, 2000.0)
+        }
+        arcs = [r.total_arc_length for r in results.values()]
+        assert len(set(arcs)) == len(arcs), f"vertical_distance is dead input: {arcs}"
+
+        # Deeper water must mean a longer riser.
+        ordered = [results[vd].total_arc_length for vd in (400.0, 500.0, 800.0, 2000.0)]
+        assert ordered == sorted(ordered)
+
+    def test_hangoff_section_spans_hangoff_down_to_the_sag_bend(self, solver):
+        """The hang-off section's vertical span is set by closure, not by MSL depth.
+
+        d_hangoff = vertical_distance - sag_bend_elevation. Previously the solver
+        used ``hangoff_below_msl`` here, which is a reporting datum, not a span.
+        """
+        config = make_config(vertical_distance=500.0, sag_bend_elevation=150.0)
+        results = solver.solve(config)
+        assert math.isclose(
+            results.hangoff_to_sag.vertical_distance, 350.0, rel_tol=1e-12
+        )
+
+    def test_returned_geometry_reaches_the_seabed(self, solver):
+        """Signed vertical spans must sum to exactly the water depth.
+
+        Down: hang-off -> sag, hog -> buoyancy end, buoyancy end -> touchdown.
+        Up:   sag -> buoyancy start, buoyancy start -> hog.
+        """
+        for vd in (400.0, 500.0, 1200.0, 3000.0):
+            results = solver.solve(make_config(vertical_distance=vd))
+            net_descent = (
+                results.hangoff_to_sag.vertical_distance
+                - results.sag_to_buoyancy.vertical_distance
+                - results.buoyancy_to_hog.vertical_distance
+                + results.hog_to_buoyancy_end.vertical_distance
+                + results.buoyancy_to_touchdown.vertical_distance
+            )
+            assert math.isclose(net_descent, vd, abs_tol=1e-9), (
+                f"geometry does not reach the seabed for vertical_distance={vd}: "
+                f"net descent {net_descent}"
+            )
+
+    def test_closure_error_is_reported_and_is_zero(self, solver):
+        results = solver.solve(make_config())
+        assert hasattr(results, "vertical_closure_error")
+        assert abs(results.vertical_closure_error) < 1e-9
+        assert abs(results.summary["VerticalClosureError"]) < 1e-9
+
+    def test_configuration_that_cannot_close_is_rejected(self):
+        """The sag bend cannot sit at or above the hang-off point."""
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(vertical_distance=150.0, sag_bend_elevation=150.0)
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(vertical_distance=100.0, sag_bend_elevation=150.0)
+
+    def test_hog_bend_must_sit_above_the_sag_bend(self):
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(hog_bend_above_seabed=150.0, sag_bend_elevation=150.0)
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(hog_bend_above_seabed=140.0, sag_bend_elevation=150.0)
+
+    def test_sag_bend_must_sit_above_the_seabed(self):
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(sag_bend_elevation=0.0)
+        with pytest.raises(LazyWaveConfigurationError):
+            make_config(sag_bend_elevation=-10.0)
+
+
+class TestDefect3HangoffBendRadiusBinding:
+    """The hang-off bend radius is derived from (depth, angle), never free."""
+
+    def test_bend_radius_is_derived_when_not_supplied(self, solver):
+        config = make_config()
+        expected = derive_hangoff_bend_radius(
+            vertical_span=500.0 - 150.0, hangoff_angle=15.0
+        )
+        assert math.isclose(config.hangoff_bend_radius, expected, rel_tol=1e-12)
+        assert math.isclose(
+            solver.solve(config).hangoff_to_sag.bend_radius, expected, rel_tol=1e-12
+        )
+
+    def test_derivation_matches_the_closed_form(self):
+        d, q = 2800.0, 8.0
+        angle = math.radians(90.0 - q)
+        expected = d * math.cos(angle) / (1.0 - math.cos(angle))
+        assert math.isclose(
+            derive_hangoff_bend_radius(vertical_span=d, hangoff_angle=q),
+            expected,
+            rel_tol=1e-12,
+        )
+
+    def test_inconsistent_supplied_bend_radius_is_rejected(self):
+        """2000 m against a derived 56.5 m must not pass silently.
+
+        This is the exact inconsistency the shipped example, unit-test fixture and
+        benchmark entry all encoded.
+        """
+        with pytest.raises(LazyWaveConfigurationError) as exc:
+            make_config(hangoff_bend_radius=2000.0)
+        assert "bend radius" in str(exc.value).lower()
+
+    def test_consistent_supplied_bend_radius_is_accepted(self):
+        derived = derive_hangoff_bend_radius(
+            vertical_span=500.0 - 150.0, hangoff_angle=15.0
+        )
+        config = make_config(hangoff_bend_radius=derived)
+        assert math.isclose(config.hangoff_bend_radius, derived, rel_tol=1e-12)
+
+    def test_one_bend_radius_is_used_everywhere(self, solver):
+        """Hang-off, sag and touchdown segments share the single derived radius."""
+        results = solver.solve(make_config())
+        r = results.hangoff_to_sag.bend_radius
+        assert math.isclose(results.sag_to_buoyancy.bend_radius, r, rel_tol=1e-12)
+        assert math.isclose(results.buoyancy_to_touchdown.bend_radius, r, rel_tol=1e-12)
+
+    def test_forces_use_the_derived_bend_radius(self, solver):
+        """Fh = R_derived * w. Previously Fh used the unbound supplied radius."""
+        config = make_config()
+        results = solver.solve(config)
+        expected_fh = (
+            results.hangoff_to_sag.bend_radius * config.weight_without_buoyancy
+        )
+        assert math.isclose(results.horizontal_force, expected_fh, rel_tol=1e-12)
+        expected_fv = expected_fh + config.weight_without_buoyancy * (
+            results.hangoff_to_sag.arc_length
+        )
+        assert math.isclose(results.vertical_force, expected_fv, rel_tol=1e-12)
+
+
+class TestHistoricalReferenceCases:
+    """Pin the repaired kernel against historical output from the ancestor solver."""
+
+    @pytest.mark.parametrize("case", REFERENCE_CASES, ids=lambda c: c["id"])
+    def test_matches_historical_result(self, solver, case):
+        config = LazyWaveConfiguration(**case["inputs"])
+        results = solver.solve(config)
+        e = case["expected"]
+
+        def close(actual, key, rel_tol=1e-9):
+            assert math.isclose(actual, e[key], rel_tol=rel_tol), (
+                f"{key}: got {actual!r}, historical {e[key]!r}"
+            )
+
+        close(results.hangoff_to_sag.vertical_distance, "hangoff_d")
+        close(results.hangoff_to_sag.bend_radius, "hangoff_bend_radius")
+        close(results.hangoff_to_sag.arc_length, "hangoff_S")
+        close(results.hangoff_to_sag.horizontal_distance, "hangoff_X")
+
+        close(results.sag_to_buoyancy.vertical_distance, "sag_to_buoyancy_d")
+        close(results.sag_to_buoyancy.arc_length, "sag_to_buoyancy_S")
+        close(results.sag_to_buoyancy.horizontal_distance, "sag_to_buoyancy_X")
+
+        close(results.buoyancy_to_hog.bend_radius, "buoyancy_to_hog_R")
+        close(results.buoyancy_to_hog.vertical_distance, "buoyancy_to_hog_d")
+        close(results.buoyancy_to_hog.arc_length, "buoyancy_to_hog_S")
+
+        close(results.hog_to_buoyancy_end.vertical_distance, "hog_to_buoyancy_d")
+        close(results.hog_to_buoyancy_end.arc_length, "hog_to_buoyancy_S")
+
+        close(results.buoyancy_to_touchdown.vertical_distance, "buoyancy_to_touchdown_d")
+        close(results.buoyancy_to_touchdown.arc_length, "buoyancy_to_touchdown_S")
+
+        close(results.total_arc_length, "total_S")
+        close(results.total_horizontal_distance, "total_X")
+        close(results.horizontal_force, "Fh")
+        close(results.vertical_force, "Fv")
+
+    @pytest.mark.parametrize("case", REFERENCE_CASES, ids=lambda c: c["id"])
+    def test_historical_cases_close_on_the_seabed(self, solver, case):
+        config = LazyWaveConfiguration(**case["inputs"])
+        results = solver.solve(config)
+        assert abs(results.vertical_closure_error) < 1e-9
+
+    @pytest.mark.parametrize("case", REFERENCE_CASES, ids=lambda c: c["id"])
+    def test_historical_hangoff_span_is_the_closure_identity(self, case):
+        """d_hangoff == vertical_distance - sag_bend_elevation held in every run."""
+        i = case["inputs"]
+        assert math.isclose(
+            case["expected"]["hangoff_d"],
+            i["vertical_distance"] - i["sag_bend_elevation"],
+            rel_tol=1e-12,
+        )
+
+    @pytest.mark.parametrize("case", REFERENCE_CASES, ids=lambda c: c["id"])
+    def test_historical_bend_radius_was_derived_not_free(self, case):
+        """The historical bend radius is reproduced by (span, angle) alone."""
+        i, e = case["inputs"], case["expected"]
+        assert math.isclose(
+            derive_hangoff_bend_radius(
+                vertical_span=i["vertical_distance"] - i["sag_bend_elevation"],
+                hangoff_angle=i["hangoff_angle"],
+            ),
+            e["hangoff_bend_radius"],
+            rel_tol=1e-9,
+        )

--- a/tests/test_lazy_wave_legacy_comparison.py
+++ b/tests/test_lazy_wave_legacy_comparison.py
@@ -36,11 +36,17 @@ class TestLegacyComparison:
         return {
             'HangOff': {
                 'q': 15.0,  # degrees
-                'd': 50.0,  # m below MSL
+                # Vertical span from the hang-off point down to the sag bend.
+                # The original driver set this to
+                # (VerticalDistance - SagBendElevationAboveSeabed) = 500 - 150,
+                # NOT to the hang-off depth below MSL (issue #1949, defect 2).
+                'd': 350.0,
                 'F': None,
                 'X': None,
                 'w': 1000.0
             },
+            'VerticalDistance': 500.0,
+            'HangoffBelowMeanSeaLevel': 50.0,
             'HogBendAboveSeabed': 300.0,
             'SagBendElevationAboveSeabed': 150.0,
             'WeightPerUnitLengthWithOutBuoyancy': 1000.0,
@@ -52,13 +58,12 @@ class TestLegacyComparison:
         """Create modern configuration."""
         return LazyWaveConfiguration(
             hangoff_angle=15.0,
-            hangoff_below_msl=50.0,
+            hangoff_below_msl=50.0,  # datum only
             hog_bend_above_seabed=300.0,
             sag_bend_elevation=150.0,
             weight_without_buoyancy=1000.0,
             weight_with_buoyancy=-500.0,
             vertical_distance=500.0,
-            hangoff_bend_radius=2000.0  # Will be calculated from legacy
         )
 
     def test_hangoff_section_matches_legacy(self, legacy_data):
@@ -66,16 +71,17 @@ class TestLegacyComparison:
         # Run legacy
         legacy_result = catenaryEquation(legacy_data['HangOff'])
 
-        # Create modern config with same bend radius
+        # The modern config derives its own bend radius from (span, angle); it is
+        # NOT handed the legacy value. Agreement is therefore a real equivalence
+        # result rather than a tautology (issue #1949, defect 3).
         modern_config = LazyWaveConfiguration(
             hangoff_angle=legacy_data['HangOff']['q'],
-            hangoff_below_msl=legacy_data['HangOff']['d'],
+            hangoff_below_msl=50.0,  # datum only; the span comes from vertical_distance
             hog_bend_above_seabed=300.0,
             sag_bend_elevation=150.0,
             weight_without_buoyancy=1000.0,
             weight_with_buoyancy=-500.0,
             vertical_distance=500.0,
-            hangoff_bend_radius=legacy_result['BendRadius']
         )
 
         solver = LazyWaveSolver()
@@ -98,13 +104,12 @@ class TestLegacyComparison:
         # Run modern
         modern_config = LazyWaveConfiguration(
             hangoff_angle=legacy_data['HangOff']['q'],
-            hangoff_below_msl=legacy_data['HangOff']['d'],
+            hangoff_below_msl=50.0,  # datum only; the span comes from vertical_distance
             hog_bend_above_seabed=legacy_data['HogBendAboveSeabed'],
             sag_bend_elevation=legacy_data['SagBendElevationAboveSeabed'],
             weight_without_buoyancy=legacy_data['WeightPerUnitLengthWithOutBuoyancy'],
             weight_with_buoyancy=legacy_data['WeightPerUnitLengthWithBuoyancy'],
             vertical_distance=500.0,
-            hangoff_bend_radius=legacy_hangoff['BendRadius']
         )
 
         solver = LazyWaveSolver()
@@ -188,13 +193,12 @@ class TestLegacyComparison:
         # Run modern
         modern_config = LazyWaveConfiguration(
             hangoff_angle=legacy_data['HangOff']['q'],
-            hangoff_below_msl=legacy_data['HangOff']['d'],
+            hangoff_below_msl=50.0,  # datum only; the span comes from vertical_distance
             hog_bend_above_seabed=legacy_data['HogBendAboveSeabed'],
             sag_bend_elevation=legacy_data['SagBendElevationAboveSeabed'],
             weight_without_buoyancy=legacy_data['WeightPerUnitLengthWithOutBuoyancy'],
             weight_with_buoyancy=legacy_data['WeightPerUnitLengthWithBuoyancy'],
             vertical_distance=500.0,
-            hangoff_bend_radius=legacy_hangoff['BendRadius']
         )
 
         solver = LazyWaveSolver()
@@ -270,13 +274,12 @@ class TestLegacyComparison:
         # Run modern and convert to legacy format
         modern_config = LazyWaveConfiguration(
             hangoff_angle=legacy_data['HangOff']['q'],
-            hangoff_below_msl=legacy_data['HangOff']['d'],
+            hangoff_below_msl=50.0,  # datum only; the span comes from vertical_distance
             hog_bend_above_seabed=legacy_data['HogBendAboveSeabed'],
             sag_bend_elevation=legacy_data['SagBendElevationAboveSeabed'],
             weight_without_buoyancy=legacy_data['WeightPerUnitLengthWithOutBuoyancy'],
             weight_with_buoyancy=legacy_data['WeightPerUnitLengthWithBuoyancy'],
             vertical_distance=500.0,
-            hangoff_bend_radius=legacy_hangoff['BendRadius']
         )
 
         solver = LazyWaveSolver()
@@ -288,8 +291,16 @@ class TestLegacyComparison:
             'HangOff', 'SagToBuoyancy', 'BuoyancyToHog', 'HogToBuoyancy',
             'BuoyancyToTouchDown', 'Summary', 'WeightPerUnitLengthWithOutBuoyancy',
             'WeightPerUnitLengthWithBuoyancy', 'HogBendAboveSeabed',
-            'SagBendElevationAboveSeabed'
+            'SagBendElevationAboveSeabed',
+            # Carried so a legacy-format consumer can place the configuration
+            # against the seabed and the waterline (issue #1949, defect 2).
+            'VerticalDistance', 'HangoffBelowMeanSeaLevel'
         }
+
+        # The legacy HangOff['d'] is the hang-off -> sag bend span.
+        assert math.isclose(
+            modern_dict['HangOff']['d'], legacy_data['HangOff']['d'], rel_tol=1e-12
+        )
 
         # Verify values match
         assert modern_dict['HangOff']['q'] == legacy_data['HangOff']['q']


### PR DESCRIPTION
Repairs the three kernel defects left open at the bottom of #1949 in
`marine_ops/marine_analysis/catenary/lazy_wave.py`. These block the buoyancy search in #1947:
as shipped, the solver searched a half-invalid space against a partly flat objective.

A working ancestor of this solver and its full harness were located on a private engineering
share, along with a historical result set. Reading the ancestor's **driver** — not just its
equations — settled defects 2 and 3 together, because both trace to a single substitution made
during the port.

## Defect 1 — sign-blindness on buoyancy

**What the port did.** `abs()` was applied to `weight_with_buoyancy` in four places. Verified by
execution: `w_buoy = +500 N/m` and `w_buoy = -500 N/m` returned bit-identical arc length,
horizontal distance and forces (`S = 3336.098539871913` for both).

**What the original did.** The same thing — `sagHogEquation` `abs()`es identically. But every one
of the 64 runs in the historical result set has `w_buoy < 0` (buoyancy factors 1.75 to 3.5, so
`w_buoy = (1 - BF)·w` is always negative). **The `abs()` branch was never exercised in the
sign-ambiguous regime.** It is untested legacy behaviour, not validated behaviour.

**Which is correct — and this is a place the original is wrong.** A non-negative net weight over
the buoyed length means the "buoyed" section is still net-heavy. No upward hog arc can form, so
the premise of the whole five-segment construction fails; there is no lazy-wave configuration to
report. `abs()` doesn't compute an answer for that case, it silently reports the mirror image.
Now rejected with `LazyWaveConfigurationError`.

Signs are validated once at construction (`w > 0`, `w_buoy < 0`), after which the magnitudes are
exact and the arithmetic is **numerically identical to before for valid input** — legacy
equivalence is preserved bit-for-bit.

## Defect 2 — `vertical_distance` was dead input

**What the port did.** `_solve_hangoff_section` used `hangoff_below_msl` as the hang-off section's
vertical span. Sweeping `vertical_distance` 100 m → 5000 m changed nothing. On the shipped fixture
the returned riser stopped **300 m short of the seabed** (net descent 200 m against a configured
500 m).

**What the original did.** Its driver built the hang-off input as:

```
"HangOff": {"d": VerticalDistance - SagBendElevationAboveSeabed, "q": declinationAngle, ...}
```

So `VerticalDistance` was never dead — it was the *primary* driver of the hang-off geometry.
`HangoffBelowMeanSeaLevel` was only a plot datum (and is `0` in all 64 historical runs, which is
why substituting it produced a `d` of zero-ish magnitude rather than an obvious crash).

**The port swapped the roles of the two parameters.** That single substitution is the root cause of
both this defect and the next one.

**Closure is exact by construction, not by iteration.** With `d1 = V - h_sag`, the five spans give
`d2 + d3 = h_hog - h_sag` and `d4 + d5 = h_hog`, so `d1 - d2 - d3 + d4 + d5 = V` identically.
Confirmed empirically: `hangoff_d == vertical_distance - sag_bend_elevation` holds exactly in
**all 64** historical runs.

Restored. `LazyWaveResults` now carries `vertical_closure_error` and the solver refuses to return a
non-closing configuration. `hangoff_below_msl` is retained and documented as the reporting datum it
always was.

## Defect 3 — `hangoff_bend_radius` was an unbound independent input

**What the port did.** `_solve_hangoff_section` derived a radius from (depth, angle) while
`_solve_sag_hog_sections` and the force balance used a separately supplied one. On the shipped
fixture: supplied 2000 m vs derived 17.46 m — **114.5x apart**, giving 5.48x divergence in arc
length and 114.5x in horizontal force. Both values were used simultaneously in the same solution.

**What the original did.** There is exactly one bend radius and it is derived inside
`catenaryEquation` from `(d, q)`; `sagHogEquation` then reads `data['HangOff']['BendRadius']` — the
derived value. It was never a free input. Confirmed against the historical set: the recorded
`HangOff.BendRadius` is reproduced from `(V - h_sag, q)` alone in every case, and the sag and
touchdown segments carry that same number verbatim.

**The original is right here.** One derived radius, reused everywhere. A supplied value is now
treated as a cross-check and an inconsistent one is rejected; omitting it (the normal usage) derives
it.

## Fixtures corrected

The shipped example, the unit-test fixture and the benchmark test-vector entry all encoded the
inconsistent radius — a fixture violating its own solver's binding is part of the defect.

One consequence worth flagging: `test_full_integration_with_legacy_values` asserted
`1000000 < Fh < 3000000` as a "typical range for risers". That band was only satisfiable *because*
of the unbound radius; against the radius the geometry actually implies it is off by an order of
magnitude. **The band was testing the defect, not the physics.** Replaced with the force-balance
identity.

The legacy-equivalence test previously passed the legacy-derived radius *into* the modern config,
so agreement was a tautology — which is exactly why it passed while the example, fixture and
benchmark all violated the binding. It now lets the modern solver derive its own radius and feeds
the legacy the hang-off span its driver used, making agreement a real result.

## Validation

TDD throughout — RED confirmed by execution for each defect before any fix.

RED (5/5 failed, against the pre-fix kernel):

```
AssertionError: abs() erases the sign: insufficient buoyancy (+500) returns exactly the same
  geometry as correct buoyancy (-500): S=3336.098539871913
AssertionError: vertical_distance is dead input; 100m->5000m all give
  {100.0: 3336.098539871913, 500.0: 3336.098539871913, 5000.0: 3336.098539871913}
AssertionError: riser stops 300.0 m short of the seabed: net descent 200.0 against
  vertical_distance 500.0
AssertionError: shipped fixture supplies 2000.0 m while the solver derives 17.45990931042749 m
  from (depth, angle) -- 114.5x apart
AssertionError: Fh uses the unbound supplied radius 2000.0 not the derived 17.45990931042749:
  Fh=2000000.0 vs 17459.90931042749
```

GREEN:

- **53 passed** across `test_lazy_wave_kernel_defects.py`, `test_lazy_wave_catenary.py`,
  `test_lazy_wave_legacy_comparison.py`
- **569 passed** across the wider catenary / `marine_engineering` selection
- 4 de-identified reference cases from the historical result set reproduce to `rel_tol=1e-9` with
  zero closure residual, spanning buoyancy factor (2.0 / 2.5 / 3.5), sag+hog elevations
  (500/800 and 1200/1500) and declination angle (8° / 14°)
- The buoyancy objective is now non-flat and `vertical_distance` monotone in total arc length —
  both prerequisites for #1947

Only de-identified numeric parameter → result pairs were carried into this repo; no identifiers,
project names or paths from the share.

## Not fixed here

Item 4 of #1949 — production routing through the legacy path at `engine.py:232` rather than the
tested OO solver — is untouched and still open. The legacy module itself is unmodified, so that
path behaves exactly as before.

## Pre-existing failure seen and confirmed unrelated

`tests/marine_ops/marine_engineering/visualization/test_no_regression_traces.py::test_capture_sequencing_source_sha_predates_refactor`
fails asserting `c1262494` is an ancestor of HEAD. It is not an ancestor of `origin/main` either,
so it fails on a clean main — unrelated to this change.

Closes the kernel items (1–3) of #1949.
