### PR TITLE
fix(openfoam): state the schema limit instead of denying prebuilt (#1969)

### DIFF
--- a/src/digitalmodel/solvers/openfoam/case_definition.py
+++ b/src/digitalmodel/solvers/openfoam/case_definition.py
@@ -340,7 +340,7 @@ def _parse_canonical(root: Mapping[str, Any]) -> ParsedAuthoredCaseV1:
         raise ValidationError("unsupported case_definition.schema_version")
     kind = require_string(definition["kind"], "case_definition.kind")
     if kind == "prebuilt":
-        raise ValidationError("prebuilt cases are not available in schema v1")
+        raise ValidationError("prebuilt reserved in schema v1; use OpenFOAMRunner.run(prebuilt_manifest=...)")
     if kind != "authored":
         raise ValidationError(f"unsupported case_definition.kind {kind!r}")
     check_keys(

--- a/src/digitalmodel/solvers/openfoam/workflow.py
+++ b/src/digitalmodel/solvers/openfoam/workflow.py
@@ -19,7 +19,11 @@ Canonical — carries the full case definition, validated fail-closed::
       output_directory: out       # relative to Analysis.result_folder
       case_definition:
         schema_version: 1
-        kind: authored            # "prebuilt" is reserved and refused in v1
+        kind: authored            # "prebuilt" is reserved in schema v1 (#1969)
+        # Prebuilt meshes are NOT unsupported -- they are unreachable from this
+        # schema only. The attested path ships and runs in CI: call
+        # OpenFOAMRunner.run(case_dir, prebuilt_manifest=...) directly, which
+        # validates the manifest before any copy (prebuilt_mesh.py).
         authored:
           case_type: sloshing
           name: my_case

--- a/tests/solvers/openfoam/test_case_definition.py
+++ b/tests/solvers/openfoam/test_case_definition.py
@@ -348,6 +348,49 @@ def test_prebuilt_kind_is_rejected_in_v1() -> None:
         parse_case_request(request)
 
 
+def _prebuilt_request() -> Dict[str, Any]:
+    """A canonical request whose kind is the reserved ``prebuilt`` arm."""
+    request = _authored_request()
+    request["case_definition"] = {
+        "schema_version": 1,
+        "kind": "prebuilt",
+        "prebuilt": {"case_id": "some_case"},
+    }
+    return request
+
+
+def test_prebuilt_refusal_names_the_supported_entry_point() -> None:
+    """The refusal must point at the attested path that does work (#1969).
+
+    Prebuilt execution ships: ``OpenFOAMRunner.run(prebuilt_manifest=...)`` is
+    covered by fourteen tests in ``test_runner_prebuilt.py`` and runs in CI. A
+    schema refusal that names no alternative strands the YAML caller.
+    """
+    with pytest.raises(CaseDefinitionError) as excinfo:
+        parse_case_request(_prebuilt_request())
+    message = str(excinfo.value)
+    assert "OpenFOAMRunner" in message
+    assert "prebuilt_manifest" in message
+
+
+def test_prebuilt_refusal_does_not_claim_the_capability_is_absent() -> None:
+    """The phrase ``not available`` is the false half of the old message (#1969).
+
+    The limit is the schema's, not the product's. This assertion is negative on
+    purpose: it can only be satisfied by removing the untrue claim, never by
+    adding words around it.
+    """
+    with pytest.raises(CaseDefinitionError) as excinfo:
+        parse_case_request(_prebuilt_request())
+    assert "not available" not in str(excinfo.value)
+
+
+def test_authored_case_is_unaffected_by_the_message_change() -> None:
+    """Regression fence: the authored arm is untouched by the #1969 wording."""
+    parsed = parse_case_request(_authored_request())
+    assert parsed.case.name == "synthetic_sloshing"
+
+
 def test_schema_version_constant_is_one() -> None:
     assert SCHEMA_VERSION == 1
 


### PR DESCRIPTION
Implements **Option B only** of the approved plan for [#1969](https://github.com/vamseeachanta/digitalmodel/issues/1969) (`docs/plans/2026-08-05-issue-1969-prebuilt-case-schema-arm.md` on `plan/1968-1970-openfoam-followons`). Option A is **not** implemented and remains unapproved.

## The message

```
- prebuilt cases are not available in schema v1
+ prebuilt reserved in schema v1; use OpenFOAMRunner.run(prebuilt_manifest=...)
```

## Why the old message was false

The issue was filed on the premise that prebuilt is "partially present and unreachable". That premise is **refuted**, and this PR reflects the correction:

- `prebuilt_mesh.py` has **four** consumers on `main`: the CI workflow, `scripts/cfd/run_synthetic_tank_3d_smoke.py`, `runner.py`, and `test_runner_prebuilt.py`.
- `test_runner_prebuilt.py` holds **14** test functions (27 collected node IDs), all green, and `gmsh-meshing-tests.yml` runs it.
- Attestation precedes the copy: `_validate_bound_case` at `prebuilt_mesh.py:91`, `shutil.copytree` at `:93`.

Prebuilt execution is not missing. Only the YAML schema cannot reach it. The phrase `not available` told YAML users that a shipped, CI-exercised capability does not exist. The new message states the **schema's** limit and names the entry point that works.

## Tests (TDD, RED committed separately at `12f3e217`)

- `test_prebuilt_refusal_names_the_supported_entry_point` — message contains `OpenFOAMRunner` and `prebuilt_manifest`
- `test_prebuilt_refusal_does_not_claim_the_capability_is_absent` — message does **not** contain `not available`; negative by design, so it cannot be satisfied by padding words around the claim
- `test_authored_case_is_unaffected_by_the_message_change` — regression fence, **green before and after by design**

The pre-existing `test_prebuilt_kind_is_rejected_in_v1` still passes unmodified; no existing assertion was weakened.

## Verification

Baseline captured in this worktree at the branch point (`2b4b2567`), compared **node-ID by node-ID**, with **no file excluded from either side**:

```
tests/solvers/openfoam + tests/workflows
baseline: 1482 outcomes (14 pre-existing failures + 1 error, all unrelated)
after:    1485 outcomes
new non-PASSED:  none
lost PASSED:     none
new PASSED:      exactly the 3 tests above
```

`test_workflow_router.py` (9 tests) and `test_runner_prebuilt.py` were **run, not excluded**, and pass.

The node-ID diff caught two regressions mid-implementation that a summary count would have hidden:

1. `test_touched_modules_stay_bounded` enforces a literal 400-line ceiling; a wrapped refusal string pushed `case_definition.py` to 401. Refixed as a single line — the file is at **399**, and 11 pre-existing lines in it already exceed 88 chars, so the single-line form matches its actual style. `black`/`ruff` do not lint this path in CI.
2. `test_openfoam_batch_identity` failed with "package source is dirty" — an artifact of running against an uncommitted tree, cleared once committed and re-verified.

## Scope

`prebuilt_mesh.py` and `runner.py` are **not modified** — verified by `git diff --stat`. No attestation, hashing, copy, or locking logic is added anywhere (plan D4). No numeric threshold introduced.

Per plan **D7**, the [#1575](https://github.com/vamseeachanta/digitalmodel/issues/1575) plan's self-contradiction is recorded as a comment on that issue rather than by editing its unmerged plan branch; no file on `chore/1575-case-definition-plan` is touched.

No legal-scan evidence is cited: `scripts/legal/legal-sanity-scan.sh` does not exist in this repo, and workspace-hub's `--repo=` form is fail-open under [workspace-hub#3804](https://github.com/vamseeachanta/workspace-hub/issues/3804).

Closes [#1969](https://github.com/vamseeachanta/digitalmodel/issues/1969) for Option B. Option A (schema arm wired to the runner) stays open and unapproved.
