### PR TITLE
Ground the small-operator work; withdraw two undefendable figures

### DIFF
--- a/docs/small_operator/GROUNDING.md
+++ b/docs/small_operator/GROUNDING.md
@@ -1,0 +1,123 @@
+# Grounding — what this program can and cannot defend
+
+Written 2026-08-09, after the decision to **stop outreach and post nothing** until
+the work is grounded in fundamentals.
+
+The first grounding check found a problem in our own output, so this document
+starts there rather than with a reading list.
+
+---
+
+## Finding 1 — we reimplemented, worse, a module this repo already had
+
+`src/digitalmodel/marine_ops/artificial_lift/dynacard/rod_pump` implements
+**API RP 11L** and is documented at `docs/domains/artificial_lift/rod-pump-rp11l.md`.
+Its quick-start example uses the *same well* the analysis scripts here were
+written for.
+
+The scripts in `examples/` hand-rolled Mills-era closed-form approximations
+beside it. Comparison on the identical inputs:
+
+| | hand-rolled script | RP 11L module | why they differ |
+|---|---|---|---|
+| Fluid load | 1,942 lb | 2,096 lb | **the script omitted the tubing-pressure term** (150 psi × 1.227 in² = 184 lb) |
+| Rod stretch | 7.39 in | ~7.7 in | consequence of the above |
+| Plunger stroke | 33.61 in | 33.29 in | consequence of the above |
+| Pump displacement | 39.19 bpd | 38.80 bpd | consequence of the above |
+| **Volumetric efficiency** | **0.587 — asserted** | **`None` — refused** | see finding 2 |
+
+The displacement error is small. The habit is not: **check whether the domain
+module exists before writing the physics again.** A hand-rolled version does not
+inherit the validation, the envelope checks, or the refusals that the real module
+carries.
+
+---
+
+## Finding 2 — we asserted a number the repo deliberately refuses to assert
+
+`rod_pump.analyse()` returns `volumetric_efficiency = None` on purpose. The
+module documentation states exactly why:
+
+> *A unit cycling on a pump-off controller has a duty cycle that looks exactly
+> like low fillage, and surface barrels are not reservoir barrels. Rather than
+> assume 24 h and Bo = 1.0, `volumetric_efficiency` returns `None`.*
+
+We published **"~59% fillage"** as a headline figure — in the analysis scripts,
+in `HANDOFF.md`, and in a drafted public reply. To get 59% you must assume:
+
+1. **24-hour runtime.** Plausible here (the operator stated no controller), but
+   an assumption, and the module refuses to make it.
+2. **Bo = 1.0.** Almost certainly wrong. 23 *stock-tank* barrels are not 23
+   *reservoir* barrels at the pump. Even a modest Bo of 1.05–1.15 moves the
+   efficiency by 5–15 percentage points on its own.
+
+The same documentation spells out the neighbouring trap we had already walked
+into once — surface stroke gives 48%, plunger stroke gives 59%, and **neither is
+an efficiency until runtime and Bo are known.**
+
+**Consequence:** the drafted public reply led with a number our own fundamentals
+module declines to state. Had it gone out, that would have been the third public
+correction on this program, and the first one that was avoidable by reading our
+own repo.
+
+---
+
+## What is actually defensible today
+
+| Claim | Status |
+|---|---|
+| Pump displacement ≈ 38.8 bpd at 6.4 SPM | **Defensible** — RP 11L, module-computed |
+| Rod stretch shortens a 41 in stroke to ~33.3 in | **Defensible** — and it is the correction we were publicly given in July |
+| Rod Goodman utilisation ~51% | **Screening-grade** — Mills α and API Modified Goodman, not a wave-equation result |
+| Card fillage from a *card* | **Defensible** — the solver measures it; the corner-detection defect is fixed and regression-tested |
+| Volumetric efficiency from *production* | **NOT defensible** without runtime and Bo |
+| "~4 SPM would lift the same barrels" | **NOT defensible** — it rests on the efficiency figure above and on 23 bbl/d being inflow-limited, which needs a fluid-level shot |
+| Compression-zone depth prediction | **Unvalidated** — first-principles impedance, never checked against a real failure record |
+
+---
+
+## The real gap: we have no data in the regime we claim to serve
+
+The corner-detection defect survived because the only real validation cards are
+**four vendor-analysed wells spanning 88–98% fillage**. The solver-parity test
+says so itself:
+
+> *these fixtures span 88.37–97.92% vendor fillage. No trustworthy severe
+> fluid-pound card is available here.*
+
+Every claim about severe pump-off — the regime this whole program is aimed at —
+rests on synthetic generators. That is why the bug reported a pounded-off pump as
+full and no test caught it, and it is the single largest thing to fix before any
+client work.
+
+---
+
+## Grounding programme, in order
+
+1. **Route the analysis scripts through `rod_pump`** instead of hand-rolled
+   closed forms, and stop reporting efficiency where the module refuses to.
+2. **Read the primary sources properly** and record what each does and does not
+   license us to say: Gibbs (1963) wave equation; API RP 11L and its envelope;
+   Everitt–Jennings SPE 18189, already implemented here; Lea & Rowlan on fluid
+   level and pump-off control.
+3. **Acquire real severe-pump-off cards.** Public state datasets, published
+   papers with digitised cards, or a vendor with permission. Until this exists,
+   the pump-off claims are physics without evidence.
+4. **Validate the compression-zone model** against a real tubing-failure depth
+   record before it is offered to anyone.
+5. **Close the screening-vs-solver gap:** where a closed form and the solver both
+   apply, run both and record where they diverge and why.
+
+Only after 1–4 does outreach resume, and then with a result rather than an offer.
+
+---
+
+## The rule this program keeps relearning
+
+Both public corrections and both self-inflicted errors have the same shape:
+**an assumption stated as a finding.** The gearbox rating inferred from an engine
+designation. Fillage computed on surface stroke. Efficiency computed without
+runtime or Bo. A compression depth computed but never validated.
+
+The repo's own module already models the correct behaviour — it returns `None`
+and lists what it would need. That is the standard to hold everything else to.

--- a/docs/small_operator/HANDOFF.md
+++ b/docs/small_operator/HANDOFF.md
@@ -112,11 +112,11 @@ what makes it postable — he can check it with a calculator.
 
 | Finding | Value |
 |---|---|
-| Elastic rod stretch | 7.4 in of a 41 in stroke never reaches the plunger |
-| Plunger stroke | 33.6 in, not 41 in |
-| Pump capacity at 6.4 SPM | 39.2 bbl/d full |
-| **Implied fillage** | **~59%** against 23 bbl/d reported |
-| **SPM to lift the same barrels full** | **~4.0** vs 6.4 today |
+| Elastic rod stretch | ~7.7 in of a 41 in stroke never reaches the plunger |
+| Plunger stroke | 33.3 in, not 41 in |
+| Pump displacement at 6.4 SPM | **38.8 bbl/d** (`rod_pump`, RP 11L). The 39.2 in the scripts omitted the tubing-pressure term. |
+| ~~Implied fillage ~59%~~ | **WITHDRAWN 2026-08-09** — undetermined without runtime and Bo; `rod_pump.analyse()` returns `None` for exactly this reason |
+| ~~SPM to lift the same barrels full ~4.0~~ | **WITHDRAWN** — rests on the efficiency figure above and on 23 bbl/d being inflow-limited, which needs a fluid-level shot |
 | Rod Goodman utilisation | 51% — string has margin, so tubing damage is side-load |
 | Compression zone at 59% fillage | ~500 ft → wear should cluster **below ~3,800 ft** |
 | Worst pound | **~50% fillage, not the emptiest barrel** — impact velocity peaks mid-stroke |
@@ -135,13 +135,24 @@ review, and only the correct one surfaced the 50%-fillage result.
 
 ---
 
+## Direction changed 2026-08-09 — no posts, ground first
+
+Outreach is **stopped**. Nothing is posted and nothing is emailed until the work
+is grounded in fundamentals, built out, and can lead with a result rather than an
+offer. The drafted Collide reply is **withdrawn, not queued** — it led with a
+number our own RP 11L module refuses to state.
+
+Read `GROUNDING.md` before resuming any of it. Short version: we hand-rolled
+physics next to a proper API RP 11L implementation in this same repo, omitted the
+tubing-pressure term, and published a volumetric efficiency that is undetermined
+without runtime and Bo. And every severe-pump-off claim rests on synthetic cards,
+because the only real validation data spans 88–98% fillage.
+
 ## Pending — needs a decision
 
-1. **Collide reply to OP-A's pump-off thread — drafted, NOT posted.** Full text
-   in the session; the analysis behind it is committed. This is the highest-value
-   pending item and the right channel. Open question: post the SPM number and the
-   wear-depth prediction only, or include the Goodman and casing analysis too
-   (roughly doubles the length).
+1. ~~Collide reply to OP-A's pump-off thread~~ — **withdrawn 2026-08-09.** Not
+   queued, not pending: the numbers it led with are not defensible yet. Rework
+   only after `GROUNDING.md` steps 1–4.
 2. **The public/private split is done** — see the top of this file. If a new
    artefact names anyone, it belongs in the private repo, not here.
 3. **The per-client card review names OP-A** and now lives only in the private repo. It goes to him or to nobody.

--- a/docs/small_operator/examples/pumpoff_spm_from_stated_data.py
+++ b/docs/small_operator/examples/pumpoff_spm_from_stated_data.py
@@ -6,6 +6,23 @@
 What SPM would stop this well pounding? — from stated data alone
 ================================================================
 
+.. warning::
+
+   **SUPERSEDED IN PART, 2026-08-09. Do not quote the efficiency or the SPM
+   figure from this script.**
+
+   This module hand-rolls closed-form approximations that
+   ``dynacard.rod_pump`` (API RP 11L) already implements properly, and it was
+   missing the tubing-pressure term in the fluid load. Worse, it reports a
+   volumetric efficiency, which ``rod_pump.analyse()`` deliberately returns as
+   ``None`` because efficiency is undetermined without **runtime** and **Bo** —
+   surface barrels are not reservoir barrels, and a cycling unit's duty cycle
+   looks exactly like low fillage.
+
+   Kept as the worked derivation, because seeing the arithmetic is useful. For
+   any number that leaves this repo, use ``rod_pump.analyse()``. See
+   ``docs/small_operator/GROUNDING.md``.
+
 A community thread told the operator, correctly, that his well is pumping off
 and that the fix is to slow the unit or set a shutdown. Nobody gave him a
 **number**. This does, using only figures he posted publicly, so every step can


### PR DESCRIPTION
Direction change: **outreach stopped, nothing posted or emailed** until the work is grounded, built out, and can lead with a result rather than an offer.

## The first grounding check found a problem in our own output

`dynacard.rod_pump` implements **API RP 11L** and its documented example uses the same well our analysis scripts were written for. The scripts hand-rolled Mills-era closed forms beside it, and omitted the **tubing-pressure term** in the fluid load (150 psi × 1.227 in² = 184 lb).

| | hand-rolled | RP 11L module |
|---|---|---|
| Fluid load | 1,942 lb | 2,096 lb |
| Plunger stroke | 33.61 in | 33.29 in |
| Pump displacement | 39.19 bpd | 38.80 bpd |
| **Volumetric efficiency** | **0.587 — asserted** | **`None` — refused** |

The displacement error is small. The habit isn't: a hand-rolled copy inherits none of the module's validation, envelope checks or refusals.

## Two figures withdrawn

`rod_pump.analyse()` returns `volumetric_efficiency = None` on purpose — *"a cycling unit's duty cycle looks exactly like low fillage, and surface barrels are not reservoir barrels."*

We published **"~59% fillage"**, which requires assuming 24 h runtime and Bo = 1.0. The first is plausible here but still an assumption; the second is almost certainly wrong, and Bo of 1.05–1.15 moves the answer 5–15 points alone. The **"~4 SPM"** recommendation rested on it, plus on 23 bbl/d being inflow-limited — which needs a fluid-level shot. Both withdrawn in `HANDOFF.md`.

Had the drafted reply gone out, it would have led with a number our own fundamentals module declines to state.

## The largest gap, now written down

Every severe-pump-off claim rests on synthetic cards. The only real validation data spans **88–98% fillage** — the solver-parity test says so itself. That is why the corner-detection defect survived, and it is the thing to fix before any client work.

`GROUNDING.md` carries the ordered programme: route through `rod_pump`, read the primary sources and record what they license, acquire real severe-pump-off cards, validate the compression-zone model, close the screening-vs-solver gap.

## Verification
1132 tests pass · all example scripts run · `problems.yml` parses · abs-path gate clean · no identities in the public tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)