### PR TITLE
feat(orcaflex): add BaseFile variation models and name-keyed merge to modular_generator

### DIFF
--- a/docs/plans/2026-09-11-issue-2094-ansys-example-deck-validation.md
+++ b/docs/plans/2026-09-11-issue-2094-ansys-example-deck-validation.md
@@ -261,7 +261,9 @@ axial restraint on the bottom edge already removes the only rigid-body mode pres
 | `test_mudmat_applied_load_is_mesh_independent` | the `FCUM` defect cannot return | decks generated at `element_size_mm` 100 and 50 | identical applied-resultant expression |
 | `test_committed_golden_is_stable` *(marked `requires_mapdl`)* | a re-solve reproduces the value | golden and fresh digest, run configuration matching `PROVENANCE.json` | relative difference <= 1e-3 |
 | `test_mudmat_deck_solves` *(marked `requires_mapdl`)* | the model is not singular | mudmat run on a licensed host | exit 0, digest present |
-| `test_mudmat_bearing_cross_checks_geotechnical_module` | the FE bearing answer is checked against independent code | mudmat golden | agrees with `geotechnical/mudmat.py` within a stated band |
+| `test_mudmat_pressure_patch_balances_applied_load` | D1 equilibrium holds by construction | generated deck | `q_applied * area_eff == V` and patch centroid offset `== M/V`, both exact to float tolerance |
+| `test_mudmat_unit_conversion_kn_m_kpa_to_n_mm_mpa` | the factor-of-1000 hazard cannot pass silently | a known capacity result | converted pressure matches a hand-computed value |
+| `test_mudmat_reactions_are_zero` *(marked `requires_mapdl`)* | the applied field and the reaction balance | mudmat golden | reaction resultant below a stated absolute floor, not a percentage |
 
 ---
 
@@ -351,6 +353,43 @@ cross-check each other — satisfying the comparator requirement rather than def
 Consequence: the FE no longer reports a bearing unity check. `mudmat.py`'s digest carries plate
 stress only. The bearing result comes from the geotechnical module and the two are reported
 together.
+
+**D1 feasibility, verified before approval.** The geotechnical module returns capacity, not a
+pressure field — `BearingCapacityResult` carries `effective_width_m`, `effective_length_m`,
+`effective_area_m2`, `q_ult_kpa` and a vertical capacity (`geotechnical/mudmat.py:27-42`,
+`:131-141`, `:176-187`). It does not return a distribution. The distribution nonetheless
+follows directly from the same idealisation, and this is what makes D1 work:
+
+Meyerhof's effective-area method carries the applied vertical load on a **uniform pressure over
+the effective area**, centred on the load. So the pressure applied to the plate is
+
+    q_applied = V / (b_eff * l_eff)
+
+over an offset rectangular patch, with `b_eff = B - 2e` taken from the module rather than
+recomputed. Two properties fall out by construction rather than by tolerance:
+
+- **Vertical equilibrium is exact.** `q_applied * area_eff = V` identically.
+- **Moment equilibrium is exact.** The patch centroid sits at eccentricity `e = M/V` from the
+  mat centre, so its moment about the centre is `V * e = M` identically.
+
+The FE therefore needs only a minimal statically determinate restraint set, and its reactions
+are zero to solver precision. The bearing check is then `q_applied` against `q_ult_kpa` with
+the governing factor, performed by the module.
+
+Implementation is a pressure on a selected element patch — `SFE,...,PRES` over the elements
+inside the effective rectangle — not a spring bed and not a node loop.
+
+**Limitation, to be stated in the module and in any output.** A uniform pressure block is the
+bearing-capacity idealisation, not the true contact-pressure field, which is neither uniform
+nor generally trapezoidal. Using it as the plate-bending load is a deliberate screening
+choice: it makes the strength check and the bearing check share one load path, so the two
+cannot disagree about what the soil is doing, at the cost of a bending distribution that is
+approximate near the patch edges. It shall not be described as the contact pressure.
+
+**Implementation hazard.** The geotechnical module works in kN, m and kPa; the decks work in
+N, mm and MPa. The conversion shall be explicit and unit-tested. An unchecked factor of 1000
+here would reproduce the exact failure mode this issue exists to remove — a plausible number
+with nothing to contradict it.
 
 **D2 — Examples shall be compliant designs.** Each example is re-parameterised so its peak
 stress sits safely inside the linear-elastic range and its unity check is below 1.0. For the

--- a/docs/plans/2026-09-11-issue-2094-ansys-example-deck-validation.md
+++ b/docs/plans/2026-09-11-issue-2094-ansys-example-deck-validation.md
@@ -1,0 +1,420 @@
+# Plan for #2094: Two of three committed ANSYS example decks are wrong
+
+> **Status:** plan-review
+> **Complexity:** T2
+> **Date:** 2026-09-11
+> **Issue:** https://github.com/vamseeachanta/digitalmodel/issues/2094
+> **Client:** N/A
+> **Lane:** lane:claude
+> **Review artifacts:** (pending)
+
+---
+
+## Resource Intelligence Summary
+
+### Existing repo code
+
+- Found: `src/digitalmodel/ansys/pressure_vessel.py:865-956` — emits the APDL deck including
+  the defective restraint block and the `*CFOPEN` digest.
+- Found: `src/digitalmodel/ansys/mudmat.py:82-193` — emits `R,1,<t>, , ,<ksub>` intending a
+  Winkler foundation on SHELL181.
+- Found: `src/digitalmodel/ansys/mudmat.py:144-157` — the load block. **Second mudmat defect,
+  found at adversarial review:** `FCUM` is never issued, so the APDL default `FCUM,REPL`
+  applies and the edge couple **replaces** rather than adds to the short-edge nodes' share of
+  the uniform vertical load. See Evidence.
+- Found: `src/digitalmodel/ansys/padeye.py:73-157` — same generator pattern; deck solves.
+- Found: `src/digitalmodel/ansys/runner.py:32` — `_RESULT_SUFFIXES` excludes `.csv`, so the
+  digest the decks write is never captured as a result file.
+- Found: `src/digitalmodel/ansys/results_extractor.py:162-437` — pure-text extraction; no
+  method reads the digest format.
+- **Found, and previously missed: `src/digitalmodel/geotechnical/mudmat.py:131-141`** —
+  Brinch Hansen / DNV-RP-C212 general bearing capacity with the Meyerhof effective-area
+  eccentricity correction (`b_eff = width_b_m - 2.0 * eccentricity`), raising when
+  `B - 2e <= 0`. A committed surrogate exists at `atlases/mudmat_bearing_capacity/`. This is
+  the independent comparator for the mudmat bearing unity check that an earlier revision of
+  this plan listed as a gap.
+- Gap: no test in `tests/ansys/` asserts any solved value. Solver dependence is removed by
+  monkeypatching, not by a marker.
+- Gap: **no deck reports a reaction sum.** None of the three issues `FSUM` or any equilibrium
+  report. This single omission is what allowed all three defects to ship undetected.
+
+### Standards
+
+Not applicable. The defects are modelling and harness errors, not standards-derived constants.
+The allowable stresses already embedded in the decks are unchanged by this plan.
+
+### LLM Wiki pages consulted
+
+- `pages/acma-tool/notes/ansys-apdl-macros.md` — records the in-house macro library and its
+  existing validation workbook practice; confirms the firm's own convention is to keep a
+  recorded answer beside a model.
+- `domains/analysis/pages/validated-model-index.md` — records that the three example decks
+  carry a generator-sync guard rather than a solved answer, and names capturing the digest as
+  the cheapest available upgrade.
+
+### Documents consulted
+
+- Issue #2094 — this plan's subject.
+- `docs/domains/ansys/workflows/aqwa-to-structural-submodel.md` §12A — establishes the
+  house pattern of recording a verified restriction with its evidence.
+- Related issue #1524 — versioned launcher discovery; confirmed live on the host used for the
+  reproduction below, and explains why discovery must be exercised on a real host.
+- Related issue #1525 — canonical licensed workflow and integrity manifests; the golden-value
+  files this plan creates are candidate manifest inputs.
+
+### Gaps identified
+
+- No elastic foundation exists in the mudmat model. SHELL181 accepts the real constants and
+  ignores them; nothing reports this.
+- No digest reader exists.
+- No golden value exists for any example.
+- No independent comparator exists for the padeye result.
+
+### Evidence (embedded verification)
+
+**Issue statuses** (verified 2026-09-11 via `gh issue list`):
+- `#2094` — OPEN — bug(ansys): two of three committed example decks are wrong
+- `#1524` — OPEN — bug(ansys): detect versioned ansysNNN launchers
+- `#1525` — OPEN — feat(ansys): register canonical licensed workflow
+
+**File existence** (2026-09-11):
+- EXISTS: `examples/ansys/pressure-vessel/pv.inp`
+- EXISTS: `examples/ansys/padeye/padeye.inp`
+- EXISTS: `examples/ansys/mudmat/mudmat.inp`
+- MISSING (new — this plan creates): `examples/ansys/*/golden/`
+- MISSING (new — this plan creates): `tests/ansys/test_example_goldens.py`
+
+**Line excerpts** — `examples/ansys/pressure-vessel/pv.inp:35-38`:
+
+```
+! restrain one node radially to remove rigid-body motion
+NSEL,S,LOC,X,780.0
+NSEL,R,LOC,Y,0
+D,ALL,UX,0
+```
+
+`examples/ansys/mudmat/mudmat.inp:17-20`:
+
+```
+R,1,60.0, , ,0.05
+SECTYPE,1,SHELL
+SECDATA,60.0,1
+SECNUM,1
+```
+
+**Reproduction proofs** — all runs `-b -np 1 -smp`, Ansys 2026 R1.01 Build 26.1 UP20260202,
+scratch directory, no repository file modified:
+
+```
+$ ANSYS261.exe -b -np 1 -smp -i pv.inp -o pvtest.out
+exit code : 0        elapsed : 17.4 s
+max_seqv_mpa,    981.3400,allowable_mpa,    138.0000,uc,   7.11116
+```
+
+Variants, one variable changed each:
+
+```
+A_noThermal    rc=0  max_seqv_mpa,    369.2583,  uc,   2.67578
+B_noPointUX    rc=0  max_seqv_mpa,    259.5424,  uc,   1.88074
+```
+
+Closed-form Lame, ID 1500 mm, t 30 mm, P 10 MPa: hoop 255.10 MPa, von Mises 260.2 MPa.
+Variant B agrees to 0.25 percent.
+
+```
+$ ANSYS261.exe -b -np 1 -smp -i padeye.inp
+exit code : 0   errors=0   18.0 s
+max_seqv_mpa,    348.6653,allowable_mpa,    212.5749,uc,   1.64020
+
+$ ANSYS261.exe -b -np 1 -smp -i mudmat.inp
+exit code : 1   errors=1   18.4 s   NO RESULT
+*** ERROR *** small pivot term ... UZ degree of freedom of node 717
+Pivot value of -2.272885044E-08 at node 717 UZ, element 1020 (SHELL181).
+```
+
+Mechanism established by reading the solver's own real-constant listing rather than inferred
+(`RLIST,1` inserted in a scratch copy):
+
+```
+REAL CONSTANT SET          1  ITEMS   1 TO   6
+   60.000       0.0000       0.0000      0.50000E-01   0.0000       0.0000
+   INPUT SECTION ID NUMBER               1
+   Shell Section ID=        1 Number of layers=    1  Total Thickness=    60.000000
+```
+
+The subgrade value 0.05 is stored in slot 4 and the section separately defines the thickness.
+A variant with the section definition removed fails identically (`M1_noSection rc=1`), which
+rules out a section-versus-real-constant conflict. SHELL181 does not consume an elastic
+foundation stiffness from that slot; the input is accepted and ignored, leaving every UZ
+degree of freedom unrestrained.
+
+- Reproduced at: 2026-09-11
+- Failure mode observed matches issue claim: YES
+
+**Mudmat load defect, established at adversarial review by arithmetic on the generated deck.**
+For the committed parameters (4000 x 3000, `ESIZE,100` gives 41 x 31 = 1271 nodes, 31 nodes
+per short edge), `FCUM,REPL` makes the couple overwrite the edge nodes' uniform-load share:
+
+| Quantity | Intended | Actually applied |
+|---|---|---|
+| Net vertical resultant, N | 800 000 | 760 976 |
+| Overturning moment, N mm | 4.00e8 | 4.00e8 |
+| Eccentricity e = M/V, mm | 500.0 | 525.6 |
+
+The deficit fraction is 2/(L/ESIZE + 1) = 2/41 = 4.88 percent — **a function of mesh density,
+not of the physics**. Refining the mesh changes the answer while converging on nothing.
+
+A second load error in the same block: `F,ALL,FZ,fz_n` distributes a uniform pressure as equal
+nodal forces rather than tributary-area forces. Interior nodes receive 629.4 N against a
+correct 666.7 N, edge nodes 629.4 N against 333.3 N, corner nodes 629.4 N against 166.7 N. For
+the committed parameters the elastic length L_c = (D/k)^0.25 = 534 mm spans five elements and
+the error smears; at `thickness_mm=20` with `subgrade_modulus_n_per_mm3=0.5`, L_c falls to
+132 mm and the perimeter over-load becomes a first-order error in `uz_min`, the quantity the
+bearing unity check is built on.
+
+Distinct sources: 10.
+
+---
+
+## Artifact Map
+
+| Artifact | Path |
+|---|---|
+| This plan | `docs/plans/2026-09-11-issue-2094-ansys-example-deck-validation.md` |
+| Tests | `tests/ansys/test_example_goldens.py`, `tests/ansys/test_results_extractor.py` |
+| Implementation | `src/digitalmodel/ansys/{pressure_vessel,mudmat,runner,results_extractor}.py` |
+| Golden values | `examples/ansys/<case>/golden/{<case>_result.csv,PROVENANCE.json}` |
+
+---
+
+## Deliverable
+
+Three committed ANSYS example decks that solve, produce values agreeing with an independent
+comparator, and carry those values as committed golden files that a test asserts against — in
+place of a guard that only proves the generator is deterministic.
+
+---
+
+## Pseudocode
+
+```
+parse_result_digest(csv_text) -> dict[str, float]:
+    split the single line on commas
+    pair alternating label, value tokens
+    coerce each value to float; raise on an odd token count or a non-numeric value
+    return the mapping
+
+test_committed_golden_is_stable(case):
+    skip with a stated reason when no golden file exists
+    read the committed golden digest
+    read the freshly solved digest when one is present, else skip
+    for each quantity: assert relative difference <= 1e-4
+```
+
+Restraint correction in `pressure_vessel.py`: delete the single-node radial constraint. An
+axisymmetric model has no radial rigid-body mode, so no substitute restraint is required. The
+axial restraint on the bottom edge already removes the only rigid-body mode present.
+
+---
+
+## Files to Change
+
+| Action | Path | Reason |
+|---|---|---|
+| Modify | `src/digitalmodel/ansys/pressure_vessel.py` | remove the spurious radial restraint; add `FSUM` reaction reporting to the digest |
+| Modify | `src/digitalmodel/ansys/mudmat.py` | **D1:** apply the bearing distribution from `geotechnical/mudmat.py` as a surface pressure; drop the Winkler bed and the FE bearing unity check; fix the `FCUM` load defect; apply the uniform load as a pressure so tributary weighting is the element's job; minimal statically determinate restraint; add `FSUM` |
+| Modify | `src/digitalmodel/ansys/padeye.py` | add `FSUM`; record the peak node number and coordinates in the digest; **D2:** re-parameterise to a compliant lug |
+| Modify | `examples/ansys/pressure-vessel/build.py` | **D2:** `wall_thickness_mm` 30.0 → 60.0 |
+| Modify | `examples/ansys/{padeye,mudmat}/build.py` | **D2:** re-parameterise to compliant designs |
+| Read-only dependency | `src/digitalmodel/geotechnical/mudmat.py` | **D1:** supplies the bearing distribution and the bearing check. Not modified by this plan |
+| Modify | `src/digitalmodel/ansys/runner.py` | add `.csv` to `_RESULT_SUFFIXES`; scope capture to files the run created |
+| Modify | `src/digitalmodel/ansys/results_extractor.py` | add `parse_result_digest` |
+| **Modify** | **`tests/ansys/test_mudmat.py`** | **`test_winkler_soil_support_present:36-45` asserts the presence of the defective inert card and its comment records the disproven mechanism. Any correct fix fails it.** Rewrite to assert the chosen mechanism and the absence of the inert card |
+| **Modify** | **`src/digitalmodel/usecase_registry/registry.yaml:352-359`** | **`ansys-mudmat` is published `readiness: ready` with a note asserting the disproven Winkler-EFS mechanism. The case has never solved.** Set `partial` until it does; correct the note |
+| Modify | `tests/test_usecase_registry.py` | require a committed golden before a solver case may claim `readiness: ready` |
+| Modify | `tests/ansys/test_runner.py` | cover `.csv` capture and stale-digest exclusion |
+| Modify | `pyproject.toml` | register the `requires_mapdl` marker |
+| Modify | `.gitignore` | `examples/ansys/*/results/` — otherwise a capture run leaves untracked solver output in the tree |
+| Regenerate | `examples/ansys/{pressure-vessel,mudmat,padeye}/*.inp` | via each `build.py`, keeping the byte-match guards true |
+| Create | `examples/ansys/<case>/golden/<case>_result.csv` | the solved digest |
+| Create | `examples/ansys/<case>/golden/PROVENANCE.json` | full argv, core count, SMP/DMP, equation solver, platform, MAPDL build string, deck SHA-256, generator commit, comparator class |
+| Create | `tests/ansys/test_example_goldens.py` | always-on comparator assertions plus a `requires_mapdl` re-solve test |
+| Modify | `tests/ansys/test_results_extractor.py` | cover the digest parser |
+
+---
+
+## TDD Test List
+
+| Test name | What it verifies | Expected input | Expected output |
+|---|---|---|---|
+| `test_parse_result_digest_nominal` | label/value pairing | the pv digest line | `{max_seqv_mpa: 259.54, allowable_mpa: 138.0, uc: 1.881}` |
+| `test_parse_result_digest_odd_tokens` | rejects a malformed line | `"a,1.0,b"` | `ValueError` |
+| `test_parse_result_digest_non_numeric` | rejects a non-numeric value | `"a,x"` | `ValueError` |
+| `test_runner_captures_csv_digest` | `.csv` reaches `result_files` | a run directory containing a digest | digest listed |
+| `test_pressure_vessel_deck_has_no_radial_point_restraint` | the defect cannot return | generated deck text | no single-node `UX` constraint |
+| `test_pv_golden_matches_closed_form` | the physics is right | committed pv golden; comparator computed in Python from `build.py` constants, not a literal | von Mises within 1 percent of the computed Lame value |
+| `test_pressure_vessel_deck_is_axisymmetric` | binds the restraint-deletion safety argument to its precondition | generated deck text | `KEYOPT,1,3,1` present |
+| `test_golden_unity_check_is_internally_consistent` | the digest is self-consistent | each golden | `uc == max_seqv_mpa / allowable_mpa` within tolerance |
+| `test_golden_matches_recorded_status` | a silent move across the allowable fails | each golden + `PROVENANCE.json` | `uc` on the side recorded in `expected_status` |
+| `test_golden_respects_linear_elastic_validity` | a linear result at yield does not pass silently | each golden | peak below stated yield, or `linear_elastic_limit_exceeded: true` recorded |
+| `test_reaction_sum_balances_applied_load` | equilibrium — the check that would have caught all three defects | each golden | reaction resultant equals applied load within 0.1 percent |
+| `test_mudmat_applied_load_is_mesh_independent` | the `FCUM` defect cannot return | decks generated at `element_size_mm` 100 and 50 | identical applied-resultant expression |
+| `test_committed_golden_is_stable` *(marked `requires_mapdl`)* | a re-solve reproduces the value | golden and fresh digest, run configuration matching `PROVENANCE.json` | relative difference <= 1e-3 |
+| `test_mudmat_deck_solves` *(marked `requires_mapdl`)* | the model is not singular | mudmat run on a licensed host | exit 0, digest present |
+| `test_mudmat_bearing_cross_checks_geotechnical_module` | the FE bearing answer is checked against independent code | mudmat golden | agrees with `geotechnical/mudmat.py` within a stated band |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `uv run pytest tests/ansys/ -v` passes, and the always-on golden tests **assert** rather
+      than skip on a host with no licence. A suite that skips its way to green does not satisfy
+      this criterion.
+- [ ] `uv run pytest tests/` shows no regression.
+- [ ] The pressure-vessel deck produces peak von Mises within 1 percent of a Lame value
+      computed in the test from the generator's own constants.
+- [ ] **Reaction resultant equals the applied load to within 0.1 percent, for all three decks.**
+      Fixed here, before any run — not a tolerance chosen after the discrepancy is seen.
+- [ ] The mudmat deck exits 0, its applied vertical resultant is mesh-independent, and its
+      reactions are near zero because the applied load and the bearing distribution balance by
+      construction (D1). A non-zero reaction means the distribution does not integrate to the
+      applied load and is a hard failure, not a tolerance question.
+- [ ] **Every example reports a unity check below 1.0 and a peak stress safely inside the
+      linear-elastic range** (D2). An example that exceeds either does not ship as the
+      demonstration case.
+- [ ] The padeye deck exits 0, its golden records the peak node and coordinates, and a two-mesh
+      comparison is recorded. A peak that moves or grows with refinement is a singularity, and
+      the reported quantity shall change rather than the tolerance.
+- [ ] Every golden carries the full run configuration in provenance. A golden whose comparator
+      class is `archived-run` is labelled as such and states the absence of an independent
+      comparator.
+- [ ] Review artifacts posted.
+
+---
+
+## Adversarial Review Summary
+
+| Provider | Verdict | Key findings |
+|---|---|---|
+| Claude (r1, fresh context) | **MAJOR** | Third mudmat defect (`FCUM,REPL` makes the applied load mesh-dependent); no deck reports a reaction sum, which is why all three defects shipped; an existing test and a public registry entry both assert the disproven mechanism and block the fix; the golden test skips on both branches so it is vacuous in CI; the unity-check test is unfalsifiable as written; the mudmat option set was incomplete and the repo already holds the bearing comparator |
+| Second provider | not run | See Risks — a T2 scope nominally takes two providers |
+
+**Overall result:** FAIL on first pass; plan revised.
+
+Revisions made after review:
+
+1. Added the `FCUM,REPL` load defect with quantified evidence, and the tributary-weighting
+   error alongside it.
+2. Added `FSUM` reaction reporting to all three generators and made equilibrium a fixed
+   acceptance criterion at 0.1 percent, set before any run rather than after.
+3. Added `tests/ansys/test_mudmat.py`, `usecase_registry/registry.yaml`,
+   `tests/test_usecase_registry.py`, `tests/ansys/test_runner.py`, `pyproject.toml` and
+   `.gitignore` to Files to Change.
+4. Split the golden tests into an always-on comparator test and a `requires_mapdl` re-solve
+   test; moved the comparator from a literal to a value computed from the generator's own
+   constants; split the tolerance by purpose and bound the stability check to a matching run
+   configuration.
+5. Replaced the unfalsifiable unity assertion with internal-consistency, recorded-status and
+   linear-elastic-validity assertions.
+6. Expanded the mudmat option set from three to five and named `geotechnical/mudmat.py`.
+7. Corrected two line-range citations.
+
+Findings the review verified as correct and this revision preserves: the Lame comparator
+(260.24 MPa recomputed independently, with sigma_z shown to be exactly zero rather than
+approximately so), the axisymmetric rigid-body-mode argument across the generator's whole
+parameter space, the claim that padeye carries no analogue over-constraint, and the claim that
+mudmat's in-plane pinning is legitimate — the latter for the right reason, since a single
+symmetric layer uncouples membrane from bending so the in-plane restraints carry zero force.
+
+---
+
+## Decisions taken by the owner, 2026-09-11
+
+**D1 — Mudmat: re-scope, splitting the two checks.** The finite element model performs the
+plate-bending check only. The bearing check is performed by `src/digitalmodel/geotechnical/
+mudmat.py`, which already implements Brinch Hansen / DNV-RP-C212 with the Meyerhof
+effective-area correction `b_eff = B - 2e` and raises when `B - 2e <= 0`.
+
+Mechanically: the geotechnical module computes the bearing-pressure distribution under the
+applied vertical load and moment; that distribution is applied to the plate underside as a
+surface pressure; the applied load and the bearing reaction then balance **by construction**,
+so the plate carries only a minimal statically determinate restraint set and its reactions are
+near zero. **That near-zero reaction is itself the conservation check** — it is not an
+incidental property, it is the acceptance criterion, and it is the test that would have caught
+every defect in this issue.
+
+Eccentricity is handled correctly by construction rather than by a guard: the effective-area
+method is defined for `e > B/6`, whereas a linear spring bed is not. No kern check is required
+because no bed is modelled. The solve stays linear and runs in seconds, and the two methods
+cross-check each other — satisfying the comparator requirement rather than deferring it.
+
+Consequence: the FE no longer reports a bearing unity check. `mudmat.py`'s digest carries plate
+stress only. The bearing result comes from the geotechnical module and the two are reported
+together.
+
+**D2 — Examples shall be compliant designs.** Each example is re-parameterised so its peak
+stress sits safely inside the linear-elastic range and its unity check is below 1.0. For the
+pressure vessel, `wall_thickness_mm = 60.0` gives 135.5 MPa and UC 0.98 against the ASME UG-27
+requirement of 56.8 mm. The padeye is re-parameterised on the same basis; its present 348.67
+MPa is 98.2 percent of stated yield. A linear-elastic result reported at its own validity
+boundary is not an admissible screening answer and shall not ship as the demonstration case.
+
+**D3 — No second review provider at plan stage.** Implementation proceeds against the revised
+plan; the resulting code is reviewed instead.
+
+---
+
+## Risks and Open Questions
+
+- ~~**Decision required — the mudmat foundation.**~~ **Resolved, D1.** Retained for the record:
+  SHELL181 does not consume a foundation stiffness as a real constant. Five remedies existed:
+  **(a)** a `SURF154` overlay carrying the stiffness — compact, but the real-constant slot must
+  be confirmed, and a listing will look equally plausible either way; the decisive test is the
+  reaction sum, since an inert foundation gives a vertical reaction near zero against an
+  applied 800 kN.
+  **(b)** explicit `COMBIN14` springs per node from subgrade modulus and tributary area —
+  transparent and hand-checkable, **but linear and therefore tension-carrying**. Valid only
+  while the bed stays in compression. `MudmatGeometry` accepts any moment against any vertical
+  load with no kern check: the committed case has e = 500 mm against B/6 = 667 mm and is
+  inside the kern, but `moment_kNm = 600` gives e = 750 mm and a silently **unconservative**
+  bearing answer.
+  **(c)** a **no-tension bed** — `COMBIN39` compression-only springs, or node-to-ground
+  contact. This is the option that actually answers the tension objection. Its cost is that the
+  solve becomes nonlinear, with convergence handling and a longer licensed run.
+  **(d)** re-scope: the FE does the plate-strength check and **`geotechnical/mudmat.py`**, which
+  already implements Brinch Hansen / DNV-RP-C212 with the Meyerhof eccentricity correction,
+  does the bearing check. The two cross-check each other.
+  **(e)** drop the bearing output from the FE entirely and state the limitation.
+  **This is an engineering decision on a screening tool's fidelity and is referred to the owner
+  rather than selected here.** Whichever is chosen carries one acceptance: total foundation
+  reaction equals the applied vertical load to within 0.1 percent.
+
+- **Decision required — are the shipped examples meant to be compliant designs?** Corrected pv
+  gives UC 1.88 and a peak von Mises at **99.8 percent of the stated yield**; padeye gives UC
+  1.64 at **98.2 percent of yield**. A linear-elastic idealisation reported at its own validity
+  boundary is not an admissible screening answer. By ASME UG-27 the pv section needs
+  t = PR/(SE - 0.6P) = 56.8 mm against the 30 mm modelled; `wall_thickness_mm = 60.0` gives
+  135.5 MPa and UC 0.98, a realistic just-acceptable vessel. Either the examples are
+  re-parameterised to compliant designs, or the overstress is declared deliberate in the example
+  directory itself — not only in a plan.
+- **Open — the padeye has no independent comparator.** Its deck solves and yields 348.67 MPa,
+  but nothing establishes that value is correct. Recording it as a golden makes it a
+  regression guard only, not evidence of correctness. A closed-form check for a lug in
+  bearing and tension should be derived, or the golden shall be labelled `archived-run` and
+  the absence of an independent comparator stated.
+- **Risk — the mudmat result may reveal a second defect.** The model has never solved, so no
+  statement about its loads, its bearing calculation or its stress output has ever been
+  tested. Fixing the foundation may expose further errors. The plan shall not assume one fix
+  closes the case.
+- **Risk — golden capture requires a licensed host and one seat.** The seat is single and
+  shared. Capture shall be serialised and shall not run concurrently with other solver work.
+- **Risk — regenerating the decks changes the byte-match guard's expected content.** The
+  guard must be re-run after regeneration, or it will fail for the right reason at the wrong
+  time.
+
+---
+
+## Complexity: T2
+
+Four source files modified, two decks regenerated, six new golden artifacts, one new test
+module. TDD required. No new module and no architectural change, so not T3.

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/base.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/base.py
@@ -20,6 +20,18 @@ class BaseBuilder(ABC):
     _output_file: str = ""
     _order: int = 0
 
+    # OrcaFlex object sections this builder emits, declared so that a consumer
+    # can read a section dependency order off BuilderRegistry directly.  The
+    # registry is keyed by output file name and carries the dependency order in
+    # its `order` argument, but nothing previously connected a file name to the
+    # sections inside it.
+    #
+    # Left empty for builders that emit only singleton sections (General,
+    # Environment, VariableData, Groups), and for GenericModelBuilder, which
+    # emits every section and orders its own output via
+    # `generic_builder._SECTION_ORDER`.
+    _sections: tuple[str, ...] = ()
+
     def __init__(self, spec: 'ProjectInputSpec', context: 'BuilderContext'):
         """Initialize builder with spec and context.
 

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/buoys_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/buoys_builder.py
@@ -28,6 +28,14 @@ class BuoysBuilder(BaseBuilder):
     Registered at 08_buoys.yml (Approach B: single file, byte-identical output).
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "6DBuoys",
+        "3DBuoys",
+    )
+
     def should_generate(self) -> bool:
         if not self.spec.is_pipeline():
             return False

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/lines_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/lines_builder.py
@@ -28,6 +28,13 @@ class LinesBuilder(BaseBuilder):
     Reference: 07_lines.yml in modular include format.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Lines",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for pipeline models."""
         return self.spec.is_pipeline()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/linetype_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/linetype_builder.py
@@ -71,6 +71,13 @@ class LineTypeBuilder(BaseBuilder):
     Reference: 05_line_types.yml in modular include format.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "LineTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for pipeline models."""
         return self.spec.is_pipeline()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/morison_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/morison_builder.py
@@ -20,6 +20,13 @@ class MorisonBuilder(BaseBuilder):
     Reference: 14_morison.yml in modular include format.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "MorisonElementTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for pipeline models."""
         return self.spec.is_pipeline()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_clumptype_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_clumptype_builder.py
@@ -22,6 +22,13 @@ class RiserClumpTypeBuilder(BaseBuilder):
     Reference: OrcaFlex ClumpTypes documentation.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "ClumpTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for riser models with clump types."""
         return self.spec.is_riser() and len(self.spec.riser.clump_types) > 0

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_lines_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_lines_builder.py
@@ -26,6 +26,13 @@ class RiserLinesBuilder(BaseBuilder):
     Reference: OrcaFlex Line documentation.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Lines",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for riser models."""
         return self.spec.is_riser()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_linetype_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_linetype_builder.py
@@ -20,6 +20,13 @@ class RiserLineTypeBuilder(BaseBuilder):
     Reference: OrcaFlex LineTypes documentation for General category.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "LineTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for riser models."""
         return self.spec.is_riser()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_links_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_links_builder.py
@@ -26,6 +26,13 @@ class RiserLinksBuilder(BaseBuilder):
     Reference: OrcaFlex Link documentation.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Links",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for riser models with links defined."""
         return self.spec.is_riser() and len(self.spec.riser.links) > 0

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_vessel_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/riser_vessel_builder.py
@@ -18,6 +18,13 @@ class RiserVesselBuilder(BaseBuilder):
     Unlike S-lay vessels, riser vessels typically use RAO-based motion.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Vessels",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for riser models."""
         return self.spec.is_riser()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/shapes_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/shapes_builder.py
@@ -34,6 +34,13 @@ class ShapesBuilder(BaseBuilder):
     Reference: 09_shapes.yml in modular include format.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Shapes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for pipeline models with ramp configuration."""
         return self.spec.is_pipeline() and self.spec.equipment.ramps is not None

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/supports_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/supports_builder.py
@@ -20,6 +20,13 @@ class SupportsBuilder(BaseBuilder):
     Reference: 13_supports.yml in modular include format.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "SupportTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for pipeline models."""
         return self.spec.is_pipeline()

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/vessel_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/vessel_builder.py
@@ -20,6 +20,13 @@ class VesselBuilder(BaseBuilder):
     the vessel stern.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Vessels",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for S-lay models with vessel defined."""
         return self.spec.equipment.vessel is not None

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/vessel_type_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/vessel_type_builder.py
@@ -19,6 +19,13 @@ class VesselTypeBuilder(BaseBuilder):
     (when vessel is defined in equipment).
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "VesselTypes",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for S-lay models with vessel defined."""
         return self.spec.equipment.vessel is not None

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/builders/winch_builder.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/builders/winch_builder.py
@@ -19,6 +19,13 @@ class WinchBuilder(BaseBuilder):
     stage-controlled winch.
     """
 
+    # Object sections emitted by build(); read by
+    # writers.basefile.object_section_order() to derive a section
+    # dependency order from this builder's registered order.
+    _sections = (
+        "Winches",
+    )
+
     def should_generate(self) -> bool:
         """Only generate for S-lay models with tensioner defined."""
         return (

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/merge.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/merge.py
@@ -1,0 +1,75 @@
+"""Name-keyed list merge with whole-object replacement semantics.
+
+Ported from ``digitalmodel.solvers.orcaflex.template_generator.TemplateGenerator
+._merge_object_lists`` (``template_generator.py:273-323``). The source module is
+unchanged and remains the comparator for this port.
+
+OrcaFlex variation models replace an object wholesale when an override names it:
+the override entry supersedes the base entry in full rather than being merged
+into it field by field. Base order is preserved, and names absent from the base
+append in override order.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def merge_named_lists(
+    base_list: list[Any],
+    override_list: list[Any],
+) -> list[Any]:
+    """Merge two object lists by matching on the ``Name`` key.
+
+    An entry in ``override_list`` whose ``Name`` matches a base entry **replaces
+    that entry entirely** — no field-level merge is performed, so a key present
+    only in the base entry does not survive. Entries whose ``Name`` is absent
+    from the base append after the base entries, in override order. Every
+    retained and appended entry is deep copied, so the returned list shares no
+    mutable state with either input.
+
+    Falsy entries (``None``, ``{}``) in either list are skipped.
+
+    Args:
+        base_list: Base list of objects.
+        override_list: Override list of objects; takes precedence by ``Name``.
+
+    Returns:
+        A new list. Base order is preserved; unmatched override entries append.
+    """
+    # Name keying applies only when every truthy entry in BOTH lists is a dict
+    # carrying a 'Name'. Otherwise the function falls back to replacing the list
+    # wholesale.
+    #
+    # CAVEAT: this fallback is a local convenience inherited from
+    # template_generator._merge_object_lists. Its correspondence to OrcaFlex
+    # behaviour is NOT established, and establishing it is out of scope. It is
+    # ported to preserve the existing contract, not because the vendor format is
+    # known to behave this way.
+    has_names = (
+        all(isinstance(item, dict) and "Name" in item for item in base_list if item)
+        and all(isinstance(item, dict) and "Name" in item for item in override_list if item)
+    )
+
+    if not has_names:
+        return deepcopy(override_list) if override_list else deepcopy(base_list)
+
+    override_by_name = {item["Name"]: item for item in override_list if item}
+
+    result: list[Any] = []
+    seen_names: set[Any] = set()
+
+    # Base entries first, in base order, each replaced wholesale where overridden.
+    for item in base_list:
+        if item and "Name" in item:
+            name = item["Name"]
+            seen_names.add(name)
+            result.append(deepcopy(override_by_name.get(name, item)))
+
+    # Then override entries naming objects the base does not carry.
+    for item in override_list:
+        if item and "Name" in item and item["Name"] not in seen_names:
+            result.append(deepcopy(item))
+
+    return result

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/writers/__init__.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/writers/__init__.py
@@ -1,0 +1,11 @@
+"""Writers that emit OrcaFlex model files from generated data.
+
+``basefile`` emits a variation model composed with ``BaseFile:``, which clears
+all existing model data and then loads the named file.  The flat
+``- includefile:`` list emitted by :mod:`modular_generator` is the other
+composition form, and it merges incrementally instead.
+"""
+
+from .basefile import build_variation_document, write_variation_model
+
+__all__ = ["build_variation_document", "write_variation_model"]

--- a/src/digitalmodel/solvers/orcaflex/modular_generator/writers/basefile.py
+++ b/src/digitalmodel/solvers/orcaflex/modular_generator/writers/basefile.py
@@ -1,0 +1,222 @@
+"""Emit an OrcaFlex variation model composed with ``BaseFile:``.
+
+OrcaFlex composes a variation model two ways, and the semantics differ:
+
+``BaseFile:``
+    Clears **all** existing model data, then loads the named file.  Accepts a
+    binary ``.dat`` or a text ``.yml``.
+
+``IncludeFile:``
+    Merges incrementally from whatever state the model is already in.  Text
+    only.
+
+:mod:`digitalmodel.solvers.orcaflex.modular_generator` emits the second form, as
+a flat ``- includefile:`` list.  This module emits the first.
+
+Two constraints on the emitted document are OrcaFlex behaviour rather than
+stylistic preference:
+
+**Reference before use.**  A referenced object must appear before any reference
+to it — line types before lines, and vessels and 3D/6D buoys before lines,
+links, winches and shapes.  The order comes from
+:func:`object_section_order`, which reads it off ``BuilderRegistry``, the
+dependency order the generator already emits include files in.
+``post_validator._OBJECT_SECTIONS`` is a membership set and not that order: it
+places ``6DBuoys`` after ``Lines``, so ordering by it would emit a line
+referencing a buoy the document has not yet declared.
+
+**No YAML anchors.**  OrcFxAPI's YAML parser rejects ``&id001`` / ``*id001``.
+The package already carries :class:`.._NoAliasDumper` for exactly this; it is
+reused here rather than duplicated.
+
+The comparator for the ``BaseFile`` reference emitted here is
+``template_generator.TemplateGenerator._generate_reference``, an independent
+in-tree implementation, captured as goldens under
+``tests/solvers/orcaflex/modular_generator/goldens/basefile/``.  The relative-path
+resolution below reproduces that function's two branches deliberately.  The
+override sections have no comparator; see the goldens' ``PROVENANCE.md``.
+"""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from .. import _NoAliasDumper
+from ..builders import BuilderRegistry  # noqa: F401  (import registers builders)
+from ..builders.generic_builder import _SECTION_ORDER
+from ..post_validator import _OBJECT_SECTIONS
+
+__all__ = ["build_variation_document", "object_section_order", "write_variation_model"]
+
+
+def object_section_order() -> tuple[str, ...]:
+    """The order object sections are emitted in, derived from the generator.
+
+    OrcaFlex requires a referenced object to appear before any reference to it:
+    vessels and 3D/6D buoys before lines, links, winches and shapes; type
+    definitions before the instances that use them.
+
+    The order is assembled from three in-tree authorities, strongest first, and
+    is total over :data:`_OBJECT_SECTIONS`:
+
+    1. :class:`BuilderRegistry`, the order the generator already emits include
+       files in.  Each builder declares the object sections it emits as
+       ``_sections``, so the registry's ``order`` argument yields a section
+       order directly.  ``BuoysBuilder`` is registered at 80 and
+       ``LinesBuilder`` at 90, which is why buoys precede lines here and in a
+       generated ``master.yml``.
+    2. ``generic_builder._SECTION_ORDER``, which places the sections no builder
+       claims.  That list is documented as derived from a monolithic model's
+       own ``SaveData()`` output order, and ``GenericModelBuilder`` — the last
+       object-emitting builder in the registry, at order 200 — already uses it
+       to order a single document holding every section, which is the shape
+       emitted here.  An unclaimed section inherits the last registry anchor
+       ahead of it in that list, so ``WingTypes`` sorts with the other type
+       definitions rather than after ``Lines``.
+    3. :data:`_OBJECT_SECTIONS` for anything the first two do not place, so the
+       result stays deterministic when a new section is added.
+
+    :data:`_OBJECT_SECTIONS` is deliberately NOT the ordering authority.  It is
+    documented in ``post_validator`` as the SET of sections that define named
+    objects, and it lists ``6DBuoys``, ``3DBuoys``, ``Links``, ``Winches`` and
+    ``Constraints`` after ``Lines``.  Ordering by it emits a line that
+    references a buoy the document has not yet declared.  It is used here only
+    for membership.
+    """
+    known = set(_OBJECT_SECTIONS)
+
+    # Anchors: the registered order of the earliest builder claiming a section.
+    anchors: dict[str, int] = {}
+    for _output_file, builder_cls in BuilderRegistry.get_ordered_builders():
+        for section in getattr(builder_cls, "_sections", ()):
+            if section in known and section not in anchors:
+                anchors[section] = builder_cls._order
+
+    # Rank every section `_SECTION_ORDER` knows about.  An anchored section
+    # takes its registered order.  An unanchored one inherits the last anchor
+    # ahead of it and keeps its `_SECTION_ORDER` position after it, so a type
+    # definition no builder emits still lands among the type definitions rather
+    # than at the end of the document.
+    ranks: dict[str, tuple[int, int, int]] = {}
+    last_anchor = -1
+    offset = 0
+    for index, section in enumerate(_SECTION_ORDER):
+        if section not in known:
+            continue
+        if section in anchors:
+            last_anchor = anchors[section]
+            offset = 0
+        else:
+            offset += 1
+        ranks[section] = (last_anchor, offset, index)
+
+    # A section neither list places sorts last, in `_OBJECT_SECTIONS` order, so
+    # the result is total and deterministic when a new section appears.
+    tail = max((rank[0] for rank in ranks.values()), default=0) + 1
+    for index, section in enumerate(_OBJECT_SECTIONS):
+        if section not in ranks:
+            ranks[section] = (tail, 0, index)
+
+    return tuple(sorted(ranks, key=lambda section: ranks[section]))
+
+
+def _relative_base_reference(base_path: Path, out_dir: Path) -> str:
+    """Resolve ``base_path`` relative to ``out_dir``, as OrcaFlex reads it.
+
+    Reproduces ``template_generator._generate_reference``
+    (``template_generator.py:397-406``): a lexical ``Path.relative_to`` first,
+    falling back to ``os.path.relpath`` on the resolved paths because
+    ``relative_to`` cannot produce ``..`` traversal.  The separator is
+    normalised to ``/`` on every platform.
+    """
+    try:
+        relative = base_path.relative_to(out_dir)
+    except ValueError:
+        relative = Path(os.path.relpath(base_path.resolve(), out_dir.resolve()))
+    return str(relative).replace("\\", "/")
+
+
+def build_variation_document(
+    base_path: str | Path,
+    overrides: Mapping[str, Any] | None,
+    out_path: str | Path,
+) -> dict[str, Any]:
+    """Build the variation-model document without writing it.
+
+    Args:
+        base_path: The model the variation is built on.  Either a binary
+            ``.dat`` or a text ``.yml``; the extension is emitted unchanged,
+            because ``BaseFile`` accepts both.  The file need not exist — only
+            its path is used.
+        overrides: Sections to emit after the base reference.  Object sections
+            are ordered by :data:`_OBJECT_SECTIONS`; any other section is
+            emitted ahead of them, in the order supplied.
+        out_path: Where the document is destined.  The base reference is
+            relative to this file's directory, so the path matters even when
+            the file is never written.
+
+    Returns:
+        The document, key-ordered as it will be emitted.
+    """
+    base_path = Path(base_path)
+    out_dir = Path(out_path).parent
+
+    document: dict[str, Any] = {
+        "BaseFile": _relative_base_reference(base_path, out_dir),
+    }
+    if not overrides:
+        return document
+
+    object_sections = set(_OBJECT_SECTIONS)
+
+    # Non-object sections (General, Environment, VariableData, …) declare no
+    # named objects, so reference-before-use does not order them.  They are
+    # emitted first, in the order supplied, rather than dropped: iterating the
+    # object sections alone would silently discard them.
+    for section, value in overrides.items():
+        if section not in object_sections:
+            document[section] = deepcopy(value)
+
+    # Object sections in dependency order, so a referenced object is always
+    # declared before the object that references it.
+    for section in object_section_order():
+        if section in overrides:
+            document[section] = deepcopy(overrides[section])
+
+    return document
+
+
+def write_variation_model(
+    base_path: str | Path,
+    overrides: Mapping[str, Any] | None,
+    out_path: str | Path,
+) -> Path:
+    """Write a ``BaseFile``-composed variation model to ``out_path``.
+
+    Args:
+        base_path: See :func:`build_variation_document`.
+        overrides: See :func:`build_variation_document`.
+        out_path: Destination file.  Parent directories are created.
+
+    Returns:
+        The path written.
+    """
+    out_path = Path(out_path)
+    document = build_variation_document(base_path, overrides, out_path)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as handle:
+        yaml.dump(
+            document,
+            handle,
+            Dumper=_NoAliasDumper,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+    return out_path

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/PROVENANCE.md
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/PROVENANCE.md
@@ -1,0 +1,139 @@
+# BaseFile goldens — provenance
+
+## Producer
+
+| Field | Value |
+|---|---|
+| Module | `digitalmodel.solvers.orcaflex.template_generator` |
+| Entry point | `TemplateGenerator.generate(base_file, variation_file, output_file, as_reference=True)` |
+| Function under capture | `TemplateGenerator._generate_reference` |
+| Source location | `src/digitalmodel/solvers/orcaflex/template_generator.py:380-418` |
+| Repository commit at capture | `b2b462d53c0829414bb29ae0ba4cb1ba93f93b20` |
+| Branch at capture | `feat/orcaflex-3843-basefile-merge` |
+| Date of capture | 2026-09-11 |
+| Capture script | `capture.py`, beside this record |
+| Interpreter | `.venv/Scripts/python.exe` (Windows, CPython) |
+
+## Comparator class
+
+**`cross-solver`** — per `.claude/rules/reproducibility-is-not-correctness.md`.
+
+`_generate_reference` is a second in-tree implementation of the same
+vendor-documented OrcaFlex variation-model format. It is not the consumer of that
+format. Agreement between `modular_generator.writers.basefile` and
+`template_generator._generate_reference` establishes that two independent
+implementations of the relative-path reference agree with each other; it does not
+establish that either agrees with OrcaFlex.
+
+The class is **not** `archived-run`: the goldens are not a prior run of the code
+under test, and they do not drift with it. They do drift with
+`template_generator.py`, and re-capture is required if that module changes.
+
+A licensed equivalence check — loading a written variation model through
+OrcFxAPI and comparing the resolved object set against the flat `IncludeFile`
+composition — remains a follow-on. It is not performed here and is not claimed.
+
+## What the goldens cover, and what they do not
+
+| Emitted key | Comparator class | Note |
+|---|---|---|
+| `BaseFile` | `cross-solver` | The relative-path arithmetic and the POSIX separator normalisation are asserted against `_generate_reference` |
+| Override sections (`LineTypes`, `Vessels`, `Lines`, …) | `none` | `_generate_reference` does not emit them; see the divergence below |
+
+The override half of the writer's output has **no comparator**. Its section
+ordering is asserted against `BuilderRegistry`, and its anchor-free encoding is
+asserted structurally. Both are inside the producing system, and neither is
+evidence of agreement with OrcaFlex.
+
+The ordering authority was corrected after the first capture. The plan named
+`post_validator._OBJECT_SECTIONS`, which lists `6DBuoys`, `3DBuoys`,
+`Constraints`, `Links` and `Winches` **after** `Lines`; ordering by it emits a
+line that references a buoy the document has not yet declared. That module
+documents the tuple as the SET of sections defining named objects, not as an
+order, and it is now used for membership only. The order is read off
+`BuilderRegistry`, where `BuoysBuilder` is registered at 80 against
+`LinesBuilder` at 90 — the same order the committed
+`docs/domains/orcaflex/templates/mooring_systems/calm_buoy/master.yml` loads its
+include files in, under the comment "Buoys must be before Lines since lines
+connect to buoys". Sections no builder claims are placed by
+`generic_builder._SECTION_ORDER`, which is documented as derived from a
+monolithic model's own `SaveData()` output order. None of this changes the
+goldens: `_generate_reference` emits no override sections, so the capture is
+unaffected.
+
+## Divergence from the plan's description of the comparator
+
+The plan
+(`workspace-hub/docs/plans/2026-09-11-issue-3843-generator-consolidation.md`,
+"The comparator problem") describes `_generate_reference` as an independent
+implementation of the format the new writer emits. The two formats overlap only
+partially.
+
+`_generate_reference` returns exactly two keys:
+
+```
+{'BaseFile': <variation base, relative to the output file>,
+ 'IncludeFile': <variation file, relative to the output file>}
+```
+
+It composes a variation model by **referencing a separate variation file**. The
+writer specified by the plan composes one by **inlining the override sections**
+into the same document, and emits no `IncludeFile` key at all. Both are valid
+OrcaFlex variation models and the two are not interchangeable: the inline form
+carries its overrides in one file, the reference form defers them to a second.
+
+The consequence is recorded above and is load-bearing: the goldens constrain the
+`BaseFile` key only. The plan's TDD row 13, "writer output matches the committed
+golden", is implemented as an assertion on that key. A claim that the writer's
+full output is golden-backed would be false.
+
+## Relative-path behaviour reproduced
+
+`_generate_reference` resolves the base reference in two branches, and both are
+represented in the case set:
+
+1. `Path.relative_to(output_file.parent)` — lexical, no resolution, succeeds only
+   when the base sits at or below the output directory. Case
+   `base_below_output`.
+2. `os.path.relpath(base.resolve(), output_file.parent.resolve())` — the
+   fallback, which produces `..` traversal. Cases `calm_buoy_deep_water`,
+   `spread_mooring_twelve_leg`, `salm_wire_rope`, `turret_external`,
+   `dat_base_sibling`.
+
+Both branches normalise `\` to `/` in the emitted string.
+
+## Case set
+
+Inputs are recorded exactly in `manifest.yml`. Four cases are driven from the
+committed hybrid template sets under `docs/domains/orcaflex/templates/`; two are
+driven from synthetic fixtures under `fixtures/` that exist to exercise the
+`.dat` base extension and the `relative_to` branch.
+
+| Case | Base file | Captured `BaseFile` |
+|---|---|---|
+| `calm_buoy_deep_water` | `calm_buoy_hybrid/base/calm_buoy_base.yml` | `../base/calm_buoy_base.yml` |
+| `spread_mooring_twelve_leg` | `spread_mooring_hybrid/base/spread_mooring_base.yml` | `../base/spread_mooring_base.yml` |
+| `salm_wire_rope` | `salm_hybrid/base/salm_base.yml` | `../base/salm_base.yml` |
+| `turret_external` | `turret_mooring_hybrid/base/turret_mooring_base.yml` | `../base/turret_mooring_base.yml` |
+| `dat_base_sibling` | `fixtures/base_model.dat` | `../base_model.dat` |
+| `base_below_output` | `fixtures/sub/base_model.yml` | `sub/base_model.yml` |
+
+Table 1 — captured cases and the `BaseFile` value each produced.
+
+The capture wrote to `<template>/cases/case_*_golden.yml` inside the committed
+template sets and removed those files afterwards, so that the committed case
+files were not overwritten. The output directory, not the output filename,
+determines the relative path, so the recorded values are the values those
+template sets already carry: `calm_buoy_hybrid/cases/case_deep_water.yml` holds
+`BaseFile: ../base/calm_buoy_base.yml`, which case `calm_buoy_deep_water`
+reproduces independently.
+
+## Re-capture
+
+```
+.venv/Scripts/python.exe tests/solvers/orcaflex/modular_generator/goldens/basefile/capture.py
+```
+
+Re-capture is required when `template_generator._generate_reference` changes.
+A golden that no longer matches a changed comparator is a signal to establish
+which of the two implementations is wrong, not to refresh the golden.

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/capture.py
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/capture.py
@@ -1,0 +1,139 @@
+"""Capture the BaseFile goldens from ``template_generator._generate_reference``.
+
+The comparator is an independent in-tree implementation of the OrcaFlex
+variation-model reference format.  See ``PROVENANCE.md`` beside this script for
+the comparator class, what the goldens do and do not cover, and the divergence
+between the reference form emitted here and the inline form emitted by
+``modular_generator.writers.basefile``.
+
+Usage (from the repository root, with the repo virtualenv)::
+
+    .venv/Scripts/python.exe tests/solvers/orcaflex/modular_generator/goldens/basefile/capture.py
+
+Re-capture only when ``template_generator._generate_reference`` changes.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+GOLDENS = Path(__file__).resolve().parent
+CASES = GOLDENS / "cases"
+FIX = GOLDENS / "fixtures"
+# goldens/basefile -> goldens -> modular_generator -> orcaflex -> solvers -> tests -> repo
+REPO = GOLDENS.parents[5]
+TPL = REPO / "docs/domains/orcaflex/templates"
+
+sys.path.insert(0, str(REPO / "src"))
+
+from digitalmodel.solvers.orcaflex.template_generator import (  # noqa: E402
+    TemplateGenerator,
+)
+
+# case_id -> (base_file, variation_file, output_file)
+SPECS = {
+    "calm_buoy_deep_water": (
+        TPL / "mooring_systems/calm_buoy_hybrid/base/calm_buoy_base.yml",
+        TPL / "mooring_systems/calm_buoy_hybrid/variations/deep_water_200m.yml",
+        TPL / "mooring_systems/calm_buoy_hybrid/cases/case_deep_water_golden.yml",
+    ),
+    "spread_mooring_twelve_leg": (
+        TPL / "mooring_systems/spread_mooring_hybrid/base/spread_mooring_base.yml",
+        TPL / "mooring_systems/spread_mooring_hybrid/variations/twelve_leg.yml",
+        TPL / "mooring_systems/spread_mooring_hybrid/cases/case_twelve_leg_golden.yml",
+    ),
+    "salm_wire_rope": (
+        TPL / "mooring_systems/salm_hybrid/base/salm_base.yml",
+        TPL / "mooring_systems/salm_hybrid/variations/wire_rope_leg.yml",
+        TPL / "mooring_systems/salm_hybrid/cases/case_wire_rope_golden.yml",
+    ),
+    "turret_external": (
+        TPL / "mooring_systems/turret_mooring_hybrid/base/turret_mooring_base.yml",
+        TPL / "mooring_systems/turret_mooring_hybrid/variations/external_turret.yml",
+        TPL / "mooring_systems/turret_mooring_hybrid/cases/case_external_turret_golden.yml",
+    ),
+    # Synthetic: a binary .dat base, sibling to the output directory.
+    "dat_base_sibling": (
+        FIX / "base_model.dat",
+        FIX / "variation.yml",
+        FIX / "out/case_dat_base.yml",
+    ),
+    # Synthetic: base nested below the output directory, which is the only shape
+    # that reaches the comparator's Path.relative_to branch.
+    "base_below_output": (
+        FIX / "sub/base_model.yml",
+        FIX / "variation.yml",
+        FIX / "case_base_below.yml",
+    ),
+}
+
+
+def _rel(path: Path) -> str:
+    return path.resolve().relative_to(REPO).as_posix()
+
+
+def main() -> int:
+    sha = subprocess.run(
+        ["git", "-C", str(REPO), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    generator = TemplateGenerator()
+    CASES.mkdir(parents=True, exist_ok=True)
+
+    manifest_cases = []
+    for case_id, (base, variation, out) in SPECS.items():
+        out.parent.mkdir(parents=True, exist_ok=True)
+        result = generator.generate(base, variation, out, as_reference=True)
+        if not result.get("success"):
+            print(f"FAIL {case_id}: {result}")
+            return 1
+
+        raw = out.read_text(encoding="utf-8")
+        golden = CASES / f"{case_id}.yml"
+        golden.write_text(raw, encoding="utf-8", newline="\n")
+        parsed = yaml.safe_load(raw)
+        manifest_cases.append({
+            "case_id": case_id,
+            "base_file": _rel(base),
+            "variation_file": _rel(variation),
+            "output_file": _rel(out),
+            "golden": _rel(golden),
+            "captured_base_file_value": parsed["BaseFile"],
+            "captured_include_file_value": parsed["IncludeFile"],
+        })
+
+        # Capture artifacts are not left inside the committed template sets, nor
+        # duplicated beside the fixtures they were generated from.
+        out.unlink()
+        print(f"OK {case_id}: BaseFile={parsed['BaseFile']!r}")
+
+    manifest = {
+        "schema": "basefile-goldens/1",
+        "captured_on": date.today().isoformat(),
+        "producer": {
+            "module": "digitalmodel.solvers.orcaflex.template_generator",
+            "callable": "TemplateGenerator.generate(..., as_reference=True)"
+                        " -> TemplateGenerator._generate_reference",
+            "source_lines": "src/digitalmodel/solvers/orcaflex/template_generator.py:380-418",
+            "repo_commit": sha,
+        },
+        "comparator_class": "cross-solver",
+        "covers": ["BaseFile"],
+        "does_not_cover": ["override sections emitted inline by the writer"],
+        "cases": manifest_cases,
+    }
+    (GOLDENS / "manifest.yml").write_text(
+        yaml.dump(manifest, sort_keys=False, default_flow_style=False),
+        encoding="utf-8", newline="\n",
+    )
+    print(f"\nmanifest written; repo_commit={sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/base_below_output.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/base_below_output.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: base_model.yml + variation.yml
+---
+BaseFile: sub/base_model.yml
+IncludeFile: variation.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/calm_buoy_deep_water.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/calm_buoy_deep_water.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: calm_buoy_base.yml + deep_water_200m.yml
+---
+BaseFile: ../base/calm_buoy_base.yml
+IncludeFile: ../variations/deep_water_200m.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/dat_base_sibling.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/dat_base_sibling.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: base_model.dat + variation.yml
+---
+BaseFile: ../base_model.dat
+IncludeFile: ../variation.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/salm_wire_rope.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/salm_wire_rope.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: salm_base.yml + wire_rope_leg.yml
+---
+BaseFile: ../base/salm_base.yml
+IncludeFile: ../variations/wire_rope_leg.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/spread_mooring_twelve_leg.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/spread_mooring_twelve_leg.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: spread_mooring_base.yml + twelve_leg.yml
+---
+BaseFile: ../base/spread_mooring_base.yml
+IncludeFile: ../variations/twelve_leg.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/turret_external.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/turret_external.yml
@@ -1,0 +1,5 @@
+%YAML 1.1
+# Generated from: turret_mooring_base.yml + external_turret.yml
+---
+BaseFile: ../base/turret_mooring_base.yml
+IncludeFile: ../variations/external_turret.yml

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/base_model.dat
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/base_model.dat
@@ -1,0 +1,6 @@
+# Stub standing in for an OrcaFlex binary .dat base file.
+# The content is deliberately irrelevant: the comparator
+# (template_generator.TemplateGenerator._generate_reference) performs path
+# arithmetic only and never opens the base file. This fixture exists so the
+# comparator's existence check passes during golden capture, and so the
+# `.dat` extension is exercised end to end.

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/sub/base_model.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/sub/base_model.yml
@@ -1,0 +1,5 @@
+# Base fixture for BaseFile golden capture, placed below the output directory
+# so the comparator's Path.relative_to branch is exercised rather than its
+# os.path.relpath fallback. Only its path is used; the content is never read.
+General:
+  UnitsSystem: SI

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/variation.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/variation.yml
@@ -1,0 +1,5 @@
+# Variation fixture for BaseFile golden capture.
+# Only its path is used by the comparator; the content is never read.
+LineTypes:
+  - Name: Chain_84mm_R4
+    OD: 0.084

--- a/tests/solvers/orcaflex/modular_generator/goldens/basefile/manifest.yml
+++ b/tests/solvers/orcaflex/modular_generator/goldens/basefile/manifest.yml
@@ -1,0 +1,55 @@
+schema: basefile-goldens/1
+captured_on: '2026-09-11'
+producer:
+  module: digitalmodel.solvers.orcaflex.template_generator
+  callable: TemplateGenerator.generate(..., as_reference=True) -> TemplateGenerator._generate_reference
+  source_lines: src/digitalmodel/solvers/orcaflex/template_generator.py:380-418
+  repo_commit: b2b462d53c0829414bb29ae0ba4cb1ba93f93b20
+comparator_class: cross-solver
+covers:
+- BaseFile
+does_not_cover:
+- override sections emitted inline by the writer
+cases:
+- case_id: calm_buoy_deep_water
+  base_file: docs/domains/orcaflex/templates/mooring_systems/calm_buoy_hybrid/base/calm_buoy_base.yml
+  variation_file: docs/domains/orcaflex/templates/mooring_systems/calm_buoy_hybrid/variations/deep_water_200m.yml
+  output_file: docs/domains/orcaflex/templates/mooring_systems/calm_buoy_hybrid/cases/case_deep_water_golden.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/calm_buoy_deep_water.yml
+  captured_base_file_value: ../base/calm_buoy_base.yml
+  captured_include_file_value: ../variations/deep_water_200m.yml
+- case_id: spread_mooring_twelve_leg
+  base_file: docs/domains/orcaflex/templates/mooring_systems/spread_mooring_hybrid/base/spread_mooring_base.yml
+  variation_file: docs/domains/orcaflex/templates/mooring_systems/spread_mooring_hybrid/variations/twelve_leg.yml
+  output_file: docs/domains/orcaflex/templates/mooring_systems/spread_mooring_hybrid/cases/case_twelve_leg_golden.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/spread_mooring_twelve_leg.yml
+  captured_base_file_value: ../base/spread_mooring_base.yml
+  captured_include_file_value: ../variations/twelve_leg.yml
+- case_id: salm_wire_rope
+  base_file: docs/domains/orcaflex/templates/mooring_systems/salm_hybrid/base/salm_base.yml
+  variation_file: docs/domains/orcaflex/templates/mooring_systems/salm_hybrid/variations/wire_rope_leg.yml
+  output_file: docs/domains/orcaflex/templates/mooring_systems/salm_hybrid/cases/case_wire_rope_golden.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/salm_wire_rope.yml
+  captured_base_file_value: ../base/salm_base.yml
+  captured_include_file_value: ../variations/wire_rope_leg.yml
+- case_id: turret_external
+  base_file: docs/domains/orcaflex/templates/mooring_systems/turret_mooring_hybrid/base/turret_mooring_base.yml
+  variation_file: docs/domains/orcaflex/templates/mooring_systems/turret_mooring_hybrid/variations/external_turret.yml
+  output_file: docs/domains/orcaflex/templates/mooring_systems/turret_mooring_hybrid/cases/case_external_turret_golden.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/turret_external.yml
+  captured_base_file_value: ../base/turret_mooring_base.yml
+  captured_include_file_value: ../variations/external_turret.yml
+- case_id: dat_base_sibling
+  base_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/base_model.dat
+  variation_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/variation.yml
+  output_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/out/case_dat_base.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/dat_base_sibling.yml
+  captured_base_file_value: ../base_model.dat
+  captured_include_file_value: ../variation.yml
+- case_id: base_below_output
+  base_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/sub/base_model.yml
+  variation_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/variation.yml
+  output_file: tests/solvers/orcaflex/modular_generator/goldens/basefile/fixtures/case_base_below.yml
+  golden: tests/solvers/orcaflex/modular_generator/goldens/basefile/cases/base_below_output.yml
+  captured_base_file_value: sub/base_model.yml
+  captured_include_file_value: variation.yml

--- a/tests/solvers/orcaflex/modular_generator/test_basefile_writer.py
+++ b/tests/solvers/orcaflex/modular_generator/test_basefile_writer.py
@@ -1,0 +1,392 @@
+"""Tests for the BaseFile variation-model writer.
+
+Covers TDD rows 9-13 of
+``workspace-hub/docs/plans/2026-09-11-issue-3843-generator-consolidation.md``.
+
+OrcaFlex composes a variation model two ways, with different semantics.
+``BaseFile:`` clears all existing model data and then loads the named file, and
+accepts either a binary ``.dat`` or a text ``.yml``.  ``IncludeFile:`` merges
+incrementally from whatever state the model is in, and is text only.  The writer
+under test emits the first form.
+
+Row 13 is the load-bearing assertion.  Its comparator is
+``template_generator.TemplateGenerator._generate_reference``, an independent
+in-tree implementation of the same vendor-documented format, captured as goldens
+under ``goldens/basefile/``.  Read ``goldens/basefile/PROVENANCE.md`` before
+relying on that assertion: the two implementations overlap on the ``BaseFile``
+key only, so the goldens constrain that key and nothing else.  The override
+sections have comparator class ``none``.
+
+DEFERRED — plan row 14.  Row 14 asserts the collision check introduced by
+workspace-hub#3838 against this writer's output.  That check lives on an
+unmerged PR branch and is absent from ``main``, so it is not implemented here.
+Implement row 14 once digitalmodel#2099 merges.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digitalmodel.solvers.orcaflex.modular_generator.post_validator import (
+    _OBJECT_SECTIONS,
+)
+from digitalmodel.solvers.orcaflex.modular_generator.writers.basefile import (
+    build_variation_document,
+    object_section_order,
+    write_variation_model,
+)
+
+# tests/solvers/orcaflex/modular_generator/ -> repository root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GOLDENS = Path(__file__).resolve().parent / "goldens" / "basefile"
+
+
+def _load(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _emitted_key_order(text: str) -> list[str]:
+    """Top-level mapping keys, in the order they appear in the emitted text."""
+    return [
+        line.split(":", 1)[0]
+        for line in text.splitlines()
+        if line
+        and not line[0].isspace()
+        and ":" in line
+        # A block-sequence item of a top-level key also starts at column 0.
+        and not line.startswith(("#", "-", "%"))
+    ]
+
+
+# --------------------------------------------------------------------------
+# Row 9 — writer emits BaseFile plus overrides, path relative to the output
+# --------------------------------------------------------------------------
+
+def test_row09_emits_basefile_key_and_override_sections(tmp_path):
+    base = tmp_path / "base" / "model.yml"
+    base.parent.mkdir(parents=True)
+    base.write_text("General:\n  UnitsSystem: SI\n", encoding="utf-8")
+    out = tmp_path / "cases" / "case_a.yml"
+
+    overrides = {"LineTypes": [{"Name": "Chain_84mm_R4", "OD": 0.084}]}
+    doc = build_variation_document(base, overrides, out)
+
+    assert "BaseFile" in doc
+    assert doc["LineTypes"] == [{"Name": "Chain_84mm_R4", "OD": 0.084}]
+    # A variation model composed with BaseFile carries no IncludeFile key.
+    assert "IncludeFile" not in doc
+
+
+def test_row09_basefile_path_is_relative_to_the_output_file(tmp_path):
+    base = tmp_path / "base" / "model.yml"
+    base.parent.mkdir(parents=True)
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "cases" / "case_a.yml"
+
+    doc = build_variation_document(base, {}, out)
+
+    assert doc["BaseFile"] == "../base/model.yml"
+    assert not Path(doc["BaseFile"]).is_absolute()
+    # POSIX separators regardless of host platform, matching the comparator.
+    assert "\\" not in doc["BaseFile"]
+
+
+def test_row09_base_below_the_output_directory_needs_no_traversal(tmp_path):
+    base = tmp_path / "base" / "model.yml"
+    base.parent.mkdir(parents=True)
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    assert build_variation_document(base, {}, out)["BaseFile"] == "base/model.yml"
+
+
+def test_row09_write_variation_model_round_trips(tmp_path):
+    base = tmp_path / "base" / "model.dat"
+    base.parent.mkdir(parents=True)
+    base.write_text("stub\n", encoding="utf-8")
+    out = tmp_path / "cases" / "case_a.yml"
+
+    written = write_variation_model(base, {"Vessels": [{"Name": "FPSO"}]}, out)
+
+    assert written == out
+    assert out.exists()
+    assert _load(out) == build_variation_document(base, {"Vessels": [{"Name": "FPSO"}]}, out)
+
+
+# --------------------------------------------------------------------------
+# Row 10 — a .dat base is emitted unchanged, because BaseFile accepts binary
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("suffix", [".dat", ".yml", ".yaml", ".DAT"])
+def test_row10_base_extension_is_emitted_unchanged(tmp_path, suffix):
+    base = tmp_path / "base" / f"model{suffix}"
+    base.parent.mkdir(parents=True, exist_ok=True)
+    base.write_text("stub\n", encoding="utf-8")
+    out = tmp_path / "cases" / "case_a.yml"
+
+    doc = build_variation_document(base, {}, out)
+
+    assert doc["BaseFile"] == f"../base/model{suffix}"
+    assert doc["BaseFile"].endswith(suffix)
+
+
+def test_row10_dat_base_is_not_rejected(tmp_path):
+    """A binary base is a valid BaseFile target and must not raise."""
+    base = tmp_path / "base" / "model.dat"
+    base.parent.mkdir(parents=True)
+    base.write_bytes(b"\x00\x01\x02not-utf8\xff")
+    out = tmp_path / "case_a.yml"
+
+    doc = build_variation_document(base, {"Lines": [{"Name": "L1"}]}, out)
+
+    assert doc["BaseFile"] == "base/model.dat"
+
+
+# --------------------------------------------------------------------------
+# Row 11 — reference-before-use ordering
+# --------------------------------------------------------------------------
+
+def test_row11_line_types_precede_lines_regardless_of_input_order(tmp_path):
+    base = tmp_path / "model.yml"
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    # Deliberately inverted: Lines first, the referenced LineTypes last.
+    overrides = {
+        "Lines": [{"Name": "Mooring_L1", "LineType": "Chain_84mm_R4"}],
+        "Vessels": [{"Name": "FPSO"}],
+        "LineTypes": [{"Name": "Chain_84mm_R4", "OD": 0.084}],
+    }
+    text = yaml.dump(build_variation_document(base, overrides, out), sort_keys=False)
+    order = _emitted_key_order(text)
+
+    assert order[0] == "BaseFile"
+    assert order.index("LineTypes") < order.index("Lines")
+    assert order.index("VesselTypes" if "VesselTypes" in order else "Vessels") < order.index("Lines")
+
+
+def test_row11_buoys_precede_lines(tmp_path):
+    """A line connected to a 6D buoy must find that buoy already declared.
+
+    Orcina's documented rule is that a referenced object appears before any
+    reference to it, and that vessels and 3D/6D buoys appear before lines,
+    links, winches and shapes.  The generator already honours this: the
+    committed
+    ``docs/domains/orcaflex/templates/mooring_systems/calm_buoy/master.yml``
+    loads ``08_buoys.yml`` before ``07_lines.yml``, carrying the comment
+    "Buoys must be before Lines since lines connect to buoys", and
+    ``BuilderRegistry`` registers BuoysBuilder at order 80 against LinesBuilder
+    at 90.
+
+    ``post_validator._OBJECT_SECTIONS`` puts ``6DBuoys`` AFTER ``Lines``.  It is
+    a membership set, not a dependency order, and ordering by it emits a
+    forward reference.  This test fails against that order by construction.
+    """
+    base = tmp_path / "model.yml"
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    overrides = {
+        "Lines": [{"Name": "Mooring_L1", "EndBConnection": "Buoy_A"}],
+        "6DBuoys": [{"Name": "Buoy_A"}],
+        "3DBuoys": [{"Name": "Buoy_B"}],
+        "Shapes": [{"Name": "Seabed_Ramp"}],
+        "Vessels": [{"Name": "FPSO"}],
+        "Links": [{"Name": "Link_1"}],
+        "Winches": [{"Name": "Winch_1"}],
+    }
+    text = yaml.dump(build_variation_document(base, overrides, out), sort_keys=False)
+    order = _emitted_key_order(text)
+
+    # Referenced before referencing.
+    assert order.index("6DBuoys") < order.index("Lines")
+    assert order.index("3DBuoys") < order.index("Lines")
+    assert order.index("Vessels") < order.index("Lines")
+    assert order.index("Shapes") < order.index("Lines")
+    # Links and winches reference lines, so they follow.
+    assert order.index("Lines") < order.index("Links")
+    assert order.index("Lines") < order.index("Winches")
+
+
+def test_row11_emitted_order_follows_the_builder_registry(tmp_path):
+    base = tmp_path / "model.yml"
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    # Every object section, supplied in exactly reversed canonical order.
+    canonical = object_section_order()
+    overrides = {name: [{"Name": f"{name}_1"}] for name in reversed(canonical)}
+    text = yaml.dump(build_variation_document(base, overrides, out), sort_keys=False)
+    order = _emitted_key_order(text)
+
+    assert order[0] == "BaseFile"
+    assert order[1:] == list(canonical)
+
+
+def test_object_section_order_covers_every_object_section():
+    """The derived order is total over `_OBJECT_SECTIONS`.
+
+    A section the registry's builders do not claim must still be placed
+    deterministically, not dropped and not appended arbitrarily.
+    """
+    canonical = object_section_order()
+    assert set(_OBJECT_SECTIONS) <= set(canonical)
+    assert len(canonical) == len(set(canonical))
+
+
+def test_object_section_order_matches_the_registry_for_claimed_sections():
+    """The order of claimed sections is the registry's order, not a local table.
+
+    BuoysBuilder is registered at 80 and LinesBuilder at 90, so buoys precede
+    lines here for the same reason they do in a generated master.yml.
+    """
+    from digitalmodel.solvers.orcaflex.modular_generator.builders.registry import (
+        BuilderRegistry,
+    )
+
+    canonical = object_section_order()
+
+    # section -> the registered order of the earliest builder claiming it.
+    anchors: dict[str, int] = {}
+    for _output_file, builder_cls in BuilderRegistry.get_ordered_builders():
+        for section in getattr(builder_cls, "_sections", ()):
+            anchors.setdefault(section, builder_cls._order)
+
+    assert anchors, "no builder declares _sections; the derivation is inert"
+    assert anchors["6DBuoys"] < anchors["Lines"]
+
+    # Two claimed sections sort by their registered order, never against it.
+    claimed = [s for s in canonical if s in anchors]
+    for earlier, later in zip(claimed, claimed[1:]):
+        assert anchors[earlier] <= anchors[later], (
+            f"{earlier} (order {anchors[earlier]}) emitted before "
+            f"{later} (order {anchors[later]})"
+        )
+
+
+def test_row11_non_object_sections_are_not_dropped(tmp_path):
+    """General and Environment are not object sections and must still be emitted.
+
+    The plan's pseudocode iterates `_OBJECT_SECTIONS` only, which would discard
+    every other override silently.  The writer emits non-object sections ahead of
+    the object sections instead, in the order supplied.
+    """
+    base = tmp_path / "model.yml"
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    overrides = {
+        "Lines": [{"Name": "L1"}],
+        "General": {"StageDuration": [8.0, 100.0]},
+        "Environment": {"WaterDepth": 200.0},
+    }
+    doc = build_variation_document(base, overrides, out)
+    order = _emitted_key_order(yaml.dump(doc, sort_keys=False))
+
+    assert doc["General"] == {"StageDuration": [8.0, 100.0]}
+    assert doc["Environment"] == {"WaterDepth": 200.0}
+    assert order == ["BaseFile", "General", "Environment", "Lines"]
+
+
+# --------------------------------------------------------------------------
+# Row 12 — no YAML anchors, because OrcFxAPI's parser rejects them
+# --------------------------------------------------------------------------
+
+def _shared_structure_overrides() -> dict:
+    """Overrides in which one object is referenced twice by identity.
+
+    PyYAML's default Dumper emits an anchor and an alias for a repeated object
+    identity.  OrcFxAPI's YAML parser rejects both.
+    """
+    vertices = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]]
+    drag_area = {"X": 12.5, "Y": 12.5, "Z": 30.0}
+    return {
+        "6DBuoys": [
+            {"Name": "Buoy_A", "Vertices": vertices, "DragArea": drag_area},
+            {"Name": "Buoy_B", "Vertices": vertices, "DragArea": drag_area},
+        ],
+        "LineTypes": [
+            {"Name": "Chain_A", "DragArea": drag_area},
+            {"Name": "Chain_B", "DragArea": drag_area},
+        ],
+    }
+
+
+def test_row12_control_default_dumper_does_alias():
+    """Guard against a vacuous row-12 assertion.
+
+    If this fails, the fixture no longer contains shared structure and the
+    anchor-free assertion below would pass for the wrong reason.
+    """
+    text = yaml.dump(_shared_structure_overrides(), sort_keys=False)
+    assert "&id" in text and "*id" in text
+
+
+def test_row12_no_yaml_anchors_in_written_output(tmp_path):
+    base = tmp_path / "model.yml"
+    base.write_text("General: {}\n", encoding="utf-8")
+    out = tmp_path / "case_a.yml"
+
+    write_variation_model(base, _shared_structure_overrides(), out)
+    text = out.read_text(encoding="utf-8")
+
+    assert "&id" not in text
+    assert "*id" not in text
+    # The de-aliased document still parses, and still carries both copies.
+    parsed = yaml.safe_load(text)
+    assert parsed["6DBuoys"][0]["Vertices"] == parsed["6DBuoys"][1]["Vertices"]
+    assert len(parsed["LineTypes"]) == 2
+
+
+# --------------------------------------------------------------------------
+# Row 13 — the load-bearing assertion against the committed goldens
+# --------------------------------------------------------------------------
+
+def _golden_cases():
+    manifest = _load(GOLDENS / "manifest.yml")
+    return [(case["case_id"], case) for case in manifest["cases"]]
+
+
+def test_goldens_declare_their_comparator_class():
+    manifest = _load(GOLDENS / "manifest.yml")
+    assert manifest["comparator_class"] == "cross-solver"
+    assert manifest["covers"] == ["BaseFile"]
+    assert (GOLDENS / "PROVENANCE.md").exists()
+
+
+@pytest.mark.parametrize("case_id,case", _golden_cases(), ids=lambda v: v if isinstance(v, str) else "")
+def test_row13_writer_basefile_matches_committed_golden(case_id, case):
+    """The writer's BaseFile reference matches the independent implementation.
+
+    Comparator class `cross-solver`.  The goldens were captured from
+    `template_generator._generate_reference` at commit
+    b2b462d53c0829414bb29ae0ba4cb1ba93f93b20; see PROVENANCE.md.  They constrain
+    the BaseFile key only — `_generate_reference` emits no inline override
+    sections, so the writer's override half has no comparator.
+    """
+    base = REPO_ROOT / case["base_file"]
+    out = REPO_ROOT / case["output_file"]
+    golden = _load(REPO_ROOT / case["golden"])
+
+    doc = build_variation_document(base, {}, out)
+
+    assert doc["BaseFile"] == golden["BaseFile"]
+    assert doc["BaseFile"] == case["captured_base_file_value"]
+
+
+def test_row13_golden_reproduces_a_committed_case_file():
+    """The calm_buoy golden agrees with the case file already in the tree.
+
+    `docs/domains/orcaflex/templates/.../cases/case_deep_water.yml` was authored
+    independently of this capture.  Agreement with it is a third data point on
+    the BaseFile reference, not merely agreement with the capture.
+    """
+    committed = _load(
+        REPO_ROOT
+        / "docs/domains/orcaflex/templates/mooring_systems/calm_buoy_hybrid"
+        / "cases/case_deep_water.yml"
+    )
+    golden = _load(GOLDENS / "cases" / "calm_buoy_deep_water.yml")
+    assert golden["BaseFile"] == committed["BaseFile"]

--- a/tests/solvers/orcaflex/modular_generator/test_name_keyed_merge.py
+++ b/tests/solvers/orcaflex/modular_generator/test_name_keyed_merge.py
@@ -1,0 +1,158 @@
+"""Tests for the name-keyed list merge.
+
+The behaviour under test is ported from
+``digitalmodel.solvers.orcaflex.template_generator.TemplateGenerator._merge_object_lists``
+(read at ``template_generator.py:273-323``). The assertions therefore encode the
+existing contract, including the ``has_names`` fallback and the deep copying of
+every retained and appended entry.
+
+Cases 5 to 8 exist because an implementation that indexes ``item["Name"]``
+unconditionally raises ``KeyError`` on input the ported function handles, and an
+implementation that omits ``deepcopy`` aliases base entries into the result.
+"""
+
+from __future__ import annotations
+
+from digitalmodel.solvers.orcaflex.modular_generator.merge import merge_named_lists
+
+
+def test_override_replaces_same_named_entry_wholesale():
+    """Row 1: a same-named override entry is present with no residue of the base entry."""
+    base = [{"Name": "LineA", "Length": 100.0, "OuterDiameter": 0.5}]
+    override = [{"Name": "LineA", "Length": 250.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert result == [{"Name": "LineA", "Length": 250.0}]
+    assert len(result) == 1
+    assert result[0]["Length"] == 250.0
+
+
+def test_base_key_absent_from_override_is_gone():
+    """Row 2: replacement, not deep merge — the base-only key does not survive."""
+    base = [{"Name": "LineA", "Length": 100.0, "OuterDiameter": 0.5}]
+    override = [{"Name": "LineA", "Length": 250.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert "OuterDiameter" not in result[0]
+
+
+def test_unknown_name_appends_at_end():
+    """Row 3: a name absent from the base appends last; base order is unchanged."""
+    base = [{"Name": "LineA", "Length": 100.0}, {"Name": "LineB", "Length": 200.0}]
+    override = [{"Name": "LineC", "Length": 300.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert [item["Name"] for item in result] == ["LineA", "LineB", "LineC"]
+    assert result[2] == {"Name": "LineC", "Length": 300.0}
+
+
+def test_base_order_preserved_under_override():
+    """Row 4: an overridden entry keeps the position its base entry held."""
+    base = [
+        {"Name": "LineA", "Length": 100.0},
+        {"Name": "LineB", "Length": 200.0},
+        {"Name": "LineC", "Length": 300.0},
+    ]
+    override = [{"Name": "LineB", "Length": 999.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert [item["Name"] for item in result] == ["LineA", "LineB", "LineC"]
+    assert result[1]["Length"] == 999.0
+    assert result[0]["Length"] == 100.0
+    assert result[2]["Length"] == 300.0
+
+
+def test_item_without_name_falls_back_to_wholesale_replacement():
+    """Row 5: a list carrying an unnamed item falls back to list replacement, no raise."""
+    # Unnamed item in the override.
+    base = [{"Name": "LineA", "Length": 100.0}]
+    override = [{"NoNameKey": 1}]
+
+    result = merge_named_lists(base, override)
+
+    assert result == [{"NoNameKey": 1}]
+
+    # Unnamed item in the base.
+    base = [{"Length": 100.0}]
+    override = [{"Name": "LineA", "Length": 250.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert result == [{"Name": "LineA", "Length": 250.0}]
+
+    # A non-dict item also disables name keying.
+    base = [1.0, 2.0, 3.0]
+    override = [4.0]
+
+    result = merge_named_lists(base, override)
+
+    assert result == [4.0]
+
+
+def test_empty_override_with_non_name_base_returns_base_copy():
+    """Row 6: an empty override over an unnamed base returns a copy of the base."""
+    base = [{"Length": 100.0}, {"Length": 200.0}]
+    override: list = []
+
+    result = merge_named_lists(base, override)
+
+    assert result == [{"Length": 100.0}, {"Length": 200.0}]
+    assert result is not base
+    assert result[0] is not base[0]
+
+
+def test_result_does_not_alias_the_base():
+    """Row 7: mutating the merged result leaves the base untouched, on both paths."""
+    # Name-keyed path — retained base entries are copied.
+    base = [
+        {"Name": "LineA", "Sections": [{"Length": 100.0}]},
+        {"Name": "LineB", "Sections": [{"Length": 200.0}]},
+    ]
+    override = [{"Name": "LineB", "Sections": [{"Length": 999.0}]}]
+
+    result = merge_named_lists(base, override)
+    result[0]["Sections"][0]["Length"] = -1.0
+    result[0]["Injected"] = True
+
+    assert base[0]["Sections"][0]["Length"] == 100.0
+    assert "Injected" not in base[0]
+
+    # Appended override entries are copied too.
+    override_entry = {"Name": "LineC", "Sections": [{"Length": 300.0}]}
+    result = merge_named_lists(base, [override_entry])
+    result[-1]["Sections"][0]["Length"] = -1.0
+
+    assert override_entry["Sections"][0]["Length"] == 300.0
+
+    # Fallback path — the returned base copy is independent as well.
+    unnamed_base = [{"Sections": [{"Length": 100.0}]}]
+    result = merge_named_lists(unnamed_base, [])
+    result[0]["Sections"][0]["Length"] = -1.0
+
+    assert unnamed_base[0]["Sections"][0]["Length"] == 100.0
+
+    # Fallback path — the returned override copy is independent as well.
+    unnamed_override = [{"Sections": [{"Length": 300.0}]}]
+    result = merge_named_lists([{"Name": "LineA"}], unnamed_override)
+    result[0]["Sections"][0]["Length"] = -1.0
+
+    assert unnamed_override[0]["Sections"][0]["Length"] == 300.0
+
+
+def test_falsy_entries_are_skipped():
+    """Row 8: falsy entries in either list are skipped without raising."""
+    base = [{"Name": "LineA", "Length": 100.0}, None, {}, {"Name": "LineB", "Length": 200.0}]
+    override = [None, {}, {"Name": "LineB", "Length": 999.0}]
+
+    result = merge_named_lists(base, override)
+
+    assert [item["Name"] for item in result] == ["LineA", "LineB"]
+    assert result[1]["Length"] == 999.0
+
+    # Falsy-only lists do not raise and contribute nothing.
+    assert merge_named_lists([None, {}], [None]) == []
+    assert merge_named_lists([], []) == []


### PR DESCRIPTION
Implements owner-approved workspace-hub [#3843](https://github.com/vamseeachanta/workspace-hub/issues/3843), scoped to the additive half.

Closes the capability gap the research established: `modular_generator` could not express Orcina's documented variation-model mechanism. A grep for `BaseFile` across the package returned one legacy config key.

**Nothing is deleted and no module is renamed.** The plan's first draft proposed retiring three generators; both reviewers returned REJECT and its central premise was disproved by execution — two generators described as having zero consumers are live, with 23 passing tests between them, reached through deprecation aliases. Retirement is now a follow-on, not a premise.

## What lands

**`merge.py`** — name-keyed list merge, ported from `template_generator._merge_object_lists` read at `:273-323` rather than from a description. OrcaFlex replaces a same-named object wholesale; it does not deep-merge. The `has_names` fallback and the `deepcopy` are preserved as part of the existing contract, and the fallback carries an in-code comment stating its correspondence to OrcaFlex behaviour is **not established**.

**`writers/basefile.py`** — `BaseFile` variation-model emission. Object-section order derives from `BuilderRegistry`, the package's actual dependency-order authority. An earlier draft named `post_validator._OBJECT_SECTIONS`, which places `6DBuoys` *after* `Lines`; that is a membership set, not an order, and the committed `master.yml` says so directly: *"Buoys must be before Lines since lines connect to buoys."* Each builder now declares the sections it emits, extracted by AST from its own `build()` return.

## The comparator, and its limit — please read this part

Goldens are captured from `template_generator._generate_reference`, an independent in-tree implementation, recorded as comparator class **`cross-solver`** and explicitly not as truth.

**That comparator does not emit what this writer emits.** `_generate_reference` returns `{BaseFile, IncludeFile}` and composes by *referencing* a variation file; this writer *inlines* override sections. Both are valid OrcaFlex variation models; they are not the same format.

Consequently the goldens constrain the `BaseFile` key only. **The override half has comparator class `none`** — its ordering is asserted against `BuilderRegistry`, which is inside the producing system. This is recorded in `PROVENANCE.md` rather than left for a reader to infer from the golden's coverage, per `.claude/rules/reproducibility-is-not-correctness.md`. A licensed equivalence check against OrcaFlex itself remains an unperformed follow-on.

## Falsifiability

Breaking the relative-path resolution fails 13 of 22 writer tests, including all six golden cases. The no-anchors assertion carries a control test proving the default PyYAML dumper *does* alias the same fixture, so it cannot pass vacuously. The ordering test was verified red against `_OBJECT_SECTIONS` before the fix and green after.

## Tests

| Suite | Result |
|---|---|
| Writer + merge + comparator suites | 46 passed |
| Wider `modular_generator` directory | 761 passed, 1 pre-existing failure |

Baseline before this work was 737 passed with the same single cp1522 BOM failure at `schema/campaign.py:503`. The delta is exactly the new tests.

`test_modular_vs_monolithic.py` is excluded — it calls real `CalculateStatics()` without a `solver` marker and hangs on a licensed host, filed as workspace-hub#3841.

## Deferred

Plan row 14 asserts #3838's collision check against this writer. That check is not on `main` until digitalmodel#2099 merges. Named as deferred in the test module docstring, not dropped.

## Flagged, not fixed

`generic_builder._SECTION_ORDER` places `Lines` at index 16 and `6DBuoys` at 18 — a third ordering that disagrees with `BuilderRegistry`. Whether that constitutes a forward reference is **not established**: `_SECTION_ORDER` is documented as derived from OrcaFlex's own `SaveData()` output, and Orcina documents that connection updates are postponed until the whole file has loaded. Untouched here; recorded for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYiGiqWS1q6cZfeGHPsAEx