### PR TITLE
fix(cfd): harden attested snapshots and fail-closed solver evidence

### DIFF
--- a/scripts/cfd/run_synthetic_tank_3d_smoke.py
+++ b/scripts/cfd/run_synthetic_tank_3d_smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import math
 import os
 import re
@@ -36,7 +37,11 @@ from digitalmodel.solvers.openfoam.smoke import (
     plan_smoke,
     write_reduced_evidence,
 )
-from digitalmodel.solvers.openfoam.smoke_evidence import capture_pre_run_artifacts
+from digitalmodel.solvers.openfoam.smoke_evidence import (
+    EvidenceValidationError,
+    capture_pre_run_artifacts,
+    cross_check_bridge_manifest,
+)
 from digitalmodel.solvers.openfoam.validation.sloshing_3d import (
     Sloshing3DConfig,
     write_sloshing_case,
@@ -141,6 +146,11 @@ def _execute_attested_smoke(
             execution_class=execution_class,
             dispatcher=dispatcher,
         )
+        # Prove the artifact that actually landed on disk embeds the attested
+        # manifest. Checking the in-memory payload would not catch a bundle
+        # that was serialized wrong or written from a different manifest.
+        written = json.loads(Path(evidence).read_text(encoding="utf-8"))
+        cross_check_bridge_manifest(written, bridge.manifest)
         return result
     finally:
         execution.release()
@@ -376,7 +386,14 @@ def main(argv: list[str] | None = None) -> int:
             execution_class=args.execution_class,
             projected_load_per_core=projected_load,
         )
-    except (GmshBridgeError, OSError, PrebuiltMeshError, SmokeError, ValueError) as exc:
+    except (
+        EvidenceValidationError,
+        GmshBridgeError,
+        OSError,
+        PrebuiltMeshError,
+        SmokeError,
+        ValueError,
+    ) as exc:
         print(f"synthetic smoke failed: {exc}")
         return 1
     print(f"synthetic smoke completed: ranks={ranks} evidence={args.evidence}")

--- a/src/digitalmodel/solvers/openfoam/prebuilt_mesh.py
+++ b/src/digitalmodel/solvers/openfoam/prebuilt_mesh.py
@@ -38,6 +38,15 @@ _CONTRACT_FIELDS = {
     "patches", "wall_patches", "atmosphere_patch", "fluid_zone", "cells",
     "faces", "internal_faces",
 }
+# Top-level entries a cleanly attested case may contain. The bridge runs
+# gmshToFoam/changeDictionary/checkMesh in a temp stage directory and promotes
+# only constant/polyMesh plus its manifest, so it leaves no residue behind.
+# Anything else at the top level is stale state from an earlier run: a numeric
+# time directory, processorN, log.*, VTK/, postProcessing/, or a stray file.
+# This is a TOP-LEVEL fence only -- the manifest and the mesh live under
+# constant/, whose own dictionaries are legitimate inputs and are not touched.
+# input.yml is allowlisted, not required; it may legitimately be absent.
+_ALLOWED_TOP_LEVEL = frozenset({"0", "system", "constant", "source.msh", "input.yml"})
 
 
 class PrebuiltMeshError(RuntimeError):
@@ -78,11 +87,13 @@ def prepare_prebuilt_execution(
     try:
         payload = _load_manifest(case, manifest)
         _reject_links(case)
+        _reject_residue(case)
         _validate_bound_case(case, payload)
         snapshot = Path(tempfile.mkdtemp(prefix=f".{case.name}.run-", dir=case.parent))
         shutil.copytree(case, snapshot, dirs_exist_ok=True, symlinks=False)
         snapshot.chmod(0o700)
         _reject_links(snapshot)
+        _reject_residue(snapshot)
         _validate_bound_case(snapshot, payload)
         _validate_bound_case(case, payload)
         protected_sha256 = _hash_protected_inputs(snapshot)
@@ -282,6 +293,21 @@ def _reject_links(root: Path) -> None:
         if candidate.is_symlink():
             raise PrebuiltMeshError(
                 f"symlink is forbidden in prebuilt case: {candidate.relative_to(root)}"
+            )
+
+
+def _reject_residue(root: Path) -> None:
+    """Fence the case to the attested top-level allowlist.
+
+    Stale residue is a live false-pass vector, not just untidiness: the motion
+    proof reads the highest-numbered time directory, so a leftover 0.5/polyMesh
+    copied into the private snapshot can be mistaken for the reconstructed mesh
+    and certify motion that never happened.
+    """
+    for entry in sorted(root.iterdir()):
+        if entry.name not in _ALLOWED_TOP_LEVEL:
+            raise PrebuiltMeshError(
+                f"unattested residue in prebuilt case: {entry.name}"
             )
 
 

--- a/src/digitalmodel/solvers/openfoam/runner.py
+++ b/src/digitalmodel/solvers/openfoam/runner.py
@@ -28,7 +28,14 @@ _ERROR_MARKERS = (
     "FOAM FATAL IO ERROR",
 )
 # Divergence markers — present in solver logs when the solution blows up.
-_DIVERGENCE_MARKERS = ("bounding", "Maximum number of iterations exceeded")
+# Kept in lockstep with smoke.py:_DIVERGENCE_MARKERS — one fail-closed
+# divergence policy, mirrored on the attested-runner path. Lowercase because
+# _detect_error matches case-insensitively, exactly as smoke.py does.
+_DIVERGENCE_MARKERS = (
+    "divergence",
+    "maximum number of iterations exceeded",
+    "bounding",
+)
 
 
 class OpenFOAMRunStatus(str, Enum):
@@ -359,25 +366,32 @@ class OpenFOAMRunner:
             stage.error_message = f"{name} invocation failed: {exc}"
             return stage
 
-        # OpenFOAM utilities write their banner+progress to stdout; persist it.
+        # OpenFOAM utilities write their banner+progress to stdout, but a FOAM
+        # FATAL can land on stderr at rc=0. Persist and inspect BOTH, or the
+        # stage log is not the whole record and the verdict is not honest.
+        combined = (proc.stdout or "") + (proc.stderr or "")
         try:
-            log_file.write_text(proc.stdout or "")
+            log_file.write_text(combined)
         except OSError:
             stage.log_file = None
 
         stage.return_code = proc.returncode
         stage.duration_seconds = time.monotonic() - start
-        stage.error_message = self._detect_error(name, proc.returncode, proc.stdout)
+        stage.error_message = self._detect_error(name, proc.returncode, combined)
         return stage
 
     @staticmethod
     def _detect_error(
-        name: str, return_code: int, stdout: Optional[str]
+        name: str, return_code: int, output: Optional[str]
     ) -> Optional[str]:
         if return_code != 0:
             return f"{name} returned non-zero exit code {return_code}"
-        text = stdout or ""
+        lowered = (output or "").lower()
+        # Fatal markers before divergence markers, mirroring smoke.py's order.
         for marker in _ERROR_MARKERS:
-            if marker in text:
+            if marker.lower() in lowered:
+                return f"{name} log contains '{marker}'"
+        for marker in _DIVERGENCE_MARKERS:
+            if marker in lowered:
                 return f"{name} log contains '{marker}'"
         return None

--- a/src/digitalmodel/solvers/openfoam/smoke_evidence.py
+++ b/src/digitalmodel/solvers/openfoam/smoke_evidence.py
@@ -225,8 +225,18 @@ def _validate_bridge(record: Any, artifacts: Mapping) -> None:
     _digest(inputs["tree_sha256"], "bridge inputs digest")
     for name in ("file_count", "total_bytes"):
         _integer(inputs[name], f"bridge inputs {name}", minimum=1)
-    if mesh["path"] != "constant/polyMesh" or mesh["tree_sha256"] != artifacts["poly_mesh"]["tree_sha256"]:
-        raise EvidenceValidationError("bridge mesh digest does not match artifacts")
+    # Bind the WHOLE duplicated tree record, not just the digest: file_count and
+    # total_bytes are carried twice and an unbound copy is a mutation that the
+    # validator would wave through.
+    mesh_artifact = artifacts["poly_mesh"]
+    mesh_matches = mesh["path"] == "constant/polyMesh" and all(
+        mesh[name] == mesh_artifact[name]
+        for name in ("tree_sha256", "file_count", "total_bytes")
+    )
+    if not mesh_matches:
+        raise EvidenceValidationError(
+            "bridge mesh digest, file count, or size does not match artifacts"
+        )
     _validate_bridge_contract(bridge["contract"])
     _validate_bridge_commands(bridge["commands"])
     toolchain = _exact(
@@ -298,6 +308,37 @@ def validate_evidence(payload: Any) -> dict[str, Any]:
     _validate_stages(item["stages"], dispatcher["ranks"])
     _validate_provenance_chains(item)
     return payload
+
+
+def cross_check_bridge_manifest(
+    evidence_payload: Any, manifest_payload: Any
+) -> None:
+    """Fail closed unless the durable bundle faithfully embeds the manifest.
+
+    The bundle's bridge section and the standalone prebuilt manifest carry the
+    same attestation twice. Validating the bundle alone cannot detect a bundle
+    that was written from a different (or edited) manifest, so compare them
+    field by field. The manifest root fields are exactly the shape of the
+    bridge section; timing, execution_class, dispatcher, motion, and provenance
+    exist only in the evidence and are deliberately out of scope here.
+    """
+    validate_evidence(evidence_payload)
+    if not isinstance(manifest_payload, Mapping):
+        raise EvidenceValidationError("prebuilt manifest must be a mapping")
+    bridge = evidence_payload["bridge"]
+    for field in sorted(set(bridge) | set(manifest_payload)):
+        if field not in manifest_payload:
+            raise EvidenceValidationError(
+                f"prebuilt manifest is missing {field}"
+            )
+        if field not in bridge:
+            raise EvidenceValidationError(
+                f"durable bundle is missing {field}"
+            )
+        if bridge[field] != manifest_payload[field]:
+            raise EvidenceValidationError(
+                f"durable bundle diverges from prebuilt manifest at {field}"
+            )
 
 
 def build_evidence_payload(
@@ -385,10 +426,20 @@ def capture_pre_run_artifacts(repo_root: Path, case: Path) -> dict[str, Any]:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("evidence", type=Path)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="standalone prebuilt manifest to cross-check the bundle against",
+    )
     args = parser.parse_args(argv)
     try:
         payload = json.loads(args.evidence.read_text(encoding="utf-8"))
         validate_evidence(payload)
+        if args.manifest is not None:
+            manifest_payload = json.loads(
+                args.manifest.read_text(encoding="utf-8")
+            )
+            cross_check_bridge_manifest(payload, manifest_payload)
     except (OSError, json.JSONDecodeError, EvidenceValidationError) as exc:
         print(f"invalid smoke evidence: {exc}", file=sys.stderr)
         return 1

--- a/tests/scripts/test_synthetic_tank_3d_smoke.py
+++ b/tests/scripts/test_synthetic_tank_3d_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import stat
 import subprocess
 import sys
@@ -186,7 +187,9 @@ def _provenance(commit: str) -> dict[str, object]:
     return {"clean": True, "commit": commit, "tracked_sources_sha256": "b" * 64}
 
 
-def _patch_pipeline_records(script, monkeypatch, events, evidence_calls) -> None:
+def _patch_pipeline_records(
+    script, monkeypatch, events, evidence_calls, cross_checks
+) -> None:
     def provenance(kind: str, commit: str) -> dict[str, object]:
         events.append(kind)
         return _provenance(commit)
@@ -204,10 +207,24 @@ def _patch_pipeline_records(script, monkeypatch, events, evidence_calls) -> None
         "_dependency_provenance",
         lambda: provenance("dependency", ASSETUTILITIES_COMMIT),
     )
+
+    def write_evidence(*args: object, **kwargs: object) -> None:
+        # The durable bundle must land on disk: the pipeline reloads it and
+        # cross-checks the persisted artifact, not the in-memory payload.
+        events.append("evidence")
+        evidence_calls.append(kwargs)
+        Path(args[0]).write_text(
+            json.dumps({"bridge": kwargs["bridge_manifest"]}), encoding="utf-8"
+        )
+
+    monkeypatch.setattr(script, "write_reduced_evidence", write_evidence)
+    # raising=False so the shared fixture still installs before the driver grows
+    # the cross-check import; only the new cross-check tests go red pre-fix.
     monkeypatch.setattr(
         script,
-        "write_reduced_evidence",
-        lambda *_a, **kwargs: events.append("evidence") or evidence_calls.append(kwargs),
+        "cross_check_bridge_manifest",
+        lambda payload, manifest: cross_checks.append((payload, manifest)),
+        raising=False,
     )
 
 
@@ -232,6 +249,7 @@ def patch_pipeline_fakes(
     )
     result = SimpleNamespace(status="completed")
     evidence_calls: list[dict] = []
+    cross_checks: list[tuple] = []
 
     def execute(*_args: object, **_kwargs: object) -> SimpleNamespace:
         events.append("execute")
@@ -246,13 +264,14 @@ def patch_pipeline_fakes(
     monkeypatch.setattr(
         script, "_execution_metrics", lambda *_a: {"actual_load1": 0.5, "actual_load_per_core": 0.125}
     )
-    _patch_pipeline_records(script, monkeypatch, events, evidence_calls)
+    _patch_pipeline_records(script, monkeypatch, events, evidence_calls, cross_checks)
     return SimpleNamespace(
         result=result,
         state=state,
         bridge=bridge,
         events=events,
         evidence_calls=evidence_calls,
+        cross_checks=cross_checks,
     )
 
 
@@ -293,6 +312,83 @@ def test_pipeline_rechecks_snapshot_and_passes_attestation_to_evidence(
         "pre_execution",
         "post_execution",
     }
+
+
+def test_pipeline_cross_checks_the_written_bundle_against_the_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The durable artifact on disk must be proven to embed the attested manifest."""
+    script = load_script()
+    fakes = patch_pipeline_fakes(script, tmp_path, monkeypatch)
+
+    script.run_pipeline(
+        ranks=2,
+        selected_ranks=2,
+        visible_cpus=4,
+        work_dir=tmp_path,
+        input_yaml=tmp_path / "input.yml",
+        evidence=tmp_path / "evidence.json",
+        cpb=6,
+        end_time=0.30,
+        delta_t=0.001,
+        time_precision=8,
+        execution_class="shared-fallback",
+        projected_load_per_core=0.625,
+    )
+
+    assert fakes.cross_checks == [
+        ({"bridge": fakes.bridge.manifest}, fakes.bridge.manifest)
+    ]
+
+
+def test_pipeline_fails_closed_when_written_bundle_diverges_from_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = load_script()
+    fakes = patch_pipeline_fakes(script, tmp_path, monkeypatch)
+
+    def diverge(_payload: object, _manifest: object) -> None:
+        raise script.EvidenceValidationError(
+            "durable bundle diverges from prebuilt manifest at contract"
+        )
+
+    monkeypatch.setattr(script, "cross_check_bridge_manifest", diverge, raising=False)
+
+    with pytest.raises(script.EvidenceValidationError, match="diverges"):
+        script.run_pipeline(
+            ranks=2,
+            selected_ranks=2,
+            visible_cpus=4,
+            work_dir=tmp_path,
+            input_yaml=tmp_path / "input.yml",
+            evidence=tmp_path / "evidence.json",
+            cpb=6,
+            end_time=0.30,
+            delta_t=0.001,
+            time_precision=8,
+            execution_class="shared-fallback",
+            projected_load_per_core=0.625,
+        )
+
+    # The snapshot lock must still be released on the fail-closed path.
+    assert fakes.state["released"] == 1
+
+
+def test_main_maps_evidence_divergence_to_a_failing_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = load_script()
+
+    def diverge(**_kwargs: object) -> None:
+        raise script.EvidenceValidationError(
+            "durable bundle diverges from prebuilt manifest at contract"
+        )
+
+    monkeypatch.setattr(script, "run_pipeline", diverge)
+    monkeypatch.setenv("CFD_DISPATCH_RANKS", "2")
+    monkeypatch.setenv("CFD_EXECUTION_CLASS", "test")
+
+    assert script.main(["--work-dir", str(tmp_path)]) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/solvers/openfoam/test_runner.py
+++ b/tests/solvers/openfoam/test_runner.py
@@ -110,14 +110,16 @@ class TestFailClosed:
 # staged execution (subprocess mocked — no OpenFOAM needed)
 # ---------------------------------------------------------------------------
 class TestStagedExecution:
-    def _patch(self, monkeypatch, *, returncode=0, stdout="end\n"):
+    def _patch(self, monkeypatch, *, returncode=0, stdout="end\n", stderr: str = ""):
         monkeypatch.setattr(
             "digitalmodel.solvers.openfoam.runner.shutil.which",
             lambda name: f"/usr/bin/{name}",
         )
 
         def fake_run(argv, **kwargs):
-            return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+            return subprocess.CompletedProcess(
+                argv, returncode, stdout=stdout, stderr=stderr
+            )
 
         monkeypatch.setattr(
             "digitalmodel.solvers.openfoam.runner.subprocess.run", fake_run
@@ -229,6 +231,63 @@ class TestStagedExecution:
         result = OpenFOAMRunner().run(case)
         assert result.status is OpenFOAMRunStatus.FAILED
         assert "FOAM FATAL ERROR" in result.stages[0].error_message
+
+    def test_divergence_marker_detected_despite_rc_zero(
+        self, tmp_path: Path, monkeypatch
+    ):
+        case = _make_case(tmp_path)
+        self._patch(
+            monkeypatch,
+            returncode=0,
+            stdout="Time = 0.2\ndivergence detected in matrix solve\n",
+        )
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.FAILED
+        assert "divergence" in result.stages[0].error_message.lower()
+
+    def test_bounding_divergence_detected_despite_rc_zero(
+        self, tmp_path: Path, monkeypatch
+    ):
+        case = _make_case(tmp_path)
+        self._patch(
+            monkeypatch,
+            returncode=0,
+            stdout="Time = 0.1\nbounding alpha.water, min: -0.1 max: 1.1\n",
+        )
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.FAILED
+        assert "bounding" in result.stages[0].error_message.lower()
+
+    def test_iteration_limit_divergence_detected_despite_rc_zero(
+        self, tmp_path: Path, monkeypatch
+    ):
+        case = _make_case(tmp_path)
+        self._patch(
+            monkeypatch,
+            returncode=0,
+            stdout="Maximum number of iterations exceeded\n",
+        )
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.FAILED
+        assert (
+            "maximum number of iterations exceeded"
+            in result.stages[0].error_message.lower()
+        )
+
+    def test_fatal_on_stderr_detected_despite_rc_zero(
+        self, tmp_path: Path, monkeypatch
+    ):
+        case = _make_case(tmp_path)
+        self._patch(
+            monkeypatch,
+            returncode=0,
+            stdout="End\n",
+            stderr="--> FOAM FATAL ERROR\n",
+        )
+        result = OpenFOAMRunner().run(case)
+        assert result.status is OpenFOAMRunStatus.FAILED
+        assert "FOAM FATAL ERROR" in result.stages[0].error_message
+        assert "FOAM FATAL ERROR" in (case / "log.blockMesh").read_text()
 
     def test_benign_sigfpe_banner_is_not_an_error(self, tmp_path: Path, monkeypatch):
         """Regression: OpenFOAM prints the FPE-trapping banner on EVERY successful

--- a/tests/solvers/openfoam/test_runner_prebuilt.py
+++ b/tests/solvers/openfoam/test_runner_prebuilt.py
@@ -225,6 +225,34 @@ def test_tampered_mesh_is_rejected_before_execution(
     assert calls == []
 
 
+@pytest.mark.parametrize(
+    "residue", ["0.5", "processor0", "VTK", "log.interFoam", "stray.txt"]
+)
+def test_stale_residue_in_prebuilt_case_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, residue: str
+) -> None:
+    case, manifest = _make_attested_case(tmp_path)
+    residue_path = case / residue
+    if residue in {"0.5", "processor0", "VTK"}:
+        residue_path.mkdir()
+    else:
+        residue_path.write_text("synthetic residue\n", encoding="utf-8")
+    if residue == "0.5":
+        # smoke._reconstructed_points_path selects the highest-numbered time for
+        # the rigid-rotation proof, so stale 0.5/polyMesh/points copied into the
+        # snapshot could be read as reconstructed mesh and produce a false motion PASS.
+        points = residue_path / "polyMesh" / "points"
+        points.parent.mkdir(parents=True)
+        points.write_text("synthetic stale points\n", encoding="utf-8")
+
+    calls = _patch_execution(monkeypatch)
+    result = _run(case, manifest)
+
+    assert result.status is OpenFOAMRunStatus.FAILED
+    assert "residue" in result.error_message.lower()
+    assert calls == []
+
+
 def test_manifest_contract_must_match_structural_mesh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/solvers/openfoam/test_smoke.py
+++ b/tests/solvers/openfoam/test_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import math
 import json
 import subprocess
@@ -363,6 +364,79 @@ def test_evidence_binds_bridge_source_size_to_artifact(tmp_path: Path) -> None:
     payload = json.loads(_write_valid_evidence(tmp_path).read_text(encoding="utf-8"))
 
     assert payload["bridge"]["source_msh"]["size"] == payload["artifacts"]["source_msh"]["size"]
+
+
+@pytest.mark.parametrize("field", ["file_count", "total_bytes"])
+def test_bridge_poly_mesh_size_or_count_mutation_is_rejected(
+    tmp_path: Path, field: str
+) -> None:
+    from digitalmodel.solvers.openfoam.smoke_evidence import (
+        EvidenceValidationError,
+        validate_evidence,
+    )
+
+    payload = json.loads(_write_valid_evidence(tmp_path).read_text(encoding="utf-8"))
+    payload["bridge"]["poly_mesh"][field] += 1
+
+    with pytest.raises(EvidenceValidationError, match="artifacts"):
+        validate_evidence(payload)
+
+
+@pytest.mark.parametrize(
+    ("path", "new_value", "section"),
+    [
+        ("case_inputs.total_bytes", 201, "case_inputs"),
+        ("contract.cells", 11, "contract"),
+        ("source_msh.sha256", "f" * 64, "source_msh"),
+        ("commands.0.return_code", 1, "commands"),
+    ],
+)
+def test_cross_check_rejects_manifest_divergence(
+    tmp_path: Path, path: str, new_value: object, section: str
+) -> None:
+    from digitalmodel.solvers.openfoam.smoke_evidence import (
+        EvidenceValidationError,
+        cross_check_bridge_manifest,
+    )
+
+    payload = json.loads(_write_valid_evidence(tmp_path).read_text(encoding="utf-8"))
+    manifest = copy.deepcopy(payload["bridge"])
+    cross_check_bridge_manifest(payload, manifest)
+
+    target = manifest
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[int(part)] if isinstance(target, list) else target[part]
+    # Guard the oracle: if the sentinel ever equals the fixture value the
+    # mutation is a no-op and the rejection assertion below becomes vacuous.
+    assert target[parts[-1]] != new_value
+    target[parts[-1]] = new_value
+
+    with pytest.raises(EvidenceValidationError, match=section):
+        cross_check_bridge_manifest(payload, manifest)
+
+
+def test_committed_durable_bundle_validates() -> None:
+    from digitalmodel.solvers.openfoam.smoke_evidence import (
+        EvidenceValidationError,
+        validate_evidence,
+    )
+
+    evidence_path = (
+        Path(__file__).resolve().parents[3]
+        / "docs"
+        / "api"
+        / "cfd"
+        / "synthetic-l-tank-smoke.json"
+    )
+    assert evidence_path.is_file() is True
+    loaded = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert validate_evidence(loaded) is loaded
+
+    mutated = copy.deepcopy(loaded)
+    mutated["bridge"]["poly_mesh"]["total_bytes"] += 1
+    with pytest.raises(EvidenceValidationError):
+        validate_evidence(mutated)
 
 
 def test_evidence_validator_rejects_unknown_and_missing_records(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1517

Implements the approved plan for [#1517](https://github.com/vamseeachanta/digitalmodel/issues/1517) — the four honest-verdict holes the adversarial review of the Gmsh→OpenFOAM bridge (merged PR #1514) left open. Library + script + tests only: no new workflow, no HTML report, no registry entry, and `docs/api/cfd/synthetic-l-tank-smoke.json` is unchanged (read-only fixture).

## TDD

Two commits, red then green, verifiable from the log:

| Commit | Scope | Effect |
|---|---|---|
| `86adce0a` | **tests only** (4 files) | 19 new nodes, all failing |
| `454fe7c1` | **source only** (4 files) | same 19 nodes pass |

## What changed

**1. `prebuilt_mesh.py` — fence the snapshot to the attested allowlist.**
`prepare_prebuilt_execution` copied the entire case tree and rejected only symlinks, so stale top-level state survived into the private snapshot. This is a live false-pass, not untidiness: the motion proof selects the **highest-numbered** time directory, so a leftover `0.5/polyMesh/points` could be read as the reconstructed mesh and certify rotation that never happened. `_reject_residue` now refuses any top-level entry outside the five a cleanly bridged case has, on both the source case and the snapshot, before `checkMesh`.

The fence is deliberately **top-level only** — the legitimate dictionaries under `constant/` are untouched — and `input.yml` is allowlisted rather than required. Verified in both directions: it accepts a clean case (with or without `input.yml`, and with nested oddities), and rejects `0.5`, `processorN`, `log.*`, `VTK`, `postProcessing`, and stray files.

**2. `runner.py` — inspect what the solver actually wrote; one divergence policy.**
- `_run_stage` persisted and scanned only `stdout`, so a FOAM FATAL on **stderr** at rc=0 was neither logged nor caught. It now persists and inspects the combined stream.
- `_detect_error` matched case-sensitively and never consulted `_DIVERGENCE_MARKERS` — dead code. It now lowercases once and scans fatal markers then divergence markers, mirroring `smoke.py`'s order.
- The divergence constant was **wrong, not merely unwired**: a 2-tuple omitting the literal `divergence` string, so even after wiring it would have passed a diverged solve. It is now the exact 3-tuple from `smoke.py:23`, which is the project's existing fail-closed policy with a passing test. This **mirrors** that reference rather than inventing one. `bounding` is kept — dropping it reopens the hole; any argument that it over-rejects belongs in a separate policy issue.
- The SIGFPE guardrail is untouched: `Floating point exception` is still not a marker, because the healthy startup banner prints it and a real FPE crash exits non-zero.

**3. `smoke_evidence.py` — close the duplicated-field hole; bind bundle to manifest.**
`bridge.poly_mesh` carries `tree_sha256`, `file_count` and `total_bytes`, but only the digest was bound to `artifacts`, so a mutated count or size validated cleanly. All three are now bound. New `cross_check_bridge_manifest` additionally proves the durable bundle's `bridge` section equals the standalone prebuilt manifest field by field — something validating the bundle alone can never detect. Timing, `execution_class`, dispatcher, motion and provenance are deliberately excluded: they exist only in the evidence. The CLI grows an optional `--manifest`; without it, behaviour is unchanged.

**4. `run_synthetic_tank_3d_smoke.py` — cross-check the artifact that actually landed.**
The driver reloads the evidence file it just wrote and cross-checks it against the attested manifest, so a run fails closed if the on-disk artifact does not faithfully embed the attestation. Checking the in-memory payload would not catch a bundle serialized wrong or written from a different manifest. `EvidenceValidationError` joins the caught tuple so it surfaces as a non-zero exit code, and the check sits inside the existing `try` so the snapshot lock is still released.

`smoke.py` is **unchanged** — it is the correct reference behaviour for this slice.

## Verification

Interpreter: `/usr/bin/python3` (pytest 9.0.2, scipy 1.17.0) on `ace-linux-1`. The repo `.venv` has neither pytest nor scipy.

- `tests/solvers/openfoam/` + `tests/scripts/` → **798 passed, 9 skipped**, failing-node set **byte-identical to the pre-change baseline** (3 pre-existing `np.trapz` failures in `validation/test_wave_excited_body.py` from numpy 2.x, unrelated to this change).
- The four files CI's gmsh gate runs → **95 passed** (19 new + 76 pre-existing).
- `ruff check` over the **exact** file list in `gmsh-meshing-tests.yml` "Lint bridge paths" → **All checks passed**.
- CI's "Validate committed smoke evidence" step reproduced locally → exit 0.
- `--manifest` reconstructed from the bundle's bridge section → exit 0; with `contract.cells` mutated → exit 1 with `durable bundle diverges from prebuilt manifest at contract`.

## Deviation from the plan (one file)

The plan listed 7 files; this PR touches 8. `tests/scripts/test_synthetic_tank_3d_smoke.py` was added because the plan's driver deliverable is **untestable without it and actively breaks it**: the shared pipeline fixture stubs `write_reduced_evidence` with a lambda that writes no file, so reloading the evidence raises `FileNotFoundError`. The fixture now writes a real evidence file and installs a cross-check recorder with `raising=False`, so only the new tests go red pre-fix and all 16 pre-existing driver nodes stay green. No existing assertion was weakened.

## Notes for review

- `machine:cfd-dedicated` was **not** needed: every test in scope drives the code through mocked `subprocess.run`/`shutil.which`. No OpenFOAM binary, MPI, or GPU was used.
- dm CI is baseline-red on `main` (engine + native segfault); the `tests/solvers/openfoam/` suite is this PR's green signal. Diff the check set against bare `origin/main` before chasing a regression.
- The pre-existing `F401 pytest imported but unused` in `tests/solvers/openfoam/test_runner.py` is on `origin/main` and that file is deliberately excluded from CI's ruff list. Left alone as out of scope.
