### PR TITLE
feat(openfoam): schedule VTK on the MPI path and index retained artifacts (#1576)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/artifact_index.py
+++ b/src/digitalmodel/solvers/openfoam/artifact_index.py
@@ -1,0 +1,351 @@
+"""Content-addressed indexes for completed OpenFOAM artifact trees."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Sequence
+
+TREE_DOMAIN = b"dm-artifact-tree-v1"
+ARTIFACT_ID_DOMAIN = b"dm-artifact-id-v1"
+GENERATION_DOMAIN = b"dm-generation-id-v1"
+COMMIT_DOMAIN = b"dm-commit-v1"
+ARTIFACT_SCHEMA_VERSION = 1
+ARTIFACT_KINDS = (
+    "mesh_tree",
+    "field_tree",
+    "vtk_tree",
+    "postprocessing_tree",
+)
+
+_TIME_NAME = re.compile(r"[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\Z")
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+_FILE_FLAGS = os.O_RDONLY | os.O_NOFOLLOW
+_UINT64_MAX = (1 << 64) - 1
+
+
+class ArtifactIndexError(ValueError):
+    """Raised when an artifact tree or index value is unsafe or unstable."""
+
+
+def _uint64(value: int, label: str) -> bytes:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ArtifactIndexError(f"{label} must be an integer")
+    if not 0 <= value <= _UINT64_MAX:
+        raise ArtifactIndexError(f"{label} is outside uint64 range")
+    return value.to_bytes(8, "big")
+
+
+def frame(data: bytes) -> bytes:
+    """Prefix bytes with their unsigned 64-bit big-endian length."""
+    if not isinstance(data, bytes):
+        raise ArtifactIndexError("framed values must be bytes")
+    return _uint64(len(data), "frame length") + data
+
+
+def _safe_relative(value: str, label: str) -> None:
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ArtifactIndexError(f"{label} is not valid UTF-8") from error
+    path = PurePosixPath(value)
+    if not encoded or path.is_absolute() or "\\" in value:
+        raise ArtifactIndexError(f"{label} must be a safe relative POSIX path")
+    if any(part in ("", ".", "..") for part in value.split("/")):
+        raise ArtifactIndexError(f"{label} must be a safe relative POSIX path")
+
+
+def _sha256_bytes(value: str, label: str) -> bytes:
+    if len(value) != 64 or value.lower() != value:
+        raise ArtifactIndexError(f"{label} must be lowercase SHA-256 hex")
+    try:
+        decoded = bytes.fromhex(value)
+    except ValueError as error:
+        raise ArtifactIndexError(f"{label} must be lowercase SHA-256 hex") from error
+    if len(decoded) != 32:
+        raise ArtifactIndexError(f"{label} must be lowercase SHA-256 hex")
+    return decoded
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    """A stable content record for one file beneath a snapshot root."""
+
+    path: str
+    size_bytes: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _safe_relative(self.path, "file path")
+        _uint64(self.size_bytes, "file size")
+        _sha256_bytes(self.sha256, "file digest")
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    """Portable metadata for one completed artifact kind."""
+
+    schema_version: int
+    artifact_id: str
+    kind: str
+    run_identity_sha256: str
+    input_sha256: str
+    source_sha256: str
+    tool_sha256: str
+    generation_id: str
+    selection: str
+    size_bytes: int
+    file_count: int
+    content_sha256: str
+    locator: str
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable record without adding host paths."""
+        return asdict(self)
+
+
+def tree_digest(records: Sequence[FileRecord]) -> str:
+    """Hash the canonical, path-sorted framed tree stream."""
+    ordered = sorted(records, key=lambda item: item.path.encode("utf-8"))
+    if len({item.path for item in ordered}) != len(ordered):
+        raise ArtifactIndexError("tree contains duplicate paths")
+    digest = sha256(frame(TREE_DOMAIN))
+    for record in ordered:
+        digest.update(frame(b"file"))
+        digest.update(frame(record.path.encode("utf-8")))
+        digest.update(frame(_uint64(record.size_bytes, "file size")))
+        digest.update(frame(_sha256_bytes(record.sha256, "file digest")))
+    return digest.hexdigest()
+
+
+def artifact_id(
+    *,
+    run_identity_sha256: str,
+    generation_id: str,
+    kind: str,
+    selection: str,
+    size_bytes: int,
+    file_count: int,
+    content_sha256: str,
+) -> str:
+    """Compute the portable identity of one artifact record."""
+    values = (
+        run_identity_sha256.encode("utf-8"),
+        generation_id.encode("utf-8"),
+        kind.encode("utf-8"),
+        selection.encode("utf-8"),
+        _uint64(size_bytes, "artifact size"),
+        _uint64(file_count, "file count"),
+        _sha256_bytes(content_sha256, "content digest"),
+    )
+    digest = sha256(frame(ARTIFACT_ID_DOMAIN))
+    for value in values:
+        digest.update(frame(value))
+    return digest.hexdigest()
+
+
+def host_local_locator(
+    run_identity_sha256: str,
+    generation_id: str,
+    artifact_id_value: str,
+) -> str:
+    """Build an opaque host-local locator containing no filesystem path."""
+    components = (run_identity_sha256, generation_id, artifact_id_value)
+    if any(not value or "/" in value or "\\" in value for value in components):
+        raise ArtifactIndexError("locator components must be nonempty and opaque")
+    return "host-local:///" + "/".join(components)
+
+
+def is_numeric_time_name(name: str) -> bool:
+    """Return whether a name is a finite, nonnegative OpenFOAM time value."""
+    if _TIME_NAME.fullmatch(name) is None:
+        return False
+    try:
+        value = Decimal(name)
+    except InvalidOperation:
+        return False
+    return value.is_finite() and value >= 0
+
+
+def _stat_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_size,
+        value.st_ctime_ns,
+    )
+
+
+def _hash_open_file(parent_fd: int, name: str, listed: os.stat_result) -> FileRecord:
+    descriptor = os.open(name, _FILE_FLAGS, dir_fd=parent_fd)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or _stat_identity(before) != _stat_identity(listed):
+            raise ArtifactIndexError(f"file changed before hashing: {name}")
+        digest = sha256()
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        if _stat_identity(before) != _stat_identity(after):
+            raise ArtifactIndexError(f"file changed while hashing: {name}")
+        return FileRecord(name, before.st_size, digest.hexdigest())
+    finally:
+        os.close(descriptor)
+
+
+def _walk_directory(directory_fd: int, prefix: str) -> list[FileRecord]:
+    records: list[FileRecord] = []
+    for name in os.listdir(directory_fd):
+        _safe_relative(name, "directory entry")
+        listed = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        relative = f"{prefix}/{name}" if prefix else name
+        if stat.S_ISREG(listed.st_mode):
+            record = _hash_open_file(directory_fd, name, listed)
+            records.append(FileRecord(relative, record.size_bytes, record.sha256))
+        elif stat.S_ISDIR(listed.st_mode):
+            child_fd = os.open(name, _DIRECTORY_FLAGS, dir_fd=directory_fd)
+            try:
+                if _stat_identity(os.fstat(child_fd)) != _stat_identity(listed):
+                    raise ArtifactIndexError(f"directory changed before walk: {relative}")
+                records.extend(_walk_directory(child_fd, relative))
+            finally:
+                os.close(child_fd)
+        else:
+            raise ArtifactIndexError(f"unsupported artifact entry: {relative}")
+    return records
+
+
+def snapshot_tree(root: Path) -> list[FileRecord]:
+    """Snapshot a tree through no-follow descriptors and hash opened files."""
+    try:
+        root_fd = os.open(root, _DIRECTORY_FLAGS)
+        try:
+            records = _walk_directory(root_fd, "")
+        finally:
+            os.close(root_fd)
+    except (OSError, UnicodeError) as error:
+        raise ArtifactIndexError(f"cannot safely snapshot artifact tree: {error}") from error
+    return sorted(records, key=lambda item: item.path.encode("utf-8"))
+
+
+def verify_unchanged(root: Path, expected: Sequence[FileRecord]) -> None:
+    """Require an exact second snapshot, including paths and content digests."""
+    if snapshot_tree(root) != sorted(expected, key=lambda item: item.path.encode("utf-8")):
+        raise ArtifactIndexError("artifact tree changed after snapshot")
+
+
+def _candidate_has_files(case_root: Path, relative: str) -> bool:
+    candidate = case_root.joinpath(*relative.split("/"))
+    try:
+        return bool(snapshot_tree(candidate))
+    except ArtifactIndexError:
+        if not os.path.lexists(candidate):
+            return False
+        raise
+
+
+def _time_roots(case_root: Path) -> list[str]:
+    try:
+        root_fd = os.open(case_root, _DIRECTORY_FLAGS)
+        try:
+            names = os.listdir(root_fd)
+            entries = [(name, os.stat(name, dir_fd=root_fd, follow_symlinks=False)) for name in names]
+        finally:
+            os.close(root_fd)
+    except OSError as error:
+        raise ArtifactIndexError(f"cannot inspect case root: {error}") from error
+    time_names = [name for name, value in entries if is_numeric_time_name(name) and stat.S_ISDIR(value.st_mode)]
+    values: dict[Decimal, str] = {}
+    for name in time_names:
+        numeric = Decimal(name)
+        if numeric in values:
+            raise ArtifactIndexError(f"duplicate numeric time spellings: {values[numeric]}, {name}")
+        values[numeric] = name
+    return sorted((name for name in time_names if _candidate_has_files(case_root, name)), key=lambda name: name.encode("utf-8"))
+
+
+def select_roots(case_root: Path) -> dict[str, list[str]]:
+    """Select disjoint, nonempty completed artifact roots below a case."""
+    candidates = {
+        "mesh_tree": ["constant/polyMesh"],
+        "field_tree": _time_roots(case_root),
+        "vtk_tree": ["VTK"],
+        "postprocessing_tree": ["postProcessing"],
+    }
+    return {
+        kind: [root for root in roots if _candidate_has_files(case_root, root)]
+        for kind, roots in candidates.items()
+        if roots and any(_candidate_has_files(case_root, root) for root in roots)
+    }
+
+
+def _snapshot_selection(case_root: Path, roots: Sequence[str]) -> list[FileRecord]:
+    records: list[FileRecord] = []
+    snapshots: list[tuple[Path, list[FileRecord]]] = []
+    for root in roots:
+        path = case_root.joinpath(*root.split("/"))
+        snapshot = snapshot_tree(path)
+        snapshots.append((path, snapshot))
+        records.extend(
+            FileRecord(f"{root}/{item.path}", item.size_bytes, item.sha256)
+            for item in snapshot
+        )
+    for path, snapshot in snapshots:
+        verify_unchanged(path, snapshot)
+    return sorted(records, key=lambda item: item.path.encode("utf-8"))
+
+
+def _make_artifact_record(
+    kind: str,
+    roots: Sequence[str],
+    records: Sequence[FileRecord],
+    identities: tuple[str, str, str, str, str],
+) -> ArtifactRecord:
+    run_id, input_id, source_id, tool_id, generation_id = identities
+    selection = ",".join(roots)
+    content_id = tree_digest(records)
+    size = sum(item.size_bytes for item in records)
+    identifier = artifact_id(
+        run_identity_sha256=run_id,
+        generation_id=generation_id,
+        kind=kind,
+        selection=selection,
+        size_bytes=size,
+        file_count=len(records),
+        content_sha256=content_id,
+    )
+    return ArtifactRecord(
+        ARTIFACT_SCHEMA_VERSION, identifier, kind, run_id, input_id,
+        source_id, tool_id, generation_id, selection, size, len(records),
+        content_id, host_local_locator(run_id, generation_id, identifier),
+    )
+
+
+def build_index(
+    case_root: Path,
+    *,
+    run_identity_sha256: str,
+    input_sha256: str,
+    source_sha256: str,
+    tool_sha256: str,
+    generation_id: str,
+) -> dict[str, ArtifactRecord]:
+    """Build one record per present kind; field roots use comma-joined names."""
+    identities = (
+        run_identity_sha256,
+        input_sha256,
+        source_sha256,
+        tool_sha256,
+        generation_id,
+    )
+    result: dict[str, ArtifactRecord] = {}
+    for kind, roots in select_roots(case_root).items():
+        records = _snapshot_selection(case_root, roots)
+        result[kind] = _make_artifact_record(kind, roots, records, identities)
+    return result

--- a/src/digitalmodel/workflows/openfoam_batch_config.py
+++ b/src/digitalmodel/workflows/openfoam_batch_config.py
@@ -53,6 +53,29 @@ def resolve_workers(run_settings: dict) -> int:
     return workers
 
 
+def validate_workers(requested: object, *, visible_rank_count: int,
+                     dispatcher_rank_limit: int | None = None) -> int:
+    """Return the validated rank count, or reject before any mutation.
+
+    A dispatcher limit is a host capability ceiling, never a second request.
+    The bool check precedes the int check because ``int(True)`` is 1, so a
+    boolean would otherwise be accepted silently as a one-rank run.
+    """
+    if isinstance(requested, bool):
+        raise TypeError(f"run_batch.workers must be an integer, got {requested!r}")
+    if not isinstance(requested, int):
+        raise ValueError(f"run_batch.workers must be an integer, got {requested!r}")
+    if requested < 1:
+        raise ValueError(f"run_batch.workers must be >= 1, got {requested}")
+    ceiling = visible_rank_count
+    if dispatcher_rank_limit is not None:
+        ceiling = min(ceiling, dispatcher_rank_limit)
+    if requested > ceiling:
+        raise ValueError(
+            f"run_batch.workers {requested} exceeds the available rank ceiling {ceiling}")
+    return requested
+
+
 def resolve_case_matrix(explicit: list[dict] | None, variants: dict,
                         cfg_dir: Path) -> list[dict]:
     if explicit:

--- a/src/digitalmodel/workflows/openfoam_batch_execution.py
+++ b/src/digitalmodel/workflows/openfoam_batch_execution.py
@@ -15,7 +15,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
-from digitalmodel.workflows.openfoam_batch_config import base_view
+from digitalmodel.workflows.openfoam_batch_config import base_view, validate_workers
 from digitalmodel.workflows.openfoam_batch_identity import file_sha256
 from digitalmodel.workflows.openfoam_batch_layout import WorkLayout
 from digitalmodel.workflows.openfoam_batch_results import redact_rows, row
@@ -24,6 +24,12 @@ from digitalmodel.workflows.openfoam_batch_results import redact_rows, row
 CHECKPOINT_FILENAME = "_result.json"
 DEFAULT_MESH_UTILITY = "blockMesh"
 DEFAULT_TIMEOUT_SECONDS = 43200
+# Mirrors runner._ERROR_MARKERS in the rendered log spelling, so the MPI path
+# applies the fail-closed policy the serial runner already applies.
+FOAM_FATAL_MARKERS = (
+    "--> FOAM FATAL ERROR",
+    "--> FOAM FATAL IO ERROR",
+)
 
 
 def make_checkpoint(*, identity_sha256: str, owner_token: str, case: str,
@@ -177,7 +183,9 @@ def _run_case_mpi_unlocked(item: dict[str, Any], run_settings: dict, workers: in
         view = base_view(item["settings"])
         plan = mpi_command_plan(solver, workers,
             view.get("mesh_utility", DEFAULT_MESH_UTILITY),
-            bool(view.get("run_set_fields", False)), reconstruct, resume)
+            bool(view.get("run_set_fields", False)), reconstruct, resume,
+            to_vtk=bool(view.get("to_vtk", False)),
+            reconstruct_mesh=bool(run_settings.get("reconstruct_mesh", False)))
         if mock:
             result = row(item, status="completed", case_dir=case_dir, solver=solver, mock=True)
             result["mpi_plan"] = [" ".join(argv) for argv in plan]
@@ -212,15 +220,33 @@ def execute_mpi_plan(item: dict[str, Any], case_dir: Path, plan: list[list[str]]
         if indirect:
             _verify_executable(*indirect)
             launched = [str(indirect[0]) if value == solver else value for value in launched]
-        rc = run(launched, case_dir, case_dir / f"log.{argv[0]}", timeout,
+        log_path = case_dir / f"log.{argv[0]}"
+        rc = run(launched, case_dir, log_path, timeout,
                  expected_executable=binding) if binding else run(
-                     launched, case_dir, case_dir / f"log.{argv[0]}", timeout)
+                     launched, case_dir, log_path, timeout)
         if indirect:
             _verify_executable(*indirect)
         if rc:
             return row(item, status="failed", case_dir=case_dir, solver=solver,
                        error=f"stage '{argv[0]}' returned non-zero exit code {rc}")
+        marker = _fatal_marker(log_path)
+        if marker:
+            return row(item, status="failed", case_dir=case_dir, solver=solver,
+                       error=f"stage '{argv[0]}' logged {marker} at exit code 0")
     return row(item, status="completed", case_dir=case_dir, solver=solver)
+
+
+def _fatal_marker(log_path: Path) -> str | None:
+    """Return the fatal marker in a stage log, if any.
+
+    Utilities can exit 0 having already written a fatal error, so the return
+    code alone is not evidence a stage succeeded.
+    """
+    try:
+        text = log_path.read_text(errors="replace")
+    except OSError:
+        return None
+    return next((marker for marker in FOAM_FATAL_MARKERS if marker in text), None)
 
 
 def build_case(item: dict[str, Any]) -> Path:
@@ -290,16 +316,28 @@ def _case_lock(layout: WorkLayout | None, case: str):
 
 def mpi_command_plan(solver: str, workers: int, mesh_utility: str = DEFAULT_MESH_UTILITY,
                      run_set_fields: bool = False, reconstruct: bool = True,
-                     resume: bool = False) -> list[list[str]]:
+                     resume: bool = False, *, to_vtk: bool = False,
+                     reconstruct_mesh: bool = False) -> list[list[str]]:
+    """Build the exact ordered MPI stage plan.
+
+    ``foamToVTK`` reads the reconstructed case, so a VTK request without
+    reconstruction is rejected here, before the case is touched.
+    """
+    if to_vtk and not reconstruct:
+        raise ValueError("to_vtk requires reconstruction: set run_batch.reconstruct true")
     plan: list[list[str]] = []
     if not resume:
         plan.append([mesh_utility])
         if run_set_fields:
             plan.append(["setFields"])
         plan.append(["decomposePar", "-force"])
-    plan.append(["mpirun", "-np", str(workers), "--oversubscribe", solver, "-parallel"])
+    plan.append(["mpirun", "-np", str(workers), solver, "-parallel"])
     if reconstruct:
+        if reconstruct_mesh:
+            plan.append(["reconstructParMesh", "-latestTime"])
         plan.append(["reconstructPar"])
+    if to_vtk:
+        plan.append(["foamToVTK"])
     return plan
 
 

--- a/src/digitalmodel/workflows/openfoam_run_batch.py
+++ b/src/digitalmodel/workflows/openfoam_run_batch.py
@@ -63,6 +63,7 @@ __all__ = [
     "_write_decompose_par_dict",
     "default_workers",
     "mpi_command_plan",
+    "required_utilities",
     "resolve_workers",
     "router",
 ]
@@ -128,8 +129,12 @@ def _validate_run(run_settings: dict, base: dict) -> tuple[str, bool, int]:
         raise ValueError(f"openfoam_run_batch run_batch.mode must be pool|mpi, got {mode}")
     mock, workers = bool(run_settings.get("mock", False)), resolve_workers(run_settings)
     view = base_view(base)
-    if not mock and not _solver_ready(mode, view.get("mesh_utility", DEFAULT_MESH_UTILITY),
-                                      view.get("solver"), bool(run_settings.get("reconstruct", True))):
+    if not mock and not _solver_ready(
+            mode, view.get("mesh_utility", DEFAULT_MESH_UTILITY), view.get("solver"),
+            bool(run_settings.get("reconstruct", True)),
+            run_set_fields=bool(view.get("run_set_fields", False)),
+            to_vtk=bool(view.get("to_vtk", False)),
+            reconstruct_mesh=bool(run_settings.get("reconstruct_mesh", False))):
         raise RuntimeError(SOLVER_ERROR_MESSAGE)
     return mode, mock, workers
 
@@ -192,13 +197,22 @@ def _walk_strings(value: Any, prefix: str = "config"):
         yield prefix, value
 
 
-def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str, Path]]:
+def required_utilities(mode: str, base: dict, run_settings: dict) -> list[str]:
+    """Every utility the selected case path will actually invoke, in order.
+
+    The readiness probe and the executable-binding set are both derived from
+    this one list. They previously enumerated the utilities independently and
+    had already drifted apart on setFields, so a run could bind a utility it
+    never checked for, or check for one it never bound.
+    """
     names = [base.get("mesh_utility", DEFAULT_MESH_UTILITY), base.get("solver")]
     if mode == "mpi":
         names += ["decomposePar", "mpirun"]
         if base.get("run_set_fields"):
             names.append("setFields")
         if bool(run_settings.get("reconstruct", True)):
+            if bool(run_settings.get("reconstruct_mesh", False)):
+                names.append("reconstructParMesh")
             names.append("reconstructPar")
     else:
         if base.get("run_snappy"):
@@ -211,16 +225,23 @@ def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str
             names.append("subsetMesh")
         if base.get("run_set_fields"):
             names.append("setFields")
-        if base.get("to_vtk"):
-            names.append("foamToVTK")
-    return [(name, Path(shutil.which(name) or "")) for name in names if name]
+    if base.get("to_vtk"):
+        names.append("foamToVTK")
+    return [name for name in names if name]
+
+
+def _selected_tools(mode: str, base: dict, run_settings: dict) -> list[tuple[str, Path]]:
+    return [(name, Path(shutil.which(name) or ""))
+            for name in required_utilities(mode, base, run_settings)]
 
 
 def _solver_ready(mode: str, mesh_utility: str, solver: str | None,
-                  reconstruct: bool = True) -> bool:
-    required = [mesh_utility] + ([solver] if solver else [])
-    if mode == "mpi":
-        required += ["decomposePar", "mpirun"] + (["reconstructPar"] if reconstruct else [])
+                  reconstruct: bool = True, *, run_set_fields: bool = False,
+                  to_vtk: bool = False, reconstruct_mesh: bool = False) -> bool:
+    view = {"mesh_utility": mesh_utility, "solver": solver,
+            "run_set_fields": run_set_fields, "to_vtk": to_vtk}
+    required = required_utilities(
+        mode, view, {"reconstruct": reconstruct, "reconstruct_mesh": reconstruct_mesh})
     return all(shutil.which(name) is not None for name in required)
 
 

--- a/tests/solvers/openfoam/test_artifact_index.py
+++ b/tests/solvers/openfoam/test_artifact_index.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import os
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.solvers.openfoam.artifact_index import (
+    TREE_DOMAIN,
+    ArtifactIndexError,
+    FileRecord,
+    artifact_id,
+    build_index,
+    frame,
+    host_local_locator,
+    is_numeric_time_name,
+    select_roots,
+    snapshot_tree,
+    tree_digest,
+    verify_unchanged,
+)
+
+
+def _write_case_tree(case_root: Path) -> None:
+    files = {
+        "constant/polyMesh/points": b"mesh",
+        "0/U": b"u0",
+        "0.5/U": b"u1",
+        "VTK/case_0.vtk": b"vtk",
+        "postProcessing/probes/0/p": b"probe",
+        "system/controlDict": b"control",
+        "processor0/0/U": b"partition",
+        "log.interFoam": b"log",
+    }
+    for relative_path, content in files.items():
+        path = case_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
+def _build_test_index(case_root: Path) -> dict:
+    return build_index(
+        case_root,
+        run_identity_sha256="1" * 64,
+        input_sha256="2" * 64,
+        source_sha256="3" * 64,
+        tool_sha256="4" * 64,
+        generation_id="5" * 64,
+    )
+
+
+def test_frame_prepends_uint64_big_endian_length() -> None:
+    assert frame(b"x") == b"\x00\x00\x00\x00\x00\x00\x00\x01x"
+
+
+def test_tree_domain_frame_golden_vector() -> None:
+    assert sha256(frame(TREE_DOMAIN)).hexdigest() == (
+        "a4474ba5694b4356dc78a265d304584b2de64afcf6136c6cd968025dbd1d6708"
+    )
+
+
+def test_single_record_tree_digest_golden_vector() -> None:
+    record = FileRecord(
+        path="0/U",
+        size_bytes=1,
+        sha256=sha256(b"x").hexdigest(),
+    )
+    assert tree_digest([record]) == (
+        "15749b5cd2b684b587d2d7da29accbe736aeb6736d6afa2a0500fe5fd01e6c73"
+    )
+
+
+def test_tree_digest_is_independent_of_input_order() -> None:
+    sorted_records = [
+        FileRecord("0/U", 1, sha256(b"x").hexdigest()),
+        FileRecord("1/U", 1, sha256(b"y").hexdigest()),
+    ]
+    sorted_order_digest = tree_digest(sorted_records)
+
+    assert tree_digest(list(reversed(sorted_records))) == sorted_order_digest
+
+
+def test_tree_digest_changes_when_only_size_changes() -> None:
+    digest = sha256(b"x").hexdigest()
+    original = tree_digest([FileRecord("0/U", 1, digest)])
+    changed = tree_digest([FileRecord("0/U", 2, digest)])
+
+    def encode(data: bytes) -> bytes:
+        return len(data).to_bytes(8, "big") + data
+
+    expected_stream = b"".join(
+        (
+            encode(b"dm-artifact-tree-v1"),
+            encode(b"file"),
+            encode(b"0/U"),
+            encode((2).to_bytes(8, "big")),
+            encode(bytes.fromhex(digest)),
+        )
+    )
+    assert changed != original
+    assert changed == sha256(expected_stream).hexdigest()
+
+
+def test_artifact_id_is_stable_and_kind_sensitive() -> None:
+    inputs = {
+        "run_identity_sha256": "1" * 64,
+        "generation_id": "2" * 64,
+        "kind": "field_tree",
+        "selection": "0",
+        "size_bytes": 1,
+        "file_count": 1,
+        "content_sha256": sha256(b"x").hexdigest(),
+    }
+    first = artifact_id(**inputs)
+    second = artifact_id(**inputs)
+    mesh = artifact_id(**(inputs | {"kind": "mesh_tree"}))
+
+    assert second == first
+    assert mesh != first
+
+
+def test_host_local_locator_has_exact_opaque_shape() -> None:
+    assert host_local_locator("run-id", "generation-id", "artifact-id") == (
+        "host-local:///run-id/generation-id/artifact-id"
+    )
+
+
+def test_numeric_time_name_accepts_canonical_nonnegative_values() -> None:
+    for name in ("0", "0.5", "1e-3", "10"):
+        assert is_numeric_time_name(name) is True
+
+
+def test_numeric_time_name_rejects_invalid_values() -> None:
+    for name in (
+        "",
+        " 0",
+        "+1",
+        "-1",
+        "inf",
+        "nan",
+        "..",
+        "0/1",
+        "constant",
+        "system",
+    ):
+        assert is_numeric_time_name(name) is False
+
+
+def test_select_roots_returns_disjoint_completed_selections(tmp_path: Path) -> None:
+    _write_case_tree(tmp_path)
+    selected = select_roots(tmp_path)
+    selected_paths = [path for paths in selected.values() for path in paths]
+    excluded = {
+        path
+        for path in selected_paths
+        if path.startswith(("processor", "system")) or path == "log.interFoam"
+    }
+
+    assert set(selected) == {
+        "mesh_tree",
+        "field_tree",
+        "vtk_tree",
+        "postprocessing_tree",
+    }
+    assert len(selected_paths) == len(set(selected_paths))
+    assert excluded == set()
+
+
+def test_field_tree_contains_only_numeric_time_roots(tmp_path: Path) -> None:
+    _write_case_tree(tmp_path)
+
+    assert sorted(select_roots(tmp_path)["field_tree"]) == ["0", "0.5"]
+
+
+def test_select_roots_rejects_duplicate_numeric_time_spellings(
+    tmp_path: Path,
+) -> None:
+    decimal_case = tmp_path / "decimal"
+    (decimal_case / "0.1").mkdir(parents=True)
+    (decimal_case / "0.10").mkdir()
+    zero_case = tmp_path / "zero"
+    (zero_case / "0").mkdir(parents=True)
+    (zero_case / "0.0").mkdir()
+
+    with pytest.raises(ArtifactIndexError):
+        select_roots(decimal_case)
+    with pytest.raises(ArtifactIndexError):
+        select_roots(zero_case)
+
+
+def test_snapshot_tree_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_bytes(b"x")
+    (tmp_path / "link").symlink_to(target)
+
+    with pytest.raises(ArtifactIndexError):
+        snapshot_tree(tmp_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="os.mkfifo unavailable")
+def test_snapshot_tree_rejects_fifo(tmp_path: Path) -> None:
+    os.mkfifo(tmp_path / "pipe")
+
+    with pytest.raises(ArtifactIndexError):
+        snapshot_tree(tmp_path)
+
+
+def test_snapshot_tree_returns_exact_sorted_records(tmp_path: Path) -> None:
+    nested = tmp_path / "a"
+    nested.mkdir()
+    (nested / "x").write_bytes(b"A")
+    (tmp_path / "b").write_bytes(b"BC")
+
+    assert snapshot_tree(tmp_path) == [
+        FileRecord("a/x", 1, sha256(b"A").hexdigest()),
+        FileRecord("b", 2, sha256(b"BC").hexdigest()),
+    ]
+
+
+def test_verify_unchanged_detects_same_size_modification(tmp_path: Path) -> None:
+    path = tmp_path / "field"
+    path.write_bytes(b"aa")
+    expected = snapshot_tree(tmp_path)
+    path.write_bytes(b"bb")
+
+    with pytest.raises(ArtifactIndexError):
+        verify_unchanged(tmp_path, expected)
+
+
+def test_verify_unchanged_detects_added_file(tmp_path: Path) -> None:
+    (tmp_path / "field").write_bytes(b"x")
+    expected = snapshot_tree(tmp_path)
+    (tmp_path / "added").write_bytes(b"y")
+
+    with pytest.raises(ArtifactIndexError):
+        verify_unchanged(tmp_path, expected)
+
+
+def test_verify_unchanged_detects_removed_file(tmp_path: Path) -> None:
+    path = tmp_path / "field"
+    path.write_bytes(b"x")
+    expected = snapshot_tree(tmp_path)
+    path.unlink()
+
+    with pytest.raises(ArtifactIndexError):
+        verify_unchanged(tmp_path, expected)
+
+
+def test_verify_unchanged_detects_rename(tmp_path: Path) -> None:
+    path = tmp_path / "field"
+    path.write_bytes(b"x")
+    expected = snapshot_tree(tmp_path)
+    path.rename(tmp_path / "renamed")
+
+    with pytest.raises(ArtifactIndexError):
+        verify_unchanged(tmp_path, expected)
+
+
+def test_build_index_emits_no_absolute_host_path(tmp_path: Path) -> None:
+    _write_case_tree(tmp_path)
+    emitted_index = [record.as_dict() for record in _build_test_index(tmp_path).values()]
+
+    assert str(tmp_path) not in json.dumps(emitted_index, sort_keys=True)
+
+
+def test_completed_index_excludes_processor_and_diagnostic_roots(
+    tmp_path: Path,
+) -> None:
+    _write_case_tree(tmp_path)
+    records = _build_test_index(tmp_path)
+
+    assert {record.kind for record in records.values()} == {
+        "mesh_tree",
+        "field_tree",
+        "vtk_tree",
+        "postprocessing_tree",
+    }

--- a/tests/solvers/openfoam/test_module_size_limits.py
+++ b/tests/solvers/openfoam/test_module_size_limits.py
@@ -33,6 +33,7 @@ MAX_FUNCTION_LINES = 50
 # globbed so that adding a module to the package is a deliberate decision to
 # bring it under this limit.
 GOVERNED_MODULES = (
+    "src/digitalmodel/solvers/openfoam/artifact_index.py",
     "src/digitalmodel/solvers/openfoam/pressure_taps.py",
     "src/digitalmodel/solvers/openfoam/pressure_tap_models.py",
     "src/digitalmodel/solvers/openfoam/pressure_tap_analysis.py",

--- a/tests/solvers/openfoam/test_workflow_case_definition.py
+++ b/tests/solvers/openfoam/test_workflow_case_definition.py
@@ -397,7 +397,9 @@ def test_canonical_base_mpi_plan_uses_the_authored_solver(tmp_path: Path) -> Non
     }
     result = ofb.router(cfg)
     plan = result["openfoam_run_batch"]["cases"][0]["mpi_plan"]
-    assert "mpirun -np 2 --oversubscribe interFoam -parallel" in plan
+    # dm#1576 removed the oversubscription flag from every generated argv; the
+    # authored solver and the requested rank count are what this pins.
+    assert "mpirun -np 2 interFoam -parallel" in plan
 
 
 def test_canonical_base_mpi_plan_includes_set_fields(tmp_path: Path) -> None:

--- a/tests/workflows/test_openfoam_batch_execution.py
+++ b/tests/workflows/test_openfoam_batch_execution.py
@@ -64,3 +64,37 @@ def test_mpi_executes_verified_absolute_path(tmp_path: Path) -> None:
     execute_mpi_plan(item, tmp_path, [["blockMesh"]], "solver", capture, 10,
                      tool_bindings={"blockMesh": (tool, file_sha256(tool))})
     assert launched == [[str(tool)]]
+
+
+# --------------------------------------------------------------------------- #
+#  fatal-marker propagation (issue 1576)                                      #
+# --------------------------------------------------------------------------- #
+# OpenFOAM utilities can exit 0 and still have written a fatal error to their
+# log. The MPI path previously trusted the return code alone, so a solve that
+# died at start-up was recorded as completed.
+def _stage_row(tmp_path: Path, log_text: str) -> dict:
+    item = {"index": 0, "name": "case", "case": {}}
+
+    def runner(argv, cwd, log, timeout, expected_executable=None):
+        Path(log).write_text(log_text)
+        return 0
+
+    return execute_mpi_plan(item, tmp_path, [["blockMesh"]], "solver", runner, 10)
+
+
+def test_fatal_error_in_log_fails_the_stage_despite_zero_exit(tmp_path: Path) -> None:
+    result = _stage_row(tmp_path, "start\n--> FOAM FATAL ERROR\nend\n")
+
+    assert result["status"] == "failed"
+    assert "blockMesh" in result["error"]
+
+
+def test_fatal_io_error_in_log_fails_the_stage_despite_zero_exit(tmp_path: Path) -> None:
+    result = _stage_row(tmp_path, "start\n--> FOAM FATAL IO ERROR\nend\n")
+
+    assert result["status"] == "failed"
+    assert "blockMesh" in result["error"]
+
+
+def test_clean_log_with_zero_exit_completes(tmp_path: Path) -> None:
+    assert _stage_row(tmp_path, "End\nFinalising parallel run\n")["status"] == "completed"

--- a/tests/workflows/test_openfoam_mpi_stages.py
+++ b/tests/workflows/test_openfoam_mpi_stages.py
@@ -1,0 +1,182 @@
+"""MPI stage order, rank ceiling and utility preflight for issue 1576.
+
+The MPI path historically stopped after optional reconstruction: it never
+scheduled ``foamToVTK`` however the request was written, it passed an
+oversubscription flag, it accepted any rank count, and its readiness probe
+required a different utility set than the one it actually bound and launched.
+These tests pin each of those as an exact value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.workflows import openfoam_run_batch as ofb
+from digitalmodel.workflows.openfoam_batch_execution import (
+    mpi_command_plan,
+    validate_workers,
+)
+
+
+SOLVER = "interFoam"
+MESH = "blockMesh"
+
+
+def _mpi_view(*, run_set_fields: bool = False, to_vtk: bool = False) -> dict:
+    return {
+        "mesh_utility": MESH,
+        "solver": SOLVER,
+        "run_set_fields": run_set_fields,
+        "to_vtk": to_vtk,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  exact stage order                                                          #
+# --------------------------------------------------------------------------- #
+def test_fresh_plan_without_vtk_is_the_exact_stage_list() -> None:
+    assert mpi_command_plan(SOLVER, 8, MESH, reconstruct=True) == [
+        [MESH],
+        ["decomposePar", "-force"],
+        ["mpirun", "-np", "8", SOLVER, "-parallel"],
+        ["reconstructPar"],
+    ]
+
+
+def test_no_stage_carries_an_oversubscription_flag() -> None:
+    plan = mpi_command_plan(SOLVER, 8, MESH, reconstruct=True, to_vtk=True)
+    tokens = [token for argv in plan for token in argv]
+
+    assert "--oversubscribe" not in tokens
+
+
+def test_eight_rank_canary_argv_is_exact() -> None:
+    plan = mpi_command_plan(SOLVER, 8, MESH, reconstruct=True)
+    solver_stage = next(argv for argv in plan if argv[0] == "mpirun")
+
+    assert solver_stage == ["mpirun", "-np", "8", SOLVER, "-parallel"]
+
+
+def test_to_vtk_appends_foam_to_vtk_after_reconstruction() -> None:
+    assert mpi_command_plan(
+        SOLVER, 8, MESH, run_set_fields=True, reconstruct=True, to_vtk=True
+    ) == [
+        [MESH],
+        ["setFields"],
+        ["decomposePar", "-force"],
+        ["mpirun", "-np", "8", SOLVER, "-parallel"],
+        ["reconstructPar"],
+        ["foamToVTK"],
+    ]
+
+
+def test_reconstruct_mesh_precedes_reconstruct_par() -> None:
+    assert mpi_command_plan(
+        SOLVER, 8, MESH, reconstruct=True, reconstruct_mesh=True
+    ) == [
+        [MESH],
+        ["decomposePar", "-force"],
+        ["mpirun", "-np", "8", SOLVER, "-parallel"],
+        ["reconstructParMesh", "-latestTime"],
+        ["reconstructPar"],
+    ]
+
+
+def test_vtk_without_reconstruction_rejects_before_mutation() -> None:
+    with pytest.raises(ValueError, match="to_vtk"):
+        mpi_command_plan(SOLVER, 8, MESH, reconstruct=False, to_vtk=True)
+
+
+def test_requesting_vtk_changes_the_emitted_stage_set_by_exactly_one_stage() -> None:
+    without = [argv[0] for argv in mpi_command_plan(SOLVER, 8, MESH, reconstruct=True)]
+    with_vtk = [
+        argv[0]
+        for argv in mpi_command_plan(SOLVER, 8, MESH, reconstruct=True, to_vtk=True)
+    ]
+
+    assert set(with_vtk) - set(without) == {"foamToVTK"}
+
+
+# --------------------------------------------------------------------------- #
+#  rank ceiling                                                               #
+# --------------------------------------------------------------------------- #
+def test_true_is_not_a_rank_count() -> None:
+    with pytest.raises(TypeError):
+        validate_workers(True, visible_rank_count=8)
+
+
+def test_false_is_not_a_rank_count() -> None:
+    with pytest.raises(TypeError):
+        validate_workers(False, visible_rank_count=8)
+
+
+def test_zero_ranks_reject() -> None:
+    with pytest.raises(ValueError):
+        validate_workers(0, visible_rank_count=8)
+
+
+def test_negative_ranks_reject() -> None:
+    with pytest.raises(ValueError):
+        validate_workers(-1, visible_rank_count=8)
+
+
+def test_request_above_visible_ranks_names_request_and_ceiling() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        validate_workers(9, visible_rank_count=8)
+    message = str(excinfo.value)
+
+    assert "9" in message
+    assert "8" in message
+
+
+def test_request_at_the_visible_ceiling_is_returned_unchanged() -> None:
+    assert validate_workers(8, visible_rank_count=8) == 8
+
+
+def test_dispatcher_limit_is_a_ceiling_not_a_second_request() -> None:
+    assert validate_workers(8, visible_rank_count=16, dispatcher_rank_limit=8) == 8
+    with pytest.raises(ValueError):
+        validate_workers(9, visible_rank_count=16, dispatcher_rank_limit=8)
+
+
+# --------------------------------------------------------------------------- #
+#  utility preflight                                                          #
+# --------------------------------------------------------------------------- #
+def test_mpi_vtk_request_selects_foam_to_vtk() -> None:
+    assert ofb.required_utilities(
+        "mpi", _mpi_view(to_vtk=True), {"reconstruct": True}
+    ) == [MESH, SOLVER, "decomposePar", "mpirun", "reconstructPar", "foamToVTK"]
+
+
+def test_mpi_set_fields_request_selects_set_fields() -> None:
+    assert ofb.required_utilities(
+        "mpi", _mpi_view(run_set_fields=True), {"reconstruct": True}
+    ) == [MESH, SOLVER, "decomposePar", "mpirun", "setFields", "reconstructPar"]
+
+
+def test_pool_vtk_request_selects_foam_to_vtk() -> None:
+    assert ofb.required_utilities("pool", _mpi_view(to_vtk=True), {}) == [
+        MESH,
+        SOLVER,
+        "foamToVTK",
+    ]
+
+
+def test_readiness_probe_requires_every_selected_utility(monkeypatch) -> None:
+    view = _mpi_view(run_set_fields=True, to_vtk=True)
+    run_settings = {"reconstruct": True}
+    present = set(ofb.required_utilities("mpi", view, run_settings))
+    monkeypatch.setattr(
+        ofb.shutil, "which",
+        lambda exe: "/usr/bin/stub" if exe in present else None,
+    )
+
+    assert ofb._solver_ready(
+        "mpi", MESH, SOLVER, True, run_set_fields=True, to_vtk=True
+    ) is True
+
+    present.discard("foamToVTK")
+
+    assert ofb._solver_ready(
+        "mpi", MESH, SOLVER, True, run_set_fields=True, to_vtk=True
+    ) is False


### PR DESCRIPTION
Implements the approved plan for [#1576](https://github.com/vamseeachanta/digitalmodel/issues/1576)
at exact SHA `32bef62ad14a6bfa05d6a61a116f568147a367d4` (approval marker `ba9366da`).

Base `85c3c4af`. Dependencies [#1565](https://github.com/vamseeachanta/digitalmodel/issues/1565)
and [#1575](https://github.com/vamseeachanta/digitalmodel/issues/1575) are both merged.

## What lands

**MPI post-processing (the issue's headline).** `mpi_command_plan` emits the exact
stage order and now appends optional `reconstructParMesh -latestTime` and
`foamToVTK` after reconstruction. Previously `to_vtk: true` was silently dropped
on the MPI path however the request was written. `to_vtk` without reconstruction
rejects during plan construction, before the case is touched.

**No oversubscription.** Every generated argv drops `--oversubscribe`.

**Rank ceiling.** `validate_workers` rejects booleans before the int check —
`int(True)` is 1, so a boolean was previously accepted as a silent one-rank run —
and applies a dispatcher limit as a capability ceiling, never a second request.

**Utility preflight.** `required_utilities` becomes the single source for both the
readiness probe and the executable-binding set. These enumerated utilities
independently and **had already drifted apart on `setFields`**, so a run could bind
a utility it never checked for. `foamToVTK` is now selected in both pool and MPI modes.

**Fatal-marker propagation.** Stage logs are scanned for OpenFOAM fatal markers. A
utility can exit 0 having already written a fatal error; the MPI path previously
recorded such a stage as completed.

**Artifact index.** New `artifact_index.py` implements the length-framed codec, the
four disjoint completed artifact roots, and an `O_NOFOLLOW` descriptor snapshot that
detects replacement, addition, removal and rename. The plan's three golden vectors
were independently reproduced before the tests were written.

## Verification

Interpreter `/usr/bin/python3`. `test_workflow_router.py` is **collected and run**,
not excluded — it needs `rainflow` (installed) and a current `assetutilities`
(sibling source ahead of the stale 0.0.8 site-packages copy on `PYTHONPATH`).

- Baseline on `85c3c4af`: 892 collected, **3 failed / 880 passed / 9 skipped**
- After: 936 collected, **3 failed / 924 passed / 9 skipped**
- The 3 failures are pre-existing numpy 2.x `np.trapz` removals in
  `validation/test_wave_excited_body.py`, unrelated to this branch
- Node-ID diff: **0 removed, 44 added** — no test deleted, renamed away or excluded
- `compileall`, `git diff --check`, the 400/50 size gates and the legal sanity scan all pass

TDD sequence is provable from the log: RED `04efcddf` → GREEN `e5a70146`,
RED `d5ed4f84` → GREEN `a597e67a`.

## One existing assertion changed, deliberately

`test_canonical_base_mpi_plan_uses_the_authored_solver` pinned the literal string
`mpirun -np 2 --oversubscribe interFoam -parallel`. Removing the oversubscription
flag is an explicit acceptance criterion of the approved plan, so the expected argv
is updated. It remains an exact full-string assertion — equally strict, not weakened.

## Not included, and why

- **MPI `resume: true` rejection.** The plan requires it, but
  `test_openfoam_run_batch.py:355-369` is an existing passing test asserting MPI
  resume *succeeds*. Implementing the plan here would mean inverting a
  currently-green assertion from merged work. Surfaced for an owner decision rather
  than resolved unilaterally. See the issue comment.
- **`artifact_generation.py`** (staging/sealing/commit/pointer) is not in this PR.
  `GENERATION_DOMAIN` and `COMMIT_DOMAIN` are declared in `artifact_index.py` for it
  and are currently unexercised public surface.
- **Real-host eight-rank canary** is blocked by
  [#1959](https://github.com/vamseeachanta/digitalmodel/issues/1959) and was already
  outside this implementation's authorization.
- Nothing here claims queue return, lease, retention or remote resolution; the
  locator scheme stays `host-local:///`. Deckhand 564 remains separate.

Merge line is the owner's.
