### PR TITLE
feat(process_diagrams): P&ID authoring module to ISA-5.1

### DIFF
--- a/docs/maps/digitalmodel-operator-map.md
+++ b/docs/maps/digitalmodel-operator-map.md
@@ -40,6 +40,7 @@ of duplicating its detailed issue history.
 | `orcaflex` | `src/digitalmodel/orcaflex/` | `tests/orcaflex/` | `docs/domains/orcaflex/` | Public OrcaFlex APIs, reporting, model and post-processing utilities | OrcFxAPI where licensed, YAML |
 | `orcawave` | `src/digitalmodel/orcawave/` | `tests/orcawave/` | `docs/domains/orcawave/` | OrcaWave package utilities, reporting, hydrodynamic inputs/outputs | OrcaWave, hydrodynamics |
 | `power` | `src/digitalmodel/power/` | `tests/power/` | `docs/domains/README.md` | Generator controls, microgrid EMS, protection relays | IEEE/NFPA power standards |
+| `process_diagrams` | `src/digitalmodel/process_diagrams/` | `tests/process_diagrams/` | `docs/domains/README.md` | P&ID authoring to ISA-5.1 — symbol set, pipe runs with line-crossing jumps, instrument-tag and line-number grammar, sheet frame and title block, drafting lint | standard library only |
 | `production_chemistry` | `src/digitalmodel/production_chemistry/` | `tests/production_chemistry/` | `docs/domains/README.md` | Mineral-scale saturation indices (Oddo-Tomson), brine mixing/waterflood compatibility | NumPy, pandas |
 | `production_engineering` | `src/digitalmodel/production_engineering/` | `tests/production_engineering/` | `docs/domains/README.md` | Well testing, nodal analysis, production quality scoring | petroleum engineering models |
 | `reservoir` | `src/digitalmodel/reservoir/` | `tests/reservoir/` | `docs/domains/reservoir/` | Reservoir engineering and production-support calculations | reservoir engineering models |

--- a/docs/registry/module-routing.yaml
+++ b/docs/registry/module-routing.yaml
@@ -176,6 +176,12 @@ modules:
     owner_wiki: docs/domains/README.md
     key_tests: [tests/power/]
     operator_map_row: docs/maps/digitalmodel-operator-map.md#power
+  - module: process_diagrams
+    entry_point: src/digitalmodel/process_diagrams/
+    maturity: beta
+    owner_wiki: docs/domains/README.md
+    key_tests: [tests/process_diagrams/]
+    operator_map_row: docs/maps/digitalmodel-operator-map.md#process_diagrams
   - module: production_chemistry
     entry_point: src/digitalmodel/production_chemistry/
     maturity: development

--- a/examples/process_diagrams/legend_sheet.py
+++ b/examples/process_diagrams/legend_sheet.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate Sheet 1 of a P&ID set: the legend and symbol sheet.
+
+Every P&ID set opens with a legend, because house variations on ISA-5.1 are
+normal and the legend is what actually governs a given set. This script builds
+one from the symbol library and writes it as a standalone SVG.
+
+Run:
+    PYTHONPATH=src python examples/process_diagrams/legend_sheet.py [out.svg]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from digitalmodel.process_diagrams import Sheet, TitleBlock, symbols
+from digitalmodel.process_diagrams.geometry import _n, escape
+
+COLUMNS = [
+    ("EQUIPMENT", [
+        (lambda x, y: symbols.vessel_vertical(x, y, 13, 16, 7), "VESSEL, VERTICAL"),
+        (lambda x, y: symbols.vessel_horizontal(x, y, 16, 13, 7), "VESSEL, HORIZONTAL"),
+        (lambda x, y: symbols.column(x, y, 12, 24, [(y - 16, y + 4)]), "TOWER / COLUMN"),
+        (lambda x, y: symbols.exchanger_shell_tube(x, y, 17), "EXCHANGER, SHELL & TUBE"),
+        (lambda x, y: symbols.exchanger_plate_fin(x, y, 17, 14), "EXCHANGER, PLATE-FIN"),
+        (lambda x, y: symbols.air_cooler(x, y, 18), "AIR COOLER (FIN-FAN)"),
+        (lambda x, y: symbols.turbomachine(x, y, 22, 13), "COMPRESSOR"),
+        (lambda x, y: symbols.turbomachine(x, y, 22, 13, True), "EXPANDER"),
+        (lambda x, y: symbols.pump(x, y, 13), "PUMP, CENTRIFUGAL"),
+    ]),
+    ("VALVES", [
+        (symbols.gate, "GATE VALVE"),
+        (symbols.globe, "GLOBE VALVE"),
+        (symbols.ball, "BALL VALVE"),
+        (symbols.check, "CHECK VALVE (NRV)"),
+        (lambda x, y: symbols.control_valve(x, y + 12, "diaphragm", "FC"),
+         "CONTROL VALVE, DIAPHRAGM"),
+        (lambda x, y: symbols.control_valve(x, y + 12, "piston", "FO"),
+         "CONTROL VALVE, PISTON"),
+        (lambda x, y: symbols.control_valve(x, y + 12, "motor", None), "MOTOR OPERATED"),
+        (lambda x, y: symbols.control_valve(x, y + 12, "solenoid", "FC"), "ESD / SHUTDOWN"),
+        (lambda x, y: symbols.relief_valve(x, y - 4), "PRESSURE SAFETY VALVE"),
+    ]),
+    ("INSTRUMENTS", [
+        (lambda x, y: symbols.bubble(x, y, "PT", "101", "field"), "FIELD MOUNTED"),
+        (lambda x, y: symbols.bubble(x, y, "PIC", "101", "bpcs"), "BPCS (THE DCS)"),
+        (lambda x, y: symbols.bubble(x, y, "PZHH", "101", "sis"), "SIS - SAFETY SYSTEM"),
+        (lambda x, y: symbols.bubble(x, y, "AIC", "101", "computer"), "COMPUTER FUNCTION"),
+        (lambda x, y: symbols.bubble(x, y, "I", "", "interlock"), "INTERLOCK LOGIC"),
+        (lambda x, y: symbols.bubble(x, y, "PI", "101", "auxiliary"), "LOCAL PANEL"),
+        (lambda x, y: symbols.orifice(x, y), "ORIFICE PLATE (FE)"),
+        (lambda x, y: symbols.transformer(x, y), "TRANSFORMER"),
+        (lambda x, y: symbols.breaker(x, y), "CIRCUIT BREAKER"),
+    ]),
+]
+
+
+def build() -> Sheet:
+    sheet = Sheet(
+        width=1120, height=720, zone_columns=6, zone_rows=4,
+        title_block=TitleBlock(
+            drawing_number="AE-0000-PID-1001",
+            title="LEGEND, SYMBOLS & LINE DESIGNATION",
+            project="TYPICAL FACILITY - REFERENCE SET",
+            originator="ACEENGINEER", location="HOUSTON, TEXAS",
+            revision="A", sheet="1 OF 3", date="2026-09-03",
+        ),
+        aria_label=(
+            "Legend sheet showing ISA-5.1 equipment, valve and instrument "
+            "symbols with their meanings."
+        ),
+    )
+    for col, (heading, rows) in enumerate(COLUMNS):
+        x0 = 50 + col * 340
+        sheet.add(
+            f'<text x="{_n(x0)}" y="60" font-size="11" letter-spacing="1.6" '
+            f'stroke="none" fill="currentColor" font-weight="600">{escape(heading)}</text>',
+            f'<path d="M{_n(x0)},70 H{_n(x0 + 300)}" stroke-width="1" opacity=".45"/>',
+        )
+        for i, (draw, label) in enumerate(rows):
+            cy = 106 + i * 54
+            sheet.add(
+                draw(x0 + 32, cy),
+                f'<text x="{_n(x0 + 82)}" y="{_n(cy + 4)}" font-size="10.5" '
+                f'stroke="none" fill="currentColor">{escape(label)}</text>',
+            )
+    sheet.note("ISA-5.1-2009: the square means shared display / shared control. "
+               "The inner shape selects BPCS or SIS - it no longer means DCS or PLC.")
+    sheet.note("Fail action (FC / FO / FL) is annotated in text on every actuated "
+               "valve, not inferred from the stem arrow.")
+    sheet.note("Line number reads SIZE-SERVICE-SEQUENCE-CLASS-INSULATION, e.g. "
+               '12"-PG-1001-A1A-IH. A new number is assigned whenever size, '
+               "service or piping class changes.")
+    return sheet
+
+
+def main() -> int:
+    sheet = build()
+    problems = sheet.lint()
+    for problem in problems:
+        print(f"lint: {problem}", file=sys.stderr)
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("legend-sheet.svg")
+    out.write_text(sheet.render(), encoding="utf-8")
+    print(f"wrote {out} ({out.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/digitalmodel/process_diagrams/__init__.py
+++ b/src/digitalmodel/process_diagrams/__init__.py
@@ -1,0 +1,39 @@
+"""Piping and instrumentation diagram (P&ID) authoring to ISA-5.1.
+
+Builds P&ID sheets as standalone SVG: the ISA-5.1 symbol set, pipe runs with
+line-crossing jumps, instrument-tag and line-number parsing, and the sheet
+scaffold (zone-gridded border, numbered notes column, title block).
+
+Pure standard library, no plotting or CAD dependency, so a sheet can be
+generated in a report pipeline or embedded in an HTML page.
+
+    >>> from digitalmodel.process_diagrams import Sheet, TitleBlock, symbols
+    >>> sheet = Sheet(width=800, height=600,
+    ...               title_block=TitleBlock(drawing_number="PID-1001",
+    ...                                      title="INLET SEPARATION"))
+    >>> _ = sheet.add(symbols.vessel_vertical(200, 300, 30, 70))
+    >>> _ = sheet.add_instrument(320, 260, "LIC-101", kind="bpcs")
+    >>> sheet.lint()
+    []
+    >>> sheet.render().startswith("<svg")
+    True
+
+The bubble taxonomy follows ISA-5.1-2009, which retired the pre-2009 reading of
+circle-in-square as "DCS" and diamond-in-square as "PLC". See
+:mod:`~digitalmodel.process_diagrams.symbols`.
+"""
+
+from __future__ import annotations
+
+from . import geometry, symbols, tags
+from .geometry import horizontal, polyline, signal, vertical
+from .sheet import Sheet, TitleBlock, hold_flag, note_flag, off_page_connector
+from .tags import LineNumber, Tag, TagError, parse_line_number, parse_tag
+
+__all__ = [
+    "Sheet", "TitleBlock", "Tag", "LineNumber", "TagError",
+    "parse_tag", "parse_line_number",
+    "horizontal", "vertical", "polyline", "signal",
+    "off_page_connector", "note_flag", "hold_flag",
+    "geometry", "symbols", "tags",
+]

--- a/src/digitalmodel/process_diagrams/geometry.py
+++ b/src/digitalmodel/process_diagrams/geometry.py
@@ -1,0 +1,124 @@
+"""Pipe-run and signal-line geometry for P&ID sheets.
+
+Process lines on a P&ID cross constantly, and the drafting convention is that
+one direction consistently hops the other across a whole sheet — a small
+semicircular jump that tells the reader the two lines are not connected. This
+module builds those runs as SVG path data.
+
+Instrument signal lines are different: they may cross process lines and each
+other freely without a hop, because their line style already distinguishes
+them. :func:`signal` therefore never inserts a jump.
+
+Coordinates are SVG user units with y increasing downward.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+HOP_RADIUS = 7.0
+"""Radius of a line-crossing jump, in user units."""
+
+
+def _hops_between(crossings: Iterable[float], start: float, end: float) -> list[float]:
+    """Crossings strictly inside the run, ordered along the direction of travel.
+
+    A crossing at or beyond an endpoint is not a crossing — the run terminates
+    there, which is a connection rather than a jump.
+    """
+    inside = [c for c in crossings if min(start, end) < c < max(start, end)]
+    return sorted(inside, reverse=end < start)
+
+
+def horizontal(x1: float, x2: float, y: float,
+               crossings: Iterable[float] = ()) -> str:
+    """Path data for a horizontal run at ``y`` from ``x1`` to ``x2``.
+
+    ``crossings`` are x positions of lines this run jumps over. The arc always
+    bulges away from the reading direction's right-hand side (upward for a
+    left-to-right run), which keeps a sheet visually consistent.
+
+    >>> horizontal(0, 100, 50)
+    'M0,50 L100,50'
+    >>> "A7" in horizontal(0, 100, 50, crossings=[40])
+    True
+    >>> horizontal(0, 100, 50, crossings=[100])   # endpoint is a connection
+    'M0,50 L100,50'
+    """
+    step = HOP_RADIUS if x2 > x1 else -HOP_RADIUS
+    d = f"M{_n(x1)},{_n(y)}"
+    for hop in _hops_between(crossings, x1, x2):
+        d += (f" L{_n(hop - step)},{_n(y)}"
+              f" A{_n(HOP_RADIUS)},{_n(HOP_RADIUS)} 0 0 1 {_n(hop + step)},{_n(y)}")
+    return d + f" L{_n(x2)},{_n(y)}"
+
+
+def vertical(y1: float, y2: float, x: float,
+             crossings: Iterable[float] = ()) -> str:
+    """Path data for a vertical run at ``x`` from ``y1`` to ``y2``.
+
+    ``crossings`` are y positions of lines this run jumps over.
+
+    >>> vertical(0, 100, 50)
+    'M50,0 L50,100'
+    >>> "A7" in vertical(0, 100, 50, crossings=[40])
+    True
+    """
+    step = HOP_RADIUS if y2 > y1 else -HOP_RADIUS
+    d = f"M{_n(x)},{_n(y1)}"
+    for hop in _hops_between(crossings, y1, y2):
+        d += (f" L{_n(x)},{_n(hop - step)}"
+              f" A{_n(HOP_RADIUS)},{_n(HOP_RADIUS)} 0 0 1 {_n(x)},{_n(hop + step)}")
+    return d + f" L{_n(x)},{_n(y2)}"
+
+
+def polyline(points: Sequence[tuple[float, float]]) -> str:
+    """Path data through a sequence of points, for runs with corners.
+
+    >>> polyline([(0, 0), (10, 0), (10, 20)])
+    'M0,0 L10,0 L10,20'
+    """
+    if len(points) < 2:
+        raise ValueError("a run needs at least two points")
+    head, *tail = points
+    return f"M{_n(head[0])},{_n(head[1])}" + "".join(
+        f" L{_n(x)},{_n(y)}" for x, y in tail)
+
+
+def signal(points: Sequence[tuple[float, float]]) -> str:
+    """Path data for an instrument signal line — never hops.
+
+    Signal lines are distinguished by dash pattern (see
+    :data:`~digitalmodel.process_diagrams.symbols.SIGNAL_DASH`), so they cross
+    process lines and each other without a jump.
+    """
+    return polyline(points)
+
+
+def run_length(points: Sequence[tuple[float, float]]) -> float:
+    """Total length of a polyline run, for line-list or takeoff estimates."""
+    total = 0.0
+    for (x1, y1), (x2, y2) in zip(points, points[1:]):
+        total += ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    return total
+
+
+def escape(text: str) -> str:
+    """Escape text for inclusion in SVG markup.
+
+    Labels routinely contain ``&`` ("SHELL & TUBE") and quote marks (a 12-inch
+    line number), both of which make the document non-parseable if passed
+    through raw.
+
+    >>> escape('EXCHANGER, SHELL & TUBE')
+    'EXCHANGER, SHELL &amp; TUBE'
+    """
+    return (text.replace("&", "&amp;").replace("<", "&lt;")
+                .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def _n(value: float) -> str:
+    """Format a coordinate without a trailing ``.0``."""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return f"{value:g}"

--- a/src/digitalmodel/process_diagrams/sheet.py
+++ b/src/digitalmodel/process_diagrams/sheet.py
@@ -1,0 +1,256 @@
+"""Drawing sheet assembly: frame, title block, notes column, and rendering.
+
+A P&ID sheet is not just a drawing — it is a controlled document. The border
+grid lets a continuation cite a zone, the title block carries the revision and
+the issue-status stamp, and the numbered notes column is where the engineering
+that does not fit on the drawing lives. This module builds that scaffold and
+renders the whole sheet as a standalone SVG fragment.
+
+Sheets carry a ``NOT FOR CONSTRUCTION`` stamp by default. A drawing that has
+not been through a hazard review and a relief study should say so on its face.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .geometry import _n, escape
+from .tags import Tag, TagError, parse_tag
+
+ZONE_LETTERS = "HGFEDCBA"
+
+
+@dataclass
+class TitleBlock:
+    """Title-block content. ``scale`` is always NONE — P&IDs are schematic."""
+
+    drawing_number: str
+    title: str
+    project: str = "TYPICAL FACILITY"
+    originator: str = ""
+    location: str = ""
+    revision: str = "A"
+    sheet: str = "1 OF 1"
+    date: str = ""
+    status: str = "NOT FOR CONSTRUCTION"
+    scale: str = "NONE"
+
+
+@dataclass
+class Sheet:
+    """An assembled P&ID sheet.
+
+    Elements are appended as raw SVG fragments (typically from
+    :mod:`~digitalmodel.process_diagrams.symbols`) and rendered inside a
+    themed group, so the whole sheet follows the host page's foreground colour.
+    """
+
+    width: float
+    height: float
+    title_block: TitleBlock
+    aria_label: str = ""
+    zone_columns: int = 8
+    zone_rows: int = 4
+    _elements: list[str] = field(default_factory=list)
+    _notes: list[str] = field(default_factory=list)
+    _tags: list[Tag] = field(default_factory=list)
+    _valves_without_fail: list[str] = field(default_factory=list)
+
+    # ---------------------------------------------------------------- content
+    def add(self, *fragments: str) -> "Sheet":
+        """Append raw SVG fragments. Returns self so calls can be chained."""
+        self._elements.extend(fragments)
+        return self
+
+    def add_instrument(self, cx: float, cy: float, tag: str, **kwargs) -> "Sheet":
+        """Add an instrument bubble, validating the tag against ISA-5.1.
+
+        Raises :class:`~digitalmodel.process_diagrams.tags.TagError` on a
+        malformed tag, which catches typos at build time rather than at
+        drawing review.
+        """
+        from .symbols import bubble
+
+        parsed = parse_tag(tag)
+        self._tags.append(parsed)
+        letters, loop = parsed.raw.split("-", 1)
+        return self.add(bubble(cx, cy, letters, loop, **kwargs))
+
+    def add_control_valve(self, cx: float, cy: float, tag: str,
+                          fail: str | None = "FC", **kwargs) -> "Sheet":
+        """Add a control valve and record whether it carries a fail action."""
+        from .symbols import control_valve
+
+        parsed = parse_tag(tag)
+        self._tags.append(parsed)
+        if not fail:
+            self._valves_without_fail.append(parsed.raw)
+        return self.add(control_valve(cx, cy, fail=fail, **kwargs))
+
+    def note(self, text: str) -> int:
+        """Append a numbered note and return its number, for flagging."""
+        self._notes.append(text)
+        return len(self._notes)
+
+    # ------------------------------------------------------------------- lint
+    def lint(self) -> list[str]:
+        """Return drafting defects found on this sheet.
+
+        Checks that are cheap and catch real errors:
+
+        - a control valve with no fail action annotated
+        - two devices sharing a tag
+        - a safety-instrumented tag drawn in a non-SIS bubble is *not* checked
+          here, because the bubble kind is not recorded against the tag
+        """
+        problems = [f"control valve {tag} has no fail action annotated"
+                    for tag in self._valves_without_fail]
+        seen: dict[str, int] = {}
+        for tag in self._tags:
+            seen[tag.raw] = seen.get(tag.raw, 0) + 1
+        problems.extend(f"tag {raw} is used {count} times"
+                        for raw, count in sorted(seen.items()) if count > 1)
+        return problems
+
+    def loops(self) -> dict[str, list[str]]:
+        """Group the sheet's tags by loop number."""
+        grouped: dict[str, list[str]] = {}
+        for tag in self._tags:
+            grouped.setdefault(tag.loop, []).append(tag.raw)
+        return grouped
+
+    # ----------------------------------------------------------------- render
+    def render(self, marker_id: str = "arrow") -> str:
+        """Render the sheet as a standalone ``<svg>`` fragment."""
+        parts = [
+            f'<svg viewBox="0 0 {_n(self.width)} {_n(self.height)}" role="img" '
+            f'width="{_n(self.width)}" aria-label="{escape(self.aria_label)}">',
+            f'<defs><marker id="{marker_id}" viewBox="0 0 10 10" refX="9" refY="5" '
+            f'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+            f'<path d="M0,1 L9,5 L0,9 Z" fill="currentColor" stroke="none"/></marker></defs>',
+            '<g fill="none" stroke="currentColor" stroke-width="2.2" '
+            'stroke-linecap="round" stroke-linejoin="round" '
+            'font-family="IBM Plex Mono, ui-monospace, monospace">',
+            self._frame(),
+            *self._elements,
+            self._notes_column(),
+            self._title_block(),
+            "</g></svg>",
+        ]
+        return "\n".join(p for p in parts if p)
+
+    def _frame(self) -> str:
+        w, h = self.width, self.height
+        out = (f'<rect x="10" y="10" width="{_n(w - 20)}" height="{_n(h - 20)}" '
+               f'stroke-width="2.4" fill="none"/>'
+               f'<rect x="26" y="26" width="{_n(w - 52)}" height="{_n(h - 52)}" '
+               f'stroke-width="1" fill="none"/>')
+        for i in range(self.zone_columns):
+            x = 26 + (w - 52) * (i + 0.5) / self.zone_columns
+            label = str(self.zone_columns - i)
+            out += (f'<text x="{_n(x)}" y="22" font-size="9" text-anchor="middle" '
+                    f'stroke="none" fill="currentColor" opacity=".5">{label}</text>'
+                    f'<text x="{_n(x)}" y="{_n(h - 13)}" font-size="9" text-anchor="middle" '
+                    f'stroke="none" fill="currentColor" opacity=".5">{label}</text>')
+        letters = ZONE_LETTERS[-self.zone_rows:]
+        for j in range(self.zone_rows):
+            y = 26 + (h - 52) * (j + 0.5) / self.zone_rows
+            out += (f'<text x="18" y="{_n(y + 3)}" font-size="9" text-anchor="middle" '
+                    f'stroke="none" fill="currentColor" opacity=".5">{letters[j]}</text>'
+                    f'<text x="{_n(w - 18)}" y="{_n(y + 3)}" font-size="9" '
+                    f'text-anchor="middle" stroke="none" fill="currentColor" '
+                    f'opacity=".5">{letters[j]}</text>')
+        return out
+
+    def _notes_column(self) -> str:
+        if not self._notes:
+            return ""
+        x, y = self.width - 320, self.height - 260
+        out = (f'<text x="{_n(x)}" y="{_n(y)}" font-size="11" letter-spacing="1.6" '
+               f'stroke="none" fill="currentColor" opacity=".85">NOTES</text>'
+               f'<path d="M{_n(x)},{_n(y + 6)} H{_n(self.width - 26)}" '
+               f'stroke-width="1.2" opacity=".5"/>')
+        for i, text in enumerate(self._notes):
+            out += (f'<text x="{_n(x)}" y="{_n(y + 28 + i * 17)}" font-size="10" '
+                    f'stroke="none" fill="currentColor" opacity=".88">'
+                    f'{i + 1}. {escape(text)}</text>')
+        return out
+
+    def _title_block(self) -> str:
+        tb = self.title_block
+        x2, y2 = self.width - 26, self.height - 26
+        x1, y1 = x2 - 460, y2 - 104
+        xs = x1 + 162
+        cx = (x1 + xs) / 2
+
+        def text(tx, ty, s, size=10.5, anchor="start", opacity=None):
+            op = f' opacity="{opacity}"' if opacity else ""
+            return (f'<text x="{_n(tx)}" y="{_n(ty)}" font-size="{_n(size)}" '
+                    f'text-anchor="{anchor}" stroke="none" fill="currentColor"{op}>{escape(str(s))}</text>')
+
+        out = (f'<rect x="{_n(x1)}" y="{_n(y1)}" width="{_n(x2 - x1)}" '
+               f'height="{_n(y2 - y1)}" stroke-width="1.6" fill="none"/>'
+               f'<path d="M{_n(xs)},{_n(y1)} V{_n(y2)} M{_n(xs)},{_n(y1 + 34)} H{_n(x2)} '
+               f'M{_n(xs)},{_n(y1 + 69)} H{_n(x2)} M{_n(x2 - 118)},{_n(y1 + 69)} V{_n(y2)}" '
+               f'stroke-width="1.3" fill="none"/>')
+        if tb.originator:
+            out += text(cx, y1 + 22, tb.originator, 18, "middle")
+        if tb.location:
+            out += text(cx, y1 + 38, tb.location, 8, "middle", ".65")
+        out += text(cx, y1 + 62, tb.status, 9, "middle")
+        out += text(cx, y1 + 90, f"SCALE: {tb.scale}  ·  {tb.date}", 8, "middle", ".65")
+        out += (text(xs + 10, y1 + 14, "PROJECT", 7.5, opacity=".6")
+                + text(xs + 10, y1 + 27, tb.project)
+                + text(xs + 10, y1 + 49, "TITLE", 7.5, opacity=".6")
+                + text(xs + 10, y1 + 62, tb.title)
+                + text(xs + 10, y1 + 84, "DRAWING NO.", 7.5, opacity=".6")
+                + text(xs + 10, y1 + 97, tb.drawing_number)
+                + text(x2 - 110, y1 + 84, "REV / SHEET", 7.5, opacity=".6")
+                + text(x2 - 110, y1 + 97, f"{tb.revision} · {tb.sheet}"))
+        return out
+
+
+def off_page_connector(x: float, y: float, lines: list[str],
+                       direction: str = "right", width: float = 150.0) -> str:
+    """Home-plate continuation flag.
+
+    Carries the continuing line number, the destination drawing number, and the
+    grid coordinate on that drawing. Incoming flags belong on the left edge and
+    outgoing on the right, so the sheet reads left to right in the direction of
+    process flow.
+    """
+    h = 15.0
+    if direction == "right":
+        d = (f"M{_n(x)},{_n(y - h)} H{_n(x + width - 16)} L{_n(x + width)},{_n(y)} "
+             f"L{_n(x + width - 16)},{_n(y + h)} H{_n(x)} Z")
+        tx = x + 8
+    else:
+        d = (f"M{_n(x + width)},{_n(y - h)} H{_n(x + 16)} L{_n(x)},{_n(y)} "
+             f"L{_n(x + 16)},{_n(y + h)} H{_n(x + width)} Z")
+        tx = x + 22
+    out = f'<path d="{d}" stroke-width="1.6" fill="none"/>'
+    if len(lines) == 1:
+        out += (f'<text x="{_n(tx)}" y="{_n(y + 4)}" font-size="10.5" stroke="none" '
+                f'fill="currentColor">{escape(lines[0])}</text>')
+    else:
+        for i, line in enumerate(lines[:2]):
+            out += (f'<text x="{_n(tx)}" y="{_n(y - 1 + i * 11)}" font-size="10" '
+                    f'stroke="none" fill="currentColor">{escape(line)}</text>')
+    return out
+
+
+def note_flag(x: float, y: float, number: int) -> str:
+    """Numbered triangular flag pointing at what a note governs."""
+    return (f'<path d="M{_n(x)},{_n(y - 12)} L{_n(x + 12)},{_n(y + 8)} '
+            f'L{_n(x - 12)},{_n(y + 8)} Z" stroke-width="1.6" fill="none"/>'
+            f'<text x="{_n(x)}" y="{_n(y + 6)}" font-size="10.5" text-anchor="middle" '
+            f'stroke="none" fill="currentColor">{number}</text>')
+
+
+def hold_flag(x: float, y: float, number: int) -> str:
+    """Hold flag — an unresolved item, conventionally clouded on a real sheet."""
+    return note_flag(x, y, number)
+
+
+__all__ = ["Sheet", "TitleBlock", "off_page_connector", "note_flag", "hold_flag",
+           "TagError"]

--- a/src/digitalmodel/process_diagrams/symbols.py
+++ b/src/digitalmodel/process_diagrams/symbols.py
@@ -1,0 +1,290 @@
+"""ISA-5.1 symbol primitives as SVG fragments.
+
+Each function returns a self-contained SVG fragment positioned at absolute
+coordinates. Fragments inherit ``stroke``/``fill`` from the enclosing group, so
+a whole sheet can be themed by setting ``stroke="currentColor"`` once.
+
+The bubble taxonomy in :func:`bubble` is the post-2009 one. ISA-5.1-2009
+retired the pre-2009 reading of circle-in-square as "DCS" and diamond-in-square
+as "PLC": the enclosing square now means *shared display, shared control*, and
+the inner shape selects the system — a circle for the basic process control
+system, a diamond for the safety instrumented system.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from .geometry import _n, escape
+
+# Signal line dash patterns, keyed by ISA-5.1 signal type.
+SIGNAL_DASH: dict[str, str | None] = {
+    "electric": "7 4",
+    "pneumatic": None,      # solid, with double-slash tick marks
+    "data": "12 10",        # internal system link, drawn with small circles
+    "capillary": None,      # solid, with X tick marks
+    "process": None,
+}
+
+BubbleKind = Literal["field", "bpcs", "sis", "computer", "interlock", "auxiliary"]
+Actuator = Literal["diaphragm", "piston", "motor", "solenoid", "manual"]
+
+
+def _t(x: float, y: float, text: str, size: float = 11.5,
+       anchor: str = "middle") -> str:
+    return (f'<text x="{_n(x)}" y="{_n(y)}" font-size="{_n(size)}" '
+            f'text-anchor="{anchor}" stroke="none" fill="currentColor">{escape(text)}</text>')
+
+
+# --------------------------------------------------------------------------- #
+# Instrument bubbles
+# --------------------------------------------------------------------------- #
+def bubble(cx: float, cy: float, top: str, bottom: str = "",
+           kind: BubbleKind = "field", radius: float = 21.0) -> str:
+    """An instrument bubble.
+
+    ``kind`` selects where the function lives, which is the whole point of the
+    symbol:
+
+    - ``field`` — discrete, field-mounted instrument (plain circle)
+    - ``bpcs`` — shared display / shared control, basic process control system
+      (circle inside a square)
+    - ``sis`` — shared display / shared control, safety instrumented system
+      (diamond inside a square)
+    - ``computer`` — computer or high-level control function (hexagon)
+    - ``interlock`` — simple interlock logic, AND/OR only (plain diamond)
+    - ``auxiliary`` — auxiliary or local panel location (circle, double line)
+    """
+    r = radius
+    out = ""
+    if kind in ("bpcs", "sis"):
+        out += (f'<rect x="{_n(cx - r)}" y="{_n(cy - r)}" width="{_n(2 * r)}" '
+                f'height="{_n(2 * r)}" fill="none"/>')
+    if kind == "sis" or kind == "interlock":
+        out += (f'<path d="M{_n(cx)},{_n(cy - r)} L{_n(cx + r)},{_n(cy)} '
+                f'L{_n(cx)},{_n(cy + r)} L{_n(cx - r)},{_n(cy)} Z" fill="none"/>')
+    elif kind == "computer":
+        h = r * 0.87
+        out += (f'<path d="M{_n(cx - r)},{_n(cy)} L{_n(cx - r / 2)},{_n(cy - h)} '
+                f'L{_n(cx + r / 2)},{_n(cy - h)} L{_n(cx + r)},{_n(cy)} '
+                f'L{_n(cx + r / 2)},{_n(cy + h)} L{_n(cx - r / 2)},{_n(cy + h)} Z" fill="none"/>')
+    else:
+        out += f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="{_n(r)}" fill="none"/>'
+    if kind == "auxiliary":
+        out += (f'<path d="M{_n(cx - r)},{_n(cy - 2.5)} H{_n(cx + r)} '
+                f'M{_n(cx - r)},{_n(cy + 2.5)} H{_n(cx + r)}"/>')
+    if bottom:
+        out += _t(cx, cy - 2, top) + _t(cx, cy + 11, bottom)
+    else:
+        out += _t(cx, cy + 4, top)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Valve bodies and actuators
+# --------------------------------------------------------------------------- #
+def gate(cx: float, cy: float, vertical_run: bool = False) -> str:
+    """Gate valve — the hollow bowtie that every other body builds on."""
+    if vertical_run:
+        d = (f"M{_n(cx - 9)},{_n(cy - 12)} L{_n(cx + 9)},{_n(cy - 12)} "
+             f"L{_n(cx - 9)},{_n(cy + 12)} L{_n(cx + 9)},{_n(cy + 12)} Z")
+    else:
+        d = (f"M{_n(cx - 12)},{_n(cy - 9)} L{_n(cx - 12)},{_n(cy + 9)} "
+             f"L{_n(cx + 12)},{_n(cy - 9)} L{_n(cx + 12)},{_n(cy + 9)} Z")
+    return f'<path d="{d}" fill="none"/>'
+
+
+def globe(cx: float, cy: float, vertical_run: bool = False) -> str:
+    """Globe valve — bowtie with a filled centre circle."""
+    return gate(cx, cy, vertical_run) + (
+        f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="4" fill="currentColor" stroke="none"/>')
+
+
+def ball(cx: float, cy: float, vertical_run: bool = False) -> str:
+    """Ball valve — bowtie with a hollow centre circle."""
+    return gate(cx, cy, vertical_run) + (
+        f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="4.5" fill="none"/>')
+
+
+def check(cx: float, cy: float) -> str:
+    """Check valve. Flow direction must be unambiguous, so the bar is drawn."""
+    return (f'<path d="M{_n(cx - 11)},{_n(cy - 9)} L{_n(cx + 9)},{_n(cy)} '
+            f'L{_n(cx - 11)},{_n(cy + 9)} Z" fill="none"/>'
+            f'<path d="M{_n(cx + 9)},{_n(cy - 9)} V{_n(cy + 9)}"/>')
+
+
+def control_valve(cx: float, cy: float, actuator: Actuator = "diaphragm",
+                  fail: str | None = "FC", vertical_run: bool = False) -> str:
+    """Control valve: a body, a stem, an actuator, and a fail-action code.
+
+    ``fail`` is annotated in text rather than left to the stem arrow, because
+    that is how it is read in practice. Passing ``fail=None`` omits it, which
+    :func:`~digitalmodel.process_diagrams.sheet.Sheet.lint` reports — a missing
+    fail action is a real drafting defect, not a cosmetic one. On a compressor
+    sheet the anti-surge recycle valve is typically the only ``FO`` among
+    otherwise ``FC`` valves, and reversing that wrecks the machine.
+    """
+    out = gate(cx, cy, vertical_run)
+    if vertical_run:
+        ax, ay = cx + 22, cy
+        out += f'<path d="M{_n(cx)},{_n(cy)} H{_n(ax)}"/>'
+    else:
+        ax, ay = cx, cy - 20
+        out += f'<path d="M{_n(cx)},{_n(cy)} V{_n(ay)}"/>'
+    out += _actuator(ax, ay, actuator)
+    if fail:
+        out += _t(ax, ay - 13 if not vertical_run else ay - 15, fail, 10)
+    return out
+
+
+def _actuator(ax: float, ay: float, kind: Actuator) -> str:
+    if kind == "diaphragm":
+        return (f'<path d="M{_n(ax - 9)},{_n(ay)} A9,8 0 0 1 {_n(ax + 9)},{_n(ay)} Z" '
+                f'fill="none"/>')
+    if kind == "piston":
+        return (f'<rect x="{_n(ax - 10)}" y="{_n(ay - 10)}" width="20" height="10" '
+                f'fill="none"/>')
+    if kind == "motor":
+        return (f'<circle cx="{_n(ax)}" cy="{_n(ay - 7)}" r="9" fill="none"/>'
+                + _t(ax, ay - 3, "M", 11))
+    if kind == "solenoid":
+        return (f'<rect x="{_n(ax - 9)}" y="{_n(ay - 13)}" width="18" height="13" '
+                f'fill="none"/>' + _t(ax, ay - 3, "S", 11))
+    return f'<path d="M{_n(ax - 9)},{_n(ay)} H{_n(ax + 9)}"/>'
+
+
+def relief_valve(cx: float, cy: float) -> str:
+    """Pressure safety valve: angle body, spring bonnet, side outlet."""
+    return (f'<path d="M{_n(cx - 10)},{_n(cy + 16)} L{_n(cx + 10)},{_n(cy + 16)} '
+            f'L{_n(cx - 10)},{_n(cy + 1)} L{_n(cx + 10)},{_n(cy + 1)} Z" fill="none"/>'
+            f'<path d="M{_n(cx)},{_n(cy + 1)} V{_n(cy - 5)}"/>'
+            f'<path d="M{_n(cx - 8)},{_n(cy - 5)} L{_n(cx + 8)},{_n(cy - 9)} '
+            f'L{_n(cx - 8)},{_n(cy - 13)} L{_n(cx + 8)},{_n(cy - 17)} '
+            f'L{_n(cx - 8)},{_n(cy - 21)} L{_n(cx + 8)},{_n(cy - 25)}" fill="none"/>'
+            f'<path d="M{_n(cx + 7)},{_n(cy + 1)} H{_n(cx + 26)}"/>')
+
+
+def orifice(cx: float, cy: float) -> str:
+    """Orifice plate primary element, with flange-tap marks."""
+    return (f'<path d="M{_n(cx)},{_n(cy - 13)} V{_n(cy + 13)}" stroke-width="2.4"/>'
+            f'<path d="M{_n(cx - 6)},{_n(cy - 9)} V{_n(cy + 9)} '
+            f'M{_n(cx + 6)},{_n(cy - 9)} V{_n(cy + 9)}" stroke-width="1" opacity=".5"/>')
+
+
+# --------------------------------------------------------------------------- #
+# Equipment
+# --------------------------------------------------------------------------- #
+def vessel_vertical(cx: float, cy: float, half_width: float, half_height: float,
+                    head_depth: float | None = None) -> str:
+    """Vertical vessel with dished heads. Draw to rough proportion."""
+    hd = head_depth if head_depth is not None else half_width * 0.5
+    return (f'<path d="M{_n(cx - half_width)},{_n(cy - half_height)} '
+            f'A{_n(half_width)},{_n(hd)} 0 0 1 {_n(cx + half_width)},{_n(cy - half_height)} '
+            f'L{_n(cx + half_width)},{_n(cy + half_height)} '
+            f'A{_n(half_width)},{_n(hd)} 0 0 1 {_n(cx - half_width)},{_n(cy + half_height)} Z" '
+            f'fill="none"/>')
+
+
+def vessel_horizontal(cx: float, cy: float, half_width: float, half_height: float,
+                      head_depth: float | None = None) -> str:
+    """Horizontal vessel. A three-phase separator is identified by *two* level
+    bridles, not by the shell — draw both if that is what it is."""
+    hd = head_depth if head_depth is not None else half_height * 0.5
+    return (f'<path d="M{_n(cx - half_width)},{_n(cy - half_height)} '
+            f'L{_n(cx + half_width)},{_n(cy - half_height)} '
+            f'A{_n(hd)},{_n(half_height)} 0 0 1 {_n(cx + half_width)},{_n(cy + half_height)} '
+            f'L{_n(cx - half_width)},{_n(cy + half_height)} '
+            f'A{_n(hd)},{_n(half_height)} 0 0 1 {_n(cx - half_width)},{_n(cy - half_height)} Z" '
+            f'fill="none"/>')
+
+
+def column(cx: float, cy: float, half_width: float, half_height: float,
+           packed_beds: list[tuple[float, float]] | None = None) -> str:
+    """Trayed or packed column. ``packed_beds`` are absolute (y_top, y_bottom) pairs."""
+    out = vessel_vertical(cx, cy, half_width, half_height, half_width * 0.5)
+    for top, bottom in packed_beds or []:
+        out += (f'<rect x="{_n(cx - half_width + 3)}" y="{_n(top)}" '
+                f'width="{_n(2 * half_width - 6)}" height="{_n(bottom - top)}" fill="none"/>')
+        y = top + 6
+        while y < bottom:
+            out += (f'<path d="M{_n(cx - half_width + 3)},{_n(y)} '
+                    f'L{_n(cx + half_width - 3)},{_n(y - 5)}" stroke-width=".8" opacity=".5"/>')
+            y += 9
+    return out
+
+
+def exchanger_shell_tube(cx: float, cy: float, r: float) -> str:
+    """Shell-and-tube exchanger."""
+    return (f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="{_n(r)}" fill="none"/>'
+            f'<path d="M{_n(cx - r)},{_n(cy - r * 0.42)} H{_n(cx + r * 0.28)} '
+            f'A{_n(r * 0.42)},{_n(r * 0.42)} 0 0 1 {_n(cx + r * 0.28)},{_n(cy + r * 0.42)} '
+            f'H{_n(cx - r)}" fill="none"/>')
+
+
+def exchanger_plate_fin(cx: float, cy: float, half_width: float,
+                        half_height: float) -> str:
+    """Brazed-aluminium plate-fin exchanger — the cold-box workhorse."""
+    return (f'<rect x="{_n(cx - half_width)}" y="{_n(cy - half_height)}" '
+            f'width="{_n(2 * half_width)}" height="{_n(2 * half_height)}" fill="none"/>'
+            f'<path d="M{_n(cx - half_width)},{_n(cy + half_height)} '
+            f'L{_n(cx + half_width)},{_n(cy - half_height)}" stroke-width="1" opacity=".55"/>')
+
+
+def air_cooler(cx: float, cy: float, half_width: float) -> str:
+    """Air cooler (fin-fan): tube bundle over a fan."""
+    return (f'<rect x="{_n(cx - half_width)}" y="{_n(cy - 18)}" '
+            f'width="{_n(2 * half_width)}" height="16" fill="none"/>'
+            f'<path d="M{_n(cx - 14)},{_n(cy + 6)} A14,9 0 0 1 {_n(cx + 14)},{_n(cy + 6)}" '
+            f'fill="none"/>'
+            f'<path d="M{_n(cx - 14)},{_n(cy + 14)} A14,9 0 0 1 {_n(cx + 14)},{_n(cy + 14)}" '
+            f'fill="none"/>')
+
+
+def turbomachine(cx: float, cy: float, half_width: float, half_height: float,
+                 expanding: bool = False) -> str:
+    """Trapezoid for a compressor (narrowing) or expander (widening)."""
+    if expanding:
+        d = (f"M{_n(cx - half_width)},{_n(cy - half_height * 0.45)} "
+             f"L{_n(cx + half_width)},{_n(cy - half_height)} "
+             f"L{_n(cx + half_width)},{_n(cy + half_height)} "
+             f"L{_n(cx - half_width)},{_n(cy + half_height * 0.45)} Z")
+    else:
+        d = (f"M{_n(cx - half_width)},{_n(cy - half_height)} "
+             f"L{_n(cx + half_width)},{_n(cy - half_height * 0.45)} "
+             f"L{_n(cx + half_width)},{_n(cy + half_height * 0.45)} "
+             f"L{_n(cx - half_width)},{_n(cy + half_height)} Z")
+    return f'<path d="{d}" fill="none"/>'
+
+
+def pump(cx: float, cy: float, r: float = 16.0, flip: bool = False) -> str:
+    """Centrifugal pump. ``flip`` points the impeller marker left for a
+    right-to-left run, so the symbol agrees with the flow arrow."""
+    d = -1 if flip else 1
+    return (f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="{_n(r)}" fill="none"/>'
+            f'<path d="M{_n(cx - d * r * 0.5)},{_n(cy - r * 0.62)} '
+            f'L{_n(cx + d * r * 0.7)},{_n(cy)} '
+            f'L{_n(cx - d * r * 0.5)},{_n(cy + r * 0.62)} Z" fill="none"/>')
+
+
+def generator(cx: float, cy: float, r: float = 16.0, label: str = "G") -> str:
+    """Rotating machine circle — generator, motor, or driver."""
+    return (f'<circle cx="{_n(cx)}" cy="{_n(cy)}" r="{_n(r)}" fill="none"/>'
+            + _t(cx, cy + 5, label, 13))
+
+
+def transformer(cx: float, cy: float, r: float = 13.0) -> str:
+    """Two-winding transformer, for the electrical one-line inset."""
+    return (f'<circle cx="{_n(cx)}" cy="{_n(cy - r * 0.62)}" r="{_n(r)}" fill="none"/>'
+            f'<circle cx="{_n(cx)}" cy="{_n(cy + r * 0.62)}" r="{_n(r)}" fill="none"/>')
+
+
+def breaker(cx: float, cy: float, half: float = 9.0) -> str:
+    """Circuit breaker."""
+    return (f'<rect x="{_n(cx - half)}" y="{_n(cy - half)}" width="{_n(2 * half)}" '
+            f'height="{_n(2 * half)}" fill="none"/>')
+
+
+def busbar(x1: float, x2: float, y: float) -> str:
+    """Switchgear bus."""
+    return (f'<path d="M{_n(x1)},{_n(y)} H{_n(x2)}" stroke-width="5" '
+            f'stroke-linecap="butt"/>')

--- a/src/digitalmodel/process_diagrams/tags.py
+++ b/src/digitalmodel/process_diagrams/tags.py
@@ -1,0 +1,239 @@
+"""ISA-5.1 tag and line-number grammar.
+
+Parsing and validation for the two identifier schemes that carry most of the
+information on a piping and instrumentation diagram:
+
+- **Instrument tags** (``PDIC-1204``) — ANSI/ISA-5.1 alphanumeric identification.
+- **Line numbers** (``12"-PG-1001-A1A-IH``) — the compound pipe identifier.
+
+The tag reads left to right as a first letter (the measured variable), an
+optional variable modifier, one or more succeeding letters (the functions the
+device performs), and the loop number. Every device on a loop shares the number,
+so ``PDIC-1204`` and its final element ``PDV-1204`` are the same loop.
+
+A ``Z`` in the modifier position marks a safety-instrumented function, which is
+how a reader distinguishes a trip from an alarm without tracing bubble geometry
+(ISA-5.1-2009 permits this or an explicit ``(SIS)`` suffix).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ISA-5.1 first letters (measured variable / initiating variable).
+VARIABLES: dict[str, str] = {
+    "A": "analysis", "B": "burner or combustion", "C": "user's choice",
+    "D": "density", "E": "voltage", "F": "flow", "G": "gauging or dimension",
+    "H": "hand", "I": "current", "J": "power", "K": "time or time schedule",
+    "L": "level", "M": "moisture or humidity", "N": "user's choice",
+    "O": "user's choice", "P": "pressure", "Q": "quantity",
+    "R": "radiation", "S": "speed or frequency", "T": "temperature",
+    "U": "multivariable", "V": "vibration", "W": "weight or force",
+    "X": "unclassified", "Y": "event, state or presence", "Z": "position",
+}
+
+# Letters that act as a variable modifier when they follow the first letter.
+VARIABLE_MODIFIERS: dict[str, str] = {
+    "D": "differential", "F": "ratio", "Q": "integrate or totalise",
+    "S": "safety", "Z": "safety instrumented system", "X": "unclassified",
+}
+
+# ISA-5.1 succeeding letters (readout / passive / output function).
+FUNCTIONS: dict[str, str] = {
+    "A": "alarm", "B": "user's choice", "C": "control", "E": "primary element",
+    "G": "glass or viewing device", "I": "indicate", "K": "control station",
+    "L": "light", "N": "user's choice", "O": "orifice or restriction",
+    "P": "test point", "Q": "integrate or totalise", "R": "record",
+    "S": "switch", "T": "transmit", "U": "multifunction",
+    "V": "valve, damper or louver", "W": "well or probe",
+    "X": "unclassified", "Y": "relay, compute or convert", "Z": "actuator",
+}
+
+# Trailing function modifiers. Longest first — HH must be tried before H.
+FUNCTION_MODIFIERS: tuple[str, ...] = ("HH", "LL", "H", "L")
+
+_TAG_RE = re.compile(
+    r"^(?P<letters>[A-Z]{1,6})-(?P<loop>[0-9]{1,6}[A-Z]?)(?:\s*\((?P<sis>SIS)\))?$"
+)
+_LINE_RE = re.compile(
+    r'^(?P<size>\d+(?:\.\d+)?|\d+/\d+|\d+-\d+/\d+)"'
+    r"-(?P<service>[A-Z]{1,4})"
+    r"-(?P<sequence>[0-9]{2,6})"
+    r"-(?P<piping_class>[A-Z0-9]{2,6})"
+    r"(?:-(?P<insulation>[A-Z]{1,3}))?$"
+)
+
+
+class TagError(ValueError):
+    """Raised when a string is not a well-formed ISA-5.1 tag or line number."""
+
+
+@dataclass(frozen=True)
+class Tag:
+    """A parsed ISA-5.1 instrument tag."""
+
+    raw: str
+    variable: str
+    variable_modifier: str | None
+    functions: str
+    function_modifier: str | None
+    loop: str
+    sis_suffix: bool = False
+
+    @property
+    def letters(self) -> str:
+        """The full letter block, e.g. ``PDIC``."""
+        parts = [self.variable, self.variable_modifier or "", self.functions,
+                 self.function_modifier or ""]
+        return "".join(parts)
+
+    @property
+    def is_safety_function(self) -> bool:
+        """True where the tag marks a safety-instrumented function.
+
+        Either the ``Z`` variable modifier or an explicit ``(SIS)`` suffix.
+        ISA-5.1-2009 allows both; a drawing set should declare which it uses
+        on its legend sheet and then stay consistent.
+        """
+        return self.variable_modifier == "Z" or self.sis_suffix
+
+    @property
+    def is_trip(self) -> bool:
+        """True where the tag carries a high-high or low-low function modifier."""
+        return self.function_modifier in ("HH", "LL")
+
+    def describe(self) -> str:
+        """Plain-language expansion, e.g. 'pressure, differential, indicate, transmit'."""
+        parts = [VARIABLES.get(self.variable, "unknown variable")]
+        if self.variable_modifier:
+            parts.append(VARIABLE_MODIFIERS.get(self.variable_modifier, "unknown modifier"))
+        parts.extend(FUNCTIONS.get(letter, "unknown function") for letter in self.functions)
+        if self.function_modifier:
+            parts.append({"HH": "high-high", "LL": "low-low",
+                          "H": "high", "L": "low"}[self.function_modifier])
+        return ", ".join(parts)
+
+    def same_loop(self, other: "Tag") -> bool:
+        """True where two tags belong to the same control loop."""
+        return self.loop == other.loop
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.raw
+
+
+def parse_tag(text: str) -> Tag:
+    """Parse an ISA-5.1 instrument tag.
+
+    >>> t = parse_tag("PDIC-1204")
+    >>> (t.variable, t.variable_modifier, t.functions, t.loop)
+    ('P', 'D', 'IC', '1204')
+    >>> parse_tag("PZHH-401").is_safety_function
+    True
+
+    Two disambiguation rules, both inherent to the grammar rather than stated
+    by the standard — a real drawing's legend sheet is the tie-breaker:
+
+    - ``Z`` in second position is always the safety-system variable modifier,
+      because as a succeeding letter it means "actuator" and never appears
+      there (position tags put Z first: ``ZV``, ``ZC``, ``ZT``).
+    - Any other modifier letter is read as a modifier only when letters follow
+      it, so ``PDT-101`` is a differential pressure transmitter.
+
+    Project-specific tags that are common in oil and gas but outside strict
+    ISA usage — ``SDV`` shutdown valve, ``BDV`` blowdown valve — parse, but
+    they parse against the ISA reading of each letter, not the house meaning.
+    """
+    m = _TAG_RE.match(text.strip().upper())
+    if not m:
+        raise TagError(f"not a well-formed ISA-5.1 tag: {text!r}")
+    letters = m.group("letters")
+
+    variable = letters[0]
+    if variable not in VARIABLES:
+        raise TagError(f"{variable!r} is not an ISA-5.1 first letter (in {text!r})")
+    rest = letters[1:]
+
+    modifier = None
+    if rest.startswith("Z"):
+        # Z in second position is always read as the safety-system variable
+        # modifier. As a succeeding letter Z means "actuator", which does not
+        # occur in second position on real tags (position tags put Z first:
+        # ZV, ZC, ZT).
+        modifier, rest = "Z", rest[1:]
+    elif len(rest) >= 2 and rest[0] in VARIABLE_MODIFIERS:
+        modifier, rest = rest[0], rest[1:]
+
+    function_modifier = None
+    for suffix in FUNCTION_MODIFIERS:
+        if len(rest) >= len(suffix) and rest.endswith(suffix):
+            function_modifier, rest = suffix, rest[: -len(suffix)]
+            break
+
+    if not rest and modifier is None and function_modifier is None:
+        raise TagError(f"tag {text!r} has no succeeding (function) letter")
+    for letter in rest:
+        if letter not in FUNCTIONS:
+            raise TagError(f"{letter!r} is not an ISA-5.1 succeeding letter (in {text!r})")
+
+    return Tag(
+        raw=text.strip(),
+        variable=variable,
+        variable_modifier=modifier,
+        functions=rest,
+        function_modifier=function_modifier,
+        loop=m.group("loop"),
+        sis_suffix=m.group("sis") is not None,
+    )
+
+
+@dataclass(frozen=True)
+class LineNumber:
+    """A parsed pipe line number, e.g. ``12"-PG-1001-A1A-IH``."""
+
+    raw: str
+    size_in: float
+    service: str
+    sequence: str
+    piping_class: str
+    insulation: str | None = None
+
+    @property
+    def is_insulated(self) -> bool:
+        return self.insulation is not None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.raw
+
+
+def parse_line_number(text: str) -> LineNumber:
+    """Parse a compound line number.
+
+    >>> ln = parse_line_number('12"-PG-1001-A1A-IH')
+    >>> (ln.size_in, ln.service, ln.piping_class, ln.insulation)
+    (12.0, 'PG', 'A1A', 'IH')
+
+    A new line number is assigned whenever size, service, or piping class
+    changes, so these three fields together are what makes a run distinct.
+    """
+    m = _LINE_RE.match(text.strip().upper())
+    if not m:
+        raise TagError(f"not a well-formed line number: {text!r}")
+    size = m.group("size")
+    if "-" in size:  # e.g. 1-1/2"
+        whole, frac = size.split("-")
+        num, den = frac.split("/")
+        size_in = float(whole) + float(num) / float(den)
+    elif "/" in size:
+        num, den = size.split("/")
+        size_in = float(num) / float(den)
+    else:
+        size_in = float(size)
+    return LineNumber(
+        raw=text.strip(),
+        size_in=size_in,
+        service=m.group("service"),
+        sequence=m.group("sequence"),
+        piping_class=m.group("piping_class"),
+        insulation=m.group("insulation"),
+    )

--- a/tests/process_diagrams/test_geometry.py
+++ b/tests/process_diagrams/test_geometry.py
@@ -1,0 +1,70 @@
+"""Pipe-run geometry: line-crossing jumps and run construction."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.process_diagrams.geometry import (
+    HOP_RADIUS,
+    horizontal,
+    polyline,
+    run_length,
+    signal,
+    vertical,
+)
+
+
+def _arc_count(path: str) -> int:
+    return path.count("A" + str(int(HOP_RADIUS)))
+
+
+class TestHops:
+    def test_run_without_crossings_is_a_straight_line(self):
+        assert horizontal(0, 100, 50) == "M0,50 L100,50"
+        assert vertical(0, 100, 50) == "M50,0 L50,100"
+
+    def test_each_crossing_inserts_one_arc(self):
+        assert _arc_count(horizontal(0, 200, 50, crossings=[40, 120])) == 2
+        assert _arc_count(vertical(0, 200, 50, crossings=[40, 120])) == 2
+
+    @pytest.mark.parametrize("crossing", [0, 100, -10, 260])
+    def test_crossing_at_or_beyond_an_endpoint_is_not_a_jump(self, crossing):
+        # A line that terminates at the crossing is a connection, not a jump.
+        assert horizontal(0, 100, 50, crossings=[crossing]) == "M0,50 L100,50"
+
+    def test_arc_straddles_the_crossing_symmetrically(self):
+        path = horizontal(0, 100, 50, crossings=[40])
+        assert f"L{40 - int(HOP_RADIUS)},50" in path
+        assert f"{40 + int(HOP_RADIUS)},50" in path
+
+    def test_right_to_left_run_orders_hops_along_travel(self):
+        path = horizontal(200, 0, 50, crossings=[40, 120])
+        # Travelling leftward the far crossing (120) is reached first, and the
+        # arc is entered on its near side at 127 before landing at 113.
+        assert path.index("127") < path.index("47")
+        assert path.startswith("M200,50")
+
+    def test_bottom_to_top_run_orders_hops_along_travel(self):
+        path = vertical(200, 0, 50, crossings=[40, 120])
+        assert path.index("127") < path.index("47")
+
+    def test_signal_lines_never_hop(self):
+        # Signal line style already distinguishes them, so they cross freely.
+        assert _arc_count(signal([(0, 50), (100, 50)])) == 0
+
+
+class TestRuns:
+    def test_polyline_walks_every_point(self):
+        assert polyline([(0, 0), (10, 0), (10, 20)]) == "M0,0 L10,0 L10,20"
+
+    def test_polyline_needs_two_points(self):
+        with pytest.raises(ValueError):
+            polyline([(0, 0)])
+
+    def test_run_length_is_euclidean(self):
+        assert run_length([(0, 0), (3, 4)]) == pytest.approx(5.0)
+        assert run_length([(0, 0), (3, 4), (3, 8)]) == pytest.approx(9.0)
+
+    def test_coordinates_drop_trailing_zeros(self):
+        assert horizontal(0.0, 100.0, 50.0) == "M0,50 L100,50"
+        assert "12.5" in horizontal(0, 100, 12.5)

--- a/tests/process_diagrams/test_sheet.py
+++ b/tests/process_diagrams/test_sheet.py
@@ -1,0 +1,170 @@
+"""Sheet assembly, rendering, and drafting lint."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from digitalmodel.process_diagrams import Sheet, TitleBlock, symbols
+from digitalmodel.process_diagrams.sheet import (
+    ZONE_LETTERS,
+    note_flag,
+    off_page_connector,
+)
+from digitalmodel.process_diagrams.tags import TagError
+
+
+@pytest.fixture
+def sheet() -> Sheet:
+    return Sheet(
+        width=800, height=600,
+        title_block=TitleBlock(
+            drawing_number="AE-0000-PID-1001", title="INLET SEPARATION",
+            originator="ACEENGINEER", revision="A", sheet="1 OF 3",
+            date="2026-09-03",
+        ),
+        aria_label="Test sheet",
+    )
+
+
+class TestRendering:
+    def test_renders_well_formed_svg(self, sheet):
+        sheet.add(symbols.vessel_vertical(200, 300, 30, 70))
+        root = ET.fromstring(sheet.render())
+        assert root.tag == "svg"
+        assert root.get("viewBox") == "0 0 800 600"
+
+    def test_carries_an_aria_label_for_screen_readers(self, sheet):
+        assert ET.fromstring(sheet.render()).get("aria-label") == "Test sheet"
+
+    def test_zone_grid_letters_run_bottom_to_top(self, sheet):
+        out = sheet.render()
+        # Four rows: A at the bottom of the sheet, D at the top.
+        for letter in ZONE_LETTERS[-4:]:
+            assert f">{letter}</text>" in out
+
+    def test_title_block_carries_the_controlled_document_fields(self, sheet):
+        out = sheet.render()
+        assert "AE-0000-PID-1001" in out
+        assert "INLET SEPARATION" in out
+        assert "A · 1 OF 3" in out
+        assert "SCALE: NONE" in out          # P&IDs are never to scale
+        assert "NOT FOR CONSTRUCTION" in out  # default status stamp
+
+    def test_status_stamp_can_be_changed_on_issue(self, sheet):
+        sheet.title_block.status = "ISSUED FOR REVIEW"
+        assert "ISSUED FOR REVIEW" in sheet.render()
+
+    def test_notes_column_numbers_notes_from_one(self, sheet):
+        assert sheet.note("First note.") == 1
+        assert sheet.note("Second note.") == 2
+        out = sheet.render()
+        assert "1. First note." in out and "2. Second note." in out
+
+    def test_no_notes_column_when_there_are_no_notes(self, sheet):
+        assert "NOTES" not in sheet.render()
+
+
+class TestTagValidation:
+    def test_instruments_are_validated_as_they_are_placed(self, sheet):
+        sheet.add_instrument(100, 100, "LIC-401", kind="bpcs")
+        assert sheet.loops() == {"401": ["LIC-401"]}
+
+    def test_a_malformed_tag_fails_at_build_time(self, sheet):
+        with pytest.raises(TagError):
+            sheet.add_instrument(100, 100, "NOTATAG", kind="field")
+
+    def test_loops_group_controller_with_final_element(self, sheet):
+        sheet.add_instrument(100, 100, "LIC-401", kind="bpcs")
+        sheet.add_control_valve(200, 100, "LV-401")
+        assert sheet.loops()["401"] == ["LIC-401", "LV-401"]
+
+
+class TestLint:
+    def test_clean_sheet_reports_nothing(self, sheet):
+        sheet.add_control_valve(200, 100, "LV-401", fail="FC")
+        assert sheet.lint() == []
+
+    def test_control_valve_without_a_fail_action_is_a_defect(self, sheet):
+        sheet.add_control_valve(200, 100, "LV-401", fail=None)
+        assert sheet.lint() == ["control valve LV-401 has no fail action annotated"]
+
+    def test_duplicate_tags_are_reported(self, sheet):
+        sheet.add_instrument(100, 100, "LIC-401", kind="bpcs")
+        sheet.add_instrument(300, 100, "LIC-401", kind="bpcs")
+        assert sheet.lint() == ["tag LIC-401 is used 2 times"]
+
+    def test_fail_open_is_accepted_and_annotated(self, sheet):
+        # The anti-surge recycle valve is normally the only FO on a
+        # compressor sheet; it must survive lint and appear on the drawing.
+        sheet.add_control_valve(200, 100, "UV-501", fail="FO", actuator="piston")
+        assert sheet.lint() == []
+        assert ">FO</text>" in sheet.render()
+
+
+class TestAnnotation:
+    def test_off_page_connector_points_the_way_it_is_told(self):
+        right = off_page_connector(0, 100, ["TO PID-1003"], direction="right")
+        left = off_page_connector(0, 100, ["FROM PID-1001"], direction="left")
+        assert "TO PID-1003" in right and "FROM PID-1001" in left
+        assert right != left
+
+    def test_connector_carries_line_number_and_destination(self):
+        out = off_page_connector(0, 100, ['16"-RG-5003-F1A', "PID-1004 / D-2"])
+        # The inch mark is escaped, or the document stops parsing.
+        assert "16&quot;-RG-5003-F1A" in out and "PID-1004 / D-2" in out
+        ET.fromstring(f'<svg xmlns="http://www.w3.org/2000/svg">{out}</svg>')
+
+    def test_ampersands_and_quotes_in_labels_are_escaped(self, sheet):
+        # "SHELL & TUBE" and a 12" line number both break a raw document.
+        sheet.note('EXCHANGER, SHELL & TUBE on 12"-PG-1001-A1A')
+        sheet.title_block.title = "AMINE & DEHYDRATION"
+        out = sheet.render()
+        ET.fromstring(out)
+        assert "SHELL &amp; TUBE" in out and "AMINE &amp; DEHYDRATION" in out
+
+    def test_note_flag_shows_its_number(self):
+        assert ">3</text>" in note_flag(100, 100, 3)
+
+
+class TestSymbols:
+    @pytest.mark.parametrize(
+        "kind,expected",
+        [("field", "circle"), ("bpcs", "rect"), ("sis", "rect"),
+         ("computer", "path"), ("interlock", "path")],
+    )
+    def test_bubble_kind_selects_the_geometry(self, kind, expected):
+        assert f"<{expected}" in symbols.bubble(50, 50, "PT", "101", kind=kind)
+
+    def test_bpcs_is_a_circle_in_a_square_and_sis_a_diamond_in_a_square(self):
+        # ISA-5.1-2009: the square means shared display / shared control; the
+        # inner shape selects BPCS vs SIS. It does NOT mean DCS vs PLC.
+        bpcs = symbols.bubble(50, 50, "PIC", "101", kind="bpcs")
+        sis = symbols.bubble(50, 50, "PZHH", "101", kind="sis")
+        assert "<circle" in bpcs and "<rect" in bpcs
+        assert "<rect" in sis and "<circle" not in sis
+
+    def test_every_symbol_is_well_formed_xml(self):
+        fragments = [
+            symbols.bubble(50, 50, "PT", "101"),
+            symbols.gate(100, 100), symbols.globe(150, 100), symbols.ball(200, 100),
+            symbols.check(250, 100), symbols.relief_valve(300, 100),
+            symbols.orifice(350, 100),
+            symbols.control_valve(400, 100, actuator="solenoid", fail="FC"),
+            symbols.vessel_vertical(100, 200, 20, 40),
+            symbols.vessel_horizontal(200, 200, 40, 20),
+            symbols.column(300, 250, 30, 100, packed_beds=[(180, 220)]),
+            symbols.exchanger_shell_tube(400, 200, 17),
+            symbols.exchanger_plate_fin(450, 200, 20, 15),
+            symbols.air_cooler(500, 200, 30),
+            symbols.turbomachine(560, 200, 25, 20, expanding=True),
+            symbols.pump(620, 200), symbols.pump(660, 200, flip=True),
+            symbols.generator(700, 200), symbols.transformer(740, 200),
+            symbols.breaker(780, 200), symbols.busbar(0, 800, 260),
+        ]
+        ET.fromstring('<svg xmlns="http://www.w3.org/2000/svg">'
+                      + "".join(fragments) + "</svg>")
+
+    def test_pump_impeller_flips_for_a_right_to_left_run(self):
+        assert symbols.pump(100, 100) != symbols.pump(100, 100, flip=True)

--- a/tests/process_diagrams/test_tags.py
+++ b/tests/process_diagrams/test_tags.py
@@ -1,0 +1,112 @@
+"""ISA-5.1 tag and line-number grammar."""
+
+from __future__ import annotations
+
+import pytest
+
+from digitalmodel.process_diagrams.tags import (
+    LineNumber,
+    TagError,
+    parse_line_number,
+    parse_tag,
+)
+
+
+class TestInstrumentTags:
+    def test_splits_variable_modifier_functions_and_loop(self):
+        tag = parse_tag("PDIC-1204")
+        assert (tag.variable, tag.variable_modifier) == ("P", "D")
+        assert tag.functions == "IC"
+        assert tag.loop == "1204"
+        assert tag.letters == "PDIC"
+
+    def test_describes_each_letter(self):
+        assert parse_tag("PDIC-1204").describe() == (
+            "pressure, differential, indicate, control"
+        )
+        assert parse_tag("FQI-416").describe() == (
+            "flow, integrate or totalise, indicate"
+        )
+
+    def test_z_in_second_position_is_the_sis_modifier(self):
+        # As a succeeding letter Z means "actuator" and never appears second;
+        # position tags put Z first (ZV, ZC, ZT).
+        tag = parse_tag("SZ-404")
+        assert tag.variable_modifier == "Z"
+        assert tag.is_safety_function
+
+        position_tag = parse_tag("ZV-403")
+        assert position_tag.variable == "Z"
+        assert position_tag.variable_modifier is None
+        assert not position_tag.is_safety_function
+
+    def test_high_high_and_low_low_are_trips(self):
+        assert parse_tag("PZHH-401").is_trip
+        assert parse_tag("LSLL-102").is_trip
+        assert not parse_tag("LAH-102").is_trip
+        assert parse_tag("LAH-102").function_modifier == "H"
+
+    @pytest.mark.parametrize(
+        "tag,expected",
+        [("PZHH-401", True), ("AZHH-305", True), ("SZ-404", True),
+         ("PSHH-401", False), ("LAHH-401", False), ("TIC-409", False)],
+    )
+    def test_safety_function_detection(self, tag, expected):
+        assert parse_tag(tag).is_safety_function is expected
+
+    def test_sis_suffix_form_is_also_accepted(self):
+        assert parse_tag("PSHH-401 (SIS)").is_safety_function
+
+    def test_same_loop_groups_controller_and_final_element(self):
+        assert parse_tag("LIC-401").same_loop(parse_tag("LV-401"))
+        assert not parse_tag("LIC-401").same_loop(parse_tag("LV-408"))
+
+    def test_case_and_whitespace_are_normalised(self):
+        assert parse_tag("  pdic-1204 ").letters == "PDIC"
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["P-101",          # no succeeding function letter
+         "PDIC1204",       # no separator
+         "1AB-101",        # digit as first letter
+         "PDIC-",          # no loop number
+         "P#C-101"],       # not a letter
+    )
+    def test_rejects_malformed_tags(self, bad):
+        with pytest.raises(TagError):
+            parse_tag(bad)
+
+
+class TestLineNumbers:
+    def test_splits_all_five_fields(self):
+        line = parse_line_number('12"-PG-1001-A1A-IH')
+        assert line == LineNumber(
+            raw='12"-PG-1001-A1A-IH', size_in=12.0, service="PG",
+            sequence="1001", piping_class="A1A", insulation="IH",
+        )
+        assert line.is_insulated
+
+    def test_insulation_code_is_optional(self):
+        line = parse_line_number('6"-NGL-6003-F1A')
+        assert line.insulation is None
+        assert not line.is_insulated
+
+    @pytest.mark.parametrize(
+        "text,size",
+        [('1-1/2"-FG-2001-C1A', 1.5), ('3/4"-VT-9001-A1A', 0.75), ('24"-FL-7002-A1A', 24.0)],
+    )
+    def test_fractional_and_whole_sizes(self, text, size):
+        assert parse_line_number(text).size_in == pytest.approx(size)
+
+    def test_cryogenic_line_carries_a_low_temperature_class(self):
+        # 304L cryogenic class with cold conservation — the cold flare header
+        # must be a distinct system from the warm carbon-steel one.
+        cold = parse_line_number('12"-FLC-7003-S1D-C')
+        warm = parse_line_number('24"-FL-7002-A1A')
+        assert cold.piping_class != warm.piping_class
+        assert cold.service != warm.service
+
+    @pytest.mark.parametrize("bad", ["12-PG-1001-A1A", '12"-PG-A1A', "PG-1001-A1A"])
+    def test_rejects_malformed_line_numbers(self, bad):
+        with pytest.raises(TagError):
+            parse_line_number(bad)


### PR DESCRIPTION
New module for building piping and instrumentation diagrams as standalone SVG. Extracted from a session that drew a sample P&ID set — a cryogenic gas plant and a behind-the-meter gas-fired data center campus — where the drawing code turned out to be general enough to keep.

Standard library only. No plotting or CAD dependency, so a sheet can be generated inside a report pipeline or embedded directly in HTML.

## What's in it

| File | Contents |
|---|---|
| `tags.py` | ISA-5.1 instrument-tag and line-number grammar |
| `geometry.py` | Pipe runs with line-crossing jumps |
| `symbols.py` | Equipment, valve, actuator, instrument and electrical symbols |
| `sheet.py` | Sheet scaffold: border grid, notes column, title block, lint |

**`tags.py`** — `parse_tag("PDIC-1204")` splits variable / modifier / functions / loop and expands each letter; `is_safety_function` and `is_trip` fall out of it. Two disambiguation rules the standard leaves open are implemented and documented:

- `Z` in second position is always the safety-system modifier. As a *succeeding* letter it means "actuator", which never appears there — position tags put Z first (`ZV`, `ZC`, `ZT`).
- Any other modifier letter counts as a modifier only when letters follow it, so `PDT-101` is a differential pressure transmitter.

**`geometry.py`** — a crossing at or beyond an endpoint is a connection, not a jump, so it gets no arc. Signal lines never hop, because their dash pattern already distinguishes them.

**`symbols.py`** — the bubble taxonomy is the post-2009 one. The enclosing square means *shared display, shared control*, and the inner shape selects BPCS vs SIS. It has not meant DCS vs PLC since ISA-5.1-2009, which is the most common error on drawings assembled from older references.

**`sheet.py`** — scale is always `NONE` and the status stamp defaults to `NOT FOR CONSTRUCTION`. `Sheet.lint()` reports control valves with no fail action annotated and duplicate tags. A missing fail action is a real defect: on a compressor sheet the anti-surge recycle valve is typically the only `FO` among otherwise `FC` valves, and reversing it wrecks the machine.

## Example

`examples/process_diagrams/legend_sheet.py` generates Sheet 1 of a set — the legend every P&ID package opens with.

## Tests

67 unit tests plus 6 doctests, all passing, run with the repo's own pytest config.

⚠️ One caveat worth flagging: the repo's documented test command (`PYTHONPATH=src uv run python -m pytest`) **cannot build an environment on this machine** — lxml 4.9.3 will not build against Python 3.14. Tests were run on a 3.11 interpreter instead. `uv.lock` is untouched. CI should be the real check here.

## Registry

Registered in `docs/registry/module-routing.yaml` and `docs/maps/digitalmodel-operator-map.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbf9oGe2nDDQEQgNmUNdVp