### PR TITLE
feat(openfoam): preserve the full case-definition contract (#1575)

### DIFF
--- a/examples/workflows/openfoam-run-batch/input.yml
+++ b/examples/workflows/openfoam-run-batch/input.yml
@@ -56,3 +56,67 @@ default:
   config:
     overwrite:
       output: true
+
+# ---------------------------------------------------------------------------
+# CANONICAL CASE-DEFINITION CONTRACT (#1575)
+# ---------------------------------------------------------------------------
+# The `base:` above is the LEGACY flat form, still fully supported. It carries
+# only case type, name, solver and a few execution knobs, so a case's domain,
+# motion, fill, time controls and function objects cannot be expressed and were
+# previously dropped in transit.
+#
+# The canonical form below carries all of them, and is validated fail-closed:
+# unknown keys are refused by name rather than silently ignored. Use EITHER
+# form, never both in one input.
+#
+#   base:
+#     case_definition:
+#       schema_version: 1
+#       kind: authored          # `prebuilt` is reserved and refused in v1
+#       authored:
+#         case_type: sloshing
+#         name: synthetic_sloshing
+#         solver: interFoam
+#         domain:               # SI metres, right-handed, z up
+#           min_coords_m: [0.0, 0.0, 0.0]
+#           max_coords_m: [2.0, 1.0, 1.0]
+#           n_cells: [20, 10, 10]
+#         motion:               # roll/pitch/yaw need deg + origin_m;
+#           type: roll          # surge/sway/heave need m and reject origin_m
+#           amplitude: 3.0
+#           amplitude_unit: deg
+#           period_s: 1.5
+#           origin_m: [1.0, 0.5, 0.0]
+#         fill:                 # needs a multiphase case + run_set_fields true
+#           level: 0.4
+#         time:
+#           start_time_s: 0.0
+#           end_time_s: 2.0
+#           delta_t_s: 0.002
+#           write_interval_steps: 25
+#           adjustable_time_step: true
+#           max_co: 0.5
+#           purge_write: 0
+#         function_objects:
+#           pressure_taps:
+#             - name: synthetic_tap
+#               location_m: [1.0, 0.5, 0.8]
+#               fields: [p, p_rgh]
+#           write_control: timeStep
+#           write_interval: 1
+#     execution:
+#       mesh_utility: blockMesh
+#       run_snappy: false
+#       run_set_fields: true
+#       to_vtk: false
+#       timeout_seconds: 43200
+#       dry_run: false
+#
+# Sweeps map knobs onto dotted authored/execution leaves, and every mapping
+# target is checked against the accepted-leaf ledger before any case renders:
+#
+#   mapping:
+#     end_time: case_definition.authored.time.end_time_s
+#
+# Rank authority stays with run_batch.workers; n_subdomains is not accepted in
+# the schema, so decomposeParDict can never disagree with the dispatched ranks.

--- a/src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml
+++ b/src/digitalmodel/base_configs/modules/openfoam_run_batch/openfoam_run_batch.yml
@@ -13,11 +13,17 @@
 basename: openfoam_run_batch
 
 openfoam_run_batch:
-  base:
-    case_type: null        # required from the user's input.yml
-    solver: null           # else read from the case's controlDict
-    mesh_utility: blockMesh
-    to_vtk: false
+  # `base` intentionally defaults to EMPTY (#1575). It is deep-merged UNDER the
+  # user's input, so any semantic key defaulted here would be injected into a
+  # canonical `case_definition:` request and rejected as a legacy/canonical mix.
+  # The two forms of base are:
+  #   legacy   — flat keys (case_type, solver, mesh_utility, run_snappy,
+  #              to_vtk, run_set_fields). Defaults are supplied by
+  #              normalisation, not here: mesh_utility blockMesh, to_vtk false.
+  #   canonical — case_definition (schema_version/kind/authored) + execution.
+  #              See examples/workflows/openfoam-run-batch/input.yml.
+  # Exactly one form per input; mixing them is refused.
+  base: {}
   cases: []                # explicit case list (mutually exclusive w/ variants)
   variants: {}             # parametric_run sweep schema
   mapping: {}              # knob name -> dotted settings path

--- a/src/digitalmodel/solvers/openfoam/_case_definition_validation.py
+++ b/src/digitalmodel/solvers/openfoam/_case_definition_validation.py
@@ -1,0 +1,116 @@
+"""Validation helpers for the authored OpenFOAM case schema."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+
+class ValidationError(ValueError):
+    """Internal validation failure translated by the public parser."""
+
+
+_SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}")
+_WINDOWS_DEVICES = {"CON", "PRN", "AUX", "NUL"} | {
+    f"{prefix}{number}"
+    for prefix in ("COM", "LPT")
+    for number in range(1, 10)
+}
+
+
+def require_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    """Require a mapping with string keys."""
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{path} must be a mapping")
+    for key in value:
+        if not isinstance(key, str):
+            raise ValidationError(f"{path} contains non-string key {key!r}")
+    return value
+
+
+def check_keys(
+    value: Mapping[str, Any],
+    *,
+    allowed: Iterable[str],
+    required: Iterable[str] = (),
+    path: str,
+) -> None:
+    """Reject unknown keys and report the first missing required key."""
+    allowed_set = set(allowed)
+    for key in value:
+        if key not in allowed_set:
+            raise ValidationError(f"unknown key {path}.{key}")
+    for key in required:
+        if key not in value:
+            raise ValidationError(f"missing required key {path}.{key}")
+
+
+def require_string(value: Any, path: str) -> str:
+    """Require a string value."""
+    if not isinstance(value, str):
+        raise ValidationError(f"{path} must be a string")
+    return value
+
+
+def require_bool(value: Any, path: str) -> bool:
+    """Require a boolean value."""
+    if type(value) is not bool:
+        raise ValidationError(f"{path} must be a boolean")
+    return value
+
+
+def require_int(value: Any, path: str, *, positive: bool = False) -> int:
+    """Require an integer, explicitly excluding booleans."""
+    if type(value) is bool or not isinstance(value, int):
+        raise ValidationError(f"{path} must be an integer")
+    if positive and value <= 0:
+        raise ValidationError(f"{path} must be positive")
+    return value
+
+
+def require_number(value: Any, path: str, *, positive: bool = False) -> float:
+    """Require a finite real number, explicitly excluding booleans."""
+    if type(value) is bool or not isinstance(value, (int, float)):
+        raise ValidationError(f"{path} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValidationError(f"{path} must be finite")
+    if positive and result <= 0.0:
+        raise ValidationError(f"{path} must be positive")
+    return result
+
+
+def require_vector(
+    value: Any,
+    path: str,
+    *,
+    integers: bool = False,
+    positive: bool = False,
+) -> tuple[Any, Any, Any]:
+    """Require a finite three-component numeric vector."""
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValidationError(f"{path} must be a three-component sequence")
+    if len(value) != 3:
+        raise ValidationError(f"{path} must contain exactly three entries")
+    validator = require_int if integers else require_number
+    entries = [validator(item, path, positive=positive) for item in value]
+    return entries[0], entries[1], entries[2]
+
+
+def validate_case_name(value: Any, path: str) -> str:
+    """Validate a confined, portable case directory name."""
+    name = require_string(value, path)
+    if _SAFE_NAME.fullmatch(name) is None or name.upper() in _WINDOWS_DEVICES:
+        raise ValidationError(f"{path} is not a safe case name: {name!r}")
+    return name
+
+
+def require_string_sequence(value: Any, path: str) -> tuple[str, ...]:
+    """Require a non-empty sequence of non-empty strings."""
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValidationError(f"{path} must be a sequence of strings")
+    result = tuple(require_string(item, path) for item in value)
+    if not result or any(not item for item in result):
+        raise ValidationError(f"{path} must contain non-empty strings")
+    return result

--- a/src/digitalmodel/solvers/openfoam/block_mesh.py
+++ b/src/digitalmodel/solvers/openfoam/block_mesh.py
@@ -11,30 +11,14 @@ from .models import DomainConfig
 __all__ = ["render_block_mesh_dict_body"]
 
 
-def render_block_mesh_dict_body(domain: DomainConfig) -> str:
-    """Render the ``system/blockMeshDict`` body for ``domain``.
-
-    The returned string excludes the FoamFile header and the trailing rule; the
-    caller composes those, matching the ``render_*_dict_body`` convention used
-    by :mod:`.motion` and :mod:`.partial_fill`.
-
-    The emitted block uses the domain's own extents and cell counts, so a
-    caller-requested domain reaches the mesh rather than a builder default.
-    """
-    verts = domain.block_mesh_vertices()
-    nx, ny, nz = domain.cell_counts()
-
-    vert_lines = "\n    ".join(
-        f"( {v[0]:>10.4f}  {v[1]:>10.4f}  {v[2]:>10.4f} )"
-        for v in verts
-    )
-
-    return f"""
+# The single hex block and its six boundary patches are fixed; only the vertex
+# coordinates and the cell counts vary with the requested domain.
+_BLOCK_MESH_TEMPLATE = """
 convertToMeters 1;
 
 vertices
 (
-    {vert_lines}
+    {vertices}
 );
 
 blocks
@@ -96,3 +80,21 @@ mergePatchPairs
 );
 
 """
+
+
+def render_block_mesh_dict_body(domain: DomainConfig) -> str:
+    """Render the ``system/blockMeshDict`` body for ``domain``.
+
+    The returned string excludes the FoamFile header and the trailing rule; the
+    caller composes those, matching the ``render_*_dict_body`` convention used
+    by :mod:`.motion` and :mod:`.partial_fill`.
+
+    The emitted block uses the domain's own extents and cell counts, so a
+    caller-requested domain reaches the mesh rather than a builder default.
+    """
+    nx, ny, nz = domain.cell_counts()
+    vertices = "\n    ".join(
+        f"( {v[0]:>10.4f}  {v[1]:>10.4f}  {v[2]:>10.4f} )"
+        for v in domain.block_mesh_vertices()
+    )
+    return _BLOCK_MESH_TEMPLATE.format(vertices=vertices, nx=nx, ny=ny, nz=nz)

--- a/src/digitalmodel/solvers/openfoam/block_mesh.py
+++ b/src/digitalmodel/solvers/openfoam/block_mesh.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Deterministic blockMeshDict body rendering for an OpenFOAM case domain,
+split out of case_builder.py so the builder holds orchestration only (#1575).
+"""
+
+from __future__ import annotations
+
+from .models import DomainConfig
+
+__all__ = ["render_block_mesh_dict_body"]
+
+
+def render_block_mesh_dict_body(domain: DomainConfig) -> str:
+    """Render the ``system/blockMeshDict`` body for ``domain``.
+
+    The returned string excludes the FoamFile header and the trailing rule; the
+    caller composes those, matching the ``render_*_dict_body`` convention used
+    by :mod:`.motion` and :mod:`.partial_fill`.
+
+    The emitted block uses the domain's own extents and cell counts, so a
+    caller-requested domain reaches the mesh rather than a builder default.
+    """
+    verts = domain.block_mesh_vertices()
+    nx, ny, nz = domain.cell_counts()
+
+    vert_lines = "\n    ".join(
+        f"( {v[0]:>10.4f}  {v[1]:>10.4f}  {v[2]:>10.4f} )"
+        for v in verts
+    )
+
+    return f"""
+convertToMeters 1;
+
+vertices
+(
+    {vert_lines}
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) ({nx} {ny} {nz}) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+    inlet
+    {{
+        type patch;
+        faces
+        (
+            (0 4 7 3)
+        );
+    }}
+    outlet
+    {{
+        type patch;
+        faces
+        (
+            (1 2 6 5)
+        );
+    }}
+    bottom
+    {{
+        type wall;
+        faces
+        (
+            (0 1 2 3)
+        );
+    }}
+    top
+    {{
+        type patch;
+        faces
+        (
+            (4 5 6 7)
+        );
+    }}
+    sides
+    {{
+        type symmetry;
+        faces
+        (
+            (0 1 5 4)
+            (3 7 6 2)
+        );
+    }}
+);
+
+mergePatchPairs
+(
+);
+
+"""

--- a/src/digitalmodel/solvers/openfoam/case_builder.py
+++ b/src/digitalmodel/solvers/openfoam/case_builder.py
@@ -18,6 +18,7 @@ from .initial_fields import (
     write_turbulence_fields,
     write_velocity_field,
 )
+from .block_mesh import render_block_mesh_dict_body
 from .models import OpenFOAMCase, TurbulenceType
 from .motion import render_dynamic_mesh_dict_body
 from .partial_fill import (
@@ -258,83 +259,8 @@ snGradSchemes
 
     def _write_block_mesh_dict(self, system_dir: Path) -> None:
         """Write system/blockMeshDict from DomainConfig."""
-        dc = self._case.domain
-        verts = dc.block_mesh_vertices()
-        nx, ny, nz = dc.cell_counts()
-
-        vert_lines = "\n    ".join(
-            f"( {v[0]:>10.4f}  {v[1]:>10.4f}  {v[2]:>10.4f} )"
-            for v in verts
-        )
-
         content = _foam_header("dictionary", "blockMeshDict")
-        content += f"""
-convertToMeters 1;
-
-vertices
-(
-    {vert_lines}
-);
-
-blocks
-(
-    hex (0 1 2 3 4 5 6 7) ({nx} {ny} {nz}) simpleGrading (1 1 1)
-);
-
-edges
-(
-);
-
-boundary
-(
-    inlet
-    {{
-        type patch;
-        faces
-        (
-            (0 4 7 3)
-        );
-    }}
-    outlet
-    {{
-        type patch;
-        faces
-        (
-            (1 2 6 5)
-        );
-    }}
-    bottom
-    {{
-        type wall;
-        faces
-        (
-            (0 1 2 3)
-        );
-    }}
-    top
-    {{
-        type patch;
-        faces
-        (
-            (4 5 6 7)
-        );
-    }}
-    sides
-    {{
-        type symmetry;
-        faces
-        (
-            (0 1 5 4)
-            (3 7 6 2)
-        );
-    }}
-);
-
-mergePatchPairs
-(
-);
-
-"""
+        content += render_block_mesh_dict_body(self._case.domain)
         content += _FOOTER
         (system_dir / "blockMeshDict").write_text(content)
 

--- a/src/digitalmodel/solvers/openfoam/case_builder.py
+++ b/src/digitalmodel/solvers/openfoam/case_builder.py
@@ -8,7 +8,7 @@ configuration. Does not require OpenFOAM to be installed.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from loguru import logger
 
@@ -19,7 +19,7 @@ from .initial_fields import (
     write_velocity_field,
 )
 from .block_mesh import render_block_mesh_dict_body
-from .models import OpenFOAMCase, TurbulenceType
+from .models import OpenFOAMCase
 from .motion import render_dynamic_mesh_dict_body
 from .partial_fill import (
     partial_fill_box,
@@ -95,10 +95,12 @@ class OpenFOAMCaseBuilder:
         case: OpenFOAMCase,
         pressure_taps: Optional[List[PressureTap]] = None,
         *,
+        tap_write_control: str = "timeStep",
         tap_write_interval: int = 1,
     ) -> None:
         self._case = case
         self._pressure_taps: List[PressureTap] = list(pressure_taps or [])
+        self._tap_write_control = tap_write_control
         self._tap_write_interval = tap_write_interval
 
     def build(self, parent_dir: Path) -> Path:
@@ -186,6 +188,7 @@ class OpenFOAMCaseBuilder:
         if self._pressure_taps:
             block = render_pressure_tap_functions(
                 self._pressure_taps,
+                write_control=self._tap_write_control,
                 write_interval=self._tap_write_interval,
             )
             lines.append("\n" + block)

--- a/src/digitalmodel/solvers/openfoam/case_definition.py
+++ b/src/digitalmodel/solvers/openfoam/case_definition.py
@@ -266,7 +266,12 @@ def _case_type(value: Any) -> CaseType:
     try:
         return CaseType(name)
     except ValueError as error:
-        raise ValidationError(f"unsupported case_type {name!r}") from error
+        # Wording preserved from the pre-#1575 router; callers and tests match
+        # on it.
+        valid = ", ".join(item.value for item in CaseType)
+        raise ValidationError(
+            f"Unknown openfoam.case_type {name!r}. Valid: {valid}"
+        ) from error
 
 
 def _parse_authored(value: Any, execution: SelectedExecutionPlan) -> ParsedAuthoredCaseV1:
@@ -348,7 +353,10 @@ def _parse_canonical(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
 
 
 def _parse_legacy(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
-    check_keys(root, allowed=_LEGACY_KEYS, required={"case_type"}, path="root")
+    check_keys(root, allowed=_LEGACY_KEYS, path="root")
+    if "case_type" not in root:
+        # Wording preserved from the pre-#1575 router.
+        raise ValidationError("openfoam.case_type is required")
     case_type = _case_type(root["case_type"])
     # The legacy generic form has always defaulted the case name from the case
     # type; normalisation must not turn that into a required key.

--- a/src/digitalmodel/solvers/openfoam/case_definition.py
+++ b/src/digitalmodel/solvers/openfoam/case_definition.py
@@ -1,0 +1,374 @@
+"""Fail-closed schema-v1 parser for authored OpenFOAM case requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ._case_definition_validation import (
+    ValidationError,
+    check_keys,
+    require_bool,
+    require_int,
+    require_mapping,
+    require_number,
+    require_string,
+    require_string_sequence,
+    require_vector,
+    validate_case_name,
+)
+from .models import CaseType, DomainConfig, OpenFOAMCase
+from .motion import MotionType, PrescribedMotion
+from .pressure_taps import PressureTap
+
+SCHEMA_VERSION = 1
+
+
+class CaseDefinitionError(ValueError):
+    """Raised when a case request does not conform to the supported schema."""
+
+
+@dataclass(frozen=True)
+class FunctionObjectsConfig:
+    """Neutral function-object settings carried to the case builder."""
+
+    pressure_taps: tuple[PressureTap, ...]
+    write_control: str
+    write_interval: int
+
+
+@dataclass(frozen=True)
+class SelectedExecutionPlan:
+    """Validated execution choices selected by the request."""
+
+    mesh_utility: str
+    run_snappy: bool
+    run_set_fields: bool
+    to_vtk: bool
+    timeout_seconds: int
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class ParsedAuthoredCaseV1:
+    """A constructed case and its non-case execution configuration."""
+
+    case: OpenFOAMCase
+    function_objects: FunctionObjectsConfig
+    execution: SelectedExecutionPlan
+
+
+_AUTHORED_KEYS = {
+    "case_type", "name", "solver", "domain", "motion", "fill", "time",
+    "function_objects",
+}
+_EXECUTION_KEYS = {
+    "mesh_utility", "run_snappy", "run_set_fields", "to_vtk",
+    "timeout_seconds", "dry_run",
+}
+_LEGACY_KEYS = {
+    "operation", "case_type", "name", "output_directory", "solver",
+    "mesh_utility", "run_snappy", "to_vtk", "dry_run", "timeout_seconds",
+}
+_CANONICAL_ROOT_KEYS = {"operation", "output_directory", "case_definition", "execution"}
+_WRITE_CONTROLS = {"timeStep", "runTime", "adjustableRunTime"}
+
+
+def _ledger() -> dict[str, str]:
+    case = "OpenFOAMCase"
+    function = "FunctionObjectsConfig"
+    execution = "SelectedExecutionPlan"
+    return {
+        "case_definition.authored.case_type": case,
+        "case_definition.authored.name": "WorkLayout/RunIdentity",
+        "case_definition.authored.solver": case,
+        "case_definition.authored.domain.min_coords_m": case,
+        "case_definition.authored.domain.max_coords_m": case,
+        "case_definition.authored.domain.n_cells": case,
+        "case_definition.authored.motion.type": case,
+        "case_definition.authored.motion.amplitude": case,
+        "case_definition.authored.motion.amplitude_unit": case,
+        "case_definition.authored.motion.period_s": case,
+        "case_definition.authored.motion.origin_m": case,
+        "case_definition.authored.motion.phase_shift_s": case,
+        "case_definition.authored.fill.level": case,
+        "case_definition.authored.time.start_time_s": case,
+        "case_definition.authored.time.end_time_s": case,
+        "case_definition.authored.time.delta_t_s": case,
+        "case_definition.authored.time.write_interval_steps": case,
+        "case_definition.authored.time.adjustable_time_step": case,
+        "case_definition.authored.time.max_co": case,
+        "case_definition.authored.time.purge_write": case,
+        "case_definition.authored.function_objects.pressure_taps": function,
+        "case_definition.authored.function_objects.write_control": function,
+        "case_definition.authored.function_objects.write_interval": function,
+        **{f"execution.{key}": execution for key in _EXECUTION_KEYS},
+    }
+
+
+ACCEPTED_LEAF_CONSUMERS: Mapping[str, str] = MappingProxyType(_ledger())
+
+
+def _parse_execution(value: Any) -> SelectedExecutionPlan:
+    data = require_mapping(value, "execution")
+    check_keys(data, allowed=_EXECUTION_KEYS, required=_EXECUTION_KEYS, path="execution")
+    return SelectedExecutionPlan(
+        mesh_utility=require_string(data["mesh_utility"], "execution.mesh_utility"),
+        run_snappy=require_bool(data["run_snappy"], "execution.run_snappy"),
+        run_set_fields=require_bool(data["run_set_fields"], "execution.run_set_fields"),
+        to_vtk=require_bool(data["to_vtk"], "execution.to_vtk"),
+        timeout_seconds=require_int(
+            data["timeout_seconds"], "execution.timeout_seconds", positive=True
+        ),
+        dry_run=require_bool(data["dry_run"], "execution.dry_run"),
+    )
+
+
+def _parse_domain(value: Any) -> DomainConfig:
+    data = require_mapping(value, "case_definition.authored.domain")
+    keys = {"min_coords_m", "max_coords_m", "n_cells"}
+    check_keys(data, allowed=keys, required=keys, path="case_definition.authored.domain")
+    minimum = require_vector(data["min_coords_m"], "domain.min_coords_m")
+    maximum = require_vector(data["max_coords_m"], "domain.max_coords_m")
+    cells = require_vector(data["n_cells"], "domain.n_cells", integers=True, positive=True)
+    if any(maximum[index] <= minimum[index] for index in range(3)):
+        raise ValidationError("domain.max_coords_m must exceed min_coords_m")
+    return DomainConfig(
+        min_coords=list(minimum), max_coords=list(maximum), n_cells=list(cells)
+    )
+
+
+def _parse_time(value: Any, case: OpenFOAMCase) -> None:
+    data = require_mapping(value, "case_definition.authored.time")
+    keys = {
+        "start_time_s", "end_time_s", "delta_t_s", "write_interval_steps",
+        "adjustable_time_step", "max_co", "purge_write",
+    }
+    check_keys(data, allowed=keys, required=keys, path="case_definition.authored.time")
+    start = require_number(data["start_time_s"], "time.start_time_s")
+    end = require_number(data["end_time_s"], "time.end_time_s")
+    if end <= start:
+        raise ValidationError("time.end_time_s must be after start_time_s")
+    solver = case.solver_config
+    solver.start_time = start
+    solver.end_time = end
+    solver.delta_t = require_number(data["delta_t_s"], "time.delta_t_s", positive=True)
+    solver.write_interval = require_int(
+        data["write_interval_steps"], "time.write_interval_steps", positive=True
+    )
+    solver.adjustable_time_step = require_bool(
+        data["adjustable_time_step"], "time.adjustable_time_step"
+    )
+    solver.max_co = require_number(data["max_co"], "time.max_co")
+    solver.purge_write = require_int(data["purge_write"], "time.purge_write")
+
+
+def _parse_motion(value: Any) -> PrescribedMotion:
+    data = require_mapping(value, "case_definition.authored.motion")
+    keys = {"type", "amplitude", "amplitude_unit", "period_s", "origin_m", "phase_shift_s"}
+    check_keys(data, allowed=keys, path="case_definition.authored.motion")
+    for required in ("type", "amplitude", "amplitude_unit", "period_s"):
+        if required not in data:
+            raise ValidationError(f"missing required key motion.{required}")
+    motion_type = _motion_type(data["type"])
+    unit = require_string(data["amplitude_unit"], "motion.amplitude_unit")
+    if motion_type.is_rotational:
+        origin, phase = _rotational_motion_values(data, unit)
+    else:
+        origin, phase = _translational_motion_values(data, unit)
+    return PrescribedMotion(
+        motion_type,
+        require_number(data["amplitude"], "motion.amplitude", positive=True),
+        require_number(data["period_s"], "motion.period_s", positive=True),
+        origin,
+        phase,
+    )
+
+
+def _motion_type(value: Any) -> MotionType:
+    name = require_string(value, "motion.type")
+    try:
+        return MotionType(name)
+    except ValueError as error:
+        raise ValidationError(f"unsupported motion.type {name!r}") from error
+
+
+def _rotational_motion_values(
+    data: Mapping[str, Any], unit: str
+) -> tuple[tuple[float, float, float], float]:
+    if unit != "deg":
+        raise ValidationError("motion.amplitude_unit must be 'deg' for rotation")
+    if "origin_m" not in data:
+        raise ValidationError("missing required key motion.origin_m")
+    if "phase_shift_s" in data:
+        raise ValidationError("motion.phase_shift_s is invalid for rotation")
+    return require_vector(data["origin_m"], "motion.origin_m"), 0.0
+
+
+def _translational_motion_values(
+    data: Mapping[str, Any], unit: str
+) -> tuple[tuple[float, float, float], float]:
+    if unit != "m":
+        raise ValidationError("motion.amplitude_unit must be 'm' for translation")
+    if "origin_m" in data:
+        raise ValidationError("motion.origin_m is invalid for translation")
+    phase = require_number(data.get("phase_shift_s", 0.0), "motion.phase_shift_s")
+    return (0.0, 0.0, 0.0), phase
+
+
+def _parse_function_objects(value: Any) -> FunctionObjectsConfig:
+    data = require_mapping(value, "case_definition.authored.function_objects")
+    keys = {"pressure_taps", "write_control", "write_interval"}
+    check_keys(data, allowed=keys, required=keys, path="case_definition.authored.function_objects")
+    control = require_string(data["write_control"], "function_objects.write_control")
+    if control not in _WRITE_CONTROLS:
+        raise ValidationError(f"unsupported write_control {control!r}")
+    taps_value = data["pressure_taps"]
+    if isinstance(taps_value, (str, bytes)) or not isinstance(taps_value, (list, tuple)):
+        raise ValidationError("function_objects.pressure_taps must be a sequence")
+    return FunctionObjectsConfig(
+        tuple(_parse_tap(tap, index) for index, tap in enumerate(taps_value)),
+        control,
+        require_int(data["write_interval"], "function_objects.write_interval", positive=True),
+    )
+
+
+def _parse_tap(value: Any, index: int) -> PressureTap:
+    path = f"function_objects.pressure_taps[{index}]"
+    data = require_mapping(value, path)
+    keys = {"name", "location_m", "fields"}
+    check_keys(data, allowed=keys, required=keys, path=path)
+    return PressureTap(
+        name=require_string(data["name"], f"{path}.name"),
+        location=require_vector(data["location_m"], f"{path}.location_m"),
+        fields=require_string_sequence(data["fields"], f"{path}.fields"),
+    )
+
+
+def _case_type(value: Any) -> CaseType:
+    name = require_string(value, "case_type")
+    try:
+        return CaseType(name)
+    except ValueError as error:
+        raise ValidationError(f"unsupported case_type {name!r}") from error
+
+
+def _parse_authored(value: Any, execution: SelectedExecutionPlan) -> ParsedAuthoredCaseV1:
+    data = require_mapping(value, "case_definition.authored")
+    required = {"case_type", "name", "solver", "domain", "time"}
+    check_keys(data, allowed=_AUTHORED_KEYS, required=required, path="case_definition.authored")
+    case = OpenFOAMCase.for_case_type(
+        _case_type(data["case_type"]), validate_case_name(data["name"], "name")
+    )
+    case.solver_config.solver_name = require_string(data["solver"], "solver")
+    case.domain = _parse_domain(data["domain"])
+    _parse_time(data["time"], case)
+    functions = _optional_function_objects(data)
+    if "motion" in data:
+        case.motion = _parse_motion(data["motion"])
+    if "fill" in data:
+        case.fill_level = _parse_fill(data["fill"])
+    _validate_combinations(case, execution)
+    return ParsedAuthoredCaseV1(case, functions, execution)
+
+
+def _optional_function_objects(data: Mapping[str, Any]) -> FunctionObjectsConfig:
+    if "function_objects" not in data:
+        return FunctionObjectsConfig((), "timeStep", 1)
+    return _parse_function_objects(data["function_objects"])
+
+
+def _parse_fill(value: Any) -> float:
+    data = require_mapping(value, "case_definition.authored.fill")
+    check_keys(data, allowed={"level"}, required={"level"}, path="case_definition.authored.fill")
+    level = require_number(data["level"], "fill.level")
+    if not 0.0 <= level <= 1.0:
+        raise ValidationError("fill.level must be between 0 and 1")
+    return level
+
+
+def _validate_combinations(case: OpenFOAMCase, plan: SelectedExecutionPlan) -> None:
+    if case.fill_level is not None and not case.solver_config.is_multiphase:
+        raise ValidationError("fill requires a multiphase case")
+    if case.fill_level is not None and not plan.run_set_fields:
+        raise ValidationError("fill requires execution.run_set_fields true")
+    if plan.run_set_fields and case.fill_level is None:
+        raise ValidationError("execution.run_set_fields requires fill")
+    if case.motion is not None and case.solver_config.solver_name not in {
+        "interFoam", "pimpleFoam"
+    }:
+        raise ValidationError("motion requires a transient solver")
+
+
+def _parse_canonical(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
+    check_keys(root, allowed=_CANONICAL_ROOT_KEYS, path="root")
+    for required in ("case_definition", "execution"):
+        if required not in root:
+            raise ValidationError(f"missing required root key {required}")
+    definition = require_mapping(root["case_definition"], "case_definition")
+    check_keys(
+        definition,
+        allowed={"schema_version", "kind", "authored", "prebuilt"},
+        required={"schema_version", "kind"},
+        path="case_definition",
+    )
+    version = require_int(
+        definition["schema_version"], "case_definition.schema_version"
+    )
+    if version != SCHEMA_VERSION:
+        raise ValidationError("unsupported case_definition.schema_version")
+    kind = require_string(definition["kind"], "case_definition.kind")
+    if kind == "prebuilt":
+        raise ValidationError("prebuilt cases are not available in schema v1")
+    if kind != "authored":
+        raise ValidationError(f"unsupported case_definition.kind {kind!r}")
+    check_keys(
+        definition,
+        allowed={"schema_version", "kind", "authored"},
+        required={"schema_version", "kind", "authored"},
+        path="case_definition",
+    )
+    return _parse_authored(definition["authored"], _parse_execution(root["execution"]))
+
+
+def _parse_legacy(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
+    check_keys(root, allowed=_LEGACY_KEYS, required={"case_type", "name"}, path="root")
+    case = OpenFOAMCase.for_case_type(
+        _case_type(root["case_type"]), validate_case_name(root["name"], "name")
+    )
+    if "solver" in root:
+        case.solver_config.solver_name = require_string(root["solver"], "solver")
+    plan = SelectedExecutionPlan(
+        mesh_utility=require_string(root.get("mesh_utility", "blockMesh"), "mesh_utility"),
+        run_snappy=require_bool(root.get("run_snappy", False), "run_snappy"),
+        run_set_fields=False,
+        to_vtk=require_bool(root.get("to_vtk", True), "to_vtk"),
+        timeout_seconds=require_int(root.get("timeout_seconds", 7200), "timeout_seconds", positive=True),
+        dry_run=require_bool(root.get("dry_run", False), "dry_run"),
+    )
+    return ParsedAuthoredCaseV1(case, FunctionObjectsConfig((), "timeStep", 1), plan)
+
+
+def parse_case_request(settings: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
+    """Validate and construct one canonical authored-v1 or legacy request."""
+    try:
+        root = require_mapping(settings, "root")
+        if "case_definition" in root or "execution" in root:
+            return _parse_canonical(root)
+        return _parse_legacy(root)
+    except (ValidationError, KeyError, TypeError, ValueError) as error:
+        if isinstance(error, CaseDefinitionError):
+            raise
+        raise CaseDefinitionError(str(error)) from error
+
+
+__all__ = [
+    "ACCEPTED_LEAF_CONSUMERS",
+    "SCHEMA_VERSION",
+    "CaseDefinitionError",
+    "FunctionObjectsConfig",
+    "ParsedAuthoredCaseV1",
+    "SelectedExecutionPlan",
+    "parse_case_request",
+]

--- a/src/digitalmodel/solvers/openfoam/case_definition.py
+++ b/src/digitalmodel/solvers/openfoam/case_definition.py
@@ -73,6 +73,10 @@ _LEGACY_KEYS = {
 }
 _CANONICAL_ROOT_KEYS = {"operation", "output_directory", "case_definition", "execution"}
 _WRITE_CONTROLS = {"timeStep", "runTime", "adjustableRunTime"}
+# The builder's own defaults; an empty tap list may carry only these, because
+# any other value would have nothing to render it onto.
+_DEFAULT_WRITE_CONTROL = "timeStep"
+_DEFAULT_WRITE_INTERVAL = 1
 
 
 def _ledger() -> dict[str, str]:
@@ -227,11 +231,22 @@ def _parse_function_objects(value: Any) -> FunctionObjectsConfig:
     taps_value = data["pressure_taps"]
     if isinstance(taps_value, (str, bytes)) or not isinstance(taps_value, (list, tuple)):
         raise ValidationError("function_objects.pressure_taps must be a sequence")
-    return FunctionObjectsConfig(
-        tuple(_parse_tap(tap, index) for index, tap in enumerate(taps_value)),
-        control,
-        require_int(data["write_interval"], "function_objects.write_interval", positive=True),
+    interval = require_int(
+        data["write_interval"], "function_objects.write_interval", positive=True
     )
+    taps = tuple(_parse_tap(tap, index) for index, tap in enumerate(taps_value))
+    if not taps:
+        # Nothing would carry these values into the emitted functions block, so
+        # accepting a non-default pair would silently drop it.
+        if control != _DEFAULT_WRITE_CONTROL:
+            raise ValidationError(
+                "function_objects.write_control is unconsumed with no pressure_taps"
+            )
+        if interval != _DEFAULT_WRITE_INTERVAL:
+            raise ValidationError(
+                "function_objects.write_interval is unconsumed with no pressure_taps"
+            )
+    return FunctionObjectsConfig(taps, control, interval)
 
 
 def _parse_tap(value: Any, index: int) -> PressureTap:
@@ -333,10 +348,12 @@ def _parse_canonical(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
 
 
 def _parse_legacy(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
-    check_keys(root, allowed=_LEGACY_KEYS, required={"case_type", "name"}, path="root")
-    case = OpenFOAMCase.for_case_type(
-        _case_type(root["case_type"]), validate_case_name(root["name"], "name")
-    )
+    check_keys(root, allowed=_LEGACY_KEYS, required={"case_type"}, path="root")
+    case_type = _case_type(root["case_type"])
+    # The legacy generic form has always defaulted the case name from the case
+    # type; normalisation must not turn that into a required key.
+    name = root.get("name") or f"{case_type.value}_case"
+    case = OpenFOAMCase.for_case_type(case_type, validate_case_name(name, "name"))
     if "solver" in root:
         case.solver_config.solver_name = require_string(root["solver"], "solver")
     plan = SelectedExecutionPlan(

--- a/src/digitalmodel/solvers/openfoam/workflow.py
+++ b/src/digitalmodel/solvers/openfoam/workflow.py
@@ -46,61 +46,75 @@ class OpenFOAMWorkflow:
                 f"Supported operations: {', '.join(_SUPPORTED_OPERATIONS)}"
             )
 
-        case_dir = self._build_case(cfg, settings)
+        case_dir, parsed = self._build_case(cfg, settings)
         settings["case_dir"] = str(case_dir)
 
         if operation == "build_case":
             settings["run_status"] = "built"
             return cfg
 
-        return self._run_openfoam(cfg, settings, case_dir)
+        return self._run_openfoam(cfg, settings, case_dir, parsed)
 
     # ------------------------------------------------------------------ #
     #  build (license-free) — delegate to OpenFOAMCaseBuilder            #
     # ------------------------------------------------------------------ #
-    def _build_case(self, cfg: dict[str, Any], settings: dict[str, Any]) -> Path:
+    def _build_case(
+        self, cfg: dict[str, Any], settings: dict[str, Any]
+    ) -> tuple[Path, Any]:
         # Lazy import: keep the engine import graph light.
         from .case_builder import OpenFOAMCaseBuilder
-        from .models import CaseType, OpenFOAMCase
+        from .case_definition import parse_case_request
 
-        case_type_raw = settings.get("case_type")
-        if case_type_raw is None:
-            raise ValueError("openfoam.case_type is required")
-        try:
-            case_type = CaseType(case_type_raw)
-        except ValueError as exc:
-            valid = ", ".join(ct.value for ct in CaseType)
-            raise ValueError(
-                f"Unknown openfoam.case_type {case_type_raw!r}. Valid: {valid}"
-            ) from exc
-
-        name = settings.get("name") or f"{case_type.value}_case"
-        case = OpenFOAMCase.for_case_type(case_type, name)
-
-        # Optional solver override (otherwise the case-type default is used).
-        solver_override = settings.get("solver")
-        if solver_override:
-            case.solver_config.solver_name = solver_override
+        # The whole request is validated as one closed contract (#1575). Every
+        # accepted semantic leaf is carried onto the typed case here; anything
+        # unknown is refused rather than silently dropped, which is what let a
+        # mock batch pass while rendering a default static case.
+        parsed = parse_case_request(self._case_request(settings))
 
         parent_dir = self._resolve_output_dir(cfg, settings)
         parent_dir.mkdir(parents=True, exist_ok=True)
-        return OpenFOAMCaseBuilder(case).build(parent_dir)
+        case_dir = OpenFOAMCaseBuilder(
+            parsed.case,
+            list(parsed.function_objects.pressure_taps),
+            tap_write_control=parsed.function_objects.write_control,
+            tap_write_interval=parsed.function_objects.write_interval,
+        ).build(parent_dir)
+        return case_dir, parsed
+
+    @staticmethod
+    def _case_request(settings: dict[str, Any]) -> dict[str, Any]:
+        """Strip adapter-owned keys the schema does not describe.
+
+        ``case_dir`` and the run-report keys are written back onto ``settings``
+        by this router, so a second pass over the same mapping must not see
+        them as unknown input.
+        """
+        adapter_owned = {"case_dir", "run_status", "outputs"}
+        return {
+            key: value
+            for key, value in settings.items()
+            if key not in adapter_owned
+        }
 
     # ------------------------------------------------------------------ #
     #  run (fail-closed) — delegate to OpenFOAMRunner                    #
     # ------------------------------------------------------------------ #
     def _run_openfoam(
-        self, cfg: dict[str, Any], settings: dict[str, Any], case_dir: Path
+        self, cfg: dict[str, Any], settings: dict[str, Any], case_dir: Path,
+        parsed: Any,
     ) -> dict[str, Any]:
         from .runner import OpenFOAMRunConfig, OpenFOAMRunner
 
-        requested_dry_run = bool(settings.get("dry_run", False))
+        # The runner is driven from the validated execution plan, so a canonical
+        # request and a normalised legacy one select the same run identically.
+        plan = parsed.execution
+        requested_dry_run = plan.dry_run
         run_cfg = OpenFOAMRunConfig(
-            solver=settings.get("solver"),
-            mesh_utility=settings.get("mesh_utility", "blockMesh"),
-            run_snappy=bool(settings.get("run_snappy", False)),
-            to_vtk=bool(settings.get("to_vtk", True)),
-            timeout_seconds=int(settings.get("timeout_seconds", 7200)),
+            solver=parsed.case.solver_config.solver_name,
+            mesh_utility=plan.mesh_utility,
+            run_snappy=plan.run_snappy,
+            to_vtk=plan.to_vtk,
+            timeout_seconds=plan.timeout_seconds,
             dry_run=requested_dry_run,
         )
         result = OpenFOAMRunner(run_cfg).run(case_dir)

--- a/src/digitalmodel/solvers/openfoam/workflow.py
+++ b/src/digitalmodel/solvers/openfoam/workflow.py
@@ -9,19 +9,53 @@ to :class:`OpenFOAMCaseBuilder` (case authoring, license-free) and
 It mirrors the ANSYS/OrcaWave/AQWA router contract so the same fixed
 ``uv run python -m digitalmodel <input>`` lane command can drive a CFD solve.
 
-Input contract::
+Input contract. Two forms are accepted and must not be mixed (#1575).
+
+Canonical — carries the full case definition, validated fail-closed::
+
+    basename: openfoam
+    openfoam:
+      operation: run_openfoam     # build_case | run_openfoam (default)
+      output_directory: out       # relative to Analysis.result_folder
+      case_definition:
+        schema_version: 1
+        kind: authored            # "prebuilt" is reserved and refused in v1
+        authored:
+          case_type: sloshing
+          name: my_case
+          solver: interFoam
+          domain: {...}           # SI metres, right-handed, z up
+          motion: {...}           # optional prescribed single-DOF forcing
+          fill: {...}             # optional VOF partial fill
+          time: {...}             # start/end/step/write controls
+          function_objects: {...} # optional pressure taps + write controls
+      execution:
+        mesh_utility: blockMesh
+        run_snappy: false
+        run_set_fields: false
+        to_vtk: false
+        timeout_seconds: 43200
+        dry_run: false
+
+Legacy — the pre-#1575 flat form, still supported and normalised onto the
+schema above. It cannot express domain, motion, fill, time or function
+objects; those keys are refused here rather than silently dropped::
 
     basename: openfoam            # (or "cfd")
     openfoam:
       operation: run_openfoam     # build_case | run_openfoam (default)
       case_type: current_loading  # any CaseType value
-      name: my_case               # case directory name
+      name: my_case               # optional; defaults to <case_type>_case
       output_directory: out       # relative to Analysis.result_folder
-      solver: simpleFoam          # optional override; else read from controlDict
+      solver: simpleFoam          # optional override; else the case-type default
       mesh_utility: blockMesh
       run_snappy: false
       to_vtk: true
       dry_run: false
+
+Unknown keys are rejected by name in both forms. Before #1575 they were
+accepted and dropped, so a request carrying a full case definition rendered a
+default static case and still reported success.
 
 Fail-closed: if a real solve was requested but no OpenFOAM is on PATH, the
 runner reports DRY_RUN and this router raises, so the licensed-run lane can

--- a/src/digitalmodel/workflows/openfoam_batch_config.py
+++ b/src/digitalmodel/workflows/openfoam_batch_config.py
@@ -18,6 +18,7 @@ HOSTED_CONTEXT = "hosted-deckhand"
 TRUSTED_LOCAL_CONTEXT = "trusted-local"
 DEFAULT_OUTPUT_DIR = "results"
 DEFAULT_WORK_DIR = "batch_runs"
+DEFAULT_MESH_UTILITY = "blockMesh"
 _COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 RESERVED_ROW_KEYS = frozenset({"index", "name", "status", "solver", "mock",
                                "error", "case_dir", "wall_seconds", "mpi_plan"})
@@ -63,6 +64,28 @@ def resolve_case_matrix(explicit: list[dict] | None, variants: dict,
 
 def _canonical(base: dict) -> bool:
     return "case_definition" in base or "execution" in base
+
+
+def base_view(base: dict) -> dict:
+    """Return the solver/utility view of either base form.
+
+    The batch router picks executables and checks solver readiness from a flat
+    set of keys. A canonical base carries the same facts under
+    ``case_definition.authored`` and ``execution``, so both forms are reduced
+    here rather than teaching every call site about the schema.
+    """
+    if not _canonical(base):
+        return base
+    authored = (base.get("case_definition") or {}).get("authored") or {}
+    execution = base.get("execution") or {}
+    return {
+        "case_type": authored.get("case_type"),
+        "solver": authored.get("solver"),
+        "mesh_utility": execution.get("mesh_utility", DEFAULT_MESH_UTILITY),
+        "run_snappy": execution.get("run_snappy", False),
+        "run_set_fields": execution.get("run_set_fields", False),
+        "to_vtk": execution.get("to_vtk", False),
+    }
 
 
 def _base_name(base: dict) -> str:

--- a/src/digitalmodel/workflows/openfoam_batch_config.py
+++ b/src/digitalmodel/workflows/openfoam_batch_config.py
@@ -61,9 +61,67 @@ def resolve_case_matrix(explicit: list[dict] | None, variants: dict,
     return _load_cases(variants, cfg_dir) if variants else [{}]
 
 
+def _canonical(base: dict) -> bool:
+    return "case_definition" in base or "execution" in base
+
+
+def _base_name(base: dict) -> str:
+    """Default case-name stem for either base form."""
+    if _canonical(base):
+        authored = (base.get("case_definition") or {}).get("authored") or {}
+        stem = authored.get("name") or authored.get("case_type")
+        if not stem:
+            raise ValueError(
+                "openfoam_run_batch.base.case_definition.authored requires "
+                "case_type"
+            )
+        return str(stem)
+    if not base.get("case_type"):
+        raise ValueError("openfoam_run_batch.base.case_type is required")
+    return str(base.get("name") or f"{base['case_type']}_case")
+
+
+def _validate_mapping_target(target: str) -> None:
+    """Refuse a knob target that is not a single accepted mutable leaf.
+
+    Mapping onto a container, the schema discriminator, or a path the schema
+    does not accept would either be silently ignored downstream or corrupt the
+    case-source union, so both are rejected before any case is rendered.
+    """
+    from digitalmodel.solvers.openfoam.case_definition import (
+        ACCEPTED_LEAF_CONSUMERS,
+    )
+
+    if target in ACCEPTED_LEAF_CONSUMERS:
+        return
+    prefixes = {
+        parent
+        for leaf in ACCEPTED_LEAF_CONSUMERS
+        for parent in _ancestors(leaf)
+    }
+    if target in prefixes:
+        raise ValueError(
+            f"openfoam_run_batch mapping target {target!r} names a container, "
+            "not a single accepted leaf"
+        )
+    raise ValueError(
+        f"openfoam_run_batch mapping target {target!r} is not an accepted "
+        "case-definition leaf"
+    )
+
+
+def _ancestors(dotted: str) -> list[str]:
+    parts = dotted.split(".")
+    return [".".join(parts[:index]) for index in range(1, len(parts))]
+
+
 def render_cases(base: dict, cases: list[dict], mapping: dict[str, str],
                  work_dir: Path) -> list[dict]:
-    base_name = base.get("name") or f"{base['case_type']}_case"
+    base_name = _base_name(base)
+    canonical = _canonical(base)
+    if canonical:
+        for target in mapping.values():
+            _validate_mapping_target(target)
     rendered = []
     for index, case in enumerate(cases):
         settings = deepcopy(base)
@@ -75,9 +133,17 @@ def render_cases(base: dict, cases: list[dict], mapping: dict[str, str],
                 f"{sorted(collisions)}"
             )
         for name, value in params.items():
-            _set_dotted(settings, mapping.get(name, name), value)
+            target = mapping.get(name, name)
+            if canonical and name not in mapping:
+                _validate_mapping_target(target)
+            _set_dotted(settings, target, value)
         name = case.get("name") or f"{base_name}_{index:03d}"
-        settings["name"] = name
+        if canonical:
+            # The canonical schema owns the case name; a root-level "name"
+            # would be refused as an unknown key by the generic adapter.
+            settings["case_definition"]["authored"]["name"] = name
+        else:
+            settings["name"] = name
         rendered.append({"index": index, "name": name, "case": params,
                          "settings": settings, "work_dir": work_dir / name})
     return rendered

--- a/src/digitalmodel/workflows/openfoam_batch_execution.py
+++ b/src/digitalmodel/workflows/openfoam_batch_execution.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from digitalmodel.workflows.openfoam_batch_config import base_view
 from digitalmodel.workflows.openfoam_batch_identity import file_sha256
 from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
 from digitalmodel.workflows.openfoam_batch_results import redact_rows, row
@@ -122,7 +123,9 @@ def solve_serial(item: dict[str, Any], case_dir: Path,
                  run_settings: dict,
                  tool_bindings: dict[str, tuple[Path, str]] | None = None) -> dict[str, Any]:
     from digitalmodel.solvers.openfoam.runner import OpenFOAMRunConfig, OpenFOAMRunner
-    settings = item["settings"]
+    # base_view reduces a canonical case_definition/execution mapping to the
+    # same flat keys a legacy one already uses, so both dispatch identically.
+    settings = base_view(item["settings"])
     config = OpenFOAMRunConfig(
         solver=settings.get("solver"),
         mesh_utility=settings.get("mesh_utility", DEFAULT_MESH_UTILITY),
@@ -163,7 +166,7 @@ def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: in
                            layout: WorkLayout | None,
                            builder: Callable[[dict[str, Any]], Path],
                            tool_bindings: dict[str, tuple[Path, str]] | None) -> dict[str, Any]:
-    solver = item["settings"].get("solver")
+    solver = base_view(item["settings"]).get("solver")
     if not solver:
         return _save(item, row(item, status="failed", error="mode: mpi requires base.solver"), layout)
     reconstruct = bool(run_settings.get("reconstruct", True))
@@ -171,9 +174,10 @@ def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: in
     start = time.monotonic()
     try:
         case_dir = _prepare_mpi_case(item, resume, layout, builder)
+        view = base_view(item["settings"])
         plan = mpi_command_plan(solver, workers,
-            item["settings"].get("mesh_utility", DEFAULT_MESH_UTILITY),
-            bool(item["settings"].get("run_set_fields", False)), reconstruct, resume)
+            view.get("mesh_utility", DEFAULT_MESH_UTILITY),
+            bool(view.get("run_set_fields", False)), reconstruct, resume)
         if mock:
             result = row(item, status="completed", case_dir=case_dir, solver=solver, mock=True)
             result["mpi_plan"] = [" ".join(argv) for argv in plan]

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from digitalmodel.workflows.openfoam_batch_config import (
     RESERVED_ROW_KEYS as _RESERVED_ROW_KEYS,
+    base_view,
     default_workers,
     render_cases as _render_cases,
     resolve_batch_paths,
@@ -113,7 +114,9 @@ def _settings(cfg: dict) -> tuple[dict, dict, dict, Path]:
     settings = cfg.get("openfoam_run_batch") or {}
     run_settings = settings.get("run_batch") or {}
     base = settings.get("base") or {}
-    if not base.get("case_type"):
+    # Either base form must name a case type: the legacy flat key, or the
+    # canonical case_definition.authored leaf.
+    if not base_view(base).get("case_type"):
         raise ValueError("openfoam_run_batch.base.case_type is required")
     cfg_dir = Path(cfg.get("_config_dir_path") or Path.cwd())
     return settings, run_settings, base, cfg_dir
@@ -124,8 +127,9 @@ def _validate_run(run_settings: dict, base: dict) -> tuple[str, bool, int]:
     if mode not in VALID_MODES:
         raise ValueError(f"openfoam_run_batch run_batch.mode must be pool|mpi, got {mode}")
     mock, workers = bool(run_settings.get("mock", False)), resolve_workers(run_settings)
-    if not mock and not _solver_ready(mode, base.get("mesh_utility", DEFAULT_MESH_UTILITY),
-                                      base.get("solver"), bool(run_settings.get("reconstruct", True))):
+    view = base_view(base)
+    if not mock and not _solver_ready(mode, view.get("mesh_utility", DEFAULT_MESH_UTILITY),
+                                      view.get("solver"), bool(run_settings.get("reconstruct", True))):
         raise RuntimeError(SOLVER_ERROR_MESSAGE)
     return mode, mock, workers
 
@@ -137,10 +141,10 @@ def _external_layout(cfg: dict, settings: dict, run_settings: dict, base: dict,
     if not paths.external:
         paths.legacy_work_dir.mkdir(parents=True, exist_ok=True)
         return None, {}, []
-    if not mock and not base.get("solver"):
+    if not mock and not base_view(base).get("solver"):
         raise ValueError("external real runs require base.solver for executable identity")
     inputs = _referenced_inputs(cfg, settings, paths.cfg_dir)
-    tools = [] if mock else _selected_tools(mode, base, run_settings)
+    tools = [] if mock else _selected_tools(mode, base_view(base), run_settings)
     identity = build_run_identity(
         effective_config=settings, referenced_inputs=inputs,
         selected_executables=tools, visible_rank_count=os.cpu_count() or 1,

--- a/tests/solvers/openfoam/test_case_definition.py
+++ b/tests/solvers/openfoam/test_case_definition.py
@@ -638,8 +638,17 @@ def test_every_canonical_authored_leaf_appears_in_the_ledger() -> None:
 
 
 def test_ledger_has_no_leaf_the_schema_does_not_accept() -> None:
-    request = _authored_request()
-    accepted = set(_accepted_paths(request))
+    # Enumerated over both motion families, because a rotational request cannot
+    # carry phase_shift_s and a translational one cannot carry origin_m. The
+    # union is exactly the set of leaves some valid request can carry, so a
+    # ledger entry naming anything else still fails here.
+    translational = _authored_with(
+        "motion",
+        {"type": "sway", "amplitude": 0.1, "amplitude_unit": "m",
+         "period_s": 1.5, "phase_shift_s": 0.25},
+    )
+    accepted = set(_accepted_paths(_authored_request()))
+    accepted |= set(_accepted_paths(translational))
     assert set(ACCEPTED_LEAF_CONSUMERS) - accepted == set()
 
 

--- a/tests/solvers/openfoam/test_case_definition.py
+++ b/tests/solvers/openfoam/test_case_definition.py
@@ -1,0 +1,661 @@
+"""Contract tests for the OpenFOAM authored case-definition schema (#1575).
+
+Every semantic leaf a caller authors must reach the rendered case. A mock batch
+that renders a default static case while silently dropping domain, motion, fill,
+time controls and function objects is the exact defect these tests exist to
+prevent, so the assertions read the emitted dictionaries rather than trusting
+that parsing succeeded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from digitalmodel.solvers.openfoam.case_builder import OpenFOAMCaseBuilder
+from digitalmodel.solvers.openfoam.case_definition import (
+    ACCEPTED_LEAF_CONSUMERS,
+    SCHEMA_VERSION,
+    CaseDefinitionError,
+    parse_case_request,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _authored_request(**overrides: Any) -> Dict[str, Any]:
+    """A complete, valid canonical request; overrides replace top-level keys."""
+    request: Dict[str, Any] = {
+        "operation": "build_case",
+        "case_definition": {
+            "schema_version": 1,
+            "kind": "authored",
+            "authored": {
+                "case_type": "sloshing",
+                "name": "synthetic_sloshing",
+                "solver": "interFoam",
+                "domain": {
+                    "min_coords_m": [0.0, 0.0, 0.0],
+                    "max_coords_m": [2.0, 1.0, 1.0],
+                    "n_cells": [20, 10, 10],
+                },
+                "motion": {
+                    "type": "roll",
+                    "amplitude": 3.0,
+                    "amplitude_unit": "deg",
+                    "period_s": 1.5,
+                    "origin_m": [1.0, 0.5, 0.0],
+                },
+                "fill": {"level": 0.4},
+                "time": {
+                    "start_time_s": 0.0,
+                    "end_time_s": 2.0,
+                    "delta_t_s": 0.002,
+                    "write_interval_steps": 25,
+                    "adjustable_time_step": True,
+                    "max_co": 0.5,
+                    "purge_write": 0,
+                },
+                "function_objects": {
+                    "pressure_taps": [
+                        {
+                            "name": "synthetic_tap",
+                            "location_m": [1.0, 0.5, 0.8],
+                            "fields": ["p", "p_rgh"],
+                        }
+                    ],
+                    "write_control": "timeStep",
+                    "write_interval": 1,
+                },
+            },
+        },
+        "execution": {
+            "mesh_utility": "blockMesh",
+            "run_snappy": False,
+            "run_set_fields": True,
+            "to_vtk": False,
+            "timeout_seconds": 43200,
+            "dry_run": False,
+        },
+    }
+    request.update(overrides)
+    return request
+
+
+def _authored_with(section: str, value: Any) -> Dict[str, Any]:
+    """Return a request whose authored[section] is replaced by ``value``."""
+    request = _authored_request()
+    if value is None:
+        request["case_definition"]["authored"].pop(section, None)
+    else:
+        request["case_definition"]["authored"][section] = value
+    return request
+
+
+def _build(request: Dict[str, Any], tmp_path: Path) -> Path:
+    parsed = parse_case_request(request)
+    builder = OpenFOAMCaseBuilder(
+        parsed.case,
+        parsed.function_objects.pressure_taps,
+        tap_write_control=parsed.function_objects.write_control,
+        tap_write_interval=parsed.function_objects.write_interval,
+    )
+    return builder.build(tmp_path)
+
+
+def _control_dict(case_dir: Path) -> Dict[str, str]:
+    """Parse the scalar ``key value;`` entries of a controlDict."""
+    entries: Dict[str, str] = {}
+    for line in (case_dir / "system" / "controlDict").read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.endswith(";") or stripped.startswith("//"):
+            continue
+        parts = stripped[:-1].split(None, 1)
+        if len(parts) == 2:
+            entries.setdefault(parts[0], parts[1].strip())
+    return entries
+
+
+# --------------------------------------------------------------------------- #
+#  propagation: every authored leaf must reach the rendered case               #
+# --------------------------------------------------------------------------- #
+
+
+def test_requested_cell_counts_reach_block_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    block_mesh = (case_dir / "system" / "blockMeshDict").read_text()
+    assert "hex (0 1 2 3 4 5 6 7) (20 10 10) simpleGrading (1 1 1)" in block_mesh
+
+
+def test_requested_domain_extent_reaches_block_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    block_mesh = (case_dir / "system" / "blockMeshDict").read_text()
+    assert "(     2.0000      1.0000      1.0000 )" in block_mesh
+
+
+def test_requested_end_time_reaches_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["endTime"] == "2.0"
+
+
+def test_requested_delta_t_reaches_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["deltaT"] == "0.002"
+
+
+def test_requested_write_interval_reaches_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["writeInterval"] == "25"
+
+
+def test_requested_max_co_reaches_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["maxCo"] == "0.5"
+
+
+def test_requested_adjustable_time_step_reaches_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["adjustTimeStep"] == "yes"
+
+
+def test_requested_solver_reaches_control_dict_application(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert _control_dict(case_dir)["application"] == "interFoam"
+
+
+def test_motion_emits_dynamic_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert (case_dir / "constant" / "dynamicMeshDict").is_file()
+
+
+def test_motion_period_reaches_dynamic_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    body = (case_dir / "constant" / "dynamicMeshDict").read_text()
+    assert "T=1.5 s" in body
+
+
+def test_motion_origin_reaches_dynamic_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    body = (case_dir / "constant" / "dynamicMeshDict").read_text()
+    assert "(1 0.5 0)" in body
+
+
+def test_absent_motion_emits_no_dynamic_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_with("motion", None), tmp_path)
+    assert not (case_dir / "constant" / "dynamicMeshDict").exists()
+
+
+def test_fill_emits_set_fields_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert (case_dir / "system" / "setFieldsDict").is_file()
+
+
+def test_fill_level_reaches_set_fields_box(tmp_path: Path) -> None:
+    # height 1.0 m over 10 cells => 0.1 m cells; a 0.4 fill lands exactly on a
+    # cell face, so the emitted box top is the requested level with no snapping.
+    case_dir = _build(_authored_request(), tmp_path)
+    body = (case_dir / "system" / "setFieldsDict").read_text()
+    assert "box (-2 -2 -2) (4 3 0.4);" in body
+
+
+def test_function_objects_reach_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    assert "synthetic_tap" in (case_dir / "system" / "controlDict").read_text()
+
+
+def test_tap_write_control_reaches_control_dict(tmp_path: Path) -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["function_objects"][
+        "write_control"
+    ] = "runTime"
+    case_dir = _build(request, tmp_path)
+    body = (case_dir / "system" / "controlDict").read_text()
+    functions_block = body[body.index("functions"):]
+    assert "writeControl    runTime;" in functions_block
+
+
+def test_tap_write_interval_reaches_control_dict(tmp_path: Path) -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["function_objects"]["write_interval"] = 7
+    case_dir = _build(request, tmp_path)
+    body = (case_dir / "system" / "controlDict").read_text()
+    functions_block = body[body.index("functions"):]
+    assert "writeInterval   7;" in functions_block
+
+
+def test_tap_fields_reach_control_dict(tmp_path: Path) -> None:
+    case_dir = _build(_authored_request(), tmp_path)
+    body = (case_dir / "system" / "controlDict").read_text()
+    assert "fields          (p p_rgh);" in body
+
+
+# --------------------------------------------------------------------------- #
+#  execution plan                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_execution_timeout_is_carried_onto_the_plan() -> None:
+    parsed = parse_case_request(_authored_request())
+    assert parsed.execution.timeout_seconds == 43200
+
+
+def test_execution_run_set_fields_is_carried_onto_the_plan() -> None:
+    parsed = parse_case_request(_authored_request())
+    assert parsed.execution.run_set_fields is True
+
+
+def test_execution_to_vtk_is_carried_onto_the_plan() -> None:
+    parsed = parse_case_request(_authored_request())
+    assert parsed.execution.to_vtk is False
+
+
+# --------------------------------------------------------------------------- #
+#  fail closed: unknown and dropped fields                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_authored_key_is_rejected_by_name() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["turbulence"] = "kOmegaSST"
+    with pytest.raises(CaseDefinitionError, match="turbulence"):
+        parse_case_request(request)
+
+
+def test_unknown_domain_key_is_rejected_by_name() -> None:
+    request = _authored_with(
+        "domain",
+        {
+            "min_coords_m": [0.0, 0.0, 0.0],
+            "max_coords_m": [2.0, 1.0, 1.0],
+            "n_cells": [20, 10, 10],
+            "base_cell_size_m": 0.1,
+        },
+    )
+    with pytest.raises(CaseDefinitionError, match="base_cell_size_m"):
+        parse_case_request(request)
+
+
+def test_unknown_execution_key_is_rejected_by_name() -> None:
+    request = _authored_request()
+    request["execution"]["n_subdomains"] = 8
+    with pytest.raises(CaseDefinitionError, match="n_subdomains"):
+        parse_case_request(request)
+
+
+def test_authored_rejects_n_subdomains_rank_authority() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["n_subdomains"] = 8
+    with pytest.raises(CaseDefinitionError, match="n_subdomains"):
+        parse_case_request(request)
+
+
+def test_unknown_root_key_is_rejected_by_name() -> None:
+    request = _authored_request()
+    request["work_root"] = "/tmp/somewhere"
+    with pytest.raises(CaseDefinitionError, match="work_root"):
+        parse_case_request(request)
+
+
+def test_missing_required_domain_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="domain"):
+        parse_case_request(_authored_with("domain", None))
+
+
+def test_missing_required_time_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="time"):
+        parse_case_request(_authored_with("time", None))
+
+
+def test_partial_optional_mapping_is_rejected() -> None:
+    # motion is optional, but a present motion must carry all applicable leaves.
+    with pytest.raises(CaseDefinitionError, match="period_s"):
+        parse_case_request(
+            _authored_with(
+                "motion",
+                {"type": "roll", "amplitude": 3.0, "amplitude_unit": "deg",
+                 "origin_m": [1.0, 0.5, 0.0]},
+            )
+        )
+
+
+def test_unsupported_schema_version_is_rejected() -> None:
+    request = _authored_request()
+    request["case_definition"]["schema_version"] = 2
+    with pytest.raises(CaseDefinitionError, match="schema_version"):
+        parse_case_request(request)
+
+
+def test_unknown_kind_is_rejected() -> None:
+    request = _authored_request()
+    request["case_definition"]["kind"] = "imported"
+    with pytest.raises(CaseDefinitionError, match="imported"):
+        parse_case_request(request)
+
+
+def test_prebuilt_kind_is_rejected_in_v1() -> None:
+    request = _authored_request()
+    request["case_definition"] = {
+        "schema_version": 1,
+        "kind": "prebuilt",
+        "prebuilt": {"case_id": "some_case"},
+    }
+    with pytest.raises(CaseDefinitionError, match="prebuilt"):
+        parse_case_request(request)
+
+
+def test_schema_version_constant_is_one() -> None:
+    assert SCHEMA_VERSION == 1
+
+
+# --------------------------------------------------------------------------- #
+#  value validation                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_boolean_is_rejected_where_integer_expected() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["time"]["write_interval_steps"] = True
+    with pytest.raises(CaseDefinitionError, match="write_interval_steps"):
+        parse_case_request(request)
+
+
+def test_non_finite_coordinate_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="max_coords_m"):
+        parse_case_request(
+            _authored_with(
+                "domain",
+                {"min_coords_m": [0.0, 0.0, 0.0],
+                 "max_coords_m": [float("inf"), 1.0, 1.0],
+                 "n_cells": [20, 10, 10]},
+            )
+        )
+
+
+def test_non_positive_cell_count_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="n_cells"):
+        parse_case_request(
+            _authored_with(
+                "domain",
+                {"min_coords_m": [0.0, 0.0, 0.0],
+                 "max_coords_m": [2.0, 1.0, 1.0],
+                 "n_cells": [20, 0, 10]},
+            )
+        )
+
+
+def test_inverted_domain_extent_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="max_coords_m"):
+        parse_case_request(
+            _authored_with(
+                "domain",
+                {"min_coords_m": [0.0, 0.0, 0.0],
+                 "max_coords_m": [-2.0, 1.0, 1.0],
+                 "n_cells": [20, 10, 10]},
+            )
+        )
+
+
+def test_fill_level_above_one_is_rejected() -> None:
+    with pytest.raises(CaseDefinitionError, match="level"):
+        parse_case_request(_authored_with("fill", {"level": 1.4}))
+
+
+def test_end_time_not_after_start_time_is_rejected() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["time"]["end_time_s"] = 0.0
+    with pytest.raises(CaseDefinitionError, match="end_time_s"):
+        parse_case_request(request)
+
+
+def test_unsupported_write_control_is_rejected() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["function_objects"][
+        "write_control"
+    ] = "onEnd"
+    with pytest.raises(CaseDefinitionError, match="onEnd"):
+        parse_case_request(request)
+
+
+# --------------------------------------------------------------------------- #
+#  coordinate frame, motion units, and incompatible combinations               #
+# --------------------------------------------------------------------------- #
+
+
+def test_rotational_motion_requires_degrees() -> None:
+    with pytest.raises(CaseDefinitionError, match="amplitude_unit"):
+        parse_case_request(
+            _authored_with(
+                "motion",
+                {"type": "roll", "amplitude": 3.0, "amplitude_unit": "m",
+                 "period_s": 1.5, "origin_m": [1.0, 0.5, 0.0]},
+            )
+        )
+
+
+def test_translational_motion_requires_metres() -> None:
+    with pytest.raises(CaseDefinitionError, match="amplitude_unit"):
+        parse_case_request(
+            _authored_with(
+                "motion",
+                {"type": "sway", "amplitude": 0.1, "amplitude_unit": "deg",
+                 "period_s": 1.5},
+            )
+        )
+
+
+def test_translational_motion_rejects_rotation_origin() -> None:
+    with pytest.raises(CaseDefinitionError, match="origin_m"):
+        parse_case_request(
+            _authored_with(
+                "motion",
+                {"type": "sway", "amplitude": 0.1, "amplitude_unit": "m",
+                 "period_s": 1.5, "origin_m": [1.0, 0.5, 0.0]},
+            )
+        )
+
+
+def test_rotational_motion_rejects_phase_shift() -> None:
+    with pytest.raises(CaseDefinitionError, match="phase_shift_s"):
+        parse_case_request(
+            _authored_with(
+                "motion",
+                {"type": "roll", "amplitude": 3.0, "amplitude_unit": "deg",
+                 "period_s": 1.5, "origin_m": [1.0, 0.5, 0.0],
+                 "phase_shift_s": 0.25},
+            )
+        )
+
+
+def test_fill_requires_run_set_fields() -> None:
+    request = _authored_request()
+    request["execution"]["run_set_fields"] = False
+    with pytest.raises(CaseDefinitionError, match="run_set_fields"):
+        parse_case_request(request)
+
+
+def test_fill_requires_a_multiphase_case() -> None:
+    request = _authored_request()
+    authored = request["case_definition"]["authored"]
+    authored["case_type"] = "current_loading"
+    authored["solver"] = "simpleFoam"
+    authored.pop("motion")
+    with pytest.raises(CaseDefinitionError, match="multiphase"):
+        parse_case_request(request)
+
+
+def test_run_set_fields_without_fill_is_rejected() -> None:
+    request = _authored_with("fill", None)
+    with pytest.raises(CaseDefinitionError, match="run_set_fields"):
+        parse_case_request(request)
+
+
+def test_motion_requires_a_transient_solver() -> None:
+    request = _authored_request()
+    authored = request["case_definition"]["authored"]
+    authored["case_type"] = "current_loading"
+    authored["solver"] = "simpleFoam"
+    authored.pop("fill")
+    request["execution"]["run_set_fields"] = False
+    with pytest.raises(CaseDefinitionError, match="transient"):
+        parse_case_request(request)
+
+
+# --------------------------------------------------------------------------- #
+#  case-name confinement                                                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["../escape", "with/separator", "with space", "dotted.name", ".", "..",
+     "", "CON", "nul", "lpt1", "trailing\x00"],
+)
+def test_unsafe_case_name_is_rejected(name: str) -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["name"] = name
+    with pytest.raises(CaseDefinitionError):
+        parse_case_request(request)
+
+
+def test_safe_case_name_is_accepted() -> None:
+    request = _authored_request()
+    request["case_definition"]["authored"]["name"] = "synthetic_case-01"
+    assert parse_case_request(request).case.name == "synthetic_case-01"
+
+
+# --------------------------------------------------------------------------- #
+#  legacy compatibility                                                        #
+# --------------------------------------------------------------------------- #
+
+
+LEGACY_REQUEST = {
+    "operation": "build_case",
+    "case_type": "current_loading",
+    "name": "legacy_case",
+    "solver": "simpleFoam",
+    "mesh_utility": "blockMesh",
+    "run_snappy": False,
+    "to_vtk": True,
+    "dry_run": False,
+    "timeout_seconds": 7200,
+}
+
+
+def test_legacy_request_still_parses() -> None:
+    parsed = parse_case_request(dict(LEGACY_REQUEST))
+    assert parsed.case.name == "legacy_case"
+
+
+def test_legacy_request_keeps_its_timeout() -> None:
+    parsed = parse_case_request(dict(LEGACY_REQUEST))
+    assert parsed.execution.timeout_seconds == 7200
+
+
+def test_legacy_request_renders_the_case_type_default_case(tmp_path: Path) -> None:
+    # The legacy form carries no domain, so the case-type default must survive
+    # normalisation byte-for-byte rather than being replaced by a schema default.
+    from digitalmodel.solvers.openfoam.models import CaseType, OpenFOAMCase
+
+    expected_dir = OpenFOAMCaseBuilder(
+        OpenFOAMCase.for_case_type(CaseType.CURRENT_LOADING, "legacy_case")
+    ).build(tmp_path / "expected")
+    actual_dir = _build(dict(LEGACY_REQUEST), tmp_path / "actual")
+    expected = (expected_dir / "system" / "blockMeshDict").read_bytes()
+    assert (actual_dir / "system" / "blockMeshDict").read_bytes() == expected
+
+
+def test_legacy_and_canonical_forms_cannot_mix() -> None:
+    request = _authored_request()
+    request["case_type"] = "sloshing"
+    with pytest.raises(CaseDefinitionError, match="case_type"):
+        parse_case_request(request)
+
+
+# --------------------------------------------------------------------------- #
+#  accepted-leaf consumption ledger                                            #
+# --------------------------------------------------------------------------- #
+
+
+VALID_CONSUMERS = frozenset(
+    {
+        "OpenFOAMCase",
+        "FunctionObjectsConfig",
+        "SelectedExecutionPlan",
+        "WorkLayout/RunIdentity",
+        "batch matrix/dispatch",
+        "generic operation/output",
+    }
+)
+
+
+def test_every_accepted_leaf_names_a_valid_consumer() -> None:
+    unknown = {
+        leaf: consumer
+        for leaf, consumer in ACCEPTED_LEAF_CONSUMERS.items()
+        if consumer not in VALID_CONSUMERS
+    }
+    assert unknown == {}
+
+
+def test_every_canonical_authored_leaf_appears_in_the_ledger() -> None:
+    authored_leaves = {
+        "case_definition.authored.case_type",
+        "case_definition.authored.name",
+        "case_definition.authored.solver",
+        "case_definition.authored.domain.min_coords_m",
+        "case_definition.authored.domain.max_coords_m",
+        "case_definition.authored.domain.n_cells",
+        "case_definition.authored.motion.type",
+        "case_definition.authored.motion.amplitude",
+        "case_definition.authored.motion.amplitude_unit",
+        "case_definition.authored.motion.period_s",
+        "case_definition.authored.motion.origin_m",
+        "case_definition.authored.motion.phase_shift_s",
+        "case_definition.authored.fill.level",
+        "case_definition.authored.time.start_time_s",
+        "case_definition.authored.time.end_time_s",
+        "case_definition.authored.time.delta_t_s",
+        "case_definition.authored.time.write_interval_steps",
+        "case_definition.authored.time.adjustable_time_step",
+        "case_definition.authored.time.max_co",
+        "case_definition.authored.time.purge_write",
+        "case_definition.authored.function_objects.pressure_taps",
+        "case_definition.authored.function_objects.write_control",
+        "case_definition.authored.function_objects.write_interval",
+        "execution.mesh_utility",
+        "execution.run_snappy",
+        "execution.run_set_fields",
+        "execution.to_vtk",
+        "execution.timeout_seconds",
+        "execution.dry_run",
+    }
+    assert authored_leaves - set(ACCEPTED_LEAF_CONSUMERS) == set()
+
+
+def test_ledger_has_no_leaf_the_schema_does_not_accept() -> None:
+    request = _authored_request()
+    accepted = set(_accepted_paths(request))
+    assert set(ACCEPTED_LEAF_CONSUMERS) - accepted == set()
+
+
+def _accepted_paths(request: Dict[str, Any], prefix: str = "") -> list[str]:
+    """Enumerate the dotted leaf paths present in a complete valid request."""
+    paths: list[str] = []
+    for key, value in request.items():
+        if key in ("operation", "output_directory"):
+            continue
+        path = f"{prefix}{key}"
+        if key in ("schema_version", "kind"):
+            continue
+        if isinstance(value, dict):
+            paths.extend(_accepted_paths(value, f"{path}."))
+        elif key == "pressure_taps":
+            paths.append(path)
+        else:
+            paths.append(path)
+    return paths

--- a/tests/solvers/openfoam/test_case_definition_structure.py
+++ b/tests/solvers/openfoam/test_case_definition_structure.py
@@ -1,0 +1,36 @@
+"""Size limits for the modules #1575 touches.
+
+Mirrors tests/workflows/test_openfoam_batch_structure.py, the convention #1565
+established, so the same literal 400/50 limits apply on both sides of the
+batch -> workflow -> case boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+FILES = [
+    ROOT / "src/digitalmodel/solvers/openfoam/case_definition.py",
+    ROOT / "src/digitalmodel/solvers/openfoam/_case_definition_validation.py",
+    ROOT / "src/digitalmodel/solvers/openfoam/block_mesh.py",
+    ROOT / "src/digitalmodel/solvers/openfoam/case_builder.py",
+    ROOT / "src/digitalmodel/solvers/openfoam/workflow.py",
+]
+
+MAX_FILE_LINES = 400
+MAX_FUNCTION_LINES = 50
+
+
+def test_touched_modules_stay_bounded() -> None:
+    for path in FILES:
+        lines = path.read_text().splitlines()
+        assert len(lines) <= MAX_FILE_LINES, (path.name, len(lines))
+        tree = ast.parse("\n".join(lines))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                end = getattr(node, "end_lineno", node.lineno)
+                span = end - node.lineno + 1
+                assert span <= MAX_FUNCTION_LINES, (path.name, node.name, span)

--- a/tests/solvers/openfoam/test_workflow_case_definition.py
+++ b/tests/solvers/openfoam/test_workflow_case_definition.py
@@ -1,0 +1,340 @@
+"""Propagation tests for the OpenFOAM generic and batch adapters (#1575).
+
+These assert the leaf actually reaches the rendered case through the adapter,
+not merely that the adapter accepted the request. A mock batch passing while a
+default static case is rendered is the defect under test, so every assertion
+reads an emitted dictionary.
+
+Imports OpenFOAMWorkflow directly rather than through the digitalmodel engine,
+because the engine import chain pulls optional solver dependencies that are not
+installed on every host.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from digitalmodel.solvers.openfoam.case_definition import CaseDefinitionError
+from digitalmodel.solvers.openfoam.workflow import OpenFOAMWorkflow
+
+
+CANONICAL_SETTINGS: Dict[str, Any] = {
+    "operation": "build_case",
+    "case_definition": {
+        "schema_version": 1,
+        "kind": "authored",
+        "authored": {
+            "case_type": "sloshing",
+            "name": "synthetic_sloshing",
+            "solver": "interFoam",
+            "domain": {
+                "min_coords_m": [0.0, 0.0, 0.0],
+                "max_coords_m": [2.0, 1.0, 1.0],
+                "n_cells": [20, 10, 10],
+            },
+            "motion": {
+                "type": "roll",
+                "amplitude": 3.0,
+                "amplitude_unit": "deg",
+                "period_s": 1.5,
+                "origin_m": [1.0, 0.5, 0.0],
+            },
+            "fill": {"level": 0.4},
+            "time": {
+                "start_time_s": 0.0,
+                "end_time_s": 2.0,
+                "delta_t_s": 0.002,
+                "write_interval_steps": 25,
+                "adjustable_time_step": True,
+                "max_co": 0.5,
+                "purge_write": 0,
+            },
+            "function_objects": {
+                "pressure_taps": [
+                    {
+                        "name": "synthetic_tap",
+                        "location_m": [1.0, 0.5, 0.8],
+                        "fields": ["p", "p_rgh"],
+                    }
+                ],
+                "write_control": "timeStep",
+                "write_interval": 1,
+            },
+        },
+    },
+    "execution": {
+        "mesh_utility": "blockMesh",
+        "run_snappy": False,
+        "run_set_fields": True,
+        "to_vtk": False,
+        "timeout_seconds": 43200,
+        "dry_run": False,
+    },
+}
+
+
+def _route(settings: Dict[str, Any], tmp_path: Path) -> Path:
+    cfg = {
+        "basename": "openfoam",
+        "Analysis": {"result_folder": str(tmp_path)},
+        "openfoam": copy.deepcopy(settings),
+    }
+    OpenFOAMWorkflow().router(cfg)
+    return Path(cfg["openfoam"]["case_dir"])
+
+
+def _control_dict(case_dir: Path) -> Dict[str, str]:
+    entries: Dict[str, str] = {}
+    for line in (case_dir / "system" / "controlDict").read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.endswith(";") or stripped.startswith("//"):
+            continue
+        parts = stripped[:-1].split(None, 1)
+        if len(parts) == 2:
+            entries.setdefault(parts[0], parts[1].strip())
+    return entries
+
+
+# --------------------------------------------------------------------------- #
+#  the five leaves the issue reports as dropped                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_router_propagates_requested_domain(tmp_path: Path) -> None:
+    case_dir = _route(CANONICAL_SETTINGS, tmp_path)
+    block_mesh = (case_dir / "system" / "blockMeshDict").read_text()
+    assert "hex (0 1 2 3 4 5 6 7) (20 10 10) simpleGrading (1 1 1)" in block_mesh
+
+
+def test_router_propagates_requested_time(tmp_path: Path) -> None:
+    case_dir = _route(CANONICAL_SETTINGS, tmp_path)
+    assert _control_dict(case_dir)["endTime"] == "2.0"
+
+
+def test_router_emits_dynamic_mesh_dict(tmp_path: Path) -> None:
+    case_dir = _route(CANONICAL_SETTINGS, tmp_path)
+    assert (case_dir / "constant" / "dynamicMeshDict").is_file()
+
+
+def test_router_emits_set_fields_dict(tmp_path: Path) -> None:
+    case_dir = _route(CANONICAL_SETTINGS, tmp_path)
+    assert (case_dir / "system" / "setFieldsDict").is_file()
+
+
+def test_router_emits_function_objects(tmp_path: Path) -> None:
+    case_dir = _route(CANONICAL_SETTINGS, tmp_path)
+    assert "synthetic_tap" in (case_dir / "system" / "controlDict").read_text()
+
+
+# --------------------------------------------------------------------------- #
+#  fail closed rather than silently rendering a default case                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_router_rejects_unknown_authored_key(tmp_path: Path) -> None:
+    settings = copy.deepcopy(CANONICAL_SETTINGS)
+    settings["case_definition"]["authored"]["turbulence"] = "kOmegaSST"
+    with pytest.raises(CaseDefinitionError, match="turbulence"):
+        _route(settings, tmp_path)
+
+
+def test_router_rejects_semantic_keys_at_the_legacy_root(tmp_path: Path) -> None:
+    # The pre-#1575 router silently accepted and dropped these, rendering a
+    # default static case. They must now be refused by name.
+    settings = {
+        "operation": "build_case",
+        "case_type": "sloshing",
+        "name": "synthetic_sloshing",
+        "solver": "interFoam",
+        "domain": {"min_coords_m": [0.0, 0.0, 0.0],
+                   "max_coords_m": [2.0, 1.0, 1.0],
+                   "n_cells": [20, 10, 10]},
+    }
+    with pytest.raises(CaseDefinitionError, match="domain"):
+        _route(settings, tmp_path)
+
+
+def test_router_rejects_case_definition_without_execution(tmp_path: Path) -> None:
+    settings = copy.deepcopy(CANONICAL_SETTINGS)
+    settings.pop("execution")
+    with pytest.raises(CaseDefinitionError, match="execution"):
+        _route(settings, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+#  unconsumed function-object controls                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_taps_reject_a_non_default_write_control(tmp_path: Path) -> None:
+    # With no taps there is nothing to carry write_control, so accepting a
+    # non-default value would silently drop it.
+    settings = copy.deepcopy(CANONICAL_SETTINGS)
+    settings["case_definition"]["authored"]["function_objects"] = {
+        "pressure_taps": [],
+        "write_control": "runTime",
+        "write_interval": 1,
+    }
+    with pytest.raises(CaseDefinitionError, match="write_control"):
+        _route(settings, tmp_path)
+
+
+def test_empty_taps_reject_a_non_default_write_interval(tmp_path: Path) -> None:
+    settings = copy.deepcopy(CANONICAL_SETTINGS)
+    settings["case_definition"]["authored"]["function_objects"] = {
+        "pressure_taps": [],
+        "write_control": "timeStep",
+        "write_interval": 9,
+    }
+    with pytest.raises(CaseDefinitionError, match="write_interval"):
+        _route(settings, tmp_path)
+
+
+def test_empty_taps_accept_the_default_controls(tmp_path: Path) -> None:
+    settings = copy.deepcopy(CANONICAL_SETTINGS)
+    settings["case_definition"]["authored"]["function_objects"] = {
+        "pressure_taps": [],
+        "write_control": "timeStep",
+        "write_interval": 1,
+    }
+    case_dir = _route(settings, tmp_path)
+    assert "functions" not in (case_dir / "system" / "controlDict").read_text()
+
+
+# --------------------------------------------------------------------------- #
+#  legacy generic requests keep working                                        #
+# --------------------------------------------------------------------------- #
+
+
+LEGACY_SETTINGS = {
+    "operation": "build_case",
+    "case_type": "current_loading",
+    "name": "legacy_case",
+    "solver": "simpleFoam",
+    "mesh_utility": "blockMesh",
+    "to_vtk": True,
+    "dry_run": False,
+}
+
+
+def test_legacy_router_request_still_builds(tmp_path: Path) -> None:
+    case_dir = _route(LEGACY_SETTINGS, tmp_path)
+    assert case_dir.name == "legacy_case"
+
+
+def test_legacy_router_request_renders_unchanged_block_mesh(tmp_path: Path) -> None:
+    from digitalmodel.solvers.openfoam.case_builder import OpenFOAMCaseBuilder
+    from digitalmodel.solvers.openfoam.models import CaseType, OpenFOAMCase
+
+    expected_dir = OpenFOAMCaseBuilder(
+        OpenFOAMCase.for_case_type(CaseType.CURRENT_LOADING, "legacy_case")
+    ).build(tmp_path / "expected")
+    actual_dir = _route(LEGACY_SETTINGS, tmp_path / "actual")
+    expected = (expected_dir / "system" / "blockMeshDict").read_bytes()
+    assert (actual_dir / "system" / "blockMeshDict").read_bytes() == expected
+
+
+def test_legacy_router_defaults_case_name_from_case_type(tmp_path: Path) -> None:
+    settings = {"operation": "build_case", "case_type": "current_loading"}
+    assert _route(settings, tmp_path).name == "current_loading_case"
+
+
+# --------------------------------------------------------------------------- #
+#  batch adapter carries the canonical contract                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_batch_renders_canonical_base_into_each_case(tmp_path: Path) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    rendered = render_cases(base, [{"name": "case_a"}], {}, tmp_path)
+    authored = rendered[0]["settings"]["case_definition"]["authored"]
+    assert authored["domain"]["n_cells"] == [20, 10, 10]
+
+
+def test_batch_mapping_reaches_the_authored_leaf(tmp_path: Path) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    rendered = render_cases(
+        base,
+        [{"name": "case_a", "end_time": 5.0}],
+        {"end_time": "case_definition.authored.time.end_time_s"},
+        tmp_path,
+    )
+    authored = rendered[0]["settings"]["case_definition"]["authored"]
+    assert authored["time"]["end_time_s"] == 5.0
+
+
+def test_batch_mapped_leaf_reaches_the_rendered_case(tmp_path: Path) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    rendered = render_cases(
+        base,
+        [{"name": "case_a", "end_time": 5.0}],
+        {"end_time": "case_definition.authored.time.end_time_s"},
+        tmp_path,
+    )
+    case_dir = _route(rendered[0]["settings"], tmp_path / "built")
+    assert _control_dict(case_dir)["endTime"] == "5.0"
+
+
+def test_batch_rejects_a_mapping_target_that_is_not_an_accepted_leaf(
+    tmp_path: Path,
+) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    with pytest.raises(ValueError, match="case_definition.authored.turbulence"):
+        render_cases(
+            base,
+            [{"name": "case_a", "knob": 1.0}],
+            {"knob": "case_definition.authored.turbulence"},
+            tmp_path,
+        )
+
+
+def test_batch_rejects_a_mapping_target_naming_a_container(tmp_path: Path) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    with pytest.raises(ValueError, match="case_definition.authored.domain"):
+        render_cases(
+            base,
+            [{"name": "case_a", "knob": 1.0}],
+            {"knob": "case_definition.authored.domain"},
+            tmp_path,
+        )
+
+
+def test_batch_rejects_a_mapping_target_naming_the_discriminator(
+    tmp_path: Path,
+) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = copy.deepcopy(CANONICAL_SETTINGS)
+    with pytest.raises(ValueError, match="case_definition.kind"):
+        render_cases(
+            base,
+            [{"name": "case_a", "knob": "authored"}],
+            {"knob": "case_definition.kind"},
+            tmp_path,
+        )
+
+
+def test_batch_legacy_base_still_renders_unmapped_knobs(tmp_path: Path) -> None:
+    from digitalmodel.workflows.openfoam_batch_config import render_cases
+
+    base = {"case_type": "current_loading", "solver": "simpleFoam",
+            "mesh_utility": "blockMesh", "to_vtk": False}
+    rendered = render_cases(
+        base, [{"name": "case_a", "solver_app": "pimpleFoam"}],
+        {"solver_app": "solver"}, tmp_path,
+    )
+    assert rendered[0]["settings"]["solver"] == "pimpleFoam"

--- a/tests/solvers/openfoam/test_workflow_case_definition.py
+++ b/tests/solvers/openfoam/test_workflow_case_definition.py
@@ -338,3 +338,75 @@ def test_batch_legacy_base_still_renders_unmapped_knobs(tmp_path: Path) -> None:
         {"solver_app": "solver"}, tmp_path,
     )
     assert rendered[0]["settings"]["solver"] == "pimpleFoam"
+
+
+# --------------------------------------------------------------------------- #
+#  the batch router accepts a canonical base end to end                        #
+# --------------------------------------------------------------------------- #
+
+
+def _canonical_batch_cfg(tmp_path: Path) -> Dict[str, Any]:
+    return {
+        "basename": "openfoam_run_batch",
+        "_config_dir_path": str(tmp_path),
+        "openfoam_run_batch": {
+            "base": copy.deepcopy(
+                {k: v for k, v in CANONICAL_SETTINGS.items() if k != "operation"}
+            ),
+            "cases": [{"name": "case_a", "end_time": 3.0},
+                      {"name": "case_b", "end_time": 4.0}],
+            "mapping": {"end_time": "case_definition.authored.time.end_time_s"},
+            "run_batch": {"mode": "pool", "workers": 2, "mock": True},
+        },
+    }
+
+
+def test_batch_router_runs_a_canonical_base_in_mock_mode(tmp_path: Path) -> None:
+    from digitalmodel.workflows import openfoam_run_batch as ofb
+
+    result = ofb.router(_canonical_batch_cfg(tmp_path))
+    statuses = [row["status"] for row in result["openfoam_run_batch"]["cases"]]
+    assert statuses == ["completed", "completed"]
+
+
+def test_batch_router_swept_leaf_reaches_each_rendered_case(tmp_path: Path) -> None:
+    from digitalmodel.workflows import openfoam_run_batch as ofb
+
+    ofb.router(_canonical_batch_cfg(tmp_path))
+    case_b = tmp_path / "batch_runs" / "case_b"
+    assert _control_dict(case_b)["endTime"] == "4.0"
+
+
+def test_batch_router_carries_motion_into_each_rendered_case(tmp_path: Path) -> None:
+    from digitalmodel.workflows import openfoam_run_batch as ofb
+
+    ofb.router(_canonical_batch_cfg(tmp_path))
+    assert (tmp_path / "batch_runs" / "case_a" / "constant" / "dynamicMeshDict").is_file()
+
+
+def test_canonical_base_mpi_plan_uses_the_authored_solver(tmp_path: Path) -> None:
+    # The mpi plan is recorded even in mock mode, so it is the observable proof
+    # that a canonical base reaches the dispatch layer rather than falling back
+    # to flat-key defaults.
+    from digitalmodel.workflows import openfoam_run_batch as ofb
+
+    cfg = _canonical_batch_cfg(tmp_path)
+    cfg["openfoam_run_batch"]["cases"] = [{"name": "case_a", "end_time": 3.0}]
+    cfg["openfoam_run_batch"]["run_batch"] = {
+        "mode": "mpi", "workers": 2, "mock": True,
+    }
+    result = ofb.router(cfg)
+    plan = result["openfoam_run_batch"]["cases"][0]["mpi_plan"]
+    assert "mpirun -np 2 --oversubscribe interFoam -parallel" in plan
+
+
+def test_canonical_base_mpi_plan_includes_set_fields(tmp_path: Path) -> None:
+    from digitalmodel.workflows import openfoam_run_batch as ofb
+
+    cfg = _canonical_batch_cfg(tmp_path)
+    cfg["openfoam_run_batch"]["cases"] = [{"name": "case_a", "end_time": 3.0}]
+    cfg["openfoam_run_batch"]["run_batch"] = {
+        "mode": "mpi", "workers": 2, "mock": True,
+    }
+    result = ofb.router(cfg)
+    assert "setFields" in result["openfoam_run_batch"]["cases"][0]["mpi_plan"]


### PR DESCRIPTION
Implements the approved plan for #1575 at SHA `b02031c7d9b300a80d81a7e986de6c1712bad537`.

## The defect

Reproduced on the branch point with a synthetic sloshing request carrying domain, roll motion, fill, time controls and one pressure tap:

```
{"dynamicMeshDict": false, "functions_present": false,
 "requested_domain_present": false, "requested_time_present": false,
 "setFieldsDict": false}
```

The generic adapter copied only `case_type`, `name` and `solver` onto a fresh `OpenFOAMCase`. Everything else was dropped — and every unknown key was **silently accepted**, so the request rendered a default static case and reported success.

## What changed

- **`case_definition.py`** — closed schema v1. A discriminated `case_definition` (`schema_version` + `kind`) with an `authored` mapping for case type, name, solver, domain, motion, fill, time and function objects, plus a separate `execution` mapping. `parse_case_request` returns one object owning the constructed `OpenFOAMCase`, an immutable `FunctionObjectsConfig` and a `SelectedExecutionPlan`.
- **Fail-closed everywhere** — unknown keys rejected by name at every level; required sections cannot be omitted; a present optional section must carry all applicable leaves; booleans refused where integers are expected; non-finite/inverted extents and non-advancing time windows refused.
- **Frame and units** — roll/pitch/yaw rotate about global x/y/z, require degrees and an origin, and refuse a phase shift; surge/sway/heave translate, require metres, and refuse an origin. Fill requires a multiphase case with `run_set_fields`; motion requires a transient solver.
- **Rank authority** — `n_subdomains` is rejected in both mappings, leaving `run_batch.workers` the sole authority, so the schema cannot disagree with `decomposeParDict`.
- **Accepted-leaf ledger** — `ACCEPTED_LEAF_CONSUMERS` maps each accepted dotted leaf to exactly one consumer. A leaf can neither be accepted without a consumer nor listed without being accepted.
- **Propagation** — the generic router, the batch renderer and the batch execution layer all now carry the definition through to the emitted dictionaries and the dispatch plan.
- **`kind: prebuilt`** is recognised and refused, per the plan's own "intentionally unavailable in v1".
- **`block_mesh.py`** — the mandatory pre-edit builder split; `case_builder.py` 420 → 346 lines.

## Compatibility

Legacy flat requests still parse, keep their timeout, default the case name from the case type, and render a **byte-identical** `blockMeshDict` against a directly constructed case-type default.

The packaged `base` default becomes `{}`. It is deep-merged *under* user input, so the semantic keys it defaulted would have been injected into every canonical request and refused as a legacy/canonical mix. Dropping them is behaviour-preserving: normalisation and the execution layer already default `mesh_utility` to `blockMesh` and `to_vtk` to `false`.

## Verification

| Suite | Baseline @ `5f437bfb` | After |
|---|---|---|
| `tests/solvers/openfoam` | 3 failed / 723 passed / 9 skipped | 3 failed / **817** passed / 9 skipped |
| openfoam batch tests | 2 failed / 52 passed | 2 failed / 52 passed |

The 3 openfoam failures are pre-existing numpy 2.x `np.trapz` removals in `validation/test_wave_excited_body.py`. The 2 batch failures are pre-existing `rainflow` import errors. Both baselines were re-established in a clean worktree at the branch point, not inherited.

`test_workflow_router.py` is excluded identically from baseline and after — it cannot collect on this interpreter (missing `rainflow`).

Also verified:
- **Builder split changes zero bytes** — sha256 of all 66 emitted files across all 5 `CaseType` values identical before and after.
- **Public namespace diff** vs the branch point — only intended additions; the three removals from `case_builder` were leaked unused imports with zero consumers (every importer takes only `OpenFOAMCaseBuilder`).
- **ruff**: all touched files pass. The same files had 3 errors at the branch point, so this is a net improvement.
- **compileall**, **`git diff --check`**, 400/50 size gates: pass.
- **Legal**: all 23 deny-list patterns checked directly against this diff — no hits.

## TDD

RED committed separately from GREEN in both cycles, so the sequence is provable from the log: `c67527f6` (58 RED) → `57b91b53` (GREEN), then `39f73656` (21 RED, 17 failing) → `568139e8` (GREEN).

Two defects were caught by the tests rather than by review:
- normalisation had made the legacy `name` key **required**; it has always been optional. A real backward-compatibility break, caught by the legacy regression test.
- function-object controls that nothing can consume are now refused — with an empty tap list, `write_control`/`write_interval` would be silently dropped.

## Not in scope

This does **not** make an emitted case runnable. #1959 (`fvSolution` structurally wrong for `interFoam` — missing `cAlpha`/`p_rgh`/`PIMPLE`) is a separate defect and must still land. This issue concerns fields dropped *in transit*; #1959 concerns the solver dictionary being wrong for the chosen solver.

Merging this unblocks #1576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)