### PR TITLE
fix(orcaflex,fatigue): close model-building integrity defects and add a cycle-counting contract

### DIFF
--- a/docs/domains/fatigue/rainflow-path-exposure-2026-09-11.md
+++ b/docs/domains/fatigue/rainflow-path-exposure-2026-09-11.md
@@ -1,0 +1,431 @@
+# Rainflow counting paths — behaviour record and exposure assessment
+
+**Issue:** https://github.com/vamseeachanta/workspace-hub/issues/3839
+**Plan:** workspace-hub `docs/plans/2026-09-11-issue-3839-rainflow-divergence.md`
+**Measured:** 2026-09-11, `digitalmodel` at `90bcff85`
+**Gate:** `src/digitalmodel/fatigue/counting_contract.py`, `tests/fatigue/test_rainflow_invariants.py`
+
+This record exists so the evidence the deferral argument rests on survives the
+session. Consolidation onto one counting implementation is deferred to a
+successor issue; retiring an implementation before this record existed would
+have removed the evidence needed to judge what the retired implementation
+produced.
+
+---
+
+## 1. Measured behaviour
+
+Each path was invoked through its public entry point on four deterministic
+signals. The invariant is that a retain-residual cycle count extracts a maximum
+range equal to the signal's peak-to-valley span, since the largest excursion is
+necessarily a reversal pair and therefore appears as a full or half cycle.
+
+| Signal | Definition |
+|---|---|
+| `astm_example` | `[-2, 1, -3, 5, -1, 3, -4, 4, -2]` |
+| `narrow_band_sine` | `50·sin(t)`, `t = linspace(0, 10·2π, 640, endpoint=False)` |
+| `broadband_random` | `default_rng(20260911).normal(0, 25, 4096)` |
+| `residual_dominated` | `linspace(0, 200, 512) + 8·sin(linspace(0, 40π, 512))` |
+
+Maximum extracted range per path; `FAIL` marks a maximum below the span.
+
+| signal | span | pylife_4pt | pypi_rainflow | sigproc_astm | calm_buoy | fapps_counting | fapps_counter | struct_fatigue |
+|---|---|---|---|---|---|---|---|---|
+| astm_example | 9.0000 | PASS | PASS | FAIL 6.0 | FAIL 7.0 | PASS | PASS | PASS |
+| narrow_band_sine | 100.0000 | PASS | PASS | PASS | FAIL 50.0 | PASS | PASS | PASS |
+| broadband_random | 177.1224 | PASS | PASS | FAIL 125.2664 | FAIL 106.3779 | FAIL 169.556 | PASS | FAIL 169.556 |
+| residual_dominated | 201.2606 | PASS | PASS | FAIL 190.6564 | FAIL 200.6303 | FAIL 200.6303 | PASS | FAIL 200.6303 |
+
+Table 1 — maximum extracted range against the peak-to-valley span, by path and signal.
+
+Table 1 reports the maximum-range invariant alone. Applying the whole contract —
+clause 1 (span extracted), clause 2 (nothing counted the signal does not
+contain), clause 3 (exact count conservation, positive half-integer counts, no
+zero-range row) — gives the verdict matrix below, which is the form committed as
+`RECORDED_VERDICTS` in `tests/fatigue/test_rainflow_invariants.py` so that any
+movement in a cell fails a test rather than going stale.
+
+| signal | pylife_4pt | pypi_rainflow | sigproc_astm | calm_buoy | fapps_counting | fapps_counter | struct_fatigue |
+|---|---|---|---|---|---|---|---|
+| astm_example | PASS | PASS | FAIL c1 | FAIL c1, c3 | PASS | PASS | PASS |
+| narrow_band_sine | PASS | PASS | FAIL c3 | FAIL c1 | PASS | PASS | PASS |
+| broadband_random | PASS | PASS | FAIL c1 | FAIL c1 | FAIL c1 | PASS | FAIL c1 |
+| residual_dominated | PASS | PASS | FAIL c1 | FAIL c1 | FAIL c1 | PASS | FAIL c1 |
+
+Table 2 — contract verdict by path and signal; `c1`, `c3` name the failing clause.
+
+Two cells diverge in **count** as well as in range, correcting the claim in the
+issue body that total counted cycles agree across all seven paths on every
+signal:
+
+- `sigproc_astm` on `narrow_band_sine` extracts the correct maximum range of
+  100.0 and would pass Table 1, but emits only 6.0 cycles of non-zero range
+  against the 10.5 the reversal count requires, with the remaining 4.5 emitted
+  as **zero-range rows**. Equal-valued extrema become adjacent on the stack
+  after the implementation pops the wrong element, and the pair is counted at
+  range zero. A zero-range cycle carries no damage, so 43 % of the counted
+  cycles on this signal contribute nothing.
+- `calm_buoy` on `astm_example` returns 3.5 cycles against 4.0 (§3.2).
+
+On the remaining twenty-six cells the totals do agree (4.0, 10.5, 1370.0, 20.5),
+so outside those two the divergence is confined to the ranges assigned.
+
+Fatigue damage under a Miner summation with an S-N slope of 3 scales as range
+cubed. A maximum range understated by 29 % (`sigproc_astm`, broadband)
+understates that cycle's damage contribution by a factor of 2.8; understated by
+40 % (`calm_buoy`, broadband) by a factor of 4.6. The direction is
+non-conservative in every failing case.
+
+**Standards-evidence limitation.** The contract is scoped to this project's
+declared convention, not to a standard. ASTM E1049-85(2023) is paywalled and was
+not read, so no clause is presented as a standards requirement.
+
+---
+
+## 2. Conditionality of the invariant
+
+The invariant is **not** universal. An implementation that discards residual
+turning points rather than counting them as half cycles can correctly omit the
+global span. The contract therefore states clause 1 against a **declared**
+residual policy, and `tests/fatigue/test_rainflow_invariants.py::test_10_*`
+proves the contract accepts a declared discard-residual counter that omits the
+span.
+
+Every path in Table 1 declares `RETAIN`, and the evidence is that total counts
+agree across all seven and end in `.5` (10.5, 20.5). The divergence is not a
+convention difference.
+
+---
+
+## 3. Per-path verdict, mechanism, consumers and refusal state
+
+Consumer inventory is call-graph derived, not import-scan derived: an import
+scan over `src/` alone misses documentation examples, standalone scripts, and
+modules reachable only through a public entry point.
+
+### 3.1 `sigproc_astm` — NON-CONSERVATIVE
+
+`src/digitalmodel/signal_processing/signal_analysis/core/rainflow.py:16`
+`RainflowCounter.count_cycles`
+
+**Mechanism, read from source.** `core/rainflow.py:162-164` reads
+`if range_XY >= range_YZ: cycle_range = range_YZ`. Both halves are inverted
+relative to ASTM §5.4.4: the rule fires when the *newer* range is the larger,
+and it extracts the *older* (inner) pair. This implementation fires when the
+older range is the larger and extracts the newer. It also draws no distinction
+between the starting-point case and the interior case — every extraction emits
+`0.5` and discards `stack[-2]` (`:168-176`), so ASTM's full-cycle rule is never
+applied, and the residual loop (`:181-195`) emits every remaining adjacent pair
+as a half cycle.
+
+**Limit of this reading.** Correcting the inversion alone does not restore the
+span: a controlled pair over the ASTM fixture that flips only the comparison
+and the extracted range still reports a maximum of 7.0 against a span of 9.0.
+The defect is therefore structural rather than a sign error, and the specific
+arithmetic that produces 6.0 on the fixture and 125.2664 on broadband is **not
+established** beyond the source reading above. Establishing it is not required
+to act: the measured shortfall in Table 1 is the finding, and the repair is
+governed by the contract regardless of which line is changed.
+
+**Second failure mode.** On `narrow_band_sine` this path extracts the correct
+maximum range and fails clause 3 instead: 6.0 cycles of non-zero range against
+the 10.5 the reversal count requires, with 4.5 emitted at range zero. Popping
+`stack[-2]` makes two equal-valued extrema adjacent, and the resulting pair is
+counted at range zero, so it carries no damage. A maximum-range check alone
+does not see this.
+
+| Consumer | Kind | Verdict |
+|---|---|---|
+| `signal_analysis/orcaflex/analyzer.py:16,46` | src | diagnostic — statistics, histogram, CSV, plots; no S-N in the file |
+| `signal_analysis/cli.py:14,48` | src | diagnostic |
+| `signal_analysis/adapters.py:14,39,69,284,312,367,396` | src | diagnostic |
+| `signal_analysis/orcaflex/error_handling.py:191` | src | diagnostic |
+| `signal_analysis/orcaflex/__main__.py:27,388` | src | diagnostic |
+| `solvers/orcaflex/time_trace_processor.py:253,266` | src | **damage** — `FatigueDamageCalculator(method='miners')`, `damage_per_hour`, `damage_design_life`, `life_years` |
+| `solvers/orcaflex/time_trace_processor.py:435,438` | src | **damage** — parallel twin of the above |
+| `solvers/orcaflex/opp_time_series_v2.py:253,259` | src | diagnostic — histogram and statistics |
+| `solvers/orcaflex/opp_time_series_v2.py:159-200` | src | **damage**, indirect — delegates to `OrcaFlexTimeTraceProcessor.process()` |
+| `tests/signal_processing/signal_analysis/test_signal_integration.py:13,58,304` | test | damage, but constructs counter and damage calculator directly |
+| `tests/signal_processing/signal_analysis/test_integration_simple.py:30` | test | damage, direct construction |
+| `tests/signal_processing/signal_analysis/test_generate_outputs.py:23,159` | test | damage, direct construction |
+| `tests/signal_processing/signal_analysis/test_orcaflex_tension_analysis.py:26,39` | test | diagnostic |
+| `docs/domains/examples/signal_analysis_usage_example.py:22,41,213` | docs | diagnostic and damage |
+| `docs/domains/examples/orcaflex_signal_analysis_example.py:21,104,178,330` | docs | diagnostic and damage, indirect |
+| `scripts/python/digitalmodel/tools/process_fatigue_simplified_rainflow.py:16,77` | script | diagnostic; import path stale (see §5) |
+
+**Refusal applied at:**
+`OrcaFlexTimeTraceProcessor._perform_fatigue_analysis` and
+`OrcaFlexTimeTraceProcessor._analyze_single_trace`. Blocking those two blocks
+`OPPTimeSeriesV2.process_fatigue_analysis` and the documentation examples that
+route through them.
+
+`FatigueDamageCalculator.calculate_damage`
+(`signal_analysis/fatigue/damage.py:15`) is **not** blocked: it never
+constructs a counter, always consuming a cycles DataFrame, so it is not bound
+to this path and blocking it would be over-broad.
+
+The engine's live OrcaFlex post-processing route is unaffected.
+`solvers/orcaflex/opp_time_series.py:458` calls
+`OrcFXAPIObject.RainflowHalfCycles(...)` — OrcaFlex's own rainflow — and
+consumes none of the seven paths. The blast radius asserted in the first
+comment on #3839 was published from imports without tracing reachability and
+was corrected; that correction is the reason this record is call-graph derived.
+
+### 3.2 `calm_buoy` — NON-CONSERVATIVE
+
+`src/digitalmodel/marine_ops/marine_engineering/calm_buoy_fatigue.py:196`
+`RainflowFatigue.count_cycles`
+
+**Mechanism, read from source, confirmed by a controlled pair.**
+`calm_buoy_fatigue.py:262-270` makes the three-point comparison correctly
+(`if x_range >= y_range: cycles.append((y_range, …))`) and correctly counts the
+starting-point case as a half cycle, which is why its failure is milder and
+differently shaped than `sigproc_astm`'s. Two lines are wrong:
+
+- `:267` `stack.pop(-2)` discards the **second** point of the counted pair.
+  ASTM rule 2 discards the **first** — the starting point — and retains the
+  second, which then becomes the new start.
+- `:268` `break` exits the extraction loop instead of re-checking the shortened
+  stack.
+
+Controlled pair, holding the reversal extraction and everything else fixed and
+changing only those two lines to `stack.pop(0)` with no `break`:
+
+| signal | span | as committed | rule 2 restored |
+|---|---|---|---|
+| `narrow_band_sine` | 100.0 | max 50.0, total 10.5 | max 100.0, total 10.5 |
+| `astm_example` | 9.0 | max 7.0, total 3.5 | max 9.0, total 4.0 |
+
+Table 3 — `calm_buoy` maximum extracted range and total counts, as committed
+against ASTM rule 2 restored.
+
+The as-committed column reproduces Table 1 exactly, so the reimplementation
+used for the comparison is faithful. Restoring rule 2 recovers both the span
+and the lost half cycle.
+
+**Additional finding, not in the issue as filed.** On `astm_example` this path
+also loses a half cycle: total 3.5 against the 4.0 that the other six report.
+The issue body's claim that total counts agree across all seven on every signal
+therefore does not hold for this pair. The divergence is in both range and
+count, not range alone.
+
+| Consumer | Kind | Verdict |
+|---|---|---|
+| `calm_buoy_fatigue.py:370,415` `ScatterDiagramFatigue` | src | **damage** — probability-weighted Miner damage per line |
+| `calm_buoy_fatigue.py:571,576` `compute_fatigue_life` | src | **damage** — Miner damage, fatigue life, inspection interval |
+| `tests/marine_ops/marine_engineering/test_calm_buoy_fatigue.py` | test | counting tests diagnostic; `TestScatterDiagramFatigue` and `TestComputeFatigueLife` damage |
+
+No consumer exists outside this module: the class is not exported from any
+`__init__.py` and no other file in `src/`, `tests/`, `docs/`, `scripts/` or
+`examples/` imports it.
+
+**Refusal applied at:** `ScatterDiagramFatigue.compute` and
+`compute_fatigue_life`. `MinersRuleDamage.compute` and `FatigueLifeReport.build`
+are damage-producing but consume pre-counted arrays and are not counter-bound;
+they remain callable.
+
+### 3.3 `fapps_counting` — NON-CONSERVATIVE
+
+`src/digitalmodel/structural/fatigue_apps/rainflow_counting.py:39`
+`RainflowCounter.process_time_series`
+
+**Mechanism, read from source.** `rainflow_counting.py:154-163` extracts only
+when the stack already holds four or more points (`if len(stack) >= 4`) and
+breaks otherwise, so ASTM rule 2 — count the pair containing the starting point
+as a half cycle and discard the starting point — is never applied. The starting
+point is therefore never shed, the stack stays four or more deep, and rule 3
+(full cycle, discard **both** points of the pair) is applied where rule 2 was
+due. A reversal that ASTM retains is discarded. This is the same defect shape
+as `struct_fatigue` §3.4, where it is confirmed by a controlled pair; the two
+report identical maxima on both failing signals.
+
+| Consumer | Kind | Verdict |
+|---|---|---|
+| `rainflow_counting.py:465` its own `main()` | src | pipeline — writes `*_cycles.csv`, `rainflow_summary.csv`, `rainflow_report.txt` |
+
+**No importer exists anywhere in the repository.** The class is not in
+`fatigue_apps/__init__.py`'s exports — that file exports the different
+`RainflowCounter` from `rainflow_counter.py` — and no module in `src/`,
+`tests/`, `docs/`, `scripts/` or `examples/` imports it. Two non-code mentions
+exist: `fatigue_apps/INPUT_FILE_STRUCTURE.md:77,116,275` documents it as
+"Module 2", invoked as `python rainflow_counting.py`; and
+`fatigue_apps/LOAD_SCALING_DOCUMENTATION.md:293` gives an import path
+(`digitalmodel.structural.fatigue_analysis.rainflow_counting`) that does not
+resolve against the current layout.
+
+**Refusal applied at:** `RainflowCounter.process_batch`. There is no in-process
+damage consumer to block, so this is the narrowest defensible placement: the
+hand-off to damage is by file, and `process_batch` is the documented Module 2
+step whose CSV output feeds the Module 3 damage calculator.
+`process_time_series` and `rainflow_counting_astm` remain callable, so the
+diagnostic use of the counter is preserved.
+
+### 3.4 `struct_fatigue` — NON-CONSERVATIVE
+
+`src/digitalmodel/structural/fatigue/rainflow.py:210` `RainflowCounter.count_cycles`
+
+**Mechanism, read from source, confirmed by a controlled pair.**
+`_rainflow_counting_numba` (`rainflow.py:183-196`) extracts only when
+`stack_size >= 4` and breaks otherwise, so ASTM rule 2 is never applied. The
+starting point is never shed, the stack stays four or more deep, and rule 3 —
+full cycle, discard **both** points of the pair — is applied where rule 2 was
+due, discarding a reversal ASTM retains. `_rainflow_with_means`
+(`rainflow.py:562-581`) repeats the defect independently for the mean-stress
+route.
+
+Controlled pair on `broadband_random`, holding the turning-point extraction
+(`_find_turning_points_numba`, 2741 points) fixed and changing only the
+`else: break` branch to apply rule 2:
+
+| variant | max range | total counts | global valley (−86.3782) |
+|---|---|---|---|
+| as committed | 169.5560 | 1370.0 | discarded by an extraction |
+| rule 2 applied | 177.1224 | 1370.0 | retained to the residual |
+
+Table 4 — `struct_fatigue` on `broadband_random`; span 177.1224,
+`len(reversals) − 1 = 2740`.
+
+The as-committed column reproduces Table 1 exactly. The discarded reversal is
+the signal's global valley: the counter emits a full cycle of 169.5560 between
+the global peak and −78.8119 and then has no valley left to pair the peak with,
+so the span is never emitted. Total counts are unchanged between the two
+variants, which is why the failing paths still satisfy count conservation.
+
+| Consumer | Kind | Verdict |
+|---|---|---|
+| `structural/fatigue/analysis.py:50,310,354,358` | src | **damage** — `FatigueAnalysisEngine.analyze_time_series` → `total_damage`, `safety_factor`, `life_fraction_used` |
+| `structural/fatigue/analysis.py:962-992` | src | **damage** — `quick_time_domain_analysis`, wrapper over the engine |
+| `structural/fatigue/__init__.py:265-277` | src | **damage** — `quick_fatigue_analysis`, an independent counter construction, not routed through the engine |
+| `fatigue/__init__.py:75-81` | src | alias import path for the above two engine callables |
+| `structural/fatigue/rainflow.py:622,750,769,784` | src | diagnostic — `RainflowBatch`, `rainflow_count`, `rainflow_with_means`, `__main__` demo |
+| `tests/structural/fatigue/test_rainflow.py` | test | diagnostic throughout |
+| `tests/structural/fatigue/test_fatigue_migration.py:324,345,352,370,402` | test | **damage** via `quick_time_domain_analysis` |
+| `examples/domains/fatigue/advanced_examples/complete_fatigue_analysis.py:170,431,446` | example | diagnostic and damage |
+| `examples/domains/fatigue/fatigue_analysis_examples.py:170,193,422` | example | **damage** |
+
+`damage_accumulation.py` and `scatter_fatigue.py` import no rainflow module and
+are not counter-bound; `analysis.analyze_psd` is spectral. None is blocked.
+
+**Refusal applied at:** `FatigueAnalysisEngine.analyze_time_series`,
+`quick_time_domain_analysis`, and `structural.fatigue.quick_fatigue_analysis`.
+The third needs its own refusal because it constructs its own counter rather
+than routing through the engine.
+
+### 3.5 Conforming paths
+
+| Path | Entry point | Status |
+|---|---|---|
+| `pylife_4pt` | `digitalmodel.fatigue.rainflow.rainflow_count` | conforming on all four signals; no refusal |
+| `pypi_rainflow` | `TimeSeriesComponents.count_cycles`, delegating to the `rainflow` PyPI package | conforming on all four signals; no refusal. One degenerate-case divergence, §4 |
+| `fapps_counter` | `structural/fatigue_apps/rainflow_counter.py:33` `RainflowCounter.count_cycles` | conforming on all four signals; no refusal |
+
+`fapps_counter` aggregates on a range key rounded to six decimals, so its
+emitted maximum can differ from the span by up to 5·10⁻⁷. The contract's
+relative tolerance of 10⁻⁶ admits that and nothing larger; the smallest
+recorded failure understates the span by 4.3 %.
+
+---
+
+## 4. Divergences found by the gate, not by the issue
+
+Recorded rather than absorbed, because each is a fact about a path that a later
+consolidation decision needs.
+
+1. **`calm_buoy` loses a half cycle on `astm_example`** (3.5 against 4.0), and
+   **`sigproc_astm` emits 4.5 of its 10.5 cycles at range zero on
+   `narrow_band_sine`**. The issue body's claim that total counted cycles agree
+   across all seven paths on every signal does not hold for either pair. The
+   second is invisible to a maximum-range check — that cell passes Table 1 —
+   which is the argument for clause 3 being an exact equality rather than an
+   aggregate sanity check. §1, §3.1, §3.2.
+2. **`rainflow` 3.2.0 returns nothing for a two-sample series.** `pylife_4pt`
+   and `fapps_counter` both emit the single half cycle at the full span;
+   `extract_cycles([0.0, 10.0])` returns `[]`. Third-party behaviour on a
+   degenerate input; recorded as a strict expected-fail
+   (`test_12b_pypi_rainflow_two_point_signal`).
+3. **The conforming paths disagree on a constant signal.** pyLife and the PyPI
+   package emit one zero-range half cycle; `fapps_counter` emits nothing. A
+   zero range contributes exactly zero damage, so neither is wrong. The
+   contract treats zero-range rows as inert but forbids them when the span is
+   non-zero, which is the case the sub-clause exists to catch.
+4. **Importing `marine_ops.marine_engineering.calm_buoy_fatigue` closes
+   `sys.stdout`.** `marine_ops/marine_analysis/extraction/run_extraction.py:11-12`
+   replaces `sys.stdout` with a new `TextIOWrapper` over the same buffer at
+   import time, and the discarded wrapper closes the buffer. Unrelated to
+   cycle counting; it makes any script that imports that package unable to
+   print. Not fixed here — out of this plan's scope.
+
+---
+
+## 5. Open items
+
+- **Deliverable exposure is not established.** Whether any issued result was
+  produced through a failing path requires access to client repositories, which
+  is outside this plan's scope and requires the owner's direction. This item is
+  named, not resolved.
+- **The exposure cannot be dated.** `git log` for the affected files returns a
+  single commit, so the interval over which a failing path was callable for
+  damage is not determinable from the repository.
+- **Eight scripts under `scripts/python/digitalmodel/tools/` import
+  `digitalmodel.modules.signal_analysis.orcaflex`**, a module path that does not
+  match the current layout. Whether they ran against an earlier layout is not
+  established; the record states that rather than assuming either way. The same
+  stale namespace appears at `docs/domains/examples/signal_analysis_usage_example.py:24-25`
+  and, wrapped in `try/except ImportError` so it silently no-ops, at
+  `structural/fatigue/__init__.py:216-217`.
+- **`opp_time_series_v2.py` has no current `src` importer.** It is constructed
+  by a committed documentation example, so "orphaned" and "unreachable"
+  overstate what the evidence supports.
+- **Consolidation onto one implementation is deferred** to a successor issue.
+  The refusals above are the interim measure; deletion is the successor's work.
+  Each expected-fail marker carries the issue number so it surfaces in triage.
+
+### 5.1 A damage entry point the refusal cannot reach
+
+`src/digitalmodel/ansys/fatigue_postprocessor.py` was raised as a candidate
+eighth counting path and is **not** one. The module contains no counting
+implementation: `rainflow` occurs exactly once in its 346 lines, at the module
+docstring, and no reversal, peak, valley, turning-point or stack logic exists
+anywhere in the file. `calculate_fatigue_damage()` at `:208` iterates
+`config.load_cases` and reads `lc.stress_range_mpa` (`:232`) and `lc.num_cycles`
+(`:247`) as caller-supplied inputs; counting is delegated to ANSYS through the
+APDL commands emitted by `generate_stress_range_extraction()` at `:272`. The
+seven-path inventory in section 3 stands. Verified independently by two sessions.
+
+It is, however, a **damage entry point that the refusal mechanism cannot
+protect**, and this is a limitation of the control rather than an omission from
+it. The refusals in section 3 guard entry points that call a failing counter
+**in process**. This one receives stress ranges and cycle counts as data — by
+CSV, by spreadsheet, or by hand — so a range produced by one of the four
+non-conservative paths can reach Miner summation here without any counter being
+called, and no in-process guard can observe it.
+
+The risk is **latent rather than live**: the module has no production caller.
+A repository-wide search for `fatigue_postprocessor`, `FatiguePostprocessor` and
+`FatigueConfig` returns only `tests/ansys/test_fatigue_postprocessor.py` and the
+re-export in `src/digitalmodel/ansys/__init__.py`. Nothing currently feeds it
+counts from a defective path. It matters because `digitalmodel.ansys` is a
+public export surface, so the hand-off is available to any external caller.
+
+A separate documentation defect is recorded here because it caused the false
+lead and would mislead the next reader identically: the module docstring at
+`:14` advertises "Rainflow cycle counting (simplified)" as a module capability
+that the module does not implement. `ansys/__init__.py:24` describes the module
+correctly as "fatigue damage evaluation (S-N, Miner)" with no counting claim, so
+the misleading advertisement is isolated to that one line. The file sits inside
+the scope of digitalmodel issue #2094, and the fix is routed to that issue's
+owner rather than made here.
+
+---
+
+## 6. Reproducing this record
+
+```
+cd digitalmodel
+.venv/Scripts/python -m pytest tests/fatigue/test_rainflow_invariants.py -q
+```
+
+The four signals, the seven registered paths and their declared residual
+policies are in `src/digitalmodel/fatigue/counting_contract.py`
+(`CONTRACT_SIGNALS`, `COUNTING_PATHS`). The contract is callable without pytest
+via `check_counting_contract` and `assert_counting_contract`.

--- a/src/digitalmodel/fatigue/counting_contract.py
+++ b/src/digitalmodel/fatigue/counting_contract.py
@@ -1,0 +1,929 @@
+"""Correctness contract for rainflow cycle counting, and the registry of paths.
+
+Issue: https://github.com/vamseeachanta/workspace-hub/issues/3839
+Plan:  workspace-hub ``docs/plans/2026-09-11-issue-3839-rainflow-divergence.md``
+
+Seven cycle-counting implementations exist in this repository. Four of them
+extract a maximum stress range **below** the signal's peak-to-valley span.
+Fatigue damage scales as range cubed, so those four understate damage — the
+non-conservative direction.
+
+This module supplies three things:
+
+1. **The contract** — four clauses a cycle count must satisfy, callable
+   independently of any test framework (:func:`check_counting_contract`,
+   :func:`assert_counting_contract`, :func:`assert_exact_distribution`).
+2. **The registry** — every counting path, its entry point, its declared
+   residual policy, its recorded verdict, and the damage entry points bound to
+   it (:data:`COUNTING_PATHS`).
+3. **The refusal** — :func:`refuse_damage_calculation`, called from the damage
+   entry points of the non-conforming paths so that a failing path cannot be
+   used to produce a damage or fatigue-life number while consolidation is
+   deferred to the successor issue.
+
+Scope limitation, stated rather than implied: the contract is scoped to this
+project's declared convention, not to a standard. ASTM E1049-85(2023) is
+paywalled and was not read, so no clause here is presented as a standards
+requirement.
+
+Clause 1 is **conditional on a declared residual policy**. An implementation
+that discards residuals rather than counting them as half cycles can correctly
+omit the global span; such an implementation is not condemned by this contract.
+Every path registered below declares ``RETAIN``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, NoReturn, Sequence
+
+import numpy as np
+
+__all__ = [
+    "ISSUE_NUMBER",
+    "ISSUE_URL",
+    "ResidualPolicy",
+    "ContractViolation",
+    "NonConservativeCountingError",
+    "CycleCount",
+    "CountingPath",
+    "COUNTING_PATHS",
+    "COUNTING_SCAN_PACKAGES",
+    "CONTRACT_SIGNALS",
+    "CONTRACT_EXACT",
+    "reversals_with_endpoints",
+    "peak_to_valley_span",
+    "check_counting_contract",
+    "assert_counting_contract",
+    "check_exact_distribution",
+    "assert_exact_distribution",
+    "refuse_damage_calculation",
+    "discover_counting_callables",
+    "unregistered_counting_callables",
+]
+
+ISSUE_NUMBER = 3839
+ISSUE_URL = "https://github.com/vamseeachanta/workspace-hub/issues/3839"
+
+#: Relative tolerance on range comparisons. Loose enough to admit an
+#: implementation that rounds its aggregation key to six decimals
+#: (``fatigue_apps/rainflow_counter.py`` does), tight enough that every
+#: recorded failure — the smallest of which understates the span by 4.3 % —
+#: is rejected by four orders of magnitude.
+DEFAULT_RTOL = 1e-6
+DEFAULT_ATOL = 1e-9
+
+#: Count tolerance. Counts are multiples of 0.5 and exactly representable.
+COUNT_ATOL = 1e-9
+
+
+class ResidualPolicy(str, Enum):
+    """What an implementation does with the residual after loop closure."""
+
+    #: Residual turning points are counted as half cycles. The global peak and
+    #: valley are necessarily a reversal pair, so the span is emitted.
+    RETAIN = "retain"
+
+    #: Residual turning points are discarded. The span may legitimately be
+    #: absent from the emitted ranges.
+    DISCARD = "discard"
+
+
+class ContractViolation(AssertionError):
+    """A cycle count violates the counting contract."""
+
+
+class NonConservativeCountingError(RuntimeError):
+    """Damage calculation refused: the bound counting path understates range."""
+
+
+@dataclass(frozen=True)
+class CycleCount:
+    """A normalised cycle count.
+
+    Attributes
+    ----------
+    ranges
+        Stress/load ranges, one per emitted row.
+    counts
+        Cycle counts, one per row; 0.5 for a half cycle, 1.0 for a full cycle,
+        or an aggregated sum of those.
+    means
+        Mean stress per row, or ``None`` when the path does not report means.
+        Clause 4 is only applicable when means are reported.
+    """
+
+    ranges: np.ndarray
+    counts: np.ndarray
+    means: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ranges", np.asarray(self.ranges, dtype=float).ravel())
+        object.__setattr__(self, "counts", np.asarray(self.counts, dtype=float).ravel())
+        if self.means is not None:
+            object.__setattr__(
+                self, "means", np.asarray(self.means, dtype=float).ravel()
+            )
+        if self.ranges.shape != self.counts.shape:
+            raise ValueError("ranges and counts must have the same length")
+        if self.means is not None and self.means.shape != self.ranges.shape:
+            raise ValueError("means, when given, must have the same length as ranges")
+
+    @property
+    def total_counts(self) -> float:
+        return float(np.sum(self.counts)) if self.counts.size else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Reversals — defined once, here, so every clause refers to the same object
+# ---------------------------------------------------------------------------
+
+
+def reversals_with_endpoints(signal: Any) -> np.ndarray:
+    """Turning points of ``signal``, including the first and last points.
+
+    Consecutive equal samples are collapsed first, so a plateau contributes one
+    point rather than several. An interior point is a reversal when the sign of
+    the difference changes across it. The first and last surviving points are
+    always retained: they bound the sequence and participate in the count.
+    """
+    x = np.asarray(signal, dtype=float).ravel()
+    if x.size == 0:
+        return x
+    keep = np.concatenate(([True], x[1:] != x[:-1]))
+    x = x[keep]
+    if x.size <= 2:
+        return x
+    d = np.diff(x)
+    interior = np.sign(d[:-1]) != np.sign(d[1:])
+    mask = np.concatenate(([True], interior, [True]))
+    return x[mask]
+
+
+def peak_to_valley_span(signal: Any) -> float:
+    """The largest excursion present in ``signal``."""
+    x = np.asarray(signal, dtype=float).ravel()
+    if x.size == 0:
+        return 0.0
+    return float(np.max(x) - np.min(x))
+
+
+# ---------------------------------------------------------------------------
+# The contract
+# ---------------------------------------------------------------------------
+
+
+def check_counting_contract(
+    result: CycleCount,
+    signal: Any,
+    residual_policy: ResidualPolicy,
+    *,
+    rtol: float = DEFAULT_RTOL,
+    atol: float = DEFAULT_ATOL,
+) -> list[str]:
+    """Return a list of clause violations; an empty list means conforming.
+
+    Clauses
+    -------
+    1. *(RETAIN only)* the maximum extracted range equals the peak-to-valley
+       span. The global peak and valley are necessarily a reversal pair, so a
+       retain-residual count emits that range as a full or half cycle.
+    2. no extracted range exceeds the span — nothing is counted that the signal
+       does not contain.
+    3. count conservation. Each reversal participates in exactly one extracted
+       range, so for RETAIN ``2 * sum(counts) == len(reversals) - 1`` exactly;
+       for DISCARD the equality relaxes to ``<=``, since discarding removes
+       counts but may never manufacture them. Every count is a positive
+       multiple of 0.5, and no zero-range cycle is emitted for a signal that
+       actually moves.
+
+    4. exact distribution — checked separately by
+       :func:`check_exact_distribution`, because it requires a hand-derived
+       reference table rather than the signal alone.
+
+    Zero-range rows
+    ---------------
+    A constant signal genuinely contains one zero-range excursion, and the
+    conforming implementations disagree about whether to emit it: pyLife and
+    the PyPI ``rainflow`` package emit ``(0.0, value, 0.5)``, while
+    ``fatigue_apps/rainflow_counter.py`` drops it. Both are defensible, since a
+    zero range contributes exactly zero damage. The contract therefore treats
+    zero-range rows as inert — excluded from clauses 1, 2 and the conservation
+    equality — but forbids them outright when the span is non-zero, which is
+    the case the sub-clause exists to catch: a counter padding its distribution
+    with zero-range rows to satisfy conservation.
+    """
+    violations: list[str] = []
+    span = peak_to_valley_span(signal)
+    reversals = reversals_with_endpoints(signal)
+    expected_half_cycles = max(len(reversals) - 1, 0)
+    tol = atol + rtol * abs(span)
+
+    all_ranges = result.ranges
+    all_counts = result.counts
+    inert = all_ranges <= atol if all_ranges.size else np.zeros(0, dtype=bool)
+    ranges = all_ranges[~inert]
+    counts = all_counts[~inert]
+    max_range = float(np.max(ranges)) if ranges.size else 0.0
+
+    # -- clause 1 ---------------------------------------------------------
+    if residual_policy is ResidualPolicy.RETAIN:
+        if ranges.size == 0:
+            if span > tol:
+                violations.append(
+                    f"clause 1: no cycles emitted but the signal spans {span:.6g}"
+                )
+        elif abs(max_range - span) > tol:
+            violations.append(
+                f"clause 1: maximum extracted range {max_range:.6g} is not the "
+                f"peak-to-valley span {span:.6g} "
+                f"(shortfall {span - max_range:.6g}; declared policy RETAIN)"
+            )
+
+    # -- clause 2 ---------------------------------------------------------
+    if ranges.size and max_range > span + tol:
+        violations.append(
+            f"clause 2: maximum extracted range {max_range:.6g} exceeds the "
+            f"peak-to-valley span {span:.6g}"
+        )
+
+    # -- clause 3 ---------------------------------------------------------
+    total = 2.0 * float(np.sum(counts)) if counts.size else 0.0
+    if residual_policy is ResidualPolicy.RETAIN:
+        if abs(total - expected_half_cycles) > COUNT_ATOL:
+            violations.append(
+                f"clause 3: 2*sum(counts) = {total:.6g}, expected "
+                f"{expected_half_cycles} (= len(reversals) - 1); declared policy RETAIN"
+            )
+    else:
+        if total - expected_half_cycles > COUNT_ATOL:
+            violations.append(
+                f"clause 3: 2*sum(counts) = {total:.6g} exceeds "
+                f"{expected_half_cycles} (= len(reversals) - 1); a discard-residual "
+                f"count may omit cycles but never manufacture them"
+            )
+
+    if all_counts.size:
+        if np.any(all_counts <= 0.0):
+            violations.append("clause 3: a non-positive count was emitted")
+        halves = all_counts * 2.0
+        off = np.abs(halves - np.rint(halves)) > COUNT_ATOL
+        if np.any(off):
+            violations.append(
+                f"clause 3: counts are not multiples of 0.5: {all_counts[off][:5]}"
+            )
+    if span > tol and np.any(inert):
+        violations.append(
+            f"clause 3: {int(np.count_nonzero(inert))} zero-range cycle(s) emitted "
+            f"for a signal that spans {span:.6g}"
+        )
+
+    return violations
+
+
+def assert_counting_contract(
+    result: CycleCount,
+    signal: Any,
+    residual_policy: ResidualPolicy,
+    *,
+    rtol: float = DEFAULT_RTOL,
+    atol: float = DEFAULT_ATOL,
+    label: str = "",
+) -> None:
+    """Raise :class:`ContractViolation` when ``result`` violates any clause."""
+    violations = check_counting_contract(
+        result, signal, residual_policy, rtol=rtol, atol=atol
+    )
+    if violations:
+        prefix = f"{label}: " if label else ""
+        raise ContractViolation(
+            prefix
+            + f"cycle count violates the counting contract ({ISSUE_URL})\n  "
+            + "\n  ".join(violations)
+        )
+
+
+def _aggregate(
+    ranges: np.ndarray,
+    means: np.ndarray,
+    counts: np.ndarray,
+    decimals: int = 9,
+) -> list[tuple[float, float, float]]:
+    acc: dict[tuple[float, float], float] = {}
+    for rng, mean, cnt in zip(ranges, means, counts):
+        key = (round(float(rng), decimals), round(float(mean), decimals))
+        acc[key] = acc.get(key, 0.0) + float(cnt)
+    return sorted((rng, mean, cnt) for (rng, mean), cnt in acc.items())
+
+
+def check_exact_distribution(
+    result: CycleCount,
+    expected: Sequence[tuple[float, float, float]],
+    *,
+    rtol: float = DEFAULT_RTOL,
+    atol: float = DEFAULT_ATOL,
+) -> list[str]:
+    """Clause 4 — the emitted ``(range, mean, count)`` table, exactly.
+
+    Clauses 1 to 3 are aggregate: a counter that fabricates counts can satisfy
+    some of them. This clause pins the whole distribution against a table
+    derived by hand.
+    """
+    if result.means is None:
+        return ["clause 4: path does not report mean stress; not applicable"]
+
+    got = _aggregate(result.ranges, result.means, result.counts)
+    want = _aggregate(
+        np.array([e[0] for e in expected], dtype=float),
+        np.array([e[1] for e in expected], dtype=float),
+        np.array([e[2] for e in expected], dtype=float),
+    )
+
+    if len(got) != len(want):
+        return [
+            f"clause 4: {len(got)} distinct (range, mean) rows emitted, "
+            f"{len(want)} expected\n    got:      {got}\n    expected: {want}"
+        ]
+
+    violations: list[str] = []
+    for (g_rng, g_mean, g_cnt), (w_rng, w_mean, w_cnt) in zip(got, want):
+        if not np.isclose(g_rng, w_rng, rtol=rtol, atol=atol):
+            violations.append(f"clause 4: range {g_rng:.10g} != {w_rng:.10g}")
+        if not np.isclose(g_mean, w_mean, rtol=rtol, atol=atol):
+            violations.append(
+                f"clause 4: mean {g_mean:.10g} != {w_mean:.10g} at range {w_rng:.10g}"
+            )
+        if abs(g_cnt - w_cnt) > COUNT_ATOL:
+            violations.append(
+                f"clause 4: count {g_cnt:g} != {w_cnt:g} at "
+                f"(range {w_rng:.10g}, mean {w_mean:.10g})"
+            )
+    return violations
+
+
+def assert_exact_distribution(
+    result: CycleCount,
+    expected: Sequence[tuple[float, float, float]],
+    *,
+    rtol: float = DEFAULT_RTOL,
+    atol: float = DEFAULT_ATOL,
+    label: str = "",
+) -> None:
+    """Raise :class:`ContractViolation` when the distribution differs."""
+    violations = check_exact_distribution(result, expected, rtol=rtol, atol=atol)
+    if violations:
+        prefix = f"{label}: " if label else ""
+        raise ContractViolation(
+            prefix
+            + f"cycle distribution differs from the hand-derived table ({ISSUE_URL})\n  "
+            + "\n  ".join(violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# The refusal
+# ---------------------------------------------------------------------------
+
+
+def refuse_damage_calculation(path_key: str, entry_point: str) -> NoReturn:
+    """Refuse to compute fatigue damage through a non-conservative counter.
+
+    Called from the damage entry points bound to a path whose recorded verdict
+    is ``non-conservative``. Cycle counting itself is left callable: it has
+    legitimate diagnostic uses (statistics, histograms, exported cycle tables).
+    What is refused is turning those cycles into a damage or fatigue-life
+    number, because the ranges are understated and damage scales as range
+    cubed.
+    """
+    path = COUNTING_PATHS.get(path_key)
+    shortfall = path.note if path is not None else ""
+    raise NonConservativeCountingError(
+        f"{entry_point} refuses to compute fatigue damage.\n"
+        f"It is bound to cycle-counting path '{path_key}', which extracts a "
+        f"maximum stress range below the signal's peak-to-valley span. Fatigue "
+        f"damage scales as range cubed, so the resulting damage is understated "
+        f"— the non-conservative direction.\n"
+        f"{shortfall}\n"
+        f"Issue #{ISSUE_NUMBER}: {ISSUE_URL}\n"
+        f"Cycle counting through this path remains available for diagnostic use. "
+        f"For damage, use a path that satisfies digitalmodel.fatigue."
+        f"counting_contract: pylife_4pt, pypi_rainflow or fapps_counter."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path adapters — lazy imports, so registering a path costs nothing until used
+# ---------------------------------------------------------------------------
+
+_TMP_OUTPUT: list[str] = []
+
+
+def _scratch_dir() -> str:
+    if not _TMP_OUTPUT:
+        _TMP_OUTPUT.append(tempfile.mkdtemp(prefix="digitalmodel-counting-contract-"))
+    return _TMP_OUTPUT[0]
+
+
+def _adapt_pylife_4pt(signal: Any) -> CycleCount:
+    from digitalmodel.fatigue.rainflow import rainflow_count
+
+    df = rainflow_count(np.asarray(signal, dtype=float))
+    return CycleCount(
+        ranges=df["stress_range"].to_numpy(dtype=float),
+        counts=df["cycles"].to_numpy(dtype=float),
+        means=df["mean_stress"].to_numpy(dtype=float),
+    )
+
+
+def _adapt_pypi_rainflow(signal: Any) -> CycleCount:
+    import rainflow as _rainflow
+
+    rows = list(_rainflow.extract_cycles(np.asarray(signal, dtype=float)))
+    if not rows:
+        empty = np.array([], dtype=float)
+        return CycleCount(ranges=empty, counts=empty.copy(), means=empty.copy())
+    return CycleCount(
+        ranges=np.array([r[0] for r in rows], dtype=float),
+        counts=np.array([r[2] for r in rows], dtype=float),
+        means=np.array([r[1] for r in rows], dtype=float),
+    )
+
+
+def _adapt_sigproc_astm(signal: Any) -> CycleCount:
+    from digitalmodel.signal_processing.signal_analysis.core.rainflow import (
+        RainflowCounter,
+    )
+
+    df = RainflowCounter().count_cycles(
+        np.asarray(signal, dtype=float), extract_info=False
+    )
+    return CycleCount(
+        ranges=df["range"].to_numpy(dtype=float),
+        counts=df["count"].to_numpy(dtype=float),
+        means=df["mean"].to_numpy(dtype=float),
+    )
+
+
+def _adapt_calm_buoy(signal: Any) -> CycleCount:
+    from digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue import (
+        RainflowFatigue,
+    )
+
+    ranges, counts = RainflowFatigue().count_cycles(np.asarray(signal, dtype=float))
+    return CycleCount(ranges=ranges, counts=counts)
+
+
+def _adapt_fapps_counting(signal: Any) -> CycleCount:
+    from digitalmodel.structural.fatigue_apps.rainflow_counting import RainflowCounter
+
+    result = RainflowCounter(output_dir=_scratch_dir()).process_time_series(
+        np.asarray(signal, dtype=float)
+    )
+    return CycleCount(ranges=result["ranges"], counts=result["counts"])
+
+
+def _adapt_fapps_counter(signal: Any) -> CycleCount:
+    from digitalmodel.structural.fatigue_apps.rainflow_counter import RainflowCounter
+
+    ranges, counts = RainflowCounter().count_cycles(np.asarray(signal, dtype=float))
+    return CycleCount(ranges=ranges, counts=counts)
+
+
+def _adapt_struct_fatigue(signal: Any) -> CycleCount:
+    from digitalmodel.structural.fatigue.rainflow import RainflowCounter
+
+    result = RainflowCounter().count_cycles(np.asarray(signal, dtype=float))
+    return CycleCount(ranges=result["ranges"], counts=result["counts"])
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CountingPath:
+    """One cycle-counting implementation, with its declared convention.
+
+    Attributes
+    ----------
+    key
+        Stable identifier used in tests, reports and refusal messages.
+    module
+        Dotted module path of the implementation.
+    entry_point
+        The public callable exercised by the contract.
+    residual_policy
+        Declared, not inferred. Clause 1 applies only to ``RETAIN``.
+    contract_status
+        Recorded verdict: ``conforming`` or ``non-conservative``.
+    implementations
+        Every ``module:qualname`` that belongs to this path, used by the
+        registry-completeness scan so a counting callable cannot be added in
+        the known packages without being registered.
+    damage_entry_points
+        Callables that turn this path's cycles into a damage or fatigue-life
+        number. Empty for a conforming path; each one refuses for a
+        non-conservative path.
+    """
+
+    key: str
+    module: str
+    entry_point: str
+    residual_policy: ResidualPolicy
+    contract_status: str
+    adapter: Callable[[Any], CycleCount]
+    implementations: tuple[str, ...] = ()
+    damage_entry_points: tuple[str, ...] = ()
+    note: str = ""
+
+    def count(self, signal: Any) -> CycleCount:
+        """Run this path's public entry point and normalise the result."""
+        return self.adapter(signal)
+
+
+_PATHS: tuple[CountingPath, ...] = (
+    CountingPath(
+        key="pylife_4pt",
+        module="digitalmodel.fatigue.rainflow",
+        entry_point="rainflow_count",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="conforming",
+        adapter=_adapt_pylife_4pt,
+        implementations=("digitalmodel.fatigue.rainflow:rainflow_count",),
+        note="Wraps pyLife FourPointDetector; residual turning points counted as half cycles.",
+    ),
+    CountingPath(
+        key="pypi_rainflow",
+        module="digitalmodel.signal_processing.time_series.time_series_components",
+        entry_point="TimeSeriesComponents.count_cycles",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="conforming",
+        adapter=_adapt_pypi_rainflow,
+        implementations=(
+            "digitalmodel.signal_processing.time_series.time_series_components:"
+            "TimeSeriesComponents.count_cycles",
+        ),
+        note="Delegates to the third-party `rainflow` PyPI package (ASTM E1049-85).",
+    ),
+    CountingPath(
+        key="sigproc_astm",
+        module="digitalmodel.signal_processing.signal_analysis.core.rainflow",
+        entry_point="RainflowCounter.count_cycles",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="non-conservative",
+        adapter=_adapt_sigproc_astm,
+        implementations=(
+            "digitalmodel.signal_processing.signal_analysis.core.rainflow:"
+            "RainflowCounter.count_cycles",
+            "digitalmodel.signal_processing.signal_analysis.core.rainflow:"
+            "RainflowCounter._rainflow_algorithm",
+            "digitalmodel.signal_processing.signal_analysis.core.rainflow:"
+            "RainflowCounter._combine_half_cycles",
+            "digitalmodel.signal_processing.signal_analysis.adapters:"
+            "TimeSeriesComponentsAdapter.get_rainflow_count_from_time_series",
+            "digitalmodel.signal_processing.signal_analysis.adapters:"
+            "FatigueAnalysisAdapter.get_rainflow_from_timetrace",
+            "digitalmodel.signal_processing.signal_analysis.adapters:"
+            "FatigueAnalysisAdapter.damage_from_rainflow_cycles",
+            "digitalmodel.signal_processing.signal_analysis.adapters:"
+            "OrcaFlexAdapter.RainflowHalfCycles",
+        ),
+        damage_entry_points=(
+            "digitalmodel.solvers.orcaflex.time_trace_processor:"
+            "OrcaFlexTimeTraceProcessor._perform_fatigue_analysis",
+            "digitalmodel.solvers.orcaflex.time_trace_processor:"
+            "OrcaFlexTimeTraceProcessor._analyze_single_trace",
+        ),
+        note=(
+            "Mechanism, read from source at core/rainflow.py:162-164: "
+            "`if range_XY >= range_YZ: cycle_range = range_YZ` inverts both halves of "
+            "ASTM 5.4.4 — the rule fires when the NEWER range is larger and extracts "
+            "the OLDER (inner) pair. It also emits 0.5 for every extraction and always "
+            "discards stack[-2], so the full-cycle rule is never applied. Correcting "
+            "the inversion alone does not restore the span (controlled pair: 7.0 of "
+            "9.0), so the defect is structural; the exact arithmetic behind 6.0 and "
+            "125.2664 is not established. Measured shortfall: 6.0 of 9.0 (ASTM "
+            "fixture), 125.2664 of 177.1224 (broadband)."
+        ),
+    ),
+    CountingPath(
+        key="calm_buoy",
+        module="digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue",
+        entry_point="RainflowFatigue.count_cycles",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="non-conservative",
+        adapter=_adapt_calm_buoy,
+        implementations=(
+            "digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue:"
+            "RainflowFatigue.count_cycles",
+            "digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue:"
+            "RainflowFatigue._rainflow_algorithm",
+        ),
+        damage_entry_points=(
+            "digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue:"
+            "compute_fatigue_life",
+            "digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue:"
+            "ScatterDiagramFatigue.compute",
+        ),
+        note=(
+            "calm_buoy_fatigue.py:262-270 makes the three-point comparison "
+            "correctly, which is why its failure is milder and differently "
+            "shaped. Two lines are wrong: :267 `stack.pop(-2)` discards the "
+            "SECOND point of the counted pair where ASTM rule 2 discards the "
+            "first, and :268 `break` exits the loop instead of re-checking the "
+            "shortened stack. Controlled pair changing only those two: the sine "
+            "goes 50.0 -> 100.0 and the ASTM fixture 7.0/3.5 -> 9.0/4.0. This "
+            "path therefore diverges in COUNT as well as range on the ASTM "
+            "fixture, unlike the other six."
+        ),
+    ),
+    CountingPath(
+        key="fapps_counting",
+        module="digitalmodel.structural.fatigue_apps.rainflow_counting",
+        entry_point="RainflowCounter.process_time_series",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="non-conservative",
+        adapter=_adapt_fapps_counting,
+        implementations=(
+            "digitalmodel.structural.fatigue_apps.rainflow_counting:"
+            "RainflowCounter.rainflow_counting_astm",
+        ),
+        damage_entry_points=(
+            "digitalmodel.structural.fatigue_apps.rainflow_counting:"
+            "RainflowCounter.process_batch",
+        ),
+        note=(
+            "No in-process damage consumer exists: no module in src/, tests/, "
+            "docs/ or scripts/ imports this class. Its hand-off to damage is by "
+            "file — `process_batch` is the documented Module 2 step whose "
+            "`*_cycles.csv` output feeds the Module 3 damage calculator "
+            "(fatigue_apps/INPUT_FILE_STRUCTURE.md:77,116,275) — so the refusal "
+            "is placed there. Mechanism: rainflow_counting.py:154-163 extracts "
+            "only when the stack holds four or more points and breaks otherwise, "
+            "so ASTM rule 2 never fires, the start point is never shed, and the "
+            "full-cycle rule discards a reversal ASTM retains. Same defect shape "
+            "as struct_fatigue, where a controlled pair confirms it; the two "
+            "report identical maxima. Measured shortfall: 169.556 of 177.1224."
+        ),
+    ),
+    CountingPath(
+        key="fapps_counter",
+        module="digitalmodel.structural.fatigue_apps.rainflow_counter",
+        entry_point="RainflowCounter.count_cycles",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="conforming",
+        adapter=_adapt_fapps_counter,
+        implementations=(
+            "digitalmodel.structural.fatigue_apps.rainflow_counter:"
+            "RainflowCounter.count_cycles",
+            "digitalmodel.structural.fatigue_apps.rainflow_counter:"
+            "RainflowCounter._rainflow_algorithm",
+            "digitalmodel.structural.fatigue_apps.rainflow_counter:"
+            "RainflowCounter._aggregate_cycles",
+            "digitalmodel.structural.fatigue_apps.rainflow_counter:rainflow_count",
+        ),
+        note=(
+            "Aggregates on a range key rounded to six decimals, so the emitted "
+            "maximum can differ from the span by up to 5e-7; DEFAULT_RTOL admits "
+            "that and nothing larger."
+        ),
+    ),
+    CountingPath(
+        key="struct_fatigue",
+        module="digitalmodel.structural.fatigue.rainflow",
+        entry_point="RainflowCounter.count_cycles",
+        residual_policy=ResidualPolicy.RETAIN,
+        contract_status="non-conservative",
+        adapter=_adapt_struct_fatigue,
+        implementations=(
+            "digitalmodel.structural.fatigue.rainflow:RainflowCounter.count_cycles",
+            "digitalmodel.structural.fatigue.rainflow:RainflowCounter._rainflow_count",
+            "digitalmodel.structural.fatigue.rainflow:RainflowCounter._rainflow_with_means",
+            "digitalmodel.structural.fatigue.rainflow:RainflowCounter."
+            "extract_cycles_with_means",
+            "digitalmodel.structural.fatigue.rainflow:_rainflow_counting_numba",
+            "digitalmodel.structural.fatigue.rainflow:rainflow_count",
+            "digitalmodel.structural.fatigue.rainflow:rainflow_with_means",
+            "digitalmodel.structural.fatigue.analysis:"
+            "FatigueAnalysisEngine._setup_rainflow_counter",
+        ),
+        damage_entry_points=(
+            "digitalmodel.structural.fatigue.analysis:"
+            "FatigueAnalysisEngine.analyze_time_series",
+            "digitalmodel.structural.fatigue.analysis:quick_time_domain_analysis",
+            "digitalmodel.structural.fatigue:quick_fatigue_analysis",
+        ),
+        note=(
+            "`_rainflow_counting_numba` (rainflow.py:183-196) extracts only when "
+            "stack_size >= 4 and breaks otherwise, so ASTM rule 2 never fires, "
+            "the start point is never shed, and rule 3 discards BOTH points of a "
+            "pair where rule 2 was due — throwing away a reversal ASTM retains. "
+            "Controlled pair on broadband, changing only that branch: 169.556 -> "
+            "177.1224, total counts unchanged at 1370.0, and the signal's global "
+            "valley goes from discarded to retained. Measured shortfall: 169.556 "
+            "of a 177.1224 span."
+        ),
+    ),
+)
+
+#: Every counting path in the repository, keyed by its stable identifier.
+COUNTING_PATHS: Mapping[str, CountingPath] = {p.key: p for p in _PATHS}
+
+
+# ---------------------------------------------------------------------------
+# Contract signals and the hand-derived fixture
+# ---------------------------------------------------------------------------
+
+
+def _narrow_band_sine() -> np.ndarray:
+    return 50.0 * np.sin(np.linspace(0.0, 10 * 2 * np.pi, 640, endpoint=False))
+
+
+def _broadband_random() -> np.ndarray:
+    return np.random.default_rng(20260911).normal(0.0, 25.0, 4096)
+
+
+def _residual_dominated() -> np.ndarray:
+    return np.linspace(0.0, 200.0, 512) + 8.0 * np.sin(
+        np.linspace(0.0, 40 * np.pi, 512)
+    )
+
+
+#: The four deterministic signals the contract is applied over. The broadband
+#: case is the one nothing in the existing suite tested; every failing
+#: implementation passes the narrow-band case.
+CONTRACT_SIGNALS: Mapping[str, np.ndarray] = {
+    "astm_example": np.array([-2, 1, -3, 5, -1, 3, -4, 4, -2], dtype=float),
+    "narrow_band_sine": _narrow_band_sine(),
+    "broadband_random": _broadband_random(),
+    "residual_dominated": _residual_dominated(),
+}
+
+
+# ---------------------------------------------------------------------------
+# CONTRACT_EXACT — hand-derived, committed as literals, never captured
+# ---------------------------------------------------------------------------
+#
+# Signal: [-2, 1, -3, 5, -1, 3, -4, 4, -2]
+#
+# Every sample is a reversal: the sequence alternates up, down, up, down, up,
+# down, up, down. So reversals = the signal itself, 9 points, 8 half cycles to
+# distribute. Span = 5 - (-4) = 9.
+#
+# Rule applied (ASTM E1049-85 §5.4.4, three-point form, residual retained):
+#   X = the newest range, formed by the two most recent points.
+#   Y = the range immediately preceding X.
+#   (1) X <  Y                       -> count nothing, read the next point.
+#   (2) X >= Y and Y holds the start -> count Y as a HALF cycle, discard the
+#                                       first point of Y, the start moves on.
+#   (3) X >= Y and Y is interior     -> count Y as a FULL cycle, discard both
+#                                       points of Y.
+#   At the end, every remaining range in the residual is a HALF cycle.
+#
+# Trace (stack shown after each step):
+#
+#  push -2          [-2]
+#  push  1          [-2, 1]
+#  push -3          [-2, 1, -3]     Y=|-2-1|=3, X=|1-(-3)|=4, X>=Y, Y holds start
+#                                   -> HALF cycle: range 3, mean (-2+1)/2 = -0.5
+#                                   drop -2                      [1, -3]
+#  push  5          [1, -3, 5]      Y=|1-(-3)|=4, X=|-3-5|=8, X>=Y, Y holds start
+#                                   -> HALF cycle: range 4, mean (1+(-3))/2 = -1.0
+#                                   drop 1                       [-3, 5]
+#  push -1          [-3, 5, -1]     Y=8, X=|5-(-1)|=6, X<Y  -> nothing
+#  push  3          [-3, 5, -1, 3]  Y=|5-(-1)|=6, X=|-1-3|=4, X<Y -> nothing
+#  push -4          [-3,5,-1,3,-4]  Y=|-1-3|=4, X=|3-(-4)|=7, X>=Y, Y interior
+#                                   -> FULL cycle: range 4, mean (-1+3)/2 = 1.0
+#                                   drop -1 and 3                [-3, 5, -4]
+#                                   re-check: Y=|-3-5|=8, X=|5-(-4)|=9, X>=Y,
+#                                   Y holds start
+#                                   -> HALF cycle: range 8, mean (-3+5)/2 = 1.0
+#                                   drop -3                      [5, -4]
+#  push  4          [5, -4, 4]      Y=|5-(-4)|=9, X=|-4-4|=8, X<Y -> nothing
+#  push -2          [5,-4,4,-2]     Y=|-4-4|=8, X=|4-(-2)|=6, X<Y -> nothing
+#
+# Residual [5, -4, 4, -2], each adjacent range a HALF cycle:
+#   |5-(-4)| = 9, mean (5+(-4))/2  =  0.5
+#   |-4-4|   = 8, mean (-4+4)/2    =  0.0
+#   |4-(-2)| = 6, mean (4+(-2))/2  =  1.0
+#
+# Checks on the derivation itself:
+#   sum(counts) = 0.5+0.5+1.0+0.5 + 0.5+0.5+0.5 = 4.0
+#   2*4.0 = 8 = len(reversals) - 1                        (clause 3)
+#   max(range) = 9 = span                                 (clause 1)
+#
+# Cross-check, NOT the source: collapsing means, this gives
+# range 3 -> 0.5, range 4 -> 1.5, range 6 -> 0.5, range 8 -> 1.0, range 9 -> 0.5,
+# which is the table ASTM E1049-85 publishes for this worked sequence and the
+# documented output of the `rainflow` PyPI package. The literals below were
+# written from the trace above before any counter was run.
+# ---------------------------------------------------------------------------
+
+CONTRACT_EXACT: Mapping[str, Any] = {
+    "signal": [-2.0, 1.0, -3.0, 5.0, -1.0, 3.0, -4.0, 4.0, -2.0],
+    # (range, mean, count)
+    "expected": (
+        (3.0, -0.5, 0.5),
+        (4.0, -1.0, 0.5),
+        (4.0, 1.0, 1.0),
+        (6.0, 1.0, 0.5),
+        (8.0, 0.0, 0.5),
+        (8.0, 1.0, 0.5),
+        (9.0, 0.5, 0.5),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness — a name-pattern scan, honestly scoped
+# ---------------------------------------------------------------------------
+
+#: Package directories, relative to ``src/``, that the completeness scan covers.
+#: A counting implementation under a novel name, or in a package not listed
+#: here, escapes the scan. The gate does not claim otherwise.
+COUNTING_SCAN_PACKAGES: tuple[str, ...] = (
+    "digitalmodel/fatigue",
+    "digitalmodel/signal_processing",
+    "digitalmodel/structural/fatigue",
+    "digitalmodel/structural/fatigue_apps",
+    "digitalmodel/marine_ops/marine_engineering",
+)
+
+#: Callable names that denote cycle counting rather than anything else.
+_EXACT_COUNTING_NAMES = frozenset(
+    {"count_cycles", "extract_cycles", "rainflow_with_means"}
+)
+_RAINFLOW = re.compile(r"rainflow", re.IGNORECASE)
+_COUNTING_VERB = re.compile(r"count|cycle", re.IGNORECASE)
+
+
+def _is_counting_name(name: str) -> bool:
+    if name in _EXACT_COUNTING_NAMES:
+        return True
+    return bool(_RAINFLOW.search(name)) and bool(_COUNTING_VERB.search(name))
+
+
+def _src_root() -> Path:
+    # .../src/digitalmodel/fatigue/counting_contract.py -> .../src
+    return Path(__file__).resolve().parents[2]
+
+
+def _iter_defs(tree: ast.Module) -> Iterable[tuple[str, str]]:
+    """Yield ``(qualname, name)`` for module-level and class-level defs."""
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node.name, node.name
+        elif isinstance(node, ast.ClassDef):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    yield f"{node.name}.{sub.name}", sub.name
+
+
+def discover_counting_callables(
+    packages: Sequence[str] = COUNTING_SCAN_PACKAGES,
+) -> list[str]:
+    """Return ``module:qualname`` for every counting-named callable found.
+
+    The scan is static (``ast``), not import-based: importing these modules has
+    side effects — one of them replaces ``sys.stdout`` — and a completeness gate
+    must not depend on those.
+    """
+    root = _src_root()
+    found: set[str] = set()
+    for pkg in packages:
+        base = root / Path(pkg)
+        if not base.is_dir():
+            continue
+        for py in sorted(base.rglob("*.py")):
+            rel = py.relative_to(root).with_suffix("")
+            module = ".".join(rel.parts)
+            try:
+                tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+            except SyntaxError:
+                continue
+            for qualname, name in _iter_defs(tree):
+                if _is_counting_name(name):
+                    found.add(f"{module}:{qualname}")
+    return sorted(found)
+
+
+def registered_implementations() -> set[str]:
+    """Every ``module:qualname`` claimed by a registered path."""
+    claimed: set[str] = set()
+    for path in COUNTING_PATHS.values():
+        claimed.update(path.implementations)
+    return claimed
+
+
+def unregistered_counting_callables(
+    packages: Sequence[str] = COUNTING_SCAN_PACKAGES,
+) -> list[str]:
+    """Counting-named callables in the known packages that no path claims."""
+    claimed = registered_implementations()
+    return [c for c in discover_counting_callables(packages) if c not in claimed]

--- a/src/digitalmodel/marine_ops/marine_engineering/calm_buoy_fatigue.py
+++ b/src/digitalmodel/marine_ops/marine_engineering/calm_buoy_fatigue.py
@@ -389,7 +389,19 @@ class ScatterDiagramFatigue:
             ValueError: If probabilities do not sum to approximately 1.0.
             KeyError: If a (Hs, Tp) bin from the scatter is absent from
                 tension_per_seastate.
+            NonConservativeCountingError: always, pending issue #3839. Damage
+                here is accumulated from RainflowFatigue.count_cycles, which
+                extracts a maximum tension range below the history's
+                peak-to-valley span (50.0 of a 100.0 span on a pure sine).
+                Counting remains callable for diagnostics; damage does not.
         """
+        from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+        refuse_damage_calculation(
+            "calm_buoy",
+            "calm_buoy_fatigue.ScatterDiagramFatigue.compute",
+        )
+
         prob_sum = float(scatter["probability"].sum())
         if abs(prob_sum - 1.0) > self._PROB_TOLERANCE:
             raise ValueError(
@@ -546,7 +558,16 @@ def compute_fatigue_life(
 
     Raises:
         ValueError: If neither tension_csv nor scatter_diagram is provided.
+        NonConservativeCountingError: always, pending issue #3839 — see
+            ScatterDiagramFatigue.compute.
     """
+    from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+    refuse_damage_calculation(
+        "calm_buoy",
+        "calm_buoy_fatigue.compute_fatigue_life",
+    )
+
     if tension_csv is None and scatter_diagram is None:
         raise ValueError(
             "Either tension_csv or (scatter_diagram + tension_per_seastate) "

--- a/src/digitalmodel/solvers/orcaflex/core/model_interface.py
+++ b/src/digitalmodel/solvers/orcaflex/core/model_interface.py
@@ -30,13 +30,15 @@ from .mock_artifacts import write_mock_artifact
 from .configuration import OrcaFlexConfig, AnalysisType
 
 
-# Try to import OrcFxAPI, but provide mock if not available
-try:
-    import OrcFxAPI
-    ORCFXAPI_AVAILABLE = True
-except ImportError:
-    OrcFxAPI = None
-    ORCFXAPI_AVAILABLE = False
+# Access to OrcFxAPI, or None where it is not installed.
+# #3838: routed through the facade instead of `import OrcFxAPI`. A module-scope
+# import binds the DLL before OrcFxAPIConfig.setLibPath() can select a version.
+from ..orcaflex_api import available as _orcaflex_available
+from ..orcaflex_api import lazy_api as _lazy_orcaflex_api
+from ..run_state import check_simulation, check_statics
+
+ORCFXAPI_AVAILABLE = _orcaflex_available()
+OrcFxAPI = _lazy_orcaflex_api() if ORCFXAPI_AVAILABLE else None
 
 
 class ModelState(Enum):
@@ -380,9 +382,12 @@ class OrcaFlexModelWrapper(LoggerMixin):
             else:
                 # Real static analysis
                 self._model.CalculateStatics()
-                
-                # Get convergence info
-                converged = True  # OrcaFlex throws if not converged
+
+                # #3838: the model state, not the absence of an exception, is
+                # what says the solve converged. check_statics raises otherwise,
+                # and the enclosing _error_handler records the failure.
+                check_statics(self._model, context="static analysis")
+                converged = True
                 iterations = getattr(self._model.state, 'StaticsIterationCount', 0)
             
             elapsed = time.time() - start_time
@@ -472,7 +477,10 @@ class OrcaFlexModelWrapper(LoggerMixin):
                 
                 # Run simulation
                 self._model.RunSimulation()
-            
+                # #3838: RunSimulation returns success for a run that went
+                # unstable; only the model state distinguishes the two.
+                check_simulation(self._model, context="dynamic analysis")
+
             elapsed = time.time() - start_time
             
             self._state = ModelState.DYNAMIC_COMPLETE

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/__init__.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/__init__.py
@@ -29,7 +29,11 @@ from .builders import (  # noqa: F401
     GroupsBuilder,
 )
 
-from .post_validator import PostGenerationValidator, ValidationWarning
+from .post_validator import (
+    PostGenerationValidator,
+    ValidationWarning,
+    check_collection_collisions,
+)
 from .routers.mooring_router import MooringRouter
 from .routers.vessel_router import VesselRouter
 from .schema.generic import GenericModel
@@ -173,7 +177,14 @@ class ModularModelGenerator:
         self._write_parameters(inputs_dir / 'parameters.yml')
 
         # Generate master.yml (only include files that were actually generated)
-        self._write_master(output_dir / 'master.yml', generated_files)
+        master_path = output_dir / 'master.yml'
+        self._write_master(master_path, generated_files)
+
+        # A list-style collection REPLACES the collection in OrcaFlex, so two
+        # includefiles emitting the same key silently delete the earlier one's
+        # objects. This fails closed rather than warning: the defect produces a
+        # model that loads cleanly and is missing objects. See workspace-hub#3838.
+        check_collection_collisions(master_path, raise_on_collision=True)
 
         # Post-generation cross-builder validation
         self._run_post_validation(includes_dir)
@@ -330,6 +341,11 @@ class ModularModelGenerator:
         self._write_parameters(inputs_dir / 'parameters.yml')
         master_path = output_dir / 'master.yml'
         self._write_master(master_path, generated_files)
+
+        # Fails closed — see the note in generate(). Campaign overrides replace
+        # whole include files, which is exactly how a second emitter of the same
+        # collection key gets introduced. workspace-hub#3838.
+        check_collection_collisions(master_path, raise_on_collision=True)
 
         # Post-generation cross-builder validation
         findings = self._run_post_validation(includes_dir)

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/post_validator.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/post_validator.py
@@ -5,6 +5,8 @@ Validates that generated model components are internally consistent:
 - Winches reference valid vessel names
 - Equipment (stinger/tensioner) is positioned coherently with vessel
 - No duplicate object names across builders
+- No OrcaFlex collection key is written in list style by more than one
+  includefile composed into the same master file
 """
 
 from __future__ import annotations
@@ -15,6 +17,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from .schema.generic import SECTION_REGISTRY, SINGLETON_SECTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -57,15 +61,105 @@ _OBJECT_SECTIONS = (
 )
 
 
+# Top-level OrcaFlex keys that are recognised but are not name-keyed
+# collections: a singleton section, or the master-file include directive.
+# Listed so that a legitimate key is not reported as unrecognised.
+_NON_COLLECTION_SECTIONS = frozenset(SINGLETON_SECTIONS) | frozenset(
+    {
+        "General",
+        "Environment",
+        # Master-file directive rather than a model section.
+        "includefile",
+        "BaseFile",
+    }
+)
+
+# Every top-level key this ecosystem recognises.  Union of the two existing
+# authorities: ``_OBJECT_SECTIONS`` above and ``SECTION_REGISTRY`` in
+# ``schema/generic.py`` (which additionally carries VariableData,
+# ExpansionTables and BrowserGroups), plus the non-collection keys.
+# ``BuilderRegistry`` is deliberately NOT a source here: it keys on output
+# file name, not on collection key.
+_KNOWN_TOP_LEVEL_KEYS = (
+    frozenset(_OBJECT_SECTIONS)
+    | frozenset(SECTION_REGISTRY)
+    | _NON_COLLECTION_SECTIONS
+)
+
+
 @dataclass
 class ValidationWarning:
     """A single validation finding."""
 
     level: str  # "error", "warning"
-    category: str  # "reference", "duplicate", "coherence"
+    category: str  # "reference", "duplicate", "coherence", "unrecognised"
     message: str
     file: str = ""
     object_name: str = ""
+
+
+@dataclass
+class CollectionCollision:
+    """One collection key written in list style by more than one file.
+
+    Attributes:
+        key: The OrcaFlex collection key, e.g. ``LineTypes``.
+        files: The composed files that each emit *key* in list style, in
+            composition order.  The last one wins in OrcaFlex; every
+            earlier one is destroyed.
+    """
+
+    key: str
+    files: list[str]
+
+    def describe(self) -> str:
+        """Return a one-line operator-readable statement of the collision."""
+        return (
+            f"Collection '{self.key}' is written in list style by "
+            f"{len(self.files)} composed includefiles: "
+            f"{', '.join(self.files)}. A list of '- Name:' entries REPLACES "
+            f"the collection in OrcaFlex, so '{self.files[-1]}' silently "
+            f"deletes every object written by "
+            f"{', '.join(self.files[:-1])}. Write each collection from "
+            f"exactly one includefile, or use name-keyed mapping style "
+            f"(which patches rather than replaces)."
+        )
+
+
+class CollectionCollisionError(Exception):
+    """Raised when composed includefiles destructively overwrite a collection.
+
+    Attributes:
+        collisions: Every collision found, not only the first.
+    """
+
+    def __init__(self, message: str, collisions: list[CollectionCollision]):
+        super().__init__(message)
+        self.collisions = collisions
+
+
+@dataclass
+class CollectionScanResult:
+    """Outcome of scanning a master file for collection-key collisions.
+
+    Attributes:
+        master: The master file scanned.
+        composed_files: Resolved includefiles, in composition order.
+        emitters: ``key -> [(display_path, style)]`` where *style* is
+            ``"list"`` or ``"mapping"``, in composition order.
+        unrecognised: ``(display_path, key)`` for every top-level key not
+            recognised as an OrcaFlex section.  Surfaced, never ignored.
+        collisions: Collection keys emitted in list style more than once.
+        warnings: Findings that do not by themselves fail the check
+            (unrecognised keys, unreadable or missing includefiles).
+    """
+
+    master: Path
+    composed_files: list[Path] = field(default_factory=list)
+    emitters: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    unrecognised: list[tuple[str, str]] = field(default_factory=list)
+    collisions: list[CollectionCollision] = field(default_factory=list)
+    warnings: list[ValidationWarning] = field(default_factory=list)
 
 
 class PostGenerationValidator:
@@ -577,3 +671,317 @@ class PostGenerationValidator:
                     )
 
         return warnings
+
+    # ------------------------------------------------------------------
+    # Collection-key collision (destructive list-style overwrite)
+    # ------------------------------------------------------------------
+
+    def check_collection_collisions(
+        self, master_path: Path | str, *, raise_on_collision: bool = True
+    ) -> CollectionScanResult:
+        """Check a master file for destructive collection-key collisions.
+
+        See the module-level :func:`check_collection_collisions` for the
+        full contract.  This method exists so callers already holding a
+        validator instance need not import the function separately.
+
+        Args:
+            master_path: Master file that composes the includefiles.
+            raise_on_collision: Fail closed when a collision is found.
+
+        Returns:
+            The scan result.
+
+        Raises:
+            CollectionCollisionError: On collision, unless
+                *raise_on_collision* is False.
+        """
+        return check_collection_collisions(
+            master_path, raise_on_collision=raise_on_collision
+        )
+
+
+# ----------------------------------------------------------------------
+# Collection-key collision check
+# ----------------------------------------------------------------------
+#
+# OrcaFlex text data files encode a collection two ways, with different
+# semantics (Orcina webhelp, "Text data files: Examples of setting data"):
+#
+#   LineTypes:            <- name-keyed MAPPING: patches the collection
+#     Chain_84mm_R4:
+#       OD: 0.084
+#
+#   LineTypes:            <- LIST: REPLACES the collection; anything not
+#     - Name: Chain        listed is deleted
+#       OD: 0.084
+#
+# The generator emits list style, which is correct for authoring but safe
+# only while each collection is written by exactly one includefile.  Two
+# composed includefiles emitting the same key in list style means the later
+# one silently deletes the earlier one's objects, and OrcaFlex raises
+# nothing.  This check makes that condition fail closed.
+
+
+def _iter_includefile_refs(data: Any) -> list[str]:
+    """Collect ``includefile`` references in document order.
+
+    Walks the parsed document because OrcaFlex accepts the directive at the
+    top level (a list of ``- includefile:`` entries, the shape the
+    generator writes) and nested inside mappings.
+
+    Implemented here rather than reusing
+    ``modular_input_validation.utils.extract_includefiles`` because
+    importing that package executes its ``__init__``, which imports
+    ``OrcFxAPI`` at module scope.  This validator must stay importable
+    without a licensed solver installation.
+
+    Args:
+        data: Parsed YAML document.
+
+    Returns:
+        Include references as written, in document order.
+    """
+    refs: list[str] = []
+
+    def traverse(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "includefile" and isinstance(value, str):
+                    refs.append(value)
+                else:
+                    traverse(value)
+        elif isinstance(node, list):
+            for item in node:
+                traverse(item)
+
+    traverse(data)
+    return refs
+
+
+def _display_path(path: Path, base: Path) -> str:
+    """Render *path* relative to *base* with forward slashes when possible.
+
+    Args:
+        path: Path to render.
+        base: Directory to render relative to (the master file's parent).
+
+    Returns:
+        A stable, operator-readable path string.
+    """
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _load_yaml_document(path: Path) -> tuple[Any, str | None]:
+    """Load a single YAML document.
+
+    Args:
+        path: File to load.
+
+    Returns:
+        Tuple of (parsed document or None, error message or None).
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh), None
+    except (yaml.YAMLError, OSError) as exc:
+        return None, str(exc)
+
+
+def _compose(
+    master_path: Path, base: Path
+) -> tuple[list[tuple[Path, Any]], list[ValidationWarning]]:
+    """Resolve the includefiles a master composes, in composition order.
+
+    Nested includes are followed depth-first at the point of reference,
+    which is the order OrcaFlex applies them.  A file already composed is
+    not revisited, so an include cycle terminates.
+
+    Args:
+        master_path: The master file.
+        base: Directory used to render paths in findings.
+
+    Returns:
+        Tuple of (list of (resolved path, parsed document), warnings).
+    """
+    composed: list[tuple[Path, Any]] = []
+    warnings: list[ValidationWarning] = []
+    seen: set[Path] = {master_path}
+
+    def walk(parent: Path, data: Any) -> None:
+        for ref in _iter_includefile_refs(data):
+            ref_path = Path(ref)
+            resolved = (
+                ref_path
+                if ref_path.is_absolute()
+                else (parent.parent / ref_path)
+            )
+            try:
+                resolved = resolved.resolve()
+            except OSError:  # pragma: no cover - platform dependent
+                resolved = resolved.absolute()
+
+            if resolved in seen:
+                warnings.append(
+                    ValidationWarning(
+                        level="warning",
+                        category="coherence",
+                        message=(
+                            f"Includefile '{ref}' is composed more than once "
+                            f"(referenced from "
+                            f"'{_display_path(parent, base)}'); the repeat "
+                            f"is not re-scanned"
+                        ),
+                        file=_display_path(parent, base),
+                    )
+                )
+                continue
+            seen.add(resolved)
+
+            if not resolved.is_file():
+                warnings.append(
+                    ValidationWarning(
+                        level="error",
+                        category="reference",
+                        message=(
+                            f"Includefile '{ref}' referenced from "
+                            f"'{_display_path(parent, base)}' does not exist"
+                        ),
+                        file=_display_path(parent, base),
+                    )
+                )
+                continue
+
+            child, error = _load_yaml_document(resolved)
+            if error is not None:
+                warnings.append(
+                    ValidationWarning(
+                        level="error",
+                        category="coherence",
+                        message=(
+                            f"Includefile '{_display_path(resolved, base)}' "
+                            f"could not be parsed: {error}"
+                        ),
+                        file=_display_path(resolved, base),
+                    )
+                )
+                continue
+
+            composed.append((resolved, child))
+            walk(resolved, child)
+
+    master_data, master_error = _load_yaml_document(master_path)
+    if master_error is not None:
+        warnings.append(
+            ValidationWarning(
+                level="error",
+                category="coherence",
+                message=(
+                    f"Master file '{_display_path(master_path, base)}' could "
+                    f"not be parsed: {master_error}"
+                ),
+                file=_display_path(master_path, base),
+            )
+        )
+        return composed, warnings
+
+    walk(master_path, master_data)
+    return composed, warnings
+
+
+def check_collection_collisions(
+    master_path: Path | str, *, raise_on_collision: bool = True
+) -> CollectionScanResult:
+    """Fail closed when composed includefiles destructively overwrite a collection.
+
+    Takes a master file rather than generator state, so it validates a
+    hand-edited ``includes/`` directory that never passed through the
+    generator — the case most likely to trigger the defect.
+
+    A collection key emitted in **list** style by more than one composed
+    includefile is a collision: OrcaFlex applies a list as a replacement,
+    so the last file silently deletes the objects written by the earlier
+    ones.  Mapping-style repeats are legitimate and do not fire, because a
+    name-keyed mapping patches the collection.
+
+    Any top-level key not recognised as an OrcaFlex section is recorded in
+    ``result.unrecognised`` and as a ``ValidationWarning``, so an unknown
+    key cannot pass silently.
+
+    Args:
+        master_path: Master file that composes the includefiles.
+        raise_on_collision: When True (the default) a collision raises.
+            Set False to inspect the result instead, e.g. to report every
+            finding at once.
+
+    Returns:
+        A :class:`CollectionScanResult` describing the composition.
+
+    Raises:
+        CollectionCollisionError: A collection key is written in list style
+            by more than one composed includefile.
+    """
+    master = Path(master_path)
+    base = master.parent
+
+    composed, warnings = _compose(master, base)
+
+    result = CollectionScanResult(master=master, warnings=list(warnings))
+    result.composed_files = [path for path, _ in composed]
+
+    for path, data in composed:
+        display = _display_path(path, base)
+        if not isinstance(data, dict):
+            # A composed file that is not a mapping defines no sections.
+            continue
+        for key, value in data.items():
+            if not isinstance(key, str):
+                continue
+            if isinstance(value, list):
+                style = "list"
+            elif isinstance(value, dict):
+                style = "mapping"
+            else:
+                # Scalar or null: defines no collection.
+                continue
+            result.emitters.setdefault(key, []).append((display, style))
+
+            if key not in _KNOWN_TOP_LEVEL_KEYS:
+                result.unrecognised.append((display, key))
+                result.warnings.append(
+                    ValidationWarning(
+                        level="warning",
+                        category="unrecognised",
+                        message=(
+                            f"Top-level key '{key}' in '{display}' is not a "
+                            f"recognised OrcaFlex section. It is not covered "
+                            f"by the collection-collision check; confirm it "
+                            f"is intended and, if it is a collection, add it "
+                            f"to the known-section set"
+                        ),
+                        file=display,
+                        object_name=key,
+                    )
+                )
+
+    # The collision rule keys on style, not on section classification: a
+    # list REPLACES whatever the key names, recognised or not.
+    for key, entries in result.emitters.items():
+        list_emitters = [name for name, style in entries if style == "list"]
+        if len(list_emitters) > 1:
+            result.collisions.append(
+                CollectionCollision(key=key, files=list_emitters)
+            )
+
+    if result.collisions and raise_on_collision:
+        raise CollectionCollisionError(
+            "Destructive collection-key collision in "
+            f"'{_display_path(master, base)}': "
+            + " ".join(collision.describe() for collision in result.collisions),
+            result.collisions,
+        )
+
+    return result

--- a/src/digitalmodel/solvers/orcaflex/modular_input_validation/level_2_orcaflex.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_input_validation/level_2_orcaflex.py
@@ -243,6 +243,17 @@ class Level2OrcaFlexValidator:
             # Try to calculate statics to generate warnings
             model.CalculateStatics()
 
+            # #3838: a solve that did not reach a static state is itself the
+            # finding. This collector returns warnings rather than raising, so
+            # the state is reported as a warning instead of being discarded.
+            from digitalmodel.solvers.orcaflex import run_state
+
+            state = run_state.state_name(model)
+            if state is not None and state not in run_state.STATICS_COMPLETE_STATES:
+                warnings.append(
+                    f"Statics did not converge: model state is {state}"
+                )
+
             # Get warnings from calculation
             # Note: OrcaFlex warnings are typically in model.WarningMessages
             if hasattr(model, 'WarningMessages'):

--- a/src/digitalmodel/solvers/orcaflex/mooring_tension_iteration/orcaflex_interface.py
+++ b/src/digitalmodel/solvers/orcaflex/mooring_tension_iteration/orcaflex_interface.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from loguru import logger
 from abc import ABC, abstractmethod
 
+from digitalmodel.solvers.orcaflex.run_state import check_statics
+
 
 @dataclass
 class MooringLine:
@@ -333,7 +335,10 @@ class OrcaFlexAPI(OrcaFlexAPIBase):
         
         logger.info("Running OrcaFlex static analysis")
         self.model.CalculateStatics()
-        
+        # #3838: the tensions read below are only meaningful from a converged
+        # static state, and the call itself does not report divergence.
+        check_statics(self.model, context="mooring tension iteration")
+
         # Extract results
         tensions = {}
         positions = {}

--- a/src/digitalmodel/solvers/orcaflex/opp_range_graph.py
+++ b/src/digitalmodel/solvers/orcaflex/opp_range_graph.py
@@ -2,9 +2,12 @@ import pandas as pd
 import math
 import copy
 
-try:
-    import OrcFxAPI
-except Exception:
+# #3838: routed through the facade instead of `import OrcFxAPI`, so the binding
+# is not loaded before a version can be selected.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available, lazy_api
+
+OrcFxAPI = lazy_api() if available() else None
+if OrcFxAPI is None:
     print("OrcaFlex license not available. Run on different computer")
 
 

--- a/src/digitalmodel/solvers/orcaflex/opp_time_series.py
+++ b/src/digitalmodel/solvers/orcaflex/opp_time_series.py
@@ -11,10 +11,12 @@ from digitalmodel.infrastructure.utils.ETL_components import ETL_components
 from digitalmodel.signal_processing.signal_analysis.adapters import TimeSeriesComponentsAdapter as TimeSeriesComponents
 from digitalmodel.solvers.orcaflex.orcaflex_objects import OrcaFlexObjects
 
-try:
-    # Third party imports
-    import OrcFxAPI
-except:
+# #3838: routed through the facade instead of `import OrcFxAPI`, so the binding
+# is not loaded before a version can be selected.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available, lazy_api
+
+OrcFxAPI = lazy_api() if available() else None
+if OrcFxAPI is None:
     logging.debug("OrcFxAPI not available")
 
 

--- a/src/digitalmodel/solvers/orcaflex/opp_visualization.py
+++ b/src/digitalmodel/solvers/orcaflex/opp_visualization.py
@@ -6,9 +6,13 @@ from loguru import logger
 from assetutilities.common.yml_utilities import is_file_valid_func
 from digitalmodel.infrastructure.utils.parallel_processing import should_use_parallel
 from assetutilities.common.path_resolver import PathResolver
-try:
-    import OrcFxAPI
-except Exception:
+# #3838: routed through the facade instead of `import OrcFxAPI`, so the binding
+# is not loaded before a version can be selected.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available, lazy_api
+from digitalmodel.solvers.orcaflex.run_state import check_statics
+
+OrcFxAPI = lazy_api() if available() else None
+if OrcFxAPI is None:
     print("OrcaFlex license not available. Run on different computer")
 
 
@@ -78,6 +82,9 @@ class OPPVisualization:
 
                 model = self.set_general_visualization_settings(model, cfg)
                 model.CalculateStatics()
+                # #3838: a view rendered from a non-converged configuration is
+                # a picture of a shape the model never reached.
+                check_statics(model, context=str(input_file))
                 self.save_all_views(cfg, model, input_file)
 
             # TODO
@@ -207,8 +214,10 @@ class OPPVisualization:
             model.LoadData(input_file)
             model = self.set_general_visualization_settings(model, cfg)
             model.CalculateStatics()
+            # #3838: as above -- the except below records this as a failure.
+            check_statics(model, context=str(input_file))
             self.save_all_views(cfg, model, input_file)
-            
+
             execution_time = time.time() - start_time
             logger.info(f"✓ Visualization completed: {os.path.basename(input_file)} ({execution_time:.2f}s)")
             return input_file, True, "Success", execution_time

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_analysis_components.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_analysis_components.py
@@ -70,10 +70,18 @@ class OrcaFlexAnalysis():
                 model.LoadData(filename_with_ext)
                 logging.info("Load input file successful")
 
+                # #3838: an unstable run returns success from the call itself,
+                # so the model state is checked before the result is saved.
+                from digitalmodel.solvers.orcaflex.run_state import (
+                    check_simulation,
+                    check_statics,
+                )
                 if self.cfg['Analysis']['input_files']['analysis_type'][fileIndex] == 'simulation':
                     model.RunSimulation()
+                    check_simulation(model, context=filename_with_ext)
                 elif self.cfg['Analysis']['input_files']['analysis_type'][fileIndex] == 'statics':
                     model.CalculateStatics()
+                    check_statics(model, context=filename_with_ext)
                 logging.info("Run simulation successful")
 
                 model.SaveSimulation(filename_without_ext + '.sim')
@@ -339,22 +347,44 @@ class OrcaFlexAnalysis():
         self.SummaryDFAllFiles = SummaryDFAllFiles
 
     def get_model_from_filename(self, file_name):
+        import logging
         import os
 
         import pandas as pd
+
+        from digitalmodel.solvers.orcaflex import run_state
         SimulationFileName = self.get_SimulationFileName(file_name)
         model = None
         if os.path.isfile(SimulationFileName):
             try:
                 model = self.loadSimulation(SimulationFileName)
-                RunStatus = str(model.state)
+            except Exception as e:
+                logging.info(f"Load simulation {SimulationFileName} ... FAIL: {e}")
+                return None
+
+            # #3838: the state gate runs FIRST and outside the bookkeeping
+            # try/except. It used to sit after a `from common.data import ...`
+            # whose failure was swallowed by a bare `except Exception: pass`,
+            # which returned the loaded model ungated. It also compared
+            # `str(model.state)` against member NAMES -- and ModelState is an
+            # IntEnum, so str() is the integer value and the comparison never
+            # matched. Both faults let a SimulationStoppedUnstable run through.
+            RunStatus = run_state.state_name(model)
+            if RunStatus is not None and RunStatus not in [
+                'Reset', 'InStaticState', 'SimulationStopped'
+            ]:
+                logging.info(
+                    f"Simulation {SimulationFileName} is in state {RunStatus} "
+                    "and is not usable for post-processing"
+                )
+                return None
+
+            try:
                 from common.data import PandasChainedAssignent
                 with PandasChainedAssignent():
                     self.load_matrix.loc[(self.load_matrix['fe_filename'] == file_name), 'RunStatus'] = RunStatus
-                if RunStatus not in ['Reset', 'InStaticState', 'SimulationStopped']:
-                    model = None
             except Exception as e:
-                pass
+                logging.info(f"Recording run status for {file_name} ... FAIL: {e}")
 
         return model
 

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_api.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_api.py
@@ -1,0 +1,370 @@
+"""The single import gate for the OrcaFlex Python binding.
+
+Why this module exists
+----------------------
+``OrcFxAPI`` loads its DLL at import time. The path it loads is decided by
+``OrcFxAPIConfig``, which reads, in order: a path previously handed to
+``setLibPath()``, the ``_OrcFxAPIlib`` environment variable, and failing both the
+registry key ``HKLM\\Software\\Orcina\\OrcaFlex\\Installation Directory`` -- which
+names the *highest-numbered* installed OrcaFlex. An OrcaFlex upgrade therefore
+changes the solver under every campaign, silently, with nothing recorded.
+
+``setLibPath()`` only has an effect while ``OrcFxAPI`` is still unimported, and
+import state is process-global. A helper function cannot fix this on its own: a
+single module-scope ``import OrcFxAPI`` anywhere on the import path of the
+calling program settles the question before the helper is ever reached. So this
+module owns the import instead:
+
+* it never imports ``OrcFxAPI`` at module scope;
+* :func:`configure` refuses to run once ``OrcFxAPI`` is in ``sys.modules``, and
+  names the module that got there first;
+* :func:`api` is the only sanctioned way for the package to reach the binding;
+* :func:`record` returns what was actually resolved, for the run manifest.
+
+Modules that want the old ``import OrcFxAPI`` spelling without the module-scope
+import use :func:`lazy_api`, which returns a proxy that resolves on first
+attribute access.
+
+Issue: https://github.com/vamseeachanta/workspace-hub/issues/3838
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+import threading
+from typing import Any, Dict, Optional
+
+__all__ = [
+    "OrcaFlexApiError",
+    "OrcFxAPIAlreadyImportedError",
+    "OrcaFlexVersionUnavailableError",
+    "api",
+    "available",
+    "configure",
+    "installed_versions",
+    "is_configured",
+    "lazy_api",
+    "record",
+]
+
+_MODULE = "OrcFxAPI"
+_CONFIG_MODULE = "OrcFxAPIConfig"
+
+#: Registry location that enumerates the installed OrcaFlex versions. Read under
+#: the 32-bit view, matching what the vendor's own ``OrcFxAPIConfig`` does.
+_REGISTRY_SUBKEY = r"Software\Orcina\OrcaFlex"
+_INSTALL_DIR_KEY = "Installation Directory"
+_INSTALL_DIR_VALUE = "Normal"
+
+_lock = threading.RLock()
+_record: Optional[Dict[str, Any]] = None
+
+
+class OrcaFlexApiError(RuntimeError):
+    """Base class for failures of the OrcaFlex import gate."""
+
+
+class OrcFxAPIAlreadyImportedError(OrcaFlexApiError):
+    """``configure()`` was called after ``OrcFxAPI`` had already been imported.
+
+    ``setLibPath()`` can no longer take effect, so the version in force is
+    whatever the binding picked on its own. The message names the importer that
+    got there first.
+    """
+
+
+class OrcaFlexVersionUnavailableError(OrcaFlexApiError):
+    """A specific OrcaFlex version was requested and is not installed."""
+
+
+# ---------------------------------------------------------------------------
+# Version discovery
+# ---------------------------------------------------------------------------
+
+
+def _dll_relative_path() -> str:
+    is64bit = sys.maxsize > 2**32
+    return os.path.join("OrcFxAPI", "Win64" if is64bit else "Win32", "OrcFxAPI.dll")
+
+
+def installed_versions() -> Dict[str, str]:
+    """Map each installed OrcaFlex version to its ``OrcFxAPI.dll``.
+
+    Returns an empty mapping off Windows, or where the Orcina registry key is
+    absent. Entries are reported whether or not the DLL is present on disk;
+    :func:`_resolve_version` is what checks for the file.
+    """
+    try:
+        import winreg  # noqa: PLC0415 -- Windows-only, imported on use
+    except ImportError:
+        return {}
+
+    versions: Dict[str, str] = {}
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            _REGISTRY_SUBKEY,
+            0,
+            winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
+        ) as root:
+            index = 0
+            while True:
+                try:
+                    name = winreg.EnumKey(root, index)
+                except OSError:
+                    break
+                index += 1
+                if name == _INSTALL_DIR_KEY:
+                    # The unversioned sibling key -- this is the "highest
+                    # installed version" default the defect is about, not a
+                    # version in its own right.
+                    continue
+                try:
+                    with winreg.OpenKey(
+                        root,
+                        f"{name}\\{_INSTALL_DIR_KEY}",
+                        0,
+                        winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
+                    ) as key:
+                        directory = winreg.QueryValueEx(key, _INSTALL_DIR_VALUE)[0]
+                except OSError:
+                    continue
+                versions[name] = os.path.join(str(directory), _dll_relative_path())
+    except OSError:
+        return {}
+    return versions
+
+
+def _resolve_version(requested: str) -> str:
+    versions = installed_versions()
+    candidates = {key: value for key, value in versions.items()}
+    path = candidates.get(requested)
+    if path is None:
+        # Accept "11.6c" against an installed "11.6": the registry keys the
+        # major.minor line, the DLL carries the build letter.
+        prefix_matches = sorted(
+            key for key in candidates if requested.startswith(key)
+        )
+        if len(prefix_matches) == 1:
+            path = candidates[prefix_matches[0]]
+    if path is None:
+        raise OrcaFlexVersionUnavailableError(
+            f"OrcaFlex version {requested!r} is not installed on this host. "
+            f"Installed versions: {sorted(versions) or 'none found in the registry'}."
+        )
+    if not os.path.isfile(path):
+        raise OrcaFlexVersionUnavailableError(
+            f"OrcaFlex version {requested!r} is registered but its library is "
+            f"missing: {path}"
+        )
+    return os.path.abspath(path)
+
+
+# ---------------------------------------------------------------------------
+# Import ordering
+# ---------------------------------------------------------------------------
+
+
+def _earlier_importers() -> list:
+    """Name the loaded modules still holding a reference to ``OrcFxAPI``.
+
+    This is a best-effort attribution: it reports every module that bound the
+    binding as an attribute, which in practice is every module that imported it.
+    A module that imported it and then deleted the name is not found, and the
+    caller says so rather than claiming the list is complete.
+    """
+    binding = sys.modules.get(_MODULE)
+    if binding is None:
+        return []
+    holders = []
+    for name, module in list(sys.modules.items()):
+        if module is None or module is binding or name == __name__:
+            continue
+        namespace = getattr(module, "__dict__", None)
+        if not isinstance(namespace, dict):
+            continue
+        try:
+            found = any(value is binding for value in list(namespace.values()))
+        except Exception:  # pragma: no cover -- a hostile __dict__ proxy
+            continue
+        if found:
+            holders.append(name)
+    return sorted(holders)
+
+
+def available() -> bool:
+    """Whether ``OrcFxAPI`` can be imported, WITHOUT importing it.
+
+    ``find_spec`` locates the module without executing it, so asking this
+    question does not itself decide which library gets loaded.
+    """
+    if _MODULE in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(_MODULE) is not None
+    except (ImportError, ValueError):  # pragma: no cover -- broken sys.path entry
+        return False
+
+
+def is_configured() -> bool:
+    return _record is not None
+
+
+def configure(
+    requested_version: Optional[str] = None,
+    *,
+    lib_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Select the OrcaFlex library for this process and record what was resolved.
+
+    Args:
+        requested_version: An OrcaFlex version as the Orcina registry spells it,
+            e.g. ``"11.6"``. ``None`` selects nothing and records whatever the
+            binding resolves on its own.
+        lib_path: An explicit ``OrcFxAPI.dll`` path, overriding version lookup.
+
+    Returns:
+        The run record: ``requested``, ``resolved_lib_path``, ``resolved_version``.
+
+    Raises:
+        OrcFxAPIAlreadyImportedError: ``OrcFxAPI`` is already imported, so
+            ``setLibPath()`` can no longer take effect.
+        OrcaFlexVersionUnavailableError: the requested version is not installed.
+    """
+    global _record
+
+    with _lock:
+        if _MODULE in sys.modules:
+            holders = _earlier_importers()
+            attribution = (
+                ", ".join(holders)
+                if holders
+                else "an importer that did not keep the name bound"
+            )
+            raise OrcFxAPIAlreadyImportedError(
+                f"{_MODULE} was already imported, so the library path is already "
+                f"decided and setLibPath() can no longer take effect. Imported "
+                f"by: {attribution}. Call configure() before anything imports "
+                f"{_MODULE}, and reach the binding through "
+                f"{__name__}.api() instead of importing it directly."
+            )
+
+        selected: Optional[str] = None
+        if lib_path is not None:
+            selected = os.path.abspath(str(lib_path))
+            if not os.path.isfile(selected):
+                raise OrcaFlexVersionUnavailableError(
+                    f"the requested OrcaFlex library does not exist: {selected}"
+                )
+        elif requested_version is not None:
+            selected = _resolve_version(str(requested_version))
+
+        if selected is not None:
+            config = importlib.import_module(_CONFIG_MODULE)
+            config.setLibPath(selected)
+
+        resolved: Dict[str, Any] = {
+            "requested": requested_version,
+            "resolved_lib_path": selected,
+            "resolved_version": None,
+        }
+
+        try:
+            binding = importlib.import_module(_MODULE)
+        except Exception as exc:
+            # Recorded rather than raised: a manifest on a host without the
+            # binding should say so, and api() re-raises for callers that need
+            # the solver. The failure is never reported as a resolved version.
+            resolved["import_error"] = f"{type(exc).__name__}: {exc}"
+            _record = resolved
+            return dict(resolved)
+
+        resolved["resolved_lib_path"] = _current_lib_path() or selected
+        resolved["resolved_version"] = _dll_version(binding)
+        _record = resolved
+        return dict(resolved)
+
+
+def _current_lib_path() -> Optional[str]:
+    try:
+        config = importlib.import_module(_CONFIG_MODULE)
+        return str(config.getLibPath())
+    except Exception:
+        return None
+
+
+def _dll_version(binding) -> Optional[str]:
+    """The version the loaded library reports.
+
+    ``DLLVersion()`` reads the loaded DLL and claims no licence seat; only
+    constructing a ``Model`` does.
+    """
+    for attribute in ("DLLVersion", "__version__"):
+        value = getattr(binding, attribute, None)
+        if value is None:
+            continue
+        try:
+            return str(value() if callable(value) else value)
+        except Exception:
+            continue
+    return None
+
+
+def api():
+    """Return the ``OrcFxAPI`` module, configuring the gate first if needed.
+
+    Every access to the binding inside this package goes through here, so the
+    selection made by :func:`configure` is the one in force.
+    """
+    with _lock:
+        if _record is None:
+            configure(None)
+        return importlib.import_module(_MODULE)
+
+
+def record() -> Dict[str, Any]:
+    """The resolved solver record, for the run manifest.
+
+    Configures with no requested version if nothing has configured yet, so a
+    manifest written by a caller that never called :func:`configure` still
+    carries the library path and version that were actually used.
+    """
+    with _lock:
+        if _record is None:
+            configure(None)
+        return dict(_record or {})
+
+
+class _LazyOrcFxAPI:
+    """A stand-in for the ``OrcFxAPI`` module that resolves on first use.
+
+    Lets a module keep writing ``OrcFxAPI.Model(...)`` at its call sites while
+    the import itself is deferred past :func:`configure`. Attribute access
+    delegates to :func:`api`, so the first touch is what triggers the import.
+    """
+
+    __slots__ = ()
+
+    def __getattr__(self, name: str):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return getattr(api(), name)
+
+    def __repr__(self) -> str:
+        if _MODULE in sys.modules:
+            return f"<lazy {_MODULE} (loaded)>"
+        return f"<lazy {_MODULE} (not yet imported)>"
+
+    def __bool__(self) -> bool:
+        return available()
+
+
+_LAZY = _LazyOrcFxAPI()
+
+
+def lazy_api() -> _LazyOrcFxAPI:
+    """The lazy ``OrcFxAPI`` stand-in; a singleton, so identity comparisons hold."""
+    return _LAZY

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_custom_analysis.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_custom_analysis.py
@@ -15,6 +15,8 @@ except ImportError:
     OrcFxAPI = None  # type: ignore
     ORCAFLEX_AVAILABLE = False
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation, check_statics
+
 from assetutilities.common.utilities import is_file_valid_func
 from assetutilities.common import file_management as fm
 from assetutilities.common.saveData import saveDataYaml
@@ -165,6 +167,9 @@ class OrcaFlexCustomAnalysis:
 
             if simulation_flag:
                 model.RunSimulation()
+                # #3838: RunSimulation returns success for a diverged run, so
+                # the state is checked before the .sim/.dat below are written.
+                check_simulation(model, context=filename_with_ext)
                 logging.info("Run simulation successful")
 
             if save_sim_flag:
@@ -214,6 +219,9 @@ class OrcaFlexCustomAnalysis:
         try:
             print("First analysis ......")
             model.CalculateStatics()
+            # #3838: a statics solve that did not reach a static state is a
+            # failed run; the bare except below turns this into the FAIL branch.
+            check_statics(model, context=filename_with_ext)
             print("First analysis ... PASS")
             self.save_model_with_calculated_positions(filename_with_ext, model)
             model = self.analysis_with_calculated_positions(model)
@@ -227,6 +235,7 @@ class OrcaFlexCustomAnalysis:
     def analysis_with_calculated_positions(self, model):
         try:
             model.CalculateStatics()
+            check_statics(model, context="analysis with calculated positions")
         except:
             print("Analysis with calculated positions ... FAIL")
 
@@ -255,6 +264,9 @@ class OrcaFlexCustomAnalysis:
     def iterate_to_target_value(self, model, iterate_cfg):
         iterations_df = pd.DataFrame(columns=["variable", "output"])
         model.CalculateStatics()
+        # #3838: an iteration seeded from a non-converged statics solve chases a
+        # meaningless output value, so the state is checked at each solve.
+        check_statics(model, context="iterate_to_target_value seed")
         model.SaveSimulation(iterate_cfg["filename_without_ext"] + ".sim")
 
         target_value = iterate_cfg["iterate"]["column"]["target_value"]
@@ -294,6 +306,9 @@ class OrcaFlexCustomAnalysis:
 
             model.SaveData(update_cfg["model_file"])
             model.CalculateStatics()
+            check_statics(
+                model, context=f"iterate_to_target_value iteration {current_iteration}"
+            )
             model.SaveSimulation(iterate_cfg["filename_without_ext"] + ".sim")
             output_current_value = round(
                 self.process_summary_by_model_and_cfg(model, column_cfg), 3

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_iterative_runs.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_iterative_runs.py
@@ -12,6 +12,8 @@ import shutil
 
 from assetutilities.common.data import SaveData
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation
+
 save_data = SaveData()
 
 
@@ -160,6 +162,9 @@ class OrcaflexIterativeRuns:
             model.LoadData(filename_with_ext)
 
             model.RunSimulation()
+            # #3838: an unstable run returns success from the call itself; the
+            # state is checked before the .sim is written.
+            check_simulation(model, context=filename_with_ext)
 
             model.SaveSimulation(filename_save_simulation)
             if self.cfg["orcaflex"]["iterate"]["overwrite_data"]:

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_modal_analysis.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_modal_analysis.py
@@ -16,6 +16,8 @@ except:
 # Reader imports
 from digitalmodel.solvers.orcaflex.orcaflex_utilities import OrcaflexUtilities
 
+from digitalmodel.solvers.orcaflex.run_state import check_statics
+
 ou = OrcaflexUtilities()
 
 
@@ -78,6 +80,9 @@ class OrcModalAnalysis:
         model = OrcFxAPI.Model()
         model.LoadData(file)
         model.CalculateStatics()
+        # #3838: modal results are taken about the static configuration, so a
+        # solve that did not reach a static state invalidates every mode below.
+        check_statics(model, context=str(file))
         ou.save_sim_file(model, file)
         lastMode = self.cfg["default"]["Analysis"]["Analyze"]["modal"]["lastMode"]
         spec = OrcFxAPI.ModalAnalysisSpecification(

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_objects.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_objects.py
@@ -3,9 +3,13 @@ import logging
 import pandas as pd
 
 # Third party imports
-try:
-    import OrcFxAPI
-except Exception:
+# #3838: routed through the facade instead of `import OrcFxAPI`. A module-scope
+# import binds the DLL before OrcFxAPIConfig.setLibPath() can select a version,
+# and this module is on the import path of the package __init__.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available, lazy_api
+
+OrcFxAPI = lazy_api() if available() else None
+if OrcFxAPI is None:
     print("OrcaFlex license not available. Run on different computer")
 
 

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_optimized_parallel.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_optimized_parallel.py
@@ -17,6 +17,8 @@ from datetime import datetime
 import traceback
 import gc
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation, check_statics
+
 # Import performance optimization modules
 from .performance_monitor import (
     PerformanceMonitor, 
@@ -144,11 +146,15 @@ class OrcaFlexOptimizedParallelAnalysis:
                 if run_static:
                     logger.info(f"Running static analysis: {file_path}")
                     model.CalculateStatics()
-                
+                    # #3838: the state is the only signal of a diverged solve,
+                    # and it is read before any output file is written.
+                    check_statics(model, context=str(file_path))
+
                 # Run dynamic analysis if requested
                 if run_dynamic:
                     logger.info(f"Running dynamic analysis: {file_path}")
                     model.RunSimulation()
+                    check_simulation(model, context=str(file_path))
                 
                 # Save results
                 if save_sim:

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_optimized_parallel_v2.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_optimized_parallel_v2.py
@@ -18,6 +18,8 @@ from datetime import datetime
 import traceback
 import gc
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation, check_statics
+
 try:
     import OrcFxAPI
     ORCAFLEX_AVAILABLE = True
@@ -94,11 +96,15 @@ def process_single_file_worker(file_info: Dict[str, Any]) -> Dict[str, Any]:
             if run_static:
                 logger.info(f"Running static analysis: {file_path}")
                 model.CalculateStatics()
-            
+                # #3838: the state is the only signal of a diverged solve, and
+                # it is read before any output file is written.
+                check_statics(model, context=str(file_path))
+
             # Run dynamic analysis if requested
             if run_dynamic:
                 logger.info(f"Running dynamic analysis: {file_path}")
                 model.RunSimulation()
+                check_simulation(model, context=str(file_path))
             
             # Save results
             if save_sim:

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_parallel_analysis.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_parallel_analysis.py
@@ -14,6 +14,8 @@ import time
 from datetime import datetime
 import traceback
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation, check_statics
+
 try:
     import OrcFxAPI
     ORCAFLEX_AVAILABLE = True
@@ -106,12 +108,16 @@ class OrcaFlexParallelAnalysis:
             if run_static:
                 logger.info(f"Running static analysis: {file_path}")
                 model.CalculateStatics()
+                # #3838: the state is the only signal of a diverged solve, and
+                # it is read before the run is recorded complete.
+                check_statics(model, context=str(file_path))
                 result['static_complete'] = True
-            
+
             # Run dynamic simulation
             if run_dynamic:
                 logger.info(f"Running dynamic simulation: {file_path}")
                 model.RunSimulation()
+                check_simulation(model, context=str(file_path))
                 result['dynamic_complete'] = True
             
             # Save SIM file

--- a/src/digitalmodel/solvers/orcaflex/orcaflex_utilities.py
+++ b/src/digitalmodel/solvers/orcaflex/orcaflex_utilities.py
@@ -3,11 +3,14 @@
 # import-time raise would be swallowed by solvers/orcaflex/__init__.py into a
 # None export -- but callers now refuse at CALL time via
 # require_orcaflex_or_raise() below.
-try:
-    import OrcFxAPI
-    ORCAFLEX_API_AVAILABLE = True
-except Exception:
-    ORCAFLEX_API_AVAILABLE = False
+# #3838: routed through the facade instead of `import OrcFxAPI`. A module-scope
+# import binds the DLL before OrcFxAPIConfig.setLibPath() can select a version,
+# and this module is on the import path of the package __init__.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available as _orcaflex_available
+from digitalmodel.solvers.orcaflex.orcaflex_api import lazy_api as _lazy_orcaflex_api
+
+ORCAFLEX_API_AVAILABLE = _orcaflex_available()
+OrcFxAPI = _lazy_orcaflex_api() if ORCAFLEX_API_AVAILABLE else None
 # Standard library imports
 import glob
 from loguru import logger
@@ -36,15 +39,13 @@ from digitalmodel.solvers.orcaflex.orcaflex_model_utilities import (
 )
 
 from digitalmodel.solvers.orcaflex.core.exceptions import LicenseError
+from digitalmodel.solvers.orcaflex import run_state
 
 save_data = SaveData()
 de = DataExploration()
 colorama.init(strip=True, convert=False)
 
-try:
-    # Third party imports
-    import OrcFxAPI
-except:
+if not ORCAFLEX_API_AVAILABLE:
     logger.debug("OrcFxAPI not available")
 # Standard library imports
 from collections import OrderedDict
@@ -123,6 +124,9 @@ class OrcaflexUtilities:
         model.LoadData(yml_file)
 
         model.RunSimulation()
+        # #3838: RunSimulation returns success for a diverged run; the model
+        # state is the only signal, and it is checked before the .sim is saved.
+        run_state.check_simulation(model, context=str(yml_file))
 
         model.SaveSimulation(sim_file)
 
@@ -594,20 +598,37 @@ class OrcaflexUtilities:
     def get_model_and_metadata(self, file_name):
         SimulationFileName = self.get_SimulationFileName(file_name)
         model = None
+        # #3838: these were assigned only inside the try, so any load failure
+        # raised UnboundLocalError while building the return dict below.
+        simulation_complete = None
+        run_status = None
+        start_time = None
+        stop_time = None
+        current_time = None
         if os.path.isfile(SimulationFileName):
             try:
                 model = self.loadSimulation(SimulationFileName)
                 simulation_complete = model.simulationComplete
-                run_status = model.state.__dict__["_name_"]
+                run_status = run_state.state_name(model)
                 start_time = model.simulationStartTime
                 stop_time = model.simulationStopTime
                 current_time = model.simulationTimeStatus.CurrentTime
 
             except Exception as e:
                 model = None
-                model = None
                 logger.info(f"Model: {SimulationFileName} ... Error Loading File")
                 logger.info(str(e))
+
+            # #3838: a simulation that stopped unstable loads without error and
+            # reports a stop time; only the state distinguishes it from a
+            # converged run. Such a model is not returned for post-processing.
+            if model is not None and run_status is not None:
+                if run_status not in run_state.STATICS_COMPLETE_STATES:
+                    logger.info(
+                        f"Model: {SimulationFileName} ... state {run_status} is "
+                        "not usable for post-processing"
+                    )
+                    model = None
 
         model_dict = {
             "model": model,

--- a/src/digitalmodel/solvers/orcaflex/pipeline_schematic.py
+++ b/src/digitalmodel/solvers/orcaflex/pipeline_schematic.py
@@ -21,12 +21,16 @@ from plotly.subplots import make_subplots
 import yaml
 from loguru import logger
 
-# Optional OrcaFlex API import
-try:
-    import OrcFxAPI
-    ORCAFLEX_AVAILABLE = True
-except ImportError:
-    ORCAFLEX_AVAILABLE = False
+# Optional OrcaFlex API access.
+# #3838: routed through the facade instead of `import OrcFxAPI`, so the binding
+# is not loaded before OrcFxAPIConfig.setLibPath() can select a version.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available as _orcaflex_available
+from digitalmodel.solvers.orcaflex.orcaflex_api import lazy_api as _lazy_orcaflex_api
+from digitalmodel.solvers.orcaflex.run_state import check_statics
+
+ORCAFLEX_AVAILABLE = _orcaflex_available()
+OrcFxAPI = _lazy_orcaflex_api() if ORCAFLEX_AVAILABLE else None
+if not ORCAFLEX_AVAILABLE:
     logger.debug("OrcFxAPI not available - API screenshot mode disabled")
 
 
@@ -1557,6 +1561,9 @@ class OrcaFlexViewCapture:
         if calculate_statics:
             logger.info("Calculating statics...")
             self._model.CalculateStatics()
+            # #3838: the schematic drawn below is of the static configuration,
+            # so a solve that did not reach one must not be captured.
+            check_statics(self._model, context=str(self.model_file))
 
     def capture_view(
         self,

--- a/src/digitalmodel/solvers/orcaflex/run_state.py
+++ b/src/digitalmodel/solvers/orcaflex/run_state.py
@@ -1,0 +1,168 @@
+"""Model-state gating for completed OrcaFlex solves.
+
+Why this module exists
+----------------------
+An unstable OrcaFlex simulation does not raise. ``RunSimulation`` returns
+``stOK`` and leaves the model in ``SimulationStoppedUnstable``; a caller that
+handles only exceptions therefore saves a diverged run and reports success. The
+state is the only signal that separates a converged run from a diverged one, so
+every path that completes a solve has to read it.
+
+Reading it correctly matters as much as reading it. ``OrcFxAPI.ModelState`` is an
+``IntEnum``, and from Python 3.11 ``str()`` of an ``IntEnum`` member is its
+integer value -- ``str(ModelState.SimulationStopped)`` is ``'4'``, not
+``'SimulationStopped'``. A whitelist compared against ``str(model.state)``
+matches nothing at all and rejects every run, converged or not.
+:func:`state_name` resolves the member name instead.
+
+Indeterminate states pass through
+---------------------------------
+The gate raises on a state it recognises as wrong. It stays silent on a state it
+cannot read -- a test double, a mock, an object with no ``state``. The purpose is
+to reject a diverged solver run, not to reject a caller whose model is a stand-in.
+
+Issue: https://github.com/vamseeachanta/workspace-hub/issues/3838
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+__all__ = [
+    "KNOWN_STATES",
+    "SIMULATION_COMPLETE_STATES",
+    "STATICS_COMPLETE_STATES",
+    "UNSTABLE_STATES",
+    "SimulationStateError",
+    "check_simulation",
+    "check_state",
+    "check_statics",
+    "state_name",
+]
+
+#: Every member ``OrcFxAPI.ModelState`` defines. A state outside this set cannot
+#: be judged, so it is treated as indeterminate rather than as a pass --
+#: except for the ``UNDEFINED_`` members the vendor enum fabricates for values it
+#: does not recognise, which are a genuine solver answer and are rejected.
+KNOWN_STATES = frozenset(
+    {
+        "Reset",
+        "CalculatingStatics",
+        "InStaticState",
+        "RunningSimulation",
+        "SimulationStopped",
+        "SimulationStoppedUnstable",
+    }
+)
+
+#: The state an unstable run lands in while its call returns success.
+UNSTABLE_STATES = frozenset({"SimulationStoppedUnstable"})
+
+#: States in which a static solve has completed and its results may be read.
+#: ``SimulationStopped`` is included because a completed dynamic run also
+#: carries valid static results.
+STATICS_COMPLETE_STATES = frozenset({"InStaticState", "SimulationStopped"})
+
+#: The only state in which a dynamic simulation has completed normally.
+SIMULATION_COMPLETE_STATES = frozenset({"SimulationStopped"})
+
+_UNDEFINED_PREFIX = "UNDEFINED_"
+
+
+class SimulationStateError(RuntimeError):
+    """A solve completed in a model state its results must not be read from.
+
+    Attributes:
+        state: The resolved model-state name.
+        allowed: The states the caller was prepared to accept.
+        context: What was being run, for the operator reading the message.
+    """
+
+    def __init__(self, state: str, allowed: Iterable[str], context: str = ""):
+        self.state = state
+        self.allowed = sorted(allowed)
+        self.context = context
+        where = f" for {context}" if context else ""
+        if state in UNSTABLE_STATES:
+            detail = (
+                "the simulation went unstable; OrcaFlex reports success from the "
+                "run call itself, so this state is the only signal"
+            )
+        elif state.startswith(_UNDEFINED_PREFIX):
+            detail = "the solver reported a model state this build does not define"
+        else:
+            detail = "the solve did not complete"
+        super().__init__(
+            f"OrcaFlex run{where} finished in state {state!r}: {detail}. "
+            f"Accepted states: {self.allowed}."
+        )
+
+
+def state_name(model: Any) -> Optional[str]:
+    """The model's state as a member NAME, or ``None`` if it cannot be resolved.
+
+    ``str(state)`` is deliberately the last resort: on an ``IntEnum`` it returns
+    the integer value, which is what made the pre-existing name whitelists dead
+    code.
+    """
+    state = getattr(model, "state", None)
+    if state is None:
+        return None
+
+    for attribute in ("name", "_name_"):
+        value = getattr(state, attribute, None)
+        if isinstance(value, str) and value:
+            return value
+
+    if isinstance(state, str):
+        return state
+
+    try:
+        text = str(state)
+    except Exception:  # pragma: no cover -- a stand-in with a hostile __str__
+        return None
+    if text in KNOWN_STATES or text.startswith(_UNDEFINED_PREFIX):
+        return text
+    # Anything else -- an integer, a repr, a mock -- is not a name.
+    return None
+
+
+def check_state(
+    model: Any,
+    allowed: Iterable[str],
+    *,
+    context: str = "",
+) -> Optional[str]:
+    """Raise unless the model's state is acceptable.
+
+    Args:
+        model: The model whose state to read.
+        allowed: The state names that are acceptable here.
+        context: What was being run, quoted back in the error message.
+
+    Returns:
+        The resolved state name, or ``None`` when the state could not be read.
+
+    Raises:
+        SimulationStateError: The state resolved to a known OrcaFlex state that
+            is not in ``allowed``, or to an undefined vendor state.
+    """
+    name = state_name(model)
+    if name is None:
+        return None
+    allowed = frozenset(allowed)
+    if name in allowed:
+        return name
+    if name in KNOWN_STATES or name.startswith(_UNDEFINED_PREFIX):
+        raise SimulationStateError(name, allowed, context)
+    return name
+
+
+def check_statics(model: Any, *, context: str = "") -> Optional[str]:
+    """Raise unless a static solve completed. See :func:`check_state`."""
+    return check_state(model, STATICS_COMPLETE_STATES, context=context)
+
+
+def check_simulation(model: Any, *, context: str = "") -> Optional[str]:
+    """Raise unless a dynamic simulation completed. See :func:`check_state`."""
+    return check_state(model, SIMULATION_COMPLETE_STATES, context=context)

--- a/src/digitalmodel/solvers/orcaflex/run_to_sim.py
+++ b/src/digitalmodel/solvers/orcaflex/run_to_sim.py
@@ -13,14 +13,18 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 from typing import List, Dict, Optional, Any
 
-try:
-    import OrcFxAPI
-    ORCAFLEX_AVAILABLE = True
-except ImportError:
-    ORCAFLEX_AVAILABLE = False
+# #3838: routed through the facade instead of `import OrcFxAPI`. A module-scope
+# import binds the DLL before OrcFxAPIConfig.setLibPath() can select a version,
+# and this module is on the import path of the package __init__.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available as _orcaflex_available
+from digitalmodel.solvers.orcaflex.orcaflex_api import lazy_api as _lazy_orcaflex_api
+
+ORCAFLEX_AVAILABLE = _orcaflex_available()
+OrcFxAPI = _lazy_orcaflex_api() if ORCAFLEX_AVAILABLE else None
 
 from digitalmodel.solvers.orcaflex.core.exceptions import LicenseError
 from digitalmodel.solvers.orcaflex.core.mock_artifacts import write_mock_artifact
+from digitalmodel.solvers.orcaflex.run_state import check_statics
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +123,10 @@ class OrcaFlexModelRunner:
                 # Run static analysis
                 logger.info(f"Running static analysis for {model_path.name}...")
                 model.CalculateStatics()
-                
+                # #3838: a solve that did not converge to a static state must
+                # not be saved as a .sim and reported as a success.
+                check_statics(model, context=str(model_path))
+
                 # Save as .sim file
                 logger.info(f"Saving to: {sim_file}")
                 model.SaveSimulation(str(sim_file))

--- a/src/digitalmodel/solvers/orcaflex/schematic_capture.py
+++ b/src/digitalmodel/solvers/orcaflex/schematic_capture.py
@@ -41,13 +41,16 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# Optional imports — gracefully absent in environments without a licence
-try:
-    import OrcFxAPI as ofx
+# Optional imports — gracefully absent in environments without a licence.
+# #3838: routed through the facade instead of `import OrcFxAPI`, so the binding
+# is not loaded before OrcFxAPIConfig.setLibPath() can select a version.
+from digitalmodel.solvers.orcaflex.orcaflex_api import available as _orcaflex_available
+from digitalmodel.solvers.orcaflex.orcaflex_api import lazy_api as _lazy_orcaflex_api
+from digitalmodel.solvers.orcaflex.run_state import check_statics
 
-    _OFX_AVAILABLE = True
-except ImportError:
-    _OFX_AVAILABLE = False
+_OFX_AVAILABLE = _orcaflex_available()
+ofx = _lazy_orcaflex_api() if _OFX_AVAILABLE else None
+if not _OFX_AVAILABLE:
     logger.debug("OrcFxAPI not available — schematic capture disabled")
 
 try:
@@ -115,6 +118,9 @@ def save_orcaflex_views(
     model.LoadData(str(model_file))
     if run_statics:
         model.CalculateStatics()
+        # #3838: the views captured below are of the static configuration, so a
+        # solve that did not reach one must not be saved as a schematic.
+        check_statics(model, context=str(model_file))
 
     saved: dict[str, Path] = {}
     view_angles = {

--- a/src/digitalmodel/solvers/orcaflex/template_generator.py
+++ b/src/digitalmodel/solvers/orcaflex/template_generator.py
@@ -26,6 +26,8 @@ from typing import Dict, Any, List, Optional, Union
 from dataclasses import dataclass, field
 from copy import deepcopy
 
+from digitalmodel.solvers.orcaflex.run_state import check_statics
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -550,6 +552,9 @@ class ModelValidator:
             if run_statics:
                 try:
                     model.CalculateStatics()
+                    # #3838: convergence is a property of the resulting model
+                    # state, not of the call returning without raising.
+                    check_statics(model, context=str(file_path))
                     result['statics_converged'] = True
                 except Exception as e:
                     result['statics_converged'] = False

--- a/src/digitalmodel/solvers/orcaflex/time_trace_processor.py
+++ b/src/digitalmodel/solvers/orcaflex/time_trace_processor.py
@@ -14,6 +14,8 @@ import logging
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import partial
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
@@ -142,6 +144,9 @@ class OrcaFlexTimeTraceProcessor:
         if model.state != OrcFxAPI.ModelState.InSimulation:
             logger.info("Running simulation...")
             model.RunSimulation()
+            # #3838: RunSimulation returns success for a diverged run; traces
+            # extracted from one are not a result.
+            check_simulation(model, context=str(self.config.file_path))
         
         # Extract time traces
         time_traces = {'Time': model.GetTimeHistory('Time')}
@@ -249,7 +254,21 @@ class OrcaFlexTimeTraceProcessor:
             
         Returns:
             Dictionary with fatigue analysis results
+
+        Raises:
+            NonConservativeCountingError: always, pending issue #3839. This
+                route counts cycles with `signal_analysis.core.rainflow`
+                (`sigproc_astm`), which extracts a maximum stress range below
+                the signal's peak-to-valley span. Counting is left callable for
+                diagnostics; damage is not.
         """
+        from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+        refuse_damage_calculation(
+            "sigproc_astm",
+            "OrcaFlexTimeTraceProcessor._perform_fatigue_analysis",
+        )
+
         from ..signal_analysis import RainflowCounter
         from ..signal_analysis.fatigue import FatigueDamageCalculator, SNCurve
         
@@ -431,7 +450,20 @@ class OrcaFlexTimeTraceProcessor:
     @staticmethod
     def _analyze_single_trace(signal, name, scf, sn_params, 
                              mean_stress_correction, design_life_years, fs):
-        """Analyze single trace (for parallel processing)"""
+        """Analyze single trace (for parallel processing)
+
+        Raises:
+            NonConservativeCountingError: always, pending issue #3839 — see
+                `_perform_fatigue_analysis`. This is the parallel twin of that
+                route and counts through the same non-conservative path.
+        """
+        from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+        refuse_damage_calculation(
+            "sigproc_astm",
+            "OrcaFlexTimeTraceProcessor._analyze_single_trace",
+        )
+
         from ..signal_analysis import RainflowCounter
         from ..signal_analysis.fatigue import FatigueDamageCalculator
         

--- a/src/digitalmodel/solvers/orcaflex/universal/batch_processor.py
+++ b/src/digitalmodel/solvers/orcaflex/universal/batch_processor.py
@@ -14,6 +14,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 import psutil
 from digitalmodel.solvers.orcaflex.core.mock_artifacts import write_mock_artifact
+
+from digitalmodel.solvers.orcaflex.run_state import check_statics
 from digitalmodel.solvers.orcaflex.file_size_optimizer import FileSizeOptimizer
 
 logger = logging.getLogger(__name__)
@@ -294,7 +296,10 @@ class BatchProcessor:
                 
                 # Run static analysis
                 model.CalculateStatics()
-                
+                # #3838: a statics solve that did not reach a static state must
+                # not be saved as a .sim and reported successful.
+                check_statics(model, context=str(model_path))
+
                 # Save simulation
                 sim_file = output_directory / f"{model_path.stem}.sim"
                 model.SaveSimulation(str(sim_file))

--- a/src/digitalmodel/solvers/orcaflex/universal/universal_runner.py
+++ b/src/digitalmodel/solvers/orcaflex/universal/universal_runner.py
@@ -18,6 +18,8 @@ import time
 from digitalmodel.solvers.orcaflex.core.exceptions import LicenseError
 from digitalmodel.solvers.orcaflex.core.mock_artifacts import write_mock_artifact
 
+from digitalmodel.solvers.orcaflex.run_state import check_simulation, check_statics
+
 
 def _mock_mode_requested() -> bool:
     """Whether an unlicensed run was explicitly opted into via the environment.
@@ -433,11 +435,15 @@ class UniversalOrcaFlexRunner:
                 if analysis_type in ['static', 'both']:
                     logger.debug(f"Running static analysis for {model_file.name}")
                     model.CalculateStatics()
-                
+                    # #3838: the state is the only signal of a diverged solve,
+                    # and it is read before the .sim is saved as a success.
+                    check_statics(model, context=str(model_file))
+
                 if analysis_type in ['dynamic', 'both']:
                     logger.debug(f"Running dynamic simulation for {model_file.name}")
                     # Run the simulation
                     model.RunSimulation()
+                    check_simulation(model, context=str(model_file))
                 
                 # Save simulation
                 sim_file = output_dir / f"{model_file.stem}.sim"

--- a/src/digitalmodel/structural/fatigue/__init__.py
+++ b/src/digitalmodel/structural/fatigue/__init__.py
@@ -248,7 +248,23 @@ def quick_fatigue_analysis(stress_time_series,
     -------
     dict
         Quick analysis results including damage, life, and cycles
+
+    Raises
+    ------
+    NonConservativeCountingError
+        Always, pending issue #3839. This function constructs its own
+        ``structural.fatigue.rainflow.RainflowCounter`` (``struct_fatigue``),
+        which extracts a maximum stress range below the signal's peak-to-valley
+        span, so the accumulated damage is understated. It does not route
+        through ``FatigueAnalysisEngine``, so it needs its own refusal.
     """
+    from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+    refuse_damage_calculation(
+        "struct_fatigue",
+        "structural.fatigue.quick_fatigue_analysis",
+    )
+
     import numpy as np
 
     # Get S-N curve

--- a/src/digitalmodel/structural/fatigue/analysis.py
+++ b/src/digitalmodel/structural/fatigue/analysis.py
@@ -329,7 +329,24 @@ class FatigueAnalysisEngine:
         -------
         AnalysisResults
             Comprehensive analysis results
+
+        Raises
+        ------
+        NonConservativeCountingError
+            Always, pending issue #3839. This engine counts cycles with
+            ``structural.fatigue.rainflow.RainflowCounter`` (``struct_fatigue``),
+            which extracts a maximum stress range below the signal's
+            peak-to-valley span (169.556 of 177.1224 on broadband input), so
+            the damage it accumulates is understated. Counting itself remains
+            callable for diagnostics; damage does not.
         """
+        from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+        refuse_damage_calculation(
+            "struct_fatigue",
+            "structural.fatigue.analysis.FatigueAnalysisEngine.analyze_time_series",
+        )
+
         logger.info("Starting time-domain fatigue analysis")
 
         # Validate inputs
@@ -981,7 +998,20 @@ def quick_time_domain_analysis(stress_time_series: AnalysisInput,
     -------
     AnalysisResults
         Analysis results
+
+    Raises
+    ------
+    NonConservativeCountingError
+        Always, pending issue #3839 — see
+        :meth:`FatigueAnalysisEngine.analyze_time_series`, which this wraps.
     """
+    from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+    refuse_damage_calculation(
+        "struct_fatigue",
+        "structural.fatigue.analysis.quick_time_domain_analysis",
+    )
+
     config = FatigueAnalysisConfig(
         sn_standard=sn_standard,
         sn_curve_class=sn_curve_class,

--- a/src/digitalmodel/structural/fatigue_apps/rainflow_counting.py
+++ b/src/digitalmodel/structural/fatigue_apps/rainflow_counting.py
@@ -340,7 +340,26 @@ class RainflowCounter:
         
         Returns:
             Summary DataFrame with all results
+
+        Raises:
+            NonConservativeCountingError: always, pending issue #3839.
+
+                No module imports this class, so there is no in-process damage
+                consumer to block. The hand-off to damage is by file: this is
+                the documented Module 2 step whose ``*_cycles.csv`` output is
+                read by the Module 3 damage calculator
+                (``INPUT_FILE_STRUCTURE.md``), and the counter understates the
+                maximum range (169.556 of a 177.1224 span on broadband input).
+                ``process_time_series`` and ``rainflow_counting_astm`` remain
+                callable for diagnostic use.
         """
+        from digitalmodel.fatigue.counting_contract import refuse_damage_calculation
+
+        refuse_damage_calculation(
+            "fapps_counting",
+            "fatigue_apps.rainflow_counting.RainflowCounter.process_batch",
+        )
+
         input_dir = Path(input_dir)
         files = sorted(input_dir.glob(pattern))
         

--- a/tests/fatigue/test_rainflow_invariants.py
+++ b/tests/fatigue/test_rainflow_invariants.py
@@ -1,0 +1,543 @@
+"""Correctness gate for every cycle-counting path in the repository.
+
+Issue: https://github.com/vamseeachanta/workspace-hub/issues/3839
+Plan:  workspace-hub docs/plans/2026-09-11-issue-3839-rainflow-divergence.md
+
+The contract under test lives in ``digitalmodel.fatigue.counting_contract`` and is
+callable independently of pytest. This module applies it to every registered path
+and, in tests 8 to 10, tests the contract itself: without those the contract is
+unfalsifiable.
+
+Test map (the plan's 14 rows):
+
+===  ======================================================================
+  1  exact distribution over a conforming path against the hand-derived table
+  2  contract over ``pylife_4pt``, four signals
+  3  contract over ``pypi_rainflow``, four signals
+  4  contract over ``fapps_counter``, four signals
+  5  contract over ``sigproc_astm``, broadband — xfail(strict)
+  6  contract over ``calm_buoy``, narrow-band sine — xfail(strict)
+  7  contract over ``fapps_counting`` and ``struct_fatigue``, broadband — xfail(strict)
+  8  a counter returning one full-span half cycle plus fabricated counts
+  9  a counter returning the correct count total but wrong ranges
+ 10  a declared discard-residual counter omitting the span
+ 11  a constant signal
+ 12  a two-point signal
+ 13  each failing path invoked for damage calculation
+ 14  registry completeness over the known fatigue and signal-processing packages
+===  ======================================================================
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from digitalmodel.fatigue.counting_contract import (
+    CONTRACT_EXACT,
+    CONTRACT_SIGNALS,
+    COUNTING_PATHS,
+    ContractViolation,
+    CycleCount,
+    NonConservativeCountingError,
+    ResidualPolicy,
+    assert_counting_contract,
+    assert_exact_distribution,
+    check_counting_contract,
+    peak_to_valley_span,
+    reversals_with_endpoints,
+    unregistered_counting_callables,
+)
+
+ISSUE = "https://github.com/vamseeachanta/workspace-hub/issues/3839"
+
+SIGNAL_KEYS = tuple(CONTRACT_SIGNALS)
+
+
+def run_path(key: str, signal: np.ndarray) -> CycleCount:
+    return COUNTING_PATHS[key].count(signal)
+
+
+def assert_path_contract(key: str, signal_key: str) -> None:
+    path = COUNTING_PATHS[key]
+    signal = CONTRACT_SIGNALS[signal_key]
+    assert_counting_contract(path.count(signal), signal, path.residual_policy)
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity — every path in the issue is registered with a declared policy
+# ---------------------------------------------------------------------------
+
+
+def test_registry_declares_all_seven_paths_with_a_residual_policy():
+    expected = {
+        "pylife_4pt",
+        "pypi_rainflow",
+        "sigproc_astm",
+        "calm_buoy",
+        "fapps_counting",
+        "fapps_counter",
+        "struct_fatigue",
+    }
+    assert set(COUNTING_PATHS) == expected
+    for path in COUNTING_PATHS.values():
+        assert isinstance(path.residual_policy, ResidualPolicy)
+
+
+# ---------------------------------------------------------------------------
+# 1 — exact distribution on the hand-derived fixture
+# ---------------------------------------------------------------------------
+
+
+def test_1_exact_distribution_matches_hand_derived_table():
+    """The literals in CONTRACT_EXACT are hand-derived, never captured."""
+    signal = np.asarray(CONTRACT_EXACT["signal"], dtype=float)
+    result = COUNTING_PATHS["pylife_4pt"].count(signal)
+    assert_exact_distribution(result, CONTRACT_EXACT["expected"])
+
+
+def test_1b_hand_derived_table_is_self_consistent():
+    """The committed table must itself satisfy the contract it is used to check."""
+    signal = np.asarray(CONTRACT_EXACT["signal"], dtype=float)
+    expected = CONTRACT_EXACT["expected"]
+    total = sum(count for _, _, count in expected)
+    assert 2 * total == len(reversals_with_endpoints(signal)) - 1
+    assert max(rng for rng, _, _ in expected) == pytest.approx(
+        peak_to_valley_span(signal)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2, 3, 4 — the conforming paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("signal_key", SIGNAL_KEYS)
+def test_2_contract_pylife_4pt(signal_key):
+    assert_path_contract("pylife_4pt", signal_key)
+
+
+@pytest.mark.parametrize("signal_key", SIGNAL_KEYS)
+def test_3_contract_pypi_rainflow(signal_key):
+    assert_path_contract("pypi_rainflow", signal_key)
+
+
+@pytest.mark.parametrize("signal_key", SIGNAL_KEYS)
+def test_4_contract_fapps_counter(signal_key):
+    assert_path_contract("fapps_counter", signal_key)
+
+
+# ---------------------------------------------------------------------------
+# 5, 6, 7 — the non-conservative paths
+#
+# strict=True: a repair reports as a FAILURE demanding this marker's removal,
+# rather than passing silently as XPASS.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "sigproc_astm does not implement the three-point rule: core/rainflow.py:"
+        "162-164 inverts both the comparison and the extracted range relative to "
+        "ASTM 5.4.4, and every extraction emits 0.5 and pops stack[-2], so the "
+        f"full-cycle rule never fires — {ISSUE}"
+    ),
+)
+def test_5_contract_sigproc_astm_broadband():
+    assert_path_contract("sigproc_astm", "broadband_random")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "calm_buoy_fatigue.py:267 discards the second point of the counted pair "
+        "where ASTM rule 2 discards the first, and :268 breaks instead of "
+        "re-checking the shortened stack; on a pure sine it reports 50.0 of a "
+        f"100.0 span — {ISSUE}"
+    ),
+)
+def test_6_contract_calm_buoy_narrow_band():
+    assert_path_contract("calm_buoy", "narrow_band_sine")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=f"fapps_counting understates the maximum range on broadband input — {ISSUE}",
+)
+def test_7a_contract_fapps_counting_broadband():
+    assert_path_contract("fapps_counting", "broadband_random")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=f"struct_fatigue understates the maximum range on broadband input — {ISSUE}",
+)
+def test_7b_contract_struct_fatigue_broadband():
+    assert_path_contract("struct_fatigue", "broadband_random")
+
+
+# Recorded verdict per (path, signal), measured 2026-09-11 and committed as the
+# behaviour record the deferral argument rests on. `True` means the path
+# satisfies every clause on that signal. Any change — a repair, a regression, or
+# a change to the contract itself — moves a cell and fails here, so the record
+# cannot go stale silently. See
+# docs/domains/fatigue/rainflow-path-exposure-2026-09-11.md.
+RECORDED_VERDICTS = {
+    ("pylife_4pt", "astm_example"): True,
+    ("pylife_4pt", "narrow_band_sine"): True,
+    ("pylife_4pt", "broadband_random"): True,
+    ("pylife_4pt", "residual_dominated"): True,
+    ("pypi_rainflow", "astm_example"): True,
+    ("pypi_rainflow", "narrow_band_sine"): True,
+    ("pypi_rainflow", "broadband_random"): True,
+    ("pypi_rainflow", "residual_dominated"): True,
+    ("fapps_counter", "astm_example"): True,
+    ("fapps_counter", "narrow_band_sine"): True,
+    ("fapps_counter", "broadband_random"): True,
+    ("fapps_counter", "residual_dominated"): True,
+    # clause 1 on three signals; on the sine the maximum range is correct but
+    # 4.5 cycles are emitted as zero-range rows and clause 3 fails instead.
+    ("sigproc_astm", "astm_example"): False,
+    ("sigproc_astm", "narrow_band_sine"): False,
+    ("sigproc_astm", "broadband_random"): False,
+    ("sigproc_astm", "residual_dominated"): False,
+    # clause 1 on all four; clause 3 as well on the ASTM fixture (3.5 of 4.0).
+    ("calm_buoy", "astm_example"): False,
+    ("calm_buoy", "narrow_band_sine"): False,
+    ("calm_buoy", "broadband_random"): False,
+    ("calm_buoy", "residual_dominated"): False,
+    # conforming on the two signals the existing suite covered; clause 1 fails
+    # on broadband and on the residual-dominated ramp.
+    ("fapps_counting", "astm_example"): True,
+    ("fapps_counting", "narrow_band_sine"): True,
+    ("fapps_counting", "broadband_random"): False,
+    ("fapps_counting", "residual_dominated"): False,
+    ("struct_fatigue", "astm_example"): True,
+    ("struct_fatigue", "narrow_band_sine"): True,
+    ("struct_fatigue", "broadband_random"): False,
+    ("struct_fatigue", "residual_dominated"): False,
+}
+
+
+@pytest.mark.parametrize(
+    ("path_key", "signal_key"),
+    sorted(RECORDED_VERDICTS),
+    ids=[f"{p}-{s}" for p, s in sorted(RECORDED_VERDICTS)],
+)
+def test_7c_recorded_verdict_matrix(path_key, signal_key):
+    path = COUNTING_PATHS[path_key]
+    signal = CONTRACT_SIGNALS[signal_key]
+    violations = check_counting_contract(path.count(signal), signal, path.residual_policy)
+    conforms = not violations
+    expected = RECORDED_VERDICTS[(path_key, signal_key)]
+    assert conforms is expected, (
+        f"{path_key} on {signal_key}: recorded {expected}, measured {conforms}.\n"
+        + "\n".join(violations)
+        + f"\nUpdate RECORDED_VERDICTS and the exposure record together — {ISSUE}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8, 9, 10 — the contract's own tests
+# ---------------------------------------------------------------------------
+
+
+def test_8_fabricated_counts_fail_clause_3():
+    """Clauses 1 and 2 alone are not sufficient.
+
+    This fake counter emits exactly one half cycle at the full peak-to-valley
+    span — satisfying clause 1 and clause 2 — and then fabricates additional
+    counts at smaller ranges. Only the exact count-conservation equality of
+    clause 3 rejects it.
+    """
+    signal = CONTRACT_SIGNALS["astm_example"]
+    span = peak_to_valley_span(signal)
+    fabricated = CycleCount(
+        ranges=np.array([span, span / 3.0]),
+        counts=np.array([0.5, 7.0]),
+        means=np.array([0.5, 0.0]),
+    )
+
+    violations = check_counting_contract(fabricated, signal, ResidualPolicy.RETAIN)
+    assert violations, "the contract accepted a fabricated count distribution"
+    assert any(v.startswith("clause 3") for v in violations), violations
+    assert not any(v.startswith("clause 1") for v in violations), violations
+    assert not any(v.startswith("clause 2") for v in violations), violations
+
+    with pytest.raises(ContractViolation):
+        assert_counting_contract(fabricated, signal, ResidualPolicy.RETAIN)
+
+
+def test_9_correct_total_wrong_ranges_fails():
+    """Correct count conservation does not license arbitrary ranges."""
+    signal = CONTRACT_SIGNALS["astm_example"]
+    span = peak_to_valley_span(signal)
+    n_rev = len(reversals_with_endpoints(signal))
+    total = (n_rev - 1) / 2.0
+
+    wrong = CycleCount(
+        ranges=np.full(int(total * 2), span / 2.0),
+        counts=np.full(int(total * 2), 0.5),
+        means=np.zeros(int(total * 2)),
+    )
+
+    violations = check_counting_contract(wrong, signal, ResidualPolicy.RETAIN)
+    assert any(v.startswith("clause 1") for v in violations), violations
+    assert not any(v.startswith("clause 3") for v in violations), violations
+
+    with pytest.raises(ContractViolation):
+        assert_exact_distribution(wrong, CONTRACT_EXACT["expected"])
+
+
+def test_10_declared_discard_residual_counter_passes():
+    """Clause 1 is conditional, and must not condemn a valid convention.
+
+    A discard-residual implementation legitimately omits the global span when
+    the span appears only in the residual. The contract must accept it.
+    """
+    signal = CONTRACT_SIGNALS["astm_example"]
+    span = peak_to_valley_span(signal)
+
+    # The closed cycles of the ASTM fixture only: the span (9.0) lives in the
+    # residual, so a discard-residual counter never emits it.
+    discarding = CycleCount(
+        ranges=np.array([4.0]),
+        counts=np.array([1.0]),
+        means=np.array([1.0]),
+    )
+
+    assert max(discarding.ranges) < span
+    assert check_counting_contract(discarding, signal, ResidualPolicy.DISCARD) == []
+    assert_counting_contract(discarding, signal, ResidualPolicy.DISCARD)
+
+    # The identical result under a RETAIN declaration must be rejected.
+    retained_violations = check_counting_contract(
+        discarding, signal, ResidualPolicy.RETAIN
+    )
+    assert any(v.startswith("clause 1") for v in retained_violations)
+
+
+def test_10b_discard_residual_may_not_manufacture_cycles():
+    """DISCARD relaxes clause 3's equality to an inequality, not to nothing."""
+    signal = CONTRACT_SIGNALS["astm_example"]
+    n_rev = len(reversals_with_endpoints(signal))
+    too_many = CycleCount(
+        ranges=np.full(20, 4.0),
+        counts=np.full(20, 1.0),
+        means=np.zeros(20),
+    )
+    assert 2 * float(np.sum(too_many.counts)) > n_rev - 1
+    violations = check_counting_contract(too_many, signal, ResidualPolicy.DISCARD)
+    assert any(v.startswith("clause 3") for v in violations), violations
+
+
+# ---------------------------------------------------------------------------
+# 11, 12 — degenerate signals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["pylife_4pt", "pypi_rainflow", "fapps_counter"])
+def test_11_constant_signal(key):
+    """Zero span is handled without division and without a damaging cycle.
+
+    The three conforming paths disagree here, and both conventions are
+    admitted: pyLife and the PyPI package emit one zero-range half cycle,
+    ``fapps_counter`` emits nothing. A zero range contributes exactly zero
+    damage, so neither is wrong; what the contract must reject is a zero-range
+    row emitted for a signal that moves, which test_11b covers.
+    """
+    signal = np.full(64, 7.5)
+    assert peak_to_valley_span(signal) == 0.0
+    assert len(reversals_with_endpoints(signal)) == 1
+
+    result = COUNTING_PATHS[key].count(signal)
+    damaging = result.ranges[result.ranges > 0.0]
+    assert damaging.size == 0
+    assert_counting_contract(result, signal, COUNTING_PATHS[key].residual_policy)
+
+
+def test_11b_zero_range_row_is_rejected_when_the_signal_moves():
+    signal = CONTRACT_SIGNALS["astm_example"]
+    padded = CycleCount(
+        ranges=np.array([9.0, 0.0, 0.0]),
+        counts=np.array([0.5, 3.0, 0.5]),
+        means=np.array([0.5, 0.0, 0.0]),
+    )
+    violations = check_counting_contract(padded, signal, ResidualPolicy.RETAIN)
+    assert any("zero-range" in v for v in violations), violations
+
+
+@pytest.mark.parametrize("key", ["pylife_4pt", "fapps_counter"])
+def test_12_two_point_signal(key):
+    """A single ramp is one half cycle at the full span."""
+    signal = np.array([0.0, 10.0])
+    assert peak_to_valley_span(signal) == 10.0
+    assert len(reversals_with_endpoints(signal)) == 2
+
+    result = COUNTING_PATHS[key].count(signal)
+    assert float(np.sum(result.counts)) == pytest.approx(0.5)
+    assert_counting_contract(result, signal, COUNTING_PATHS[key].residual_policy)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Divergence found by this gate, not by the issue: rainflow 3.2.0's "
+        "extract_cycles returns nothing for a two-sample series, so the single "
+        "half cycle at the full span is lost. Third-party behaviour, degenerate "
+        "input, recorded rather than hidden — see the exposure record for #3839."
+    ),
+)
+def test_12b_pypi_rainflow_two_point_signal():
+    signal = np.array([0.0, 10.0])
+    path = COUNTING_PATHS["pypi_rainflow"]
+    assert_counting_contract(path.count(signal), signal, path.residual_policy)
+
+
+# ---------------------------------------------------------------------------
+# 13 — refusal of damage calculation
+# ---------------------------------------------------------------------------
+
+
+def _dummy_self(cls):
+    """An uninitialised instance, sufficient because refusal is the first statement."""
+    return cls.__new__(cls)
+
+
+def _damage_calls():
+    """(path_key, label, thunk) for every damage entry point bound to a failing path."""
+    calls = []
+
+    def sigproc_perform():
+        from digitalmodel.solvers.orcaflex.time_trace_processor import (
+            OrcaFlexTimeTraceProcessor,
+        )
+
+        OrcaFlexTimeTraceProcessor._perform_fatigue_analysis(
+            _dummy_self(OrcaFlexTimeTraceProcessor), None
+        )
+
+    def sigproc_single():
+        from digitalmodel.solvers.orcaflex.time_trace_processor import (
+            OrcaFlexTimeTraceProcessor,
+        )
+
+        OrcaFlexTimeTraceProcessor._analyze_single_trace(
+            None, "x", 1.0, {}, None, 25.0, 1.0
+        )
+
+    calls += [
+        ("sigproc_astm", "OrcaFlexTimeTraceProcessor._perform_fatigue_analysis", sigproc_perform),
+        ("sigproc_astm", "OrcaFlexTimeTraceProcessor._analyze_single_trace", sigproc_single),
+    ]
+
+    def calm_compute_life():
+        from digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue import (
+            CHAIN_SN_SEAWATER,
+            compute_fatigue_life,
+        )
+
+        compute_fatigue_life(None, CHAIN_SN_SEAWATER)
+
+    def calm_scatter():
+        from digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue import (
+            CHAIN_SN_SEAWATER,
+            ScatterDiagramFatigue,
+        )
+
+        ScatterDiagramFatigue(sn_curve=CHAIN_SN_SEAWATER).compute(None, {})
+
+    calls += [
+        ("calm_buoy", "calm_buoy_fatigue.compute_fatigue_life", calm_compute_life),
+        ("calm_buoy", "ScatterDiagramFatigue.compute", calm_scatter),
+    ]
+
+    def fapps_batch():
+        from digitalmodel.structural.fatigue_apps.rainflow_counting import (
+            RainflowCounter,
+        )
+
+        RainflowCounter.process_batch(_dummy_self(RainflowCounter), ".")
+
+    calls += [("fapps_counting", "rainflow_counting.RainflowCounter.process_batch", fapps_batch)]
+
+    def struct_engine():
+        from digitalmodel.structural.fatigue.analysis import FatigueAnalysisEngine
+
+        FatigueAnalysisEngine.analyze_time_series(
+            _dummy_self(FatigueAnalysisEngine), None
+        )
+
+    def struct_quick_tds():
+        from digitalmodel.structural.fatigue.analysis import quick_time_domain_analysis
+
+        quick_time_domain_analysis(None)
+
+    def struct_quick():
+        from digitalmodel.structural.fatigue import quick_fatigue_analysis
+
+        quick_fatigue_analysis(None)
+
+    calls += [
+        ("struct_fatigue", "FatigueAnalysisEngine.analyze_time_series", struct_engine),
+        ("struct_fatigue", "analysis.quick_time_domain_analysis", struct_quick_tds),
+        ("struct_fatigue", "structural.fatigue.quick_fatigue_analysis", struct_quick),
+    ]
+
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("path_key", "label", "thunk"),
+    _damage_calls(),
+    ids=[f"{k}::{label}" for k, label, _ in _damage_calls()],
+)
+def test_13_failing_path_refuses_damage_calculation(path_key, label, thunk):
+    with pytest.raises(NonConservativeCountingError) as excinfo:
+        thunk()
+    message = str(excinfo.value)
+    assert "3839" in message, message
+    assert path_key in message, message
+
+
+def test_13b_every_failing_path_has_at_least_one_refusing_entry_point():
+    failing = {
+        key for key, path in COUNTING_PATHS.items() if path.contract_status == "non-conservative"
+    }
+    covered = {key for key, _, _ in _damage_calls()}
+    assert failing == covered, (failing, covered)
+
+
+def test_13c_conforming_paths_are_not_blocked():
+    """Refusal must not spread to a path the contract accepts."""
+    for key in ("pylife_4pt", "pypi_rainflow", "fapps_counter"):
+        assert COUNTING_PATHS[key].damage_entry_points == ()
+
+
+def test_13d_cycle_counting_itself_remains_callable():
+    """Refusal targets damage, not the diagnostic use of the counters."""
+    for key in COUNTING_PATHS:
+        result = COUNTING_PATHS[key].count(CONTRACT_SIGNALS["astm_example"])
+        assert len(result.ranges) > 0
+
+
+# ---------------------------------------------------------------------------
+# 14 — registry completeness
+# ---------------------------------------------------------------------------
+
+
+def test_14_registry_completeness_over_known_packages():
+    """A counting-named callable in the known packages cannot be added unregistered.
+
+    Scope, stated honestly: this is a name-pattern scan over the fatigue and
+    signal-processing packages named in COUNTING_SCAN_PACKAGES. A counting
+    implementation under a novel name, or in an unrelated package, escapes it.
+    The gate does not claim otherwise.
+    """
+    unregistered = unregistered_counting_callables()
+    assert unregistered == [], (
+        "counting-named callables found that no registered path claims:\n  "
+        + "\n  ".join(unregistered)
+        + f"\n\nRegister each in COUNTING_PATHS[...].implementations — {ISSUE}"
+    )

--- a/tests/marine_ops/marine_engineering/test_calm_buoy_fatigue.py
+++ b/tests/marine_ops/marine_engineering/test_calm_buoy_fatigue.py
@@ -32,6 +32,27 @@ from digitalmodel.marine_ops.marine_engineering.calm_buoy_fatigue import (
     WIRE_ROPE_SN_SEAWATER,
     compute_fatigue_life,
 )
+from digitalmodel.fatigue.counting_contract import NonConservativeCountingError
+
+# Issue #3839: RainflowFatigue.count_cycles extracts a maximum tension range below the
+# history's peak-to-valley span (50.0 of a 100.0 span on a pure sine), so damage
+# accumulated from it is understated. `ScatterDiagramFatigue.compute` and
+# `compute_fatigue_life` — the two damage entry points bound to that counter — now
+# refuse. The assertions below are preserved verbatim rather than rewritten, and marked
+# expected-fail against the refusal; strict=True turns a repair into a failure demanding
+# this marker's removal and a re-review of the numbers asserted here.
+#
+# Cost recorded rather than hidden: the refusal is unconditional and precedes input
+# validation, so `test_scatter_probabilities_must_sum_to_one`,
+# `test_missing_seastate_tension_raises_keyerror` and
+# `test_compute_requires_either_csv_or_scatter` no longer exercise the validation they
+# were written for. Those validations guard a calculation that cannot run.
+# https://github.com/vamseeachanta/workspace-hub/issues/3839
+_REFUSED_3839 = pytest.mark.xfail(
+    raises=NonConservativeCountingError,
+    strict=True,
+    reason="calm_buoy refuses damage calculation pending #3839",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +347,7 @@ class TestMinersRuleDamage:
 # 5. ScatterDiagramFatigue
 # ---------------------------------------------------------------------------
 
+@_REFUSED_3839
 class TestScatterDiagramFatigue:
     """Unit tests for scatter-diagram weighted damage."""
 
@@ -490,6 +512,7 @@ class TestMooringLineResult:
 # 8. compute_fatigue_life integration function
 # ---------------------------------------------------------------------------
 
+@_REFUSED_3839
 class TestComputeFatigueLife:
     """Integration tests for the top-level convenience function."""
 

--- a/tests/solvers/orcaflex/modular_generator/test_collection_collision.py
+++ b/tests/solvers/orcaflex/modular_generator/test_collection_collision.py
@@ -1,0 +1,278 @@
+"""Tests for the OrcaFlex collection-key collision check.
+
+An OrcaFlex text data file encodes an object collection two ways, with
+different semantics:
+
+- a name-keyed **mapping** (``LineTypes:`` then ``MyType:`` then fields)
+  PATCHES the collection;
+- a **list** of ``- Name:`` entries REPLACES the whole collection, so any
+  object not listed is deleted.
+
+The modular generator emits list style, which is correct for authoring but
+safe only while each collection is written by exactly one includefile.  Two
+includefiles emitting the same collection key in list style means the later
+one silently deletes everything the earlier one created.  The check under
+test fails closed on that condition.
+
+Test-pair dependency, do not delete one without the other:
+``test_calm_buoy_template_passes`` (real committed template set, no
+regression) is meaningless unless ``test_two_list_style_emitters_collide``
+proves the check fires at all.  A check that never raises passes the
+template test trivially.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digitalmodel.solvers.orcaflex.modular_generator.post_validator import (
+    CollectionCollisionError,
+    check_collection_collisions,
+)
+
+CALM_BUOY_TEMPLATE = (
+    Path(__file__).resolve().parents[4]
+    / "docs"
+    / "domains"
+    / "orcaflex"
+    / "templates"
+    / "mooring_systems"
+    / "calm_buoy"
+    / "master.yml"
+)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _write_model(root: Path, master_entries: list[str], files: dict[str, str]) -> Path:
+    """Write a master file plus its includes under *root*.
+
+    Args:
+        root: Directory to build the model in.
+        master_entries: Include paths, relative to *root*, in composition order.
+        files: Mapping of relative path -> file body.
+
+    Returns:
+        Path to the written ``master.yml``.
+    """
+    for rel_path, body in files.items():
+        target = root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+
+    master = root / "master.yml"
+    master.write_text(
+        "%YAML 1.1\n---\n"
+        + "".join(f"- includefile: {entry}\n" for entry in master_entries),
+        encoding="utf-8",
+    )
+    return master
+
+
+_LIST_STYLE_LINE_TYPES_A = """\
+LineTypes:
+  - Name: Chain_84mm_R4
+    Category: General
+    OD: 0.084
+"""
+
+_LIST_STYLE_LINE_TYPES_B = """\
+LineTypes:
+  - Name: Wire_90mm
+    Category: General
+    OD: 0.090
+"""
+
+_MAPPING_STYLE_LINE_TYPES = """\
+LineTypes:
+  Chain_84mm_R4:
+    OD: 0.084
+"""
+
+_MAPPING_STYLE_LINE_TYPES_B = """\
+LineTypes:
+  Wire_90mm:
+    OD: 0.090
+"""
+
+
+# ----------------------------------------------------------------------
+# Test 1 — the check fires (paired with test 6)
+# ----------------------------------------------------------------------
+
+
+def test_two_list_style_emitters_collide(tmp_path: Path) -> None:
+    """Two includefiles emitting LineTypes in list style must fail closed.
+
+    Paired with ``test_calm_buoy_template_passes`` — that test is
+    meaningless without this one.
+    """
+    master = _write_model(
+        tmp_path,
+        ["includes/05_line_types.yml", "includes/09_more_line_types.yml"],
+        {
+            "includes/05_line_types.yml": _LIST_STYLE_LINE_TYPES_A,
+            "includes/09_more_line_types.yml": _LIST_STYLE_LINE_TYPES_B,
+        },
+    )
+
+    with pytest.raises(CollectionCollisionError) as exc_info:
+        check_collection_collisions(master)
+
+    message = str(exc_info.value)
+    assert "LineTypes" in message
+    assert "includes/05_line_types.yml" in message
+    assert "includes/09_more_line_types.yml" in message
+
+
+# ----------------------------------------------------------------------
+# Test 2 — one list, one mapping
+# ----------------------------------------------------------------------
+
+
+def test_list_plus_mapping_passes(tmp_path: Path) -> None:
+    """A mapping patches the collection, so it does not collide with a list."""
+    master = _write_model(
+        tmp_path,
+        ["includes/05_line_types.yml", "includes/10_patch.yml"],
+        {
+            "includes/05_line_types.yml": _LIST_STYLE_LINE_TYPES_A,
+            "includes/10_patch.yml": _MAPPING_STYLE_LINE_TYPES,
+        },
+    )
+
+    result = check_collection_collisions(master)
+
+    assert result.collisions == []
+    styles = [style for _, style in result.emitters["LineTypes"]]
+    assert styles == ["list", "mapping"]
+
+
+# ----------------------------------------------------------------------
+# Test 3 — two mappings
+# ----------------------------------------------------------------------
+
+
+def test_two_mapping_style_emitters_pass(tmp_path: Path) -> None:
+    """Two mapping-style emitters both patch; neither replaces."""
+    master = _write_model(
+        tmp_path,
+        ["includes/a.yml", "includes/b.yml"],
+        {
+            "includes/a.yml": _MAPPING_STYLE_LINE_TYPES,
+            "includes/b.yml": _MAPPING_STYLE_LINE_TYPES_B,
+        },
+    )
+
+    result = check_collection_collisions(master)
+
+    assert result.collisions == []
+
+
+# ----------------------------------------------------------------------
+# Test 4 — one collection per includefile
+# ----------------------------------------------------------------------
+
+
+def test_one_collection_per_includefile_passes(tmp_path: Path) -> None:
+    """The shape the generator emits must remain valid."""
+    master = _write_model(
+        tmp_path,
+        [
+            "includes/05_line_types.yml",
+            "includes/06_vessels.yml",
+            "includes/07_lines.yml",
+            "includes/08_buoys.yml",
+        ],
+        {
+            "includes/05_line_types.yml": _LIST_STYLE_LINE_TYPES_A,
+            "includes/06_vessels.yml": "Vessels:\n  - Name: FPSO\n",
+            "includes/07_lines.yml": "Lines:\n  - Name: Mooring1\n",
+            "includes/08_buoys.yml": "6DBuoys:\n  - Name: CALM Buoy\n",
+        },
+    )
+
+    result = check_collection_collisions(master)
+
+    assert result.collisions == []
+    assert result.unrecognised == []
+    assert len(result.composed_files) == 4
+
+
+# ----------------------------------------------------------------------
+# Test 5 — collision outside the composition
+# ----------------------------------------------------------------------
+
+
+def test_collision_in_unreferenced_file_passes(tmp_path: Path) -> None:
+    """Only files the master actually composes are in scope."""
+    master = _write_model(
+        tmp_path,
+        ["includes/05_line_types.yml"],
+        {
+            "includes/05_line_types.yml": _LIST_STYLE_LINE_TYPES_A,
+            # Present in includes/ but never referenced by the master.
+            "includes/99_orphan_line_types.yml": _LIST_STYLE_LINE_TYPES_B,
+        },
+    )
+
+    result = check_collection_collisions(master)
+
+    assert result.collisions == []
+    composed = {path.name for path in result.composed_files}
+    assert "99_orphan_line_types.yml" not in composed
+
+
+# ----------------------------------------------------------------------
+# Test 6 — the real committed template set (paired with test 1)
+# ----------------------------------------------------------------------
+
+
+def test_calm_buoy_template_passes() -> None:
+    """The committed CALM-buoy template must pass unchanged.
+
+    Paired with ``test_two_list_style_emitters_collide``, which proves the
+    check fires; without it this test passes trivially.
+    """
+    assert CALM_BUOY_TEMPLATE.is_file(), f"template missing: {CALM_BUOY_TEMPLATE}"
+
+    result = check_collection_collisions(CALM_BUOY_TEMPLATE)
+
+    assert result.collisions == []
+    assert result.unrecognised == [], (
+        "every top-level key in the committed template must be recognised; "
+        f"unrecognised: {result.unrecognised}"
+    )
+    assert len(result.composed_files) == 8
+
+
+# ----------------------------------------------------------------------
+# Test 7 — unrecognised top-level key
+# ----------------------------------------------------------------------
+
+
+def test_unrecognised_top_level_key_is_surfaced(tmp_path: Path) -> None:
+    """An unknown top-level key is reported, never silently ignored."""
+    master = _write_model(
+        tmp_path,
+        ["includes/05_line_types.yml", "includes/50_unknown.yml"],
+        {
+            "includes/05_line_types.yml": _LIST_STYLE_LINE_TYPES_A,
+            "includes/50_unknown.yml": "NotARealOrcaFlexSection:\n  - Name: X\n",
+        },
+    )
+
+    result = check_collection_collisions(master)
+
+    assert result.collisions == []
+    assert ("includes/50_unknown.yml", "NotARealOrcaFlexSection") in result.unrecognised
+    assert any(
+        warning.category == "unrecognised"
+        and "NotARealOrcaFlexSection" in warning.message
+        for warning in result.warnings
+    )

--- a/tests/solvers/orcaflex/test_run_state_gating.py
+++ b/tests/solvers/orcaflex/test_run_state_gating.py
@@ -1,0 +1,231 @@
+"""Defect 3 of workspace-hub#3838 -- an unstable OrcaFlex run reports success.
+
+``RunSimulation`` returns ``stOK`` while setting the model to
+``SimulationStoppedUnstable``, so exception-only handling ships a diverged run as
+good. The remedy under test is
+``digitalmodel.solvers.orcaflex.run_state``: one gate the run paths call after a
+solve completes.
+
+Every case here drives a stubbed model state, so none of them needs an OrcaFlex
+licence. The two cases that read the vendor enum need only the import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os.path
+
+import pytest
+
+from digitalmodel.solvers.orcaflex import run_state
+
+ORCFXAPI_INSTALLED = importlib.util.find_spec("OrcFxAPI") is not None
+
+
+class _EnumLikeState:
+    """Stands in for ``OrcFxAPI.ModelState``: carries a name, prints as an int.
+
+    The vendor enum is an ``IntEnum``, so ``str()`` of a member is the integer
+    value, not the member name. A gate that compares ``str(model.state)`` to a
+    list of names therefore never matches anything.
+    """
+
+    def __init__(self, name: str, value: int):
+        self.name = name
+        self._name_ = name
+        self.value = value
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class _StubModel:
+    def __init__(self, state):
+        self.state = state
+
+
+def _model(state_name: str) -> _StubModel:
+    values = {
+        "Reset": 0,
+        "CalculatingStatics": 1,
+        "InStaticState": 2,
+        "RunningSimulation": 3,
+        "SimulationStopped": 4,
+        "SimulationStoppedUnstable": 5,
+    }
+    return _StubModel(_EnumLikeState(state_name, values[state_name]))
+
+
+# ---------------------------------------------------------------------------
+# Test 13 -- a run completing in SimulationStoppedUnstable is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_unstable_simulation_is_rejected():
+    with pytest.raises(run_state.SimulationStateError) as excinfo:
+        run_state.check_simulation(_model("SimulationStoppedUnstable"), context="run.sim")
+
+    message = str(excinfo.value)
+    assert "SimulationStoppedUnstable" in message
+    assert "run.sim" in message
+
+
+def test_unstable_statics_is_rejected():
+    with pytest.raises(run_state.SimulationStateError):
+        run_state.check_statics(_model("SimulationStoppedUnstable"), context="statics")
+
+
+# ---------------------------------------------------------------------------
+# Test 14 -- a run completing in SimulationStopped is accepted
+# ---------------------------------------------------------------------------
+
+
+def test_completed_simulation_is_accepted():
+    assert run_state.check_simulation(_model("SimulationStopped")) == "SimulationStopped"
+
+
+def test_completed_statics_is_accepted():
+    assert run_state.check_statics(_model("InStaticState")) == "InStaticState"
+
+
+def test_simulation_stopped_is_accepted_by_the_statics_gate():
+    assert run_state.check_statics(_model("SimulationStopped")) == "SimulationStopped"
+
+
+# ---------------------------------------------------------------------------
+# Incomplete runs are rejected too -- the gate is about the state, not only
+# about instability.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["Reset", "InStaticState", "RunningSimulation"])
+def test_simulation_gate_rejects_states_that_are_not_a_finished_dynamic_run(name):
+    with pytest.raises(run_state.SimulationStateError):
+        run_state.check_simulation(_model(name))
+
+
+@pytest.mark.parametrize("name", ["Reset", "CalculatingStatics"])
+def test_statics_gate_rejects_states_that_are_not_a_finished_solve(name):
+    with pytest.raises(run_state.SimulationStateError):
+        run_state.check_statics(_model(name))
+
+
+# ---------------------------------------------------------------------------
+# The name resolution the gate depends on
+# ---------------------------------------------------------------------------
+
+
+def test_state_name_prefers_the_member_name_over_str():
+    """``str(state)`` is the integer, so the name must come from ``.name``."""
+    model = _model("SimulationStopped")
+    assert str(model.state) == "4"
+    assert run_state.state_name(model) == "SimulationStopped"
+
+
+def test_an_unresolvable_state_is_indeterminate_and_does_not_raise():
+    """A test double whose state is not an OrcaFlex state must pass through.
+
+    The gate is added to paths that existing tests already drive with mocks. It
+    must reject a state it recognises as bad, never a state it cannot read.
+    """
+
+    class _Opaque:
+        pass
+
+    assert run_state.state_name(_StubModel(_Opaque())) is None
+    assert run_state.check_simulation(_StubModel(_Opaque())) is None
+    assert run_state.check_statics(_StubModel(_Opaque())) is None
+
+
+def test_a_model_without_a_state_attribute_is_indeterminate():
+    class _NoState:
+        pass
+
+    assert run_state.state_name(_NoState()) is None
+    assert run_state.check_simulation(_NoState()) is None
+
+
+def test_an_undefined_vendor_state_is_rejected():
+    """``IntEnumAllowsUndefined`` fabricates ``UNDEFINED_<n>`` members. An
+    unrecognised state coming back from the solver is not a pass."""
+    with pytest.raises(run_state.SimulationStateError):
+        run_state.check_simulation(_StubModel(_EnumLikeState("UNDEFINED_9", 9)))
+
+
+@pytest.mark.solver
+@pytest.mark.skipif(not ORCFXAPI_INSTALLED, reason="OrcFxAPI is not installed")
+def test_vendor_enum_members_resolve_by_name():
+    """Importing OrcFxAPI claims no licence; only constructing a Model does."""
+    import OrcFxAPI
+
+    assert str(OrcFxAPI.ModelState.SimulationStopped) != "SimulationStopped", (
+        "the premise of this defect: str() of the vendor enum is not its name"
+    )
+    assert (
+        run_state.state_name(_StubModel(OrcFxAPI.ModelState.SimulationStopped))
+        == "SimulationStopped"
+    )
+    assert (
+        run_state.state_name(_StubModel(OrcFxAPI.ModelState.SimulationStoppedUnstable))
+        == "SimulationStoppedUnstable"
+    )
+    with pytest.raises(run_state.SimulationStateError):
+        run_state.check_simulation(
+            _StubModel(OrcFxAPI.ModelState.SimulationStoppedUnstable)
+        )
+
+
+@pytest.mark.solver
+@pytest.mark.skipif(not ORCFXAPI_INSTALLED, reason="OrcFxAPI is not installed")
+def test_the_gate_covers_every_state_the_vendor_enum_defines():
+    """A state the gate does not know is a state it cannot judge, so the known
+    set must track the vendor enum rather than a hand-copied list."""
+    import OrcFxAPI
+
+    vendor = {
+        name
+        for name in dir(OrcFxAPI.ModelState)
+        if not name.startswith("_") and isinstance(
+            getattr(OrcFxAPI.ModelState, name), OrcFxAPI.ModelState
+        )
+    }
+    assert vendor == set(run_state.KNOWN_STATES)
+
+
+# ---------------------------------------------------------------------------
+# The load-time gate in orcaflex_analysis_components
+# ---------------------------------------------------------------------------
+
+
+def test_loaded_simulation_in_an_unstable_state_is_not_returned(monkeypatch):
+    from digitalmodel.solvers.orcaflex import orcaflex_analysis_components as oac
+
+    analysis = oac.OrcaFlexAnalysis.__new__(oac.OrcaFlexAnalysis)
+    unstable = _model("SimulationStoppedUnstable")
+
+    monkeypatch.setattr(os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(
+        oac.OrcaFlexAnalysis, "loadSimulation", lambda self, name: unstable
+    )
+    monkeypatch.setattr(
+        oac.OrcaFlexAnalysis, "get_SimulationFileName", lambda self, name: "x.sim"
+    )
+
+    assert analysis.get_model_from_filename("x.yml") is None
+
+
+def test_loaded_simulation_in_a_stopped_state_is_returned(monkeypatch):
+    from digitalmodel.solvers.orcaflex import orcaflex_analysis_components as oac
+
+    analysis = oac.OrcaFlexAnalysis.__new__(oac.OrcaFlexAnalysis)
+    stopped = _model("SimulationStopped")
+
+    monkeypatch.setattr(os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(
+        oac.OrcaFlexAnalysis, "loadSimulation", lambda self, name: stopped
+    )
+    monkeypatch.setattr(
+        oac.OrcaFlexAnalysis, "get_SimulationFileName", lambda self, name: "x.sim"
+    )
+
+    assert analysis.get_model_from_filename("x.yml") is stopped

--- a/tests/solvers/orcaflex/test_solver_version_record.py
+++ b/tests/solvers/orcaflex/test_solver_version_record.py
@@ -1,0 +1,334 @@
+"""Defect 2 of workspace-hub#3838 -- the OrcaFlex solver version is unpinned.
+
+``OrcFxAPI`` binds to the highest-numbered installed OrcaFlex unless
+``OrcFxAPIConfig.setLibPath()`` is called BEFORE ``import OrcFxAPI``. An OrcaFlex
+upgrade therefore changes the solver under every campaign with no record of it.
+
+The remedy under test is the facade ``digitalmodel.solvers.orcaflex.orcaflex_api``:
+it owns the import, selects the library when a version is requested, and records
+what was actually resolved so a run manifest can carry it.
+
+Import state is process-global and cannot be reset inside a pytest session -- a
+single earlier ``import OrcFxAPI`` anywhere in the session would decide the
+outcome of every case below. Every case that touches ``configure()`` therefore
+runs in a fresh subprocess.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ORCAFLEX_PKG = REPO_ROOT / "src" / "digitalmodel" / "solvers" / "orcaflex"
+
+ORCFXAPI_INSTALLED = importlib.util.find_spec("OrcFxAPI") is not None
+requires_orcfxapi = pytest.mark.skipif(
+    not ORCFXAPI_INSTALLED, reason="OrcFxAPI is not installed on this host"
+)
+
+
+def _probe(code: str) -> dict:
+    """Run ``code`` in a fresh interpreter and return its RESULT payload.
+
+    The snippet must print exactly one line beginning ``RESULT:`` followed by a
+    JSON object. A non-zero exit or a missing marker fails the calling test with
+    the full child output attached, so a broken snippet is never read as a pass.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    detail = f"\n--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    assert proc.returncode == 0, f"subprocess exited {proc.returncode}{detail}"
+    markers = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT:")]
+    assert len(markers) == 1, f"expected exactly one RESULT line{detail}"
+    return json.loads(markers[0][len("RESULT:") :])
+
+
+# ---------------------------------------------------------------------------
+# Test 8 -- version requested and available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.solver
+@requires_orcfxapi
+def test_requested_version_is_selected_and_recorded():
+    out = _probe(
+        """
+        import json, os
+        from digitalmodel.solvers.orcaflex import orcaflex_api
+
+        versions = orcaflex_api.installed_versions()
+        if not versions:
+            print("RESULT:" + json.dumps({"skip": "no versioned OrcaFlex install"}))
+        else:
+            wanted = sorted(versions)[-1]
+            expected = os.path.normcase(os.path.abspath(versions[wanted]))
+            record = orcaflex_api.configure(wanted)
+            record["resolved_lib_path"] = os.path.normcase(
+                os.path.abspath(record["resolved_lib_path"])
+            )
+            print("RESULT:" + json.dumps(
+                {"record": record, "wanted": wanted, "expected": expected}
+            ))
+        """
+    )
+    if "skip" in out:
+        pytest.skip(out["skip"])
+
+    record = out["record"]
+    assert record["requested"] == out["wanted"]
+    assert record["resolved_lib_path"] == out["expected"]
+    assert record["resolved_version"], "resolved_version must be populated"
+
+
+# ---------------------------------------------------------------------------
+# Test 9 -- no version requested
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.solver
+@requires_orcfxapi
+def test_record_is_complete_when_no_version_is_requested():
+    out = _probe(
+        """
+        import json
+        from digitalmodel.solvers.orcaflex import orcaflex_api
+        print("RESULT:" + json.dumps({"record": orcaflex_api.configure()}))
+        """
+    )
+    record = out["record"]
+    assert record["requested"] is None
+    assert record["resolved_lib_path"], "resolved_lib_path must be recorded"
+    assert record["resolved_version"], "resolved_version must be recorded"
+
+
+# ---------------------------------------------------------------------------
+# Test 10 -- version requested but absent
+# ---------------------------------------------------------------------------
+
+
+def test_absent_version_raises_naming_the_requested_version():
+    out = _probe(
+        """
+        import json
+        from digitalmodel.solvers.orcaflex import orcaflex_api
+        try:
+            orcaflex_api.configure("99.99-not-installed")
+        except Exception as exc:
+            print("RESULT:" + json.dumps(
+                {"type": type(exc).__name__, "message": str(exc)}
+            ))
+        else:
+            print("RESULT:" + json.dumps({"type": None, "message": ""}))
+        """
+    )
+    assert out["type"] == "OrcaFlexVersionUnavailableError", out
+    assert "99.99-not-installed" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# Test 11 -- configure() after OrcFxAPI is already imported
+# ---------------------------------------------------------------------------
+
+
+def test_configure_after_import_raises_naming_the_earlier_importer():
+    """A stand-in module is registered as ``OrcFxAPI`` so this case needs no
+    OrcaFlex install and no licence; what is under test is the ordering check,
+    not the binding."""
+    out = _probe(
+        """
+        import json, sys, types
+
+        # Import the facade FIRST so the package initialisation is not the thing
+        # that trips the check -- the case under test is a LATER importer.
+        from digitalmodel.solvers.orcaflex import orcaflex_api
+
+        stand_in = types.ModuleType("OrcFxAPI")
+        sys.modules["OrcFxAPI"] = stand_in
+        earlier = types.ModuleType("campaign_module_that_imported_first")
+        earlier.OrcFxAPI = stand_in
+        sys.modules["campaign_module_that_imported_first"] = earlier
+
+        try:
+            orcaflex_api.configure("11.6")
+        except Exception as exc:
+            print("RESULT:" + json.dumps(
+                {"type": type(exc).__name__, "message": str(exc)}
+            ))
+        else:
+            print("RESULT:" + json.dumps({"type": None, "message": ""}))
+        """
+    )
+    assert out["type"] == "OrcFxAPIAlreadyImportedError", out
+    assert "campaign_module_that_imported_first" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# Test 12 -- the selected path survives a later module-scope importer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.solver
+@requires_orcfxapi
+def test_selected_lib_path_is_in_force_for_a_later_module_scope_importer():
+    out = _probe(
+        """
+        import json, os
+        from digitalmodel.solvers.orcaflex import orcaflex_api
+
+        versions = orcaflex_api.installed_versions()
+        if not versions:
+            print("RESULT:" + json.dumps({"skip": "no versioned OrcaFlex install"}))
+        else:
+            wanted = sorted(versions)[-1]
+            record = orcaflex_api.configure(wanted)
+
+            # A module that imports OrcFxAPI at module scope, imported AFTER the
+            # facade configured the library path.
+            from digitalmodel.solvers.orcaflex import run_to_sim  # noqa: F401
+
+            import OrcFxAPIConfig
+            print("RESULT:" + json.dumps({
+                "selected": os.path.normcase(os.path.abspath(versions[wanted])),
+                "in_force": os.path.normcase(
+                    os.path.abspath(OrcFxAPIConfig.getLibPath())
+                ),
+                "recorded": os.path.normcase(
+                    os.path.abspath(record["resolved_lib_path"])
+                ),
+            }))
+        """
+    )
+    if "skip" in out:
+        pytest.skip(out["skip"])
+    assert out["in_force"] == out["selected"]
+    assert out["recorded"] == out["selected"]
+
+
+# ---------------------------------------------------------------------------
+# The ban that makes selection possible at all
+# ---------------------------------------------------------------------------
+
+
+def test_importing_the_orcaflex_package_does_not_import_orcfxapi():
+    """The facade can only select a library while ``OrcFxAPI`` is unimported.
+
+    Any module-scope ``import OrcFxAPI`` reachable from the package
+    initialisation defeats ``setLibPath()`` for the life of the process, so
+    ``import digitalmodel.solvers.orcaflex`` must not pull the binding in.
+    """
+    out = _probe(
+        """
+        import json, sys
+        import digitalmodel.solvers.orcaflex  # noqa: F401
+
+        binding = sys.modules.get("OrcFxAPI")
+        holders = []
+        if binding is not None:
+            for name, module in list(sys.modules.items()):
+                if module is None or module is binding:
+                    continue
+                namespace = getattr(module, "__dict__", None)
+                if not isinstance(namespace, dict):
+                    continue
+                if any(value is binding for value in list(namespace.values())):
+                    holders.append(name)
+        print("RESULT:" + json.dumps(
+            {"imported": binding is not None, "holders": sorted(holders)}
+        ))
+        """
+    )
+    assert out["imported"] is False, (
+        "importing the orcaflex package imported OrcFxAPI at module scope via: "
+        f"{out['holders']}"
+    )
+
+
+def test_importing_the_facade_does_not_import_orcfxapi():
+    out = _probe(
+        """
+        import json, sys
+        from digitalmodel.solvers.orcaflex import orcaflex_api  # noqa: F401
+        print("RESULT:" + json.dumps({"imported": "OrcFxAPI" in sys.modules}))
+        """
+    )
+    assert out["imported"] is False
+
+
+# Modules under solvers/orcaflex that still import OrcFxAPI at module scope.
+# The set is a ratchet, not a licence: it may shrink, never grow. Each entry
+# names a module that is NOT reachable from the package initialisation, so none
+# of them can defeat setLibPath() before the facade runs -- but any new
+# module-scope import could be, so a new one must be justified by editing this
+# list deliberately.
+KNOWN_MODULE_SCOPE_IMPORTERS = {
+    "OrcaFlexAnalysis.py",
+    "all_vars.py",
+    "comprehensive_benchmark.py",
+    "orcaflex_custom_analysis.py",
+    "orcaflex_iterative_runs.py",
+    "orcaflex_modal_analysis.py",
+    "orcaflex_optimized_parallel.py",
+    "orcaflex_optimized_parallel_v2.py",
+    "orcaflex_parallel_analysis.py",
+    "orcaflex_yml_converter.py",
+    "opp_time_series_v2.py",
+    "post_results/postProcess.py",
+    "reporting/extractors/aggregator.py",
+    "reporting/extractors/boundary_conditions_extractor.py",
+    "reporting/extractors/geometry_extractor.py",
+    "reporting/extractors/loads_extractor.py",
+    "reporting/extractors/materials_extractor.py",
+    "reporting/extractors/mesh_extractor.py",
+    "reporting/extractors/results_extractor.py",
+}
+
+_FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+def _imports_orcfxapi_at_module_scope(tree: ast.Module) -> bool:
+    """Whether the module body executes ``import OrcFxAPI`` at import time.
+
+    A ``try:``/``if:``/``with:`` wrapper is still module scope -- the import
+    still runs when the module is imported. Only a function body defers it.
+    """
+    stack = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, _FUNCTION_NODES):
+            continue
+        if isinstance(node, ast.Import):
+            if any(alias.name.split(".")[0] == "OrcFxAPI" for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] == "OrcFxAPI":
+                return True
+        stack.extend(ast.iter_child_nodes(node))
+    return False
+
+
+def test_module_scope_orcfxapi_imports_do_not_grow():
+    found = set()
+    for path in sorted(ORCAFLEX_PKG.rglob("*.py")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        if "OrcFxAPI" not in source:
+            continue
+        if _imports_orcfxapi_at_module_scope(ast.parse(source)):
+            found.add(path.relative_to(ORCAFLEX_PKG).as_posix())
+
+    new = found - KNOWN_MODULE_SCOPE_IMPORTERS
+    assert not new, (
+        "new module-scope `import OrcFxAPI` under solvers/orcaflex: "
+        f"{sorted(new)} -- route access through orcaflex_api.api() instead"
+    )

--- a/tests/structural/fatigue/test_fatigue_migration.py
+++ b/tests/structural/fatigue/test_fatigue_migration.py
@@ -36,6 +36,21 @@ from digitalmodel.fatigue import (
     quick_time_domain_analysis,
     quick_frequency_domain_analysis
 )
+from digitalmodel.fatigue.counting_contract import NonConservativeCountingError
+
+# Issue #3839: `quick_time_domain_analysis` and `FatigueAnalysisEngine.analyze_time_series`
+# count cycles through `structural.fatigue.rainflow`, which extracts a maximum stress
+# range below the signal's peak-to-valley span and so understates damage. Those entry
+# points now refuse damage calculation. The assertions below are preserved verbatim
+# rather than rewritten, and marked expected-fail against the refusal: when the path is
+# repaired or retired, strict=True turns the pass into a failure that demands this
+# marker's removal and a re-review of the numbers these tests assert.
+# https://github.com/vamseeachanta/workspace-hub/issues/3839
+_REFUSED_3839 = pytest.mark.xfail(
+    raises=NonConservativeCountingError,
+    strict=True,
+    reason="struct_fatigue refuses damage calculation pending #3839",
+)
 
 
 class TestSNCurveMigration:
@@ -315,6 +330,7 @@ class TestShearAnalysisMigration:
 class TestEngineeringValidationMigration:
     """Test engineering validation functions"""
 
+    @_REFUSED_3839
     def test_time_domain_validation(self):
         """Test time domain analysis validation"""
         # Generate test data with known characteristics
@@ -336,6 +352,7 @@ class TestEngineeringValidationMigration:
         # Should have some recommendations
         assert len(validation.recommendations) > 0
 
+    @_REFUSED_3839
     def test_validation_with_problematic_data(self):
         """Test validation with problematic input data"""
         # Very short time series
@@ -362,6 +379,7 @@ class TestEngineeringValidationMigration:
         )
         assert has_warning, "Expected warnings or damage for 10 GPa stress range"
 
+    @_REFUSED_3839
     def test_safety_factor_validation(self):
         """Test safety factor validation"""
         # Generate high damage scenario
@@ -380,6 +398,7 @@ class TestEngineeringValidationMigration:
 class TestComprehensiveIntegration:
     """Test comprehensive integration of migrated functionality"""
 
+    @_REFUSED_3839
     def test_full_analysis_workflow(self):
         """Test complete analysis workflow from data to report"""
         # Generate realistic stress history


### PR DESCRIPTION
Implements two owner-approved plans. Both were carried through r1 (Claude inline) and r2 (Codex) adversarial review, which **rejected the first drafts**; r3 patches were applied before implementation began.

- workspace-hub [#3838](https://github.com/vamseeachanta/workspace-hub/issues/3838) — three model-building integrity defects
- workspace-hub [#3839](https://github.com/vamseeachanta/workspace-hub/issues/3839) — rainflow counting contract

## The finding that matters most

**The existing instability guard was dead, and the plan was wrong to call it sound.**

`orcaflex_analysis_components.py:354` compared `str(model.state)` against member names. `OrcFxAPI.ModelState` is an `IntEnum`, so on Python 3.12 `str(ModelState.SimulationStopped)` is `'4'` and the whitelist matched nothing. It also sat after a failing import inside a `try` whose `except Exception: pass` swallowed the error, so control never reached it.

Verified directly:

```
str(state) = '4'
whitelist match: False
has InSimulation: False
```

The plan asserted "the guard pattern IS correct where applied" on the strength of having verified that `SimulationStoppedUnstable` exists. That verified the enum member and never the comparison — an instance of the failure the new `reproducibility-is-not-correctness` rule describes.

## What lands

**#3839 — cycle counting.** Four of seven counting paths extract a maximum stress range below the signal's peak-to-valley span. Damage scales with the cube of range, so all four understate it. Adds a four-clause contract, a seven-path registry declaring each path's residual policy, and a hand-derived exact-distribution fixture. Clause 1 is conditional on a retain-residual policy, because the invariant is **not universal** — a declared discard-residual implementation may correctly omit the span, and a test proves the contract does not condemn one. Damage entry points on failing paths now raise rather than return an understated number. No counting algorithm is deleted; consolidation is deferred to a successor issue.

**#3838 — model building.** A duplicated list-style collection key silently deleted objects, because a list REPLACES a collection in OrcaFlex; the check is wired into both generation paths so it fails closed, and takes a master path so it also covers hand-edited includefiles. The solver version was unpinned; an import facade now allows selection, with nine modules binding a lazy proxy so call sites are unchanged. 24 of 38 run-site call sites are now gated.

## Tests

| Suite | Result |
|---|---|
| Protected rainflow (174) | 174 passed |
| New counting gate | 65 passed, 5 xfailed (strict) |
| New orcaflex tests | 26 passed |
| Generator suite | 714 passed, 2 skipped, 1 pre-existing failure |

The generator failure is the cp1252 BOM defect (workspace-hub#3834), reproducible at HEAD. 35 failures in the wider orcaflex suite were proven pre-existing in a pristine worktree at HEAD, not introduced here.

## Known limitations, stated rather than omitted

- **A damage entry point the refusal cannot reach.** `ansys/fatigue_postprocessor.py` takes stress ranges as data, so a range from a failing counter can reach Miner summation with no counter called. Latent, not live — the module has no production caller. Recorded in the exposure document.
- **`time_trace_processor.py:142`** reads `ModelState.InSimulation`, which the vendor enum does not define. Found, not fixed — outside plan scope.
- **AC2 partially met.** 19 modules still import `OrcFxAPI` at module scope; none is on the package import path, so none can defeat `setLibPath`. A ratchet test lets that set shrink but not grow.
- **Whether any issued deliverable used a failing path is not established.** It requires client-repository access and awaits owner direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYiGiqWS1q6cZfeGHPsAEx