### PR TITLE
docs(orcawave): intended API specs, lifted out of the skill corpus

### DIFF
--- a/docs/domains/orcawave/intended-api/README.md
+++ b/docs/domains/orcawave/intended-api/README.md
@@ -1,0 +1,31 @@
+# OrcaWave — specifications for unbuilt capability
+
+Seven analysis capabilities documented in the AceEngineer marine-offshore
+skill corpus against an API that does not exist in `digitalmodel`.
+
+Discovered when a real engagement followed one of these skills and found the
+import missing (`aceengineer-strategy#262`, then `#267`). A sweep showed 134
+documented paths across 28 skills did not resolve; most were stale after the
+`solvers/` and `hydrodynamics/` reorganisation and were repointed. These seven
+were not drift — the capability was never built.
+
+| Spec | Snippets | Absent paths |
+|---|---|---|
+| [OrcaWave analysis](analysis.md) | 2 | 8 |
+| [OrcaWave aqwa benchmark](aqwa-benchmark.md) | 2 | 6 |
+| [OrcaWave damping sweep](damping-sweep.md) | 3 | 7 |
+| [OrcaWave mesh generation](mesh-generation.md) | 2 | 7 |
+| [OrcaWave multi body](multi-body.md) | 2 | 6 |
+| [OrcaWave qtf analysis](qtf-analysis.md) | 2 | 6 |
+| [OrcaWave to orcaflex](to-orcaflex.md) | 2 | 9 |
+
+## Why these are here and not in the skill corpus
+
+A skill that documents a non-existent API is worse than no skill: it reads as
+an asset, survives review, and fails at the moment an agent depends on it.
+Moving the specification to the repository that would implement it turns a
+trap into a build target.
+
+The skills keep their engineering content and now carry an explicit warning
+plus an `ace:known-missing` marker, so the absence is declared rather than
+silently carried.

--- a/docs/domains/orcawave/intended-api/analysis.md
+++ b/docs/domains/orcawave/intended-api/analysis.md
@@ -1,0 +1,68 @@
+# Specification: OrcaWave analysis
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/analysis`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.orcawave.batch`
+- `digitalmodel.orcawave.batch.OrcaWaveBatch`
+- `digitalmodel.orcawave.mesh_study`
+- `digitalmodel.orcawave.mesh_study.MeshConvergenceStudy`
+- `digitalmodel.orcawave.orcaflex_export`
+- `digitalmodel.orcawave.orcaflex_export.OrcaFlexExporter`
+- `digitalmodel.orcawave.orcawave_analysis`
+- `digitalmodel.orcawave.orcawave_analysis.OrcaWaveAnalysis`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Analysis
+
+```python
+from digitalmodel.orcawave.orcawave_analysis import OrcaWaveAnalysis
+
+# Initialize analysis
+orcawave = OrcaWaveAnalysis()
+
+# Configure analysis
+config = {
+    "vessel_mesh": "geometry/hull_panels.dat",
+    "water_depth": 1000.0,
+
+*See sub-skills for full details.*
+### Batch Processing
+```
+
+### OrcaFlex Integration
+
+```python
+from digitalmodel.orcawave.orcaflex_export import OrcaFlexExporter
+
+# Initialize exporter
+exporter = OrcaFlexExporter()
+
+# Load OrcaWave results
+exporter.load_results("orcawave_results/vessel.dat")
+
+# Export to OrcaFlex hydrodynamic database
+
+*See sub-skills for full details.*
+### Mesh Convergence Study
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/aqwa-benchmark.md
+++ b/docs/domains/orcawave/intended-api/aqwa-benchmark.md
@@ -1,0 +1,66 @@
+# Specification: OrcaWave aqwa benchmark
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/aqwa-benchmark`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.diffraction.comparison_framework`
+- `digitalmodel.diffraction.comparison_framework.MatrixComparator`
+- `digitalmodel.diffraction.comparison_framework.PeakRAOComparator`
+- `digitalmodel.diffraction.comparison_framework.StatisticalAnalyzer`
+- `digitalmodel.diffraction.orcawave_converter`
+- `digitalmodel.diffraction.orcawave_converter.OrcaWaveConverter`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Comparison
+
+```python
+from digitalmodel.diffraction.comparison_framework import (
+    DiffractionComparator,
+    PeakRAOComparator
+)
+from digitalmodel.hydrodynamics.diffraction.aqwa_converter import AQWAConverter
+from digitalmodel.diffraction.orcawave_converter import OrcaWaveConverter
+
+# Load AQWA results
+aqwa_converter = AQWAConverter()
+
+*See sub-skills for full details.*
+### Peak-Focused Validation
+```
+
+### Matrix Comparison
+
+```python
+from digitalmodel.diffraction.comparison_framework import MatrixComparator
+
+# Compare added mass matrices
+matrix_comp = MatrixComparator()
+
+# Compare at specific frequency
+freq = 0.1  # rad/s
+am_comparison = matrix_comp.compare_added_mass(
+    aqwa_matrix=aqwa_results['added_mass'][freq],
+
+*See sub-skills for full details.*
+### Statistical Analysis
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/damping-sweep.md
+++ b/docs/domains/orcawave/intended-api/damping-sweep.md
@@ -1,0 +1,84 @@
+# Specification: OrcaWave damping sweep
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/damping-sweep`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.orcawave.damping`
+- `digitalmodel.orcawave.damping.BilgeKeelDamping`
+- `digitalmodel.orcawave.damping.CriticalDampingCalculator`
+- `digitalmodel.orcawave.damping.DampingPeriodAnalyzer`
+- `digitalmodel.orcawave.damping.DampingSweep`
+- `digitalmodel.orcawave.damping.ModelTestComparison`
+- `digitalmodel.orcawave.damping.MultiParameterDampingSweep`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Damping Sweep
+
+```python
+from digitalmodel.orcawave.damping import DampingSweep
+
+# Initialize sweep
+sweep = DampingSweep()
+
+# Load base model
+sweep.load_model("models/fpso.owr")
+
+# Define damping values to sweep
+
+*See sub-skills for full details.*
+### Multi-Parameter Sweep
+```
+
+### Critical Damping Calculation
+
+```python
+from digitalmodel.orcawave.damping import CriticalDampingCalculator
+
+# Initialize calculator
+calc = CriticalDampingCalculator()
+
+# Load model with mass and stiffness
+calc.load_model("models/fpso.owr")
+
+# Calculate critical damping for each DOF
+
+*See sub-skills for full details.*
+### Model Test Comparison
+```
+
+### Bilge Keel Estimation
+
+```python
+from digitalmodel.orcawave.damping import BilgeKeelDamping
+
+# Initialize bilge keel damping estimator
+bk = BilgeKeelDamping()
+
+# Configure vessel parameters
+bk.configure_vessel(
+    beam=50.0,          # m
+    draft=22.0,         # m
+
+*See sub-skills for full details.*
+### Damping-Period Relationship
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/mesh-generation.md
+++ b/docs/domains/orcawave/intended-api/mesh-generation.md
@@ -1,0 +1,67 @@
+# Specification: OrcaWave mesh generation
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/mesh-generation`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.orcawave.converters`
+- `digitalmodel.orcawave.converters.STLtoGDFConverter`
+- `digitalmodel.orcawave.mesh`
+- `digitalmodel.orcawave.mesh.OrcaWaveMeshGenerator`
+- `digitalmodel.orcawave.mesh.WaterlineRefiner`
+- `digitalmodel.orcawave.mesh_study`
+- `digitalmodel.orcawave.mesh_study.MeshConvergenceStudy`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Mesh Generation
+
+```python
+from digitalmodel.orcawave.mesh import OrcaWaveMeshGenerator
+
+# Initialize generator
+generator = OrcaWaveMeshGenerator()
+
+# Load CAD geometry
+generator.load_geometry("geometry/hull.stl")
+
+# Generate panel mesh
+
+*See sub-skills for full details.*
+### Mesh Convergence Study
+```
+
+### STL to GDF Conversion
+
+```python
+from digitalmodel.orcawave.converters import STLtoGDFConverter
+
+# Initialize converter
+converter = STLtoGDFConverter()
+
+# Convert with options
+converter.convert(
+    input_file="geometry/hull.stl",
+    output_file="geometry/hull.gdf",
+
+*See sub-skills for full details.*
+### Waterline Refinement
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/multi-body.md
+++ b/docs/domains/orcawave/intended-api/multi-body.md
@@ -1,0 +1,66 @@
+# Specification: OrcaWave multi body
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/multi-body`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.orcawave.multibody`
+- `digitalmodel.orcawave.multibody.CouplingMatrixExtractor`
+- `digitalmodel.orcawave.multibody.GapResonanceAnalyzer`
+- `digitalmodel.orcawave.multibody.MultiBodyAnalysis`
+- `digitalmodel.orcawave.multibody.ShieldingAnalyzer`
+- `digitalmodel.orcawave.multibody.SideBySideAnalysis`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Multi-Body Setup
+
+```python
+from digitalmodel.orcawave.multibody import MultiBodyAnalysis
+
+# Initialize multi-body analysis
+mb = MultiBodyAnalysis()
+
+# Add primary vessel (FPSO)
+mb.add_body(
+    name="FPSO",
+    mesh_file="geometry/fpso_panels.gdf",
+
+*See sub-skills for full details.*
+### Gap Resonance Analysis
+```
+
+### Side-by-Side Operations
+
+```python
+from digitalmodel.orcawave.multibody import SideBySideAnalysis
+
+# Initialize STS analysis
+sts = SideBySideAnalysis()
+
+# Configure vessels
+sts.configure_fpso(
+    mesh="geometry/fpso.gdf",
+    loa=300.0,
+
+*See sub-skills for full details.*
+### Hydrodynamic Coupling Matrices
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/qtf-analysis.md
+++ b/docs/domains/orcawave/intended-api/qtf-analysis.md
@@ -1,0 +1,66 @@
+# Specification: OrcaWave qtf analysis
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/qtf-analysis`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.orcawave.qtf`
+- `digitalmodel.orcawave.qtf.FullQTFComputation`
+- `digitalmodel.orcawave.qtf.MeanDriftAnalyzer`
+- `digitalmodel.orcawave.qtf.NewmanApproximation`
+- `digitalmodel.orcawave.qtf.OrcaWaveQTF`
+- `digitalmodel.orcawave.qtf.SlowDriftResponse`
+
+## Intended usage (verbatim from the skill)
+
+### Basic QTF Computation
+
+```python
+from digitalmodel.orcawave.qtf import OrcaWaveQTF
+
+# Initialize QTF analysis
+qtf = OrcaWaveQTF()
+
+# Load OrcaWave model with first-order results
+qtf.load_model("models/fpso.owr")
+
+# Configure QTF computation
+
+*See sub-skills for full details.*
+### Full QTF Matrix Generation
+```
+
+### Newman Approximation
+
+```python
+from digitalmodel.orcawave.qtf import NewmanApproximation
+
+# Initialize Newman approximation
+newman = NewmanApproximation()
+
+# Load first-order results
+newman.load_first_order_results("results/fpso_raos.csv")
+
+# Compute approximate QTF
+
+*See sub-skills for full details.*
+### Mean Drift Analysis
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.

--- a/docs/domains/orcawave/intended-api/to-orcaflex.md
+++ b/docs/domains/orcawave/intended-api/to-orcaflex.md
@@ -1,0 +1,69 @@
+# Specification: OrcaWave to orcaflex
+
+> **Status: NOT IMPLEMENTED.** This is a specification of intended
+> capability, lifted verbatim from the AceEngineer marine-offshore skill
+> corpus (`engineering/marine-offshore/orcawave/to-orcaflex`). None of the
+> API below exists in `digitalmodel` today.
+>
+> It lives here rather than in the skill corpus because a specification
+> belongs with the codebase that would implement it — in a skill corpus an
+> agent may act on it as though it runs. Tracked in
+> `aceengineer-strategy#267`.
+
+## Absent API surface
+
+- `digitalmodel.diffraction.orcawave_converter`
+- `digitalmodel.diffraction.orcawave_converter.OrcaWaveConverter`
+- `digitalmodel.orcawave.coordinate_transform`
+- `digitalmodel.orcawave.coordinate_transform.CoordinateTransformer`
+- `digitalmodel.orcawave.orcaflex_export`
+- `digitalmodel.orcawave.orcaflex_export.HydrodynamicDatabaseCreator`
+- `digitalmodel.orcawave.orcaflex_export.OrcaWaveToOrcaFlex`
+- `digitalmodel.orcawave.rao_import`
+- `digitalmodel.orcawave.rao_import.RAOImporter`
+
+## Intended usage (verbatim from the skill)
+
+### Basic Conversion
+
+```python
+from digitalmodel.diffraction.orcawave_converter import OrcaWaveConverter
+from digitalmodel.hydrodynamics.diffraction.orcaflex_exporter import OrcaFlexExporter
+
+# Load OrcaWave results
+import OrcFxAPI
+
+# Option 1: From OrcaWave model directly
+orcawave_model = OrcFxAPI.DiffractionModel("models/fpso.owr")
+vessel = orcawave_model.Vessel
+
+*See sub-skills for full details.*
+### With Viscous Damping
+```
+
+### Full Hydrodynamic Database
+
+```python
+from digitalmodel.orcawave.orcaflex_export import HydrodynamicDatabaseCreator
+
+# Create complete hydrodynamic database
+db_creator = HydrodynamicDatabaseCreator()
+
+# Load all loading conditions
+db_creator.add_condition(
+    name="full_load",
+    orcawave_file="models/fpso_full.owr",
+
+*See sub-skills for full details.*
+### RAO Import with Validation
+```
+
+## Notes for an implementer
+
+- The snippets are **intent, not contract**. Names and signatures were
+  written against an API that was never built, so treat them as a starting
+  point rather than a spec to match exactly.
+- The engineering content that surrounded them — when to use this analysis,
+  what to watch for — stays in the skill corpus and is unaffected.
+- If a capability here is built, remove it from the skill's
+  `ace:known-missing` marker so the corpus check reflects reality.


### PR DESCRIPTION
## What

Adds `docs/domains/orcawave/intended-api/` — seven specifications for OrcaWave analysis capability that is **documented but not implemented** in this repo.

Docs only. No code changes.

## Why

The AceEngineer marine-offshore skill corpus documents seven OrcaWave capabilities against an API that does not exist here — neither `digitalmodel.orcawave` nor `digitalmodel.solvers.orcawave` has `qtf`, `mesh`, `multibody` or `converters`.

This surfaced when a real engagement followed one of those skills and hit the missing import. A sweep then found **134 documented paths across 28 skills that did not resolve**. Most were stale after the `solvers/` and `hydrodynamics/` reorganisation and have been repointed upstream. These seven were not drift — the capability was never built.

## The reasoning

A skill that documents a non-existent API is worse than no skill: it reads as an asset, survives review, and fails at the moment an agent depends on it. In one case here the nearest real class was *quarantined* for returning hardcoded fractions of water depth — so following the documentation silently produced fabricated geometry rather than an error.

The prose in those skills — when to use each analysis, what to watch for — is sound engineering and stays where it is. The code blocks are a **specification**, and a specification belongs with the codebase that would implement it. In a skill corpus, an agent may act on it as though it runs.

Snippets are lifted **verbatim**. They are somebody's intent about an API surface, and paraphrasing intent loses the part that mattered. Each spec is explicit that names and signatures are a starting point, not a contract.

## Contents

| Spec | Snippets | Absent paths |
|---|---|---|
| analysis | 2 | 8 |
| aqwa-benchmark | 2 | 6 |
| damping-sweep | 3 | 7 |
| mesh-generation | 2 | 7 |
| multi-body | 2 | 6 |
| qtf-analysis | 2 | 6 |
| to-orcaflex | 2 | 9 |

## Note on placement

Intended for `docs/specs/`, but `.gitignore` excludes a bare `specs/` alongside `outputs/` — evidently aimed at generated scratch dirs. Placed under `docs/domains/orcawave/` beside the existing OrcaWave docs rather than forcing past that rule.

## Related

- `vamseeachanta/aceengineer-strategy#262` — the engagement that found it
- `vamseeachanta/aceengineer-strategy#267` — the corpus sweep and triage
- #2044 — a separate `LazyWaveSolver.vertical_force` defect found in the same run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhjqyL6pfKDFksVBJ8ZPGe