### PR TITLE
fix(dynacard): field-health must not fall back to the gibbs solver (#1857)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/models.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/models.py
@@ -477,7 +477,9 @@ class AnalysisResults(BaseModel):
     diagnostic_message: str = "Analysis not yet performed"
 
     # Solver metadata
-    solver_method: str = "gibbs"  # "gibbs" or "finite_difference"
+    # Reporting metadata only -- always overwritten by the solver that ran
+    # (solver.py:235). One of "everitt_jennings", "gibbs", "finite_difference".
+    solver_method: str = "gibbs"
 
     class Config:
         """Pydantic configuration for AnalysisResults."""

--- a/src/digitalmodel/marine_ops/artificial_lift/field_health.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/field_health.py
@@ -70,7 +70,12 @@ def run_field_troubleshooter(settings: dict[str, Any]) -> list[dict[str, Any]]:
         raise ValueError("artificial_lift_field_health requires at least one well")
 
     defaults = settings.get("well_defaults") or {}
-    solver_method = str(settings.get("solver_method", "gibbs"))
+    # Must match DynacardWorkflow's own default. 'gibbs' does not transform
+    # load at all (dm#1857) and must not be used for diagnosis; the shipped
+    # base config already sets everitt_jennings, so this fallback only reaches
+    # callers that build settings by hand -- which is precisely who would not
+    # know to override it.
+    solver_method = str(settings.get("solver_method", "everitt_jennings"))
     rows = []
     for well in wells:
         ctx = load_and_map_well(well, defaults)

--- a/tests/marine_ops/artificial_lift/test_field_health_solver_default.py
+++ b/tests/marine_ops/artificial_lift/test_field_health_solver_default.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Guards the solver default in the field-health entry point against
+ABOUTME: silently falling back to a solver documented as unusable for diagnosis.
+"""
+
+import inspect
+
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift import field_health
+from digitalmodel.marine_ops.artificial_lift.dynacard.solver import DynacardWorkflow
+
+
+# The solvers that actually reconstruct a downhole card. 'gibbs' does not
+# transform the load at all (dm#1857) and 'finite_difference' diverges; the
+# DynacardWorkflow docstring says neither should be used for diagnosis.
+DIAGNOSTIC_SOLVERS = {"everitt_jennings"}
+
+
+def _default_of(func, param):
+    return inspect.signature(func).parameters[param].default
+
+
+class TestFieldHealthSolverDefault:
+    """`run_field_troubleshooter` must not fall back to a non-diagnostic solver."""
+
+    def test_fallback_is_a_diagnostic_solver(self):
+        """Settings without an explicit solver_method must not land on gibbs.
+
+        The shipped base config sets everitt_jennings explicitly, so this
+        fallback is latent rather than live -- which is exactly why it needs a
+        test. Any caller building a settings dict by hand (a notebook, a new
+        workflow, a test) silently gets the solver the module documents as
+        unusable, and nothing in the output says so.
+        """
+        source = inspect.getsource(field_health.run_field_troubleshooter)
+        assert 'settings.get("solver_method", "gibbs")' not in source, (
+            "run_field_troubleshooter falls back to 'gibbs', which does not "
+            "transform load (dm#1857) and must not be used for diagnosis"
+        )
+
+    def test_fallback_matches_the_workflow_default(self):
+        """The two defaults must not disagree.
+
+        DynacardWorkflow defaults to everitt_jennings. A caller-side default
+        that differs is worse than no default: both values are valid members
+        of the Literal, so type checking and tests pass either way, and the
+        disagreement is only visible by reading both files.
+        """
+        workflow_default = _default_of(DynacardWorkflow.__init__, "solver_method")
+        assert workflow_default in DIAGNOSTIC_SOLVERS
+
+        source = inspect.getsource(field_health.run_field_troubleshooter)
+        assert f'"solver_method", "{workflow_default}"' in source, (
+            f"field_health fallback disagrees with DynacardWorkflow's default "
+            f"({workflow_default!r})"
+        )
+
+    @pytest.mark.parametrize("bad_solver", ["gibbs", "finite_difference"])
+    def test_non_diagnostic_solvers_are_not_defaults_anywhere(self, bad_solver):
+        """Neither non-diagnostic solver may be a default in this call path."""
+        workflow_default = _default_of(DynacardWorkflow.__init__, "solver_method")
+        assert workflow_default != bad_solver
+
+        source = inspect.getsource(field_health.run_field_troubleshooter)
+        assert f'"solver_method", "{bad_solver}"' not in source


### PR DESCRIPTION
Two defaults disagreed about which physics solver runs, and the one that won was the one the module documents as unusable.

## The defect

| Site | Default |
|---|---|
| `dynacard/solver.py:51` — `DynacardWorkflow.__init__` | `everitt_jennings` |
| `field_health.py:73` — `run_field_troubleshooter` | **`gibbs`** |

`DynacardWorkflow`'s own docstring calls `everitt_jennings` *"the only one that reproduces the reference downhole cards"*, and says of the other two: *"Neither should be used for diagnosis."* Of Gibbs specifically:

> `'gibbs'` does not transform the load at all — it returns an affine rescale of the surface card (issue #1857) — so it cannot resolve pump condition.

With measurements already recorded in that same docstring, against the stored reference downhole cards on five fixture wells:

| solver | med nRMSE | med \|stroke err\| | med corr |
|---|---|---|---|
| **everitt_jennings** | **0.9%** | 0.0% | 1.000 |
| gibbs | 17.3% | 2.7% | 0.966 |

## Severity: latent, not live

The shipped base config (`artificial_lift_field_health.yml:7`) sets `everitt_jennings` explicitly, with a comment already citing #1857. **So the standard config-driven path was never affected**, and no published field-health output is wrong because of this.

The fallback reached only callers assembling a settings dict by hand — a notebook, a new workflow, a test fixture. Those are precisely the callers least likely to know an override was required, and the failure is silent: the run completes, produces a full diagnosis, and reports `solver_method: gibbs` in a metadata field nobody reads as a warning.

## Why nothing caught it

Both values are valid members of `Literal['everitt_jennings', 'gibbs', 'finite_difference']`. Type checking passes either way. Every existing test passes either way. The disagreement is visible **only** by reading two files side by side and noticing they differ — which is not a thing tests do.

So the fix ships with a test that pins the *relationship* rather than the value: the fallback must equal `DynacardWorkflow`'s own default, whatever that is. If someone changes one in future, the other is forced to follow or the test fails.

## Changes

- `field_health.py:73` — fallback `"gibbs"` → `"everitt_jennings"`, with the reasoning inline.
- `models.py` — corrects a stale comment on `AnalysisResults.solver_method` that listed only `"gibbs" or "finite_difference"`, omitting `everitt_jennings` entirely. That field is reporting metadata, always overwritten at `solver.py:235`; **its value is unchanged**.
- `tests/marine_ops/artificial_lift/test_field_health_solver_default.py` — new.

## Verification

- RED first: 3 failed / 1 passed before the fix, with the failure naming the exact fallback string.
- GREEN: 20 passed across the new test plus `test_dynacard.py` and `test_solver_parity.py`.
- Full `tests/marine_ops/artificial_lift/`: **973 passed**.
- One pre-existing collection error, unrelated: `test_vision_benchmark.py` imports `dynacard.benchmark.test_set_builder`, which does not exist. Untouched by this change.

## Provenance

Found by adversarial plan review on #1955, which proposed repairing the Gibbs load propagation. Both reviewers returned MAJOR, and their blast-radius findings led here instead — to a one-word defect worth more than the repair the plan was for. #1955 is closed as a duplicate of this issue; the physics analysis is preserved in a comment here.

This PR does **not** fix the underlying Gibbs defect. #1857 stays open for that.
