### PR TITLE
fix(dynacard): ingest the survey and give the gravity term a datum (#1894)

### DIFF
--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/card_generators.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/card_generators.py
@@ -928,7 +928,6 @@ def surface_card_from_pump_card(
             damping=damping,
             friction_coefficient=ctx.calc_params.coulomb_friction_coefficient,
             n_nodes=n_nodes,
-            include_gravity=False,
         )
         # ``sim.up_dn`` is the turnaround of ``guess_position``, so on every
         # pass but the first this is the turnaround of the card the previous

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/data_loader.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/data_loader.py
@@ -11,10 +11,85 @@ from .models import (
     PumpProperties,
     SurfaceUnit,
     MotorProperties,
+    SurveyData,
     WellTestData,
     InputParameters,
     CalculationParameters,
 )
+
+
+def _finite(value: Any) -> Optional[float]:
+    """Return ``value`` as a finite float, or None if it is unusable."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def parse_survey(survey_raw: Any) -> Optional[SurveyData]:
+    """Build the wellbore trajectory from legacy ``surveyData`` stations.
+
+    Measured depth and inclination place a station on the rod string; a
+    station missing either cannot be used and is dropped rather than guessed
+    at. Azimuth only enters the solver through its gradient, so an unknown
+    azimuth holds the last known value: that contributes no turn instead of
+    inventing one.
+
+    Returns None -- leaving the caller on its documented vertical fallback --
+    when the record carries no survey, when fewer than two stations survive,
+    or when measured depth does not strictly increase. A repeated depth makes
+    the inclination gradient divide by zero, so a non-monotonic record is not
+    trustworthy enough to partially salvage.
+
+    Args:
+        survey_raw: The raw ``surveyData`` value, normally a list of station
+            dictionaries. None, a non-list, or an empty list all abstain.
+
+    Returns:
+        A :class:`SurveyData`, or None when no usable trajectory exists.
+    """
+    if not isinstance(survey_raw, list) or not survey_raw:
+        return None
+
+    measured_depth = []
+    inclination = []
+    azimuth = []
+    last_azimuth = 0.0
+
+    for station in survey_raw:
+        if not isinstance(station, dict):
+            continue
+        depth = _finite(station.get('MD'))
+        angle = _finite(station.get('Inclination'))
+        if depth is None or angle is None:
+            continue
+        heading = _finite(station.get('Azimuth'))
+        if heading is None:
+            heading = last_azimuth
+        last_azimuth = heading
+
+        measured_depth.append(depth)
+        inclination.append(angle)
+        azimuth.append(heading)
+
+    if len(measured_depth) < 2:
+        return None
+    if any(
+        measured_depth[i] >= measured_depth[i + 1]
+        for i in range(len(measured_depth) - 1)
+    ):
+        return None
+
+    return SurveyData(
+        measured_depth=measured_depth,
+        inclination=inclination,
+        azimuth=azimuth,
+    )
 
 
 def load_from_json_file(filepath: Union[str, Path]) -> DynacardAnalysisContext:
@@ -155,6 +230,10 @@ def parse_legacy_json(data: Dict[str, Any]) -> DynacardAnalysisContext:
         mixed_sg = water_sg * water_cut + oil_sg * (1.0 - water_cut)
         fluid_density = mixed_sg * 62.4
 
+    # Wellbore trajectory. Absent in many records, in which case the solver
+    # keeps its documented vertical fallback.
+    survey = parse_survey(data.get('surveyData'))
+
     # Create context
     context = DynacardAnalysisContext(
         api14=api14,
@@ -167,6 +246,7 @@ def parse_legacy_json(data: Dict[str, Any]) -> DynacardAnalysisContext:
         fluid_density=fluid_density,
         runtime=runtime,
         well_test=well_test,
+        survey=survey,
         input_params=input_params,
     )
 

--- a/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
+++ b/src/digitalmodel/marine_ops/artificial_lift/dynacard/everitt_jennings/solver.py
@@ -198,6 +198,7 @@ class Simulation:
     rod_length: float = 0.0
     areas: np.ndarray = field(default_factory=lambda: np.empty(0))
     rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
+    buoyant_rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
     moduli: np.ndarray = field(default_factory=lambda: np.empty(0))
     damping: np.ndarray = field(default_factory=lambda: np.empty(0))
     densities: np.ndarray = field(default_factory=lambda: np.empty(0))
@@ -228,6 +229,7 @@ class Coefficients:
     moduli: np.ndarray = field(default_factory=lambda: np.empty(0))
     areas: np.ndarray = field(default_factory=lambda: np.empty(0))
     rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
+    buoyant_rho_a: np.ndarray = field(default_factory=lambda: np.empty(0))
     damping: np.ndarray = field(default_factory=lambda: np.empty(0))
     phi: np.ndarray = field(default_factory=lambda: np.empty(0))
     d_phi: np.ndarray = field(default_factory=lambda: np.empty(0))
@@ -251,7 +253,6 @@ def build_simulation(
     friction_coefficient: float = 0.0,
     n_nodes: int = DEFAULT_NUM_NODES,
     gravity: float = GRAVITY_M_S2,
-    include_gravity: bool = True,
 ) -> Simulation:
     """Assemble the simulation grid from surface measurements and rod data.
 
@@ -269,8 +270,13 @@ def build_simulation(
         friction_coefficient: Coulomb friction coefficient for deviated wells.
         n_nodes: Number of spatial nodes down the string.
         gravity: Gravitational acceleration, m/s^2.
-        include_gravity: When False, gravity and friction terms are muted —
-            useful for isolating the elastic response.
+
+    Note:
+        There is deliberately no ``include_gravity`` argument here. The
+        boundary is now datum-invariant — the vertical buoyant weight is
+        always removed at the polished rod — so nothing this function builds
+        depends on whether the kernel's gravity terms are muted. Muting stays
+        where it is actually applied, on :class:`EverittJenningsSolver`.
 
     Returns:
         A populated :class:`Simulation`.
@@ -307,6 +313,7 @@ def build_simulation(
     sim.densities = rods.densities
     sim.moduli = rods.moduli
     sim.rho_a = rods.densities * rods.areas
+    sim.buoyant_rho_a = (rods.densities - fluid_density) * rods.areas
     sim.damping = (
         np.zeros(2 * sim.n_tap, dtype=np.float64)
         if damping is None
@@ -326,29 +333,31 @@ def build_simulation(
     sim.x = np.linspace(0.0, sim.rod_length, sim.n_x)
     sim.dx = sim.x[1] - sim.x[0]
 
-    # Distributed buoyant weight, accumulated from the pump upward.
-    d_volume = sim.dx * sim.areas
-    d_weight = sim.densities * d_volume
-    d_buoyant = (d_weight - d_volume * fluid_density) * gravity
-
+    # Exact buoyant weight remaining below every node. Integrating section
+    # overlap avoids counting a full terminal grid cell at the pump.
     cuts = _section_cuts(sim.taper_lengths)
-    per_node = np.full(sim.n_x, np.nan, dtype=np.float64)
+    sim.cumulative_buoyant = np.zeros(sim.n_x, dtype=np.float64)
     for i in range(len(cuts) - 1):
-        mask = (cuts[i] <= sim.x) & (sim.x <= cuts[i + 1])
-        per_node[mask] = d_buoyant[i]
-    sim.cumulative_buoyant = np.flip(np.cumsum(per_node), 0)
+        remaining_length = np.clip(
+            cuts[i + 1] - np.maximum(sim.x, cuts[i]),
+            0.0,
+            sim.taper_lengths[i],
+        )
+        sim.cumulative_buoyant += (
+            sim.buoyant_rho_a[i] * gravity * remaining_length
+        )
 
     # Index at which the stroke turns from down to up.
     sim.up_dn = int(np.mean(np.where(sim.u == np.min(sim.u))[0]))
 
     # Boundary forcing at the polished rod.
     #
-    # The static rod weight is accounted for in exactly one place, never two.
-    # When the gravity term is active in the marching kernel, the PDE carries
-    # it and the boundary takes the measured load as-is. When gravity is muted,
-    # the buoyant weight is instead pre-subtracted here. Getting this backwards
-    # double-counts the string weight and shifts the whole downhole card.
-    sim.boundary = sim.f if include_gravity else sim.f - sim.buoyant_weight
+    # The vertical buoyant rod weight is always removed here. When gravity is
+    # active the marching kernel carries only the deviation from that vertical
+    # datum, g * (cos(phi) - 1), plus normal contact. This keeps the datum
+    # invariant instead of moving the full string weight between the boundary
+    # and a grid-dependent distributed quadrature.
+    sim.boundary = sim.f - sim.buoyant_weight
     return sim
 
 
@@ -363,6 +372,7 @@ def build_coefficients(sim: Simulation, survey: Survey) -> Coefficients:
         ("moduli", sim.moduli),
         ("areas", sim.areas),
         ("rho_a", sim.rho_a),
+        ("buoyant_rho_a", sim.buoyant_rho_a),
     ):
         matrix = np.full((n_x, n_t), np.nan, dtype=np.float64)
         for i in range(len(cuts) - 1):
@@ -418,12 +428,15 @@ def _normal_force_per_length(
     curvature_normal = axial_force * d_phi
     azimuth_normal = axial_force * d_psi * np.sin(phi)
     return np.sqrt(
-        (gravity_normal - curvature_normal) ** 2 + azimuth_normal ** 2
+        (gravity_normal + curvature_normal) ** 2 + azimuth_normal ** 2
     )
 
 
 @_njit(cache=True)
-def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi, muteg):
+def _march(
+    u, n_x, n_t, dt, dx, lam, rho_a, buoyant_rho_a,
+    remaining_buoyant, g, c, e_mod, area, phi, d_phi, d_psi, muteg,
+):
     """March the damped wave equation down the rod string.
 
     Explicit in space: each new row ``i+1`` is built from rows ``i`` and
@@ -435,6 +448,7 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
             ea_plus = (e_mod[i + 1, j] * area[i + 1, j] + e_mod[i, j] * area[i, j]) / 2.0
             ea_minus = (e_mod[i - 1, j] * area[i - 1, j] + e_mod[i, j] * area[i, j]) / 2.0
             rho_a_ij = rho_a[i, j]
+            buoyant_rho_a_ij = buoyant_rho_a[i, j]
             rho_a_c = rho_a[i, j] * c[i, j]
 
             # Direction of travel, for Coulomb friction.
@@ -449,11 +463,14 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
             c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
             c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
             c3 = (lam * sign / ea_plus) * dx ** 2
-            c4 = (rho_a_ij / ea_plus) * dx ** 2
+            c4 = (buoyant_rho_a_ij / ea_plus) * dx ** 2
 
-            axial_force = ea_minus * (u[i, j] - u[i - 1, j]) / dx
+            reduced_axial_force = (
+                ea_minus * (u[i, j] - u[i - 1, j]) / dx
+            )
+            axial_force = reduced_axial_force + remaining_buoyant[i]
             q_n = _normal_force_per_length(
-                rho_a_ij,
+                buoyant_rho_a_ij,
                 g,
                 phi[i, j],
                 d_phi[i, j],
@@ -468,7 +485,7 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
                 + c1 * (u[i, j + 1] - 2 * u[i, j] + u[i, j - 1])
                 + c2 * (u[i, j + 1] - u[i, j - 1]) / 2.0
                 + c3 * q_n * muteg
-                - c4 * g * np.cos(phi[i, j]) * muteg
+                - c4 * g * (np.cos(phi[i, j]) - 1.0) * muteg
             )
 
         # Wrap-around time step. Coefficients are re-evaluated at j = 0 rather
@@ -477,16 +494,28 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
         ea_plus = (e_mod[i + 1, 0] * area[i + 1, 0] + e_mod[i, 0] * area[i, 0]) / 2.0
         ea_minus = (e_mod[i - 1, 0] * area[i - 1, 0] + e_mod[i, 0] * area[i, 0]) / 2.0
         rho_a_ij = rho_a[i, 0]
+        buoyant_rho_a_ij = buoyant_rho_a[i, 0]
         rho_a_c = rho_a[i, 0] * c[i, 0]
 
         c1 = (rho_a_ij / ea_plus) * (dx / dt) ** 2
         c2 = (rho_a_c / ea_plus) * dx ** 2 / dt
-        c3 = (lam / ea_plus) * dx ** 2
-        c4 = (rho_a_ij / ea_plus) * dx ** 2
+        delta = u[i, 1] - u[i, 0]
+        if delta > 0:
+            sign = 1.0
+        elif delta < 0:
+            sign = -1.0
+        else:
+            sign = 0.0
 
-        axial_force = ea_minus * (u[i, 0] - u[i - 1, 0]) / dx
+        c3 = (lam * sign / ea_plus) * dx ** 2
+        c4 = (buoyant_rho_a_ij / ea_plus) * dx ** 2
+
+        reduced_axial_force = (
+            ea_minus * (u[i, 0] - u[i - 1, 0]) / dx
+        )
+        axial_force = reduced_axial_force + remaining_buoyant[i]
         q_n = _normal_force_per_length(
-            rho_a_ij,
+            buoyant_rho_a_ij,
             g,
             phi[i, 0],
             d_phi[i, 0],
@@ -501,7 +530,7 @@ def _march(u, n_x, n_t, dt, dx, lam, rho_a, g, c, e_mod, area, phi, d_phi, d_psi
             + c1 * (u[i, 1] - 2 * u[i, 0] + u[i, n_t - 2])
             + c2 * (u[i, 1] - u[i, n_t - 2]) / 2.0
             + c3 * q_n * muteg
-            - c4 * g * np.cos(phi[i, 0]) * muteg
+            - c4 * g * (np.cos(phi[i, 0]) - 1.0) * muteg
         )
         u[i + 1, n_t - 1] = u[i + 1, 0]
 
@@ -560,11 +589,20 @@ class EverittJenningsSolver:
         viscosity: Produced-fluid dynamic viscosity in Pa-s, used to estimate
             damping when no explicit coefficients are supplied.
         friction_coefficient: Coulomb friction coefficient (deviated wells).
-        include_gravity: When True the marching kernel carries the gravity and
-            Coulomb-friction terms directly. When False (the default, matching
-            the reference implementation) those terms are muted and the static
-            buoyant weight is pre-subtracted at the surface boundary instead.
-            Either way the rod weight is counted exactly once.
+        include_gravity: When True the marching kernel carries the along-hole
+            weight deficit and the Coulomb-friction contact term. The vertical
+            buoyant weight is pre-subtracted at the surface boundary either
+            way, so the datum does not move and a vertical well is bit-for-bit
+            identical with this flag on or off.
+
+            It defaults to False, which for a vertical well is not an
+            approximation but the identical answer. On a deviated well it is
+            an abstention: as of dm#1894 enabling it moves the one deviated
+            reference well from 0.53% to 6.44% load nRMSE against its vendor
+            downhole card, and the available data cannot say whether the
+            solver got worse or the vendor's own pipeline was deviation-blind.
+            Do not flip this default until a reference computed from a survey
+            (or a measured downhole card, dm#1898) settles that question.
         smooth_window: Savitzky-Golay window for the downhole load. Space
             marching amplifies measurement noise, so some smoothing is
             required; set to 0 to disable.
@@ -643,7 +681,6 @@ class EverittJenningsSolver:
             damping=damping,
             friction_coefficient=self.friction_coefficient,
             n_nodes=self.n_nodes,
-            include_gravity=self.include_gravity,
         )
         coeff = build_coefficients(sim, survey)
         u = initial_matrix(sim, coeff)
@@ -651,8 +688,9 @@ class EverittJenningsSolver:
         muteg = 1.0 if self.include_gravity else 0.0
         u, dh_position, dh_load = _march(
             u, sim.n_x, sim.n_t, sim.dt, sim.dx, sim.friction,
-            coeff.rho_a, sim.gravity, coeff.damping, coeff.moduli,
-            coeff.areas, coeff.phi, coeff.d_phi, coeff.d_psi, muteg,
+            coeff.rho_a, coeff.buoyant_rho_a, sim.cumulative_buoyant,
+            sim.gravity, coeff.damping, coeff.moduli, coeff.areas, coeff.phi,
+            coeff.d_phi, coeff.d_psi, muteg,
         )
 
         if self.smooth_window and self.smooth_window > self.smooth_order:

--- a/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
+++ b/tests/marine_ops/artificial_lift/dynacard/test_everitt_jennings.py
@@ -240,6 +240,8 @@ def test_curvature_friction_uses_axial_force_per_unit_length():
         0.5,
         0.2,
         zeros,
+        zeros,  # buoyant line density; weightless here, so gravity drops out
+        np.zeros(n_x),  # buoyant weight remaining below each node
         0.0,
         zeros,
         elastic_modulus,

--- a/tests/marine_ops/artificial_lift/test_deviation_survey.py
+++ b/tests/marine_ops/artificial_lift/test_deviation_survey.py
@@ -1,0 +1,341 @@
+# ABOUTME: Tests that the wellbore survey is ingested and actually drives the solver.
+# ABOUTME: Expected values are derived from named physical inputs, never fitted to output.
+"""Deviation must reach the solver, and must change the answer when it does.
+
+Every gate in dm#1894 shares one shape: the deviation machinery exists, runs,
+and returns plausible numbers while contributing exactly zero. A test that only
+checks a survey object was built would pass against that defect, so the tests
+here are written to fail if the survey is inert:
+
+* the load-datum tests assert the gravity term is *exactly* zero for a vertical
+  well, so switching gravity on cannot silently move a well that has no
+  deviation to move;
+* the liveness tests assert the downhole card moves by the along-hole weight
+  deficit that the survey itself implies, computed here from rod density,
+  fluid density and inclination -- never read back from the solver.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from digitalmodel.marine_ops.artificial_lift.dynacard.data_loader import (
+    load_from_json_file,
+    parse_legacy_json,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings import (
+    units as U,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings.adapter import (
+    rod_string_from_context,
+    survey_from_context,
+)
+from digitalmodel.marine_ops.artificial_lift.dynacard.everitt_jennings.solver import (
+    EverittJenningsSolver,
+    RodString,
+    Survey,
+    _normal_force_per_length,
+)
+
+DATA_DIR = Path(__file__).with_name("test_data")
+
+# cleansed_well_005 is the only deviated fixture: 31 stations, kicking off at
+# 1,797 ft and building to 39.98 deg. cleansed_well_001 is a two-station
+# vertical record; 003 and 004 carry no survey block at all.
+DEVIATED_FIXTURE = DATA_DIR / "cleansed_well_005.json"
+VERTICAL_FIXTURE = DATA_DIR / "cleansed_well_001.json"
+
+GRAVITY_M_S2 = 9.80665
+
+
+def _minimal_legacy_payload(survey_stations):
+    """Smallest legacy record that parses, carrying the survey under test."""
+    return {
+        "CardDetails": {"Api14": "TEST"},
+        "InputParameters": {"StrokesPerMinute": 6.0},
+        "cardData": {"Position": [0.0, 1.0, 0.0, -1.0], "Load": [1.0] * 4},
+        "equipmentData": {
+            "Rods": [{"Diameter": 0.875, "TotalLength": 2000.0, "Count": 80}],
+            "Pump": {"Diameter": 1.75, "Depth": 2000.0},
+        },
+        "surveyData": survey_stations,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ingestion: the survey must survive the loader
+# ---------------------------------------------------------------------------
+def test_deviated_well_survey_is_ingested_with_every_station():
+    """All 31 stations of the deviated fixture must reach the context."""
+    context = load_from_json_file(DEVIATED_FIXTURE)
+
+    assert len(context.survey.measured_depth) == 31
+
+
+def test_ingested_survey_preserves_the_maximum_inclination():
+    """The build angle must arrive intact, in degrees, as recorded."""
+    context = load_from_json_file(DEVIATED_FIXTURE)
+
+    assert max(context.survey.inclination) == 39.98
+
+
+def test_vertical_two_station_survey_is_still_ingested():
+    """A vertical record is a survey too; it must not be discarded as empty."""
+    context = load_from_json_file(VERTICAL_FIXTURE)
+
+    assert len(context.survey.measured_depth) == 2
+
+
+def test_survey_reaches_the_solver_converted_to_radians():
+    """The adapter owns the unit crossing, so the solver must see radians."""
+    context = load_from_json_file(DEVIATED_FIXTURE)
+    rods = rod_string_from_context(context)
+
+    survey = survey_from_context(context, rods)
+
+    assert float(np.max(survey.inclination)) == pytest.approx(
+        39.98 * U.DEG2RAD, rel=1e-12
+    )
+
+
+def test_unusable_station_is_dropped_and_the_rest_survive():
+    """A null inclination costs one station, not the whole trajectory.
+
+    Abstaining on the entire survey because one station is incomplete would
+    silently return a well to the vertical assumption, which is the failure
+    this issue exists to remove.
+    """
+    payload = _minimal_legacy_payload(
+        [
+            {"MD": 0.0, "Inclination": 0.0, "Azimuth": 10.0},
+            {"MD": 900.0, "Inclination": None, "Azimuth": 10.0},
+            {"MD": 1800.0, "Inclination": 30.0, "Azimuth": 10.0},
+        ]
+    )
+
+    context = parse_legacy_json(payload)
+
+    assert len(context.survey.measured_depth) == 2
+
+
+def test_loader_abstains_exactly_when_the_survey_is_unusable():
+    """Absent and degenerate surveys abstain; a usable one must still load.
+
+    Two stations at one depth divide by zero in the inclination gradient, and
+    a missing block has nothing to place, so both must leave the context
+    without a survey. Asserting the usable case in the same test keeps the
+    abstention a real discrimination rather than the loader ignoring surveys
+    wholesale -- which is precisely the behaviour on record before this fix.
+    """
+    stations = [
+        {"MD": 0.0, "Inclination": 0.0, "Azimuth": 0.0},
+        {"MD": 900.0, "Inclination": 15.0, "Azimuth": 0.0},
+        {"MD": 900.0, "Inclination": 30.0, "Azimuth": 0.0},
+    ]
+    degenerate = parse_legacy_json(_minimal_legacy_payload(stations))
+    absent = parse_legacy_json(_minimal_legacy_payload(None))
+
+    distinct = [dict(station) for station in stations]
+    distinct[2]["MD"] = 1800.0
+    usable = parse_legacy_json(_minimal_legacy_payload(distinct))
+
+    assert degenerate.survey is None
+    assert absent.survey is None
+    assert len(usable.survey.measured_depth) == 3
+
+
+# ---------------------------------------------------------------------------
+# The contact force must follow the soft-string formula the issue states
+# ---------------------------------------------------------------------------
+def test_contact_force_sums_gravity_and_curvature_components():
+    """N' = sqrt((F dphi/ds + w_b sin phi)^2 + (F dpsi/ds sin phi)^2).
+
+    Gravity pulls the rod onto the low side and curvature in a build presses
+    it the same way, so the two add. Subtracting them cancels a real contact
+    load and can drive the normal force to zero where it is largest.
+    """
+    buoyant_line_density = 10.0  # kg/m
+    gravity = 10.0  # m/s^2
+    inclination = np.pi / 6.0  # sin = 0.5 exactly
+    axial_force = 1000.0  # N
+    inclination_gradient = 0.03  # rad/m
+    azimuth_gradient = 0.008  # rad/m
+
+    normal_force = _normal_force_per_length(
+        buoyant_line_density,
+        gravity,
+        inclination,
+        inclination_gradient,
+        azimuth_gradient,
+        axial_force,
+    )
+
+    # gravity  = 10 * 10 * 0.5             = 50 N/m
+    # curvature= 1000 * 0.03               = 30 N/m
+    # azimuth  = 1000 * 0.008 * 0.5        =  4 N/m
+    expected = np.sqrt((50.0 + 30.0) ** 2 + 4.0 ** 2)
+    assert normal_force == pytest.approx(expected, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The load datum must not move when gravity is switched on
+# ---------------------------------------------------------------------------
+def _uniform_string(length_m=1500.0):
+    """Single-taper string, so the weight deficit has a closed form."""
+    return RodString(
+        diameters=np.array([0.0222]),
+        lengths=np.array([length_m]),
+        densities=np.array([7850.0]),
+        moduli=np.array([2.05e11]),
+    )
+
+
+def _solve_at_inclination(inclination_deg, include_gravity, n_nodes=150):
+    """Solve one synthetic card down a constant-inclination hole."""
+    rods = _uniform_string()
+    samples = np.linspace(0.0, 2.0 * np.pi, 200)
+    survey = Survey(
+        measured_depth=np.array([0.0, rods.total_length]),
+        inclination=np.full(2, np.deg2rad(inclination_deg)),
+        azimuth=np.zeros(2),
+    )
+    solver = EverittJenningsSolver(
+        n_nodes=n_nodes,
+        include_gravity=include_gravity,
+        friction_coefficient=0.0,
+        smooth_window=0,
+    )
+    return solver.solve(
+        position=np.sin(samples),
+        load=40000.0 + 6000.0 * np.sin(samples),
+        rods=rods,
+        strokes_per_minute=6.0,
+        pump_diameter=0.0445,
+        tubing_id=0.062,
+        fluid_density=1000.0,
+        survey=survey,
+    )
+
+
+def test_vertical_well_is_bit_for_bit_identical_with_gravity_on():
+    """cos(0) = 1, so a vertical well has no along-hole deficit to apply.
+
+    Any difference at all means the static rod weight is being counted in a
+    different place rather than the same place, which is the datum defect that
+    produced the factor-of-7 inversion in dm#1893.
+    """
+    with_gravity = _solve_at_inclination(0.0, include_gravity=True)
+    without_gravity = _solve_at_inclination(0.0, include_gravity=False)
+
+    assert np.array_equal(with_gravity.load, without_gravity.load)
+
+
+def test_gravity_offset_equals_the_along_hole_weight_deficit():
+    """Turning gravity on must add exactly W_b (1 - cos phi), no more.
+
+    The boundary removes the full buoyant string weight, but only the
+    along-hole component W_b cos phi is actually carried, so the solver has to
+    put W_b (1 - cos phi) back. The 1% tolerance is the one-cell quadrature
+    deficit at the pump: the distributed term is applied at interior nodes
+    only, giving (n_x - 2) / (n_x - 1) = 148/149 of the closed-form value.
+    """
+    inclination_deg = 60.0
+    with_gravity = _solve_at_inclination(inclination_deg, include_gravity=True)
+    without_gravity = _solve_at_inclination(inclination_deg, include_gravity=False)
+
+    buoyant_weight = with_gravity.simulation.buoyant_weight
+    expected = buoyant_weight * (1.0 - np.cos(np.deg2rad(inclination_deg)))
+
+    offset = float(np.mean(with_gravity.load) - np.mean(without_gravity.load))
+    assert offset == pytest.approx(expected, rel=0.01)
+
+
+def test_load_offset_ratio_tracks_inclination_exactly():
+    """Vary the survey and the output must move by the predicted factor.
+
+    This is the liveness check. The grid quadrature factor is common to both
+    solves and cancels in the ratio, so the expected value is exact rather
+    than tolerance-bounded: it depends on nothing but the two inclinations.
+    """
+    def offset(inclination_deg):
+        on = _solve_at_inclination(inclination_deg, include_gravity=True)
+        off = _solve_at_inclination(inclination_deg, include_gravity=False)
+        return float(np.mean(on.load) - np.mean(off.load))
+
+    measured_ratio = offset(60.0) / offset(30.0)
+
+    expected_ratio = (1.0 - np.cos(np.deg2rad(60.0))) / (
+        1.0 - np.cos(np.deg2rad(30.0))
+    )
+    assert measured_ratio == pytest.approx(expected_ratio, rel=1e-6)
+
+
+def test_real_deviated_card_moves_by_its_own_survey_weight_deficit():
+    """On the real deviated well, the survey must drive the card it produces.
+
+    The expected shift is integral w_b(s) (1 - cos phi(s)) ds over the rod
+    string, built here from rod density, fluid density and the recorded
+    inclinations. Nothing in the oracle is read back from the solver, so a
+    survey that is parsed and then ignored cannot pass this.
+    """
+    context = load_from_json_file(DEVIATED_FIXTURE)
+    rods = rod_string_from_context(context)
+
+    # Built straight from the fixture rather than through the loader. Reading
+    # the trajectory back out of the code under test would make the oracle
+    # collapse to 0 == 0 the moment the survey stopped being ingested, which
+    # is exactly the defect these tests exist to catch.
+    stations = json.loads(DEVIATED_FIXTURE.read_text())["surveyData"]
+    real_survey = Survey(
+        measured_depth=np.array([s["MD"] for s in stations]) * U.FT2M,
+        inclination=np.array([s["Inclination"] for s in stations]) * U.DEG2RAD,
+        azimuth=np.array([s["Azimuth"] for s in stations]) * U.DEG2RAD,
+    )
+    vertical_survey = Survey.vertical(rods.total_length)
+
+    position = np.asarray(context.surface_card.position, dtype=float) * U.IN2M
+    load = np.asarray(context.surface_card.load, dtype=float) * U.LB2N
+    fluid_density_si = context.fluid_density * U.LBPFT32KGPM3
+
+    def solve(survey):
+        solver = EverittJenningsSolver(
+            n_nodes=200,
+            viscosity=0.01,
+            friction_coefficient=0.0,
+            include_gravity=True,
+            smooth_window=0,
+        )
+        return solver.solve(
+            position=position,
+            load=load,
+            rods=rods,
+            strokes_per_minute=context.spm,
+            pump_diameter=context.pump.diameter * U.IN2M,
+            tubing_id=2.441 * U.IN2M,
+            fluid_density=fluid_density_si,
+            survey=survey,
+        )
+
+    deviated = solve(real_survey)
+    vertical = solve(vertical_survey)
+    simulation = deviated.simulation
+
+    # Buoyant weight per unit length of each taper, from first principles.
+    buoyant_line_weight = (
+        (rods.densities - fluid_density_si) * rods.areas * GRAVITY_M_S2
+    )
+    cuts = np.zeros(len(rods.lengths) + 1)
+    cuts[1:] = np.cumsum(rods.lengths)
+    per_node = np.full(simulation.n_x, np.nan)
+    for index in range(len(cuts) - 1):
+        span = (cuts[index] <= simulation.x) & (simulation.x <= cuts[index + 1])
+        per_node[span] = buoyant_line_weight[index]
+
+    deficit = 1.0 - np.cos(real_survey.phi(simulation.x))
+    # The distributed term is applied at interior nodes only.
+    expected = float(np.sum(per_node[1:-1] * deficit[1:-1]) * simulation.dx)
+
+    offset = float(np.mean(deviated.load) - np.mean(vertical.load))
+    assert offset == pytest.approx(expected, rel=1e-3)


### PR DESCRIPTION
Closes part of [#1894](https://github.com/vamseeachanta/digitalmodel/issues/1894). **Does not close the issue** — see "What is deliberately not here".

## What was inert, and the measurement that proves it

The solver has full deviation physics and multiplied all of it by zero. Feeding the real survey through with gravity muted reproduces all five cleansed fixtures **bit for bit** — that is the inertness, measured rather than argued.

Underneath sat a second defect that made the first one unfixable. `include_gravity=True` was not merely untested, it was **wrong for vertical wells too**:

| | W1 | W2 | W3 | W4 | W5 |
|---|---:|---:|---:|---:|---:|
| baseline load nRMSE | 0.4541% | 1.2459% | 0.9450% | 2.1532% | 0.5339% |
| `include_gravity=True` on `main` | 20.80% | 17.22% | 19.72% | 15.08% | 11.84% |
| after this PR | 0.4541% | 1.2459% | 0.9450% | 2.1532% | 0.5339% |

`build_simulation` defaulted that flag to `True`, so the broken path was reachable. The cause is the boundary branch at `solver.py:351`: the muted path pre-subtracts the buoyant string weight, the active path passed measured load through and expected the kernel's distributed `cos(phi)` quadrature to make it up. Two different datums, differing by more than the grid error.

## The fix

The datum is now fixed on one side. The vertical buoyant weight is **always** removed at the boundary and the kernel carries only the deviation from it, `g(cos(phi) - 1)` — identically zero when `phi` is zero. A vertical well is therefore bit-for-bit identical with gravity on or off, not merely close.

Four corrections make that decomposition true: buoyant rather than in-air line density; the contact force **sums** its gravity and curvature components per the soft-string formula the issue body itself quotes (`main` subtracted them, cancelling real contact load near the kick-off where it peaks); the axial force in that term includes the buoyant weight still hanging below the node; and `cumulative_buoyant` is integrated by section overlap, so it now equals total buoyant weight at surface and **exactly zero** at the pump. Also fixes the wrap-around time step, which applied Coulomb friction with no direction sign.

Ingestion is deliberately conservative — `SurveyData` declares `List[float]`, so one null inclination would have raised a `ValidationError` and taken out a record that loads today. Stations missing MD or inclination are dropped; unknown azimuth holds its previous value (no invented turn); fewer than two usable stations or non-monotonic depth abstains to the documented vertical fallback.

## Proof the machinery is live

A passing test is weak evidence here, so the oracles are built from rod density, fluid density, gravity and the recorded inclinations — never read back from the solver:

- **Exact, grid-independent**: vary inclination and the load offset ratio equals `(1-cos60)/(1-cos30) = 3.732051` to `rel=1e-6`. The quadrature factor cancels in the ratio.
- **Real field data**: on the deviated well the card moves by `INT w_b(s)(1-cos phi(s)) ds` — agreement **1.000069**. The trajectory is read straight from the fixture, not through the loader, so an inert survey collapses the oracle to `0 == 0` and the test fails rather than passing vacuously.

## What is deliberately not here

**`include_gravity` still defaults to `False`, and friction still defaults to `0.0`.** Enabling gravity moves the one deviated reference well from 0.5339% to 6.4376% load nRMSE; friction makes it worse. The plan's success criterion is that deviated wells improve or are unchanged, and its instruction is that a worse result is a finding to report, not a number to tune away.

Mean `cos phi` over W5's rod interval is 0.9393 — a 6.07% along-hole weight deficit, which is the size of the shift. The physics is doing what it should. Whether the solver got worse or the vendor reference is itself deviation-blind **cannot be settled with this data**; that needs a survey-aware reference or the measured downhole pairs in [#1898](https://github.com/vamseeachanta/digitalmodel/issues/1898). This PR makes deviation correct and opt-in rather than broken and unreachable.

## Verification

`/usr/bin/python3` (pytest 9.0.2, scipy 1.17.0; the repo `.venv` has neither).

- `tests/marine_ops/artificial_lift/`: **997 passed, 0 failed** vs a **986 passed, 0 failed** baseline — 11 added, none regressed. Failing-node-ID diff against baseline is empty.
- Red-then-green is verifiable from the log: all 11 tests fail at `a427e824`, all pass at `d5c03729`.
- `ruff` output over the touched trees is byte-identical to baseline; `scripts/enforcement/check-no-abs-paths.sh --added origin/main` exits 0.
- Pre-existing and unrelated: `tests/workflows/test_durable_workflows.py` fails collection on `main` too (`ModuleNotFoundError: rainflow`).

No assertion was weakened. The `_march` signature test keeps its expected 0.023 m — that fixture is weightless with `g = 0`, so the new buoyant arguments drop out.

No labels changed. Not merging this myself.
