### PR TITLE
feat(pipeline): Hobbs (1984) closed-form lateral buckling

### DIFF
--- a/docs/domains/pipelines/hobbs-lateral-buckling.md
+++ b/docs/domains/pipelines/hobbs-lateral-buckling.md
@@ -1,0 +1,138 @@
+# Hobbs closed-form lateral buckling
+
+`digitalmodel.subsea.pipeline.global_buckling`
+
+## Why this exists
+
+`digitalmodel.subsea.pipeline.lateral_buckling` already builds the
+effective-axial-force profile along a route from a YAML config, finds the
+anchor lengths, and applies a single susceptibility screen
+(`0.65 x 2.26 (EA)^0.25 (EI)^0.25 phi_L^0.5`, plus a route-curve criterion).
+It answers **"can this line buckle?"**
+
+It does not answer the question that follows: **"and then what?"** — how long
+is the buckle, how far does it sweep, what bending moment and combined stress
+does it carry, and how much hotter can the line get before the buckle snaps
+onto the long branch.
+
+This package supplies that half, from the closed-form solution in
+Hobbs (1984). It is deliberately standalone: SI units, plain dataclasses, no
+config plumbing, no pandas, so it can be called from a notebook, from a study
+script, or from the existing runner.
+
+## Reference
+
+Hobbs, R.E. (1984). *In-Service Buckling of Heated Pipelines.*
+ASCE Journal of Transportation Engineering **110**(2), 175–189.
+DOI: [10.1061/(ASCE)0733-947X(1984)110:2(175)](https://doi.org/10.1061/(ASCE)0733-947X(1984)110:2(175))
+
+Lateral modes 1–4 come from Table 1 with Eqs. 26–29; the periodic
+("infinite") mode from Eqs. 20–25.
+
+## Equations
+
+With `q_A = phi_A w` and `q_L = phi_L w` the fully mobilised axial and lateral
+soil resistance per unit length, and `L` the characteristic lobe length:
+
+| Quantity | Modes 1–4 | Periodic mode |
+|---|---|---|
+| Buckle force | `P = k1 EI / L^2` | `P = 4 pi^2 EI / L^2` |
+| Force release | `P0 - P = k3 q_A L [sqrt(1+z) - 1]`, `z = k2 EA q_L^2 L^5 / (q_A (EI)^2)` | `P0 - P = k2 EA q_L^2 L^6 / (EI)^2` |
+| Amplitude | `y = k4 q_L L^4 / EI` | same form |
+| Peak moment | `M = k5 q_L L^2` | same form |
+| Peak slope | not given | `k6 q_L L^3 / EI` |
+
+| Mode | k1 | k2 | k3 | k4 | k5 | k6 |
+|---|---|---|---|---|---|---|
+| 1 | 80.76 | 6.391e-5 | 0.500 | 2.407e-3 | 6.938e-2 | — |
+| 2 | 4 pi^2 | 1.743e-4 | 1.000 | 5.532e-3 | 1.088e-1 | — |
+| 3 | 34.06 | 1.668e-4 | 1.294 | 1.032e-2 | 1.434e-1 | — |
+| 4 | 28.20 | 2.144e-4 | 1.608 | 1.047e-2 | 1.483e-1 | — |
+| infinite | 4 pi^2 | 4.7050e-5 | 0 | 4.4495e-3 | 5.066e-2 | 1.267e-2 |
+
+Most textbook presentations assume one friction coefficient for both
+directions. That is a real simplification — axial breakout is typically
+0.3–0.6 while lateral breakout is 0.5–1.2 on the same soil — so this
+implementation keeps `phi_A` and `phi_L` separate. Setting them equal
+recovers the textbook form exactly, because `z` collapses to
+`k2 EA q L^5 / (EI)^2`; there is a regression test that asserts it.
+
+## The shape of the solution
+
+`P0(L)` is **not** monotonic. It falls as the buckle lengthens (the
+`k1 EI / L^2` term) and then rises as the feed-in term grows, so it has a
+minimum. That minimum is the classical Hobbs snap-through force:
+
+* below it, no equilibrium buckle of that mode exists;
+* at it, the two roots merge;
+* above it there are two — a short, tightly curved branch and the long
+  post-snap branch, which is the damaging one.
+
+`critical_state()` returns the minimum, `equilibria_at_temperature()` returns
+the roots.
+
+## Usage
+
+```python
+from digitalmodel.subsea.pipeline.global_buckling import (
+    PipeSection, SoilResistance, critical_state, effective_driving_force,
+    equilibria_at_temperature, screen_modes,
+)
+
+pipe = PipeSection.from_dimensions(
+    e_modulus_pa=207e9,
+    od_m=0.3239,          # 12.75 in
+    wt_m=0.0159,
+    submerged_weight_N_m=900.0,
+    thermal_expansion_per_K=1.17e-5,
+)
+soil = SoilResistance(axial_friction=0.5, lateral_friction=0.7)
+
+# What force does the line actually offer?
+s_eff = effective_driving_force(
+    pipe,
+    temperature_rise_K=60.0,
+    internal_pressure_pa=15e6,
+    internal_area_m2=0.06700,
+)                                      # 2 638 kN
+
+# Which mode goes first, and by how much is it exceeded?
+for result in screen_modes(pipe, soil, s_eff):
+    state = result.critical_state
+    print(result.mode.value, f"{state.temperature_rise_K:.1f} C",
+          f"util {result.utilisation:.2f}")
+```
+
+For the section above this gives:
+
+| Mode | L [m] | P0 [kN] | dT [°C] | amplitude [m] | M [kN·m] | combined stress [MPa] |
+|---|---|---|---|---|---|---|
+| 3 | 50.3 | 782 | 21.0 | 1.10 | 229 | 236 |
+| 4 | 45.7 | 783 | 21.0 | 0.76 | 195 | 206 |
+| 2 | 53.9 | 794 | 21.3 | 0.78 | 199 | 210 |
+| 1 | 76.1 | 818 | 21.9 | 1.35 | 253 | 259 |
+| infinite | 43.2 | 1071 | 28.7 | 0.26 | 59 | 105 |
+
+Mode 3 governs, as it usually does for a surface-laid line on this class of
+soil. At 1.5× the mode-3 critical temperature the two branches are 34.0 m /
+0.23 m and 69.9 m / 4.09 m — the second one carries 408 MPa of combined
+stress, which is the point of running the calculation at all.
+
+## What this is not
+
+The Hobbs solution is small-slope, elastic, and assumes an **initially
+straight** line with idealised fully mobilised Coulomb friction. It gives
+equilibrium paths, not the initiation temperature of a real line, which
+buckles earlier at its out-of-straightness. For initiation use an
+imperfection method (Taylor & Gan 1986) or FE per DNV-RP-F110.
+
+Not included: coating bending stiffness, cyclic soil memory / ratcheting,
+walking, upheaval (vertical) buckling, and any design-code acceptance check.
+
+## Related
+
+* `docs/domains/pipelines/lateral_buckling.md` — route-based screening scope
+* `docs/domains/pipelines/uplheaval_buckling.md` — buried-line vertical case
+* `docs/domains/orcaflex/library/model_library/m01_pipeline_lateral_buckling/` —
+  the OrcaFlex FE model to cross-check against
+* Tests: `tests/subsea/pipeline/test_hobbs_lateral_buckling.py`

--- a/docs/domains/pipelines/lateral_buckling.md
+++ b/docs/domains/pipelines/lateral_buckling.md
@@ -47,3 +47,10 @@ Objective:  Estimate the thermal movement and associated reaction forces for sin
 - Route
   - lay tension
   - Route Curve radius
+
+## Closed-form post-buckling
+
+The screening above says whether a line is susceptible. For buckle length,
+amplitude, bending moment and combined stress once it has buckled, see
+[Hobbs closed-form lateral buckling](hobbs-lateral-buckling.md)
+(`digitalmodel.subsea.pipeline.global_buckling`).

--- a/docs/domains/pipelines/uplheaval_buckling.md
+++ b/docs/domains/pipelines/uplheaval_buckling.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-Lateral buckling of pipelines is a phenomenon that occurs when a pipeline is subjected to thermal expansion or contraction. This can cause the pipeline to buckle laterally, which can lead to damage or failure of the pipeline. Lateral buckling can be caused by a number of factors, including temperature changes, pressure changes, and external forces. It is important to design pipelines to prevent lateral buckling and to ensure that they are safe and reliable.
+Upheaval buckling occurs when a buried or trenched pipeline, put into axial compression by thermal expansion and internal pressure, cannot move sideways and instead vents that compression vertically at an out-of-straightness such as an overbend. It is resisted by the download available from the pipe's submerged weight plus the uplift resistance of the cover, so the design levers are cover depth and imperfection sharpness rather than lateral friction. The surface-laid counterpart is [lateral buckling](lateral_buckling.md).
 
 Objective:  Estimate the thermal movement and associated reaction forces for single pipe or Pipe-in-Pipe (PIP) systems.
 

--- a/src/digitalmodel/subsea/pipeline/global_buckling/__init__.py
+++ b/src/digitalmodel/subsea/pipeline/global_buckling/__init__.py
@@ -1,0 +1,79 @@
+"""
+digitalmodel.subsea.pipeline.global_buckling
+============================================
+Closed-form global (lateral / snaking) buckling of heated submarine pipelines,
+after Hobbs (1984).
+
+This complements the existing config-driven :mod:`digitalmodel.subsea.pipeline.
+lateral_buckling` runner, which builds the effective-axial-force profile along
+a route and applies a single susceptibility screen.  This package answers the
+other half of the question: *given* that the line is susceptible, what is the
+buckle length, amplitude, bending moment and combined stress, and at what
+temperature does each mode become possible?
+
+Public API
+----------
+PipeSection             Section, weight and thermal properties (SI)
+SoilResistance          Axial and lateral Coulomb friction coefficients
+HobbsMode               Modes 1-4 and the periodic ("infinite") mode
+LateralBuckleState      One point on an equilibrium path
+lateral_equilibrium     Evaluate the path at a chosen buckle length
+critical_state          Minimum-P0 turning point (snap-through force)
+equilibria_at_temperature   Roots of P0 = EA alpha dT (0, 1 or 2)
+governing_mode          Mode with the lowest critical force
+screen_modes            Utilisation of a driving force against every mode
+effective_driving_force Fully-restrained S_eff from dT, pressure and lay tension
+
+Quick-start::
+
+    from digitalmodel.subsea.pipeline.global_buckling import (
+        PipeSection, SoilResistance, critical_state,
+    )
+
+    pipe = PipeSection.from_dimensions(
+        e_modulus_pa=207e9, od_m=0.3239, wt_m=0.0159,
+        submerged_weight_N_m=900.0,
+    )
+    soil = SoilResistance(axial_friction=0.5, lateral_friction=0.7)
+    state = critical_state(pipe, soil, mode=3)
+    print(f"L = {state.buckle_length_m:.1f} m, dT = {state.temperature_rise_K:.1f} C")
+
+All quantities are SI and axial force is positive in compression.  Results are
+elastic small-slope equilibrium paths, not design acceptance checks; see
+DNV-RP-F110 for the design framework.
+"""
+from __future__ import annotations
+
+from .hobbs_lateral import (
+    critical_state,
+    effective_driving_force,
+    equilibria_at_temperature,
+    governing_mode,
+    lateral_equilibrium,
+    screen_modes,
+)
+from .models import (
+    MODE_CONSTANTS,
+    HobbsConstants,
+    HobbsMode,
+    LateralBuckleState,
+    ModeSusceptibility,
+    PipeSection,
+    SoilResistance,
+)
+
+__all__ = [
+    "MODE_CONSTANTS",
+    "HobbsConstants",
+    "HobbsMode",
+    "LateralBuckleState",
+    "ModeSusceptibility",
+    "PipeSection",
+    "SoilResistance",
+    "critical_state",
+    "effective_driving_force",
+    "equilibria_at_temperature",
+    "governing_mode",
+    "lateral_equilibrium",
+    "screen_modes",
+]

--- a/src/digitalmodel/subsea/pipeline/global_buckling/hobbs_lateral.py
+++ b/src/digitalmodel/subsea/pipeline/global_buckling/hobbs_lateral.py
@@ -1,0 +1,356 @@
+"""
+Hobbs (1984) closed-form lateral (snaking) post-buckling of a heated pipeline.
+
+Reference
+---------
+Hobbs, R.E. (1984). "In-Service Buckling of Heated Pipelines."
+ASCE Journal of Transportation Engineering 110(2), 175-189.
+Lateral modes 1-4: Table 1 with Eqs. 26-29.  Periodic mode: Eqs. 20-25.
+
+Equations implemented
+---------------------
+With ``q_A = phi_A w`` and ``q_L = phi_L w`` (fully-mobilised axial and
+lateral soil resistance per unit length), for the finite modes 1-4::
+
+    P    = k1 EI / L^2
+    z    = k2 EA q_L^2 L^5 / (q_A (EI)^2)
+    P0   = P + k3 q_A L [sqrt(1 + z) - 1]
+    yhat = k4 q_L L^4 / EI
+    Mhat = k5 q_L L^2
+
+and for the periodic ("infinite") mode, where there is no axial feed-in and
+therefore no k3 slip term::
+
+    P    = 4 pi^2 EI / L^2
+    P0   = P + k2 EA q_L^2 L^6 / (EI)^2
+    slope_max = k6 q_L L^3 / EI
+
+The single-friction form quoted in most textbooks (``phi_A = phi_L = phi``)
+is recovered exactly: ``z`` collapses to ``k2 EA q L^5 / (EI)^2``.
+
+Shape of the equilibrium path
+-----------------------------
+``P0(L)`` is not monotonic.  It falls as the buckle lengthens (the ``k1 EI/L^2``
+term) and then rises as the feed-in term grows, so it has a **minimum**.  That
+minimum is the classical Hobbs "safe" / snap-through force: below it no
+equilibrium buckle of that mode exists, and above it there are two roots -- a
+short, high-curvature branch and the long post-snap branch.
+
+Limitations
+-----------
+Small-slope elastic equilibrium with idealised fully-mobilised Coulomb
+friction and an initially straight line.  This predicts equilibrium paths, not
+the *initiation* temperature of a real line with out-of-straightness -- for
+that, imperfection methods (Taylor & Gan 1986) or FE per DNV-RP-F110 are
+required.  Coating bending stiffness, cyclic soil memory, residual lay
+tension, and code acceptance checks are outside this module.
+"""
+from __future__ import annotations
+
+import math
+
+from scipy.optimize import brentq, minimize_scalar
+
+from .models import (
+    MODE_CONSTANTS,
+    HobbsMode,
+    LateralBuckleState,
+    ModeSusceptibility,
+    PipeSection,
+    SoilResistance,
+)
+
+__all__ = [
+    "critical_state",
+    "effective_driving_force",
+    "equilibria_at_temperature",
+    "governing_mode",
+    "lateral_equilibrium",
+    "screen_modes",
+]
+
+# Decades of buckle length scanned either side of the dimensional anchor when
+# bracketing the minimum of P0(L).  Ten decades comfortably covers every
+# realistic combination of section stiffness and soil resistance.
+_SCAN_DECADES = 5.0
+_SCAN_POINTS = 121
+
+
+def _as_mode(mode: HobbsMode | str | int) -> HobbsMode:
+    if isinstance(mode, HobbsMode):
+        return mode
+    try:
+        return HobbsMode(str(mode))
+    except ValueError:
+        raise ValueError(
+            f"mode must be 1, 2, 3, 4 or 'infinite', got {mode!r}"
+        ) from None
+
+
+def _check_positive(name: str, value: float) -> None:
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive, got {value!r}")
+
+
+def lateral_equilibrium(
+    pipe: PipeSection,
+    soil: SoilResistance,
+    buckle_length_m: float,
+    mode: HobbsMode | str | int = HobbsMode.MODE_3,
+) -> LateralBuckleState:
+    """Evaluate one point on the lateral post-buckling equilibrium path.
+
+    Parameters
+    ----------
+    pipe             section, weight and thermal properties
+    soil             axial and lateral friction coefficients
+    buckle_length_m  L, the Hobbs characteristic lobe length [m]
+    mode             Hobbs mode 1-4 or ``'infinite'``
+
+    Returns
+    -------
+    LateralBuckleState with force, amplitude, moment and stress.
+    """
+    _check_positive("buckle_length_m", buckle_length_m)
+    mode = _as_mode(mode)
+    k = MODE_CONSTANTS[mode]
+
+    length = buckle_length_m
+    weight = pipe.submerged_weight_N_m
+    q_axial = soil.axial_resistance_N_m(weight)
+    q_lateral = soil.lateral_resistance_N_m(weight)
+    EI = pipe.EI
+
+    buckle_force = k.k1 * EI / length**2
+
+    if mode is HobbsMode.INFINITE:
+        release = k.k2 * pipe.EA * q_lateral**2 * length**6 / EI**2
+        max_slope: float | None = k.k6 * q_lateral * length**3 / EI  # type: ignore[operator]
+    else:
+        z = k.k2 * pipe.EA * q_lateral**2 * length**5 / (q_axial * EI**2)
+        # sqrt(1+z) - 1 loses precision for small z; the rationalised form
+        # z / (sqrt(1+z) + 1) is algebraically identical and stable.
+        release = k.k3 * q_axial * length * z / (math.sqrt(1.0 + z) + 1.0)
+        max_slope = None
+
+    far_field_force = buckle_force + release
+    amplitude = k.k4 * q_lateral * length**4 / EI
+    moment = k.k5 * q_lateral * length**2
+
+    axial_stress = buckle_force / pipe.area_m2
+    bending_stress = moment * pipe.outer_radius_m / pipe.inertia_m4
+
+    return LateralBuckleState(
+        mode=mode,
+        buckle_length_m=length,
+        buckle_force_N=buckle_force,
+        far_field_force_N=far_field_force,
+        temperature_rise_K=far_field_force
+        / (pipe.EA * pipe.thermal_expansion_per_K),
+        amplitude_m=amplitude,
+        max_moment_Nm=moment,
+        axial_stress_pa=axial_stress,
+        bending_stress_pa=bending_stress,
+        combined_stress_pa=axial_stress + bending_stress,
+        max_slope=max_slope,
+    )
+
+
+def _length_anchor(pipe: PipeSection, soil: SoilResistance) -> float:
+    """Dimensional length scale (EI^3 / (EA q_A q_L))^(1/8) used to seed scans.
+
+    For ``phi_A = phi_L`` this is the exact scale that makes the periodic-mode
+    minimum a pure function of the mode constants, so it lands within a decade
+    or so of the turning point for every realistic input.
+    """
+    weight = pipe.submerged_weight_N_m
+    q_axial = soil.axial_resistance_N_m(weight)
+    q_lateral = soil.lateral_resistance_N_m(weight)
+    return (pipe.EI**3 / (pipe.EA * q_axial * q_lateral)) ** 0.125
+
+
+def critical_state(
+    pipe: PipeSection,
+    soil: SoilResistance,
+    mode: HobbsMode | str | int = HobbsMode.MODE_3,
+) -> LateralBuckleState:
+    """Minimum of ``P0(L)`` -- the snap-through / "safe" force for this mode.
+
+    The periodic mode is minimised analytically::
+
+        L_min = (k1 EI^3 / (3 k2 EA q_L^2))^(1/8)
+
+    The finite modes have no closed-form minimum, so ``P0`` is bracketed on a
+    geometric scan around the dimensional anchor and then refined.
+
+    Notes
+    -----
+    This is the lowest far-field force at which an equilibrium buckle of the
+    given mode can exist.  It is **not** an initiation prediction and it is not
+    a design allowable: a real line with imperfections buckles at a lower force
+    (see DNV-RP-F110 and Taylor & Gan 1986).
+    """
+    mode = _as_mode(mode)
+    k = MODE_CONSTANTS[mode]
+    weight = pipe.submerged_weight_N_m
+    q_lateral = soil.lateral_resistance_N_m(weight)
+
+    if mode is HobbsMode.INFINITE:
+        length = (
+            k.k1 * pipe.EI**3 / (3.0 * k.k2 * pipe.EA * q_lateral**2)
+        ) ** 0.125
+        return lateral_equilibrium(pipe, soil, length, mode)
+
+    anchor = _length_anchor(pipe, soil)
+    exponents = [
+        -_SCAN_DECADES + 2.0 * _SCAN_DECADES * i / (_SCAN_POINTS - 1)
+        for i in range(_SCAN_POINTS)
+    ]
+    lengths = [anchor * 10.0**e for e in exponents]
+    forces = [
+        lateral_equilibrium(pipe, soil, length, mode).far_field_force_N
+        for length in lengths
+    ]
+
+    index = min(range(len(forces)), key=forces.__getitem__)
+    if index in (0, len(forces) - 1):
+        raise RuntimeError(
+            f"could not bracket the P0 minimum for mode {mode.value} within "
+            f"{_SCAN_DECADES} decades of L = {anchor:.4g} m"
+        )
+
+    result = minimize_scalar(
+        lambda log_length: math.log(
+            lateral_equilibrium(
+                pipe, soil, math.exp(log_length), mode
+            ).far_field_force_N
+        ),
+        bounds=(math.log(lengths[index - 1]), math.log(lengths[index + 1])),
+        method="bounded",
+        options={"xatol": 1e-12},
+    )
+    if not result.success:
+        raise RuntimeError(
+            f"P0 minimum refinement failed for mode {mode.value}: {result.message}"
+        )
+    return lateral_equilibrium(pipe, soil, math.exp(result.x), mode)
+
+
+def equilibria_at_temperature(
+    pipe: PipeSection,
+    soil: SoilResistance,
+    temperature_rise_K: float,
+    mode: HobbsMode | str | int = HobbsMode.MODE_3,
+) -> tuple[LateralBuckleState, ...]:
+    """Equilibrium buckles that satisfy ``P0 = EA alpha dT``, shortest first.
+
+    Returns an empty tuple below the critical force, a single state at the
+    turning point, and two states above it: the short unstable branch and the
+    long post-snap branch of Hobbs Fig. 7.
+
+    The two-root structure is geometric, not a dynamic stability analysis --
+    the short branch is not physically held by a real line.
+    """
+    mode = _as_mode(mode)
+    target = pipe.fully_restrained_thermal_force(temperature_rise_K)
+    turning_point = critical_state(pipe, soil, mode)
+
+    tolerance = 1e-10 * max(target, turning_point.far_field_force_N)
+    difference = target - turning_point.far_field_force_N
+    if difference < -tolerance:
+        return ()
+    if abs(difference) <= tolerance:
+        return (turning_point,)
+
+    def residual(length: float) -> float:
+        return (
+            lateral_equilibrium(pipe, soil, length, mode).far_field_force_N / target
+            - 1.0
+        )
+
+    lower = turning_point.buckle_length_m
+    for _ in range(200):
+        lower /= 2.0
+        if residual(lower) > 0.0:
+            break
+    else:  # pragma: no cover - unreachable for finite positive inputs
+        raise RuntimeError("could not bracket the short equilibrium branch")
+
+    upper = turning_point.buckle_length_m
+    for _ in range(200):
+        upper *= 2.0
+        if residual(upper) > 0.0:
+            break
+    else:  # pragma: no cover
+        raise RuntimeError("could not bracket the long equilibrium branch")
+
+    roots = (
+        brentq(residual, lower, turning_point.buckle_length_m, xtol=1e-12),
+        brentq(residual, turning_point.buckle_length_m, upper, xtol=1e-12),
+    )
+    return tuple(lateral_equilibrium(pipe, soil, root, mode) for root in roots)
+
+
+def effective_driving_force(
+    pipe: PipeSection,
+    *,
+    temperature_rise_K: float,
+    internal_pressure_pa: float = 0.0,
+    internal_area_m2: float = 0.0,
+    poisson_ratio: float = 0.3,
+    residual_lay_tension_N: float = 0.0,
+) -> float:
+    """Fully-restrained compressive effective axial force S_eff [N], positive.
+
+        S_eff = EA alpha dT + p_i A_i (1 - 2 nu) - H
+
+    ``H`` is the residual (as-laid) tension, which relieves compression.  The
+    result is clipped at zero: a line in net tension cannot buckle globally.
+    """
+    if internal_pressure_pa < 0.0:
+        raise ValueError("internal_pressure_pa must be non-negative")
+    if internal_area_m2 < 0.0:
+        raise ValueError("internal_area_m2 must be non-negative")
+    thermal = pipe.fully_restrained_thermal_force(temperature_rise_K)
+    pressure = internal_pressure_pa * internal_area_m2 * (1.0 - 2.0 * poisson_ratio)
+    return max(0.0, thermal + pressure - residual_lay_tension_N)
+
+
+def screen_modes(
+    pipe: PipeSection,
+    soil: SoilResistance,
+    driving_force_N: float,
+    modes: tuple[HobbsMode, ...] | None = None,
+) -> tuple[ModeSusceptibility, ...]:
+    """Compare a driving force against every mode's critical force.
+
+    Returned in ascending order of critical force, so the first entry is the
+    governing (most easily triggered) mode.
+    """
+    _check_positive("driving_force_N", driving_force_N)
+    selected = modes if modes is not None else tuple(HobbsMode)
+    results = []
+    for mode in selected:
+        state = critical_state(pipe, soil, mode)
+        utilisation = driving_force_N / state.far_field_force_N
+        results.append(
+            ModeSusceptibility(
+                mode=mode,
+                critical_state=state,
+                driving_force_N=driving_force_N,
+                utilisation=utilisation,
+                susceptible=utilisation >= 1.0,
+            )
+        )
+    return tuple(sorted(results, key=lambda r: r.critical_state.far_field_force_N))
+
+
+def governing_mode(
+    pipe: PipeSection,
+    soil: SoilResistance,
+    modes: tuple[HobbsMode, ...] | None = None,
+) -> LateralBuckleState:
+    """Critical state of the mode with the lowest snap-through force."""
+    selected = modes if modes is not None else tuple(HobbsMode)
+    states = [critical_state(pipe, soil, mode) for mode in selected]
+    return min(states, key=lambda state: state.far_field_force_N)

--- a/src/digitalmodel/subsea/pipeline/global_buckling/models.py
+++ b/src/digitalmodel/subsea/pipeline/global_buckling/models.py
@@ -1,0 +1,225 @@
+"""
+Data models for closed-form global (lateral) buckling of submarine pipelines.
+
+Reference
+---------
+Hobbs, R.E. (1984). "In-Service Buckling of Heated Pipelines."
+ASCE Journal of Transportation Engineering 110(2), 175-189.
+DOI: 10.1061/(ASCE)0733-947X(1984)110:2(175)
+
+Conventions
+-----------
+* All quantities are SI.  Axial force is **positive in compression**.
+* ``L`` is the Hobbs characteristic buckle length (the lobe length of the
+  mode shape), NOT the total length of pipeline affected by the buckle.
+* Soil resistance is fully-mobilised Coulomb friction; axial and lateral
+  coefficients are kept separate because they differ materially in practice
+  (axial breakout is typically 0.3-0.6, lateral 0.5-1.2 on soft clay).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+
+class HobbsMode(Enum):
+    """Hobbs (1984) lateral post-buckling mode shapes.
+
+    Modes 1-4 are the finite (localised) lobed shapes of Fig. 3; ``INFINITE``
+    is the periodic (sinusoidal, infinite-mode) solution of Eqs. 20-25.
+    """
+
+    MODE_1 = "1"
+    MODE_2 = "2"
+    MODE_3 = "3"
+    MODE_4 = "4"
+    INFINITE = "infinite"
+
+
+@dataclass(frozen=True)
+class HobbsConstants:
+    """Mode coefficients from Hobbs (1984) Table 1.
+
+    k1  buckle force coefficient        P  = k1 EI / L^2
+    k2  force-release coefficient       (inside the radical, see hobbs_lateral)
+    k3  axial slip coefficient          (zero for the periodic mode)
+    k4  amplitude coefficient           y_hat = k4 q_L L^4 / EI
+    k5  bending moment coefficient      M_hat = k5 q_L L^2
+    k6  maximum slope coefficient       periodic mode only (Eq. 25), else None
+    """
+
+    k1: float
+    k2: float
+    k3: float
+    k4: float
+    k5: float
+    k6: float | None = None
+
+
+# Hobbs (1984) Table 1 for the lateral modes; the periodic ("infinite") row
+# follows Eqs. 20-25.  These are published mathematical mode coefficients.
+MODE_CONSTANTS: dict[HobbsMode, HobbsConstants] = {
+    HobbsMode.MODE_1: HobbsConstants(80.76, 6.391e-5, 0.500, 2.407e-3, 6.938e-2),
+    HobbsMode.MODE_2: HobbsConstants(4.0 * math.pi**2, 1.743e-4, 1.000, 5.532e-3, 1.088e-1),
+    HobbsMode.MODE_3: HobbsConstants(34.06, 1.668e-4, 1.294, 1.032e-2, 1.434e-1),
+    HobbsMode.MODE_4: HobbsConstants(28.20, 2.144e-4, 1.608, 1.047e-2, 1.483e-1),
+    HobbsMode.INFINITE: HobbsConstants(
+        4.0 * math.pi**2, 4.7050e-5, 0.0, 4.4495e-3, 5.066e-2, 1.267e-2
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PipeSection:
+    """Homogeneous elastic steel section carrying the buckling load.
+
+    Parameters
+    ----------
+    e_modulus_pa           Young's modulus E [Pa]
+    area_m2                steel cross-sectional area A_s [m^2]
+    inertia_m4             steel second moment of area I [m^4]
+    outer_radius_m         extreme-fibre radius for bending stress [m]
+    submerged_weight_N_m   submerged weight w of the pipe **including
+                           coatings and contents** [N/m]
+    thermal_expansion_per_K  alpha [1/K]
+
+    ``area_m2`` and ``inertia_m4`` are stored explicitly (rather than always
+    derived) so that published rounded section properties can be reproduced
+    exactly when benchmarking.  Use :meth:`from_dimensions` for the usual case.
+    """
+
+    e_modulus_pa: float
+    area_m2: float
+    inertia_m4: float
+    outer_radius_m: float
+    submerged_weight_N_m: float
+    thermal_expansion_per_K: float = 1.17e-5
+
+    def __post_init__(self) -> None:
+        for name in (
+            "e_modulus_pa",
+            "area_m2",
+            "inertia_m4",
+            "outer_radius_m",
+            "submerged_weight_N_m",
+            "thermal_expansion_per_K",
+        ):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive, got {value!r}")
+
+    @classmethod
+    def from_dimensions(
+        cls,
+        *,
+        e_modulus_pa: float,
+        od_m: float,
+        wt_m: float,
+        submerged_weight_N_m: float,
+        thermal_expansion_per_K: float = 1.17e-5,
+    ) -> PipeSection:
+        """Build from the steel annulus: A = pi/4 (D^2 - d^2), I = pi/64 (D^4 - d^4)."""
+        if not math.isfinite(od_m) or od_m <= 0.0:
+            raise ValueError("od_m must be finite and positive")
+        if not math.isfinite(wt_m) or wt_m <= 0.0:
+            raise ValueError("wt_m must be finite and positive")
+        if 2.0 * wt_m >= od_m:
+            raise ValueError("wt_m must be less than half of od_m")
+        id_m = od_m - 2.0 * wt_m
+        return cls(
+            e_modulus_pa=e_modulus_pa,
+            area_m2=math.pi / 4.0 * (od_m**2 - id_m**2),
+            inertia_m4=math.pi / 64.0 * (od_m**4 - id_m**4),
+            outer_radius_m=od_m / 2.0,
+            submerged_weight_N_m=submerged_weight_N_m,
+            thermal_expansion_per_K=thermal_expansion_per_K,
+        )
+
+    @property
+    def EA(self) -> float:
+        """Axial stiffness E*A_s [N]."""
+        return self.e_modulus_pa * self.area_m2
+
+    @property
+    def EI(self) -> float:
+        """Bending stiffness E*I [N m^2]."""
+        return self.e_modulus_pa * self.inertia_m4
+
+    def fully_restrained_thermal_force(self, temperature_rise_K: float) -> float:
+        """Compressive force E*A*alpha*dT in a fully-restrained line [N]."""
+        if not math.isfinite(temperature_rise_K) or temperature_rise_K < 0.0:
+            raise ValueError("temperature_rise_K must be finite and non-negative")
+        return self.EA * self.thermal_expansion_per_K * temperature_rise_K
+
+
+@dataclass(frozen=True)
+class SoilResistance:
+    """Fully-mobilised Coulomb friction coefficients.
+
+    axial_friction     phi_A [-], resists feed-in along the pipe axis
+    lateral_friction   phi_L [-], resists sideways sweep of the buckle
+    """
+
+    axial_friction: float
+    lateral_friction: float
+
+    def __post_init__(self) -> None:
+        for name in ("axial_friction", "lateral_friction"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive, got {value!r}")
+
+    def axial_resistance_N_m(self, submerged_weight_N_m: float) -> float:
+        """q_A = phi_A * w [N/m]."""
+        return self.axial_friction * submerged_weight_N_m
+
+    def lateral_resistance_N_m(self, submerged_weight_N_m: float) -> float:
+        """q_L = phi_L * w [N/m]."""
+        return self.lateral_friction * submerged_weight_N_m
+
+
+@dataclass(frozen=True)
+class LateralBuckleState:
+    """One point on a Hobbs lateral post-buckling equilibrium path.
+
+    buckle_length_m     L, the characteristic lobe length [m]
+    buckle_force_N      P, compressive force inside the buckle [N]
+    far_field_force_N   P0, compressive force in the fully-restrained line [N]
+    temperature_rise_K  thermal-only dT that generates P0 (= P0 / (EA alpha))
+    amplitude_m         y_hat, peak lateral displacement [m]
+    max_moment_Nm       M_hat, peak bending moment magnitude [N m]
+    axial_stress_pa     P / A_s [Pa]
+    bending_stress_pa   M_hat * r_o / I [Pa]
+    combined_stress_pa  axial + extreme-fibre bending [Pa]
+    max_slope           peak |dy/dx| [-]; periodic mode only, else None
+    """
+
+    mode: HobbsMode
+    buckle_length_m: float
+    buckle_force_N: float
+    far_field_force_N: float
+    temperature_rise_K: float
+    amplitude_m: float
+    max_moment_Nm: float
+    axial_stress_pa: float
+    bending_stress_pa: float
+    combined_stress_pa: float
+    max_slope: float | None = None
+
+
+@dataclass(frozen=True)
+class ModeSusceptibility:
+    """Screening outcome for one mode against a given driving force.
+
+    critical_state       the minimum-P0 turning point on the path
+    driving_force_N      the effective compressive force offered by the line
+    utilisation          driving_force / critical far-field force [-]
+    susceptible          True when the line can reach the turning point
+    """
+
+    mode: HobbsMode
+    critical_state: LateralBuckleState
+    driving_force_N: float
+    utilisation: float
+    susceptible: bool

--- a/tests/subsea/pipeline/test_hobbs_lateral_buckling.py
+++ b/tests/subsea/pipeline/test_hobbs_lateral_buckling.py
@@ -1,0 +1,362 @@
+"""
+Tests for digitalmodel.subsea.pipeline.global_buckling (Hobbs 1984).
+
+The checks are of three kinds:
+
+1. **Closed-form identities** -- the published equations evaluated directly and
+   compared with the module, so a typo in a coefficient or an exponent fails.
+2. **Structural properties of the solution** -- the P0(L) turning point really
+   is a minimum, the two roots either side of it really reproduce the target
+   force, the periodic mode's analytic minimum agrees with a numeric scan.
+3. **Guard rails** -- invalid geometry and non-physical inputs raise.
+
+There is no benchmark against published worked examples here: Hobbs' own
+tabulated cases are not redistributable, and a synthetic number asserted
+against itself would prove nothing.
+"""
+import math
+
+import pytest
+
+from digitalmodel.subsea.pipeline.global_buckling import (
+    MODE_CONSTANTS,
+    HobbsMode,
+    PipeSection,
+    SoilResistance,
+    critical_state,
+    effective_driving_force,
+    equilibria_at_temperature,
+    governing_mode,
+    lateral_equilibrium,
+    screen_modes,
+)
+
+# A representative 12.75 in x 15.9 mm X65 export line.
+OD_M = 0.3239
+WT_M = 0.0159
+E_PA = 207e9
+WEIGHT_N_M = 900.0
+
+
+@pytest.fixture
+def pipe() -> PipeSection:
+    return PipeSection.from_dimensions(
+        e_modulus_pa=E_PA,
+        od_m=OD_M,
+        wt_m=WT_M,
+        submerged_weight_N_m=WEIGHT_N_M,
+    )
+
+
+@pytest.fixture
+def soil() -> SoilResistance:
+    return SoilResistance(axial_friction=0.5, lateral_friction=0.7)
+
+
+# ----------------------------------------------------------------------
+# Section properties
+# ----------------------------------------------------------------------
+
+
+def test_from_dimensions_matches_annulus_formulae(pipe):
+    id_m = OD_M - 2.0 * WT_M
+    assert pipe.area_m2 == pytest.approx(math.pi / 4.0 * (OD_M**2 - id_m**2))
+    assert pipe.inertia_m4 == pytest.approx(math.pi / 64.0 * (OD_M**4 - id_m**4))
+    assert pipe.outer_radius_m == pytest.approx(OD_M / 2.0)
+    assert pipe.EA == pytest.approx(E_PA * pipe.area_m2)
+    assert pipe.EI == pytest.approx(E_PA * pipe.inertia_m4)
+
+
+def test_wall_thicker_than_radius_rejected():
+    with pytest.raises(ValueError, match="less than half"):
+        PipeSection.from_dimensions(
+            e_modulus_pa=E_PA, od_m=0.3, wt_m=0.16, submerged_weight_N_m=900.0
+        )
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, float("nan"), float("inf")])
+def test_non_physical_weight_rejected(bad):
+    with pytest.raises(ValueError):
+        PipeSection.from_dimensions(
+            e_modulus_pa=E_PA, od_m=OD_M, wt_m=WT_M, submerged_weight_N_m=bad
+        )
+
+
+@pytest.mark.parametrize("bad", [0.0, -0.3, float("nan")])
+def test_non_physical_friction_rejected(bad):
+    with pytest.raises(ValueError):
+        SoilResistance(axial_friction=bad, lateral_friction=0.7)
+    with pytest.raises(ValueError):
+        SoilResistance(axial_friction=0.5, lateral_friction=bad)
+
+
+# ----------------------------------------------------------------------
+# Hobbs Table 1 constants
+# ----------------------------------------------------------------------
+
+
+def test_mode_2_and_periodic_buckle_coefficient_is_four_pi_squared():
+    # Modes 2 and infinity share the Euler-like coefficient 4*pi^2.
+    assert MODE_CONSTANTS[HobbsMode.MODE_2].k1 == pytest.approx(39.4784, abs=1e-4)
+    assert MODE_CONSTANTS[HobbsMode.INFINITE].k1 == pytest.approx(39.4784, abs=1e-4)
+
+
+def test_periodic_mode_has_no_axial_slip_term():
+    # k3 = 0: the periodic solution has no feed-in from outside the buckle.
+    assert MODE_CONSTANTS[HobbsMode.INFINITE].k3 == 0.0
+    assert MODE_CONSTANTS[HobbsMode.INFINITE].k6 is not None
+    for mode in (HobbsMode.MODE_1, HobbsMode.MODE_2, HobbsMode.MODE_3, HobbsMode.MODE_4):
+        assert MODE_CONSTANTS[mode].k3 > 0.0
+        assert MODE_CONSTANTS[mode].k6 is None
+
+
+# ----------------------------------------------------------------------
+# Equilibrium equations, evaluated independently
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode", [HobbsMode.MODE_1, HobbsMode.MODE_2, HobbsMode.MODE_3, HobbsMode.MODE_4]
+)
+def test_finite_mode_equations(pipe, soil, mode):
+    length = 60.0
+    k = MODE_CONSTANTS[mode]
+    q_a = soil.axial_friction * WEIGHT_N_M
+    q_l = soil.lateral_friction * WEIGHT_N_M
+
+    expected_p = k.k1 * pipe.EI / length**2
+    z = k.k2 * pipe.EA * q_l**2 * length**5 / (q_a * pipe.EI**2)
+    expected_p0 = expected_p + k.k3 * q_a * length * (math.sqrt(1.0 + z) - 1.0)
+    expected_amplitude = k.k4 * q_l * length**4 / pipe.EI
+    expected_moment = k.k5 * q_l * length**2
+
+    state = lateral_equilibrium(pipe, soil, length, mode)
+    assert state.buckle_force_N == pytest.approx(expected_p, rel=1e-12)
+    assert state.far_field_force_N == pytest.approx(expected_p0, rel=1e-9)
+    assert state.amplitude_m == pytest.approx(expected_amplitude, rel=1e-12)
+    assert state.max_moment_Nm == pytest.approx(expected_moment, rel=1e-12)
+    assert state.max_slope is None
+
+
+def test_periodic_mode_equations(pipe, soil):
+    length = 60.0
+    k = MODE_CONSTANTS[HobbsMode.INFINITE]
+    q_l = soil.lateral_friction * WEIGHT_N_M
+
+    expected_p = k.k1 * pipe.EI / length**2
+    expected_p0 = expected_p + k.k2 * pipe.EA * q_l**2 * length**6 / pipe.EI**2
+
+    state = lateral_equilibrium(pipe, soil, length, HobbsMode.INFINITE)
+    assert state.buckle_force_N == pytest.approx(expected_p, rel=1e-12)
+    assert state.far_field_force_N == pytest.approx(expected_p0, rel=1e-12)
+    assert state.max_slope == pytest.approx(k.k6 * q_l * length**3 / pipe.EI, rel=1e-12)
+
+
+def test_equal_friction_collapses_to_single_coefficient_form(pipe):
+    """With phi_A = phi_L the radical reduces to the textbook k2 EA q L^5 / EI^2."""
+    phi = 0.6
+    soil = SoilResistance(axial_friction=phi, lateral_friction=phi)
+    q = phi * WEIGHT_N_M
+    length = 55.0
+    k = MODE_CONSTANTS[HobbsMode.MODE_3]
+
+    z = k.k2 * pipe.EA * q * length**5 / pipe.EI**2
+    expected = k.k1 * pipe.EI / length**2 + k.k3 * q * length * (math.sqrt(1.0 + z) - 1.0)
+
+    state = lateral_equilibrium(pipe, soil, length, HobbsMode.MODE_3)
+    assert state.far_field_force_N == pytest.approx(expected, rel=1e-9)
+
+
+def test_amplitude_and_moment_scale_with_length_powers(pipe, soil):
+    short = lateral_equilibrium(pipe, soil, 40.0, HobbsMode.MODE_3)
+    long = lateral_equilibrium(pipe, soil, 80.0, HobbsMode.MODE_3)
+    assert long.amplitude_m / short.amplitude_m == pytest.approx(2.0**4, rel=1e-12)
+    assert long.max_moment_Nm / short.max_moment_Nm == pytest.approx(2.0**2, rel=1e-12)
+    assert long.buckle_force_N / short.buckle_force_N == pytest.approx(2.0**-2, rel=1e-12)
+
+
+def test_stresses_follow_from_force_and_moment(pipe, soil):
+    state = lateral_equilibrium(pipe, soil, 70.0, HobbsMode.MODE_3)
+    assert state.axial_stress_pa == pytest.approx(state.buckle_force_N / pipe.area_m2)
+    assert state.bending_stress_pa == pytest.approx(
+        state.max_moment_Nm * pipe.outer_radius_m / pipe.inertia_m4
+    )
+    assert state.combined_stress_pa == pytest.approx(
+        state.axial_stress_pa + state.bending_stress_pa
+    )
+
+
+def test_temperature_is_the_thermal_equivalent_of_the_far_field_force(pipe, soil):
+    state = lateral_equilibrium(pipe, soil, 70.0, HobbsMode.MODE_2)
+    recovered = pipe.fully_restrained_thermal_force(state.temperature_rise_K)
+    assert recovered == pytest.approx(state.far_field_force_N, rel=1e-12)
+
+
+@pytest.mark.parametrize("bad", [0.0, -10.0, float("nan")])
+def test_non_physical_buckle_length_rejected(pipe, soil, bad):
+    with pytest.raises(ValueError):
+        lateral_equilibrium(pipe, soil, bad, HobbsMode.MODE_3)
+
+
+def test_unknown_mode_rejected(pipe, soil):
+    with pytest.raises(ValueError, match="mode must be"):
+        lateral_equilibrium(pipe, soil, 60.0, "mode-5")
+
+
+def test_mode_accepts_int_and_string_aliases(pipe, soil):
+    by_enum = lateral_equilibrium(pipe, soil, 60.0, HobbsMode.MODE_3)
+    by_int = lateral_equilibrium(pipe, soil, 60.0, 3)
+    by_str = lateral_equilibrium(pipe, soil, 60.0, "3")
+    assert by_int.far_field_force_N == by_enum.far_field_force_N
+    assert by_str.far_field_force_N == by_enum.far_field_force_N
+
+
+# ----------------------------------------------------------------------
+# The turning point of P0(L)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", list(HobbsMode))
+def test_critical_state_is_a_local_minimum(pipe, soil, mode):
+    state = critical_state(pipe, soil, mode)
+    for factor in (0.9, 0.99, 1.01, 1.1):
+        neighbour = lateral_equilibrium(
+            pipe, soil, state.buckle_length_m * factor, mode
+        )
+        assert neighbour.far_field_force_N > state.far_field_force_N
+
+
+def test_periodic_analytic_minimum_agrees_with_a_numeric_scan(pipe, soil):
+    state = critical_state(pipe, soil, HobbsMode.INFINITE)
+    lengths = [state.buckle_length_m * (0.5 + i / 100.0) for i in range(101)]
+    scanned = min(
+        lengths,
+        key=lambda length: lateral_equilibrium(
+            pipe, soil, length, HobbsMode.INFINITE
+        ).far_field_force_N,
+    )
+    assert scanned == pytest.approx(state.buckle_length_m, rel=2e-2)
+
+
+@pytest.mark.parametrize("mode", list(HobbsMode))
+def test_critical_state_gives_a_physically_plausible_buckle(pipe, soil, mode):
+    state = critical_state(pipe, soil, mode)
+    # A 12.75 in line on friction of this order buckles over tens of metres at
+    # a temperature rise of order tens of degrees, with amplitude under a
+    # metre; anything outside these bands means a coefficient or exponent slip.
+    assert 5.0 < state.buckle_length_m < 500.0
+    assert 1.0 < state.temperature_rise_K < 300.0
+    assert 0.0 < state.amplitude_m < 5.0
+
+
+def test_higher_lateral_friction_raises_the_critical_force(pipe):
+    low = critical_state(
+        pipe, SoilResistance(axial_friction=0.5, lateral_friction=0.4), HobbsMode.MODE_3
+    )
+    high = critical_state(
+        pipe, SoilResistance(axial_friction=0.5, lateral_friction=1.0), HobbsMode.MODE_3
+    )
+    assert high.far_field_force_N > low.far_field_force_N
+    # Stiffer lateral restraint also shortens the buckle.
+    assert high.buckle_length_m < low.buckle_length_m
+
+
+# ----------------------------------------------------------------------
+# Roots at a given temperature
+# ----------------------------------------------------------------------
+
+
+def test_below_the_critical_temperature_there_is_no_equilibrium(pipe, soil):
+    critical = critical_state(pipe, soil, HobbsMode.MODE_3)
+    assert equilibria_at_temperature(
+        pipe, soil, critical.temperature_rise_K * 0.95, HobbsMode.MODE_3
+    ) == ()
+
+
+def test_at_the_critical_temperature_the_two_roots_merge(pipe, soil):
+    critical = critical_state(pipe, soil, HobbsMode.MODE_3)
+    states = equilibria_at_temperature(
+        pipe, soil, critical.temperature_rise_K, HobbsMode.MODE_3
+    )
+    assert len(states) == 1
+    assert states[0].buckle_length_m == pytest.approx(critical.buckle_length_m)
+
+
+def test_above_the_critical_temperature_there_are_two_branches(pipe, soil):
+    critical = critical_state(pipe, soil, HobbsMode.MODE_3)
+    target = critical.temperature_rise_K * 1.5
+    states = equilibria_at_temperature(pipe, soil, target, HobbsMode.MODE_3)
+
+    assert len(states) == 2
+    short, long = states
+    assert short.buckle_length_m < critical.buckle_length_m < long.buckle_length_m
+    for state in states:
+        assert state.temperature_rise_K == pytest.approx(target, rel=1e-9)
+    # The post-snap branch is the damaging one: longer, larger, more curved.
+    assert long.amplitude_m > short.amplitude_m
+    assert long.max_moment_Nm > short.max_moment_Nm
+
+
+# ----------------------------------------------------------------------
+# Mode screening
+# ----------------------------------------------------------------------
+
+
+def test_screen_modes_is_ordered_and_flags_the_governing_mode(pipe, soil):
+    governing = governing_mode(pipe, soil)
+    results = screen_modes(pipe, soil, driving_force_N=governing.far_field_force_N * 1.2)
+
+    forces = [r.critical_state.far_field_force_N for r in results]
+    assert forces == sorted(forces)
+    assert results[0].mode is governing.mode
+    assert results[0].susceptible is True
+    assert results[0].utilisation == pytest.approx(1.2, rel=1e-9)
+
+
+def test_a_line_below_every_critical_force_is_not_susceptible(pipe, soil):
+    governing = governing_mode(pipe, soil)
+    results = screen_modes(pipe, soil, driving_force_N=governing.far_field_force_N * 0.5)
+    assert all(not r.susceptible for r in results)
+
+
+def test_screen_modes_rejects_a_non_positive_driving_force(pipe, soil):
+    with pytest.raises(ValueError):
+        screen_modes(pipe, soil, driving_force_N=0.0)
+
+
+# ----------------------------------------------------------------------
+# Effective driving force
+# ----------------------------------------------------------------------
+
+
+def test_effective_driving_force_sums_thermal_and_pressure_terms(pipe):
+    dt = 60.0
+    pressure = 15e6
+    internal_area = math.pi / 4.0 * (OD_M - 2.0 * WT_M) ** 2
+
+    force = effective_driving_force(
+        pipe,
+        temperature_rise_K=dt,
+        internal_pressure_pa=pressure,
+        internal_area_m2=internal_area,
+        poisson_ratio=0.3,
+    )
+    expected = pipe.fully_restrained_thermal_force(dt) + pressure * internal_area * 0.4
+    assert force == pytest.approx(expected, rel=1e-12)
+
+
+def test_residual_lay_tension_relieves_compression(pipe):
+    with_tension = effective_driving_force(
+        pipe, temperature_rise_K=40.0, residual_lay_tension_N=50e3
+    )
+    without = effective_driving_force(pipe, temperature_rise_K=40.0)
+    assert with_tension == pytest.approx(without - 50e3)
+
+
+def test_a_line_in_net_tension_has_no_driving_force(pipe):
+    assert (
+        effective_driving_force(
+            pipe, temperature_rise_K=1.0, residual_lay_tension_N=1e9
+        )
+        == 0.0
+    )


### PR DESCRIPTION
## What

Adds `digitalmodel.subsea.pipeline.global_buckling` — a standalone SI implementation of the Hobbs (1984) lateral post-buckling solution: modes 1–4 and the periodic mode, the `P0(L)` equilibrium path, its snap-through minimum, and the two roots either side of it.

## Why

`lateral_buckling.py` already builds the effective-axial-force profile along a route from YAML, finds the anchor lengths, and applies a single susceptibility screen. It answers **"can this line buckle?"**

It does not answer what follows: how long the buckle is, how far it sweeps, what bending moment and combined stress it carries, and how much hotter the line can get before it snaps onto the long branch. This fills that gap.

The new package is deliberately decoupled — SI units, plain dataclasses, scipy only, no config plumbing — so it can be called from a notebook or a study script as well as from the existing runner.

## Departure from the usual presentation

Most textbook forms collapse axial and lateral friction into a single coefficient. This keeps `φ_A` and `φ_L` separate, since axial breakout is typically 0.3–0.6 while lateral breakout on the same soil is 0.5–1.2. Setting them equal recovers the single-coefficient form exactly, and there is a regression test asserting it.

The friction dependence inside the radical (`z = k2·EA·q_L²·L⁵ / (q_A·(EI)²)`) was re-derived from the axial feed-in compatibility condition rather than taken from a secondary source, because secondary presentations disagree on the power of `φ_A`.

## Provenance

Prompted by a public research package on the same topic ([zgu214/pipeline-lateral-buckling](https://github.com/zgu214/pipeline-lateral-buckling)). **That repository states no software licence has been selected**, so nothing is copied from it — not code, not text. The equations here are implemented from Hobbs (1984) Table 1 and Eqs. 20–29.

## Verification

- 46 tests in `tests/subsea/pipeline/test_hobbs_lateral_buckling.py`: closed-form identities (a typo in any coefficient or exponent fails), turning-point structure, guard rails.
- Cross-checked against the independent worked example in `llm-wiki` `wikis/pipeline-engineering/wiki/concepts/pipeline-upheaval-lateral-buckling.md`: the same 12.75 in line gives `S_eff = 2637.7 kN` from both.
- No published benchmark table is asserted — Hobbs' own tabulated cases are not redistributable, and a synthetic number checked against itself would prove nothing.

## Also

Fixes a copy-pasted lateral-buckling intro paragraph sitting in `docs/domains/pipelines/uplheaval_buckling.md`.

## Scope

Not included: coating bending stiffness, cyclic soil memory, walking, upheaval (vertical) buckling, imperfection/initiation methods, and any design-code acceptance check. The module docstrings say so explicitly and point at DNV-RP-F110 and Taylor & Gan (1986).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Tu4bkpqQnfpVbekPm7GYx