### PR TITLE
feat(reporting): let a report name the organisation that issues it

### DIFF
--- a/src/digitalmodel/reporting/calc_report.py
+++ b/src/digitalmodel/reporting/calc_report.py
@@ -91,6 +91,43 @@ def _esc(text: str) -> str:
     return text if ("<" in text or "&" in text) else html.escape(text)
 
 
+#: The house organisation, and the wordmark it is set in on the masthead.
+#: Only the house name gets the two-tone treatment. Where to split another
+#: organisation's name into stem and stress is a typographic decision about
+#: someone else's identity, and guessing it wrong is worse than not trying:
+#: any other name is set as plain text.
+_HOUSE_ORGANISATION = "AceEngineer"
+_HOUSE_WORDMARK = "Ace<b>Engineer</b>"
+
+
+def _wordmark(organisation: str) -> str:
+    """The masthead form of an organisation name."""
+    if organisation == _HOUSE_ORGANISATION:
+        return _HOUSE_WORDMARK
+    return _esc(organisation)
+
+
+def _logo_img(data_uri: str, alt: str) -> str:
+    """The masthead logo, or nothing when no logo is set.
+
+    Only a ``data:`` image URI is accepted. A report is a single
+    self-contained file that has to render from an email attachment with no
+    network, so a remote logo would leave a broken image on the client's
+    screen; and an arbitrary URI in an ``src`` attribute is the same
+    injection surface the reference links are guarded against.
+    """
+    if not data_uri:
+        return ""
+    if not data_uri.startswith("data:image/"):
+        raise ValueError(
+            "organisation_logo must be a self-contained data:image/ URI, "
+            f"not {data_uri[:32]!r}")
+    return (f'<img class="brand-logo" src="{html.escape(data_uri, quote=True)}" '
+            f'alt="{html.escape(alt, quote=True)}" '
+            'style="height:30px;width:auto;display:inline-block;'
+            'vertical-align:middle;margin-right:10px">')
+
+
 # ---------------------------------------------------------------------------
 # Typed section content
 # ---------------------------------------------------------------------------
@@ -393,6 +430,15 @@ class CalcReport(ReportDataModel):
     revision: str = "A"
     preliminary: bool = False
 
+    #: Who the report is issued by. Carried in three places that have to
+    #: agree -- the masthead, the footer byline and the foot-bar -- so they
+    #: are set from one field rather than three strings that can drift apart.
+    #: Defaults to the house mark, so an existing report is unchanged.
+    organisation: str = _HOUSE_ORGANISATION
+    #: Optional masthead logo as a self-contained ``data:`` image URI. Empty
+    #: by default: the house masthead is a wordmark, not an image.
+    organisation_logo: str = ""
+
     objective: Objective
     design_data: List[DesignDataGroup] = Field(default_factory=list)
     assumptions: List[DesignDataGroup] = Field(default_factory=list)
@@ -527,6 +573,9 @@ class CalcReport(ReportDataModel):
 
         prelim = " &middot; Preliminary" if self.preliminary else ""
         kpis = "".join(k.render() for k in self.kpis)
+        logo = _logo_img(self.organisation_logo, self.organisation)
+        brand = _wordmark(self.organisation)
+        org = html.escape(self.organisation)
 
         return f"""<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
@@ -536,7 +585,7 @@ class CalcReport(ReportDataModel):
 </head><body>
 <div class="doc" id="top">
   <header class="masthead"><div class="wrap" style="max-width:1240px">
-    <div class="brand">Ace<b>Engineer</b> &middot; {html.escape(self.discipline)}</div>
+    <div class="brand">{logo}{brand} &middot; {html.escape(self.discipline)}</div>
     <div class="mh-legend">
       <span class="lg"><span class="sw" style="background:var(--cfd)"></span>Validated</span>
       <span class="lg"><span class="sw" style="background:var(--ro)"></span>Analytical</span>
@@ -557,13 +606,13 @@ class CalcReport(ReportDataModel):
   <footer><div class="wrap" style="max-width:1240px">
     <div class="foot-grid">
       <div><h3>{html.escape(self.report_id)} &middot; Rev {html.escape(self.revision)}</h3>
-        <p>Prepared by AceEngineer {html.escape(self.discipline)}.</p></div>
+        <p>Prepared by {org} {html.escape(self.discipline)}.</p></div>
       <div><h3>Provenance</h3><ul>
         <li><span class="num">Teal</span> &mdash; validated</li>
         <li><span class="num">Amber</span> &mdash; analytical, assumptions carried</li>
         <li><span class="num">Muted</span> &mdash; pending data</li></ul></div>
     </div>
-    <div class="foot-bar"><span>AceEngineer &middot; {html.escape(self.discipline)}</span>
+    <div class="foot-bar"><span>{org} &middot; {html.escape(self.discipline)}</span>
       <span>Standard calculation report format &middot; Rev A</span></div>
   </div></footer>
 </div>

--- a/tests/reporting/test_calc_report.py
+++ b/tests/reporting/test_calc_report.py
@@ -239,3 +239,88 @@ def test_print_uses_auto_table_layout_not_fixed():
     html_out = minimal_report().render_html()
     assert "table-layout: auto" in html_out
     assert "table-layout: fixed" not in html_out
+
+
+# ---------------------------------------------------------------------------
+# The organisation marks
+#
+# A report carries the issuing organisation in three places that have to agree
+# -- masthead, footer byline, foot-bar. They are driven from one field so they
+# cannot drift apart, and that field defaults to the house mark so that adding
+# it moved no report that already existed.
+# ---------------------------------------------------------------------------
+
+#: The three marks exactly as they rendered *before* `organisation` and
+#: `organisation_logo` existed, captured from the previous revision of the
+#: module. They are byte-for-byte, not fuzzy matches: the point of the default
+#: is that every report already in a client's hands still renders the same.
+HOUSE_MASTHEAD = '<div class="brand">Ace<b>Engineer</b> &middot; Test</div>'
+HOUSE_BYLINE = "<p>Prepared by AceEngineer Test.</p>"
+HOUSE_FOOT_BAR = '<div class="foot-bar"><span>AceEngineer &middot; Test</span>'
+
+#: SHA-256 of the whole rendered document for the same report, captured at the
+#: same point. The three assertions above name what changed if this moves; this
+#: one catches a change anywhere else in the page. A deliberate house-format
+#: change is expected to move it -- regenerate it then, having first read the
+#: diff and confirmed the marks above are still intact.
+HOUSE_RENDER_SHA256 = (
+    "5f8da8c0b4bb55e634a8250ed51b74727c1922dfb28ef49a494cb17ac0d9c558")
+
+
+def test_default_organisation_renders_the_house_marks_unchanged():
+    """A report that sets neither field renders byte-identically to before."""
+    import hashlib
+
+    html_out = minimal_report().render_html()
+    assert HOUSE_MASTHEAD in html_out, "the masthead wordmark moved"
+    assert HOUSE_BYLINE in html_out, "the footer byline moved"
+    assert HOUSE_FOOT_BAR in html_out, "the foot-bar mark moved"
+    assert "brand-logo" not in html_out, (
+        "the house masthead is a wordmark; no logo element belongs in it")
+    assert hashlib.sha256(html_out.encode()).hexdigest() == HOUSE_RENDER_SHA256, (
+        "the rendered house report is no longer byte-identical; see "
+        "HOUSE_RENDER_SHA256")
+
+
+def test_organisation_carries_to_all_three_marks():
+    """Setting the organisation moves every mark, not just the masthead.
+
+    A masthead that says one organisation over a footer that says another is
+    the mixed-branding defect this field exists to prevent.
+    """
+    html_out = minimal_report(organisation="Nordwind Marine Ltd").render_html()
+    assert '<div class="brand">Nordwind Marine Ltd &middot; Test</div>' in html_out
+    assert "<p>Prepared by Nordwind Marine Ltd Test.</p>" in html_out
+    assert ('<div class="foot-bar"><span>Nordwind Marine Ltd &middot; Test</span>'
+            in html_out)
+    assert "AceEngineer" not in html_out, (
+        "no house mark may survive in a report issued by someone else")
+
+
+def test_only_the_house_name_gets_the_two_tone_wordmark():
+    """Another organisation's name is set plain, not split at a guessed seam."""
+    html_out = minimal_report(organisation="Ace Marine").render_html()
+    assert "<b>" not in re.search(
+        r'<div class="brand">.*?</div>', html_out, re.S).group(0)
+
+
+def test_an_organisation_logo_renders_in_the_masthead():
+    pixel = ("data:image/gif;base64,"
+             "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7")
+    html_out = minimal_report(
+        organisation="Nordwind Marine Ltd", organisation_logo=pixel).render_html()
+    brand = re.search(r'<div class="brand">.*?</div>', html_out, re.S).group(0)
+    assert f'src="{pixel}"' in brand
+    assert 'alt="Nordwind Marine Ltd"' in brand, (
+        "the logo carries the organisation as its accessible name")
+    assert brand.index("<img") < brand.index("Nordwind"), (
+        "the logo precedes the name on the first line")
+
+
+def test_a_logo_that_is_not_self_contained_is_refused():
+    """A remote logo leaves a broken image on a client reading offline, and an
+    arbitrary URI in an ``src`` is the injection surface the reference links
+    are already guarded against."""
+    report = minimal_report(organisation_logo="https://example.invalid/logo.png")
+    with pytest.raises(ValueError, match="data:image/"):
+        report.render_html()


### PR DESCRIPTION
## What

`CalcReport` hardcoded the house mark in three places -- the masthead wordmark, the footer `Prepared by ...` byline and the foot-bar. A report issued under a different organisation could not carry its own identity, and patching the three strings per report is exactly how a masthead ends up disagreeing with a footer.

Two new fields:

| field | default | drives |
|---|---|---|
| `organisation` | the house name | masthead, footer byline, foot-bar -- all three from one value |
| `organisation_logo` | `""` | an optional masthead logo, as a self-contained `data:` image URI |

## Why it is safe for every existing report

Both fields default to the present marks, so a report that sets neither renders **byte-identically**. `test_default_organisation_renders_the_house_marks_unchanged` pins that two ways: the three mark strings verbatim as they rendered before these fields existed, and a SHA-256 of the whole rendered document. The three string assertions name what moved; the hash catches a change anywhere else on the page.

## Design notes

- **Logo must be a `data:` URI.** A report is one self-contained file, opened from an email attachment with no network -- a remote logo is a broken image on the reader's screen. An arbitrary URI in an `src` is also the same injection surface `Reference.url` is already guarded against, so a non-`data:` logo raises rather than rendering.
- **Only the house name gets the two-tone wordmark.** Where to split another organisation's name into stem and stress is a typographic decision about someone else's identity, and guessing wrong is worse than not trying. Any other name is set plain.

## Test

```
uv run --with-editable '.[test]' python -m pytest tests/reporting/ -q -o addopts=""
69 passed
```

flake8 on both changed files reports only the three findings already present on the base commit.

## Base

Stacked on `feat/1173-calm-water-hull-resistance`, which is where `RevisionEntry` lives -- this change builds on that branch's rendering work and does not apply to `main` on its own.

Refs #1173.