### PR TITLE
fix(dynacard): legacy fallback abstains from pump tagging instead of guessing up (#1952 D3)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/diagnostics.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/diagnostics.py
@@ -8,8 +8,12 @@ import numpy as np
 
 from .models import CardData, AnalysisResults, DiagnosticResult
 from .feature_extraction import FeatureExtractor
+# PUMP_TAGGING_LOAD_THRESHOLD_LBS is deliberately not imported. It was the
+# peak-load test in _classify_legacy, which could not tell tagging up from
+# tagging down and did not in fact detect either (see _classify_legacy). The
+# constant is left defined in constants.py for anyone who wants a barrel-rating
+# exceedance check, but it no longer backs a failure-mode claim here.
 from .constants import (
-    PUMP_TAGGING_LOAD_THRESHOLD_LBS,
     FLUID_POUND_LOAD_DIFF_THRESHOLD_LBS,
     GAS_INTERFERENCE_MIN_LOAD_THRESHOLD_LBS,
 )
@@ -22,7 +26,10 @@ class PumpDiagnostics:
 
     Uses a pre-trained GradientBoosting classifier on Bezerra vertical
     projection features to classify card patterns into 20 pump failure modes.
-    Falls back to legacy threshold-based rules if the model file is missing.
+    Falls back to legacy threshold-based rules if the model file is missing --
+    a narrower fallback that reports only NORMAL, FLUID_POUND and
+    GAS_INTERFERENCE and abstains from anything needing card morphology,
+    notably the two tagging directions. See :meth:`_classify_legacy`.
     """
 
     FAILURE_MODES = {
@@ -258,14 +265,57 @@ class PumpDiagnostics:
 
     @staticmethod
     def _classify_legacy(downhole_card: CardData) -> str:
-        """Legacy threshold-based classification (fallback)."""
+        """Legacy threshold-based classification (fallback).
+
+        Fires only when :meth:`_load_model` returns ``None`` -- the shipped
+        ``data/dynacard_classifier.json`` is missing or unparseable. That is a
+        degraded install, not a normal operating mode, and it is the worst
+        possible moment to guess.
+
+        **This classifier does not diagnose pump tagging, in either
+        direction.** Tagging up and tagging down are opposite mechanisms with
+        opposite repairs -- space the pump down versus space it up -- so a
+        one-sided answer is not a partial answer, it is a 50% chance of the
+        inverse field action. Distinguishing them needs card *morphology*
+        (which end of the stroke the impact sits at, and whether load spikes
+        above the upstroke plateau or dips below the downstroke line), which
+        is what the trained model reads and what a peak/trough threshold
+        cannot. Abstaining leaves the operator to look at the card; guessing
+        sends a crew to re-space a pump the wrong way.
+
+        The rule this replaced compared peak load against
+        ``PUMP_TAGGING_LOAD_THRESHOLD_LBS`` (38,000 lb) and returned
+        ``PUMP_TAGGING_UP``. Two independent problems, both measurable against
+        this package's own generators:
+
+        1. It could never return ``PUMP_TAGGING_DOWN``. A down-tag is a load
+           *minimum*; a maximum-load test is structurally blind to it.
+        2. It did not detect tagging up either. Every card
+           ``generate_pump_tagging_up_card`` produces peaks at 16-21 klb, so
+           the 38 klb rule never fired on a real up-tagging card. What it
+           actually fired on was absolute load above a barrel rating -- a
+           magnitude excursion that carries no information about which end of
+           the pump is being struck, and that a genuinely tagging-down card on
+           a deep well trips just as readily.
+
+        So the branch was not "tagging detection missing its down half"; it
+        detected a different quantity and mislabelled it. Making it two-sided
+        would mean writing a second, uncalibrated morphology classifier and
+        shipping it under the fallback -- a fabricated capability, and exactly
+        the defect class dm#1952 objects to.
+
+        Returning the retired direction-neutral ``PUMP_TAGGING`` is not an
+        available escape either: ``card_generators.MODE_ALIASES`` and
+        ``report_sections.TROUBLESHOOTING_ALIASES`` both resolve it back to
+        ``PUMP_TAGGING_UP``, so the report would still print "space the pump
+        down".
+
+        Returns:
+            One of ``NORMAL``, ``FLUID_POUND``, ``GAS_INTERFERENCE`` -- the
+            findings a threshold rule can honestly support.
+        """
         pos = np.array(downhole_card.position)
         load = np.array(downhole_card.load)
-
-        if np.max(load) > PUMP_TAGGING_LOAD_THRESHOLD_LBS:
-            # A peak-load threshold can only see the *upward* tag; tagging
-            # down shows as a load minimum and this rule cannot detect it.
-            return "PUMP_TAGGING_UP"
 
         mid_point = len(pos) // 2
         downstroke_load = load[mid_point:]

--- a/tests/marine_ops/artificial_lift/dynacard/test_diagnostics.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_diagnostics.py
@@ -12,15 +12,35 @@ from digitalmodel.marine_ops.artificial_lift.dynacard.models import DiagnosticRe
 from digitalmodel.marine_ops.artificial_lift.dynacard.card_generators import (
     generate_normal_card,
     generate_pump_tagging_card,
+    generate_pump_tagging_up_card,
+    generate_pump_tagging_down_card,
     generate_fluid_pound_card,
     generate_gas_interference_card,
+    resolve_mode,
     ALL_GENERATORS,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.report_sections import (
+    _guide_key,
 )
 from digitalmodel.marine_ops.artificial_lift.dynacard.constants import (
     PUMP_TAGGING_LOAD_THRESHOLD_LBS,
     FLUID_POUND_LOAD_DIFF_THRESHOLD_LBS,
     GAS_INTERFERENCE_MIN_LOAD_THRESHOLD_LBS,
 )
+
+# Every name that carries, or resolves to, a tagging *direction*. A direction
+# is a repair instruction: up means space the pump down, down means space it
+# up. The retired merged name is in here because both alias tables in the
+# package map it straight onto PUMP_TAGGING_UP, so returning it is not an
+# abstention -- it is the same one-sided guess with an extra hop.
+TAGGING_DIRECTION_NAMES = {
+    "PUMP_TAGGING_UP",
+    "PUMP_TAGGING_DOWN",
+    "PUMP_TAGGING",
+}
+
+# What a peak/trough threshold rule can honestly support.
+LEGACY_REACHABLE_MODES = {"NORMAL", "FLUID_POUND", "GAS_INTERFERENCE"}
 
 
 # --- Legacy card helpers (kept for backward compat tests) ---
@@ -33,12 +53,38 @@ def create_normal_card(num_points: int = 100) -> CardData:
     return CardData(position=position.tolist(), load=load.tolist())
 
 
-def create_pump_tagging_card(num_points: int = 100) -> CardData:
-    """Create a card with pump tagging (extreme loads)."""
+def create_over_threshold_load_card(num_points: int = 100) -> CardData:
+    """Create a card whose peak load clears PUMP_TAGGING_LOAD_THRESHOLD_LBS.
+
+    Deliberately not named a "tagging" card. Its shape is an ordinary sinusoid
+    -- no impact spike at either end of the stroke -- and all that is unusual
+    about it is that 40 klb of absolute load is above the barrel rating the
+    threshold constant cites. That is a load-magnitude excursion, not tagging
+    morphology, and the two must not be conflated: this card is exactly what
+    the old legacy rule reported as PUMP_TAGGING_UP.
+    """
     t = np.linspace(0, 2 * np.pi, num_points)
     position = 50 * (1 - np.cos(t))
     load = 30000 + 10000 * np.sin(t)
     return CardData(position=position.tolist(), load=load.tolist())
+
+
+def deep_well_tagging_card(down: bool, seed: int = 0) -> CardData:
+    """A real generated tagging card lifted onto a deep well's load scale.
+
+    The generators draw tagging *shape* on a 14-19 klb card, which never
+    reaches the 38 klb threshold. Adding a constant offset is precisely what a
+    heavier rod string does -- buoyant rod weight rides under the whole card
+    and shifts it up without touching its shape -- so this is still the
+    generator's tagging morphology, now on a well deep enough for the legacy
+    peak-load rule to see it. It is the only way a genuine tagging-*down* card
+    ever reaches that rule.
+    """
+    gen = generate_pump_tagging_down_card if down else generate_pump_tagging_up_card
+    card = gen(seed=seed)
+    load = np.array(card.load)
+    load = load + (PUMP_TAGGING_LOAD_THRESHOLD_LBS + 2_000 - load.max())
+    return CardData(position=list(card.position), load=load.tolist())
 
 
 def create_fluid_pound_card(num_points: int = 100) -> CardData:
@@ -158,26 +204,97 @@ class TestClassifyCardLegacy:
         result = PumpDiagnostics._classify_legacy(create_normal_card())
         assert result == "NORMAL"
 
-    def test_legacy_classifies_pump_tagging(self):
-        """Legacy classifier should detect pump tagging -- upward only.
+    def test_legacy_does_not_name_a_tagging_direction_for_a_tagging_down_card(self):
+        """The inversion case: a tagging-DOWN card must not be called tagging UP.
 
-        The legacy rule is a peak-load threshold, so it can only see the
-        plunger striking the *top* of the pump. Tagging down shows as a load
-        minimum below the downstroke line and this rule is blind to it.
+        This is the harm in dm#1952 D3 stated as an assertion. The card is the
+        generator's tagging-down morphology on a deep well, so the correct
+        repair is *space the pump up*; PUMP_TAGGING_UP prints "space the pump
+        down", which is the exact opposite intervention.
         """
-        result = PumpDiagnostics._classify_legacy(create_pump_tagging_card())
-        assert result == "PUMP_TAGGING_UP"
+        card = deep_well_tagging_card(down=True, seed=0)
+        result = PumpDiagnostics._classify_legacy(card)
+        assert result not in TAGGING_DIRECTION_NAMES, (
+            f"legacy fallback named a tagging direction ({result}) for a "
+            f"tagging-down card; that inverts the field repair"
+        )
 
-    def test_legacy_pump_tagging_threshold(self):
-        """Legacy pump tagging detection should use the defined threshold."""
+    def test_legacy_never_names_a_tagging_direction(self):
+        """The fallback must abstain from tagging on every card, not guess one.
+
+        A peak-load threshold cannot see a load *minimum*, so it can never
+        reach PUMP_TAGGING_DOWN -- which makes any tagging answer it does give
+        one-sided by construction. The honest output set for a threshold rule
+        is the three modes a threshold can actually support.
+        """
+        cards = [("over_threshold_sinusoid", create_over_threshold_load_card())]
+        for seed in (0, 1, 2):
+            cards.append((f"deep_well_tagging_down[{seed}]",
+                          deep_well_tagging_card(down=True, seed=seed)))
+            cards.append((f"deep_well_tagging_up[{seed}]",
+                          deep_well_tagging_card(down=False, seed=seed)))
+            for name, gen in ALL_GENERATORS.items():
+                cards.append((f"{name}[{seed}]", gen(seed=seed)))
+
+        for name, card in cards:
+            result = PumpDiagnostics._classify_legacy(card)
+            assert result in LEGACY_REACHABLE_MODES, (
+                f"{name}: legacy fallback returned {result!r}, which is "
+                f"outside what a threshold rule can support"
+            )
+
+    def test_legacy_output_survives_alias_resolution_without_gaining_direction(self):
+        """Abstention must survive the alias tables, not be undone by them.
+
+        Returning the retired merged name PUMP_TAGGING looks like a
+        direction-neutral answer, but ``card_generators.MODE_ALIASES`` and
+        ``report_sections.TROUBLESHOOTING_ALIASES`` both map it onto
+        PUMP_TAGGING_UP -- so the report would print "space the pump down"
+        anyway. Anything the fallback emits has to be direction-free after
+        both tables have had their turn.
+        """
+        cards = [
+            create_over_threshold_load_card(),
+            deep_well_tagging_card(down=True, seed=0),
+            deep_well_tagging_card(down=False, seed=0),
+        ]
+        for card in cards:
+            raw = PumpDiagnostics._classify_legacy(card)
+            for resolver in (resolve_mode, _guide_key):
+                assert resolver(raw) not in TAGGING_DIRECTION_NAMES, (
+                    f"{raw!r} resolves to {resolver(raw)!r} via "
+                    f"{resolver.__name__}, reinstating a repair direction"
+                )
+
+    def test_crossing_the_peak_load_threshold_names_no_tagging_mode(self):
+        """Peak load above the barrel rating is a magnitude fact, not a mode.
+
+        Replaces the old threshold test, which asserted that crossing
+        PUMP_TAGGING_LOAD_THRESHOLD_LBS *is* tagging up. A single sample
+        spiked above a barrel rating on an otherwise ordinary sinusoid says
+        nothing about which end of the pump is being struck.
+        """
         card = create_normal_card()
         card.load[50] = PUMP_TAGGING_LOAD_THRESHOLD_LBS - 1
-        result = PumpDiagnostics._classify_legacy(card)
-        assert result != "PUMP_TAGGING_UP"
+        assert PumpDiagnostics._classify_legacy(card) not in TAGGING_DIRECTION_NAMES
 
         card.load[50] = PUMP_TAGGING_LOAD_THRESHOLD_LBS + 1
-        result = PumpDiagnostics._classify_legacy(card)
-        assert result == "PUMP_TAGGING_UP"
+        assert PumpDiagnostics._classify_legacy(card) not in TAGGING_DIRECTION_NAMES
+
+    def test_ml_path_still_classifies_both_tagging_directions(self):
+        """Tagging stays classifiable -- by the calibrated path, which has both.
+
+        The fallback abstaining is only defensible because the trained model
+        resolves the direction, and does so for both mechanisms. If this ever
+        goes red, abstention has become a real capability loss rather than an
+        honest one.
+        """
+        PumpDiagnostics.reset_model_cache()
+        assert PumpDiagnostics._load_model() is not None
+        up = PumpDiagnostics.classify_card(generate_pump_tagging_up_card(seed=0))
+        down = PumpDiagnostics.classify_card(generate_pump_tagging_down_card(seed=0))
+        assert up == "PUMP_TAGGING_UP"
+        assert down == "PUMP_TAGGING_DOWN"
 
     def test_legacy_classifies_fluid_pound(self):
         """Legacy classifier should detect fluid pound."""
@@ -205,13 +322,20 @@ class TestClassifyCardLegacy:
         result = PumpDiagnostics._classify_legacy(card)
         assert result == "GAS_INTERFERENCE"
 
-    def test_legacy_priority_pump_tagging_over_fluid_pound(self):
-        """Pump tagging should be detected before fluid pound in legacy mode."""
-        card = create_pump_tagging_card()
+    def test_legacy_high_load_does_not_pre_empt_fluid_pound(self):
+        """A sharp downstroke drop is still reported when loads are high.
+
+        The old rule short-circuited on peak load, so this card was called
+        PUMP_TAGGING_UP and the fluid-pound signature -- which a threshold
+        rule *can* legitimately see -- was thrown away. With the unreachable
+        tagging branch gone, the finding the fallback can actually support is
+        the one it reports.
+        """
+        card = create_over_threshold_load_card()
         mid = len(card.load) // 2
         card.load[mid + 10] = card.load[mid + 9] - 10000
         result = PumpDiagnostics._classify_legacy(card)
-        assert result == "PUMP_TAGGING_UP"
+        assert result == "FLUID_POUND"
 
 
 class TestGenerateTroubleshootingReport:


### PR DESCRIPTION
Addresses **D3 only** of #1952. D1/D2 (`physics.py`, `constants.py`) and D4 are out of scope for this branch and are being handled separately.

## The defect

`PumpDiagnostics._classify_legacy` opened with:

```python
if np.max(load) > PUMP_TAGGING_LOAD_THRESHOLD_LBS:
    # A peak-load threshold can only see the *upward* tag; tagging
    # down shows as a load minimum and this rule cannot detect it.
    return "PUMP_TAGGING_UP"
```

A maximum-load test is structurally blind to a load *minimum*, so `PUMP_TAGGING_DOWN` was unreachable through this path. The two are not variants of one condition — tagging up means *space the pump down*, tagging down means *space the pump up*. A one-sided fallback is not a partial answer; it is a coin-flip on the inverse field action.

## What measurement added to the issue's reading

Running the module's own generators through the legacy path shows the branch was worse than one-sided — it did not detect tagging **up** either:

```
seed  card                        max load   legacy verdict   model verdict
0     tagging DOWN                  17,462    GAS_INTERFERENCE  PUMP_TAGGING_DOWN
0     tagging UP                    19,795    NORMAL            PUMP_TAGGING_UP
1..4  tagging UP                 16.1-20.9k   NORMAL            PUMP_TAGGING_UP
```

Every card `generate_pump_tagging_up_card` produces peaks at 16–21 klb, against a 38 klb threshold. The rule never fired on a real up-tagging card. What it actually fired on was absolute load above a barrel rating — a magnitude excursion that says nothing about which end of the pump is being struck, and that a genuine tagging-*down* card on a deep well trips just as readily. So the branch was not "tagging detection missing its down half"; it measured a different quantity and mislabelled it.

## Decision: abstain, don't go two-sided

`_classify_legacy` fires only when `_load_model()` returns `None` — the shipped `data/dynacard_classifier.json` is missing or unparseable. That is a degraded install, not a normal mode, and the worst moment to guess.

Making the rule genuinely two-sided would mean writing a second morphology classifier (impact position, spike above the upstroke plateau vs dip below the downstroke line), calibrating it against 20 modes to keep false positives down, and shipping it as the fallback for a broken install. That is a new uncalibrated capability presented as a working one — the same defect class #1952 objects to. The trained model already reads morphology and gets both directions right; it is the calibrated path.

A symmetric *threshold* rule was checked and rejected on the numbers: the obvious mirror (min load below the compression threshold, `-500 lb`) never fires on the down-tagging generator either, whose minima run +1,548 to +4,907 lb. That would have been two unreachable branches instead of one.

Returning the retired direction-neutral `PUMP_TAGGING` was rejected too, and this is the non-obvious one: `card_generators.MODE_ALIASES` and `report_sections.TROUBLESHOOTING_ALIASES` **both** map `PUMP_TAGGING` → `PUMP_TAGGING_UP`, so the report would still print "space the pump down". It looks like an abstention and is the same one-sided guess with an extra hop. A test now pins this.

The legacy path returns only `NORMAL`, `FLUID_POUND`, `GAS_INTERFERENCE` — what a threshold rule can honestly support. The reasoning lives in the method docstring so the next reader does not have to re-derive it.

## Tests

TDD: 5 new/rewritten assertions confirmed RED before the source changed.

- `test_legacy_does_not_name_a_tagging_direction_for_a_tagging_down_card` — the inversion case, built from `generate_pump_tagging_down_card` plus a constant load offset (physically, a heavier rod string: it shifts the card without changing its shape), which is the only way a genuine down-tagging card reaches the peak-load rule at all.
- `test_legacy_never_names_a_tagging_direction` — sweep over all 20 generators × 3 seeds plus the deep-well and over-threshold cards.
- `test_legacy_output_survives_alias_resolution_without_gaining_direction` — guards the alias-laundering route.
- `test_crossing_the_peak_load_threshold_names_no_tagging_mode` — replaces the old test that asserted crossing the threshold *is* tagging up.
- `test_legacy_high_load_does_not_pre_empt_fluid_pound` — the finding the fallback can support is no longer discarded by the short-circuit.
- `test_ml_path_still_classifies_both_tagging_directions` — pins that abstention is honest rather than a capability loss.

**Three existing tests asserted the one-sided behaviour as correct** and are replaced: `test_legacy_classifies_pump_tagging` (whose docstring explicitly blessed "upward only"), `test_legacy_pump_tagging_threshold`, and `test_legacy_priority_pump_tagging_over_fluid_pound`. The helper `create_pump_tagging_card` is renamed `create_over_threshold_load_card` — its shape is a plain sinusoid with no impact spike at either end, so its old name asserted something false.

Mutation-checked: re-introducing the branch as `return "PUMP_TAGGING_UP"` fails 5 tests; as `return "PUMP_TAGGING"` fails 5 tests. Neither test set is tautological.

`tests/marine_ops/`: 1834 passed, 1 failed — `test_capture_sequencing_source_sha_predates_refactor`, a known pre-existing failure unrelated to this change.

## Loose end

`PUMP_TAGGING_LOAD_THRESHOLD_LBS` is now unreferenced in `src/` (still exercised by tests, which pin that crossing it produces no tagging label). It is left defined; `constants.py` is out of scope on this branch.