### PR TITLE
feat(reporting): revision history, reference URLs, and an issuing organisation

### DIFF
--- a/src/digitalmodel/reporting/assets/calc_report_format.html
+++ b/src/digitalmodel/reporting/assets/calc_report_format.html
@@ -240,14 +240,24 @@
   .chip{font-family:var(--mono);font-size:11.5px;background:var(--surface);border:1px solid var(--hairline);border-radius:999px;padding:5px 11px;color:var(--ink-2)}
 
   /* data / definition tables */
-  .datagrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px;margin-top:4px}
+  /* Single column, always. A multi-column track promised a 260px minimum,
+     but `.kv table{min-width:0}` below defeats the 440px floor this sheet
+     sets for every other table, and `.kv{overflow:hidden}` turns that into
+     SILENT TRUNCATION -- values cut mid-word with no visual cue. The grid
+     was only ever safe for groups with short labels AND short values, and
+     no report can promise that. See the min-width follow-up issue. */
+  .datagrid{display:grid;grid-template-columns:1fr;gap:18px;margin-top:4px}
   .kv{border:1px solid var(--hairline);border-radius:12px;overflow:hidden;background:var(--surface);box-shadow:var(--shadow)}
   .kv .cap{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-muted);
     padding:11px 15px;background:var(--surface-2);border-bottom:1px solid var(--hairline);font-weight:600}
   .kv table{min-width:0}
   .kv td{border-bottom:1px solid var(--hairline)}
   .kv tr:last-child td{border-bottom:none}
-  .kv td:first-child{color:var(--ink-2)}
+  /* Label sized to its own content, value takes the remaining measure, so a
+     row reads as one line across the page instead of a stub with dead space
+     beside it -- and a long value wraps rather than being clipped. */
+  .kv td:first-child{color:var(--ink-2);width:1%;white-space:nowrap;padding-right:30px}
+  .kv td:last-child{width:99%;white-space:normal;overflow-wrap:break-word}
   .kv td:last-child{color:var(--ink);font-weight:600;font-family:var(--mono);font-size:13px}
   .kv td .un{color:var(--ink-muted);font-weight:400;font-size:11px}
 

--- a/src/digitalmodel/reporting/calc_report.py
+++ b/src/digitalmodel/reporting/calc_report.py
@@ -558,17 +558,16 @@ class CalcReport(ReportDataModel):
         return (
             '<div class="l2" id="s8-1"><div class="l2head"><span class="n"></span>'
             "<h3>Issued revisions</h3></div>"
-            '<p class="prose">Each row is one issue of this document to the '
-            "client. The revision letter moves only on issue; it is set when "
-            "the document is sent, not when it is edited. This is the record "
-            "of what has been received.</p>"
+            '<p class="prose">One row per issue to the client. The revision '
+            "letter moves only on issue: it is set when the document is sent, "
+            "not when it is edited.</p>"
             f"{issued}</div>"
             '<div class="l2" id="s8-2"><div class="l2head"><span class="n"></span>'
             "<h3>Internal revisions</h3></div>"
             '<p class="prose">Changes made within the issuing organisation '
-            "between issues, numbered under the revision letter they will be "
-            "issued as. These have not been separately issued to the client: "
-            "they are folded into the next lettered revision above.</p>"
+            "between issues, numbered under the letter they will be issued "
+            "as. They are folded into the lettered revision above, not "
+            "separately issued.</p>"
             f"{self._revhist_table(internal_rows)}</div>"
         )
 

--- a/src/digitalmodel/reporting/calc_report.py
+++ b/src/digitalmodel/reporting/calc_report.py
@@ -342,11 +342,44 @@ class Reference(ReportDataModel):
 
 
 class RevisionEntry(ReportDataModel):
-    """One row of the revision history.
+    """One row of the revision history: one issue to the client.
 
     The header already carries the CURRENT revision. This is the trail behind
     it, which is what a reviewer holding an earlier copy actually needs: not
     which revision this is, but what changed since theirs.
+
+    ``revision`` is a letter -- A, B, C -- and it moves only when the report is
+    issued to the client. It is never derived and never auto-incremented: the
+    person issuing the report sets it. An internal edit is not an issue, and a
+    letter that moved without one would tell a client they are holding a
+    superseded document when they are not.
+
+    ``incorporates`` names the internal range that issue folded in, e.g.
+    ``"A.1-A.9"``. It is the link between the two tiers and is optional: a
+    report that keeps no internal log has nothing to point at.
+    """
+
+    revision: str
+    date: str
+    description: str
+    by: Optional[str] = None
+    incorporates: str = ""
+
+
+class InternalRevision(ReportDataModel):
+    """One staff change to the document between issues.
+
+    Numbered under the main letter that is currently pending -- ``A.1``,
+    ``A.2``, ``A.3`` -- so the number says at a glance which issue the work
+    belongs to, and the internal log resets naturally when the letter moves.
+
+    These rows are client-visible in the delivered PDF. They record what
+    changed in the document, not why: "waterline lengths corrected across the
+    condition matrix" is a revision entry, an account of how the error got
+    there is not.
+
+    ``by`` should name the function that made the change rather than an
+    individual, unless the individual is genuinely known.
     """
 
     revision: str
@@ -448,7 +481,15 @@ class CalcReport(ReportDataModel):
     way_forward: List[WayForwardStage] = Field(default_factory=list)
     references: List[Reference] = Field(default_factory=list)
     kpis: List[KPI] = Field(default_factory=list)
+    #: The client-facing trail: one row per issue, keyed by revision letter.
     revision_history: List[RevisionEntry] = Field(default_factory=list)
+    #: The staff change log between issues, keyed A.1, A.2, ... under the
+    #: pending letter. Rendered beneath the issued table and labelled apart
+    #: from it. Empty by default, so no report that predates it changes.
+    #: Rendered in the order given -- descending is the house convention, but
+    #: sorting "A.10" against "A.9" as strings would invert them, and the
+    #: caller already knows the order it means.
+    internal_revisions: List[InternalRevision] = Field(default_factory=list)
 
     def completeness(self):
         """Which required house sections are still empty."""
@@ -473,6 +514,62 @@ class CalcReport(ReportDataModel):
             f"<h2>{title}</h2></div>"
             f'<p class="l1sub">{_esc(subtitle)}</p>{body}'
             f'<a class="backtop" href="#top">↑ contents</a></section>'
+        )
+
+    @staticmethod
+    def _revhist_table(rows: str, incorporates: bool = False) -> str:
+        """The house revision table. Both tiers use it, so they read alike."""
+        inc = "<th>Incorporates</th>" if incorporates else ""
+        return ('<table class="revhist"><thead><tr><th>Rev</th><th>Date</th>'
+                f'<th>Description</th>{inc}<th>By</th></tr></thead>'
+                f"<tbody>{rows}</tbody></table>")
+
+    def _revision_history(self) -> str:
+        """The revision-history body: the issued table, then the internal log.
+
+        The issued table is first and is the client-facing record. When there
+        is an internal log beneath it, both tiers are given a labelled
+        subsection so a client reading the PDF cannot mistake our change log
+        for the list of documents they have been sent. When there is no
+        internal log there is nothing to distinguish, so the labels are not
+        rendered -- which is also what keeps every report that predates this
+        feature byte-identical.
+        """
+        # The Incorporates column earns its place only when a row uses it. A
+        # permanently-empty column in a client-facing table is noise, and
+        # rendering it unconditionally would move every existing report.
+        show_inc = any(h.incorporates for h in self.revision_history)
+        issued_rows = "".join(
+            f'<tr><td>{_esc(h.revision)}</td><td>{_esc(h.date)}</td>'
+            f"<td>{_esc(h.description)}</td>"
+            + (f"<td>{_esc(h.incorporates)}</td>" if show_inc else "")
+            + f'<td>{_esc(h.by or "")}</td></tr>'
+            for h in self.revision_history)
+        issued = self._revhist_table(issued_rows, incorporates=show_inc)
+
+        if not self.internal_revisions:
+            return issued
+
+        internal_rows = "".join(
+            f'<tr><td>{_esc(r.revision)}</td><td>{_esc(r.date)}</td>'
+            f"<td>{_esc(r.description)}</td>"
+            f'<td>{_esc(r.by or "")}</td></tr>'
+            for r in self.internal_revisions)
+        return (
+            '<div class="l2" id="s8-1"><div class="l2head"><span class="n"></span>'
+            "<h3>Issued revisions</h3></div>"
+            '<p class="prose">Each row is one issue of this document to the '
+            "client. The revision letter moves only on issue; it is set when "
+            "the document is sent, not when it is edited. This is the record "
+            "of what has been received.</p>"
+            f"{issued}</div>"
+            '<div class="l2" id="s8-2"><div class="l2head"><span class="n"></span>'
+            "<h3>Internal revisions</h3></div>"
+            '<p class="prose">Changes made within the issuing organisation '
+            "between issues, numbered under the revision letter they will be "
+            "issued as. These have not been separately issued to the client: "
+            "they are folded into the next lettered revision above.</p>"
+            f"{self._revhist_table(internal_rows)}</div>"
         )
 
     def _toc(self) -> str:
@@ -558,18 +655,11 @@ class CalcReport(ReportDataModel):
                            "Methods, data sources, traceability.",
                            f'<ol class="refs">{refs}</ol>')
 
-        if self.revision_history:
-            rows = "".join(
-                f'<tr><td>{_esc(h.revision)}</td><td>{_esc(h.date)}</td>'
-                f'<td>{_esc(h.description)}</td>'
-                f'<td>{_esc(h.by or "")}</td></tr>'
-                for h in self.revision_history)
+        if self.revision_history or self.internal_revisions:
             s7 += self._section(
                 "s8", "Revision history",
                 "What changed, and when.",
-                '<table class="revhist"><thead><tr><th>Rev</th><th>Date</th>'
-                '<th>Description</th><th>By</th></tr></thead>'
-                f'<tbody>{rows}</tbody></table>')
+                self._revision_history())
 
         prelim = " &middot; Preliminary" if self.preliminary else ""
         kpis = "".join(k.render() for k in self.kpis)
@@ -690,11 +780,13 @@ __all__ = [
     "DataRow",
     "DesignDataGroup",
     "Equation",
+    "InternalRevision",
     "KPI",
     "MethodBlock",
     "Objective",
     "Reference",
     "ResultBlock",
+    "RevisionEntry",
     "ValidationItem",
     "VariableDef",
     "WayForwardStage",

--- a/src/digitalmodel/reporting/calc_report.py
+++ b/src/digitalmodel/reporting/calc_report.py
@@ -91,6 +91,43 @@ def _esc(text: str) -> str:
     return text if ("<" in text or "&" in text) else html.escape(text)
 
 
+#: The house organisation, and the wordmark it is set in on the masthead.
+#: Only the house name gets the two-tone treatment. Where to split another
+#: organisation's name into stem and stress is a typographic decision about
+#: someone else's identity, and guessing it wrong is worse than not trying:
+#: any other name is set as plain text.
+_HOUSE_ORGANISATION = "AceEngineer"
+_HOUSE_WORDMARK = "Ace<b>Engineer</b>"
+
+
+def _wordmark(organisation: str) -> str:
+    """The masthead form of an organisation name."""
+    if organisation == _HOUSE_ORGANISATION:
+        return _HOUSE_WORDMARK
+    return _esc(organisation)
+
+
+def _logo_img(data_uri: str, alt: str) -> str:
+    """The masthead logo, or nothing when no logo is set.
+
+    Only a ``data:`` image URI is accepted. A report is a single
+    self-contained file that has to render from an email attachment with no
+    network, so a remote logo would leave a broken image on the client's
+    screen; and an arbitrary URI in an ``src`` attribute is the same
+    injection surface the reference links are guarded against.
+    """
+    if not data_uri:
+        return ""
+    if not data_uri.startswith("data:image/"):
+        raise ValueError(
+            "organisation_logo must be a self-contained data:image/ URI, "
+            f"not {data_uri[:32]!r}")
+    return (f'<img class="brand-logo" src="{html.escape(data_uri, quote=True)}" '
+            f'alt="{html.escape(alt, quote=True)}" '
+            'style="height:30px;width:auto;display:inline-block;'
+            'vertical-align:middle;margin-right:10px">')
+
+
 # ---------------------------------------------------------------------------
 # Typed section content
 # ---------------------------------------------------------------------------
@@ -291,9 +328,31 @@ class WayForwardStage(ReportDataModel):
 
 
 class Reference(ReportDataModel):
-    """One cited standard, paper or data source."""
+    """One cited standard, paper or data source.
+
+    ``url`` is optional and rendered as a link on the citation text when
+    present. A reference a reader cannot follow is a claim of provenance
+    rather than provenance itself -- but many legitimate sources have no
+    public URL (a purchased standard, a client-supplied model), so this is
+    where-applicable and never required.
+    """
 
     text: str
+    url: Optional[str] = None
+
+
+class RevisionEntry(ReportDataModel):
+    """One row of the revision history.
+
+    The header already carries the CURRENT revision. This is the trail behind
+    it, which is what a reviewer holding an earlier copy actually needs: not
+    which revision this is, but what changed since theirs.
+    """
+
+    revision: str
+    date: str
+    description: str
+    by: Optional[str] = None
 
 
 class KPI(ReportDataModel):
@@ -371,6 +430,15 @@ class CalcReport(ReportDataModel):
     revision: str = "A"
     preliminary: bool = False
 
+    #: Who the report is issued by. Carried in three places that have to
+    #: agree -- the masthead, the footer byline and the foot-bar -- so they
+    #: are set from one field rather than three strings that can drift apart.
+    #: Defaults to the house mark, so an existing report is unchanged.
+    organisation: str = _HOUSE_ORGANISATION
+    #: Optional masthead logo as a self-contained ``data:`` image URI. Empty
+    #: by default: the house masthead is a wordmark, not an image.
+    organisation_logo: str = ""
+
     objective: Objective
     design_data: List[DesignDataGroup] = Field(default_factory=list)
     assumptions: List[DesignDataGroup] = Field(default_factory=list)
@@ -380,6 +448,7 @@ class CalcReport(ReportDataModel):
     way_forward: List[WayForwardStage] = Field(default_factory=list)
     references: List[Reference] = Field(default_factory=list)
     kpis: List[KPI] = Field(default_factory=list)
+    revision_history: List[RevisionEntry] = Field(default_factory=list)
 
     def completeness(self):
         """Which required house sections are still empty."""
@@ -473,15 +542,40 @@ class CalcReport(ReportDataModel):
             "the answer.",
             "".join(s.render(i) for i, s in enumerate(self.way_forward, start=1)))
 
+        def _ref_body(r: "Reference") -> str:
+            # Only http(s) is linkified: a javascript: or data: URL in a
+            # citation field would be an injection vector, and no legitimate
+            # reference needs one.
+            if r.url and r.url.startswith(("http://", "https://")):
+                return (f'<a href="{_esc(r.url)}" rel="noopener noreferrer" '
+                        f'target="_blank">{_esc(r.text)}</a>')
+            return _esc(r.text)
+
         refs = "".join(
-            f'<li><span class="rn">R{i}</span><span>{_esc(r.text)}</span></li>'
+            f'<li><span class="rn">R{i}</span><span>{_ref_body(r)}</span></li>'
             for i, r in enumerate(self.references, start=1))
         s7 = self._section("s7", "References &amp; provenance",
                            "Methods, data sources, traceability.",
                            f'<ol class="refs">{refs}</ol>')
 
+        if self.revision_history:
+            rows = "".join(
+                f'<tr><td>{_esc(h.revision)}</td><td>{_esc(h.date)}</td>'
+                f'<td>{_esc(h.description)}</td>'
+                f'<td>{_esc(h.by or "")}</td></tr>'
+                for h in self.revision_history)
+            s7 += self._section(
+                "s8", "Revision history",
+                "What changed, and when.",
+                '<table class="revhist"><thead><tr><th>Rev</th><th>Date</th>'
+                '<th>Description</th><th>By</th></tr></thead>'
+                f'<tbody>{rows}</tbody></table>')
+
         prelim = " &middot; Preliminary" if self.preliminary else ""
         kpis = "".join(k.render() for k in self.kpis)
+        logo = _logo_img(self.organisation_logo, self.organisation)
+        brand = _wordmark(self.organisation)
+        org = html.escape(self.organisation)
 
         return f"""<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
@@ -491,7 +585,7 @@ class CalcReport(ReportDataModel):
 </head><body>
 <div class="doc" id="top">
   <header class="masthead"><div class="wrap" style="max-width:1240px">
-    <div class="brand">Ace<b>Engineer</b> &middot; {html.escape(self.discipline)}</div>
+    <div class="brand">{logo}{brand} &middot; {html.escape(self.discipline)}</div>
     <div class="mh-legend">
       <span class="lg"><span class="sw" style="background:var(--cfd)"></span>Validated</span>
       <span class="lg"><span class="sw" style="background:var(--ro)"></span>Analytical</span>
@@ -512,13 +606,13 @@ class CalcReport(ReportDataModel):
   <footer><div class="wrap" style="max-width:1240px">
     <div class="foot-grid">
       <div><h3>{html.escape(self.report_id)} &middot; Rev {html.escape(self.revision)}</h3>
-        <p>Prepared by AceEngineer {html.escape(self.discipline)}.</p></div>
+        <p>Prepared by {org} {html.escape(self.discipline)}.</p></div>
       <div><h3>Provenance</h3><ul>
         <li><span class="num">Teal</span> &mdash; validated</li>
         <li><span class="num">Amber</span> &mdash; analytical, assumptions carried</li>
         <li><span class="num">Muted</span> &mdash; pending data</li></ul></div>
     </div>
-    <div class="foot-bar"><span>AceEngineer &middot; {html.escape(self.discipline)}</span>
+    <div class="foot-bar"><span>{org} &middot; {html.escape(self.discipline)}</span>
       <span>Standard calculation report format &middot; Rev A</span></div>
   </div></footer>
 </div>
@@ -574,8 +668,12 @@ _PRINT_CSS = """
   .datagrid { display: block !important; }
   .datagrid > .kv { width: 100% !important; margin: 0 0 10px 0 !important;
                     break-inside: avoid; page-break-inside: avoid; }
-  .kv table { width: 100% !important; table-layout: fixed !important; }
-  .kv td { word-break: break-word !important; white-space: normal !important; }
+  /* auto, not fixed: `fixed` split every row 50/50, spending half the page
+     measure on a short label while the value wrapped beside it. */
+  .kv table { width: 100% !important; table-layout: auto !important; }
+  .kv td:first-child { white-space: nowrap !important; width: 1% !important; }
+  .kv td:last-child { white-space: normal !important; word-break: break-word !important;
+                      width: 99% !important; text-align: right; }
   .kpis { display: grid !important; grid-template-columns: 1fr 1fr !important; }
   section { break-inside: auto; }
   .l1head, .l2head { break-after: avoid; page-break-after: avoid; }

--- a/tests/reporting/test_calc_report.py
+++ b/tests/reporting/test_calc_report.py
@@ -7,6 +7,8 @@ things worth pinning are the section order, the provenance encoding, and the
 completeness gate that stops a half-written report shipping.
 """
 
+import re
+
 import pytest
 
 from digitalmodel.reporting import (
@@ -151,3 +153,174 @@ def test_print_stylesheet_collapses_the_data_grid():
     html = minimal_report().render_html()
     assert "@media print" in html
     assert ".datagrid { display: block !important; }" in html
+
+
+def test_a_reference_with_a_url_renders_as_a_link():
+    """A reference a reader cannot follow is a claim of provenance, not
+    provenance. Where a source has a public URL, it should be reachable."""
+    from digitalmodel.reporting.calc_report import Reference
+    r = Reference(text="ITTC 7.5-03-01-01", url="https://example.org/ittc")
+    report = minimal_report(references=[r])
+    html_out = report.render_html()
+    assert 'href="https://example.org/ittc"' in html_out
+    assert "ITTC 7.5-03-01-01" in html_out
+    assert 'rel="noopener noreferrer"' in html_out
+
+
+def test_a_reference_without_a_url_is_still_valid():
+    """Purchased standards and client-supplied models have no public URL.
+    The field is where-applicable, never required."""
+    from digitalmodel.reporting.calc_report import Reference
+    report = minimal_report(references=[Reference(text="Client hull model")])
+    html_out = report.render_html()
+    assert "Client hull model" in html_out
+    assert "<a href" not in html_out.split('class="refs"')[1].split("</ol>")[0]
+
+
+def test_a_non_http_reference_url_is_not_linkified():
+    """A javascript: or data: URL in a citation field is an injection vector
+    and no legitimate reference needs one."""
+    from digitalmodel.reporting.calc_report import Reference
+    report = minimal_report(
+        references=[Reference(text="bad", url="javascript:alert(1)")])
+    html_out = report.render_html()
+    assert "javascript:" not in html_out
+
+
+def test_revision_history_renders_when_present():
+    """The header carries the CURRENT revision; a reviewer holding an earlier
+    copy needs the trail behind it."""
+    from digitalmodel.reporting.calc_report import RevisionEntry
+    report = minimal_report(revision_history=[
+        RevisionEntry(revision="A", date="2026-08-21",
+                      description="First issue", by="AE"),
+        RevisionEntry(revision="B", date="2026-08-22",
+                      description="Conditions updated"),
+    ])
+    html_out = report.render_html()
+    assert "Revision history" in html_out
+    assert "First issue" in html_out and "Conditions updated" in html_out
+
+
+def test_revision_history_is_optional():
+    """A first issue has no history and must not render an empty table."""
+    assert "Revision history" not in minimal_report().render_html()
+
+
+def test_design_data_tables_stack_rather_than_sitting_abreast():
+    """A multi-column datagrid truncated values, it did not merely tighten them.
+
+    The track promised a 260px minimum, `.kv table{min-width:0}` defeated the
+    440px floor this sheet sets for every other table, and `.kv{overflow:hidden}`
+    turned the contradiction into values cut mid-word with no visual cue. Two
+    client-facing reports lost data to it before it was found.
+    """
+    html_out = minimal_report().render_html()
+    grid = re.search(r"\.datagrid\{[^}]*\}", html_out)
+    assert grid, "the datagrid rule must exist"
+    assert "grid-template-columns:1fr" in grid.group(0), grid.group(0)
+    assert "auto-fit" not in grid.group(0), (
+        "a multi-column track reintroduces the truncation")
+
+
+def test_a_long_design_data_value_can_wrap_instead_of_being_clipped():
+    """The label is sized to its content and the value takes the remainder, so
+    a long value wraps rather than being clipped by the container."""
+    html_out = minimal_report().render_html()
+    assert re.search(r"\.kv td:last-child\{[^}]*white-space:normal", html_out), (
+        "the value cell must be allowed to wrap")
+    assert re.search(r"\.kv td:first-child\{[^}]*white-space:nowrap", html_out), (
+        "the label cell must not wrap; that is what keeps a row on one line")
+
+
+def test_print_uses_auto_table_layout_not_fixed():
+    """`fixed` split every row 50/50, spending half the page measure on a short
+    label while the value wrapped beside it."""
+    html_out = minimal_report().render_html()
+    assert "table-layout: auto" in html_out
+    assert "table-layout: fixed" not in html_out
+
+
+# ---------------------------------------------------------------------------
+# The organisation marks
+#
+# A report carries the issuing organisation in three places that have to agree
+# -- masthead, footer byline, foot-bar. They are driven from one field so they
+# cannot drift apart, and that field defaults to the house mark so that adding
+# it moved no report that already existed.
+# ---------------------------------------------------------------------------
+
+#: The three marks exactly as they rendered *before* `organisation` and
+#: `organisation_logo` existed, captured from the previous revision of the
+#: module. They are byte-for-byte, not fuzzy matches: the point of the default
+#: is that every report already in a client's hands still renders the same.
+HOUSE_MASTHEAD = '<div class="brand">Ace<b>Engineer</b> &middot; Test</div>'
+HOUSE_BYLINE = "<p>Prepared by AceEngineer Test.</p>"
+HOUSE_FOOT_BAR = '<div class="foot-bar"><span>AceEngineer &middot; Test</span>'
+
+#: SHA-256 of the whole rendered document for the same report, captured at the
+#: same point. The three assertions above name what changed if this moves; this
+#: one catches a change anywhere else in the page. A deliberate house-format
+#: change is expected to move it -- regenerate it then, having first read the
+#: diff and confirmed the marks above are still intact.
+HOUSE_RENDER_SHA256 = (
+    "5f8da8c0b4bb55e634a8250ed51b74727c1922dfb28ef49a494cb17ac0d9c558")
+
+
+def test_default_organisation_renders_the_house_marks_unchanged():
+    """A report that sets neither field renders byte-identically to before."""
+    import hashlib
+
+    html_out = minimal_report().render_html()
+    assert HOUSE_MASTHEAD in html_out, "the masthead wordmark moved"
+    assert HOUSE_BYLINE in html_out, "the footer byline moved"
+    assert HOUSE_FOOT_BAR in html_out, "the foot-bar mark moved"
+    assert "brand-logo" not in html_out, (
+        "the house masthead is a wordmark; no logo element belongs in it")
+    assert hashlib.sha256(html_out.encode()).hexdigest() == HOUSE_RENDER_SHA256, (
+        "the rendered house report is no longer byte-identical; see "
+        "HOUSE_RENDER_SHA256")
+
+
+def test_organisation_carries_to_all_three_marks():
+    """Setting the organisation moves every mark, not just the masthead.
+
+    A masthead that says one organisation over a footer that says another is
+    the mixed-branding defect this field exists to prevent.
+    """
+    html_out = minimal_report(organisation="Nordwind Marine Ltd").render_html()
+    assert '<div class="brand">Nordwind Marine Ltd &middot; Test</div>' in html_out
+    assert "<p>Prepared by Nordwind Marine Ltd Test.</p>" in html_out
+    assert ('<div class="foot-bar"><span>Nordwind Marine Ltd &middot; Test</span>'
+            in html_out)
+    assert "AceEngineer" not in html_out, (
+        "no house mark may survive in a report issued by someone else")
+
+
+def test_only_the_house_name_gets_the_two_tone_wordmark():
+    """Another organisation's name is set plain, not split at a guessed seam."""
+    html_out = minimal_report(organisation="Ace Marine").render_html()
+    assert "<b>" not in re.search(
+        r'<div class="brand">.*?</div>', html_out, re.S).group(0)
+
+
+def test_an_organisation_logo_renders_in_the_masthead():
+    pixel = ("data:image/gif;base64,"
+             "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7")
+    html_out = minimal_report(
+        organisation="Nordwind Marine Ltd", organisation_logo=pixel).render_html()
+    brand = re.search(r'<div class="brand">.*?</div>', html_out, re.S).group(0)
+    assert f'src="{pixel}"' in brand
+    assert 'alt="Nordwind Marine Ltd"' in brand, (
+        "the logo carries the organisation as its accessible name")
+    assert brand.index("<img") < brand.index("Nordwind"), (
+        "the logo precedes the name on the first line")
+
+
+def test_a_logo_that_is_not_self_contained_is_refused():
+    """A remote logo leaves a broken image on a client reading offline, and an
+    arbitrary URI in an ``src`` is the injection surface the reference links
+    are already guarded against."""
+    report = minimal_report(organisation_logo="https://example.invalid/logo.png")
+    with pytest.raises(ValueError, match="data:image/"):
+        report.render_html()

--- a/tests/reporting/test_calc_report.py
+++ b/tests/reporting/test_calc_report.py
@@ -324,3 +324,168 @@ def test_a_logo_that_is_not_self_contained_is_refused():
     report = minimal_report(organisation_logo="https://example.invalid/logo.png")
     with pytest.raises(ValueError, match="data:image/"):
         report.render_html()
+
+
+# ---------------------------------------------------------------------------
+# The two revision tiers
+#
+# A client-facing report carries two different kinds of "revision" and they
+# must never be confused for one another:
+#
+#   * the MAIN revision -- letters A, B, C -- which moves only when the report
+#     is issued to the client. It is set by hand, never derived, never
+#     auto-incremented. It is the record of what the client has been given.
+#   * the INTERNAL revisions -- A.1, A.2, ... nested under the main letter that
+#     is currently pending -- which record what staff changed between issues.
+#
+# The main table stays first and stays the client-facing record; the internal
+# log sits beneath it, labelled so a client reading the PDF cannot mistake one
+# for the other. `incorporates` on a main row names the internal range that
+# issue folded in, which is the link between the two tiers.
+# ---------------------------------------------------------------------------
+
+
+def _revised_report(**overrides):
+    """A report carrying the pre-existing single-tier revision history."""
+    from digitalmodel.reporting.calc_report import RevisionEntry
+    base = dict(revision_history=[
+        RevisionEntry(revision="A", date="2026-08-21",
+                      description="First issue", by="AE"),
+    ])
+    base.update(overrides)
+    return minimal_report(**base)
+
+
+#: The revision-history section exactly as it rendered *before* the internal
+#: tier existed. Byte-for-byte, for the same reason the organisation marks are:
+#: a report that does not opt into the second tier must be unmoved by its
+#: arrival. If this string has to change, the change is not backward
+#: compatible and the two-tier feature has leaked into the single-tier path.
+SINGLE_TIER_REVHIST = (
+    '<table class="revhist"><thead><tr><th>Rev</th><th>Date</th>'
+    '<th>Description</th><th>By</th></tr></thead>'
+    '<tbody><tr><td>A</td><td>2026-08-21</td>'
+    '<td>First issue</td><td>AE</td></tr></tbody></table>'
+)
+
+#: SHA-256 of the whole rendered document for that same single-tier report.
+#: HOUSE_RENDER_SHA256 above covers a report with no revision history at all;
+#: this one covers the report that has one and declines the second tier, which
+#: is the case the internal-revision work could most easily have moved.
+#: Captured by rendering this exact report against the module as it stood
+#: *before* `InternalRevision` and `incorporates` were added, not by copying
+#: the value the changed code happened to produce.
+SINGLE_TIER_RENDER_SHA256 = (
+    "8bc5345b0ea3e25af0ae3d6e52d100aabf7aa73ccf9f98fa389eba72f8edbabf")
+
+
+def test_a_single_tier_report_is_unmoved_by_the_internal_tier():
+    """Setting neither `internal_revisions` nor `incorporates` renders exactly
+    what rendered before either field existed."""
+    import hashlib
+
+    html_out = _revised_report().render_html()
+    assert SINGLE_TIER_REVHIST in html_out, (
+        "the single-tier revision table moved; the two-tier feature has "
+        "leaked into the path that does not use it")
+    assert "Internal revisions" not in html_out, (
+        "a report with no internal revisions must not render the subsection")
+    assert "Incorporates" not in html_out, (
+        "the Incorporates column must not appear when no row names a range")
+    assert hashlib.sha256(html_out.encode()).hexdigest() == SINGLE_TIER_RENDER_SHA256
+
+
+def test_internal_revisions_render_beneath_the_main_table():
+    """The main table stays first; the internal log sits under it, labelled."""
+    from digitalmodel.reporting.calc_report import InternalRevision
+
+    html_out = _revised_report(internal_revisions=[
+        InternalRevision(revision="A.2", date="2026-08-22",
+                         description="Waterline lengths corrected", by="Naval architecture"),
+        InternalRevision(revision="A.1", date="2026-08-21",
+                         description="First assembly", by="Naval architecture"),
+    ]).render_html()
+
+    assert "Issued revisions" in html_out and "Internal revisions" in html_out
+    # Order on the page is the whole point: the client-facing record first.
+    assert html_out.index("Issued revisions") < html_out.index("Internal revisions")
+    # And the internal rows are below the main row, not interleaved with it.
+    assert html_out.index("First issue") < html_out.index("Waterline lengths corrected")
+    assert "A.1" in html_out and "A.2" in html_out
+
+
+def test_the_internal_table_reuses_the_house_revision_styling():
+    """A second visual language for the same kind of content is a defect."""
+    from digitalmodel.reporting.calc_report import InternalRevision
+
+    html_out = _revised_report(internal_revisions=[
+        InternalRevision(revision="A.1", date="2026-08-21",
+                         description="First assembly", by="Naval architecture"),
+    ]).render_html()
+    assert html_out.count('<table class="revhist">') == 2, (
+        "both tiers render as the house revision table")
+
+
+def test_the_caller_order_of_internal_revisions_is_preserved():
+    """The module renders what it is given; it does not re-sort.
+
+    Descending order is the house convention, but sorting "A.10" against
+    "A.9" as strings would put them in the wrong order, and the caller
+    already knows the order it means.
+    """
+    from digitalmodel.reporting.calc_report import InternalRevision
+
+    html_out = _revised_report(internal_revisions=[
+        InternalRevision(revision="A.10", date="2026-08-22", description="Tenth"),
+        InternalRevision(revision="A.9", date="2026-08-21", description="Ninth"),
+    ]).render_html()
+    assert html_out.index("Tenth") < html_out.index("Ninth")
+
+
+def test_a_main_row_can_name_the_internal_range_it_incorporates():
+    """The link between the tiers: which internal work an issue folded in."""
+    from digitalmodel.reporting.calc_report import InternalRevision, RevisionEntry
+
+    html_out = minimal_report(
+        revision_history=[RevisionEntry(
+            revision="A", date="TBA", description="First issue",
+            incorporates="A.1–A.6", by="Naval architecture")],
+        internal_revisions=[InternalRevision(
+            revision="A.1", date="2026-08-20", description="First assembly")],
+    ).render_html()
+    assert "<th>Incorporates</th>" in html_out
+    assert "A.1–A.6" in html_out
+    # The column sits in the main table, between the description and the by.
+    assert re.search(
+        r"<th>Description</th><th>Incorporates</th><th>By</th>", html_out)
+
+
+def test_the_main_revision_is_never_derived_from_the_internal_ones():
+    """The main letter moves only on issue to the client, by hand.
+
+    Ten internal revisions under a pending Rev A leave the header at Rev A.
+    """
+    from digitalmodel.reporting.calc_report import InternalRevision
+
+    report = _revised_report(internal_revisions=[
+        InternalRevision(revision=f"A.{i}", date="2026-08-21",
+                         description=f"Change {i}")
+        for i in range(1, 11)])
+    assert report.revision == "A"
+    assert "Rev A" in report.render_html()
+    assert "Rev B" not in report.render_html()
+
+
+def test_internal_revisions_alone_still_render_the_section():
+    """A report whose first issue has not happened yet still has a change log."""
+    from digitalmodel.reporting.calc_report import InternalRevision
+
+    html_out = minimal_report(internal_revisions=[
+        InternalRevision(revision="A.1", date="2026-08-20",
+                         description="First assembly")]).render_html()
+    assert "Revision history" in html_out and "Internal revisions" in html_out
+
+
+def test_internal_revisions_default_to_empty():
+    """No existing report changes shape by upgrading."""
+    assert minimal_report().internal_revisions == []


### PR DESCRIPTION
## Why

Three reporting-module changes were stranded on `feat/1173-calm-water-hull-resistance` — a **49-commit CFD branch with no PR of its own**. `RevisionEntry` appears zero times on `origin/main`, so a live client deliverable could only be rebuilt from an unmerged, unreviewed branch, and would have stopped building if that checkout ever moved.

This lifts only the reporting module onto `main`. No CFD code.

## What

| | |
|---|---|
| `RevisionEntry` / `revision_history` | a report carries its own revision table |
| `Reference.url` | a reference may link out; only `http`/`https` are linkified, so a reference cannot inject an arbitrary scheme |
| `organisation` / `organisation_logo` | the issuing organisation is a field, not a hardcoded mark |

One value drives the masthead wordmark, the footer "Prepared by" line and the foot-bar, so the three marks cannot drift apart. `organisation_logo` accepts a `data:` URI only — a remote logo breaks in an offline attachment, and an arbitrary `src` is the same injection surface `Reference.url` is guarded against.

## No other report moves

Both new fields default to the present house values. A regression test pins the three mark strings **verbatim** and SHA-256s the whole rendered document, so an existing report renders byte-identically. Only a report that explicitly sets the fields changes.

**69 tests pass.** No client, vessel or job identifier appears in this diff — the default is the house name, and any client mark lives in that client's own build script.

## Supersedes #2029

#2029 carried the organisation field but was stacked on the CFD branch, so merging it would not have made anything buildable from `main`. Closing it in favour of this. The 49-commit CFD branch lands separately on its own merits.

Refs #1173