### PR TITLE
fix(dynacard): compute pump fillage; derive failure-mode count (#1952 D1+D2)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/constants.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/constants.py
@@ -174,9 +174,15 @@ sinusoidal or helical buckling in the rod string.
 
 DEFAULT_PUMP_FILLAGE = 0.85
 """
-Default pump fillage (volumetric efficiency) as decimal.
+Assumed pump fillage (volumetric efficiency) as a decimal *fraction*.
 85% is typical for wells operating within normal parameters.
 Range: 0.0 (empty) to 1.0 (full stroke).
+
+This is a planning assumption for cases with no card, not a measurement.
+Never substitute it for a computed fillage: use
+``calculations.calculate_pump_fillage`` on a downhole card instead. Note also
+that ``AnalysisResults.pump_fillage`` is a *percentage* (0-100), so this value
+is not on that scale (issue #1952 D1).
 """
 
 
@@ -250,5 +256,52 @@ Typical range: 50-200.
 BEZERRA_N_BINS = 8
 """Number of position bins per half-cycle for Bezerra vertical projections."""
 
-N_FAILURE_MODES = 18
-"""Total number of diagnostic failure modes in the ML classifier."""
+RETIRED_FAILURE_MODE_ALIASES = frozenset({"VALVE_LEAK", "PUMP_TAGGING"})
+"""Failure-mode keys retained only for backward compatibility.
+
+``PumpDiagnostics.FAILURE_MODES`` keeps these so archived results and stored
+configs carrying an old label still resolve to a description. The trained
+classifier never predicts them -- each was split into a pair of modes with
+opposite repairs (``VALVE_LEAK_TV``/``VALVE_LEAK_SV``,
+``PUMP_TAGGING_UP``/``PUMP_TAGGING_DOWN``) -- so they are not diagnostic modes
+and are excluded from :data:`N_FAILURE_MODES`.
+"""
+
+
+# ``N_FAILURE_MODES`` is derived from ``PumpDiagnostics.FAILURE_MODES`` rather
+# than restated here: it was hardcoded to 18 against 20 predictable modes, and
+# a second copy of a number is a second thing to forget (issue #1952 D2).
+# ``diagnostics`` imports this module, so the derivation is deferred to first
+# attribute access via PEP 562 and memoised into the module globals; that keeps
+# the dependency one-directional at import time whatever order modules load in.
+def _derive_n_failure_modes() -> int:
+    """Count the failure modes the classifier can actually predict."""
+    from .diagnostics import PumpDiagnostics
+
+    return len(
+        set(PumpDiagnostics.FAILURE_MODES) - RETIRED_FAILURE_MODE_ALIASES
+    )
+
+
+_LAZY_CONSTANTS = {"N_FAILURE_MODES": _derive_n_failure_modes}
+
+
+def __getattr__(name: str):
+    """Resolve lazily-derived module constants (PEP 562).
+
+    N_FAILURE_MODES: total number of diagnostic failure modes in the ML
+    classifier, excluding :data:`RETIRED_FAILURE_MODE_ALIASES`.
+    """
+    derive = _LAZY_CONSTANTS.get(name)
+    if derive is None:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        )
+    value = derive()
+    globals()[name] = value  # memoise; __getattr__ is not consulted again
+    return value
+
+
+def __dir__() -> list:
+    """Keep lazily-derived constants discoverable via ``dir()``."""
+    return sorted(set(globals()) | set(_LAZY_CONSTANTS))

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/physics.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/physics.py
@@ -1,5 +1,7 @@
 import numpy as np
 from scipy.signal import savgol_filter
+from .calculations import calculate_pump_fillage
+from .exceptions import PhysicsError
 from .models import DynacardAnalysisContext, CardData, AnalysisResults
 from .constants import (
     FEET_TO_INCHES,
@@ -13,7 +15,6 @@ from .constants import (
     LOAD_ATTENUATION_FACTOR,
     STROKE_SCALING_FACTOR,
     BUCKLING_DETECTION_LOAD_THRESHOLD_LBS,
-    DEFAULT_PUMP_FILLAGE,
 )
 
 class DynacardPhysicsSolver:
@@ -124,10 +125,33 @@ class DynacardPhysicsSolver:
         return self.results.buckling_detected
 
     def calculate_fillage(self):
-        """Calculate pump fillage (simplified default).
+        """Calculate pump fillage from the solved downhole card.
+
+        Delegates to :func:`calculations.calculate_pump_fillage`, which
+        derives fillage from the net and gross plunger travel of the downhole
+        card. This is the same computation ``DynacardAnalyzer.run_full_analysis``
+        runs, so ``results.pump_fillage`` carries one meaning and one scale
+        regardless of which entry point produced it.
 
         Returns:
-            The pump fillage value as a float (default constant).
+            Pump fillage as a percentage of gross stroke (0-100).
+
+        Raises:
+            PhysicsError: If :meth:`solve_wave_equation` has not been run, so
+                there is no downhole card to measure. This method previously
+                assigned ``DEFAULT_PUMP_FILLAGE`` and returned it without
+                examining the card, reporting the same fillage for every well
+                -- and on a 0-1 scale, against the 0-100 percentage the
+                analyzer pipeline writes into the same field (issue #1952 D1).
         """
-        self.results.pump_fillage = DEFAULT_PUMP_FILLAGE
+        if not self.results.downhole_card:
+            raise PhysicsError(
+                "Pump fillage requires a downhole card; "
+                "call solve_wave_equation() first.",
+                solver="gibbs",
+            )
+
+        self.results.pump_fillage = calculate_pump_fillage(
+            self.results.downhole_card
+        ).fillage
         return self.results.pump_fillage

--- a/tests/marine_ops/artificial_lift/dynacard/test_constants.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_constants.py
@@ -1,0 +1,75 @@
+# ABOUTME: Tests for dynacard constants that must stay consistent with code.
+# ABOUTME: Guards N_FAILURE_MODES against drifting from the classifier's modes.
+
+import json
+from pathlib import Path
+
+from digitalmodel.marine_ops.artificial_lift.dynacard import constants
+from digitalmodel.marine_ops.artificial_lift.dynacard.diagnostics import (
+    PumpDiagnostics,
+)
+
+_MODEL_PATH = (
+    Path(constants.__file__).parent / "data" / "dynacard_classifier.json"
+)
+
+
+class TestFailureModeCount:
+    """Tests for N_FAILURE_MODES (issue #1952 D2).
+
+    The constant was hardcoded to 18 while ``PumpDiagnostics.FAILURE_MODES``
+    held 22 entries -- 20 predictable modes plus 2 retired aliases kept only
+    so archived results carrying an old label still resolve to a description.
+    It must be derived, not restated, so it cannot drift again.
+    """
+
+    def test_retired_aliases_are_present_in_failure_modes(self):
+        """The exclusion list must name keys that actually exist.
+
+        If a retired alias is finally deleted from FAILURE_MODES, this fails
+        rather than letting the exclusion silently under-count.
+        """
+        assert constants.RETIRED_FAILURE_MODE_ALIASES
+        assert constants.RETIRED_FAILURE_MODE_ALIASES <= set(
+            PumpDiagnostics.FAILURE_MODES
+        )
+
+    def test_count_excludes_retired_aliases(self):
+        """N_FAILURE_MODES must be derived from FAILURE_MODES, minus aliases."""
+        expected = len(
+            set(PumpDiagnostics.FAILURE_MODES)
+            - constants.RETIRED_FAILURE_MODE_ALIASES
+        )
+
+        assert constants.N_FAILURE_MODES == expected
+
+    def test_count_matches_shipped_classifier(self):
+        """The count must match what the trained model can actually predict.
+
+        This is the semantic anchor: N_FAILURE_MODES documents the ML
+        classifier, and the shipped model is a 20-class model whose labels
+        are exactly FAILURE_MODES minus the retired aliases.
+        """
+        model = json.loads(_MODEL_PATH.read_text())
+
+        assert constants.N_FAILURE_MODES == model["n_classes"]
+        assert set(model["class_labels"]) == (
+            set(PumpDiagnostics.FAILURE_MODES)
+            - constants.RETIRED_FAILURE_MODE_ALIASES
+        )
+
+    def test_count_is_twenty(self):
+        """Canary: adding or removing a mode must be a deliberate change."""
+        assert constants.N_FAILURE_MODES == 20
+
+    def test_count_importable_directly(self):
+        """`from ... import N_FAILURE_MODES` must work despite lazy derivation."""
+        from digitalmodel.marine_ops.artificial_lift.dynacard.constants import (
+            N_FAILURE_MODES,
+        )
+
+        assert N_FAILURE_MODES == constants.N_FAILURE_MODES
+
+    def test_count_is_discoverable_via_dir(self):
+        """The lazily-derived name must still show up in dir(constants)."""
+        assert "N_FAILURE_MODES" in dir(constants)

--- a/tests/marine_ops/artificial_lift/dynacard/test_physics.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_physics.py
@@ -11,10 +11,14 @@ from digitalmodel.marine_ops.artificial_lift.dynacard import (
     PumpProperties,
     SurfaceUnit,
 )
+from digitalmodel.marine_ops.artificial_lift.dynacard.calculations import (
+    calculate_pump_fillage,
+)
 from digitalmodel.marine_ops.artificial_lift.dynacard.constants import (
     DEFAULT_PUMP_FILLAGE,
     BUCKLING_DETECTION_LOAD_THRESHOLD_LBS,
 )
+from digitalmodel.marine_ops.artificial_lift.dynacard.exceptions import PhysicsError
 
 
 def create_test_context(
@@ -225,25 +229,78 @@ class TestDetectBuckling:
 
 
 class TestCalculateFillage:
-    """Tests for the calculate_fillage method."""
+    """Tests for the calculate_fillage method.
 
-    def test_returns_default_fillage(self):
-        """Should return the default fillage value."""
+    Issue #1952 D1: this method used to assign ``DEFAULT_PUMP_FILLAGE`` and
+    return it without ever looking at the card, so every well reported the
+    same fillage -- and on a 0-1 scale, while ``DynacardAnalyzer``'s pipeline
+    writes a 0-100 percentage into the very same ``results.pump_fillage``
+    field. It must run the real computation on the solved downhole card.
+    """
+
+    def test_delegates_to_the_real_fillage_calculation(self):
+        """Should return exactly what calculations.calculate_pump_fillage gives."""
         ctx = create_test_context()
         solver = DynacardPhysicsSolver(ctx)
+        results = solver.solve_wave_equation()
+
+        expected = calculate_pump_fillage(results.downhole_card).fillage
+
+        assert solver.calculate_fillage() == pytest.approx(expected)
+
+    def test_does_not_return_the_default_constant(self):
+        """Should not hand back the fabricated placeholder value."""
+        ctx = create_test_context()
+        solver = DynacardPhysicsSolver(ctx)
+        solver.solve_wave_equation()
+
+        assert solver.calculate_fillage() != pytest.approx(DEFAULT_PUMP_FILLAGE)
+
+    def test_fillage_depends_on_the_card(self):
+        """Different cards must produce different fillage values."""
+        fillages = []
+        for kwargs in (
+            {},
+            {"peak_load": 20000.0, "min_load": 2000.0},
+            {"stroke_length": 64.0, "rod_length": 3000.0},
+        ):
+            solver = DynacardPhysicsSolver(create_test_context(**kwargs))
+            solver.solve_wave_equation()
+            fillages.append(solver.calculate_fillage())
+
+        assert len(set(fillages)) == len(fillages), (
+            f"fillage must vary with the card, got {fillages}"
+        )
+
+    def test_reports_percentage_scale(self):
+        """Should use the 0-100 percentage scale of results.pump_fillage."""
+        ctx = create_test_context()
+        solver = DynacardPhysicsSolver(ctx)
+        solver.solve_wave_equation()
 
         fillage = solver.calculate_fillage()
 
-        assert fillage == DEFAULT_PUMP_FILLAGE
+        assert 1.0 < fillage <= 100.0
 
     def test_sets_fillage_in_results(self):
-        """Should set fillage in results."""
+        """Should set the computed fillage in results."""
+        ctx = create_test_context()
+        solver = DynacardPhysicsSolver(ctx)
+        results = solver.solve_wave_equation()
+
+        returned = solver.calculate_fillage()
+        expected = calculate_pump_fillage(results.downhole_card).fillage
+
+        assert solver.results.pump_fillage == pytest.approx(expected)
+        assert solver.results.pump_fillage == pytest.approx(returned)
+
+    def test_raises_when_wave_equation_not_solved(self):
+        """Should refuse to invent a number when there is no downhole card."""
         ctx = create_test_context()
         solver = DynacardPhysicsSolver(ctx)
 
-        solver.calculate_fillage()
-
-        assert solver.results.pump_fillage == DEFAULT_PUMP_FILLAGE
+        with pytest.raises(PhysicsError):
+            solver.calculate_fillage()
 
 
 class TestPhysicsWithRealWorldValues:


### PR DESCRIPTION
Addresses **D1 and D2 of #1952 only**. D3 and D4 are explicitly out of scope; `diagnostics.py` is not modified (another change is in flight against D3).

## D1 — `calculate_fillage()` returned a constant

`DynacardPhysicsSolver.calculate_fillage()` assigned `DEFAULT_PUMP_FILLAGE` and returned it without ever looking at the card, so every well reported 0.85.

A second problem the issue didn't name: `DEFAULT_PUMP_FILLAGE` is a **0-1 fraction**, while `DynacardAnalyzer.run_full_analysis` (`solver.py:250`) writes `p1_results['fillage'].fillage` — a **0-100 percentage** — into the *same* `AnalysisResults.pump_fillage` field. One field carried two incompatible scales depending on which entry point ran. `field_health.py` and `data_loader.py` both read it on the percentage convention.

### Option chosen: delegate to the real calculation

`calculate_fillage()` now calls `calculations.calculate_pump_fillage` on the solved downhole card — the exact computation `run_full_analysis` already performs — so both entry points agree in value and in scale. If `solve_wave_equation()` has not run there is no card to measure, and it raises `PhysicsError` rather than inventing a number.

Rejected the `default_fillage` rename: **no caller wanted a default.** The method has zero production callers, and the only callers anywhere were two tests asserting the fabricated constant. Renaming would have preserved a trap for whoever next reaches for the obvious method name on the obvious solver class. Rejected a bare `raise` because the real computation already exists two modules away and the caller plainly wants fillage.

`DEFAULT_PUMP_FILLAGE` is kept as a documented planning assumption for card-free cases; its docstring now states it is a fraction, is not a measurement, and is not on the `AnalysisResults` scale.

### Callers found

`grep -rn "calculate_fillage|DEFAULT_PUMP_FILLAGE" src/ tests/ examples/ docs/`

| Site | Depends on 0.85? |
|---|---|
| `physics.py:126,132` (the definition) | n/a — changed |
| `tests/.../test_physics.py::TestCalculateFillage` (2 tests) | **Yes** — both asserted `== DEFAULT_PUMP_FILLAGE`. Rewritten. |
| everything else | none — no production caller exists |

`DynacardAnalyzer.run_full_analysis` never calls it; it goes through `run_p1_calculations`. Nothing in `examples/` or `docs/` references it.

## D2 — `N_FAILURE_MODES = 18` was stale

`PumpDiagnostics.FAILURE_MODES` holds 22 entries: 20 predictable modes plus 2 retired aliases (`VALVE_LEAK`, `PUMP_TAGGING`).

### Aliases do not count — value is 20

`N_FAILURE_MODES` documents *the ML classifier*, and the shipped model `data/dynacard_classifier.json` reports `n_classes: 20` with `class_labels` **exactly** equal to `FAILURE_MODES` minus those two aliases. The aliases exist only so archived results and stored configs carrying an old label still resolve to a description; each was split into a pair of modes with **opposite repairs** (`VALVE_LEAK_TV`/`VALVE_LEAK_SV`, `PUMP_TAGGING_UP`/`PUMP_TAGGING_DOWN`), so counting them would overstate what the classifier can distinguish.

### Derived, not restated

The value is now computed from `FAILURE_MODES` minus a named `RETIRED_FAILURE_MODE_ALIASES` set. `diagnostics` imports `constants`, so the derivation is deferred to first attribute access via PEP 562 `__getattr__` and memoised into the module globals — the import dependency stays one-directional in any load order (verified both orders explicitly). `__dir__` keeps the name discoverable.

Ideally `RETIRED_FAILURE_MODE_ALIASES` would sit next to `FAILURE_MODES` in `diagnostics.py`; it lives in `constants.py` because this change may not touch `diagnostics.py`. Worth folding in once the D3 work lands.

## TDD

RED confirmed before any implementation — 10 failures:

```
tests/.../test_physics.py:294: assert solver.results.pump_fillage == pytest.approx(expected)
E   assert 0.85 == 97.97552634481569 +- 9.8e-05
tests/.../test_physics.py:257: assert solver.calculate_fillage() != pytest.approx(DEFAULT_PUMP_FILLAGE)
E   assert 0.85 != 0.85 +- 8.5e-07
tests/.../test_physics.py:283: assert 1.0 < fillage <= 100.0
E   assert 1.0 < 0.85
tests/.../test_physics.py:271: AssertionError: fillage must vary with the card, got [0.85, 0.85, 0.85]
E   assert 1 == 3
tests/.../test_constants.py:32: AttributeError: module '...constants' has no attribute 'RETIRED_FAILURE_MODE_ALIASES'
tests/.../test_constants.py:63: assert constants.N_FAILURE_MODES == 20
E   assert 18 == 20
tests/.../test_constants.py:55: assert constants.N_FAILURE_MODES == model["n_classes"]
E   assert 18 == 20
...
10 failed, 2 passed
```

Tests added/rewritten:

- `test_physics.py::TestCalculateFillage` — delegation equality, not-the-default-constant, varies-with-the-card, percentage scale, results field, and raises-without-a-solved-card.
- `test_constants.py` (new) — derivation, alias-list validity (fails if an alias is deleted rather than silently under-counting), three-way agreement with the shipped classifier's `class_labels`, a `== 20` canary, direct importability, `dir()` discoverability.

## Verification (execution, not reading)

- Targeted: **25 passed**.
- Every test module that references `artificial_lift`/`dynacard` (`tests/marine_ops/artificial_lift/`, `tests/scripts/artificial_lift/`, `tests/well/tubulars/test_sucker_rod.py`, `tests/workflows/test_durable_workflows.py`): **1143 passed, 3 skipped**.
- Full suite on this box: 193 failed / 20553 passed / 510 skipped. That baseline is far dirtier than the 7 documented pre-existing failures — but no failing module imports `dynacard` (verified by grep), and the failures sampled against a stashed working tree (i.e. unmodified `main`) reproduce identically. The change is confined to the `dynacard` package.
- Import-order robustness for the PEP 562 derivation checked in both directions plus package import.
- `ruff check` on the touched files: 2 findings, both pre-existing on `main` (unused `savgol_filter`, `E701` at `physics.py:121`), left alone to keep this PR scoped.
- `scripts/enforcement/check-no-abs-paths.sh --added` -> rc 0.
